### PR TITLE
refactor(external-crates/move-compiler): parallelize typing

### DIFF
--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -295,7 +295,7 @@ pub enum BuiltinTypeName_ {
 }
 pub type BuiltinTypeName = Spanned<BuiltinTypeName_>;
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 #[allow(clippy::large_enum_variant)]
 pub enum TypeName_ {
     // exp-list/tuple type
@@ -782,7 +782,7 @@ impl TypeName_ {
     pub fn single_type(&self) -> Option<TypeName_> {
         match self {
             TypeName_::Multiple(_) => None,
-            TypeName_::Builtin(_) | TypeName_::ModuleType(_, _) => Some(self.clone()),
+            TypeName_::Builtin(_) | TypeName_::ModuleType(_, _) => Some(*self),
         }
     }
 

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -240,13 +240,13 @@ fn use_funs(context: &mut Context, uf: &mut N::UseFuns) {
             loc,
             attributes,
             is_public,
-            tname: tn.clone(),
+            tname: tn,
             target_function: (target_m, target_f),
             kind,
             used,
         };
         let nuf_loc = nuf.loc;
-        let methods = resolved.entry(tn.clone()).or_insert_with(UniqueMap::new);
+        let methods = resolved.entry(tn).or_insert_with(UniqueMap::new);
         if let Err((_, prev)) = methods.add(method, nuf) {
             let msg = format!("Duplicate 'use fun' for '{}.{}'", tn, method);
             let tn_msg = match ekind {
@@ -293,7 +293,7 @@ fn is_valid_method(
         N::TypeName_::ModuleType(m, _) => m,
     };
     if defining_module == target_m {
-        Some((target_f, tn.clone()))
+        Some((target_f, *tn))
     } else {
         None
     }

--- a/external-crates/move/crates/move-compiler/src/naming/syntax_methods.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/syntax_methods.rs
@@ -78,7 +78,7 @@ pub(super) fn resolve_syntax_attributes(
         return None;
     }
 
-    let method_entry = syntax_methods.entry(type_name.clone()).or_default();
+    let method_entry = syntax_methods.entry(type_name).or_default();
 
     for prekind in syntax_method_prekinds {
         let Some(kind) = determine_valid_kind(context, prekind, &param_ty) else {
@@ -98,7 +98,7 @@ pub(super) fn resolve_syntax_attributes(
                 loc: function_name.0.loc,
                 visibility: function.visibility,
                 kind,
-                tname: type_name.clone(),
+                tname: type_name,
                 target_function: (*module_name, *function_name),
             };
             let method_opt: &mut Option<Box<SyntaxMethod>> = method_entry.lookup_kind_entry(&kind);
@@ -293,7 +293,7 @@ fn determine_subject_type_name(
                 N::TypeName_::ModuleType(m, _) => Some(m),
             };
             if Some(cur_module) == defining_module {
-                Some(type_name.clone())
+                Some(*type_name)
             } else {
                 context.add_diag(diag!(
                     Declarations::InvalidSyntaxMethod,

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -1808,7 +1808,7 @@ fn use_funs(context: &mut Context, eufs: E::UseFuns) -> N::UseFuns {
         .flat_map(|e| explicit_use_fun(context, e))
         .collect();
     for (tn, method, nuf) in resolved_vec {
-        let methods = resolved.entry(tn.clone()).or_default();
+        let methods = resolved.entry(tn).or_default();
         let nuf_loc = nuf.loc;
         if let Err((_, prev)) = methods.add(method, nuf) {
             let msg = format!("Duplicate 'use fun' for '{}.{}'", tn, method);
@@ -1913,7 +1913,7 @@ fn explicit_use_fun(
         loc,
         attributes,
         is_public,
-        tname: tn.clone(),
+        tname: tn,
         target_function,
         kind: N::UseFunKind::Explicit,
         used: is_public.is_some(), // suppress unused warning for public use funs

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -6,7 +6,6 @@
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet, HashMap},
-    sync::Arc,
 };
 
 use known_attributes::AttributePosition;
@@ -14,7 +13,7 @@ use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 
 use crate::{
-    FullyCompiledProgram, debug_display, diag,
+    debug_display, diag,
     diagnostics::{
         Diagnostic, DiagnosticReporter, Diagnostics,
         codes::{NameResolution, TypeSafety},
@@ -48,11 +47,25 @@ use crate::{
 // Context
 //**************************************************************************************************
 
-pub struct UseFunsScope {
+pub struct UseFunsScope<'env, 'outer> {
     color: Option<Color>,
     count: usize,
-    use_funs: ResolvedUseFuns,
+    use_funs: UseFunsScope_<'env, 'outer>
 }
+
+pub type UsedMethods = BTreeSet<(TypeName, Name)>;
+
+pub enum UseFunsScope_<'env, 'outer> {
+    Global(&'env ResolvedUseFuns),
+    Outer(&'outer ResolvedUseFuns, UsedMethods),
+    Local(ResolvedUseFuns),
+}
+enum FoundMethod<'outer, 'local> {
+    Global(&'outer N::UseFun),
+    Outer(&'outer N::UseFun, &'local mut UsedMethods),
+    Local(&'local mut N::UseFun),
+}
+
 
 pub enum Constraint {
     AbilityConstraint {
@@ -100,22 +113,43 @@ pub struct TVarCounter {
     next: u64,
 }
 
-pub struct Context<'env> {
-    pub modules: NamingProgramInfo,
-    macros: UniqueMap<ModuleIdent, UniqueMap<FunctionName, N::Sequence>>,
+pub struct ModuleContext<'env> {
     pub env: &'env CompilationEnv,
     pub reporter: DiagnosticReporter<'env>,
+    pub info: &'env NamingProgramInfo,
+    macros: &'env UniqueMap<ModuleIdent, UniqueMap<FunctionName, N::Sequence>>,
     #[allow(dead_code)]
     pub(super) debug: TypingDebugFlags,
 
+    use_funs: Vec<UseFunsScope<'env, /* unused */ 'static>>,
     deprecations: Deprecations,
-
-    // for generating new variables during match compilation
-    next_match_var_id: usize,
-
-    use_funs: Vec<UseFunsScope>,
     pub current_package: Option<Symbol>,
     pub current_module: Option<ModuleIdent>,
+    /// collects all friends that should be added over the course of 'public(package)' calls
+    /// structured as (defining module, new friend, location) where `new friend` is usually the
+    /// context's current module. Note there may be more than one location in practice, but
+    /// tracking a single one is sufficient for error reporting.
+    pub new_friends: BTreeSet<(ModuleIdent, Loc)>,
+    /// collects all used module members (functions and constants) but it's a superset of these in
+    /// that it may contain other identifiers that do not in fact represent a function or a constant
+    pub used_module_members: BTreeMap<ModuleIdent_, BTreeSet<Symbol>>,
+}
+
+pub struct Context<'env, 'outer> {
+    pub outer: &'outer ModuleContext<'env>,
+
+    pub reporter: DiagnosticReporter<'env>,
+    /// collects all friends that should be added over the course of 'public(package)' calls
+    /// structured as (defining module, new friend, location) where `new friend` is usually the
+    /// context's current module. Note there may be more than one location in practice, but
+    /// tracking a single one is sufficient for error reporting.
+    pub new_friends: BTreeSet<(ModuleIdent, Loc)>,
+    /// collects all used module members (functions and constants) but it's a superset of these in
+    /// that it may contain other identifiers that do not in fact represent a function or a constant
+    pub used_module_members: BTreeMap<ModuleIdent_, BTreeSet<Symbol>>,
+    // for generating new variables during match compilation
+    next_match_var_id: usize,
+    use_funs: Vec<UseFunsScope<'env, 'outer>>,
     pub current_function: Option<FunctionName>,
     pub in_macro_function: bool,
     max_variable_color: RefCell<u16>,
@@ -128,16 +162,6 @@ pub struct Context<'env> {
 
     named_block_map: BTreeMap<BlockLabel, Type>,
 
-    /// collects all friends that should be added over the course of
-    /// 'public(package)' calls structured as (defining module, new friend,
-    /// location) where `new friend` is usually the context's current
-    /// module. Note there may be more than one location in practice, but
-    /// tracking a single one is sufficient for error reporting.
-    pub new_friends: BTreeSet<(ModuleIdent, Loc)>,
-    /// collects all used module members (functions and constants) but it's a
-    /// superset of these in that it may contain other identifiers that do
-    /// not in fact represent a function or a constant
-    pub used_module_members: BTreeMap<ModuleIdent_, BTreeSet<Symbol>>,
     /// Current macros being expanded
     pub macro_expansion: Vec<MacroExpansion>,
     /// Stack of items from `macro_expansion` pushed/popped when
@@ -158,51 +182,236 @@ pub struct ResolvedFunctionType {
     pub return_: Type,
 }
 
-impl UseFunsScope {
-    pub fn global(info: &NamingProgramInfo) -> Self {
-        let count = 1;
-        let mut use_funs = BTreeMap::new();
-        for (_, _, minfo) in &info.modules {
-            for (tn, methods) in &minfo.use_funs {
-                let public_methods = methods.ref_filter_map(|_, uf| {
-                    if uf.is_public.is_some() {
-                        Some(uf.clone())
-                    } else {
-                        None
-                    }
-                });
-                if public_methods.is_empty() {
-                    continue;
+pub fn global_use_funs(info: &NamingProgramInfo) -> ResolvedUseFuns {
+    let mut global_use_funs = BTreeMap::new();
+    for (_, _, minfo) in &info.modules {
+        for (tn, methods) in &minfo.use_funs {
+            let public_methods = methods.ref_filter_map(|_, uf| {
+                if uf.is_public.is_some() {
+                    Some(uf.clone())
+                } else {
+                    None
                 }
-
-                assert!(
-                    !use_funs.contains_key(tn),
-                    "ICE public methods should have been filtered to the defining module.
-                    tn: {tn}.
-                    prev: {}
-                    new: {}",
-                    debug_display!((tn, (use_funs.get(tn).unwrap()))),
-                    debug_display!((tn, &public_methods))
-                );
-                use_funs.insert(tn.clone(), public_methods);
+            });
+            if public_methods.is_empty() {
+                continue;
             }
+
+            assert!(
+                !global_use_funs.contains_key(tn),
+                "ICE public methods should have been filtered to the defining module.
+                tn: {tn}.
+                prev: {}
+                new: {}",
+                debug_display!((tn, (global_use_funs.get(tn).unwrap()))),
+                debug_display!((tn, &public_methods))
+            );
+            global_use_funs.insert(*tn, public_methods);
         }
+    }
+    global_use_funs
+}
+
+impl<'env> UseFunsScope<'env, '_> {
+    pub fn global(global_use_funs: &'env ResolvedUseFuns) -> Self {
         UseFunsScope {
             color: None,
-            count,
-            use_funs,
+            count: 1,
+            use_funs: UseFunsScope_::Global(global_use_funs),
         }
     }
 }
 
-impl<'env> Context<'env> {
+impl UseFunsScope_<'_, '_> {
+    pub fn resolved(&self) -> &ResolvedUseFuns {
+        match self {
+            UseFunsScope_::Global(r) => r,
+            UseFunsScope_::Outer(r, _) => r,
+            UseFunsScope_::Local(r) => r,
+        }
+    }
+}
+
+impl FoundMethod<'_, '_> {
+    pub fn use_fun(&self) -> &N::UseFun {
+        match self {
+            FoundMethod::Global(use_fun) => use_fun,
+            FoundMethod::Outer(use_fun, _) => use_fun,
+            FoundMethod::Local(use_fun) => use_fun,
+        }
+    }
+
+    pub fn mark_used(&mut self, tn: &TypeName, method_name: &Name) {
+        match self {
+            FoundMethod::Global(_) => (),
+            FoundMethod::Outer(_, used) => {
+                used.insert((*tn, *method_name));
+            }
+            FoundMethod::Local(use_fun) => {
+                use_fun.used = true;
+            }
+        }
+    }
+}
+
+macro_rules! add_use_funs_scope {
+    ($self:ident, $new_scope:expr) => {{
+        let N::UseFuns {
+            color,
+            resolved: mut new_scope,
+            implicit_candidates,
+        } = $new_scope;
+        assert!(
+            implicit_candidates.is_empty(),
+            "ICE use fun candidates should have been resolved"
+        );
+        let cur = $self.use_funs.last_mut().unwrap();
+        if new_scope.is_empty() && cur.color == Some(color) {
+            cur.count += 1;
+            return;
+        }
+        for (tn, methods) in &mut new_scope {
+            for (method, use_fun) in methods.key_cloned_iter_mut() {
+                if use_fun.used || !matches!(use_fun.kind, UseFunKind::Explicit) {
+                    continue;
+                }
+                let mut same_target = false;
+                let mut case = None;
+                let Some(prev) = $self.find_method_impl(tn, &method, |mut prev| {
+                    let prev_use_fun = prev.use_fun();
+                    if use_fun.target_function == prev_use_fun.target_function {
+                        case = Some(match &prev_use_fun.kind {
+                            UseFunKind::UseAlias | UseFunKind::Explicit => "Duplicate",
+                            UseFunKind::FunctionDeclaration => "Unnecessary",
+                        });
+                        same_target = true;
+                        // suppress unused warning
+                        prev.mark_used(tn, &method);
+                    }
+                    }) else {
+                    continue;
+                };
+                if same_target {
+                    let case = case.unwrap();
+                    let prev_loc = prev.loc;
+                    let (target_m, target_f) = &use_fun.target_function;
+                    let msg =
+                        format!("{case} method alias '{tn}.{method}' for '{target_m}::{target_f}'");
+                    $self.add_diag(diag!(
+                        Declarations::DuplicateAlias,
+                        (use_fun.loc, msg),
+                        (prev_loc, "The same alias was previously declared here")
+                    ));
+                }
+            }
+        }
+        $self.use_funs.push(UseFunsScope {
+            count: 1,
+            use_funs: UseFunsScope_::Local(new_scope),
+            color: Some(color),
+        })
+    }};
+}
+
+fn pop_use_funs_scope(use_funs: &mut Vec<UseFunsScope>) -> N::UseFuns {
+    let cur = use_funs.last_mut().unwrap();
+    if cur.count > 1 {
+        cur.count -= 1;
+        return N::UseFuns::new(cur.color.unwrap_or(0));
+    }
+    let UseFunsScope {
+        use_funs, color, ..
+    } = use_funs.pop().unwrap();
+    let use_funs = match use_funs {
+        UseFunsScope_::Global(_) => panic!("ICE global scope should never be popped"),
+        UseFunsScope_::Outer(_, _) => panic!("ICE outer scope should never be popped"),
+        UseFunsScope_::Local(use_funs) => use_funs,
+    };
+    N::UseFuns {
+        resolved: use_funs,
+        color: color.unwrap_or(0),
+        implicit_candidates: UniqueMap::new(),
+    }
+}
+
+fn report_unused_use_funs(reporter: &mut DiagnosticReporter, use_funs: &N::UseFuns) {
+    for (tn, methods) in &use_funs.resolved {
+        let unused = methods.iter().filter(|(_, _, uf)| !uf.used);
+        for (_, method, use_fun) in unused {
+            let N::UseFun {
+                doc: _,
+                loc,
+                kind,
+                attributes: _,
+                is_public: _,
+                tname: _,
+                target_function: _,
+                used: _,
+            } = use_fun;
+            match kind {
+                UseFunKind::Explicit => {
+                    let msg = format!("Unused 'use fun' of '{tn}.{method}'. Consider removing it");
+                    reporter.add_diag(diag!(UnusedItem::Alias, (*loc, msg)))
+                }
+                UseFunKind::UseAlias => {
+                    let msg = format!("Unused 'use' of alias '{method}'. Consider removing it");
+                    reporter.add_diag(diag!(UnusedItem::Alias, (*loc, msg)))
+                }
+                UseFunKind::FunctionDeclaration => {
+                    let diag = ice!((
+                        *loc,
+                        "ICE fun declaration 'use' funs should never be added to 'use' funs"
+                    ));
+                    reporter.add_diag(diag);
+                }
+            }
+        }
+    }
+}
+
+fn use_funs_find_method<'local>(
+    use_funs: &'local mut [UseFunsScope],
+    tn: &TypeName,
+    method_name: &Name,
+    mut fmap_use_fun: impl FnMut(FoundMethod<'_, '_>),
+) -> Option<&'local UseFun> {
+    let cur_color = use_funs.last().unwrap().color;
+    use_funs.iter_mut().rev().find_map(|scope| {
+        // scope color is None for global scope, which is always in consideration
+        // otherwise, the color must match the current color. In practice, we are preventing
+        // macro scopes from interfering with each the scopes in which they are expanded
+        if scope.color.is_some() && scope.color != cur_color {
+            return None;
+        }
+        match &mut scope.use_funs {
+            UseFunsScope_::Global(r) => {
+                let method = r.get(tn)?.get(method_name)?;
+                fmap_use_fun(FoundMethod::Global(method));
+                Some(method)
+            }
+            UseFunsScope_::Outer(r, used) => {
+                let method = r.get(tn)?.get(method_name)?;
+                fmap_use_fun(FoundMethod::Outer(method, used));
+                Some(method)
+            }
+            UseFunsScope_::Local(r) => {
+                let method = r.get_mut(tn)?.get_mut(method_name)?;
+                fmap_use_fun(FoundMethod::Local(method));
+                Some(&*method)
+            }
+        }
+    })
+}
+
+impl<'env> ModuleContext<'env> {
     pub fn new(
         env: &'env CompilationEnv,
-        _pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
-        info: NamingProgramInfo,
-    ) -> Self {
-        let global_use_funs = UseFunsScope::global(&info);
-        let deprecations = Deprecations::new(env, &info);
+        info: &'env NamingProgramInfo,
+        global_use_funs: &'env ResolvedUseFuns,
+        macros: &'env UniqueMap<ModuleIdent, UniqueMap<FunctionName, N::Sequence>>,
+    ) -> Box<Self> {
+        let global_use_funs = UseFunsScope::global(global_use_funs);
+        let deprecations = Deprecations::new(env, info);
         let debug = TypingDebugFlags {
             match_counterexample: false,
             autocomplete_resolution: false,
@@ -210,32 +419,19 @@ impl<'env> Context<'env> {
             type_elaboration: false,
         };
         let reporter = env.diagnostic_reporter_at_top_level();
-        Context {
+        Box::new(ModuleContext {
             use_funs: vec![global_use_funs],
-            tvar_counter: TVarCounter::new(),
-            subst: Subst::empty(),
             current_package: None,
             current_module: None,
-            current_function: None,
-            in_macro_function: false,
-            max_variable_color: RefCell::new(0),
-            return_type: None,
-            constraints: vec![],
-            locals: UniqueMap::new(),
-            modules: info,
-            macros: UniqueMap::new(),
-            named_block_map: BTreeMap::new(),
+            info,
+            macros,
             env,
             reporter,
             debug,
-            next_match_var_id: 0,
             new_friends: BTreeSet::new(),
             used_module_members: BTreeMap::new(),
-            macro_expansion: vec![],
-            lambda_expansion: vec![],
-            ide_info: IDEInfo::new(),
             deprecations,
-        }
+        })
     }
 
     pub fn add_diag(&self, diag: Diagnostic) {
@@ -262,143 +458,388 @@ impl<'env> Context<'env> {
         self.reporter.pop_warning_filter_scope()
     }
 
-    pub fn check_feature(&self, package: Option<Symbol>, feature: FeatureGate, loc: Loc) -> bool {
-        self.env
-            .check_feature(&self.reporter, package, feature, loc)
-    }
-
-    pub fn set_macros(
-        &mut self,
-        macros: UniqueMap<ModuleIdent, UniqueMap<FunctionName, N::Sequence>>,
-    ) {
-        debug_assert!(self.macros.is_empty());
-        self.macros = macros;
-    }
-
     pub fn add_use_funs_scope(&mut self, new_scope: N::UseFuns) {
-        let N::UseFuns {
-            color,
-            resolved: mut new_scope,
-            implicit_candidates,
-        } = new_scope;
-        assert!(
-            implicit_candidates.is_empty(),
-            "ICE use fun candidates should have been resolved"
-        );
-        let cur = self.use_funs.last_mut().unwrap();
-        if new_scope.is_empty() && cur.color == Some(color) {
-            cur.count += 1;
-            return;
-        }
-        for (tn, methods) in &mut new_scope {
-            for (method, use_fun) in methods.key_cloned_iter_mut() {
-                if use_fun.used || !matches!(use_fun.kind, UseFunKind::Explicit) {
-                    continue;
-                }
-                let mut same_target = false;
-                let mut case = None;
-                let Some(prev) = self.find_method_impl(tn, method, |prev| {
-                    if use_fun.target_function == prev.target_function {
-                        case = Some(match &prev.kind {
-                            UseFunKind::UseAlias | UseFunKind::Explicit => "Duplicate",
-                            UseFunKind::FunctionDeclaration => "Unnecessary",
-                        });
-                        same_target = true;
-                        // suppress unused warning
-                        prev.used = true;
-                    }
-                }) else {
-                    continue;
-                };
-                if same_target {
-                    let case = case.unwrap();
-                    let prev_loc = prev.loc;
-                    let (target_m, target_f) = &use_fun.target_function;
-                    let msg =
-                        format!("{case} method alias '{tn}.{method}' for '{target_m}::{target_f}'");
-                    self.add_diag(diag!(
-                        Declarations::DuplicateAlias,
-                        (use_fun.loc, msg),
-                        (prev_loc, "The same alias was previously declared here")
-                    ));
-                }
-            }
-        }
-        self.use_funs.push(UseFunsScope {
-            count: 1,
-            use_funs: new_scope,
-            color: Some(color),
-        })
+        add_use_funs_scope!(self, new_scope)
     }
 
-    pub fn pop_use_funs_scope(&mut self) -> N::UseFuns {
-        let cur = self.use_funs.last_mut().unwrap();
-        if cur.count > 1 {
-            cur.count -= 1;
-            return N::UseFuns::new(cur.color.unwrap_or(0));
+    pub fn finish_use_funs_scope(
+        &mut self,
+        used_methods: &BTreeSet<(TypeName, Name)>,
+    ) -> N::UseFuns {
+        let mut use_funs = pop_use_funs_scope(&mut self.use_funs);
+        for (tn, method) in used_methods {
+            use_funs
+                .resolved
+                .get_mut(tn)
+                .unwrap()
+                .get_mut(method)
+                .unwrap()
+                .used = true;
         }
-        let UseFunsScope {
-            use_funs, color, ..
-        } = self.use_funs.pop().unwrap();
-        for (tn, methods) in use_funs.iter() {
-            let unused = methods.iter().filter(|(_, _, uf)| !uf.used);
-            for (_, method, use_fun) in unused {
-                let N::UseFun {
-                    doc: _,
-                    loc,
-                    kind,
-                    attributes: _,
-                    is_public: _,
-                    tname: _,
-                    target_function: _,
-                    used: _,
-                } = use_fun;
-                match kind {
-                    UseFunKind::Explicit => {
-                        let msg =
-                            format!("Unused 'use fun' of '{tn}.{method}'. Consider removing it");
-                        self.add_diag(diag!(UnusedItem::Alias, (*loc, msg)))
-                    }
-                    UseFunKind::UseAlias => {
-                        let msg = format!("Unused 'use' of alias '{method}'. Consider removing it");
-                        self.add_diag(diag!(UnusedItem::Alias, (*loc, msg)))
-                    }
-                    UseFunKind::FunctionDeclaration => {
-                        let diag = ice!((
-                            *loc,
-                            "ICE fun declaration 'use' funs should never be added to 'use' funs"
-                        ));
-                        self.add_diag(diag);
-                    }
-                }
-            }
-        }
-        N::UseFuns {
-            resolved: use_funs,
-            color: color.unwrap_or(0),
-            implicit_candidates: UniqueMap::new(),
-        }
+        report_unused_use_funs(&mut self.reporter, &use_funs);
+        use_funs
     }
 
     fn find_method_impl(
         &mut self,
         tn: &TypeName,
-        method: Name,
-        mut fmap_use_fun: impl FnMut(&mut N::UseFun),
+        method: &Name,
+        fmap_use_fun: impl FnMut(FoundMethod<'_, '_>),
     ) -> Option<&UseFun> {
-        let cur_color = self.use_funs.last().unwrap().color;
-        self.use_funs.iter_mut().rev().find_map(|scope| {
-            // scope color is None for global scope, which is always in consideration
-            // otherwise, the color must match the current color. In practice, we are
-            // preventing macro scopes from interfering with each the scopes in
-            // which they are expanded
-            if scope.color.is_some() && scope.color != cur_color {
-                return None;
-            }
-            let use_fun = scope.use_funs.get_mut(tn)?.get_mut(&method)?;
-            fmap_use_fun(use_fun);
-            Some(&*use_fun)
+        use_funs_find_method(&mut self.use_funs, tn, method, fmap_use_fun)
+    }
+
+    pub fn check_feature(&self, package: Option<Symbol>, feature: FeatureGate, loc: Loc) -> bool {
+        self.env
+            .check_feature(&self.reporter, package, feature, loc)
+    }
+
+    pub fn new_module_member<'a>(&'a self) -> Context<'env, 'a> {
+        let use_funs = self
+            .use_funs
+            .iter()
+            .map(|scope| {
+                let UseFunsScope {
+                    color,
+                    count,
+                    use_funs,
+                } = scope;
+                match use_funs {
+                    UseFunsScope_::Global(r) => {
+                        let use_funs = UseFunsScope_::Global(r);
+                        UseFunsScope {
+                            color: *color,
+                            count: *count,
+                            use_funs,
+                        }
+                    }
+                    UseFunsScope_::Outer(_, _) => unreachable!(),
+                    UseFunsScope_::Local(r) => {
+                        let scope = UseFunsScope_::Outer(r, BTreeSet::new());
+                        debug_assert_eq!(color, &Some(0));
+                        debug_assert_eq!(count, &1);
+                        UseFunsScope {
+                            color: *color,
+                            count: *count,
+                            use_funs: scope,
+                        }
+                    }
+                }
+            })
+            .collect();
+        Context {
+            outer: self,
+            reporter: self.reporter.clone(),
+            new_friends: BTreeSet::new(),
+            used_module_members: BTreeMap::new(),
+            next_match_var_id: 0,
+            use_funs,
+            current_function: None,
+            in_macro_function: false,
+            max_variable_color: RefCell::new(0),
+            return_type: None,
+            locals: UniqueMap::new(),
+            tvar_counter: TVarCounter::new(),
+            subst: Subst::empty(),
+            constraints: Constraints::new(),
+            named_block_map: BTreeMap::new(),
+            macro_expansion: vec![],
+            lambda_expansion: vec![],
+            ide_info: IDEInfo::new(),
+        }
+    }
+
+    pub fn error_type(&self, loc: Loc) -> Type {
+        sp(loc, Type_::UnresolvedError)
+    }
+
+    pub fn is_current_module(&self, m: &ModuleIdent) -> bool {
+        match &self.current_module {
+            Some(curm) => curm == m,
+            None => false,
+        }
+    }
+
+    pub fn current_package(&self) -> Option<Symbol> {
+        self.current_module
+            .as_ref()
+            .and_then(|mident| self.module_info(mident).package)
+    }
+
+    fn current_module_shares_package_and_address(&self, m: &ModuleIdent) -> bool {
+        self.current_module.is_some_and(|current_mident| {
+            m.value.address == current_mident.value.address
+                && self.module_info(m).package == self.module_info(&current_mident).package
         })
+    }
+
+    fn current_module_is_a_friend_of(&self, m: &ModuleIdent) -> bool {
+        match &self.current_module {
+            None => false,
+            Some(current_mident) => {
+                let minfo = self.module_info(m);
+                minfo.friends.contains_key(current_mident)
+            }
+        }
+    }
+
+    fn module_info(&self, m: &ModuleIdent) -> &ModuleInfo {
+        self.info.module(m)
+    }
+
+    fn struct_definition(&self, m: &ModuleIdent, n: &DatatypeName) -> &StructDefinition {
+        self.info.struct_definition(m, n)
+    }
+
+    pub fn struct_declared_abilities(&self, m: &ModuleIdent, n: &DatatypeName) -> &AbilitySet {
+        self.info.struct_declared_abilities(m, n)
+    }
+
+    pub fn struct_declared_loc(&self, m: &ModuleIdent, n: &DatatypeName) -> Loc {
+        self.info.struct_declared_loc(m, n)
+    }
+
+    pub fn struct_tparams(&self, m: &ModuleIdent, n: &DatatypeName) -> &Vec<DatatypeTypeParameter> {
+        self.info.struct_type_parameters(m, n)
+    }
+
+    fn enum_definition(&self, m: &ModuleIdent, n: &DatatypeName) -> &EnumDefinition {
+        self.info.enum_definition(m, n)
+    }
+
+    pub fn enum_declared_abilities(&self, m: &ModuleIdent, n: &DatatypeName) -> &AbilitySet {
+        self.info.enum_declared_abilities(m, n)
+    }
+
+    pub fn enum_declared_loc(&self, m: &ModuleIdent, n: &DatatypeName) -> Loc {
+        self.info.enum_declared_loc(m, n)
+    }
+
+    pub fn enum_tparams(&self, m: &ModuleIdent, n: &DatatypeName) -> &Vec<DatatypeTypeParameter> {
+        self.info.enum_type_parameters(m, n)
+    }
+
+    pub fn datatype_kind(&self, m: &ModuleIdent, n: &DatatypeName) -> DatatypeKind {
+        self.info.datatype_kind(m, n)
+    }
+
+    pub fn function_info(&self, m: &ModuleIdent, n: &FunctionName) -> &FunctionInfo {
+        self.info.function_info(m, n)
+    }
+
+    pub fn macro_body(&self, m: &ModuleIdent, n: &FunctionName) -> Option<&N::Sequence> {
+        self.macros.get(m)?.get(n)
+    }
+
+    pub fn constant_info(&self, m: &ModuleIdent, n: &ConstantName) -> &ConstantInfo {
+        let constants = &self.module_info(m).constants;
+        constants.get(n).expect("ICE should have failed in naming")
+    }
+
+    /// Find all valid fields in scope for a given `TypeName`. This is used for autocomplete.
+    pub fn find_all_fields(&self, tn: &TypeName) -> Vec<(Symbol, N::Type)> {
+        debug_print!(self.debug.autocomplete_resolution, (msg "fields"), ("name" => tn));
+        let fields_info = match &tn.value {
+            TypeName_::Multiple(_) => vec![],
+            // TODO(cswords): are there any valid builtin fields?
+            TypeName_::Builtin(_) => vec![],
+            TypeName_::ModuleType(m, _n) if !self.is_current_module(m) => vec![],
+            TypeName_::ModuleType(m, n) => match self.datatype_kind(m, n) {
+                DatatypeKind::Enum => vec![],
+                DatatypeKind::Struct => match &self.struct_definition(m, n).fields {
+                    N::StructFields::Native(_) => vec![],
+                    N::StructFields::Defined(is_positional, fields) => {
+                        if *is_positional {
+                            fields
+                                .iter()
+                                .enumerate()
+                                .map(|(idx, (_, _, (_, (_, t))))| {
+                                    (format!("{}", idx).into(), t.clone())
+                                })
+                                .collect::<Vec<_>>()
+                        } else {
+                            fields
+                                .key_cloned_iter()
+                                .map(|(k, (_, (_, t)))| (k.value(), t.clone()))
+                                .collect::<Vec<_>>()
+                        }
+                    }
+                },
+            },
+        };
+        debug_print!(self.debug.autocomplete_resolution, (lines "fields" => &fields_info; dbg));
+        fields_info
+    }
+}
+
+impl<'env, 'outer> Context<'env, 'outer> {
+    pub fn env(&self) -> &'outer CompilationEnv {
+        self.outer.env
+    }
+
+    pub fn reporter(&self) -> &'outer DiagnosticReporter<'env> {
+        &self.outer.reporter
+    }
+
+    pub fn info(&self) -> &'outer NamingProgramInfo {
+        self.outer.info
+    }
+
+    pub fn macros(&self) -> &'outer UniqueMap<ModuleIdent, UniqueMap<FunctionName, N::Sequence>> {
+        self.outer.macros
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn debug(&self) -> &'outer TypingDebugFlags {
+        &self.outer.debug
+    }
+
+    pub fn deprecations(&self) -> &'outer Deprecations {
+        &self.outer.deprecations
+    }
+
+    pub fn current_module(&self) -> Option<&'outer ModuleIdent> {
+        self.outer.current_module.as_ref()
+    }
+
+    pub fn check_feature(&self, package: Option<Symbol>, feature: FeatureGate, loc: Loc) -> bool {
+        self.outer.check_feature(package, feature, loc)
+    }
+
+    pub fn error_type(&mut self, loc: Loc) -> Type {
+        self.outer.error_type(loc)
+    }
+
+    pub fn is_current_module(&self, m: &ModuleIdent) -> bool {
+        self.outer.is_current_module(m)
+    }
+
+    pub fn current_package(&self) -> Option<Symbol> {
+        self.outer.current_package()
+    }
+
+    pub fn current_module_shares_package_and_address(&self, m: &ModuleIdent) -> bool {
+        self.outer.current_module_shares_package_and_address(m)
+    }
+
+    pub fn current_module_is_a_friend_of(&self, m: &ModuleIdent) -> bool {
+        self.outer.current_module_is_a_friend_of(m)
+    }
+
+    pub fn module_info(&self, m: &ModuleIdent) -> &ModuleInfo {
+        self.outer.module_info(m)
+    }
+
+    pub fn struct_definition(&self, m: &ModuleIdent, n: &DatatypeName) -> &StructDefinition {
+        self.outer.struct_definition(m, n)
+    }
+
+    pub fn struct_declared_abilities(&self, m: &ModuleIdent, n: &DatatypeName) -> &AbilitySet {
+        self.outer.struct_declared_abilities(m, n)
+    }
+
+    pub fn struct_declared_loc(&self, m: &ModuleIdent, n: &DatatypeName) -> Loc {
+        self.outer.struct_declared_loc(m, n)
+    }
+
+    pub fn struct_tparams(&self, m: &ModuleIdent, n: &DatatypeName) -> &Vec<DatatypeTypeParameter> {
+        self.outer.struct_tparams(m, n)
+    }
+
+    pub fn enum_definition(&self, m: &ModuleIdent, n: &DatatypeName) -> &EnumDefinition {
+        self.outer.enum_definition(m, n)
+    }
+
+    pub fn enum_declared_abilities(&self, m: &ModuleIdent, n: &DatatypeName) -> &AbilitySet {
+        self.outer.enum_declared_abilities(m, n)
+    }
+
+    pub fn enum_declared_loc(&self, m: &ModuleIdent, n: &DatatypeName) -> Loc {
+        self.outer.enum_declared_loc(m, n)
+    }
+
+    pub fn enum_tparams(&self, m: &ModuleIdent, n: &DatatypeName) -> &Vec<DatatypeTypeParameter> {
+        self.outer.enum_tparams(m, n)
+    }
+
+    pub fn datatype_kind(&self, m: &ModuleIdent, n: &DatatypeName) -> DatatypeKind {
+        self.outer.datatype_kind(m, n)
+    }
+
+    pub fn function_info(&self, m: &ModuleIdent, n: &FunctionName) -> &FunctionInfo {
+        self.outer.function_info(m, n)
+    }
+    pub fn macro_body(&self, m: &ModuleIdent, n: &FunctionName) -> Option<&N::Sequence> {
+        self.outer.macro_body(m, n)
+    }
+
+    pub fn constant_info(&self, m: &ModuleIdent, n: &ConstantName) -> &ConstantInfo {
+        self.outer.constant_info(m, n)
+    }
+
+    pub fn find_all_fields(&self, tn: &TypeName) -> Vec<(Symbol, N::Type)> {
+        self.outer.find_all_fields(tn)
+    }
+
+    pub fn add_diag(&self, diag: Diagnostic) {
+        self.reporter.add_diag(diag);
+    }
+
+    pub fn add_diags(&self, diags: Diagnostics) {
+        self.reporter.add_diags(diags);
+    }
+
+    pub fn extend_ide_info(&self, info: IDEInfo) {
+        self.reporter.extend_ide_info(info);
+    }
+
+    pub fn add_ide_annotation(&self, loc: Loc, info: IDEAnnotation) {
+        self.reporter.add_ide_annotation(loc, info);
+    }
+
+    pub fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
+        self.reporter.push_warning_filter_scope(filters)
+    }
+
+    pub fn pop_warning_filter_scope(&mut self) {
+        self.reporter.pop_warning_filter_scope()
+    }
+
+    pub fn emit_warning_if_deprecated(
+        &mut self,
+        mident: &ModuleIdent,
+        name: Name,
+        method_opt: Option<Name>,
+    ) {
+        let in_same_module = self.is_current_module(mident);
+        if let Some(deprecation) = self.deprecations().get_deprecation(*mident, name) {
+            // Don't register a warning if we are in the module that is deprecated and the actual
+            // member is not deprecated.
+            if deprecation.location == AttributePosition::Module && in_same_module {
+                return;
+            }
+            let diags = deprecation.deprecation_warnings(name, method_opt);
+            self.add_diags(diags);
+        }
+    }
+
+    pub fn add_use_funs_scope(&mut self, new_scope: N::UseFuns) {
+          add_use_funs_scope!(self, new_scope)
+    }
+
+    pub fn pop_use_funs_scope(&mut self) -> N::UseFuns {
+        let popped_scope = pop_use_funs_scope(&mut self.use_funs);
+        report_unused_use_funs(&mut self.reporter, &popped_scope);
+        popped_scope
+    }
+
+    fn find_method_impl(
+        &mut self,
+        tn: &TypeName,
+        method: &Name,
+        fmap_use_fun: impl FnMut(FoundMethod<'_, '_>),
+    ) -> Option<&UseFun> {
+        use_funs_find_method(&mut self.use_funs, tn, method, fmap_use_fun)
     }
 
     pub fn find_method_and_mark_used(
@@ -406,8 +847,7 @@ impl<'env> Context<'env> {
         tn: &TypeName,
         method: Name,
     ) -> Option<(ModuleIdent, FunctionName)> {
-        self.find_method_impl(tn, method, |use_fun| use_fun.used = true)
-            .map(|use_fun| use_fun.target_function)
+          self.find_method_impl(tn, &method, |mut use_fun| use_fun.mark_used(tn, &method)).map(|use_fun| use_fun.target_function)
     }
 
     /// true iff it is safe to expand,
@@ -546,29 +986,6 @@ impl<'env> Context<'env> {
         self.use_funs.last().unwrap().color.unwrap()
     }
 
-    pub fn reset_for_module_item(&mut self, loc: Loc) {
-        self.named_block_map = BTreeMap::new();
-        self.return_type = None;
-        self.locals = UniqueMap::new();
-        self.subst = Subst::empty();
-        self.tvar_counter = TVarCounter::new();
-        self.constraints = Constraints::new();
-        self.current_function = None;
-        self.in_macro_function = false;
-        self.max_variable_color = RefCell::new(0);
-        self.macro_expansion = vec![];
-        self.lambda_expansion = vec![];
-
-        if !self.ide_info.is_empty() {
-            self.add_diag(ice!((loc, "IDE info should be cleared after each item")));
-            self.ide_info = IDEInfo::new();
-        }
-    }
-
-    pub fn error_type(&mut self, loc: Loc) -> Type {
-        sp(loc, Type_::UnresolvedError)
-    }
-
     pub fn add_ability_constraint(
         &mut self,
         loc: Loc,
@@ -641,51 +1058,21 @@ impl<'env> Context<'env> {
         self.locals.get(var).unwrap().clone()
     }
 
-    pub fn is_current_module(&self, m: &ModuleIdent) -> bool {
-        match &self.current_module {
-            Some(curm) => curm == m,
-            None => false,
-        }
-    }
-
     pub fn is_current_function(&self, m: &ModuleIdent, f: &FunctionName) -> bool {
         self.is_current_module(m) && matches!(&self.current_function, Some(curf) if curf == f)
     }
 
-    pub fn current_package(&self) -> Option<Symbol> {
-        self.current_module
-            .as_ref()
-            .and_then(|mident| self.module_info(mident).package)
-    }
-
     // `loc` indicates the location that caused the add to occur
     fn record_current_module_as_friend(&mut self, m: &ModuleIdent, loc: Loc) {
-        if matches!(self.current_module, Some(current_mident) if m != &current_mident) {
+         if !self.is_current_module(m) {
             self.new_friends.insert((*m, loc));
-        }
-    }
-
-    fn current_module_shares_package_and_address(&self, m: &ModuleIdent) -> bool {
-        self.current_module.is_some_and(|current_mident| {
-            m.value.address == current_mident.value.address
-                && self.module_info(m).package == self.module_info(&current_mident).package
-        })
-    }
-
-    fn current_module_is_a_friend_of(&self, m: &ModuleIdent) -> bool {
-        match &self.current_module {
-            None => false,
-            Some(current_mident) => {
-                let minfo = self.module_info(m);
-                minfo.friends.contains_key(current_mident)
-            }
         }
     }
 
     /// current_module.is_test_only || current_function.is_test_only ||
     /// current_function.is_test
     fn is_testing_context(&self) -> bool {
-        self.current_module.as_ref().is_some_and(|m| {
+        self.current_module().as_ref().is_some_and(|m| {
             let minfo = self.module_info(m);
             let is_test_only = minfo.attributes.is_test_or_test_only();
             is_test_only
@@ -694,79 +1081,6 @@ impl<'env> Context<'env> {
                     finfo.attributes.is_test_or_test_only()
                 })
         })
-    }
-
-    pub fn emit_warning_if_deprecated(
-        &mut self,
-        mident: &ModuleIdent,
-        name: Name,
-        method_opt: Option<Name>,
-    ) {
-        let in_same_module = self
-            .current_module
-            .is_some_and(|current| current == *mident);
-        if let Some(deprecation) = self.deprecations.get_deprecation(*mident, name) {
-            // Don't register a warning if we are in the module that is deprecated and the
-            // actual member is not deprecated.
-            if deprecation.location == AttributePosition::Module && in_same_module {
-                return;
-            }
-            let diags = deprecation.deprecation_warnings(name, method_opt);
-            self.add_diags(diags);
-        }
-    }
-
-    fn module_info(&self, m: &ModuleIdent) -> &ModuleInfo {
-        self.modules.module(m)
-    }
-
-    fn struct_definition(&self, m: &ModuleIdent, n: &DatatypeName) -> &StructDefinition {
-        self.modules.struct_definition(m, n)
-    }
-
-    pub fn struct_declared_abilities(&self, m: &ModuleIdent, n: &DatatypeName) -> &AbilitySet {
-        self.modules.struct_declared_abilities(m, n)
-    }
-
-    pub fn struct_declared_loc(&self, m: &ModuleIdent, n: &DatatypeName) -> Loc {
-        self.modules.struct_declared_loc(m, n)
-    }
-
-    pub fn struct_tparams(&self, m: &ModuleIdent, n: &DatatypeName) -> &Vec<DatatypeTypeParameter> {
-        self.modules.struct_type_parameters(m, n)
-    }
-
-    fn enum_definition(&self, m: &ModuleIdent, n: &DatatypeName) -> &EnumDefinition {
-        self.modules.enum_definition(m, n)
-    }
-
-    pub fn enum_declared_abilities(&self, m: &ModuleIdent, n: &DatatypeName) -> &AbilitySet {
-        self.modules.enum_declared_abilities(m, n)
-    }
-
-    pub fn enum_declared_loc(&self, m: &ModuleIdent, n: &DatatypeName) -> Loc {
-        self.modules.enum_declared_loc(m, n)
-    }
-
-    pub fn enum_tparams(&self, m: &ModuleIdent, n: &DatatypeName) -> &Vec<DatatypeTypeParameter> {
-        self.modules.enum_type_parameters(m, n)
-    }
-
-    pub fn datatype_kind(&self, m: &ModuleIdent, n: &DatatypeName) -> DatatypeKind {
-        self.modules.datatype_kind(m, n)
-    }
-
-    pub fn function_info(&self, m: &ModuleIdent, n: &FunctionName) -> &FunctionInfo {
-        self.modules.function_info(m, n)
-    }
-
-    pub fn macro_body(&self, m: &ModuleIdent, n: &FunctionName) -> Option<&N::Sequence> {
-        self.macros.get(m)?.get(n)
-    }
-
-    pub fn constant_info(&mut self, m: &ModuleIdent, n: &ConstantName) -> &ConstantInfo {
-        let constants = &self.module_info(m).constants;
-        constants.get(n).expect("ICE should have failed in naming")
     }
 
     // pass in a location for a better error location
@@ -807,6 +1121,28 @@ impl<'env> Context<'env> {
         self.next_match_var_id
     }
 
+        pub fn finish(
+        self,
+    ) -> (
+        BTreeSet<(ModuleIdent, Loc)>,
+        BTreeMap<ModuleIdent_, BTreeSet<Symbol>>,
+        UsedMethods,
+    ) {
+        let Self {
+            used_module_members,
+            new_friends,
+            mut use_funs,
+            ..
+        } = self;
+        assert!(use_funs.len() <= 2);
+        let used_methods = match use_funs.pop().unwrap().use_funs {
+            UseFunsScope_::Global(_) => BTreeSet::new(),
+            UseFunsScope_::Outer(_, used) => used,
+            UseFunsScope_::Local(_) => panic!("ICE last scope should never be local"),
+        };
+        (new_friends, used_module_members, used_methods)
+    }
+
     //********************************************
     // IDE Information
     //********************************************
@@ -814,12 +1150,12 @@ impl<'env> Context<'env> {
     /// Find all valid methods in scope for a given `TypeName`. This is used for
     /// autocomplete.
     pub fn find_all_methods(&mut self, tn: &TypeName) -> Vec<AutocompleteMethod> {
-        debug_print!(self.debug.autocomplete_resolution, (msg "methods"), ("name" => tn));
+        debug_print!(self.debug().autocomplete_resolution, (msg "methods"), ("name" => tn));
         if !self
-            .env
+            .env()
             .supports_feature(self.current_package(), FeatureGate::DotCall)
         {
-            debug_print!(self.debug.autocomplete_resolution, (msg "dot call unsupported"));
+            debug_print!(self.debug().autocomplete_resolution, (msg "dot call unsupported"));
             return vec![];
         }
         let cur_color = self.use_funs.last().unwrap().color;
@@ -828,7 +1164,7 @@ impl<'env> Context<'env> {
             if scope.color.is_some() && scope.color != cur_color {
                 return;
             }
-            if let Some(names) = scope.use_funs.get(tn) {
+            if let Some(names) = scope.use_funs.resolved().get(tn) {
                 let mut new_names = names
                     .iter()
                     .map(|(_, method_name, use_fun)| {
@@ -863,50 +1199,15 @@ impl<'env> Context<'env> {
         different
     }
 
-    /// Find all valid fields in scope for a given `TypeName`. This is used for
-    /// autocomplete.
-    pub fn find_all_fields(&mut self, tn: &TypeName) -> Vec<(Symbol, N::Type)> {
-        debug_print!(self.debug.autocomplete_resolution, (msg "fields"), ("name" => tn));
-        let fields_info = match &tn.value {
-            TypeName_::Multiple(_) => vec![],
-            // TODO(cswords): are there any valid builtin fields?
-            TypeName_::Builtin(_) => vec![],
-            TypeName_::ModuleType(m, _n) if !self.is_current_module(m) => vec![],
-            TypeName_::ModuleType(m, n) => match self.datatype_kind(m, n) {
-                DatatypeKind::Enum => vec![],
-                DatatypeKind::Struct => match &self.struct_definition(m, n).fields {
-                    N::StructFields::Native(_) => vec![],
-                    N::StructFields::Defined(is_positional, fields) => {
-                        if *is_positional {
-                            fields
-                                .iter()
-                                .enumerate()
-                                .map(|(idx, (_, _, (_, (_, t))))| {
-                                    (format!("{}", idx).into(), t.clone())
-                                })
-                                .collect::<Vec<_>>()
-                        } else {
-                            fields
-                                .key_cloned_iter()
-                                .map(|(k, (_, (_, t)))| (k.value(), t.clone()))
-                                .collect::<Vec<_>>()
-                        }
-                    }
-                },
-            },
-        };
-        debug_print!(self.debug.autocomplete_resolution, (lines "fields" => &fields_info; dbg));
-        fields_info
-    }
-
+   
     pub fn add_ide_info(&mut self, loc: Loc, info: IDEAnnotation) {
         self.ide_info.add_ide_annotation(loc, info);
     }
 }
 
-impl MatchContext<false> for Context<'_> {
+impl MatchContext<false> for Context<'_, '_> {
     fn env(&self) -> &CompilationEnv {
-        self.env
+        self.env()
     }
 
     fn reporter(&self) -> &DiagnosticReporter {
@@ -933,7 +1234,7 @@ impl MatchContext<false> for Context<'_> {
     }
 
     fn program_info(&self) -> &ProgramInfo<false> {
-        &self.modules
+        self.info()
     }
 }
 
@@ -1350,7 +1651,7 @@ pub fn make_struct_field_type(
 pub fn find_index_funs(context: &mut Context, type_name: &TypeName) -> Option<IndexSyntaxMethods> {
     let module_ident = match &type_name.value {
         TypeName_::Multiple(_) => return None,
-        TypeName_::Builtin(builtin_name) => context.env.primitive_definer(builtin_name.value)?,
+        TypeName_::Builtin(builtin_name) => context.env().primitive_definer(builtin_name.value)?,
         TypeName_::ModuleType(m, _) => m,
     };
     let module_defn = context.module_info(module_ident);
@@ -1432,7 +1733,7 @@ pub fn make_constant_type(
     m: &ModuleIdent,
     c: &ConstantName,
 ) -> Type {
-    let in_current_module = Some(m) == context.current_module.as_ref();
+    let in_current_module = context.is_current_module(m);
     context.emit_warning_if_deprecated(m, c.0, None);
     let (defined_loc, signature) = {
         let ConstantInfo {
@@ -1484,12 +1785,12 @@ pub fn make_method_call_type(
                 context.add_diag(diag);
                 return None;
             }
-            TypeName_::Builtin(sp!(_, bt_)) => context.env.primitive_definer(*bt_),
+            TypeName_::Builtin(sp!(_, bt_)) => context.env().primitive_definer(*bt_),
             TypeName_::ModuleType(m, _) => Some(m),
         };
         let finfo_opt = defining_module.and_then(|m| {
             let finfo = context
-                .modules
+                .info()
                 .module(m)
                 .functions
                 .get(&FunctionName(method))?;
@@ -1660,16 +1961,13 @@ fn check_function_visibility(
     entry_opt: Option<Loc>,
     visibility: Visibility,
 ) {
-    let in_current_module = match &context.current_module {
-        Some(current) => m == current,
-        None => false,
-    };
+    let in_current_module = context.is_current_module(m);
     let public_for_testing =
-        public_testing_visibility(context.env, context.current_package, f, entry_opt);
+       public_testing_visibility(context.env(), context.current_package(), f, entry_opt);
     let is_testing_context = context.is_testing_context();
     let supports_public_package = context
-        .env
-        .supports_feature(context.current_package, FeatureGate::PublicPackage);
+        .env()
+        .supports_feature(context.current_package(), FeatureGate::PublicPackage);
     match visibility {
         _ if is_testing_context && public_for_testing.is_some() => (),
         Visibility::Internal if in_current_module => (),
@@ -1718,12 +2016,12 @@ fn check_function_visibility(
                     .map(|pkg_name| format!("{}", pkg_name))
                     .unwrap_or("<unknown package>".to_string()),
                 &context
-                    .current_module
+                    .current_module()
                     .map(|cur_module| cur_module.value.address.to_string())
                     .unwrap_or("<unknown addr>".to_string()),
                 &context
-                    .current_module
-                    .and_then(|cur_module| context.module_info(&cur_module).package)
+                    .current_module()
+                    .and_then(|cur_module| context.module_info(cur_module).package)
                     .map(|pkg_name| format!("{}", pkg_name))
                     .unwrap_or("<unknown package>".to_string())
             );
@@ -1798,7 +2096,7 @@ fn report_visibility_error_(
         (call_loc, call_msg),
         (vis_loc, vis_msg),
     );
-    if context.env.flags().is_testing() {
+    if context.env().flags().is_testing() {
         if let Some(case) = public_for_testing {
             let (test_loc, test_msg) = match case {
                 PublicForTesting::Entry(entry_loc) => {
@@ -1929,7 +2227,8 @@ fn solve_ability_constraint(
     constraints: AbilitySet,
 ) {
     let ty = unfold_type(&context.subst, ty);
-    let ty_abilities = infer_abilities(&context.modules, &context.subst, ty.clone());
+    let ty_abilities = infer_abilities(context.info(), &context.subst, ty.clone());
+
 
     let (declared_loc_opt, declared_abilities, ty_args) = debug_abilities_info(context, &ty);
     for constraint in constraints {
@@ -1950,7 +2249,7 @@ fn solve_ability_constraint(
             declared_loc_opt,
             &declared_abilities,
             ty_args.iter().map(|ty_arg| {
-                let abilities = infer_abilities(&context.modules, &context.subst, ty_arg.clone());
+                let abilities = infer_abilities(context.info(), &context.subst, ty_arg.clone());
                 (ty_arg, abilities)
             }),
         );
@@ -2644,7 +2943,7 @@ fn join_impl(
                 k2
             );
             let (subst, tys) = join_impl_types(counter, subst, case, tys1, tys2)?;
-            Ok((subst, sp(*loc, Apply(k2.clone(), n2.clone(), tys))))
+            Ok((subst, sp(*loc, Apply(k2.clone(), *n2, tys))))
         }
         (sp!(_, Fun(a1, _)), sp!(_, Fun(a2, _))) if a1.len() != a2.len() => {
             Err(TypingError::FunArityMismatch(

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -60,10 +60,10 @@ pub fn type_(context: &mut Context, ty: &mut Type) {
         Anything | UnresolvedError | Param(_) | Unit => (),
         Ref(_, b) => type_(context, b),
         Var(tvar) => {
-            debug_print!(context.debug.type_elaboration, ("before" => Var(*tvar)));
+            debug_print!(context.debug().type_elaboration, ("before" => Var(*tvar)));
             let ty_tvar = sp(ty.loc, Var(*tvar));
             let replacement = core::unfold_type(&context.subst, ty_tvar);
-            debug_print!(context.debug.type_elaboration, ("resolved" => replacement));
+            debug_print!(context.debug().type_elaboration, ("resolved" => replacement));
             let replacement = match replacement {
                 sp!(loc, Var(_)) => {
                     let diag = ice!((
@@ -87,7 +87,7 @@ pub fn type_(context: &mut Context, ty: &mut Type) {
             };
             *ty = replacement;
             type_(context, ty);
-            debug_print!(context.debug.type_elaboration, ("after" => ty));
+            debug_print!(context.debug().type_elaboration, ("after" => ty));
         }
         Apply(Some(_), sp!(_, TypeName_::Builtin(_)), tys) => types(context, tys),
         aty @ Apply(Some(_), _, _) => {
@@ -99,7 +99,7 @@ pub fn type_(context: &mut Context, ty: &mut Type) {
             *ty = sp(ty.loc, UnresolvedError)
         }
         Apply(None, _, _) => {
-            let abilities = core::infer_abilities(&context.modules, &context.subst, ty.clone());
+            let abilities = core::infer_abilities(context.info(), &context.subst, ty.clone());
             match &mut ty.value {
                 Apply(abilities_opt, _, tys) => {
                     *abilities_opt = Some(abilities);
@@ -125,7 +125,7 @@ pub fn type_(context: &mut Context, ty: &mut Type) {
 }
 
 fn unexpected_lambda_type(context: &mut Context, loc: Loc) {
-    if context.check_feature(context.current_package, FeatureGate::MacroFuns, loc) {
+    if context.check_feature(context.current_package(), FeatureGate::MacroFuns, loc) {
         let msg = "Unexpected lambda type. \
             Lambdas can only be used with 'macro' functions, as parameters or direct arguments";
         context.add_diag(diag!(TypeSafety::UnexpectedFunctionType, (loc, msg)));
@@ -193,7 +193,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
         E::Use(v) => {
             let from_user = false;
             let var = *v;
-            let abs = core::infer_abilities(&context.modules, &context.subst, e.ty.clone());
+            let abs = core::infer_abilities(context.info(), &context.subst, e.ty.clone());
             e.exp.value = if abs.has_ability_(Ability_::Copy) {
                 E::Copy { from_user, var }
             } else {

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -30,8 +30,8 @@ struct ParamInfo {
     used: bool,
 }
 
-struct Context<'a, 'b> {
-    core: &'a mut core::Context<'b>,
+struct Context<'context, 'outer, 'env> {
+    core: &'context mut core::Context<'outer, 'env>,
     // used for removing unbound params
     all_params: BTreeMap<Var_, ParamInfo>,
     // used for expanding lambda calls in VarCall
@@ -92,7 +92,7 @@ pub(crate) fn call(
         ) {
             Ok(res) => res,
             Err(None) => {
-                assert!(context.env.has_errors());
+                assert!(context.env().has_errors());
                 return None;
             }
             Err(Some(diag)) => {
@@ -103,7 +103,7 @@ pub(crate) fn call(
     context.set_max_variable_color(max_color);
 
     if macro_type_params.len() != type_args.len() || macro_params.len() != args.len() {
-        assert!(context.env.has_errors());
+        assert!(context.env().has_errors());
         return None;
     }
     // tparam subst
@@ -143,7 +143,7 @@ pub(crate) fn call(
             let arg_exp = match arg {
                 Arg::ByValue(_) => {
                     assert!(
-                        context.env.has_errors(),
+                        context.env().has_errors(),
                         "ICE lambda args should never be by value"
                     );
                     continue;
@@ -727,7 +727,7 @@ fn recolor_pat(ctx: &mut Recolor, sp!(_, p_): &mut N::MatchPattern) {
 // subst args
 //**************************************************************************************************
 
-impl Context<'_, '_> {
+impl Context<'_, '_, '_> {
     fn mark_used(&mut self, v: &Var_) {
         self.all_params.get_mut(v).unwrap().used = true;
     }
@@ -797,7 +797,7 @@ fn lvalue(context: &mut Context, sp!(_, lv_): &mut N::LValue) {
         } => {
             if context.all_params.contains_key(v_) {
                 assert!(
-                    context.core.env.has_errors(),
+                    context.core.env().has_errors(),
                     "ICE cannot assign to macro parameter"
                 );
                 *lv_ = N::LValue_::Ignore
@@ -866,7 +866,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                     valid_binders.retain(|(_, sp!(_, var_))| {
                         if context.all_params.contains_key(var_) {
                             assert!(
-                                context.core.env.has_errors(),
+                                context.core.env().has_errors(),
                                 "ICE cannot use macro parameter in pattern"
                             );
                             false
@@ -1066,7 +1066,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                 from_macro_argument: None,
                 seq: (N::UseFuns::new(context.macro_color), result),
             });
-            if context.core.env.ide_mode() {
+            if context.core.env().ide_mode() {
                 context
                     .core
                     .add_ide_annotation(*eloc, IDEAnnotation::ExpandedLambda);
@@ -1128,7 +1128,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                 assert!(!context.lambdas.contains_key(v_));
                 assert!(!context.by_name_args.contains_key(v_));
                 assert!(
-                    context.core.env.has_errors(),
+                    context.core.env().has_errors(),
                     "ICE unbound param should have already resulted in an error"
                 );
                 *e_ = N::Exp_::UnresolvedError;
@@ -1144,7 +1144,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                 assert!(!context.lambdas.contains_key(v_));
                 assert!(!context.by_name_args.contains_key(v_));
                 assert!(
-                    context.core.env.has_errors(),
+                    context.core.env().has_errors(),
                     "ICE unbound param should have already resulted in an error"
                 );
                 *e_ = N::Exp_::UnresolvedError;
@@ -1208,7 +1208,7 @@ fn pat(context: &mut Context, sp!(_, p_): &mut N::MatchPattern) {
         MP::Binder(_mut, var, _) => {
             if context.all_params.contains_key(&var.value) {
                 assert!(
-                    context.core.env.has_errors(),
+                    context.core.env().has_errors(),
                     "ICE cannot use macro parameter in pattern"
                 );
                 *p_ = MP::ErrorPat;
@@ -1221,7 +1221,7 @@ fn pat(context: &mut Context, sp!(_, p_): &mut N::MatchPattern) {
         MP::At(var, _unused_var, inner) => {
             if context.all_params.contains_key(&var.value) {
                 assert!(
-                    context.core.env.has_errors(),
+                    context.core.env().has_errors(),
                     "ICE cannot use macro parameter in pattern"
                 );
             }

--- a/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
@@ -39,22 +39,22 @@ use std::{
 // Entry and Visitor
 //**************************************************************************************************
 
-struct MatchCompiler<'ctx, 'env> {
-    context: &'ctx mut Context<'env>,
+struct MatchCompiler<'ctx, 'outer, 'env> {
+    context: &'ctx mut Context<'outer, 'env>,
 }
 
-impl TypingMutVisitorContext for MatchCompiler<'_, '_> {
+impl TypingMutVisitorContext for MatchCompiler<'_, '_, '_> {
     fn visit_exp_custom(&mut self, exp: &mut T::Exp) -> bool {
         use T::UnannotatedExp_ as E;
         let eloc = exp.exp.loc;
         if let E::Match(subject, arms) = &exp.exp.value {
-            debug_print!(self.context.debug.match_counterexample,
+            debug_print!(self.context.debug().match_counterexample,
                 ("subject" => subject),
                 (lines "arms" => &arms.value)
             );
             if invalid_match(self.context, eloc, subject, arms) {
                 debug_print!(
-                    self.context.debug.match_counterexample,
+                    self.context.debug().match_counterexample,
                     (msg "counterexample found")
                 );
                 let err_exp = T::exp(
@@ -106,7 +106,7 @@ fn invalid_match(
     let mut counterexample_matrix = pattern_matrix.clone();
     let has_guards = counterexample_matrix.has_guards();
     counterexample_matrix.remove_guarded_arms();
-    if context.env.ide_mode() {
+    if context.env().ide_mode() {
         // Do this first, as it's a borrow and a shallow walk.
         ide_report_missing_arms(context, arms_loc, &counterexample_matrix);
     }
@@ -234,8 +234,8 @@ fn find_counterexample(
     // If the matrix is only errors (or empty), it was all error or something else (like typing)
     // went wrong; no counterexample is required.
     if !matrix.is_empty() && !matrix.patterns_empty() && matrix.all_errors() {
-        debug_print!(context.debug.match_counterexample, (msg "errors"), ("matrix" => matrix; dbg));
-        assert!(context.env.has_errors());
+        debug_print!(context.debug().match_counterexample, (msg "errors"), ("matrix" => matrix; dbg));
+        assert!(context.env().has_errors());
         return true;
     }
     find_counterexample_impl(context, loc, matrix, has_guards)
@@ -366,23 +366,21 @@ fn find_counterexample_impl(
         datatype_name: DatatypeName,
     ) -> Option<Vec<CounterExample>> {
         debug_print!(
-            context.debug.match_counterexample,
+            context.debug().match_counterexample,
             (lines "matrix types" => &matrix.tys; verbose)
         );
-        if context.modules.is_struct(&mident, &datatype_name) {
+        if context.info().is_struct(&mident, &datatype_name) {
             // For a struct, we only care if we destructure it. If we do, we want to specialize and
             // recur. If we don't, we check it as a default specialization.
             if let Some((ploc, arg_types)) = matrix.first_struct_ctors() {
                 let ctor_arity = arg_types.len() as u32;
                 let decl_fields = context
-                    .modules
+                    .info()
                     .struct_fields(&mident, &datatype_name)
                     .unwrap();
                 let fringe_binders =
                     context.make_imm_ref_match_binders(decl_fields, ploc, arg_types);
-                let is_positional = context
-                    .modules
-                    .struct_is_positional(&mident, &datatype_name);
+                let is_positional = context.info().struct_is_positional(&mident, &datatype_name);
                 let names = fringe_binders
                     .iter()
                     .map(|(name, _, _)| name.to_string())
@@ -427,7 +425,7 @@ fn find_counterexample_impl(
             }
         } else {
             let mut unmatched_variants = context
-                .modules
+                .info()
                 .enum_variants(&mident, &datatype_name)
                 .into_iter()
                 .collect::<BTreeSet<_>>();
@@ -440,14 +438,14 @@ fn find_counterexample_impl(
                 for (ctor, (ploc, arg_types)) in ctors {
                     let ctor_arity = arg_types.len() as u32;
                     let decl_fields = context
-                        .modules
+                        .info()
                         .enum_variant_fields(&mident, &datatype_name, &ctor)
                         .unwrap();
                     let fringe_binders =
                         context.make_imm_ref_match_binders(decl_fields, ploc, arg_types);
                     let is_positional =
                         context
-                            .modules
+                            .info()
                             .enum_variant_is_positional(&mident, &datatype_name, &ctor);
                     let names = fringe_binders
                         .iter()
@@ -492,13 +490,13 @@ fn find_counterexample_impl(
                         Some(result)
                     } else {
                         let variant_name = unmatched_variants.first().unwrap();
-                        let is_positional = context.modules.enum_variant_is_positional(
+                        let is_positional = context.info().enum_variant_is_positional(
                             &mident,
                             &datatype_name,
                             variant_name,
                         );
                         let ctor_args = context
-                            .modules
+                            .info()
                             .enum_variant_fields(&mident, &datatype_name, variant_name)
                             .unwrap();
                         let names = ctor_args
@@ -533,7 +531,7 @@ fn find_counterexample_impl(
         arity: u32,
         ndx: &mut u32,
     ) -> Option<Vec<CounterExample>> {
-        debug_print!(context.debug.match_counterexample, ("checking matrix" => matrix; verbose));
+        debug_print!(context.debug().match_counterexample, ("checking matrix" => matrix; verbose));
         let result = if matrix.patterns_empty() {
             None
         } else if let Some(ty) = matrix.tys.first() {
@@ -564,7 +562,7 @@ fn find_counterexample_impl(
             Some(make_wildcards(arity as usize))
         } else {
             // An error case: no entry on the fringe but no
-            if !context.env.has_errors() {
+            if !context.env().has_errors() {
                 context.add_diag(ice!((
                     matrix.loc,
                     "Non-empty matrix with non errors but no type"
@@ -572,7 +570,7 @@ fn find_counterexample_impl(
             }
             None
         };
-        debug_print!(context.debug.match_counterexample, (opt "result" => &result; sdbg));
+        debug_print!(context.debug().match_counterexample, (opt "result" => &result; sdbg));
         result
     }
 
@@ -580,7 +578,7 @@ fn find_counterexample_impl(
 
     if let Some(mut counterexample) = counterexample_rec(context, matrix, 1, &mut ndx) {
         debug_print!(
-            context.debug.match_counterexample,
+            context.debug().match_counterexample,
             ("counterexamples #" => counterexample.len(); fmt),
             (lines "counterexamples" => &counterexample; fmt)
         );
@@ -645,15 +643,15 @@ fn ide_report_missing_arms(context: &mut Context, loc: Loc, matrix: &PatternMatr
         mident: ModuleIdent,
         name: DatatypeName,
     ) {
-        if context.modules.is_struct(&mident, &name) {
+        if context.info().is_struct(&mident, &name) {
             if !matrix.is_empty() {
                 // If the matrix isn't empty, we _must_ have matched the struct with at least one
                 // non-guard arm (either wildcards or the struct itself), so we're fine.
                 return;
             }
             // If the matrix _is_ empty, we suggest adding an unpack.
-            let is_positional = context.modules.struct_is_positional(&mident, &name);
-            let Some(fields) = context.modules.struct_fields(&mident, &name) else {
+            let is_positional = context.info().struct_is_positional(&mident, &name);
+            let Some(fields) = context.info().struct_fields(&mident, &name) else {
                 context.add_diag(ice!((
                     loc,
                     "Tried to look up fields for this struct and found none"
@@ -689,7 +687,7 @@ fn ide_report_missing_arms(context: &mut Context, loc: Loc, matrix: &PatternMatr
             }
 
             let mut unmatched_variants = context
-                .modules
+                .info()
                 .enum_variants(&mident, &name)
                 .into_iter()
                 .collect::<BTreeSet<_>>();
@@ -703,19 +701,17 @@ fn ide_report_missing_arms(context: &mut Context, loc: Loc, matrix: &PatternMatr
             }
             let mut arms = vec![];
             // re-iterate the original so we generate these in definition order
-            for variant in context.modules.enum_variants(&mident, &name).into_iter() {
+            for variant in context.info().enum_variants(&mident, &name).into_iter() {
                 if !unmatched_variants.contains(&variant) {
                     continue;
                 }
                 let is_empty = context
-                    .modules
+                    .info()
                     .enum_variant_is_empty(&mident, &name, &variant);
                 let is_positional = context
-                    .modules
+                    .info()
                     .enum_variant_is_positional(&mident, &name, &variant);
-                let Some(fields) = context
-                    .modules
-                    .enum_variant_fields(&mident, &name, &variant)
+                let Some(fields) = context.info().enum_variant_fields(&mident, &name, &variant)
                 else {
                     context.add_diag(ice!((
                         loc,
@@ -769,7 +765,7 @@ fn ide_report_missing_arms(context: &mut Context, loc: Loc, matrix: &PatternMatr
     {
         report_datatype(context, loc, matrix, mident, datatype_name)
     } else {
-        if !context.env.has_errors() {
+        if !context.env().has_errors() {
             // It's unclear how we got here, so report an ICE and suggest a wildcard.
             context.add_diag(ice!((
                 loc,

--- a/external-crates/move/crates/move-compiler/src/typing/syntax_methods.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/syntax_methods.rs
@@ -38,7 +38,7 @@ pub fn validate_syntax_methods(
                 if !validate_index_syntax_methods(context, index_defn, index_mut_defn) {
                     // If we didn't validate they wre comptaible, we remove the mut one to avoid
                     // more typing issues later.
-                    assert!(context.env.has_errors());
+                    assert!(context.env().has_errors());
                     *index_mut = None;
                 }
             }
@@ -179,7 +179,6 @@ fn validate_index_syntax_methods(
         index_fn,
         Some(mut_tparam_types),
     );
-    context.current_module = None;
 
     let index_params = index_ty.params.iter().map(|(_, t1)| t1);
     let mut_params = mut_finfo.signature.parameters.iter().map(|(_, _, ty)| ty);

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -13,8 +13,8 @@ use crate::{
     },
     ice, ice_assert,
     naming::ast::{
-        self as N, BlockLabel, DatatypeTypeParameter, IndexSyntaxMethods, TParam, TParamID, Type,
-        TypeName, TypeName_, Type_,
+        self as N, BlockLabel, DatatypeTypeParameter, IndexSyntaxMethods, ResolvedUseFuns, TParam,
+        TParamID, Type, TypeName, TypeName_, Type_,
     },
     parser::ast::{
         Ability_, BinOp, BinOp_, ConstantName, DatatypeName, DocComment, Field, FunctionName,
@@ -24,7 +24,7 @@ use crate::{
         ide::{DotAutocompleteInfo, IDEAnnotation, MacroCallInfo},
         known_attributes::{SyntaxAttribute, TestingAttribute},
         process_binops,
-        program_info::{ConstantInfo, DatatypeKind, TypingProgramInfo},
+        program_info::{ConstantInfo, DatatypeKind, NamingProgramInfo, TypingProgramInfo},
         string_utils::{debug_print, make_ascii_titlecase},
         unique_map::UniqueMap,
         *,
@@ -33,8 +33,8 @@ use crate::{
     typing::{
         ast::{self as T},
         core::{
-            self, public_testing_visibility, report_visibility_error, Context, PublicForTesting,
-            ResolvedFunctionType, Subst,
+            self, global_use_funs, public_testing_visibility, report_visibility_error, Context,
+            ModuleContext, PublicForTesting, ResolvedFunctionType, Subst,
         },
         dependency_ordering, expand, infinite_instantiations, macro_expand, match_analysis,
         recursive_datatypes,
@@ -44,10 +44,11 @@ use crate::{
 };
 use move_ir_types::location::*;
 use move_proc_macros::growing_stack;
+use move_symbol_pool::Symbol;
 use rayon::prelude::*;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 //**************************************************************************************************
@@ -60,26 +61,19 @@ pub fn program(
     prog: N::Program,
 ) -> T::Program {
     let N::Program {
-        info,
+        mut info,
         warning_filters_table,
         inner: N::Program_ { modules: nmodules },
     } = prog;
-    let mut context = Box::new(Context::new(
-        compilation_env,
-        pre_compiled_lib.clone(),
-        info,
-    ));
 
-    extract_macros(&mut context, &nmodules, &pre_compiled_lib);
-    let mut modules = modules(&mut context, nmodules);
+    let all_macro_definitions = extract_macros(&nmodules, &pre_compiled_lib);
+    let mut modules = modules(compilation_env, &mut info, &all_macro_definitions, nmodules);
 
-    assert!(context.constraints.is_empty());
-    dependency_ordering::program(context.env, &mut modules);
-    recursive_datatypes::modules(context.env, &modules);
-    infinite_instantiations::modules(context.env, &modules);
+    dependency_ordering::program(compilation_env, &mut modules);
+    recursive_datatypes::modules(compilation_env, &modules);
+    infinite_instantiations::modules(compilation_env, &modules);
     // we extract module use funs into the module info context
-    let module_use_funs = context
-        .modules
+    let module_use_funs = info
         .modules
         .into_iter()
         .map(|(mident, minfo)| (mident, minfo.use_funs))
@@ -100,10 +94,9 @@ pub fn program(
 }
 
 fn extract_macros(
-    context: &mut Context,
     modules: &UniqueMap<ModuleIdent, N::ModuleDefinition>,
     pre_compiled_lib: &Option<Arc<FullyCompiledProgram>>,
-) {
+) -> UniqueMap<ModuleIdent, UniqueMap<FunctionName, N::Sequence>> {
     // Merges the methods of the module into the local methods for each macro.
     fn merge_use_funs(module_use_funs: &N::UseFuns, mut macro_use_funs: N::UseFuns) -> N::UseFuns {
         let N::UseFuns {
@@ -112,7 +105,7 @@ fn extract_macros(
             implicit_candidates,
         } = module_use_funs;
         for (tn, module_methods) in resolved {
-            let macro_methods = macro_use_funs.resolved.entry(tn.clone()).or_default();
+            let macro_methods = macro_use_funs.resolved.entry(*tn).or_default();
             for (name, method) in module_methods.key_cloned_iter() {
                 if !macro_methods.contains_key(&name) {
                     macro_methods.add(name, method.clone()).unwrap();
@@ -147,7 +140,7 @@ fn extract_macros(
         ))
         .unwrap();
 
-    let all_macro_definitions = all_modules.map(|_mident, mdef| {
+    all_modules.map(|_mident, mdef| {
         mdef.functions.ref_filter_map(|_name, f| {
             let _macro_loc = f.macro_?;
             if let N::FunctionBody_::Defined((use_funs, body)) = &f.body.value {
@@ -156,30 +149,52 @@ fn extract_macros(
             } else {
                 None
             }
-        })
-    });
-
-    context.set_macros(all_macro_definitions);
+        })  
+    })
 }
 
 fn modules(
-    context: &mut Context,
+     compilation_env: &CompilationEnv,
+    info: &mut NamingProgramInfo,
+    all_macro_definitions: &UniqueMap<ModuleIdent, UniqueMap<FunctionName, N::Sequence>>,
     mut modules: UniqueMap<ModuleIdent, N::ModuleDefinition>,
 ) -> UniqueMap<ModuleIdent, T::ModuleDefinition> {
-    let mut all_new_friends = BTreeMap::new();
+    let global_use_funs = global_use_funs(info);
     // We validate the syntax methods first so that processing syntax method forms
     // later are better-typed. It would be preferable to do this in naming, but
     // the typing machinery makes it much easier to enforce the typeclass-like
     // constraints. We also update the program info to reflect any changes that
     // happened.
-    for (key, mdef) in modules.key_cloned_iter_mut() {
-        validate_syntax_methods(context, &key, mdef);
-        context
-            .modules
-            .set_module_syntax_methods(key, mdef.syntax_methods.clone());
+   for (mident, mdef) in modules.key_cloned_iter_mut() {
+        let context = ModuleContext::new(
+            compilation_env,
+            info,
+            &global_use_funs,
+            all_macro_definitions,
+        );
+        validate_syntax_methods(&mut context.new_module_member(), &mident, mdef);
     }
-    let mut typed_modules = modules.map(|ident, mdef| {
-        let (typed_mdef, new_friends) = module(context, ident, mdef);
+    for (mident, mdef) in modules.key_cloned_iter() {
+        info.set_module_syntax_methods(mident, mdef.syntax_methods.clone());
+    }
+ let typed_modules = Mutex::new(UniqueMap::new());
+    let all_new_friends = Mutex::new(BTreeMap::new());
+    let used_module_members = Mutex::new(BTreeMap::new());
+    modules.into_par_iter().for_each(|(ident, mdef)| {
+        let (typed_mdef, new_friends, used_members) = module(
+            compilation_env,
+            info,
+            &global_use_funs,
+            all_macro_definitions,
+            ident,
+            mdef,
+        );
+        typed_modules
+            .lock()
+            .unwrap()
+            .add(ident, typed_mdef)
+            .unwrap();
+        let mut all_new_friends = all_new_friends.lock().unwrap();
         for (pub_package_module, loc) in new_friends {
             let friend = Friend {
                 attributes: UniqueMap::new(),
@@ -191,8 +206,17 @@ fn modules(
                 .or_insert_with(BTreeMap::new)
                 .insert(ident, friend);
         }
-        typed_mdef
+        let mut used_module_members = used_module_members.lock().unwrap();
+        for (mident, members) in used_members {
+            used_module_members
+                .entry(mident)
+                .or_insert_with(BTreeSet::new)
+                .extend(members);
+        }
     });
+    let mut typed_modules = typed_modules.into_inner().unwrap();
+    let all_new_friends = all_new_friends.into_inner().unwrap();
+    let used_module_members = used_module_members.into_inner().unwrap();
 
     for (mident, friends) in all_new_friends {
         let mdef = typed_modules.get_mut(&mident).unwrap();
@@ -204,17 +228,33 @@ fn modules(
     }
 
     for (_, mident, mdef) in &typed_modules {
-        unused_module_members(context, mident, mdef);
+        unused_module_members(compilation_env, &used_module_members, mident, mdef);
     }
 
     typed_modules
 }
 
-fn module(
-    context: &mut Context,
+fn module<'env>(
+    env: &'env CompilationEnv,
+    info: &'env NamingProgramInfo,
+    global_use_funs: &'env ResolvedUseFuns,
+    macros: &'env UniqueMap<ModuleIdent, UniqueMap<FunctionName, N::Sequence>>,
     ident: ModuleIdent,
     mdef: N::ModuleDefinition,
-) -> (T::ModuleDefinition, BTreeSet<(ModuleIdent, Loc)>) {
+) -> (
+    T::ModuleDefinition,
+    BTreeSet<(ModuleIdent, Loc)>,
+    BTreeMap<ModuleIdent_, BTreeSet<Symbol>>,
+) {
+    enum Member<S, E, C, F> {
+        Struct(S),
+        Enum(E),
+        Constant(C),
+        Function(F),
+    }
+
+    let mut context = ModuleContext::new(env, info, global_use_funs, macros);
+
     assert!(context.current_package.is_none());
     assert!(context.new_friends.is_empty());
 
@@ -228,8 +268,8 @@ fn module(
         syntax_methods,
         use_funs,
         friends,
-        mut structs,
-        mut enums,
+        structs: nstructs,
+        enums: nenums,
         functions: nfunctions,
         constants: nconstants,
     } = mdef;
@@ -237,17 +277,60 @@ fn module(
     context.current_package = package_name;
     context.push_warning_filter_scope(warning_filter);
     context.add_use_funs_scope(use_funs);
-    structs
-        .iter_mut()
-        .for_each(|(loc, _name, s)| struct_def(context, loc, s));
-    enums.iter_mut().for_each(|(_, _, e)| enum_def(context, e));
-    process_attributes(context, &attributes);
-    let constants = nconstants.map(|name, c| constant(context, name, c));
-    let functions = nfunctions.map(|name, f| function(context, name, f));
-    assert!(context.constraints.is_empty());
-    context.current_package = None;
-    let use_funs = context.pop_use_funs_scope();
-    context.pop_warning_filter_scope();
+    process_module_attributes(&mut context, &attributes);
+    let structs = Mutex::new(UniqueMap::new());
+    let enums = Mutex::new(UniqueMap::new());
+    let constants = Mutex::new(UniqueMap::new());
+    let functions = Mutex::new(UniqueMap::new());
+    let new_friends = Mutex::new(BTreeSet::new());
+    let used_members = Mutex::new(BTreeMap::new());
+    let used_methods = Mutex::new(BTreeSet::new());
+    nstructs
+        .into_par_iter()
+        .map(Member::Struct)
+        .chain(nenums.into_par_iter().map(Member::Enum))
+        .chain(nconstants.into_par_iter().map(Member::Constant))
+        .chain(nfunctions.into_par_iter().map(Member::Function))
+        .for_each(|member| {
+            let mut context = context.new_module_member();
+            match member {
+                Member::Struct((name, mut s)) => {
+                    struct_def(&mut context, name.loc(), &mut s);
+                    structs.lock().unwrap().add(name, s).unwrap();
+                }
+                Member::Enum((name, mut e)) => {
+                    enum_def(&mut context, &mut e);
+                    enums.lock().unwrap().add(name, e).unwrap();
+                }
+                Member::Constant((name, c)) => {
+                    let c = constant(&mut context, name, c);
+                    constants.lock().unwrap().add(name, c).unwrap();
+                }
+                Member::Function((name, f)) => {
+                    let f = function(&mut context, name, f);
+                    functions.lock().unwrap().add(name, f).unwrap();
+                }
+            };
+            let (cur_new_friends, cur_used_members, cur_used_methods) = context.finish();
+            new_friends.lock().unwrap().extend(cur_new_friends);
+            let mut used_members = used_members.lock().unwrap();
+            for (mident, members) in cur_used_members {
+                used_members
+                    .entry(mident)
+                    .or_insert_with(BTreeSet::new)
+                    .extend(members);
+            }
+            used_methods.lock().unwrap().extend(cur_used_methods);
+        });
+    let structs = structs.into_inner().unwrap();
+    let enums = enums.into_inner().unwrap();
+    let constants = constants.into_inner().unwrap();
+    let functions = functions.into_inner().unwrap();
+    let new_friends = new_friends.into_inner().unwrap();
+    let used_members = used_members.into_inner().unwrap();
+    let used_methods = used_methods.into_inner().unwrap();
+
+    let use_funs = context.finish_use_funs_scope(&used_methods);
     let typed_module = T::ModuleDefinition {
         doc,
         loc,
@@ -266,13 +349,11 @@ fn module(
         constants,
         functions,
     };
-    // get the list of new friends and reset the list.
-    let new_friends = std::mem::take(&mut context.new_friends);
-    (typed_module, new_friends)
+    (typed_module, new_friends, used_members)
 }
 
 fn finalize_ide_info(context: &mut Context) {
-    if !context.env.ide_mode() {
+    if !context.env().ide_mode() {
         assert!(context.ide_info.is_empty());
         return;
     }
@@ -302,12 +383,11 @@ fn function(context: &mut Context, name: FunctionName, f: N::Function) -> T::Fun
     } = f;
     context.push_warning_filter_scope(warning_filter);
     assert!(context.constraints.is_empty());
-    context.reset_for_module_item(name.loc());
     context.current_function = Some(name);
     context.in_macro_function = macro_.is_some();
     process_attributes(context, &attributes);
     let compiled_visibility =
-        match public_testing_visibility(context.env, context.current_package, &name, entry) {
+        match public_testing_visibility(context.env(), context.current_package(), &name, entry) {
             Some(PublicForTesting::Entry(loc)) => Visibility::Public(loc),
             None => visibility,
         };
@@ -367,7 +447,7 @@ fn function_body(context: &mut Context, sp!(loc, nb_): N::FunctionBody) -> T::Fu
     let mut b_ = match nb_ {
         N::FunctionBody_::Native => T::FunctionBody_::Native,
         N::FunctionBody_::Defined(es) => {
-            debug_print!(context.debug.function_translation, ("input" => es));
+            debug_print!(context.debug().function_translation, ("input" => es));
             let seq = sequence(context, es);
             let ety = sequence_type(&seq);
             let ret_ty = context.return_type.clone().unwrap();
@@ -386,7 +466,7 @@ fn function_body(context: &mut Context, sp!(loc, nb_): N::FunctionBody) -> T::Fu
     core::solve_constraints(context);
     expand::function_body_(context, &mut b_);
     match_analysis::function_body_(context, &mut b_);
-    debug_print!(context.debug.function_translation, ("output" => b_));
+    debug_print!(context.debug().function_translation, ("output" => b_));
     sp(loc, b_)
 }
 
@@ -394,9 +474,8 @@ fn function_body(context: &mut Context, sp!(loc, nb_): N::FunctionBody) -> T::Fu
 // Constants
 //**************************************************************************************************
 
-fn constant(context: &mut Context, name: ConstantName, nconstant: N::Constant) -> T::Constant {
+fn constant(context: &mut Context, _name: ConstantName, nconstant: N::Constant) -> T::Constant {
     assert!(context.constraints.is_empty());
-    context.reset_for_module_item(name.loc());
 
     let N::Constant {
         doc,
@@ -437,7 +516,7 @@ fn constant(context: &mut Context, name: ConstantName, nconstant: N::Constant) -
     expand::exp(context, &mut value);
 
     check_valid_constant::exp(context, &value);
-    if context.env.ide_mode() {
+    if context.env().ide_mode() {
         finalize_ide_info(context);
     }
     context.pop_warning_filter_scope();
@@ -713,9 +792,8 @@ mod check_valid_constant {
 // Data Types
 //**************************************************************************************************
 
-fn struct_def(context: &mut Context, sloc: Loc, s: &mut N::StructDefinition) {
+fn struct_def(context: &mut Context, _sloc: Loc, s: &mut N::StructDefinition) {
     assert!(context.constraints.is_empty());
-    context.reset_for_module_item(sloc);
     context.push_warning_filter_scope(s.warning_filter);
 
     let field_map = match &mut s.fields {
@@ -786,13 +864,12 @@ fn enum_def(context: &mut Context, enum_: &mut N::EnumDefinition) {
 
 fn variant_def(
     context: &mut Context,
-    vloc: Loc,
+    _vloc: Loc,
     enum_abilities: &AbilitySet,
     enum_tparams: &[DatatypeTypeParameter],
     v: &mut N::VariantDefinition,
 ) -> Vec<(usize, Type)> {
-    context.reset_for_module_item(vloc);
-
+    assert!(context.constraints.is_empty());
     let field_map = match &mut v.fields {
         N::VariantFields::Empty => return vec![],
         N::VariantFields::Defined(_, m) => m,
@@ -1546,7 +1623,7 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
             );
             match ty_call_opt {
                 None => {
-                    assert!(context.env.has_errors());
+                    assert!(context.env().has_errors());
                     (context.error_type(eloc), TE::UnresolvedError)
                 }
                 Some(ty_call) => ty_call,
@@ -1578,7 +1655,7 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
             );
             match ty_call_opt {
                 None => {
-                    assert!(context.env.has_errors());
+                    assert!(context.env().has_errors());
                     (context.error_type(eloc), TE::UnresolvedError)
                 }
                 Some(ty_call) => ty_call,
@@ -1599,7 +1676,7 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
         NE::VarCall(_, sp!(_, nargs_)) => {
             exp_vec(context, nargs_);
             assert!(
-                context.env.has_errors(),
+                context.env().has_errors(),
                 "ICE unbound var call. Should be expanded"
             );
             (context.error_type(eloc), TE::UnresolvedError)
@@ -1712,7 +1789,7 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
             res
         }
         NE::Lambda(_) => {
-            if context.check_feature(context.current_package, FeatureGate::Lambda, eloc) {
+            if context.check_feature(context.current_package(), FeatureGate::Lambda, eloc) {
                 let msg = "Lambdas can only be used directly as arguments to 'macro' functions";
                 context.add_diag(diag!(TypeSafety::UnexpectedLambda, (eloc, msg)))
             }
@@ -1940,7 +2017,7 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
             (rhs, e_)
         }
         NE::UnresolvedError => {
-            assert!(context.env.has_errors());
+            assert!(context.env().has_errors());
             (context.error_type(eloc), TE::UnresolvedError)
         }
 
@@ -1962,7 +2039,7 @@ fn binop(
     let (ty, operand_ty) = match &bop.value {
         Eq | Neq
             if context
-                .env
+                .env()
                 .supports_feature(context.current_package(), FeatureGate::AutoborrowEq) =>
         {
             let lhs_type = core::ready_tvars(&context.subst, el.ty.clone());
@@ -2720,7 +2797,7 @@ fn lvalue(
             TL::Ignore
         }
         NL::Error => {
-            assert!(context.env.has_errors());
+            assert!(context.env().has_errors());
             TL::Ignore
         }
         NL::Var {
@@ -2975,7 +3052,7 @@ fn add_variant_field_types<T>(
             if !fields.is_empty() {
                 ice_assert!(
                     context.reporter,
-                    context.env.has_errors(),
+                    context.env().has_errors(),
                     loc,
                     "Empty variant with fields but no error from naming"
                 );
@@ -3279,7 +3356,7 @@ fn process_exp_dotted(
                 inner.accessors.push(index_access);
                 inner
             }
-            N::ExpDotted_::DotAutocomplete(loc, ndot) if context.env.ide_mode() => {
+            N::ExpDotted_::DotAutocomplete(loc, ndot) if context.env().ide_mode() => {
                 let mut inner = process_exp_dotted_inner(context, Some("dot access"), *ndot);
                 assert!(inner.autocomplete_last.is_none());
                 inner.autocomplete_last = Some(loc);
@@ -3468,8 +3545,8 @@ fn resolve_exp_dotted(
     };
 
     if let Some(loc) = autocomplete_last {
-        assert!(context.env.ide_mode());
-        debug_print!(context.debug.autocomplete_resolution, ("computing unresolved dot autocomplete" => result; dbg));
+        assert!(context.env().ide_mode());
+        debug_print!(context.debug().autocomplete_resolution, ("computing unresolved dot autocomplete" => result; dbg));
         ide_report_autocomplete(context, &loc, &edotted_ty);
     }
     if let Some(mdot_loc) = method_dot_loc {
@@ -3581,12 +3658,12 @@ fn borrow_exp_dotted(
                 base_type: index_base_type,
             } => {
                 let Some(index_methods) = syntax_methods else {
-                    assert!(context.env.has_errors());
+                    assert!(context.env().has_errors());
                     exp = make_error_exp(context, loc);
                     break;
                 };
                 if matches!(index_base_type.value, Type_::UnresolvedError) {
-                    assert!(context.env.has_errors());
+                    assert!(context.env().has_errors());
                     exp = make_error_exp(context, loc);
                     break;
                 }
@@ -3775,7 +3852,7 @@ fn warn_on_constant_borrow(context: &mut Context, loc: Loc, e: &T::Exp) {
 }
 
 fn ide_report_autocomplete(context: &mut Context, at_loc: &Loc, in_ty: &Type) {
-    if !context.env.ide_mode() {
+    if !context.env().ide_mode() {
         return;
     }
     let mut outer_ty = in_ty.clone();
@@ -3827,7 +3904,7 @@ fn method_call(
     let (m, f, fty, usage) =
         match method_call_resolve(context, call_loc, &edotted, method, ty_args_opt) {
             ResolvedMethodCall::Resolved(m, f, fty, usage) => (*m, f, fty, usage),
-            ResolvedMethodCall::UnknownName if context.env.ide_mode() => {
+            ResolvedMethodCall::UnknownName if context.env().ide_mode() => {
                 // Even if the method name fails to resolve, we want autocomplete information.
                 edotted.autocomplete_last = Some(method.loc);
                 let err_ty = context.error_type(call_loc);
@@ -3843,7 +3920,7 @@ fn method_call(
             ResolvedMethodCall::InvalidBaseType | ResolvedMethodCall::UnknownName => return None,
         };
     // report autocomplete information for the IDE
-    let method_dot_loc = if context.env.ide_mode() {
+    let method_dot_loc = if context.env().ide_mode() {
         edotted.autocomplete_last = Some(method.loc);
         Some(dot_loc)
     } else {
@@ -3923,7 +4000,7 @@ fn type_to_type_name_(
                     )
                 }
                 Ty::UnresolvedError => {
-                    assert!(context.env.has_errors());
+                    assert!(context.env().has_errors());
                     return None;
                 }
                 Ty::Ref(_, _) | Ty::Var(_) => {
@@ -4357,7 +4434,7 @@ fn macro_method_call(
     let (m, f, fty, usage) = match method_call_resolve(context, loc, &edotted, method, ty_args_opt)
     {
         ResolvedMethodCall::Resolved(m, f, fty, usage) => (*m, f, fty, usage),
-        ResolvedMethodCall::UnknownName if context.env.ide_mode() => {
+        ResolvedMethodCall::UnknownName if context.env().ide_mode() => {
             // Even if the method name fails to resolve, we want autocomplete information.
             edotted.autocomplete_last = Some(method.loc);
             let err_ty = context.error_type(loc);
@@ -4373,7 +4450,7 @@ fn macro_method_call(
         ResolvedMethodCall::InvalidBaseType | ResolvedMethodCall::UnknownName => return None,
     };
     // report autocomplete information for the IDE
-    let method_dot_loc = if context.env.ide_mode() {
+    let method_dot_loc = if context.env().ide_mode() {
         edotted.autocomplete_last = Some(method.loc);
         Some(dot_loc)
     } else {
@@ -4560,13 +4637,13 @@ fn expand_macro(
 
     let valid = context.add_macro_expansion(m, f, call_loc);
     if !valid {
-        assert!(context.env.has_errors());
+        assert!(context.env().has_errors());
         return (context.error_type(call_loc), TE::UnresolvedError);
     }
     let res = match macro_expand::call(context, call_loc, m, f, type_args.clone(), args, return_ty)
     {
         None => {
-            if !(context.env.has_errors() || context.env.ide_mode()) {
+            if !(context.env().has_errors() || context.env().ide_mode()) {
                 context.add_diag(ice!((
                     call_loc,
                     "No macro found, but name resolution passed."
@@ -4604,7 +4681,7 @@ fn expand_macro(
             seq.push_back(sp(body.exp.loc, TS::Seq(body)));
             let use_funs = N::UseFuns::new(context.current_call_color());
             let block = TE::Block((use_funs, seq));
-            if context.env.ide_mode() {
+            if context.env().ide_mode() {
                 let macro_call_info = MacroCallInfo {
                     module: m,
                     name: f,
@@ -4656,26 +4733,39 @@ fn convert_macro_arg_to_block(context: &Context, sp!(loc, ne_): N::Exp) -> N::Ex
 // Utils
 //**************************************************************************************************
 
-fn process_attributes<T: TName>(context: &mut Context, all_attributes: &UniqueMap<T, Attribute>) {
-    for (_, _, attr) in all_attributes {
-        match &attr.value {
-            Attribute_::Name(_) => (),
-            Attribute_::Parameterized(_, attrs) => process_attributes(context, attrs),
-            Attribute_::Assigned(_, val) => {
-                let AttributeValue_::ModuleAccess(mod_access) = &val.value else {
-                    continue;
-                };
-                if let ModuleAccess_::ModuleAccess(mident, name) = mod_access.value {
-                    // conservatively assume that each `ModuleAccess` refers to a constant name
-                    context
-                        .used_module_members
-                        .entry(mident.value)
-                        .or_default()
-                        .insert(name.value);
+macro_rules! process_attributes_impl {
+    ($rec:ident, $context:ident, $all_attributes: expr) => {
+        for (_, _, attr) in $all_attributes {
+            match &attr.value {
+                Attribute_::Name(_) => (),
+                Attribute_::Parameterized(_, attrs) => $rec($context, attrs),
+                Attribute_::Assigned(_, val) => {
+                    let AttributeValue_::ModuleAccess(mod_access) = &val.value else {
+                        continue;
+                    };
+                    if let ModuleAccess_::ModuleAccess(mident, name) = mod_access.value {
+                        // conservatively assume that each `ModuleAccess` refers to a constant name
+                        $context
+                            .used_module_members
+                            .entry(mident.value)
+                            .or_default()
+                            .insert(name.value);
+                    }
                 }
             }
         }
-    }
+    };
+}
+
+fn process_module_attributes<T: TName>(
+    context: &mut ModuleContext,
+    all_attributes: &UniqueMap<T, Attribute>,
+) {
+    process_attributes_impl!(process_module_attributes, context, all_attributes);
+}
+
+fn process_attributes<T: TName>(context: &mut Context, all_attributes: &UniqueMap<T, Attribute>) {
+    process_attributes_impl!(process_attributes, context, all_attributes);
 }
 
 //**************************************************************************************************
@@ -4684,7 +4774,12 @@ fn process_attributes<T: TName>(context: &mut Context, all_attributes: &UniqueMa
 
 /// Generates warnings for unused (private) functions and unused constants.
 /// Should be called after the whole program has been processed.
-fn unused_module_members(context: &mut Context, mident: &ModuleIdent_, mdef: &T::ModuleDefinition) {
+fn unused_module_members(
+    env: &CompilationEnv,
+    used_module_members: &BTreeMap<ModuleIdent_, BTreeSet<Symbol>>,
+    mident: &ModuleIdent_,
+    mdef: &T::ModuleDefinition,
+) {
     if !matches!(
         mdef.target_kind,
         TargetKind::Source {
@@ -4697,19 +4792,20 @@ fn unused_module_members(context: &mut Context, mident: &ModuleIdent_, mdef: &T:
         return;
     }
 
-    let is_iota_mode = context.env.package_config(mdef.package_name).flavor == Flavor::Iota;
-    context.push_warning_filter_scope(mdef.warning_filter);
+    let mut reporter = env.diagnostic_reporter_at_top_level();
+    let is_iota_mode = env.package_config(mdef.package_name).flavor == Flavor::Iota;
+    reporter.push_warning_filter_scope(mdef.warning_filter);
 
     for (loc, name, c) in &mdef.constants {
-        context.push_warning_filter_scope(c.warning_filter);
+        reporter.push_warning_filter_scope(c.warning_filter);
 
-        let members = context.used_module_members.get(mident);
+        let members = used_module_members.get(mident);
         if members.is_none() || !members.unwrap().contains(name) {
             let msg = format!("The constant '{name}' is never used. Consider removing it.");
-            context.add_diag(diag!(UnusedItem::Constant, (loc, msg)))
+            reporter.add_diag(diag!(UnusedItem::Constant, (loc, msg)))
         }
 
-        context.pop_warning_filter_scope();
+        reporter.pop_warning_filter_scope();
     }
 
     for (loc, name, fun) in &mdef.functions {
@@ -4725,9 +4821,9 @@ fn unused_module_members(context: &mut Context, mident: &ModuleIdent_, mdef: &T:
             // an IOTA-specific filter to avoid signaling that the init function is unused
             continue;
         }
-        context.push_warning_filter_scope(fun.warning_filter);
+        reporter.push_warning_filter_scope(fun.warning_filter);
 
-        let members = context.used_module_members.get(mident);
+         let members = used_module_members.get(mident);
         if fun.entry.is_none()
             && matches!(fun.visibility, Visibility::Internal)
             && (members.is_none() || !members.unwrap().contains(name))
@@ -4738,10 +4834,10 @@ fn unused_module_members(context: &mut Context, mident: &ModuleIdent_, mdef: &T:
                 "The non-'public', non-'entry' function '{name}' is never called. \
                 Consider removing it."
             );
-            context.add_diag(diag!(UnusedItem::Function, (loc, msg)))
+            reporter.add_diag(diag!(UnusedItem::Function, (loc, msg)))
         }
-        context.pop_warning_filter_scope();
+        reporter.pop_warning_filter_scope();
     }
 
-    context.pop_warning_filter_scope();
+    reporter.pop_warning_filter_scope();
 }


### PR DESCRIPTION
# Description of change

Parallelize typing in move-compiler

- Final results with this lock-based approach on join yielded about a 5%
improvement in total build time, which isn't bad considering a lot of
that time is dominated by the package system.

According to [changes](https://github.com/MystenLabs/sui/commit/44ab76d89b674f21f4919e0eab13eaba04aa9e00).

## Links to any relevant issues

Fixes #8260 .

## How the change has been tested

For initial breaking changes check run
`cargo b` in external-crates/move-compiler