### PR TITLE
refactor(iota-move-natives): make native extensions falliable

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/native_extensions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/native_extensions.rs
@@ -6,6 +6,8 @@
 use std::{any::TypeId, collections::HashMap};
 
 use better_any::{Tid, TidAble, TidExt};
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::vm_status::StatusCode;
 
 /// A data type to represent a heterogeneous collection of extensions which are
 /// available to native functions. A value to this is passed into the session
@@ -30,35 +32,50 @@ impl<'a> NativeContextExtensions<'a> {
         )
     }
 
-    pub fn get<T: TidAble<'a>>(&self) -> &T {
+    pub fn get<T: TidAble<'a>>(&self) -> PartialVMResult<&T> {
         self.map
             .get(&T::id())
-            .expect("extension unknown")
-            .as_ref()
-            .downcast_ref::<T>()
-            .unwrap()
+            .ok_or_else(|| {
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("native extension not found".to_string())
+            })
+            .and_then(|t| {
+                t.as_ref().downcast_ref::<T>().ok_or_else(|| {
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message("downcast error".to_string())
+                })
+            })
     }
 
-    pub fn get_mut<T: TidAble<'a>>(&mut self) -> &mut T {
+    pub fn get_mut<T: TidAble<'a>>(&mut self) -> PartialVMResult<&mut T> {
         self.map
             .get_mut(&T::id())
-            .expect("extension unknown")
-            .as_mut()
-            .downcast_mut::<T>()
-            .unwrap()
+            .ok_or_else(|| {
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("native extension not found".to_string())
+            })
+            .and_then(|t| {
+                t.as_mut().downcast_mut::<T>().ok_or_else(|| {
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message("downcast error".to_string())
+                })
+            })
     }
 
-    pub fn remove<T: TidAble<'a>>(&mut self) -> T {
+    pub fn remove<T: TidAble<'a>>(&mut self) -> PartialVMResult<T> {
         // can't use expect below because it requires `T: Debug`.
-        match self
-            .map
+        self.map
             .remove(&T::id())
-            .expect("extension unknown")
-            .downcast_box::<T>()
-        {
-            Ok(val) => *val,
-            Err(_) => panic!("downcast error"),
-        }
+            .ok_or_else(|| {
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("native extension not found".to_string())
+            })
+            .and_then(|t| {
+                t.downcast_box::<T>().map(|t| *t).map_err(|_| {
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message("downcast error".to_string())
+                })
+            })
     }
 }
 
@@ -79,10 +96,10 @@ mod tests {
         let e = Ext { a: &mut v };
         let mut exts = NativeContextExtensions::default();
         exts.add(e);
-        *exts.get_mut::<Ext>().a += 1;
-        assert_eq!(*exts.get_mut::<Ext>().a, 24);
-        *exts.get_mut::<Ext>().a += 1;
-        let e1 = exts.remove::<Ext>();
+        *exts.get_mut::<Ext>().unwrap().a += 1;
+        assert_eq!(*exts.get_mut::<Ext>().unwrap().a, 24);
+        *exts.get_mut::<Ext>().unwrap().a += 1;
+        let e1 = exts.remove::<Ext>().unwrap();
         assert_eq!(*e1.a, 25)
     }
 }

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
@@ -237,7 +237,7 @@ mod checked {
             })
         }
 
-         pub fn object_runtime(&self) -> Result<&ObjectRuntime, ExecutionError> {
+        pub fn object_runtime(&self) -> Result<&ObjectRuntime, ExecutionError> {
             self.native_extensions
                 .get::<ObjectRuntime>()
                 .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))
@@ -704,13 +704,9 @@ mod checked {
                 refund_max_gas_budget(&mut additional_writes, gas_charger, gas_id)?;
             }
 
-            let object_runtime: ObjectRuntime = native_extensions.remove().map_err(|e| {
-                convert_vm_error(
-                    e.finish(Location::Undefined),
-                    vm,
-                    &linkage_view,
-                )
-            })?;
+            let object_runtime: ObjectRuntime = native_extensions
+                .remove()
+                .map_err(|e| convert_vm_error(e.finish(Location::Undefined), vm, &linkage_view))?;
 
             let RuntimeResults {
                 writes,

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
@@ -237,25 +237,27 @@ mod checked {
             })
         }
 
