### PR TITLE
fix(wallet): Fix NFT form address sending

### DIFF
--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -51,7 +51,7 @@ function GasBudgetComponent({
     objectType?: string | null;
 }) {
     const { values, isValid } = useFormikContext<SendNftFormValues>();
-    const recipientAddress = isValid ? (values.resolvedAddress ?? values.to ?? '') : '';
+    const recipientAddress = isValid ? values.resolvedAddress || values.to || '' : '';
 
     const { data: gasBudgetEst } = useAssetGasBudgetEstimation({
         objectId,
@@ -129,7 +129,7 @@ export function TransferNFTForm({ objectId, objectType }: TransferNFTFormProps) 
     });
 
     function handleSubmit(values: SendNftFormValues) {
-        const recipient = values.resolvedAddress ?? values.to;
+        const recipient = values.resolvedAddress || values.to;
         transferNFT.mutate(recipient);
     }
 


### PR DESCRIPTION
Regression of https://github.com/iotaledger/iota/pull/7976/files#diff-297b0142e3e657c45fcac55441a37b7ed1633caac1a135432d1e3f28288b9a06

TLDR:
You cannot send NFTs by writing an address.
error:
<img width="363" height="682" alt="image" src="https://github.com/user-attachments/assets/dd167c77-3adb-4e5f-a0f4-246e2e7416e6" />
solution and cause:

<img width="234" height="80" alt="image" src="https://github.com/user-attachments/assets/89a6b7e1-9355-44f8-8dd7-37faa307d083" />