### PR TITLE
feat(indexer): Speed up get_transaction_block

### DIFF
--- a/crates/iota-indexer/src/apis/read_api.rs
+++ b/crates/iota-indexer/src/apis/read_api.rs
@@ -238,11 +238,13 @@ impl ReadApiServer for ReadApi {
         digest: TransactionDigest,
         options: Option<IotaTransactionBlockResponseOptions>,
     ) -> RpcResult<IotaTransactionBlockResponse> {
-        let mut txn = self
-            .multi_get_transaction_blocks(vec![digest], options)
+        let options = options.unwrap_or_default();
+        let txn = self
+            .inner
+            .get_single_transaction_block_response(digest, options)
             .await?;
 
-        let txn = txn.pop().ok_or_else(|| {
+        let txn = txn.ok_or_else(|| {
             IndexerError::InvalidArgument(format!("Transaction {digest} not found"))
         })?;
 

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -18,6 +18,7 @@ use diesel::{
     sql_types::{BigInt, Bool},
 };
 use fastcrypto::encoding::{Encoding, Hex};
+use futures::stream::{FuturesUnordered, StreamExt};
 use iota_json_rpc_types::{
     AddressMetrics, Balance, CheckpointId, Coin as IotaCoin, DisplayFieldsResponse, EpochInfo,
     EventFilter, IotaCoinMetadata, IotaEvent, IotaMoveValue, IotaObjectDataFilter,
@@ -673,15 +674,11 @@ impl IndexerReader {
         .await
     }
 
-    fn multi_get_transactions(
+    fn get_checkpointed_transactions(
         &self,
-        digests: &[TransactionDigest],
+        digests: &[Vec<u8>],
     ) -> Result<Vec<StoredTransaction>, IndexerError> {
-        let digests = digests
-            .iter()
-            .map(|digest| digest.inner().to_vec())
-            .collect::<HashSet<_>>();
-        let checkpointed_txs = run_query!(&self.pool, |conn| {
+        run_query!(&self.pool, |conn| {
             transactions::table
                 .inner_join(
                     tx_digests::table
@@ -689,18 +686,17 @@ impl IndexerReader {
                 )
                 // we filter the tx_digests table because it is indexed by digest,
                 // transactions table is not
-                .filter(tx_digests::tx_digest.eq_any(&digests))
+                .filter(tx_digests::tx_digest.eq_any(digests))
                 .select(StoredTransaction::as_select())
                 .load::<StoredTransaction>(conn)
-        })?;
-        if checkpointed_txs.len() == digests.len() {
-            return Ok(checkpointed_txs);
-        }
-        let mut missing_digests = digests;
-        for tx in &checkpointed_txs {
-            missing_digests.remove(&tx.transaction_digest);
-        }
-        let optimistic_txs = run_query!(&self.pool, |conn| {
+        })
+    }
+
+    fn get_optimistic_transactions(
+        &self,
+        digests: &[Vec<u8>],
+    ) -> Result<Vec<OptimisticTransaction>, IndexerError> {
+        run_query!(&self.pool, |conn| {
             optimistic_transactions::table
                 .inner_join(
                     tx_global_order::table.on(optimistic_transactions::global_sequence_number
@@ -712,10 +708,65 @@ impl IndexerReader {
                 )
                 // we filter the `tx_global_order` table because it is indexed by digest,
                 // optimistic_transactions table is not
-                .filter(tx_global_order::tx_digest.eq_any(missing_digests))
+                .filter(tx_global_order::tx_digest.eq_any(digests))
                 .select(OptimisticTransaction::as_select())
                 .load::<OptimisticTransaction>(conn)
-        })?;
+        })
+    }
+
+    async fn get_single_transaction(
+        &self,
+        digest: TransactionDigest,
+    ) -> IndexerResult<Option<StoredTransaction>> {
+        let digest_bytes = digest.inner().to_vec();
+        let checkpointed_tx_future = {
+            let this = self.clone();
+            let digest_bytes = digest_bytes.clone();
+            tokio::task::spawn_blocking(move || {
+                this.get_checkpointed_transactions(&[digest_bytes])
+                    .map(|mut txs| txs.pop())
+            })
+        };
+        let optimistic_tx_future = {
+            let this = self.clone();
+            tokio::task::spawn_blocking(move || {
+                this.get_optimistic_transactions(&[digest_bytes])
+                    .map(|mut txs| txs.pop().map(Into::into))
+            })
+        };
+
+        let mut tx_futures = FuturesUnordered::new();
+        tx_futures.push(checkpointed_tx_future);
+        tx_futures.push(optimistic_tx_future);
+
+        while let Some(result) = tx_futures.next().await {
+            if let Some(tx) = result?? {
+                return Ok(Some(tx));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn multi_get_transactions(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Result<Vec<StoredTransaction>, IndexerError> {
+        let digests: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
+        let checkpointed_txs = self.get_checkpointed_transactions(&digests)?;
+
+        if checkpointed_txs.len() == digests.len() {
+            return Ok(checkpointed_txs);
+        }
+
+        let mut missing_digests: HashSet<Vec<u8>> = digests.iter().cloned().collect();
+        for tx in &checkpointed_txs {
+            missing_digests.remove(&tx.transaction_digest);
+        }
+        let missing_digests = missing_digests.into_iter().collect::<Vec<_>>();
+
+        let optimistic_txs = self.get_optimistic_transactions(&missing_digests)?;
+
         Ok(checkpointed_txs
             .into_iter()
             .chain(optimistic_txs.into_iter().map(Into::into))
@@ -1275,6 +1326,24 @@ impl IndexerReader {
             .await?;
         self.stored_transaction_to_transaction_block(stored_txes, options)
             .await
+    }
+
+    pub(crate) async fn get_single_transaction_block_response(
+        &self,
+        digest: TransactionDigest,
+        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
+    ) -> IndexerResult<Option<IotaTransactionBlockResponse>> {
+        let stored_tx = self.get_single_transaction(digest).await?;
+        if let Some(stored_tx) = stored_tx {
+            Ok(Some(
+                self.stored_transaction_to_transaction_block(vec![stored_tx], options)
+                    .await?
+                    .pop()
+                    .expect("There should be exactly one response"),
+            ))
+        } else {
+            Ok(None)
+        }
     }
 
     async fn multi_get_transaction_block_response_by_sequence_numbers_in_blocking_task(

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{
     collections::{HashMap, HashSet},
+    future::Future,
+    pin::Pin,
     sync::{Arc, Mutex},
 };
 
@@ -18,7 +20,7 @@ use diesel::{
     sql_types::{BigInt, Bool},
 };
 use fastcrypto::encoding::{Encoding, Hex};
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::stream::{FuturesOrdered, StreamExt};
 use iota_json_rpc_types::{
     AddressMetrics, Balance, CheckpointId, Coin as IotaCoin, DisplayFieldsResponse, EpochInfo,
     EventFilter, IotaCoinMetadata, IotaEvent, IotaMoveValue, IotaObjectDataFilter,
@@ -719,27 +721,26 @@ impl IndexerReader {
         digest: TransactionDigest,
     ) -> IndexerResult<Option<StoredTransaction>> {
         let digest_bytes = digest.inner().to_vec();
-        let checkpointed_tx_future = {
-            let this = self.clone();
+        let checkpointed_tx_future: Pin<Box<dyn Future<Output = _> + Send>> = {
             let digest_bytes = digest_bytes.clone();
-            tokio::task::spawn_blocking(move || {
+            Box::pin(self.spawn_blocking(move |this| {
                 this.get_checkpointed_transactions(&[digest_bytes])
                     .map(|mut txs| txs.pop())
-            })
+            }))
         };
-        let optimistic_tx_future = {
-            let this = self.clone();
-            tokio::task::spawn_blocking(move || {
+        let optimistic_tx_future: Pin<Box<dyn Future<Output = _> + Send>> = {
+            let digest_bytes = digest_bytes.clone();
+            Box::pin(self.spawn_blocking(move |this| {
                 this.get_optimistic_transactions(&[digest_bytes])
                     .map(|mut txs| txs.pop().map(Into::into))
-            })
+            }))
         };
 
         let mut tx_futures =
-            FuturesUnordered::from_iter([checkpointed_tx_future, optimistic_tx_future]);
+            FuturesOrdered::from_iter([checkpointed_tx_future, optimistic_tx_future]);
 
         while let Some(result) = tx_futures.next().await {
-            if let Some(tx) = result?? {
+            if let Some(tx) = result? {
                 return Ok(Some(tx));
             }
         }

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -743,17 +743,17 @@ impl IndexerReader {
         digest: TransactionDigest,
     ) -> IndexerResult<Option<StoredTransaction>> {
         let digest_bytes = digest.inner().to_vec();
-        let mut checkpointed_tx_future = {
-            let digest_bytes = digest_bytes.clone();
-            Box::pin(self.spawn_blocking(move |this| {
-                this.get_checkpointed_transactions(&[digest_bytes])
-                    .map(|mut txs| txs.pop())
-            }))
-        };
         let mut optimistic_tx_future = {
             let digest_bytes = digest_bytes.clone();
             Box::pin(self.spawn_blocking(move |this| {
                 this.get_optimistic_transactions_with_cp_info(&[digest_bytes])
+                    .map(|mut txs| txs.pop())
+            }))
+        };
+        let mut checkpointed_tx_future = {
+            let digest_bytes = digest_bytes.clone();
+            Box::pin(self.spawn_blocking(move |this| {
+                this.get_checkpointed_transactions(&[digest_bytes])
                     .map(|mut txs| txs.pop())
             }))
         };

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -20,7 +20,7 @@ use diesel::{
     sql_types::{BigInt, Bool},
 };
 use fastcrypto::encoding::{Encoding, Hex};
-use futures::stream::{FuturesOrdered, StreamExt};
+use futures::stream::{FuturesUnordered, StreamExt};
 use iota_json_rpc_types::{
     AddressMetrics, Balance, CheckpointId, Coin as IotaCoin, DisplayFieldsResponse, EpochInfo,
     EventFilter, IotaCoinMetadata, IotaEvent, IotaMoveValue, IotaObjectDataFilter,
@@ -716,6 +716,31 @@ impl IndexerReader {
         })
     }
 
+    fn get_optimistic_transactions_with_cp_info(
+        &self,
+        digests: &[Vec<u8>],
+    ) -> Result<Vec<(OptimisticTransaction, Option<i64>)>, IndexerError> {
+        run_query!(&self.pool, |conn| {
+            optimistic_transactions::table
+                .inner_join(
+                    tx_global_order::table.on(optimistic_transactions::global_sequence_number
+                        .eq(tx_global_order::global_sequence_number)
+                        .and(
+                            optimistic_transactions::optimistic_sequence_number
+                                .eq(tx_global_order::optimistic_sequence_number),
+                        )),
+                )
+                // we filter the `tx_global_order` table because it is indexed by digest,
+                // optimistic_transactions table is not
+                .filter(tx_global_order::tx_digest.eq_any(digests))
+                .select((
+                    OptimisticTransaction::as_select(),
+                    tx_global_order::chk_tx_sequence_number,
+                ))
+                .load::<(OptimisticTransaction, Option<i64>)>(conn)
+        })
+    }
+
     async fn get_single_transaction(
         &self,
         digest: TransactionDigest,
@@ -725,27 +750,40 @@ impl IndexerReader {
             let digest_bytes = digest_bytes.clone();
             Box::pin(self.spawn_blocking(move |this| {
                 this.get_checkpointed_transactions(&[digest_bytes])
-                    .map(|mut txs| txs.pop())
+                    .map(|mut txs| txs.pop().map(|tx| (tx, false)))
             }))
         };
         let optimistic_tx_future: Pin<Box<dyn Future<Output = _> + Send>> = {
             let digest_bytes = digest_bytes.clone();
             Box::pin(self.spawn_blocking(move |this| {
-                this.get_optimistic_transactions(&[digest_bytes])
-                    .map(|mut txs| txs.pop().map(Into::into))
+                this.get_optimistic_transactions_with_cp_info(&[digest_bytes])
+                    .map(|mut txs| {
+                        // Mark the result as fallback if cp info is set meaning that we can
+                        // potentially get more data on this tx from
+                        // standard checkpointed tables and shouldn't return
+                        // incomplete optimistic result right away
+                        txs.pop()
+                            .map(|(tx, cp_info)| (tx.into(), cp_info.is_some()))
+                    })
             }))
         };
 
         let mut tx_futures =
-            FuturesOrdered::from_iter([checkpointed_tx_future, optimistic_tx_future]);
+            FuturesUnordered::from_iter([checkpointed_tx_future, optimistic_tx_future]);
+
+        let mut fallback_result = None;
 
         while let Some(result) = tx_futures.next().await {
-            if let Some(tx) = result? {
-                return Ok(Some(tx));
+            if let Some((tx, is_fallback_result)) = result? {
+                if is_fallback_result {
+                    fallback_result = Some(tx);
+                } else {
+                    return Ok(Some(tx));
+                }
             }
         }
 
-        Ok(None)
+        Ok(fallback_result)
     }
 
     fn multi_get_transactions(

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{
     collections::{HashMap, HashSet},
-    future::Future,
-    pin::Pin,
     sync::{Arc, Mutex},
 };
 
@@ -20,7 +18,7 @@ use diesel::{
     sql_types::{BigInt, Bool},
 };
 use fastcrypto::encoding::{Encoding, Hex};
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::future::Either;
 use iota_json_rpc_types::{
     AddressMetrics, Balance, CheckpointId, Coin as IotaCoin, DisplayFieldsResponse, EpochInfo,
     EventFilter, IotaCoinMetadata, IotaEvent, IotaMoveValue, IotaObjectDataFilter,
@@ -746,44 +744,43 @@ impl IndexerReader {
         digest: TransactionDigest,
     ) -> IndexerResult<Option<StoredTransaction>> {
         let digest_bytes = digest.inner().to_vec();
-        let checkpointed_tx_future: Pin<Box<dyn Future<Output = _> + Send>> = {
+        let checkpointed_tx_future = {
             let digest_bytes = digest_bytes.clone();
             Box::pin(self.spawn_blocking(move |this| {
                 this.get_checkpointed_transactions(&[digest_bytes])
-                    .map(|mut txs| txs.pop().map(|tx| (tx, false)))
+                    .map(|mut txs| txs.pop())
             }))
         };
-        let optimistic_tx_future: Pin<Box<dyn Future<Output = _> + Send>> = {
+        let optimistic_tx_future = {
             let digest_bytes = digest_bytes.clone();
             Box::pin(self.spawn_blocking(move |this| {
                 this.get_optimistic_transactions_with_cp_info(&[digest_bytes])
-                    .map(|mut txs| {
-                        // Mark the result as fallback if cp info is set meaning that we can
-                        // potentially get more data on this tx from
-                        // standard checkpointed tables and shouldn't return
-                        // incomplete optimistic result right away
-                        txs.pop()
-                            .map(|(tx, cp_info)| (tx.into(), cp_info.is_some()))
-                    })
+                    .map(|mut txs| txs.pop())
             }))
         };
 
-        let mut tx_futures =
-            FuturesUnordered::from_iter([checkpointed_tx_future, optimistic_tx_future]);
-
-        let mut fallback_result = None;
-
-        while let Some(result) = tx_futures.next().await {
-            if let Some((tx, is_fallback_result)) = result? {
-                if is_fallback_result {
-                    fallback_result = Some(tx);
-                } else {
-                    return Ok(Some(tx));
+        let result =
+            match futures::future::select(checkpointed_tx_future, optimistic_tx_future).await {
+                Either::Left((checkpointed_tx, optimistic_tx_future)) => match checkpointed_tx? {
+                    Some(checkpointed_tx) => Some(checkpointed_tx),
+                    None => optimistic_tx_future
+                        .await?
+                        .map(|(optimistic_tx, _)| optimistic_tx.into()),
+                },
+                Either::Right((optimistic_tx_with_cp_info, checkpointed_tx_future)) => {
+                    match optimistic_tx_with_cp_info? {
+                        Some((optimistic_tx, Some(_cp_info))) => Some(
+                            checkpointed_tx_future
+                                .await?
+                                .unwrap_or_else(|| optimistic_tx.into()),
+                        ),
+                        Some((optimistic_tx, None)) => Some(optimistic_tx.into()),
+                        None => checkpointed_tx_future.await?,
+                    }
                 }
-            }
-        }
+            };
 
-        Ok(fallback_result)
+        Ok(result)
     }
 
     fn multi_get_transactions(

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -735,9 +735,8 @@ impl IndexerReader {
             })
         };
 
-        let mut tx_futures = FuturesUnordered::new();
-        tx_futures.push(checkpointed_tx_future);
-        tx_futures.push(optimistic_tx_future);
+        let mut tx_futures =
+            FuturesUnordered::from_iter([checkpointed_tx_future, optimistic_tx_future]);
 
         while let Some(result) = tx_futures.next().await {
             if let Some(tx) = result?? {
@@ -759,11 +758,14 @@ impl IndexerReader {
             return Ok(checkpointed_txs);
         }
 
-        let mut missing_digests: HashSet<Vec<u8>> = digests.iter().cloned().collect();
-        for tx in &checkpointed_txs {
-            missing_digests.remove(&tx.transaction_digest);
-        }
-        let missing_digests = missing_digests.into_iter().collect::<Vec<_>>();
+        let checkpointed_tx_digests_set = checkpointed_txs
+            .iter()
+            .map(|tx| &tx.transaction_digest)
+            .collect::<HashSet<&Vec<u8>>>();
+        let missing_digests = digests
+            .into_iter()
+            .filter(|digest| !checkpointed_tx_digests_set.contains(digest))
+            .collect::<Vec<Vec<u8>>>();
 
         let optimistic_txs = self.get_optimistic_transactions(&missing_digests)?;
 

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -743,20 +743,21 @@ impl IndexerReader {
         digest: TransactionDigest,
     ) -> IndexerResult<Option<StoredTransaction>> {
         let digest_bytes = digest.inner().to_vec();
-        let mut optimistic_tx_future = {
+        let optimistic_tx_future = {
             let digest_bytes = digest_bytes.clone();
-            Box::pin(self.spawn_blocking(move |this| {
+            self.spawn_blocking(move |this| {
                 this.get_optimistic_transactions_with_cp_info(&[digest_bytes])
                     .map(|mut txs| txs.pop())
-            }))
+            })
         };
-        let mut checkpointed_tx_future = {
+        let checkpointed_tx_future = {
             let digest_bytes = digest_bytes.clone();
-            Box::pin(self.spawn_blocking(move |this| {
+            self.spawn_blocking(move |this| {
                 this.get_checkpointed_transactions(&[digest_bytes])
                     .map(|mut txs| txs.pop())
-            }))
+            })
         };
+        tokio::pin!(optimistic_tx_future, checkpointed_tx_future);
 
         let result = tokio::select! {
                 checkpointed_tx = &mut checkpointed_tx_future => match checkpointed_tx? {

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -18,7 +18,6 @@ use diesel::{
     sql_types::{BigInt, Bool},
 };
 use fastcrypto::encoding::{Encoding, Hex};
-use futures::future::Either;
 use iota_json_rpc_types::{
     AddressMetrics, Balance, CheckpointId, Coin as IotaCoin, DisplayFieldsResponse, EpochInfo,
     EventFilter, IotaCoinMetadata, IotaEvent, IotaMoveValue, IotaObjectDataFilter,
@@ -744,14 +743,14 @@ impl IndexerReader {
         digest: TransactionDigest,
     ) -> IndexerResult<Option<StoredTransaction>> {
         let digest_bytes = digest.inner().to_vec();
-        let checkpointed_tx_future = {
+        let mut checkpointed_tx_future = {
             let digest_bytes = digest_bytes.clone();
             Box::pin(self.spawn_blocking(move |this| {
                 this.get_checkpointed_transactions(&[digest_bytes])
                     .map(|mut txs| txs.pop())
             }))
         };
-        let optimistic_tx_future = {
+        let mut optimistic_tx_future = {
             let digest_bytes = digest_bytes.clone();
             Box::pin(self.spawn_blocking(move |this| {
                 this.get_optimistic_transactions_with_cp_info(&[digest_bytes])
@@ -759,15 +758,14 @@ impl IndexerReader {
             }))
         };
 
-        let result =
-            match futures::future::select(checkpointed_tx_future, optimistic_tx_future).await {
-                Either::Left((checkpointed_tx, optimistic_tx_future)) => match checkpointed_tx? {
+        let result = tokio::select! {
+                checkpointed_tx = &mut checkpointed_tx_future => match checkpointed_tx? {
                     Some(checkpointed_tx) => Some(checkpointed_tx),
                     None => optimistic_tx_future
                         .await?
                         .map(|(optimistic_tx, _)| optimistic_tx.into()),
                 },
-                Either::Right((optimistic_tx_with_cp_info, checkpointed_tx_future)) => {
+                optimistic_tx_with_cp_info = &mut optimistic_tx_future => {
                     match optimistic_tx_with_cp_info? {
                         Some((optimistic_tx, Some(_cp_info))) => Some(
                             checkpointed_tx_future
@@ -778,7 +776,7 @@ impl IndexerReader {
                         None => checkpointed_tx_future.await?,
                     }
                 }
-            };
+        };
 
         Ok(result)
     }

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -361,10 +361,9 @@ impl StoredTransaction {
                         })
                         .collect::<Result<Vec<Event>, IndexerError>>()?
             };
-            let timestamp = self.timestamp_ms as u64;
             let tx_events = TransactionEvents { data: events };
 
-            tx_events_to_iota_tx_events(tx_events, package_resolver, tx_digest, Some(timestamp))
+            tx_events_to_iota_tx_events(tx_events, package_resolver, tx_digest, timestamp_ms)
                 .await?
         } else {
             None

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -923,6 +923,96 @@ fn get_events() {
 }
 
 #[test]
+fn get_newly_indexed_optimistic_transaction() -> Result<(), anyhow::Error> {
+    let ApiTestSetup {
+        runtime,
+        store,
+        cluster,
+        client,
+    } = ApiTestSetup::get_or_init();
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+        let (sender, sender_kp): (_, AccountKeyPair) = get_key_pair();
+
+        let gas_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(10_000_000_000),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
+
+        let (_, package_id) = deploy_basics_pkg(sender, &sender_kp, client).await;
+        let basic_obj_1 = create_basic_object(sender, &sender_kp, client, &package_id).await?;
+        let basic_obj_2 = create_basic_object(sender, &sender_kp, client, &package_id).await?;
+
+        // Update the object to generate new event
+        let res = crate::coin_api::execute_move_call(
+            client,
+            sender,
+            &sender_kp,
+            package_id,
+            "object_basics".to_string(),
+            "update".to_string(),
+            type_args![].unwrap(),
+            call_args!(basic_obj_1, basic_obj_2).unwrap(),
+            None,
+        )
+        .await?;
+        assert_eq!(res.status_ok(), Some(true));
+
+        // despite the naming, there is no 100% guarantee that the result here comes
+        // from optimistic indexing, but it's very likely
+        let result_optimistic = client
+            .get_transaction_block(
+                res.digest,
+                Some(IotaTransactionBlockResponseOptions::full_content()),
+            )
+            .await
+            .unwrap();
+        let tx_data_to_compare_opt = (
+            &result_optimistic.digest,
+            &result_optimistic.transaction,
+            &result_optimistic.raw_transaction,
+            &result_optimistic.effects,
+            &result_optimistic.object_changes,
+            &result_optimistic.balance_changes,
+            &result_optimistic.errors,
+            &result_optimistic.raw_effects,
+        );
+
+        indexer_wait_for_transaction(res.digest, store, client).await;
+
+        let result_checkpointed = client
+            .get_transaction_block(
+                res.digest,
+                Some(IotaTransactionBlockResponseOptions::full_content()),
+            )
+            .await
+            .unwrap();
+        let tx_data_to_compare_ckpt = (
+            &result_checkpointed.digest,
+            &result_checkpointed.transaction,
+            &result_checkpointed.raw_transaction,
+            &result_checkpointed.effects,
+            &result_checkpointed.object_changes,
+            &result_checkpointed.balance_changes,
+            &result_checkpointed.errors,
+            &result_checkpointed.raw_effects,
+        );
+        assert_eq!(tx_data_to_compare_opt, tx_data_to_compare_ckpt);
+        // comparing only selected fields, because timestamp_ms/checkpoint changes from
+        // None to Some after checkpoint indexing kicks in
+
+        assert!(result_checkpointed.checkpoint.is_some());
+        assert!(result_checkpointed.timestamp_ms.is_some());
+
+        Ok(())
+    })
+}
+
+#[test]
 fn get_newly_created_optimistically_indexed_event() -> Result<(), anyhow::Error> {
     let ApiTestSetup {
         runtime,

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -203,6 +203,10 @@ fn get_transaction_block_with_options(options: IotaTransactionBlockResponseOptio
         // match
         assert_eq!(fullnode_tx, tx);
 
+        // Those fields should be present for checkpoint indexed transactions
+        assert!(tx.checkpoint.is_some());
+        assert!(tx.timestamp_ms.is_some());
+
         assert!(
             match_transaction_block_resp_options(&options, &[fullnode_tx]),
             "fullnode transaction block assertion failed"


### PR DESCRIPTION
# Description of change

get_transaction_block currently uses the same implementation as multi_get_transaction_blocks, which reads data sequentially first from transactions table and then from optimistic_transactions table.

This PR speeds it up by reading from 2 tables in parallel

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/8352

## How the change has been tested

Compared performance of get_transaction_block of indexer and node on staging env.

The indexer is currently 1.8× slower than the node for simple read queries, a notable improvement from the earlier measurement of 5× slower, but it happens only for fresh txs that can be returned from optimistic tables.
For old txs where we need to wait for checkpoint tables read the speedup is not that noticeable. Indexer is in such case 4.5x times slower than the node which is similar to the previous situation.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
