### PR TITLE
feat(verifier): add verify_authenticate_param_type

### DIFF
--- a/account_auth_example/sources/account_auth_example.move
+++ b/account_auth_example/sources/account_auth_example.move
@@ -1,4 +1,4 @@
-module account_auth_example::m;
+module account_auth_example::main_m;
 
 // temporary placeholder
 public struct AuthContext has drop {}
@@ -24,29 +24,8 @@ public fun auth_context_isnt_struct(_auth_ctx: u64, _ctx: &TxContext) {}
 
 public fun tx_context_isnt_struct(_auth_ctx: &AuthContext, _ctx: u64) {}
 
-public struct Object has key {
-    id: iota::object::UID,
-}
-
-public fun arg_immutable_ref(_object: &Object, _auth_ctx: &AuthContext, _ctx: &TxContext) {}
-
 public fun arg_value(_val: u8, _auth_ctx: &AuthContext, _ctx: &TxContext) {}
 
 public fun arg_mutable_value(mut _val: u8, _auth_ctx: &AuthContext, _ctx: &TxContext) {}
-
-public fun arg_template<T: drop>(_val: T, _auth_ctx: &AuthContext, _ctx: &TxContext) {}
-
-#[allow(unused_field)]
-public struct Templated<T: drop> has drop {
-    t: T
-}
-
-public fun arg_templated_struct<T: drop>(_val: Templated<T>, _auth_ctx: &AuthContext, _ctx: &TxContext) {}
-
-public struct Drop has drop {}
-
-public fun with_vector(_data: vector<Drop>, _auth_ctx: &AuthContext, _ctx: &TxContext) {}
-
-public fun with_vector_template<T: drop>(_data: vector<Templated<T>>, _auth_ctx: &AuthContext, _ctx: &TxContext) {}
 
 public fun with_signer(_s: signer, _auth_ctx: &AuthContext, _ctx: &TxContext) {}

