### PR TITLE
chore(graphql-rpc): update docs about epoch.validatorSet

### DIFF
--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -1155,6 +1155,9 @@ type Epoch {
 	referenceGasPrice: BigInt
 	"""
 	Validator related properties, including the active validators.
+	
+	For epochs other than the current the data provided refer to the start
+	of the epoch.
 	"""
 	validatorSet: ValidatorSet
 	"""
@@ -4754,17 +4757,18 @@ type Validator {
 	"""
 	poolTokenBalance: BigInt
 	"""
-	Pending stake amount for this epoch.
+	Pending stake amount for the current epoch, emptied at epoch boundaries.
+	Zero for past epochs.
 	"""
 	pendingStake: BigInt
 	"""
 	Pending stake withdrawn during the current epoch, emptied at epoch
-	boundaries.
+	boundaries. Zero for past epochs.
 	"""
 	pendingTotalIotaWithdraw: BigInt
 	"""
 	Pending pool token withdrawn during the current epoch, emptied at epoch
-	boundaries.
+	boundaries. Zero for past epochs.
 	"""
 	pendingPoolTokenWithdraw: BigInt
 	"""

--- a/crates/iota-graphql-rpc/src/types/epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/epoch.rs
@@ -65,6 +65,9 @@ impl Epoch {
     }
 
     /// Validator related properties, including the active validators.
+    ///
+    /// For epochs other than the current the data provided refer to the start
+    /// of the epoch.
     async fn validator_set(&self, ctx: &Context<'_>) -> Result<Option<ValidatorSet>> {
         let system_state = ctx
             .data_unchecked::<PgManager>()

--- a/crates/iota-graphql-rpc/src/types/validator.rs
+++ b/crates/iota-graphql-rpc/src/types/validator.rs
@@ -298,13 +298,14 @@ impl Validator {
         Some(BigInt::from(self.validator_summary.pool_token_balance))
     }
 
-    /// Pending stake amount for this epoch.
+    /// Pending stake amount for the current epoch, emptied at epoch boundaries.
+    /// Zero for past epochs.
     async fn pending_stake(&self) -> Option<BigInt> {
         Some(BigInt::from(self.validator_summary.pending_stake))
     }
 
     /// Pending stake withdrawn during the current epoch, emptied at epoch
-    /// boundaries.
+    /// boundaries. Zero for past epochs.
     async fn pending_total_iota_withdraw(&self) -> Option<BigInt> {
         Some(BigInt::from(
             self.validator_summary.pending_total_iota_withdraw,
@@ -312,7 +313,7 @@ impl Validator {
     }
 
     /// Pending pool token withdrawn during the current epoch, emptied at epoch
-    /// boundaries.
+    /// boundaries. Zero for past epochs.
     async fn pending_pool_token_withdraw(&self) -> Option<BigInt> {
         Some(BigInt::from(
             self.validator_summary.pending_pool_token_withdraw,

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1159,6 +1159,9 @@ type Epoch {
 	referenceGasPrice: BigInt
 	"""
 	Validator related properties, including the active validators.
+	
+	For epochs other than the current the data provided refer to the start
+	of the epoch.
 	"""
 	validatorSet: ValidatorSet
 	"""
@@ -4758,17 +4761,18 @@ type Validator {
 	"""
 	poolTokenBalance: BigInt
 	"""
-	Pending stake amount for this epoch.
+	Pending stake amount for the current epoch, emptied at epoch boundaries.
+	Zero for past epochs.
 	"""
 	pendingStake: BigInt
 	"""
 	Pending stake withdrawn during the current epoch, emptied at epoch
-	boundaries.
+	boundaries. Zero for past epochs.
 	"""
 	pendingTotalIotaWithdraw: BigInt
 	"""
 	Pending pool token withdrawn during the current epoch, emptied at epoch
-	boundaries.
+	boundaries. Zero for past epochs.
 	"""
 	pendingPoolTokenWithdraw: BigInt
 	"""


### PR DESCRIPTION
# Description of change

Updates GraphQL docs to be more precise about epoch information returned for active validators in past epochs.

## Links to any relevant issues

Resolves #8210

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

