### PR TITLE
fix(move-vm-runtime):  fix typos u16 to u32 and u256

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
@@ -1124,7 +1124,7 @@ impl Frame {
                     .push(Value::u16(integer_value.cast_u16()?))?;
             }
             Bytecode::CastU32 => {
-                gas_meter.charge_simple_instr(S::CastU16)?;
+                gas_meter.charge_simple_instr(S::CastU32)?;
                 let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
                 interpreter
                     .operand_stack
@@ -1145,7 +1145,7 @@ impl Frame {
                     .push(Value::u128(integer_value.cast_u128()?))?;
             }
             Bytecode::CastU256 => {
-                gas_meter.charge_simple_instr(S::CastU16)?;
+                gas_meter.charge_simple_instr(S::CastU256)?;
                 let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
                 interpreter
                     .operand_stack


### PR DESCRIPTION
# Description of change

Fix small mistake found in what simple instruction was used for casts.
Change does not need to be protocol versioned as the underlying abstract
size for these is the same.

According to [changes](https://github.com/orgs/iotaledger/projects/79/views/26?pane=issue&itemId=124917292&issue=iotaledger%7Ciota%7C8263).

## Links to any relevant issues

Fixes #8263 .
