### PR TITLE
fix(external-crates/move-vm-runtime): allow references to flow in and out of entrypoints

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
@@ -31,7 +31,7 @@ use smallvec::SmallVec;
 use tracing::error;
 
 use crate::{
-    close_frame, close_initial_frame, close_instruction,
+    close_frame, close_initial_native_frame, close_instruction,
     loader::{Function, Loader, Resolver},
     native_extensions::NativeContextExtensions,
     native_functions::NativeContext,
@@ -151,7 +151,7 @@ impl Interpreter {
                         .finish(Location::Module(function.module_id().clone()))
                 });
 
-            close_initial_frame!(tracer, &function, &return_values, gas_meter);
+            close_initial_native_frame!(tracer, &function, &return_values, gas_meter);
 
             Ok(return_values?.into_iter().collect())
         } else {

--- a/external-crates/move/crates/move-vm-runtime/src/tracing2/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/tracing2/mod.rs
@@ -30,11 +30,11 @@ macro_rules! open_initial_frame {
 }
 
 #[macro_export]
-macro_rules! close_initial_frame {
+macro_rules! close_initial_native_frame {
     ($tracer: expr, $function: expr, $return_values: expr, $gas_meter: expr) => {
         if $crate::tracing2::TRACING_ENABLED {
             $tracer.as_mut().map(|tracer| {
-                tracer.close_initial_frame($return_values, $gas_meter.remaining_gas().into())
+                tracer.close_initial_native_frame($return_values, $gas_meter.remaining_gas().into())
             });
             move_vm_profiler::profile_close_frame!($gas_meter, $function.pretty_string());
         }

--- a/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
@@ -413,6 +413,34 @@ impl VMTracer<'_> {
             .expect("Link context always set by this point")
     }
 
+    /// Load global data into the tracer state returning back the `TraceValue` and the `TraceIndex`
+    /// of the load (suitable for use in global locations).
+    fn emit_data_load(&mut self, value: MoveValue, ref_type: &RefType) -> (TraceIndex, TraceValue) {
+        // We treat any references coming out of a native as global reference.
+        // This generally works fine as long as you don't have a native function returning a
+        // mutable reference within a mutable reference passed-in.
+        let id = self.trace.current_trace_offset();
+
+        let location = RuntimeLocation::Global(id);
+
+        self.trace.effect(EF::DataLoad(DataLoad {
+            ref_type: ref_type.clone(),
+            location: location.as_trace_location(),
+            snapshot: value.clone(),
+        }));
+        let trace_value = match ref_type {
+            RefType::Imm => TraceValue::ImmRef {
+                location: location.as_trace_location(),
+                snapshot: Box::new(value),
+            },
+            RefType::Mut => TraceValue::MutRef {
+                location: location.as_trace_location(),
+                snapshot: Box::new(value),
+            },
+        };
+        (id, trace_value)
+    }
+
     /// Load data returned by a native function into the tracer state.
     /// We also emit a data load event for the data loaded from the native function.
     fn load_data(
@@ -426,31 +454,10 @@ impl VMTracer<'_> {
         let Some(ref_type) = reftype else {
             return None;
         };
+        let (trace_index, trace_value) = self.emit_data_load(value, ref_type);
 
-        // We treat any references coming out of a native as global reference.
-        // This generally works fine as long as you don't have a native function returning a
-        // mutable reference within a mutable reference passed-in.
-        let id = self.trace.current_trace_offset();
-
-        let location = RuntimeLocation::Global(id);
-
-        self.trace.effect(EF::DataLoad(DataLoad {
-            ref_type: ref_type.clone(),
-            location: location.as_trace_location(),
-            snapshot: value.clone(),
-        }));
-        let trace_value = match &ref_type {
-            RefType::Imm => TraceValue::ImmRef {
-                location: location.as_trace_location(),
-                snapshot: Box::new(value),
-            },
-            RefType::Mut => TraceValue::MutRef {
-                location: location.as_trace_location(),
-                snapshot: Box::new(value),
-            },
-        };
-        self.loaded_data.insert(id, trace_value);
-        Some((ref_type.clone(), location))
+        self.loaded_data.insert(trace_index, trace_value);
+        Some((ref_type.clone(), RuntimeLocation::Global(trace_index)))
     }
 
     /// Handle (and load) any data returned by a native function.
@@ -496,6 +503,7 @@ impl VMTracer<'_> {
         let function_type_info = FunctionTypeInfo::new(function, loader, ty_args, link_context)?;
 
         assert!(function_type_info.local_types.len() == function.local_count());
+        let start_trace_index = self.trace.current_trace_offset();
 
         let call_args: Vec<_> = args
             .iter()
@@ -503,8 +511,14 @@ impl VMTracer<'_> {
             .map(|(value, tag_with_layout_info_opt)| {
                 let (layout, ref_type) = tag_with_layout_info_opt.layout;
                 let move_value = value.as_annotated_move_value_for_tracing_only(&layout?)?;
-                assert!(ref_type.is_none());
-                Some(TraceValue::RuntimeValue { value: move_value })
+                match ref_type {
+                    Some(ref_type) => {
+                        let (id, trace_value) = self.emit_data_load(move_value, &ref_type);
+                        self.loaded_data.insert(id, trace_value.clone());
+                        Some(trace_value)
+                    }
+                    None => Some(TraceValue::RuntimeValue { value: move_value }),
+                }
             })
             .collect::<Option<_>>()?;
 
@@ -512,14 +526,23 @@ impl VMTracer<'_> {
             .local_types
             .iter()
             .cloned()
-            .map(|tag_with_layout_info_opt| {
+            .enumerate()
+            .map(|(i, tag_with_layout_info_opt)| {
                 let (layout, ref_type) = tag_with_layout_info_opt.layout;
                 LocalType {
                     layout,
                     ref_type: ref_type
-                        .map(|r_type| match r_type {
-                            RefType::Imm => ReferenceType::Empty { ref_type: r_type },
-                            RefType::Mut => ReferenceType::Empty { ref_type: r_type },
+                        .map(|r_type| {
+                            let possible_location = start_trace_index + i;
+                            if self.loaded_data.contains_key(&possible_location) {
+                                let location = RuntimeLocation::Global(possible_location);
+                                ReferenceType::Filled {
+                                    ref_type: r_type,
+                                    location,
+                                }
+                            } else {
+                                ReferenceType::Empty { ref_type: r_type }
+                            }
                         })
                         .unwrap_or(ReferenceType::Value),
                 }
@@ -560,7 +583,11 @@ impl VMTracer<'_> {
         Some(())
     }
 
-    fn close_initial_frame_(&mut self, return_values: &[Value], remaining_gas: u64) -> Option<()> {
+    fn close_initial_native_frame_(
+        &mut self,
+        return_values: &[Value],
+        remaining_gas: u64,
+    ) -> Option<()> {
         let current_frame_return_tys = self.current_frame()?.return_types.clone();
         let return_values: Vec<_> = return_values
             .iter()
@@ -568,8 +595,14 @@ impl VMTracer<'_> {
             .map(|(value, tag_with_layout_info_opt)| {
                 let (layout, ref_type) = tag_with_layout_info_opt.layout;
                 let move_value = value.as_annotated_move_value_for_tracing_only(&layout?)?;
-                assert!(ref_type.is_none());
-                Some(TraceValue::RuntimeValue { value: move_value })
+                match ref_type {
+                    Some(ref_type) => {
+                        let (id, trace_value) = self.emit_data_load(move_value, &ref_type);
+                        self.loaded_data.insert(id, trace_value.clone());
+                        Some(trace_value)
+                    }
+                    None => Some(TraceValue::RuntimeValue { value: move_value }),
+                }
             })
             .collect::<Option<_>>()?;
         self.trace.close_frame(
@@ -1555,7 +1588,7 @@ impl<'a> VMTracer<'a> {
         self.emit_trace_error_if_err(opt.is_none());
     }
 
-    pub(crate) fn close_initial_frame(
+    pub(crate) fn close_initial_native_frame(
         &mut self,
         return_values: &VMResult<SmallVec<[Value; 1]>>,
         remaining_gas: u64,
@@ -1568,7 +1601,7 @@ impl<'a> VMTracer<'a> {
                 return;
             }
         };
-        let opt = self.close_initial_frame_(return_values, remaining_gas);
+        let opt = self.close_initial_native_frame_(return_values, remaining_gas);
         self.emit_trace_error_if_err(opt.is_none());
     }
 


### PR DESCRIPTION
# Description of change

Fixes a bug that was found during the implementation of the tracer for PTBs. In
particular tracing never allowed/accounted for external references being
able to flow into- and out-of entrypoints (and native entrypoints). This
fixes this problem by issuing global data loads in the trace + recording
the proper value fills in locals in the frame for external references.

This also renames the function/macro `close_initial_frame` to
`close_initial_native_frame` as this function is only called in the case
where the entrypoint is a native function. Otherwise the normal
`close_frame` is called.

According to [changes](https://github.com/MystenLabs/sui/commit/9bbad2bbbe35538142fed7919eb5c85b368a6b74#diff-4bb1dd9124603745159b75afc551c1d177edb1b8e5ab5d368b209fba2709a0c2)


## Links to any relevant issues

Fixes #8259  .