-        pub fn object_runtime(&mut self) -> &ObjectRuntime {
-            self.native_extensions.get()
+         pub fn object_runtime(&self) -> Result<&ObjectRuntime, ExecutionError> {
+            self.native_extensions
+                .get::<ObjectRuntime>()
+                .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))
         }
 
         /// Create a new ID and update the state
         pub fn fresh_id(&mut self) -> Result<ObjectID, ExecutionError> {
             let object_id = self.tx_context.fresh_id();
-            let object_runtime: &mut ObjectRuntime = self.native_extensions.get_mut();
-            object_runtime
-                .new_id(object_id)
+            self.native_extensions
+                .get_mut()
+                .and_then(|object_runtime: &mut ObjectRuntime| object_runtime.new_id(object_id))
                 .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))?;
             Ok(object_id)
         }
 
         /// Delete an ID and update the state
         pub fn delete_id(&mut self, object_id: ObjectID) -> Result<(), ExecutionError> {
-            let object_runtime: &mut ObjectRuntime = self.native_extensions.get_mut();
-            object_runtime
-                .delete_id(object_id)
+            self.native_extensions
+                .get_mut()
+                .and_then(|object_runtime: &mut ObjectRuntime| object_runtime.delete_id(object_id))
                 .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))
         }
 
@@ -308,8 +310,11 @@ mod checked {
             function: FunctionDefinitionIndex,
             last_offset: CodeOffset,
         ) -> Result<(), ExecutionError> {
-            let object_runtime: &mut ObjectRuntime = self.native_extensions.get_mut();
-            let events = object_runtime.take_user_events();
+            let events = self
+                .native_extensions
+                .get_mut()
+                .map(|object_runtime: &mut ObjectRuntime| object_runtime.take_user_events())
+                .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))?;
             let num_events = self.user_events.len() + events.len();
             let max_events = self.protocol_config.max_num_event_emit();
             if num_events as u64 > max_events {
@@ -699,7 +704,13 @@ mod checked {
                 refund_max_gas_budget(&mut additional_writes, gas_charger, gas_id)?;
             }
 
-            let object_runtime: ObjectRuntime = native_extensions.remove();
+            let object_runtime: ObjectRuntime = native_extensions.remove().map_err(|e| {
+                convert_vm_error(
+                    e.finish(Location::Undefined),
+                    vm,
+                    &linkage_view,
+                )
+            })?;
 
             let RuntimeResults {
                 writes,

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -107,7 +107,7 @@ mod checked {
             if let Err(err) =
                 execute_command::<Mode>(&mut context, &mut mode_results, command, trace_builder_opt)
             {
-                let object_runtime: &ObjectRuntime = context.object_runtime();
+                let object_runtime: &ObjectRuntime = context.object_runtime()?;
                 // We still need to record the loaded child objects for replay
                 let loaded_runtime_objects = object_runtime.loaded_runtime_objects();
                 // we do not save the wrapped objects since on error, they should not be
@@ -119,7 +119,7 @@ mod checked {
         }
 
         // Save loaded objects table in case we fail in post execution
-        let object_runtime: &ObjectRuntime = context.object_runtime();
+        let object_runtime: &ObjectRuntime = context.object_runtime()?;
         // We still need to record the loaded child objects for replay
         // Record the objects loaded at runtime (dynamic fields + received) for
         // storage rebate calculation.

--- a/iota-execution/latest/iota-move-natives/src/address.rs
+++ b/iota-execution/latest/iota-move-natives/src/address.rs
@@ -36,7 +36,7 @@ pub fn from_bytes(
 
     let address_from_bytes_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .address_from_bytes_cost_params
         .clone();
 
@@ -76,7 +76,7 @@ pub fn to_u256(
 
     let address_to_u256_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .address_to_u256_cost_params
         .clone();
 
@@ -116,7 +116,7 @@ pub fn from_u256(
 
     let address_from_u256_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .address_from_u256_cost_params
         .clone();
 

--- a/iota-execution/latest/iota-move-natives/src/config.rs
+++ b/iota-execution/latest/iota-move-natives/src/config.rs
@@ -44,7 +44,7 @@ pub fn read_setting_impl(
         config_read_setting_impl_cost_per_byte,
     } = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .config_read_setting_impl_cost_params
         .clone();
 
@@ -85,7 +85,7 @@ pub fn read_setting_impl(
             E_BCS_SERIALIZATION_FAILURE,
         ));
     };
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
 
     let read_value_opt = consistent_value_before_current_epoch(
         object_runtime,

--- a/iota-execution/latest/iota-move-natives/src/crypto/bls12381.rs
+++ b/iota-execution/latest/iota-move-natives/src/crypto/bls12381.rs
@@ -60,7 +60,7 @@ pub fn bls12381_min_sig_verify(
     // Load the cost parameters from the protocol config
     let bls12381_bls12381_min_sig_verify_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .bls12381_bls12381_min_sig_verify_cost_params
         .clone();
     // Charge the base cost for this oper
@@ -148,7 +148,7 @@ pub fn bls12381_min_pk_verify(
     // Load the cost parameters from the protocol config
     let bls12381_bls12381_min_pk_verify_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .bls12381_bls12381_min_pk_verify_cost_params
         .clone();
 

--- a/iota-execution/latest/iota-move-natives/src/crypto/ecdsa_k1.rs
+++ b/iota-execution/latest/iota-move-natives/src/crypto/ecdsa_k1.rs
@@ -91,7 +91,7 @@ pub fn ecrecover(
 
     // Load the cost parameters from the protocol config
     let (ecdsa_k1_ecrecover_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>();
+        let cost_table = &context.extensions().get::<NativesCostTable>()?;
         (
             cost_table.ecdsa_k1_ecrecover_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,
@@ -173,7 +173,7 @@ pub fn decompress_pubkey(
     // Load the cost parameters from the protocol config
     let ecdsa_k1_decompress_pubkey_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .ecdsa_k1_decompress_pubkey_cost_params
         .clone();
     // Charge the base cost for this oper
@@ -250,7 +250,7 @@ pub fn secp256k1_verify(
 
     // Load the cost parameters from the protocol config
     let (ecdsa_k1_secp256k1_verify_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>();
+        let cost_table = &context.extensions().get::<NativesCostTable>()?;
         (
             cost_table.ecdsa_k1_secp256k1_verify_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,

--- a/iota-execution/latest/iota-move-natives/src/crypto/ecdsa_r1.rs
+++ b/iota-execution/latest/iota-move-natives/src/crypto/ecdsa_r1.rs
@@ -83,7 +83,7 @@ pub fn ecrecover(
 
     // Load the cost parameters from the protocol config
     let (ecdsa_r1_ecrecover_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>();
+        let cost_table = &context.extensions().get::<NativesCostTable>()?;
         (
             cost_table.ecdsa_r1_ecrecover_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,
@@ -200,7 +200,7 @@ pub fn secp256r1_verify(
     debug_assert!(args.len() == 4);
     // Load the cost parameters from the protocol config
     let (ecdsa_r1_secp256_r1_verify_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>();
+        let cost_table = &context.extensions().get::<NativesCostTable>()?;
         (
             cost_table.ecdsa_r1_secp256_r1_verify_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,

--- a/iota-execution/latest/iota-move-natives/src/crypto/ecvrf.rs
+++ b/iota-execution/latest/iota-move-natives/src/crypto/ecvrf.rs
@@ -63,7 +63,7 @@ pub fn ecvrf_verify(
     // Load the cost parameters from the protocol config
     let ecvrf_ecvrf_verify_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .ecvrf_ecvrf_verify_cost_params
         .clone();
     // Charge the base cost for this oper

--- a/iota-execution/latest/iota-move-natives/src/crypto/ed25519.rs
+++ b/iota-execution/latest/iota-move-natives/src/crypto/ed25519.rs
@@ -57,7 +57,7 @@ pub fn ed25519_verify(
     // Load the cost parameters from the protocol config
     let ed25519_verify_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .ed25519_verify_cost_params
         .clone();
     // Charge the base cost for this oper

--- a/iota-execution/latest/iota-move-natives/src/crypto/groth16.rs
+++ b/iota-execution/latest/iota-move-natives/src/crypto/groth16.rs
@@ -56,7 +56,7 @@ pub fn prepare_verifying_key_internal(
 
     // Load the cost parameters from the protocol config
     let (groth16_prepare_verifying_key_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>();
+        let cost_table = &context.extensions().get::<NativesCostTable>()?;
         (
             cost_table.groth16_prepare_verifying_key_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,
@@ -154,7 +154,7 @@ pub fn verify_groth16_proof_internal(
 
     // Load the cost parameters from the protocol config
     let (groth16_verify_groth16_proof_internal_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>();
+        let cost_table = &context.extensions().get::<NativesCostTable>()?;
         (
             cost_table
                 .groth16_verify_groth16_proof_internal_cost_params
@@ -207,7 +207,7 @@ pub fn verify_groth16_proof_internal(
             context.charge_gas(crypto_invalid_arguments_cost);
             let cost = if context
                 .extensions()
-                .get::<ObjectRuntime>()
+                .get::<ObjectRuntime>()?
                 .protocol_config
                 .native_charging_v2()
             {

--- a/iota-execution/latest/iota-move-natives/src/crypto/group_ops.rs
+++ b/iota-execution/latest/iota-move-natives/src/crypto/group_ops.rs
@@ -29,25 +29,27 @@ pub const NOT_SUPPORTED_ERROR: u64 = 0;
 pub const INVALID_INPUT_ERROR: u64 = 1;
 pub const INPUT_TOO_LONG_ERROR: u64 = 2;
 
-fn is_msm_supported(context: &NativeContext) -> bool {
-    context
+fn is_msm_supported(context: &NativeContext) -> PartialVMResult<bool> {
+    Ok(context
         .extensions()
-        .get::<ObjectRuntime>()
+        .get::<ObjectRuntime>()?
         .protocol_config
-        .enable_group_ops_native_function_msm()
+        .enable_group_ops_native_function_msm())
 }
 
-fn v2_native_charge(context: &NativeContext, cost: InternalGas) -> InternalGas {
-    if context
-        .extensions()
-        .get::<ObjectRuntime>()
-        .protocol_config
-        .native_charging_v2()
-    {
-        context.gas_used()
-    } else {
-        cost
-    }
+fn v2_native_charge(context: &NativeContext, cost: InternalGas) -> PartialVMResult<InternalGas> {
+    Ok(
+        if context
+            .extensions()
+            .get::<ObjectRuntime>()?
+            .protocol_config
+            .native_charging_v2()
+        {
+            context.gas_used()
+        } else {
+            cost
+        },
+    )
 }
 
 fn map_op_result(
@@ -57,24 +59,24 @@ fn map_op_result(
 ) -> PartialVMResult<NativeResult> {
     match result {
         Ok(bytes) => Ok(NativeResult::ok(
-            v2_native_charge(context, cost),
+            v2_native_charge(context, cost)?,
             smallvec![Value::vector_u8(bytes)],
         )),
         // Since all Element<G> are validated on construction, this error should never happen unless
         // the requested type is wrong or inputs are invalid.
         Err(_) => Ok(NativeResult::err(
-            v2_native_charge(context, cost),
+            v2_native_charge(context, cost)?,
             INVALID_INPUT_ERROR,
         )),
     }
 }
 
-fn is_uncompressed_g1_supported(context: &NativeContext) -> bool {
-    context
+fn is_uncompressed_g1_supported(context: &NativeContext) -> PartialVMResult<bool> {
+    Ok(context
         .extensions()
-        .get::<ObjectRuntime>()
+        .get::<ObjectRuntime>()?
         .protocol_config
-        .uncompressed_g1_group_elements()
+        .uncompressed_g1_group_elements())
 }
 
 // Gas related structs and functions.
@@ -232,7 +234,7 @@ pub fn internal_validate(
 
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .group_ops_cost_params
         .clone();
 
@@ -253,7 +255,7 @@ pub fn internal_validate(
     };
 
     Ok(NativeResult::ok(
-        v2_native_charge(context, cost),
+        v2_native_charge(context, cost)?,
         smallvec![Value::bool(result)],
     ))
 }
@@ -283,7 +285,7 @@ pub fn internal_add(
 
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .group_ops_cost_params
         .clone();
 
@@ -335,7 +337,7 @@ pub fn internal_sub(
 
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .group_ops_cost_params
         .clone();
 
@@ -387,7 +389,7 @@ pub fn internal_mul(
 
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .group_ops_cost_params
         .clone();
 
@@ -454,7 +456,7 @@ pub fn internal_div(
 
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .group_ops_cost_params
         .clone();
 
@@ -521,7 +523,7 @@ pub fn internal_hash_to(
 
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .group_ops_cost_params
         .clone();
 
@@ -666,7 +668,7 @@ pub fn internal_multi_scalar_mul(
     debug_assert!(args.len() == 3);
 
     let cost = context.gas_used();
-    if !is_msm_supported(context) {
+    if !is_msm_supported(context)? {
         return Ok(NativeResult::err(cost, NOT_SUPPORTED_ERROR));
     }
 
@@ -678,7 +680,7 @@ pub fn internal_multi_scalar_mul(
 
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .group_ops_cost_params
         .clone();
 
@@ -719,7 +721,7 @@ pub fn internal_multi_scalar_mul(
             elements.as_ref(),
         ),
         _ => Ok(NativeResult::err(
-            v2_native_charge(context, cost),
+            v2_native_charge(context, cost)?,
             INVALID_INPUT_ERROR,
         )),
     }
@@ -749,7 +751,7 @@ pub fn internal_pairing(
 
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .group_ops_cost_params
         .clone();
 
@@ -786,7 +788,7 @@ pub fn internal_convert(
 
     let cost = context.gas_used();
 
-    if !(is_uncompressed_g1_supported(context)) {
+    if !(is_uncompressed_g1_supported(context))? {
         return Ok(NativeResult::err(cost, NOT_SUPPORTED_ERROR));
     }
 
@@ -797,7 +799,7 @@ pub fn internal_convert(
 
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .group_ops_cost_params
         .clone();
 
@@ -846,13 +848,13 @@ pub fn internal_sum(
 
     let cost = context.gas_used();
 
-    if !(is_uncompressed_g1_supported(context)) {
+    if !(is_uncompressed_g1_supported(context))? {
         return Ok(NativeResult::err(cost, NOT_SUPPORTED_ERROR));
     }
 
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .group_ops_cost_params
         .clone();
 

--- a/iota-execution/latest/iota-move-natives/src/crypto/hash.rs
+++ b/iota-execution/latest/iota-move-natives/src/crypto/hash.rs
@@ -86,7 +86,7 @@ pub fn keccak256(
     // Load the cost parameters from the protocol config
     let hash_keccak256_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .hash_keccak256_cost_params
         .clone();
     // Charge the base cost for this oper
@@ -130,7 +130,7 @@ pub fn blake2b256(
     // Load the cost parameters from the protocol config
     let hash_blake2b256_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .hash_blake2b256_cost_params
         .clone();
     // Charge the base cost for this oper

--- a/iota-execution/latest/iota-move-natives/src/crypto/hmac.rs
+++ b/iota-execution/latest/iota-move-natives/src/crypto/hmac.rs
@@ -53,7 +53,7 @@ pub fn hmac_sha3_256(
     // Load the cost parameters from the protocol config
     let hmac_hmac_sha3_256_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .hmac_hmac_sha3_256_cost_params
         .clone();
 

--- a/iota-execution/latest/iota-move-natives/src/crypto/poseidon.rs
+++ b/iota-execution/latest/iota-move-natives/src/crypto/poseidon.rs
@@ -21,12 +21,12 @@ use crate::{NativesCostTable, object_runtime::ObjectRuntime};
 pub const NON_CANONICAL_INPUT: u64 = 0;
 pub const NOT_SUPPORTED_ERROR: u64 = 1;
 
-fn is_supported(context: &NativeContext) -> bool {
-    context
+fn is_supported(context: &NativeContext) -> PartialVMResult<bool> {
+    Ok(context
         .extensions()
-        .get::<ObjectRuntime>()
+        .get::<ObjectRuntime>()?
         .protocol_config
-        .enable_poseidon()
+        .enable_poseidon())
 }
 
 #[derive(Clone)]
@@ -53,14 +53,14 @@ pub fn poseidon_bn254_internal(
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     let cost = context.gas_used();
-    if !is_supported(context) {
+    if !is_supported(context)? {
         return Ok(NativeResult::err(cost, NOT_SUPPORTED_ERROR));
     }
 
     // Load the cost parameters from the protocol config
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .poseidon_bn254_cost_params
         .clone();
 

--- a/iota-execution/latest/iota-move-natives/src/crypto/vdf.rs
+++ b/iota-execution/latest/iota-move-natives/src/crypto/vdf.rs
@@ -24,12 +24,12 @@ use crate::{NativesCostTable, object_runtime::ObjectRuntime};
 pub const INVALID_INPUT_ERROR: u64 = 0;
 pub const NOT_SUPPORTED_ERROR: u64 = 1;
 
-fn is_supported(context: &NativeContext) -> bool {
-    context
+fn is_supported(context: &NativeContext) -> PartialVMResult<bool> {
+    Ok(context
         .extensions()
-        .get::<ObjectRuntime>()
+        .get::<ObjectRuntime>()?
         .protocol_config
-        .enable_vdf()
+        .enable_vdf())
 }
 
 #[derive(Clone)]
@@ -56,14 +56,14 @@ pub fn vdf_verify_internal(
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     let cost = context.gas_used();
-    if !is_supported(context) {
+    if !is_supported(context)? {
         return Ok(NativeResult::err(cost, NOT_SUPPORTED_ERROR));
     }
 
     // Load the cost parameters from the protocol config
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .vdf_cost_params
         .clone();
 
@@ -129,14 +129,14 @@ pub fn hash_to_input_internal(
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     let cost = context.gas_used();
-    if !is_supported(context) {
+    if !is_supported(context)? {
         return Ok(NativeResult::err(cost, NOT_SUPPORTED_ERROR));
     }
 
     // Load the cost parameters from the protocol config
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .vdf_cost_params
         .clone();
 

--- a/iota-execution/latest/iota-move-natives/src/crypto/zklogin.rs
+++ b/iota-execution/latest/iota-move-natives/src/crypto/zklogin.rs
@@ -52,7 +52,7 @@ pub fn check_zklogin_id_internal(
     // Load the cost parameters from the protocol config
     let check_zklogin_id_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .check_zklogin_id_cost_params
         .clone();
 
@@ -155,7 +155,7 @@ pub fn check_zklogin_issuer_internal(
     // Load the cost parameters from the protocol config
     let check_zklogin_issuer_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .check_zklogin_issuer_cost_params
         .clone();
 

--- a/iota-execution/latest/iota-move-natives/src/dynamic_field.rs
+++ b/iota-execution/latest/iota-move-natives/src/dynamic_field.rs
@@ -51,7 +51,7 @@ macro_rules! get_or_fetch_object {
             }
         };
 
-        let object_runtime: &mut ObjectRuntime = $context.extensions_mut().get_mut();
+        let object_runtime: &mut ObjectRuntime = $context.extensions_mut().get_mut()?;
         object_runtime.get_or_fetch_child_object(
             $parent,
             $child_id,
@@ -97,7 +97,7 @@ pub fn hash_type_and_key(
 
     let dynamic_field_hash_type_and_key_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .dynamic_field_hash_type_and_key_cost_params
         .clone();
 
@@ -187,7 +187,7 @@ pub fn add_child_object(
 
     let dynamic_field_add_child_object_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .dynamic_field_add_child_object_cost_params
         .clone();
 
@@ -245,7 +245,7 @@ pub fn add_child_object(
             * struct_tag_size.into()
     );
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     object_runtime.add_child_object(
         parent,
         child_id,
@@ -291,7 +291,7 @@ pub fn borrow_child_object(
 
     let dynamic_field_borrow_child_object_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .dynamic_field_borrow_child_object_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -374,7 +374,7 @@ pub fn remove_child_object(
 
     let dynamic_field_remove_child_object_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .dynamic_field_remove_child_object_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -439,7 +439,7 @@ pub fn has_child_object(
 
     let dynamic_field_has_child_object_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .dynamic_field_has_child_object_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -449,7 +449,7 @@ pub fn has_child_object(
 
     let child_id = pop_arg!(args, AccountAddress).into();
     let parent = pop_arg!(args, AccountAddress).into();
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let has_child = object_runtime.child_object_exists(parent, child_id)?;
     Ok(NativeResult::ok(
         context.gas_used(),
@@ -488,7 +488,7 @@ pub fn has_child_object_with_ty(
 
     let dynamic_field_has_child_object_with_ty_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .dynamic_field_has_child_object_with_ty_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -526,7 +526,7 @@ pub fn has_child_object_with_ty(
             * u64::from(tag.abstract_size_for_gas_metering()).into()
     );
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let has_child = object_runtime.child_object_exists_and_has_type(
         parent,
         child_id,

--- a/iota-execution/latest/iota-move-natives/src/event.rs
+++ b/iota-execution/latest/iota-move-natives/src/event.rs
@@ -46,7 +46,7 @@ pub fn emit(
 
     let event_emit_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .event_emit_cost_params
         .clone();
 
@@ -82,7 +82,7 @@ pub fn emit(
             * u64::from(tag_size).into()
     );
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let max_event_emit_size = obj_runtime.protocol_config.max_event_emit_size();
     let ev_size = u64::from(tag_size + event_value_size);
     // Check if the event size is within the limit
@@ -120,7 +120,7 @@ pub fn emit(
         event_emit_cost_params.event_emit_output_cost_per_byte * ev_size.into()
     );
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
 
     obj_runtime.emit_event(ty, *tag, event_value)?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
@@ -134,7 +134,7 @@ pub fn num_events(
 ) -> PartialVMResult<NativeResult> {
     assert!(ty_args.is_empty());
     assert!(args.is_empty());
-    let object_runtime_ref: &ObjectRuntime = context.extensions().get();
+    let object_runtime_ref: &ObjectRuntime = context.extensions().get()?;
     let num_events = object_runtime_ref.state.events().len();
     Ok(NativeResult::ok(
         legacy_test_cost(),
@@ -151,7 +151,7 @@ pub fn get_events_by_type(
     assert_eq!(ty_args.len(), 1);
     let specified_ty = ty_args.pop().unwrap();
     assert!(args.is_empty());
-    let object_runtime_ref: &ObjectRuntime = context.extensions().get();
+    let object_runtime_ref: &ObjectRuntime = context.extensions().get()?;
     let matched_events = object_runtime_ref
         .state
         .events()

--- a/iota-execution/latest/iota-move-natives/src/object.rs
+++ b/iota-execution/latest/iota-move-natives/src/object.rs
@@ -38,7 +38,7 @@ pub fn borrow_uid(
 
     let borrow_uid_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .borrow_uid_cost_params
         .clone();
 
@@ -71,7 +71,7 @@ pub fn delete_impl(
 
     let delete_impl_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .delete_impl_cost_params
         .clone();
 
@@ -84,7 +84,7 @@ pub fn delete_impl(
     // unwrap safe because the interface of native function guarantees it.
     let uid_bytes = pop_arg!(args, AccountAddress);
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     obj_runtime.delete_id(uid_bytes.into())?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }
@@ -109,7 +109,7 @@ pub fn record_new_uid(
 
     let record_new_id_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .record_new_id_cost_params
         .clone();
 
@@ -122,7 +122,7 @@ pub fn record_new_uid(
     // unwrap safe because the interface of native function guarantees it.
     let uid_bytes = pop_arg!(args, AccountAddress);
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     obj_runtime.new_id(uid_bytes.into())?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }

--- a/iota-execution/latest/iota-move-natives/src/test_scenario.rs
+++ b/iota-execution/latest/iota-move-natives/src/test_scenario.rs
@@ -99,7 +99,7 @@ pub fn end_transaction(
 ) -> PartialVMResult<NativeResult> {
     assert!(ty_args.is_empty());
     assert!(args.is_empty());
-    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let taken_shared_or_imm: BTreeMap<_, _> = object_runtime_ref
         .test_inventories
         .taken
@@ -159,7 +159,7 @@ pub fn end_transaction(
             ));
         }
     };
-    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let all_active_child_objects_with_values = object_runtime_ref
         .all_active_child_objects()
         .filter(|child| child.copied_value.is_some())
@@ -241,7 +241,7 @@ pub fn end_transaction(
     }
 
     // For any unused allocated tickets, remove them from the store.
-    let store: &&InMemoryTestStore = context.extensions().get();
+    let store: &&InMemoryTestStore = context.extensions().get()?;
     for id in unreceived {
         if store
             .0
@@ -267,7 +267,7 @@ pub fn end_transaction(
     }
     // find all wrapped objects
     let mut all_wrapped = BTreeSet::new();
-    let object_runtime_ref: &ObjectRuntime = context.extensions().get();
+    let object_runtime_ref: &ObjectRuntime = context.extensions().get()?;
     find_all_wrapped_objects(
         context,
         &mut all_wrapped,
@@ -301,7 +301,7 @@ pub fn end_transaction(
     }
 
     // new input objects are remaining taken objects not written/deleted
-    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let mut config_settings = vec![];
     for child in object_runtime_ref.all_active_child_objects() {
         let s: StructTag = child.move_type.clone().into();
@@ -377,7 +377,7 @@ pub fn take_from_address_by_id(
     let account: IotaAddress = pop_arg!(args, AccountAddress).into();
     pop_arg!(args, StructRef);
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
@@ -409,7 +409,7 @@ pub fn ids_for_address(
     let specified_ty = get_specified_ty(ty_args);
     let account: IotaAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let ids = inventories
         .address_inventories
@@ -430,7 +430,7 @@ pub fn most_recent_id_for_address(
     let specified_ty = get_specified_ty(ty_args);
     let account: IotaAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = match inventories.address_inventories.get(&account) {
         None => pack_option(None),
@@ -452,7 +452,7 @@ pub fn was_taken_from_address(
     let id = pop_id(&mut args)?;
     let account: IotaAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let was_taken = inventories
         .taken
@@ -475,7 +475,7 @@ pub fn take_immutable_by_id(
     let id = pop_id(&mut args)?;
     pop_arg!(args, StructRef);
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
@@ -512,7 +512,7 @@ pub fn most_recent_immutable_id(
 ) -> PartialVMResult<NativeResult> {
     let specified_ty = get_specified_ty(ty_args);
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = most_recent_at_ty(
         &inventories.taken,
@@ -534,7 +534,7 @@ pub fn was_taken_immutable(
     assert!(ty_args.is_empty());
     let id = pop_id(&mut args)?;
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let was_taken = inventories
         .taken
@@ -557,7 +557,7 @@ pub fn take_shared_by_id(
     let id = pop_id(&mut args)?;
     pop_arg!(args, StructRef);
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
@@ -587,7 +587,7 @@ pub fn most_recent_id_shared(
 ) -> PartialVMResult<NativeResult> {
     let specified_ty = get_specified_ty(ty_args);
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = most_recent_at_ty(
         &inventories.taken,
@@ -609,7 +609,7 @@ pub fn was_taken_shared(
     assert!(ty_args.is_empty());
     let id = pop_id(&mut args)?;
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let was_taken = inventories
         .taken
@@ -636,7 +636,7 @@ pub fn allocate_receiving_ticket_for_object(
             E_UNABLE_TO_ALLOCATE_RECEIVING_TICKET,
         ));
     };
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let object_version = SequenceNumber::new();
     let inventories = &mut object_runtime.test_inventories;
     if inventories.allocated_tickets.contains_key(&id) {
@@ -691,7 +691,7 @@ pub fn allocate_receiving_ticket_for_object(
 
     // NB: Must be a `&&` reference since the extension stores a static ref to the
     // object storage.
-    let store: &&InMemoryTestStore = context.extensions().get();
+    let store: &&InMemoryTestStore = context.extensions().get()?;
     store.0.with_borrow_mut(|store| store.insert_object(object));
 
     Ok(NativeResult::ok(
@@ -707,7 +707,7 @@ pub fn deallocate_receiving_ticket_for_object(
 ) -> PartialVMResult<NativeResult> {
     let id = pop_id(&mut args)?;
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     // Deallocate the ticket -- we should never hit this scenario
     let Some((_, value)) = inventories.allocated_tickets.remove(&id) else {
@@ -722,7 +722,7 @@ pub fn deallocate_receiving_ticket_for_object(
     inventories.objects.insert(id, value);
 
     // Remove the object from storage. We should never hit this scenario either.
-    let store: &&InMemoryTestStore = context.extensions().get();
+    let store: &&InMemoryTestStore = context.extensions().get()?;
     if store
         .0
         .with_borrow_mut(|store| store.remove_object(id).is_none())

--- a/iota-execution/latest/iota-move-natives/src/transfer.rs
+++ b/iota-execution/latest/iota-move-natives/src/transfer.rs
@@ -53,7 +53,7 @@ pub fn receive_object_internal(
     debug_assert!(args.len() == 3);
     let transfer_receive_object_internal_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .transfer_receive_object_internal_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -79,7 +79,7 @@ pub fn receive_object_internal(
         ));
     };
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let child = match object_runtime.receive_object(
         parent,
         child_id,
@@ -129,7 +129,7 @@ pub fn transfer_internal(
 
     let transfer_transfer_internal_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .transfer_transfer_internal_cost_params
         .clone();
 
@@ -168,7 +168,7 @@ pub fn freeze_object(
 
     let transfer_freeze_object_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .transfer_freeze_object_cost_params
         .clone();
 
@@ -205,7 +205,7 @@ pub fn share_object(
 
     let transfer_share_object_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .transfer_share_object_cost_params
         .clone();
 
@@ -248,6 +248,6 @@ fn object_runtime_transfer(
         );
     }
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     obj_runtime.transfer(owner, ty, obj)
 }

--- a/iota-execution/latest/iota-move-natives/src/tx_context.rs
+++ b/iota-execution/latest/iota-move-natives/src/tx_context.rs
@@ -36,7 +36,7 @@ pub fn derive_id(
 
     let tx_context_derive_id_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .tx_context_derive_id_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -51,7 +51,7 @@ pub fn derive_id(
     // `TransactionDigest`
     let digest = TransactionDigest::try_from(tx_hash.as_slice()).unwrap();
     let address = AccountAddress::from(ObjectID::derive_id(digest, ids_created));
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     obj_runtime.new_id(address.into())?;
 
     Ok(NativeResult::ok(

--- a/iota-execution/latest/iota-move-natives/src/types.rs
+++ b/iota-execution/latest/iota-move-natives/src/types.rs
@@ -70,7 +70,7 @@ pub fn is_one_time_witness(
 
     let type_is_one_time_witness_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .type_is_one_time_witness_cost_params
         .clone();
 

--- a/iota-execution/latest/iota-move-natives/src/validator.rs
+++ b/iota-execution/latest/iota-move-natives/src/validator.rs
@@ -39,7 +39,7 @@ pub fn validate_metadata_bcs(
 
     let validator_validate_metadata_bcs_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .validator_validate_metadata_bcs_cost_params
         .clone();
 


### PR DESCRIPTION
# Description of change

According to [changes](https://github.com/MystenLabs/sui/commit/52fa3af24691e32ba9e66741a52490223250e7a9#diff-adfd42913620835dfcc9377361231836628f6f7fb513c26d717251f4b894364c).
Please read the [comment](https://github.com/orgs/iotaledger/projects/79/views/26?pane=issue&itemId=124917172&issue=iotaledger%7Ciota%7C8257) 

## Links to any relevant issues

Fixes #8257  .