--- a/account_auth_example/sources/account_auth_example_object.move
+++ b/account_auth_example/sources/account_auth_example_object.move
@@ -1,0 +1,28 @@
+module account_auth_example::object_m;
+
+// temporary placeholder
+public struct AuthContext has drop {}
+
+public fun bind_to_test_module() {}
+
+// Object
+
+public struct Object has key, store {
+    id: iota::object::UID,
+}
+
+public fun object_immutable_ref_success(
+    _object: &Object,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun object_by_value_fail(object: Object, _auth_ctx: &AuthContext, _ctx: &TxContext) {
+    transfer::public_share_object(object);
+}
+
+public fun object_by_mutable_ref_fail(
+    _object: &mut Object,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}

--- a/account_auth_example/sources/account_auth_example_option.move
+++ b/account_auth_example/sources/account_auth_example_option.move
@@ -1,0 +1,166 @@
+module account_auth_example::option_m;
+
+// temporary placeholder
+public struct AuthContext has drop {}
+
+public fun bind_to_test_module() {}
+
+public struct Object has key, store {
+    id: iota::object::UID,
+}
+
+#[allow(unused_field)]
+public struct ObjectTemplated<T: key + store> has copy, drop, store {
+    t: T,
+}
+
+#[allow(unused_field)]
+public struct NonObjectTemplated<T: copy + drop + store> has copy, drop, store {
+    t: T,
+}
+
+public struct NonObject has copy, drop, store {}
+
+// Option
+
+public fun option_primitive_immutable_reference_success(
+    _arg: &Option<u8>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_primitive_mutable_reference_fail(
+    _arg: &mut Option<u8>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_primitive_by_value_success(
+    _arg: Option<u8>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_non_object_immutable_ref_success(
+    _arg: &Option<NonObject>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_non_object_mutable_ref_fail(
+    _arg: &mut Option<NonObject>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_non_object_by_value_fail(
+    _arg: Option<NonObject>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+// Option and object
+
+public fun option_object_immutable_ref_success(
+    _objects: &Option<Object>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_object_mutable_ref_fail(
+    _objects: &mut Option<Object>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_object_by_value_fail(
+    objects: Option<Object>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {
+    objects.do!(|object| transfer::public_share_object(object));
+}
+
+// Option and template
+
+// error[E06001]: unused value without 'drop'
+//public fun option_template_non_object_by_value_success<T>(
+//    _arg: Option<T>,
+//    _auth_ctx: &AuthContext,
+//    _ctx: &TxContext,
+//) {}
+
+public fun option_template_non_object_immutable_ref_success<T>(
+    _arg: &Option<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_template_non_object_mutable_ref_fail<T>(
+    _arg: &mut Option<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_templated_non_object_by_value_fail<T: copy + drop + store>(
+    _arg: Option<NonObjectTemplated<T>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_templated_non_object_immutable_ref_success<T: copy + drop + store>(
+    _arg: &Option<NonObjectTemplated<T>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_templated_non_object_mutable_ref_fail<T: copy + drop + store>(
+    _arg: &mut Option<NonObjectTemplated<T>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+// Option, template and object
+
+public fun option_template_object_immutable_reference_success<T: key>(
+    _objects: &Option<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_template_object_by_value_fail<T: key + store>(
+    objects: Option<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {
+    objects.do!(|object| transfer::public_share_object(object));
+}
+
+public fun option_template_object_mutable_reference_fail<T: key>(
+    _objects: &mut Option<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_templated_object_immutable_ref_success<T: key + store>(
+    _objects: &Option<ObjectTemplated<T>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun option_templated_object_by_value_fail<T: key + store>(
+    objects: Option<ObjectTemplated<T>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {
+    objects.do!(|object| {
+        let ObjectTemplated { t } = object;
+        transfer::public_share_object(t);
+    });
+}
+
+public fun option_templated_object_mutable_ref_fail<T: key + store>(
+    _objects: &mut Option<ObjectTemplated<T>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}

--- a/account_auth_example/sources/account_auth_example_template.move
+++ b/account_auth_example/sources/account_auth_example_template.move
@@ -1,0 +1,89 @@
+module account_auth_example::template_m;
+
+// temporary placeholder
+public struct AuthContext has drop {}
+
+public fun bind_to_test_module() {}
+
+public struct Object has key, store {
+    id: iota::object::UID,
+}
+
+// Template
+
+#[allow(unused_field)]
+public struct NonObjectTemplated<T: copy + drop + store> has copy, drop, store {
+    t: T,
+}
+
+public fun template_primitive_success<T: copy + drop + store>(
+    _arg: T,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun templated_non_object_immutable_ref_success<T: copy + drop + store>(
+    _arg: &NonObjectTemplated<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun templated_non_object_mutable_ref_fail<T: copy + drop + store>(
+    _arg: &mut NonObjectTemplated<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun templated_non_object_by_value_fail<T: copy + drop + store>(
+    _arg: NonObjectTemplated<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+// Template and object
+
+public fun template_object_immutable_ref_success<T: key>(
+    _object: &T,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun template_object_by_value_fail<T: key + store>(
+    object: T,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {
+    transfer::public_share_object(object);
+}
+
+public fun template_object_mutable_ref_fail<T: key>(
+    _object: &mut T,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+#[allow(unused_field)]
+public struct ObjectTemplated<T: key + store> has copy, drop, store {
+    t: T,
+}
+
+public fun templated_object_immutable_ref_success<T: key + store>(
+    _object: &ObjectTemplated<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun templated_object_by_value_fail<T: key + store>(
+    object: ObjectTemplated<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {
+    let ObjectTemplated { t } = object;
+    transfer::public_share_object(t);
+}
+
+public fun templated_object_mutable_ref_fail<T: key + store>(
+    _object: &mut ObjectTemplated<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}

--- a/account_auth_example/sources/account_auth_example_vector.move
+++ b/account_auth_example/sources/account_auth_example_vector.move
@@ -1,0 +1,166 @@
+module account_auth_example::vector_m;
+
+// temporary placeholder
+public struct AuthContext has drop {}
+
+public fun bind_to_test_module() {}
+
+public struct Object has key, store {
+    id: iota::object::UID,
+}
+
+#[allow(unused_field)]
+public struct ObjectTemplated<T: key + store> has copy, drop, store {
+    t: T,
+}
+
+#[allow(unused_field)]
+public struct NonObjectTemplated<T: copy + drop + store> has copy, drop, store {
+    t: T,
+}
+
+public struct NonObject has copy, drop, store {}
+
+// Vector
+
+public fun vector_primitive_immutable_reference_success(
+    _arg: &vector<u8>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_primitive_mutable_reference_fail(
+    _arg: &mut vector<u8>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_primitive_by_value_success(
+    _arg: vector<u8>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_non_object_immutable_ref_success(
+    _arg: &vector<NonObject>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_non_object_mutable_ref_fail(
+    _arg: &mut vector<NonObject>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_non_object_by_value_fail(
+    _arg: vector<NonObject>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+// Vector and object
+
+public fun vector_object_immutable_ref_success(
+    _objects: &vector<Object>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_object_mutable_ref_fail(
+    _objects: &mut vector<Object>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_object_by_value_fail(
+    objects: vector<Object>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {
+    objects.do!(|object| transfer::public_share_object(object));
+}
+
+// Vector and template
+
+// error[E06001]: unused value without 'drop'
+//public fun vector_template_non_object_by_value_success<T>(
+//    _arg: vector<T>,
+//    _auth_ctx: &AuthContext,
+//    _ctx: &TxContext,
+//) {}
+
+public fun vector_template_non_object_immutable_ref_success<T>(
+    _arg: &vector<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_template_non_object_mutable_ref_fail<T>(
+    _arg: &mut vector<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_templated_non_object_by_value_fail<T: copy + drop + store>(
+    _arg: vector<NonObjectTemplated<T>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_templated_non_object_immutable_ref_success<T: copy + drop + store>(
+    _arg: &vector<NonObjectTemplated<T>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_templated_non_object_mutable_ref_fail<T: copy + drop + store>(
+    _arg: &mut vector<NonObjectTemplated<T>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+// Vector, template and object
+
+public fun vector_template_object_immutable_reference_success<T: key>(
+    _objects: &vector<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_template_object_by_value_fail<T: key + store>(
+    objects: vector<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {
+    objects.do!(|object| transfer::public_share_object(object));
+}
+
+public fun vector_template_object_mutable_reference_fail<T: key>(
+    _objects: &mut vector<T>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_templated_object_immutable_ref_success<T: key + store>(
+    _objects: &vector<ObjectTemplated<T>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+public fun vector_templated_object_by_value_fail<T: key + store>(
+    objects: vector<ObjectTemplated<T>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {
+    objects.do!(|object| {
+        let ObjectTemplated { t } = object;
+        transfer::public_share_object(t);
+    });
+}
+
+public fun vector_templated_object_mutable_ref_fail<T: key + store>(
+    _objects: &mut vector<ObjectTemplated<T>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}

--- a/account_auth_example/tests/account_auth_example_tests.move
+++ b/account_auth_example/tests/account_auth_example_tests.move
@@ -1,118 +1,673 @@
-
 #[test_only]
 module account_auth_example::account_auth_example_tests;
 
-use account_auth_example::m;
-use std::ascii;
+use account_auth_example::main_m;
+use account_auth_example::object_m;
+use account_auth_example::option_m;
+use account_auth_example::template_m;
+use account_auth_example::vector_m;
 use iota::account;
+use std::ascii;
 
 #[test]
 fun bind_to_test_module() {
     // This is necessary to force the move compiler in including the
     // account_auth_example::m in the test module.
-    // Without this call, the main module won't be available from the test module
+    // Without this call, the main_m module won't be available from the test module
     // making all the test fail outright, because the functions weren't found.
-    m::bind_to_test_module();
+    main_m::bind_to_test_module();
+    object_m::bind_to_test_module();
+    template_m::bind_to_test_module();
+    vector_m::bind_to_test_module();
+    option_m::bind_to_test_module();
 }
 
 #[test]
 fun test_minimally_viable_auth_function() {
-    let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"minimally_viable_auth_function"));
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"main_m"),
+        ascii::string(b"minimally_viable_auth_function"),
+    );
     account::drop_auth_info_v1(account_info);
 }
 
 #[test, expected_failure]
 fun has_to_be_public_auth_function() {
-    let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"has_to_be_public_auth_function"));
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"main_m"),
+        ascii::string(b"has_to_be_public_auth_function"),
+    );
     account::drop_auth_info_v1(account_info);
 }
 
 #[test, expected_failure]
 fun crate_auth_at_least_two_args() {
-    let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"crate_auth_at_least_two_args"));
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"main_m"),
+        ascii::string(b"crate_auth_at_least_two_args"),
+    );
     account::drop_auth_info_v1(account_info);
 }
 
 #[test, expected_failure]
 fun crate_auth_auth_context_cant_be_value() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"crate_auth_auth_context_cant_be_value"));
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"main_m"),
+        ascii::string(b"crate_auth_auth_context_cant_be_value"),
+    );
     account::drop_auth_info_v1(account_info);
 }
 
 #[test, expected_failure]
 fun auth_context_cant_be_mutable_ref() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"auth_context_cant_be_mutable_ref"));
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"main_m"),
+        ascii::string(b"auth_context_cant_be_mutable_ref"),
+    );
     account::drop_auth_info_v1(account_info);
 }
 
 #[test, expected_failure]
 fun tx_context_cant_be_value() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"tx_context_cant_be_value"));
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"main_m"),
+        ascii::string(b"tx_context_cant_be_value"),
+    );
     account::drop_auth_info_v1(account_info);
 }
 
 #[test, expected_failure]
 fun tx_context_cant_be_mutable_ref() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"tx_context_cant_be_mutable_ref"));
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"main_m"),
+        ascii::string(b"tx_context_cant_be_mutable_ref"),
+    );
     account::drop_auth_info_v1(account_info);
 }
 
 #[test, expected_failure]
 fun auth_context_isnt_struct() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"auth_context_isnt_struct"));
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"main_m"),
+        ascii::string(b"auth_context_isnt_struct"),
+    );
     account::drop_auth_info_v1(account_info);
 }
 
 #[test, expected_failure]
 fun tx_context_isnt_struct() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"tx_context_is_struct"));
-    account::drop_auth_info_v1(account_info);
-}
-
-#[test]
-fun arg_immutable_ref() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"arg_immutable_ref"));
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"main_m"),
+        ascii::string(b"tx_context_is_struct"),
+    );
     account::drop_auth_info_v1(account_info);
 }
 
 #[test]
 fun arg_value() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"arg_value"));
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"main_m"),
+        ascii::string(b"arg_value"),
+    );
     account::drop_auth_info_v1(account_info);
 }
 
 #[test]
 fun arg_mutable_value() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"arg_mutable_value"));
