### PR TITLE
upstream(core): Fix expensive callsites of iterator

### DIFF
--- a/crates/iota-common/src/lib.rs
+++ b/crates/iota-common/src/lib.rs
@@ -6,3 +6,4 @@ pub mod logging;
 pub mod metrics;
 pub mod stream_ext;
 pub mod sync;
+pub mod try_iterator_ext;

--- a/crates/iota-common/src/try_iterator_ext.rs
+++ b/crates/iota-common/src/try_iterator_ext.rs
@@ -14,7 +14,7 @@ pub trait TryIteratorExt<T, E>: Iterator<Item = Result<T, E>> + Sized {
 
     /// Try taking at most limit items while predicate holds collecting mapped
     /// values and breaking early on errors.
-    fn try_take_while_map_and_collect<U, F, P, B>(
+    fn try_take_map_while_and_collect<U, F, P, B>(
         self,
         limit: Option<usize>,
         mut predicate: P,

--- a/crates/iota-common/src/try_iterator_ext.rs
+++ b/crates/iota-common/src/try_iterator_ext.rs
@@ -2,63 +2,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub trait TryIteratorExt<T, E>: Iterator<Item = Result<T, E>> + Sized {
-    /// Tries to collect items from an iterator, stopping early on first error,
-    /// with an optional limit and optional take_while filter_fn.
-    /// This avoids creating an intermediate Vec when we just need to propagate
-    /// errors.
-    fn try_map_while_and_collect<U, F, P, B>(self, mut predicate: P, map_fn: F) -> B
+    /// Tries to map and collect items from a fallible iterator, stopping early
+    /// on the first error.
+    fn try_map_while_and_collect<U, P, B>(self, mut predicate: P) -> B
     where
-        F: Fn(T) -> U,
-        P: FnMut(&T) -> bool,
+        P: FnMut(T) -> Option<U>,
         B: FromIterator<Result<U, E>>,
     {
-        FromIterator::from_iter(self.map_while(|result| -> Option<Result<U, E>> {
-            match result {
-                Ok(v) => {
-                    if predicate(&v) {
-                        Some(Ok(map_fn(v)))
-                    } else {
-                        None
-                    }
-                }
-                Err(e) => Some(Err(e)),
-            }
-        }))
+        FromIterator::from_iter(self.map_while(|result| result.map(&mut predicate).transpose()))
     }
 
-    fn try_skip_filter_map_and_collect<U, F, P, B>(
+    /// Try taking at most limit items while predicate holds collecting mapped
+    /// values and breaking early on errors.
+    fn try_take_while_map_and_collect<U, F, P, B>(
         self,
-        mut limit: Option<usize>,
-        mut predicate: Option<P>,
+        limit: Option<usize>,
+        mut predicate: P,
         map_fn: F,
-    ) -> B
+    ) -> Result<B, E>
     where
         F: Fn(T) -> U,
         P: FnMut(&T) -> bool,
-        B: FromIterator<Result<U, E>>,
+        B: FromIterator<U>,
     {
-        self.try_map_while_and_collect(
-            |v| {
-                let within_limit = if let Some(ref mut limited) = limit {
-                    if *limited == 0 {
-                        false
-                    } else {
-                        *limited -= 1;
-                        true
-                    }
-                } else {
-                    true
-                };
+        let predicate = |v| predicate(&v).then(|| map_fn(v));
 
-                let pass_filter = if let Some(ref mut filter) = predicate {
-                    filter(v)
-                } else {
-                    true
-                };
-                within_limit && pass_filter
-            },
-            map_fn,
-        )
+        if let Some(limit) = limit {
+            self.take(limit).try_map_while_and_collect(predicate)
+        } else {
+            self.try_map_while_and_collect(predicate)
+        }
     }
 }
 
@@ -70,23 +43,29 @@ mod tests {
 
     #[test]
     fn test_try_skip_filter_map_and_collect() {
-        let data: Vec<Result<i32, &str>> = vec![Ok(1), Ok(2), Ok(3), Ok(8), Ok(4)];
-        let result: Vec<_> = data.into_iter().try_skip_filter_map_and_collect(
-            Some(4),
-            Some(|&x: &i32| x < 8),
-            |x| x * 2,
-        );
-        assert_eq!(result, vec![Ok(2), Ok(4), Ok(6)]); // stops at 8, so only gets 1,2,3 doubled
+        let result: Result<Vec<_>, &str> = [1, 2, 3, 8]
+            .into_iter()
+            .map(Ok)
+            .chain(std::iter::from_fn(|| panic!()))
+            .try_take_map_while_and_collect(Some(5), |&x: &i32| x < 8, |x| x * 2);
+        assert_eq!(result, Ok(vec![2, 4, 6])); // stops at 8
     }
 
     #[test]
     fn test_try_skip_filter_map_and_collect_with_error() {
-        let data: Vec<Result<i32, &str>> = vec![Ok(1), Ok(2), Err("error"), Ok(8), Ok(4)];
-        let result: Result<Vec<i32>, &str> = data.into_iter().try_skip_filter_map_and_collect(
-            Some(4),
-            Some(|&x: &i32| x < 8),
-            |x| x * 2,
-        );
-        assert_eq!(result, Err("error"));
+        let result: Result<Vec<_>, _> = [Ok(1), Ok(2), Err("error")]
+            .into_iter()
+            .chain(std::iter::from_fn(|| panic!()))
+            .try_take_map_while_and_collect(None, |&x: &i32| x < 8, |x| x * 2);
+        assert_eq!(result, Err("error")); // stops on the first error
+    }
+
+    #[test]
+    fn test_try_skip_filter_map_and_collect_with_limit() {
+        let result: Result<Vec<_>, &str> = [Ok(1), Ok(2)]
+            .into_iter()
+            .chain(std::iter::from_fn(|| panic!()))
+            .try_take_map_while_and_collect(Some(2), |&x: &i32| x < 8, |x| x * 2);
+        assert_eq!(result, Ok(vec![2, 4])); // respects limit stopping before panic
     }
 }

--- a/crates/iota-common/src/try_iterator_ext.rs
+++ b/crates/iota-common/src/try_iterator_ext.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 IOTA Stiftung
+// Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 pub trait TryIteratorExt<T, E>: Iterator<Item = Result<T, E>> + Sized {

--- a/crates/iota-common/src/try_iterator_ext.rs
+++ b/crates/iota-common/src/try_iterator_ext.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub trait TryIteratorExt<T, E>: Iterator<Item = Result<T, E>> + Sized {
+    /// Tries to collect items from an iterator, stopping early on first error,
+    /// with an optional limit and optional take_while filter_fn.
+    /// This avoids creating an intermediate Vec when we just need to propagate
+    /// errors.
+    fn try_take_while_map_and_collect<U, F, P>(
+        self,
+        limit: Option<usize>,
+        filter_fn: Option<P>,
+        map_fn: F,
+    ) -> Result<Vec<U>, E>
+    where
+        F: FnMut(T) -> U,
+        P: FnMut(&T) -> bool;
+}
+
+impl<I, T, E> TryIteratorExt<T, E> for I
+where
+    I: Iterator<Item = Result<T, E>>,
+{
+    fn try_take_while_map_and_collect<U, F, P>(
+        self,
+        limit: Option<usize>,
+        mut filter_fn: Option<P>,
+        mut map_fn: F,
+    ) -> Result<Vec<U>, E>
+    where
+        F: FnMut(T) -> U,
+        P: FnMut(&T) -> bool,
+    {
+        let mut result = Vec::new();
+
+        for (count, item_result) in self.enumerate() {
+            // Check limit first
+            if let Some(max_count) = limit {
+                if count >= max_count {
+                    break;
+                }
+            }
+
+            // Try to get the item, propagating error immediately
+            let item = item_result?;
+
+            // Check condition if provided
+            if let Some(ref mut filter) = filter_fn {
+                if !filter(&item) {
+                    break;
+                }
+            }
+
+            // Map and add to result
+            result.push(map_fn(item));
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_take_while_map_and_collect() {
+        let data: Vec<Result<i32, &str>> = vec![Ok(1), Ok(2), Ok(3), Ok(8), Ok(4)];
+        let result =
+            data.into_iter()
+                .try_take_while_map_and_collect(Some(4), Some(|&x: &i32| x < 8), |x| x * 2);
+        assert_eq!(result, Ok(vec![2, 4, 6])); // stops at 8, so only gets 1,2,3 doubled
+    }
+
+    #[test]
+    fn test_try_take_while_map_and_collect_with_error() {
+        let data: Vec<Result<i32, &str>> = vec![Ok(1), Ok(2), Err("error"), Ok(8), Ok(4)];
+        let result =
+            data.into_iter()
+                .try_take_while_map_and_collect(Some(4), Some(|&x: &i32| x < 8), |x| x * 2);
+        assert_eq!(result, Err("error"));
+    }
+}

--- a/crates/iota-common/src/try_iterator_ext.rs
+++ b/crates/iota-common/src/try_iterator_ext.rs
@@ -6,78 +6,87 @@ pub trait TryIteratorExt<T, E>: Iterator<Item = Result<T, E>> + Sized {
     /// with an optional limit and optional take_while filter_fn.
     /// This avoids creating an intermediate Vec when we just need to propagate
     /// errors.
-    fn try_take_while_map_and_collect<U, F, P>(
-        self,
-        limit: Option<usize>,
-        filter_fn: Option<P>,
-        map_fn: F,
-    ) -> Result<Vec<U>, E>
+    fn try_map_while_and_collect<U, F, P, B>(self, mut predicate: P, map_fn: F) -> B
     where
-        F: FnMut(T) -> U,
-        P: FnMut(&T) -> bool;
-}
-
-impl<I, T, E> TryIteratorExt<T, E> for I
-where
-    I: Iterator<Item = Result<T, E>>,
-{
-    fn try_take_while_map_and_collect<U, F, P>(
-        self,
-        limit: Option<usize>,
-        mut filter_fn: Option<P>,
-        mut map_fn: F,
-    ) -> Result<Vec<U>, E>
-    where
-        F: FnMut(T) -> U,
+        F: Fn(T) -> U,
         P: FnMut(&T) -> bool,
+        B: FromIterator<Result<U, E>>,
     {
-        let mut result = Vec::new();
-
-        for (count, item_result) in self.enumerate() {
-            // Check limit first
-            if let Some(max_count) = limit {
-                if count >= max_count {
-                    break;
+        FromIterator::from_iter(self.map_while(|result| -> Option<Result<U, E>> {
+            match result {
+                Ok(v) => {
+                    if predicate(&v) {
+                        Some(Ok(map_fn(v)))
+                    } else {
+                        None
+                    }
                 }
+                Err(e) => Some(Err(e)),
             }
+        }))
+    }
 
-            // Try to get the item, propagating error immediately
-            let item = item_result?;
+    fn try_skip_filter_map_and_collect<U, F, P, B>(
+        self,
+        mut limit: Option<usize>,
+        mut predicate: Option<P>,
+        map_fn: F,
+    ) -> B
+    where
+        F: Fn(T) -> U,
+        P: FnMut(&T) -> bool,
+        B: FromIterator<Result<U, E>>,
+    {
+        self.try_map_while_and_collect(
+            |v| {
+                let within_limit = if let Some(ref mut limited) = limit {
+                    if *limited == 0 {
+                        false
+                    } else {
+                        *limited -= 1;
+                        true
+                    }
+                } else {
+                    true
+                };
 
-            // Check condition if provided
-            if let Some(ref mut filter) = filter_fn {
-                if !filter(&item) {
-                    break;
-                }
-            }
-
-            // Map and add to result
-            result.push(map_fn(item));
-        }
-
-        Ok(result)
+                let pass_filter = if let Some(ref mut filter) = predicate {
+                    filter(v)
+                } else {
+                    true
+                };
+                within_limit && pass_filter
+            },
+            map_fn,
+        )
     }
 }
+
+impl<I, T, E> TryIteratorExt<T, E> for I where I: Iterator<Item = Result<T, E>> {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_try_take_while_map_and_collect() {
+    fn test_try_skip_filter_map_and_collect() {
         let data: Vec<Result<i32, &str>> = vec![Ok(1), Ok(2), Ok(3), Ok(8), Ok(4)];
-        let result =
-            data.into_iter()
-                .try_take_while_map_and_collect(Some(4), Some(|&x: &i32| x < 8), |x| x * 2);
-        assert_eq!(result, Ok(vec![2, 4, 6])); // stops at 8, so only gets 1,2,3 doubled
+        let result: Vec<_> = data.into_iter().try_skip_filter_map_and_collect(
+            Some(4),
+            Some(|&x: &i32| x < 8),
+            |x| x * 2,
+        );
+        assert_eq!(result, vec![Ok(2), Ok(4), Ok(6)]); // stops at 8, so only gets 1,2,3 doubled
     }
 
     #[test]
-    fn test_try_take_while_map_and_collect_with_error() {
+    fn test_try_skip_filter_map_and_collect_with_error() {
         let data: Vec<Result<i32, &str>> = vec![Ok(1), Ok(2), Err("error"), Ok(8), Ok(4)];
-        let result =
-            data.into_iter()
-                .try_take_while_map_and_collect(Some(4), Some(|&x: &i32| x < 8), |x| x * 2);
+        let result: Result<Vec<i32>, &str> = data.into_iter().try_skip_filter_map_and_collect(
+            Some(4),
+            Some(|&x: &i32| x < 8),
+            |x| x * 2,
+        );
         assert_eq!(result, Err("error"));
     }
 }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -70,7 +70,7 @@ use tap::TapOptional;
 use tokio::{sync::OnceCell, time::Instant};
 use tracing::{debug, error, info, instrument, trace, warn};
 use typed_store::{
-    DBMapUtils, Map, TypedStoreError,
+    DBMapUtils, Map,
     rocks::{
         DBBatch, DBMap, DBOptions, MetricConf, ReadWriteOptions, default_db_options,
         read_size_from_env,

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -15,6 +15,7 @@ use std::{
     },
 };
 
+use iota_common::try_iterator_ext::TryIteratorExt;
 use iota_json_rpc_types::{IotaObjectDataFilter, TransactionFilter};
 use iota_storage::{mutex_table::MutexTable, sharded_lru::ShardedLruCache};
 use iota_types::{
@@ -726,40 +727,31 @@ impl IndexStore {
         reverse: bool,
     ) -> IotaResult<Vec<TransactionDigest>> {
         Ok(if reverse {
-            let iter = index
+            index
                 .reversed_safe_iter_with_bounds(
                     None,
                     Some((key.clone(), cursor.unwrap_or(TxSequenceNumber::MAX))),
                 )?
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .take_while(|result| {
-                    result
-                        .as_ref()
-                        .map(|((id, _), _)| *id == key)
-                        .unwrap_or(false)
-                })
-                .map(|result| result.map(|(_, digest)| digest));
-            if let Some(limit) = limit {
-                iter.take(limit).collect::<Result<Vec<_>, _>>()?
-            } else {
-                iter.collect::<Result<Vec<_>, _>>()?
-            }
+                .try_take_while_map_and_collect(
+                    limit,
+                    Some(|((id, _), _): &((KeyT, TxSequenceNumber), TransactionDigest)| *id == key),
+                    |(_, digest)| digest,
+                )?
         } else {
-            let iter = index
-                .iter_with_bounds(
+            index
+                .safe_iter_with_bounds(
                     Some((key.clone(), cursor.unwrap_or(TxSequenceNumber::MIN))),
                     None,
                 )
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .take_while(|((id, _), _)| *id == key)
-                .map(|(_, digest)| digest);
-            if let Some(limit) = limit {
-                iter.take(limit).collect()
-            } else {
-                iter.collect()
-            }
+                .try_take_while_map_and_collect(
+                    limit,
+                    Some(|((id, _), _): &((KeyT, TxSequenceNumber), TransactionDigest)| *id == key),
+                    |(_, digest)| digest,
+                )?
         })
     }
 
@@ -866,46 +858,45 @@ impl IndexStore {
 
         let key = (package, module_val, function_val, cursor_val);
         Ok(if reverse {
-            let iter = self
-                .tables
+            self.tables
                 .transactions_by_move_function
                 .reversed_safe_iter_with_bounds(None, Some(key))?
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .take_while(|result| {
-                    result
-                        .as_ref()
-                        .map(|((id, m, f, _), _)| {
+                .try_take_while_map_and_collect(
+                    limit,
+                    Some(
+                        |((id, m, f, _), _): &(
+                            (ObjectID, String, String, TxSequenceNumber),
+                            TransactionDigest,
+                        )| {
                             *id == package
                                 && module.as_ref().map(|x| x == m).unwrap_or(true)
                                 && function.as_ref().map(|x| x == f).unwrap_or(true)
-                        })
-                        .unwrap_or(false)
-                })
-                .map(|result| result.map(|(_, digest)| digest));
-            if let Some(limit) = limit {
-                iter.take(limit).collect::<Result<Vec<_>, _>>()?
-            } else {
-                iter.collect::<Result<Vec<_>, _>>()?
-            }
+                        },
+                    ),
+                    |(_, digest)| digest,
+                )?
         } else {
-            let iter = self
-                .tables
+            self.tables
                 .transactions_by_move_function
-                .iter_with_bounds(Some(key), None)
+                .safe_iter_with_bounds(Some(key), None)
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .take_while(|((id, m, f, _), _)| {
-                    *id == package
-                        && module.as_ref().map(|x| x == m).unwrap_or(true)
-                        && function.as_ref().map(|x| x == f).unwrap_or(true)
-                })
-                .map(|(_, digest)| digest);
-            if let Some(limit) = limit {
-                iter.take(limit).collect()
-            } else {
-                iter.collect()
-            }
+                .try_take_while_map_and_collect(
+                    limit,
+                    Some(
+                        |((id, m, f, _), _): &(
+                            (ObjectID, String, String, TxSequenceNumber),
+                            TransactionDigest,
+                        )| {
+                            *id == package
+                                && module.as_ref().map(|x| x == m).unwrap_or(true)
+                                && function.as_ref().map(|x| x == f).unwrap_or(true)
+                        },
+                    ),
+                    |(_, digest)| digest,
+                )?
         })
     }
 
@@ -977,29 +968,34 @@ impl IndexStore {
             self.tables
                 .event_order
                 .reversed_safe_iter_with_bounds(None, Some((min(tx_seq, seq), event_seq)))?
-                .take_while(|result| {
-                    result
-                        .as_ref()
-                        .map(|((tx, _), _)| tx == &seq)
-                        .unwrap_or(false)
-                })
-                .take(limit)
-                .map(|result| {
-                    result.map(|((_, event_seq), (digest, tx_digest, time))| {
+                .try_take_while_map_and_collect(
+                    Some(limit),
+                    Some(
+                        |((tx, _), _): &(
+                            (TxSequenceNumber, usize),
+                            (TransactionEventsDigest, TransactionDigest, u64),
+                        )| tx == &seq,
+                    ),
+                    |((_, event_seq), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
-                    })
-                })
-                .collect::<Result<Vec<_>, _>>()?
+                    },
+                )?
         } else {
             self.tables
                 .event_order
-                .iter_with_bounds(Some((max(tx_seq, seq), event_seq)), None)
-                .take_while(|((tx, _), _)| tx == &seq)
-                .take(limit)
-                .map(|((_, event_seq), (digest, tx_digest, time))| {
-                    (digest, tx_digest, event_seq, time)
-                })
-                .collect()
+                .safe_iter_with_bounds(Some((max(tx_seq, seq), event_seq)), None)
+                .try_take_while_map_and_collect(
+                    Some(limit),
+                    Some(
+                        |((tx, _), _): &(
+                            (TxSequenceNumber, usize),
+                            (TransactionEventsDigest, TransactionDigest, u64),
+                        )| tx == &seq,
+                    ),
+                    |((_, event_seq), (digest, tx_digest, time))| {
+                        (digest, tx_digest, event_seq, time)
+                    },
+                )?
         })
     }
 
@@ -1014,23 +1010,33 @@ impl IndexStore {
         Ok(if descending {
             index
                 .reversed_safe_iter_with_bounds(None, Some((key.clone(), (tx_seq, event_seq))))?
-                .take_while(|result| result.as_ref().map(|((m, _), _)| m == key).unwrap_or(false))
-                .take(limit)
-                .map(|result| {
-                    result.map(|((_, (_, event_seq)), (digest, tx_digest, time))| {
+                .try_take_while_map_and_collect(
+                    Some(limit),
+                    Some(
+                        |((m, _), _): &(
+                            (KeyT, EventId),
+                            (TransactionEventsDigest, TransactionDigest, u64),
+                        )| m == key,
+                    ),
+                    |((_, (_, event_seq)), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
-                    })
-                })
-                .collect::<Result<Vec<_>, _>>()?
+                    },
+                )?
         } else {
             index
-                .iter_with_bounds(Some((key.clone(), (tx_seq, event_seq))), None)
-                .take_while(|((m, _), _)| m == key)
-                .take(limit)
-                .map(|((_, (_, event_seq)), (digest, tx_digest, time))| {
-                    (digest, tx_digest, event_seq, time)
-                })
-                .collect()
+                .safe_iter_with_bounds(Some((key.clone(), (tx_seq, event_seq))), None)
+                .try_take_while_map_and_collect(
+                    Some(limit),
+                    Some(
+                        |((m, _), _): &(
+                            (KeyT, EventId),
+                            (TransactionEventsDigest, TransactionDigest, u64),
+                        )| m == key,
+                    ),
+                    |((_, (_, event_seq)), (digest, tx_digest, time))| {
+                        (digest, tx_digest, event_seq, time)
+                    },
+                )?
         })
     }
 
@@ -1119,29 +1125,24 @@ impl IndexStore {
             self.tables
                 .event_by_time
                 .reversed_safe_iter_with_bounds(None, Some((end_time, (tx_seq, event_seq))))?
-                .take_while(|result| {
-                    result
-                        .as_ref()
-                        .map(|((m, _), _)| m >= &start_time)
-                        .unwrap_or(false)
-                })
-                .take(limit)
-                .map(|result| {
-                    result.map(|((_, (_, event_seq)), (digest, tx_digest, time))| {
+                .try_take_while_map_and_collect(
+                    Some(limit),
+                    Some(|((m, _), _): &((u64, EventId), EventIndex)| m >= &start_time),
+                    |((_, (_, event_seq)), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
-                    })
-                })
-                .collect::<Result<Vec<_>, _>>()?
+                    },
+                )?
         } else {
             self.tables
                 .event_by_time
-                .iter_with_bounds(Some((start_time, (tx_seq, event_seq))), None)
-                .take_while(|((m, _), _)| m <= &end_time)
-                .take(limit)
-                .map(|((_, (_, event_seq)), (digest, tx_digest, time))| {
-                    (digest, tx_digest, event_seq, time)
-                })
-                .collect()
+                .safe_iter_with_bounds(Some((start_time, (tx_seq, event_seq))), None)
+                .try_take_while_map_and_collect(
+                    Some(limit),
+                    Some(|((m, _), _): &((u64, EventId), EventIndex)| m <= &end_time),
+                    |((_, (_, event_seq)), (digest, tx_digest, time))| {
+                        (digest, tx_digest, event_seq, time)
+                    },
+                )?
         })
     }
 

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -726,7 +726,7 @@ impl IndexStore {
         limit: Option<usize>,
         reverse: bool,
     ) -> IotaResult<Vec<TransactionDigest>> {
-        Ok(if reverse {
+        if reverse {
             index
                 .reversed_safe_iter_with_bounds(
                     None,
@@ -734,11 +734,12 @@ impl IndexStore {
                 )?
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .try_take_while_map_and_collect(
+                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
                     limit,
                     Some(|((id, _), _): &((KeyT, TxSequenceNumber), TransactionDigest)| *id == key),
                     |(_, digest)| digest,
-                )?
+                )
+                .map_err(Into::into)
         } else {
             index
                 .safe_iter_with_bounds(
@@ -747,12 +748,13 @@ impl IndexStore {
                 )
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .try_take_while_map_and_collect(
+                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
                     limit,
                     Some(|((id, _), _): &((KeyT, TxSequenceNumber), TransactionDigest)| *id == key),
                     |(_, digest)| digest,
-                )?
-        })
+                )
+                .map_err(Into::into)
+        }
     }
 
     pub fn get_transactions_by_input_object(
@@ -857,13 +859,13 @@ impl IndexStore {
                 .unwrap_or(if reverse { max_string } else { "".to_string() });
 
         let key = (package, module_val, function_val, cursor_val);
-        Ok(if reverse {
+        if reverse {
             self.tables
                 .transactions_by_move_function
                 .reversed_safe_iter_with_bounds(None, Some(key))?
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .try_take_while_map_and_collect(
+                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
                     limit,
                     Some(
                         |((id, m, f, _), _): &(
@@ -876,14 +878,15 @@ impl IndexStore {
                         },
                     ),
                     |(_, digest)| digest,
-                )?
+                )
+                .map_err(Into::into)
         } else {
             self.tables
                 .transactions_by_move_function
                 .safe_iter_with_bounds(Some(key), None)
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .try_take_while_map_and_collect(
+                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
                     limit,
                     Some(
                         |((id, m, f, _), _): &(
@@ -896,8 +899,9 @@ impl IndexStore {
                         },
                     ),
                     |(_, digest)| digest,
-                )?
-        })
+                )
+                .map_err(Into::into)
+        }
     }
 
     pub fn get_transactions_to_addr(
@@ -964,11 +968,11 @@ impl IndexStore {
         let seq = self
             .get_transaction_seq(digest)?
             .ok_or(IotaError::TransactionNotFound { digest: *digest })?;
-        Ok(if descending {
+        if descending {
             self.tables
                 .event_order
                 .reversed_safe_iter_with_bounds(None, Some((min(tx_seq, seq), event_seq)))?
-                .try_take_while_map_and_collect(
+                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
                     Some(limit),
                     Some(
                         |((tx, _), _): &(
@@ -979,12 +983,13 @@ impl IndexStore {
                     |((_, event_seq), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
                     },
-                )?
+                )
+                .map_err(Into::into)
         } else {
             self.tables
                 .event_order
                 .safe_iter_with_bounds(Some((max(tx_seq, seq), event_seq)), None)
-                .try_take_while_map_and_collect(
+                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
                     Some(limit),
                     Some(
                         |((tx, _), _): &(
@@ -995,8 +1000,9 @@ impl IndexStore {
                     |((_, event_seq), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
                     },
-                )?
-        })
+                )
+                .map_err(Into::into)
+        }
     }
 
     fn get_event_from_index<KeyT: Clone + PartialEq + Serialize + DeserializeOwned>(
@@ -1007,10 +1013,10 @@ impl IndexStore {
         limit: usize,
         descending: bool,
     ) -> IotaResult<Vec<(TransactionEventsDigest, TransactionDigest, usize, u64)>> {
-        Ok(if descending {
+        if descending {
             index
                 .reversed_safe_iter_with_bounds(None, Some((key.clone(), (tx_seq, event_seq))))?
-                .try_take_while_map_and_collect(
+                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
                     Some(limit),
                     Some(
                         |((m, _), _): &(
@@ -1021,11 +1027,12 @@ impl IndexStore {
                     |((_, (_, event_seq)), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
                     },
-                )?
+                )
+                .map_err(Into::into)
         } else {
             index
                 .safe_iter_with_bounds(Some((key.clone(), (tx_seq, event_seq))), None)
-                .try_take_while_map_and_collect(
+                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
                     Some(limit),
                     Some(
                         |((m, _), _): &(
@@ -1036,8 +1043,9 @@ impl IndexStore {
                     |((_, (_, event_seq)), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
                     },
-                )?
-        })
+                )
+                .map_err(Into::into)
+        }
     }
 
     pub fn events_by_module_id(
@@ -1121,29 +1129,31 @@ impl IndexStore {
         limit: usize,
         descending: bool,
     ) -> IotaResult<Vec<(TransactionEventsDigest, TransactionDigest, usize, u64)>> {
-        Ok(if descending {
+        if descending {
             self.tables
                 .event_by_time
                 .reversed_safe_iter_with_bounds(None, Some((end_time, (tx_seq, event_seq))))?
-                .try_take_while_map_and_collect(
+                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
                     Some(limit),
                     Some(|((m, _), _): &((u64, EventId), EventIndex)| m >= &start_time),
                     |((_, (_, event_seq)), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
                     },
-                )?
+                )
+                .map_err(Into::into)
         } else {
             self.tables
                 .event_by_time
                 .safe_iter_with_bounds(Some((start_time, (tx_seq, event_seq))), None)
-                .try_take_while_map_and_collect(
+                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
                     Some(limit),
                     Some(|((m, _), _): &((u64, EventId), EventIndex)| m <= &end_time),
                     |((_, (_, event_seq)), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
                     },
-                )?
-        })
+                )
+                .map_err(Into::into)
+        }
     }
 
     pub fn get_dynamic_fields_iterator(

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -741,7 +741,7 @@ impl IndexStore {
         iter
             // skip one more if exclusive cursor is Some
             .skip(usize::from(cursor.is_some()))
-            .try_take_while_map_and_collect(limit, |((id, _), _)| *id == key, |(_, digest)| digest)
+            .try_take_map_while_and_collect(limit, |((id, _), _)| *id == key, |(_, digest)| digest)
             .map_err(Into::into)
     }
 
@@ -863,7 +863,7 @@ impl IndexStore {
         iter
             // skip one more if exclusive cursor is Some
             .skip(usize::from(cursor.is_some()))
-            .try_take_while_map_and_collect(
+            .try_take_map_while_and_collect(
                 limit,
                 |((id, m, f, _), _)| {
                     *id == package
@@ -952,7 +952,7 @@ impl IndexStore {
                     .safe_iter_with_bounds(Some((max(tx_seq, seq), event_seq)), None),
             )
         };
-        iter.try_take_while_map_and_collect(
+        iter.try_take_map_while_and_collect(
             Some(limit),
             |((tx, _), _)| tx == &seq,
             |((_, event_seq), (digest, tx_digest, time))| (digest, tx_digest, event_seq, time),
@@ -979,7 +979,7 @@ impl IndexStore {
                     index.safe_iter_with_bounds(Some((key.clone(), (tx_seq, event_seq))), None),
                 )
             };
-        iter.try_take_while_map_and_collect(
+        iter.try_take_map_while_and_collect(
             Some(limit),
             |((m, _), _)| m == key,
             |((_, (_, event_seq)), (digest, tx_digest, time))| (digest, tx_digest, event_seq, time),
@@ -1072,7 +1072,7 @@ impl IndexStore {
             self.tables
                 .event_by_time
                 .reversed_safe_iter_with_bounds(None, Some((end_time, (tx_seq, event_seq))))?
-                .try_take_while_map_and_collect(
+                .try_take_map_while_and_collect(
                     Some(limit),
                     |((m, _), _)| m >= &start_time,
                     |((_, (_, event_seq)), (digest, tx_digest, time))| {
@@ -1084,7 +1084,7 @@ impl IndexStore {
             self.tables
                 .event_by_time
                 .safe_iter_with_bounds(Some((start_time, (tx_seq, event_seq))), None)
-                .try_take_while_map_and_collect(
+                .try_take_map_while_and_collect(
                     Some(limit),
                     |((m, _), _)| m <= &end_time,
                     |((_, (_, event_seq)), (digest, tx_digest, time))| {

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -734,9 +734,9 @@ impl IndexStore {
                 )?
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
+                .try_take_while_map_and_collect(
                     limit,
-                    Some(|((id, _), _): &((KeyT, TxSequenceNumber), TransactionDigest)| *id == key),
+                    |((id, _), _)| *id == key,
                     |(_, digest)| digest,
                 )
                 .map_err(Into::into)
@@ -748,9 +748,9 @@ impl IndexStore {
                 )
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
+                .try_take_while_map_and_collect(
                     limit,
-                    Some(|((id, _), _): &((KeyT, TxSequenceNumber), TransactionDigest)| *id == key),
+                    |((id, _), _)| *id == key,
                     |(_, digest)| digest,
                 )
                 .map_err(Into::into)
@@ -865,18 +865,13 @@ impl IndexStore {
                 .reversed_safe_iter_with_bounds(None, Some(key))?
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
+                .try_take_while_map_and_collect(
                     limit,
-                    Some(
-                        |((id, m, f, _), _): &(
-                            (ObjectID, String, String, TxSequenceNumber),
-                            TransactionDigest,
-                        )| {
-                            *id == package
-                                && module.as_ref().map(|x| x == m).unwrap_or(true)
-                                && function.as_ref().map(|x| x == f).unwrap_or(true)
-                        },
-                    ),
+                    |((id, m, f, _), _)| {
+                        *id == package
+                            && module.as_ref().map(|x| x == m).unwrap_or(true)
+                            && function.as_ref().map(|x| x == f).unwrap_or(true)
+                    },
                     |(_, digest)| digest,
                 )
                 .map_err(Into::into)
@@ -886,18 +881,13 @@ impl IndexStore {
                 .safe_iter_with_bounds(Some(key), None)
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
+                .try_take_while_map_and_collect(
                     limit,
-                    Some(
-                        |((id, m, f, _), _): &(
-                            (ObjectID, String, String, TxSequenceNumber),
-                            TransactionDigest,
-                        )| {
-                            *id == package
-                                && module.as_ref().map(|x| x == m).unwrap_or(true)
-                                && function.as_ref().map(|x| x == f).unwrap_or(true)
-                        },
-                    ),
+                    |((id, m, f, _), _)| {
+                        *id == package
+                            && module.as_ref().map(|x| x == m).unwrap_or(true)
+                            && function.as_ref().map(|x| x == f).unwrap_or(true)
+                    },
                     |(_, digest)| digest,
                 )
                 .map_err(Into::into)
@@ -972,14 +962,9 @@ impl IndexStore {
             self.tables
                 .event_order
                 .reversed_safe_iter_with_bounds(None, Some((min(tx_seq, seq), event_seq)))?
-                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
+                .try_take_while_map_and_collect(
                     Some(limit),
-                    Some(
-                        |((tx, _), _): &(
-                            (TxSequenceNumber, usize),
-                            (TransactionEventsDigest, TransactionDigest, u64),
-                        )| tx == &seq,
-                    ),
+                    |((tx, _), _)| tx == &seq,
                     |((_, event_seq), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
                     },
@@ -989,14 +974,9 @@ impl IndexStore {
             self.tables
                 .event_order
                 .safe_iter_with_bounds(Some((max(tx_seq, seq), event_seq)), None)
-                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
+                .try_take_while_map_and_collect(
                     Some(limit),
-                    Some(
-                        |((tx, _), _): &(
-                            (TxSequenceNumber, usize),
-                            (TransactionEventsDigest, TransactionDigest, u64),
-                        )| tx == &seq,
-                    ),
+                    |((tx, _), _)| tx == &seq,
                     |((_, event_seq), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
                     },
@@ -1016,14 +996,9 @@ impl IndexStore {
         if descending {
             index
                 .reversed_safe_iter_with_bounds(None, Some((key.clone(), (tx_seq, event_seq))))?
-                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
+                .try_take_while_map_and_collect(
                     Some(limit),
-                    Some(
-                        |((m, _), _): &(
-                            (KeyT, EventId),
-                            (TransactionEventsDigest, TransactionDigest, u64),
-                        )| m == key,
-                    ),
+                    |((m, _), _)| m == key,
                     |((_, (_, event_seq)), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
                     },
@@ -1032,14 +1007,9 @@ impl IndexStore {
         } else {
             index
                 .safe_iter_with_bounds(Some((key.clone(), (tx_seq, event_seq))), None)
-                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
+                .try_take_while_map_and_collect(
                     Some(limit),
-                    Some(
-                        |((m, _), _): &(
-                            (KeyT, EventId),
-                            (TransactionEventsDigest, TransactionDigest, u64),
-                        )| m == key,
-                    ),
+                    |((m, _), _)| m == key,
                     |((_, (_, event_seq)), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
                     },
@@ -1133,9 +1103,9 @@ impl IndexStore {
             self.tables
                 .event_by_time
                 .reversed_safe_iter_with_bounds(None, Some((end_time, (tx_seq, event_seq))))?
-                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
+                .try_take_while_map_and_collect(
                     Some(limit),
-                    Some(|((m, _), _): &((u64, EventId), EventIndex)| m >= &start_time),
+                    |((m, _), _)| m >= &start_time,
                     |((_, (_, event_seq)), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
                     },
@@ -1145,9 +1115,9 @@ impl IndexStore {
             self.tables
                 .event_by_time
                 .safe_iter_with_bounds(Some((start_time, (tx_seq, event_seq))), None)
-                .try_skip_filter_map_and_collect::<_, _, _, Result<_, TypedStoreError>>(
+                .try_take_while_map_and_collect(
                     Some(limit),
-                    Some(|((m, _), _): &((u64, EventId), EventIndex)| m <= &end_time),
+                    |((m, _), _)| m <= &end_time,
                     |((_, (_, event_seq)), (digest, tx_digest, time))| {
                         (digest, tx_digest, event_seq, time)
                     },

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -15,6 +15,7 @@ use std::{
     },
 };
 
+use either::Either;
 use iota_common::try_iterator_ext::TryIteratorExt;
 use iota_json_rpc_types::{IotaObjectDataFilter, TransactionFilter};
 use iota_storage::{mutex_table::MutexTable, sharded_lru::ShardedLruCache};
@@ -726,35 +727,22 @@ impl IndexStore {
         limit: Option<usize>,
         reverse: bool,
     ) -> IotaResult<Vec<TransactionDigest>> {
-        if reverse {
-            index
-                .reversed_safe_iter_with_bounds(
-                    None,
-                    Some((key.clone(), cursor.unwrap_or(TxSequenceNumber::MAX))),
-                )?
-                // skip one more if exclusive cursor is Some
-                .skip(usize::from(cursor.is_some()))
-                .try_take_while_map_and_collect(
-                    limit,
-                    |((id, _), _)| *id == key,
-                    |(_, digest)| digest,
-                )
-                .map_err(Into::into)
+        let iter = if reverse {
+            Either::Left(index.reversed_safe_iter_with_bounds(
+                None,
+                Some((key.clone(), cursor.unwrap_or(TxSequenceNumber::MAX))),
+            )?)
         } else {
-            index
-                .safe_iter_with_bounds(
-                    Some((key.clone(), cursor.unwrap_or(TxSequenceNumber::MIN))),
-                    None,
-                )
-                // skip one more if exclusive cursor is Some
-                .skip(usize::from(cursor.is_some()))
-                .try_take_while_map_and_collect(
-                    limit,
-                    |((id, _), _)| *id == key,
-                    |(_, digest)| digest,
-                )
-                .map_err(Into::into)
-        }
+            Either::Right(index.safe_iter_with_bounds(
+                Some((key.clone(), cursor.unwrap_or(TxSequenceNumber::MIN))),
+                None,
+            ))
+        };
+        iter
+            // skip one more if exclusive cursor is Some
+            .skip(usize::from(cursor.is_some()))
+            .try_take_while_map_and_collect(limit, |((id, _), _)| *id == key, |(_, digest)| digest)
+            .map_err(Into::into)
     }
 
     pub fn get_transactions_by_input_object(
@@ -859,39 +847,32 @@ impl IndexStore {
                 .unwrap_or(if reverse { max_string } else { "".to_string() });
 
         let key = (package, module_val, function_val, cursor_val);
-        if reverse {
-            self.tables
-                .transactions_by_move_function
-                .reversed_safe_iter_with_bounds(None, Some(key))?
-                // skip one more if exclusive cursor is Some
-                .skip(usize::from(cursor.is_some()))
-                .try_take_while_map_and_collect(
-                    limit,
-                    |((id, m, f, _), _)| {
-                        *id == package
-                            && module.as_ref().map(|x| x == m).unwrap_or(true)
-                            && function.as_ref().map(|x| x == f).unwrap_or(true)
-                    },
-                    |(_, digest)| digest,
-                )
-                .map_err(Into::into)
+        let iter = if reverse {
+            Either::Left(
+                self.tables
+                    .transactions_by_move_function
+                    .reversed_safe_iter_with_bounds(None, Some(key))?,
+            )
         } else {
-            self.tables
-                .transactions_by_move_function
-                .safe_iter_with_bounds(Some(key), None)
-                // skip one more if exclusive cursor is Some
-                .skip(usize::from(cursor.is_some()))
-                .try_take_while_map_and_collect(
-                    limit,
-                    |((id, m, f, _), _)| {
-                        *id == package
-                            && module.as_ref().map(|x| x == m).unwrap_or(true)
-                            && function.as_ref().map(|x| x == f).unwrap_or(true)
-                    },
-                    |(_, digest)| digest,
-                )
-                .map_err(Into::into)
-        }
+            Either::Right(
+                self.tables
+                    .transactions_by_move_function
+                    .safe_iter_with_bounds(Some(key), None),
+            )
+        };
+        iter
+            // skip one more if exclusive cursor is Some
+            .skip(usize::from(cursor.is_some()))
+            .try_take_while_map_and_collect(
+                limit,
+                |((id, m, f, _), _)| {
+                    *id == package
+                        && module.as_ref().map(|x| x == m).unwrap_or(true)
+                        && function.as_ref().map(|x| x == f).unwrap_or(true)
+                },
+                |(_, digest)| digest,
+            )
+            .map_err(Into::into)
     }
 
     pub fn get_transactions_to_addr(
@@ -958,31 +939,25 @@ impl IndexStore {
         let seq = self
             .get_transaction_seq(digest)?
             .ok_or(IotaError::TransactionNotFound { digest: *digest })?;
-        if descending {
-            self.tables
-                .event_order
-                .reversed_safe_iter_with_bounds(None, Some((min(tx_seq, seq), event_seq)))?
-                .try_take_while_map_and_collect(
-                    Some(limit),
-                    |((tx, _), _)| tx == &seq,
-                    |((_, event_seq), (digest, tx_digest, time))| {
-                        (digest, tx_digest, event_seq, time)
-                    },
-                )
-                .map_err(Into::into)
+        let iter = if descending {
+            Either::Left(
+                self.tables
+                    .event_order
+                    .reversed_safe_iter_with_bounds(None, Some((min(tx_seq, seq), event_seq)))?,
+            )
         } else {
-            self.tables
-                .event_order
-                .safe_iter_with_bounds(Some((max(tx_seq, seq), event_seq)), None)
-                .try_take_while_map_and_collect(
-                    Some(limit),
-                    |((tx, _), _)| tx == &seq,
-                    |((_, event_seq), (digest, tx_digest, time))| {
-                        (digest, tx_digest, event_seq, time)
-                    },
-                )
-                .map_err(Into::into)
-        }
+            Either::Right(
+                self.tables
+                    .event_order
+                    .safe_iter_with_bounds(Some((max(tx_seq, seq), event_seq)), None),
+            )
+        };
+        iter.try_take_while_map_and_collect(
+            Some(limit),
+            |((tx, _), _)| tx == &seq,
+            |((_, event_seq), (digest, tx_digest, time))| (digest, tx_digest, event_seq, time),
+        )
+        .map_err(Into::into)
     }
 
     fn get_event_from_index<KeyT: Clone + PartialEq + Serialize + DeserializeOwned>(
@@ -993,29 +968,23 @@ impl IndexStore {
         limit: usize,
         descending: bool,
     ) -> IotaResult<Vec<(TransactionEventsDigest, TransactionDigest, usize, u64)>> {
-        if descending {
-            index
-                .reversed_safe_iter_with_bounds(None, Some((key.clone(), (tx_seq, event_seq))))?
-                .try_take_while_map_and_collect(
-                    Some(limit),
-                    |((m, _), _)| m == key,
-                    |((_, (_, event_seq)), (digest, tx_digest, time))| {
-                        (digest, tx_digest, event_seq, time)
-                    },
+        let iter =
+            if descending {
+                Either::Left(index.reversed_safe_iter_with_bounds(
+                    None,
+                    Some((key.clone(), (tx_seq, event_seq))),
+                )?)
+            } else {
+                Either::Right(
+                    index.safe_iter_with_bounds(Some((key.clone(), (tx_seq, event_seq))), None),
                 )
-                .map_err(Into::into)
-        } else {
-            index
-                .safe_iter_with_bounds(Some((key.clone(), (tx_seq, event_seq))), None)
-                .try_take_while_map_and_collect(
-                    Some(limit),
-                    |((m, _), _)| m == key,
-                    |((_, (_, event_seq)), (digest, tx_digest, time))| {
-                        (digest, tx_digest, event_seq, time)
-                    },
-                )
-                .map_err(Into::into)
-        }
+            };
+        iter.try_take_while_map_and_collect(
+            Some(limit),
+            |((m, _), _)| m == key,
+            |((_, (_, event_seq)), (digest, tx_digest, time))| (digest, tx_digest, event_seq, time),
+        )
+        .map_err(Into::into)
     }
 
     pub fn events_by_module_id(

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -733,14 +733,17 @@ impl IndexStore {
                 )?
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .take_while(|((id, _), _)| *id == key)
-                .map(|(_, digest)| digest);
+                .take_while(|result| {
+                    result
+                        .as_ref()
+                        .map(|((id, _), _)| *id == key)
+                        .unwrap_or(false)
+                })
+                .map(|result| result.map(|(_, digest)| digest));
             if let Some(limit) = limit {
-                iter.take(limit).collect()
+                iter.take(limit).collect::<Result<Vec<_>, _>>()?
             } else {
-                iter.collect()
+                iter.collect::<Result<Vec<_>, _>>()?
             }
         } else {
             let iter = index
@@ -869,18 +872,21 @@ impl IndexStore {
                 .reversed_safe_iter_with_bounds(None, Some(key))?
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .take_while(|((id, m, f, _), _)| {
-                    *id == package
-                        && module.as_ref().map(|x| x == m).unwrap_or(true)
-                        && function.as_ref().map(|x| x == f).unwrap_or(true)
+                .take_while(|result| {
+                    result
+                        .as_ref()
+                        .map(|((id, m, f, _), _)| {
+                            *id == package
+                                && module.as_ref().map(|x| x == m).unwrap_or(true)
+                                && function.as_ref().map(|x| x == f).unwrap_or(true)
+                        })
+                        .unwrap_or(false)
                 })
-                .map(|(_, digest)| digest);
+                .map(|result| result.map(|(_, digest)| digest));
             if let Some(limit) = limit {
-                iter.take(limit).collect()
+                iter.take(limit).collect::<Result<Vec<_>, _>>()?
             } else {
-                iter.collect()
+                iter.collect::<Result<Vec<_>, _>>()?
             }
         } else {
             let iter = self
@@ -971,14 +977,19 @@ impl IndexStore {
             self.tables
                 .event_order
                 .reversed_safe_iter_with_bounds(None, Some((min(tx_seq, seq), event_seq)))?
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .take_while(|((tx, _), _)| tx == &seq)
-                .take(limit)
-                .map(|((_, event_seq), (digest, tx_digest, time))| {
-                    (digest, tx_digest, event_seq, time)
+                .take_while(|result| {
+                    result
+                        .as_ref()
+                        .map(|((tx, _), _)| tx == &seq)
+                        .unwrap_or(false)
                 })
-                .collect()
+                .take(limit)
+                .map(|result| {
+                    result.map(|((_, event_seq), (digest, tx_digest, time))| {
+                        (digest, tx_digest, event_seq, time)
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?
         } else {
             self.tables
                 .event_order
@@ -1003,14 +1014,14 @@ impl IndexStore {
         Ok(if descending {
             index
                 .reversed_safe_iter_with_bounds(None, Some((key.clone(), (tx_seq, event_seq))))?
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .take_while(|((m, _), _)| m == key)
+                .take_while(|result| result.as_ref().map(|((m, _), _)| m == key).unwrap_or(false))
                 .take(limit)
-                .map(|((_, (_, event_seq)), (digest, tx_digest, time))| {
-                    (digest, tx_digest, event_seq, time)
+                .map(|result| {
+                    result.map(|((_, (_, event_seq)), (digest, tx_digest, time))| {
+                        (digest, tx_digest, event_seq, time)
+                    })
                 })
-                .collect()
+                .collect::<Result<Vec<_>, _>>()?
         } else {
             index
                 .iter_with_bounds(Some((key.clone(), (tx_seq, event_seq))), None)
@@ -1108,14 +1119,19 @@ impl IndexStore {
             self.tables
                 .event_by_time
                 .reversed_safe_iter_with_bounds(None, Some((end_time, (tx_seq, event_seq))))?
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .take_while(|((m, _), _)| m >= &start_time)
-                .take(limit)
-                .map(|((_, (_, event_seq)), (digest, tx_digest, time))| {
-                    (digest, tx_digest, event_seq, time)
+                .take_while(|result| {
+                    result
+                        .as_ref()
+                        .map(|((m, _), _)| m >= &start_time)
+                        .unwrap_or(false)
                 })
-                .collect()
+                .take(limit)
+                .map(|result| {
+                    result.map(|((_, (_, event_seq)), (digest, tx_digest, time))| {
+                        (digest, tx_digest, event_seq, time)
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?
         } else {
             self.tables
                 .event_by_time


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.44.3, v1.45.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/b40bce37d61ea57859a02da816c3c240660df7ae
- Description:
This fixes expensive call sites caused by https://github.com/MystenLabs/sui/commit/0269b42498befb8f4cf628dd16b277d2e9d250dc ([typed store] iterators: deprecate skip_to/skip_prior_to/skip_to_last/reverse methods), #8143


## Links to any relevant issues

Part of #6153 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