-    account::drop_auth_info_v1(account_info);
-}
-
-#[test]
-fun arg_template() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"arg_template"));
-    account::drop_auth_info_v1(account_info);
-}
-
-#[test]
-fun arg_templated_struct() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"arg_templated_struct"));
-    account::drop_auth_info_v1(account_info);
-}
-
-#[test]
-fun with_vector() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"with_vector"));
-    account::drop_auth_info_v1(account_info);
-}
-
-#[test]
-fun with_vector_template() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"with_vector_template"));
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"main_m"),
+        ascii::string(b"arg_mutable_value"),
+    );
     account::drop_auth_info_v1(account_info);
 }
 
 #[test, expected_failure]
 fun with_signer() {
-   let account_info = account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"with_signer"));
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"main_m"),
+        ascii::string(b"with_signer"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"object_m"),
+        ascii::string(b"object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"object_m"),
+        ascii::string(b"object_by_value_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun object_by_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"object_m"),
+        ascii::string(b"object_by_mutable_ref_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun template_primitive_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"template_m"),
+        ascii::string(b"template_primitive_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun templated_non_object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"template_m"),
+        ascii::string(b"templated_non_object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun templated_non_object_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"template_m"),
+        ascii::string(b"templated_non_object_mutable_ref_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun templated_non_object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"template_m"),
+        ascii::string(b"templated_non_object_by_value_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun template_object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"template_m"),
+        ascii::string(b"template_object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun template_object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"template_m"),
+        ascii::string(b"template_object_by_value_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun template_object_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"template_m"),
+        ascii::string(b"template_object_mutable_ref_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun templated_object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"template_m"),
+        ascii::string(b"templated_object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun templated_object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"template_m"),
+        ascii::string(b"templated_object_by_value_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun templated_object_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"template_m"),
+        ascii::string(b"templated_object_mutable_ref_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun vector_primitive_immutable_reference_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_primitive_immutable_reference_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun vector_primitive_mutable_reference_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_primitive_mutable_reference_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun vector_primitive_by_value_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_primitive_by_value_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun vector_non_object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_non_object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun vector_non_object_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_non_object_mutable_ref_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun vector_non_object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_non_object_by_value_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun vector_object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun vector_object_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_object_mutable_ref_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun vector_object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_object_by_value_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun vector_template_non_object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_template_non_object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun vector_template_non_object_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_template_non_object_mutable_ref_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun vector_templated_non_object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_templated_non_object_by_value_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun vector_templated_non_object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_templated_non_object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun vector_templated_non_object_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_templated_non_object_mutable_ref_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun vector_template_object_immutable_reference_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_template_object_immutable_reference_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun vector_template_object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_template_object_by_value_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun vector_template_object_mutable_reference_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_template_object_mutable_reference_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun vector_templated_object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_templated_object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun vector_templated_object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_templated_object_by_value_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun vector_templated_object_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"vector_m"),
+        ascii::string(b"vector_templated_object_mutable_ref_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun option_primitive_immutable_reference_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_primitive_immutable_reference_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun option_primitive_mutable_reference_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_primitive_mutable_reference_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun option_primitive_by_value_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_primitive_by_value_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun option_non_object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_non_object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun option_non_object_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_non_object_mutable_ref_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun option_non_object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_non_object_by_value_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun option_object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun option_object_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_object_mutable_ref_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun option_object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_object_by_value_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun option_template_non_object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_template_non_object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun option_template_non_object_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_template_non_object_mutable_ref_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun option_templated_non_object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_templated_non_object_by_value_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun option_templated_non_object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_templated_non_object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun option_templated_non_object_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_templated_non_object_mutable_ref_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun option_template_object_immutable_reference_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_template_object_immutable_reference_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun option_template_object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_template_object_by_value_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun option_template_object_mutable_reference_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_template_object_mutable_reference_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test]
+fun option_templated_object_immutable_ref_success() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_templated_object_immutable_ref_success"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun option_templated_object_by_value_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_templated_object_by_value_fail"),
+    );
+    account::drop_auth_info_v1(account_info);
+}
+
+#[test, expected_failure]
+fun option_templated_object_mutable_ref_fail() {
+    let account_info = account::create_auth_info_v1(
+        @0x0,
+        ascii::string(b"option_m"),
+        ascii::string(b"option_templated_object_mutable_ref_fail"),
+    );
     account::drop_auth_info_v1(account_info);
 }

--- a/iota-execution/latest/iota-verifier/src/account_auth_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/account_auth_verifier.rs
@@ -156,7 +156,7 @@ pub fn verify_authenticate_func(
 ///       `T` -> this is not allowed by design, as an authenticate function has
 ///       no returns;
 ///    2. not use the `<T: drop>` constraint but the `<T: key>` constraint ->
-///       this is not allowed by this verify funciton;
+///       this is not allowed by this verify function;
 ///    3. use the `<T: drop>` constraint -> this means no object type can be
 ///       used as concrete type because an object with `drop` ability cannot
 ///       exist.

--- a/iota-execution/latest/iota-verifier/src/account_auth_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/account_auth_verifier.rs
@@ -129,61 +129,42 @@ pub fn verify_authenticate_func(
     Ok(())
 }
 
-/// ************ FOR DEMONSTRATION PURPOSES ONLY ***********************
-
-// Below is the "implementation" of the checks that the above [verify_authenticate_func]
-// should perform.
-// This does not seem to be feasible at the moment, because the appropriate
-// type_args/[TypeTag](move-core-types::TypeTag) are not available to this scope.
-// The native function [create_auth_info_v1_impl] calling [verify_authenticate_func], does have
-// a set of type_args but those are for its context and not for the passed in `authenticate`
-// function.
-//
-// On the callsite:
-// ```
-// account::create_auth_info_v1(@0x0, ascii::string(b"m"), ascii::string(b"minimally_viable_auth_function"))
-// ```
-//
-// There is nothing we know about the exact types of the referred by the authenticate function.
-// Let us assume we can load the code containing this function for this verification step and
-// further assume that it is some templated type.
-//
-// ```
-// pub fn authenticate<T>(v: T, auth_ctx: &AuthContext, ctx: &TxContext)
-// ```
-/// The verifier can check the signature of this function as it appears in
-/// CompiledModule, by the templated type, in this case `T`, denoted as
-/// `TypeParameter`. It doesn't actually know what type is there, because this
-/// is not known during compilation, thus it isn't part of CompiledModule.
-/// Only during execution when the transaction's call-chain is initiated do we
-/// receive this additional context through
-/// the [TypeTag](move-core-types::TypeTag) arguments.
-///
-/// Another higher level example for potentially more clarity:
-/// Context one: Tx -> somewhere inside call create_auth_info_v1 and attach the
-/// function to the object, here verifier has only access to the CompiledModule
-/// for the referred function Context two: Tx -> call authenticate (as part of
-/// the process), here we have all the additional type information
-///
-/// For an example how all this comes together take a look at [resolve_call_arg](https://github.com/iotaledger/iota/blob/2f7e29c18b6b986cc795e068d135f4b46732f992/crates/iota-json/src/lib.rs#L698) which is called when a function is move function called.
-
-/// Returns `true` if [SignatureToken] is a primitive type
-#[warn(dead_code)]
-fn primitive(st: &SignatureToken) -> bool {
-    use SignatureToken::*;
-
-    matches!(st, U8 | U16 | U32 | U64 | U128 | U256 | Bool | Address)
-}
-
 /// Evaluate that signature type is of [pure input](https://docs.iota.org/developer/iota-101/transactions/ptb/programmable-transaction-blocks#inputs)
 ///
-/// A `pure input` is seems to be any type that can't be used to modify ledger
-/// state in any way and can be constructed before calling the function itself.
-/// The ledger state can be modified:
-///     - through `&mut TxContext`
-///     - through `&mut T`
-///     - by publishing (publish_shared) of objects (thus object even as a
-///       value, cannot be used)
+/// ATTENTION!///
+/// This check implements a very loose definition of a pure type, because it is
+/// based on the assumption that the authenticate function is executed
+/// equivalently to a PTB with a single command.
+/// 1. This means that potentially, a parameter of type `T`, with `T` being a
+///    generic, would be accepted by the check of this verify function even if
+///    the instance of `T` is not pure by definition. An example is passing an
+///    instance of the `Simple` as concrete type of T; in this case, `Simple` is
+///    not considered pure. This verify function works as this because it is
+///    executed in a moment in which the concrete types of a generic are not
+///    known. However, since the authenticate function is executed equivalently
+///    to a PTB with a single command, this assures that onpy pure types and
+///    objects can actually be passed by design. So the case of having ´Simple´
+///    as concrete type of `T` cannot exist.
+/// 2. Moreover, this check assures that no object can be passed as concrete
+///    type of a generic `T` because in the constraints of every generic it
+///    checks that the `key` ability is not set. This is not enough because a
+///    case like this could happen `fn authenticate()<T>(...)` where the key
+///    constraint is not set. In this case the compiler helps us by forcing the
+///    `T` concrete type to have a `drop` ability. To calm the compiler down the
+///    function `authenticate` must either:
+///    1. not use the `<T: drop>` constraint and return the parameter with type
+///       `T` -> this is not allowed by design, as an authenticate function has
+///       no returns;
+///    2. not use the `<T: drop>` constraint but the `<T: key>` constraint ->
+///       this is not allowed by this verify funciton;
+///    3. use the `<T: drop>` constraint -> this means no object type can be
+///       used as concrete type because an object with `drop` ability cannot
+///       exist.
+/// ////////////
+///
+/// A parameter is considered `pure input` if that can't be used to modify
+/// ledger state in any way, i.e., not an object, and thatcan be constructed
+/// before calling the function itself.
 ///
 /// A general struct, with no unresolved template arguments:
 /// ```
@@ -192,13 +173,13 @@ fn primitive(st: &SignatureToken) -> bool {
 ///   some_vec: vector<ascii::String>
 /// }
 /// ```
-/// should be also acceptable, but isn't considered a pure_type either as it
-/// isn't a built-in type so it can't be constructed before the call itself. On
+/// is not considered a `pure input` either as it is not a built-in type so it
+/// can't be constructed before the (single) PTB move call itself. On
 /// the contrary std::ascii::String and std::string::String are okay.
 /// On a similar notion a simple `vector<T>` and an `Option<T>` are both also
 /// acceptable as they are built-in move types with rust side counterpart as
 /// long as `T` is recursively `pure` as well.
-fn verify_pure_type(
+fn verify_pure_input_type(
     module: &CompiledModule,
     function_type_args: &[AbilitySet],
     param: &SignatureToken,
@@ -207,7 +188,7 @@ fn verify_pure_type(
 
     match param {
         U8 | U16 | U32 | U64 | U128 | U256 | Bool | Address => Ok(()),
-        Vector(inner) => verify_pure_type(module, function_type_args, inner),
+        Vector(inner) => verify_pure_input_type(module, function_type_args, inner),
         Datatype(handle_index) => {
             let resolved_struct = resolve_struct(module, *handle_index);
             if resolved_struct == RESOLVED_ASCII_STR
@@ -226,7 +207,7 @@ fn verify_pure_type(
             let (idx, type_args) = &**datatype_instance;
             let resolved_struct = resolve_struct(module, *idx);
             if resolved_struct == RESOLVED_STD_OPTION && type_args.len() == 1 {
-                verify_pure_type(module, function_type_args, &type_args[0])
+                verify_pure_input_type(module, function_type_args, &type_args[0])
             } else {
                 Err(format!(
                     "Invalid pure type. A datatype instantiation must be an option of pure types, offending argument: {:?}",
@@ -259,6 +240,10 @@ fn verify_pure_type(
     }
 }
 
+/// Verify that the parameter type is a valid type for an `authenticate`
+/// function The parameter type can be:
+/// - an immutable reference
+/// - a pure input type (see [verify_pure_input_type])
 fn verify_authenticate_param_type(
     module: &CompiledModule,
     function_type_args: &[AbilitySet],
@@ -270,7 +255,7 @@ fn verify_authenticate_param_type(
         Reference(_) => Ok(()),
         // This mutable reference could be allowed to enable a smother authenticate() function
         // composition, but its usage must be checked before being enabled:
-        // MutableReference(inner) => verify_pure_type(module, function_type_args, inner),
-        _ => verify_pure_type(module, function_type_args, param),
+        // MutableReference(inner) => verify_pure_input_type(module, function_type_args, inner),
+        _ => verify_pure_input_type(module, function_type_args, param),
     }
 }

--- a/iota-execution/latest/iota-verifier/src/account_auth_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/account_auth_verifier.rs
@@ -12,13 +12,15 @@
 use iota_types::{
     Identifier,
     auth_context::{AuthContext, AuthContextKind},
-    base_types::{RESOLVED_ASCII_STR, RESOLVED_UTF8_STR, TxContext, TxContextKind},
+    base_types::{
+        RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TxContext, TxContextKind,
+    },
     error::ExecutionError,
     id::RESOLVED_IOTA_ID,
 };
 use move_binary_format::{
     CompiledModule,
-    file_format::{SignatureToken, Visibility},
+    file_format::{AbilitySet, SignatureToken, Visibility},
 };
 use move_bytecode_utils::resolve_struct;
 
@@ -77,20 +79,13 @@ pub fn verify_authenticate_func(
     // Apart from AuthContext and TxContext we only require that the arguments are
     // not mutable references. They can be mutable values, as their mutability
     // cannot affect outside state.
-    for token in function_signature
+    for param in function_signature
         .0
         .iter()
         .take(function_signature.len() - 2)
     {
-        match token {
-            SignatureToken::Signer | SignatureToken::MutableReference(_) => {
-                return Err(verification_failure(format!(
-                    "Authenticator function '{function_identifier}' cannot use mutable references or signers, offending argument: {:?}",
-                    token
-                )));
-            }
-            _ => (),
-        }
+        verify_authenticate_param_type(module, &function_handle.type_parameters, param)
+            .map_err(verification_failure)?;
     }
 
     // Check type of AuthContext and TxContext, they both must be structs with the
@@ -203,30 +198,79 @@ fn primitive(st: &SignatureToken) -> bool {
 /// On a similar notion a simple `vector<T>` and an `Option<T>` are both also
 /// acceptable as they are built-in move types with rust side counterpart as
 /// long as `T` is recursively `pure` as well.
-#[warn(dead_code)]
-fn pure_type(module: &CompiledModule, st: &SignatureToken) -> bool {
+fn verify_pure_type(
+    module: &CompiledModule,
+    function_type_args: &[AbilitySet],
+    param: &SignatureToken,
+) -> Result<(), String> {
     use SignatureToken::*;
 
-    match st {
-        st if primitive(st) => true,
+    match param {
+        U8 | U16 | U32 | U64 | U128 | U256 | Bool | Address => Ok(()),
+        Vector(inner) => verify_pure_type(module, function_type_args, inner),
         Datatype(handle_index) => {
             let resolved_struct = resolve_struct(module, *handle_index);
-            resolved_struct == RESOLVED_ASCII_STR
+            if resolved_struct == RESOLVED_ASCII_STR
                 || resolved_struct == RESOLVED_UTF8_STR
                 || resolved_struct == RESOLVED_IOTA_ID
+            {
+                Ok(())
+            } else {
+                Err(format!(
+                    "Invalid pure type. A datatype must be a string or an ID, offending argument: {:?}",
+                    param
+                ))
+            }
         }
-        // DatatypeInstantiation(datatype_instance) => {
-        //     let (idx, type_tokens) = &**datatype_instance;
-        //     let resolved_struct = resolve_struct(module, *idx);
-        //     // is option of a primitive
-        //     resolved_struct == RESOLVED_STD_OPTION && type_tokens.len() == 1 // && check if type
-        // argument is of pure input }
-        // TypeParameter(idx) =>
-        //     // check if type argument is of pure type
-        // ,
-        // Vector(type_token) => {
-        //     // check if type argument is of pure input
-        // }
-        _ => false,
+        DatatypeInstantiation(datatype_instance) => {
+            let (idx, type_args) = &**datatype_instance;
+            let resolved_struct = resolve_struct(module, *idx);
+            if resolved_struct == RESOLVED_STD_OPTION && type_args.len() == 1 {
+                verify_pure_type(module, function_type_args, &type_args[0])
+            } else {
+                Err(format!(
+                    "Invalid pure type. A datatype instantiation must be an option of pure types, offending argument: {:?}",
+                    param
+                ))
+            }
+        }
+        TypeParameter(idx) => {
+            if function_type_args[*idx as usize].has_key() {
+                Err(format!(
+                    "Invalid pure type. A type parameter cannot have the 'key' ability, offending argument: {:?}",
+                    param
+                ))
+            } else {
+                Ok(())
+            }
+        }
+        Signer => Err(format!(
+            "Invalid pure type. Signer is not a pure type, offending argument: {:?}",
+            param
+        )),
+        Reference(_) => Err(format!(
+            "Invalid pure type. Reference is not a pure type, offending argument: {:?}",
+            param
+        )),
+        MutableReference(_) => Err(format!(
+            "Invalid pure type. MutableReference is not a pure type, offending argument: {:?}",
+            param
+        )),
+    }
+}
+
+fn verify_authenticate_param_type(
+    module: &CompiledModule,
+    function_type_args: &[AbilitySet],
+    param: &SignatureToken,
+) -> Result<(), String> {
+    use SignatureToken::*;
+
+    match param {
+        Reference(_) => Ok(()),
+        // This mutable reference could be allowed to enable a smother authenticate() function
+        // composition, but its usage must be checked before being enabled:
+        // MutableReference(inner) => verify_pure_type(module, function_type_args, inner),
+        _ => verify_pure_type(module, function_type_args, param),
     }
 }


### PR DESCRIPTION
A suggestion to deal with `TypeParameter`. In particular, we can just check that the type has no key ability, i.e., accept abilities just for primitive types https://github.com/iotaledger/iota/blob/dceb64b9ccf364b0438015b0cc3a1540bd9eeeb7/external-crates/move/crates/move-binary-format/src/file_format.rs#L850-L851

Moreover, I added new test cases. Is this now an exhaustive set of tests?
