### PR TITLE
feat(bytecode-verifier): Added additional tests for reference safety passes

### DIFF
--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/call_with_mut_and_imm.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/call_with_mut_and_imm.mvir
@@ -1,0 +1,31 @@
+// tests that function calls treat the return references as disjoint
+
+//# publish
+
+module 0x1.Tester {
+    struct T has copy { f: u64, g: u64, h: u64 }
+
+    borrow(s1: &mut Self.T): &mut u64 * &mut u64 * &u64 * &u64 {
+    label b0:
+        return (&mut copy(s1).T::f, &mut copy(s1).T::g, &copy(s1).T::h, &copy(s1).T::h);
+    }
+
+    t(s: &mut Self.T): &mut u64 * &mut u64 * &u64 * &u64 {
+        let m1: &mut u64;
+        let m2: &mut u64;
+        let i3: &u64;
+        let i4: &u64;
+    label b0:
+        m1, m2, i3, i4 = Self.borrow(copy(s));
+        // all are readable
+        _ = *copy(m1);
+        _ = *copy(m2);
+        _ = *copy(i3);
+        _ = *copy(i4);
+        // mutable ones are writable
+        *copy(m1) = 0;
+        *copy(m2) = 0;
+        // all returnable
+        return (move(m1), move(m2), move(i3), move(i4));
+    }
+}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/call_with_mut_and_imm.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/call_with_mut_and_imm.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/enum_variant_factor.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/enum_variant_factor.mvir
@@ -1,6 +1,6 @@
 //# publish
-module 0x1.o {
-    enum X has drop { 
+module 0x1.o1 {
+    enum X has drop {
         Empty { },
         One { x: u64, y: u64 },
     }
@@ -17,8 +17,8 @@ module 0x1.o {
 }
 
 //# publish
-module 0x1.o {
-    enum X has drop { 
+module 0x1.o2 {
+    enum X has drop {
         One { x: u64, y: u64 },
         Two { x: u64, y: u64},
     }
@@ -36,8 +36,8 @@ module 0x1.o {
 }
 
 //# publish
-module 0x1.o {
-    enum X has drop { 
+module 0x1.o3 {
+    enum X has drop {
         One { x: u64, y: u64 },
         Two { x: u64, y: u64},
     }
@@ -54,8 +54,8 @@ module 0x1.o {
 }
 
 //# publish
-module 0x1.o {
-    enum X has drop { 
+module 0x1.o4 {
+    enum X has drop {
         One { x: u64, y: u64 },
         Two { x: u64, y: u64},
     }
@@ -74,8 +74,8 @@ module 0x1.o {
 }
 
 //# publish
-module 0x1.o {
-    enum X has drop { 
+module 0x1.o5 {
+    enum X has drop {
         One { x: u64, y: u64 },
         Two { x: u64, y: u64},
     }
@@ -95,7 +95,7 @@ module 0x1.o {
 
 //# publish
 module 0x1.invalid {
-    enum X has drop { 
+    enum X has drop {
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -118,8 +118,8 @@ module 0x1.invalid {
 }
 
 //# publish
-module 0x1.invalid {
-    enum X has drop { 
+module 0x1.invalid2 {
+    enum X has drop {
         One { x: u64 },
         Two { x: u64, y: u64},
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/enum_variant_factor.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/enum_variant_factor.snap
@@ -1,45 +1,44 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/enum_variant_factor.mvir
 ---
 processed 7 tasks
 
 task 0, lines 1-17:
 //# publish
-Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::o'. Got VMError: {
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::o1'. Got VMError: {
     major_status: FIELD_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
-    location: 0x1::o,
+    location: 0x1::o1,
     indices: [(FunctionDefinition, 0)],
     offsets: [(FunctionDefinitionIndex(0), 5)],
 }
 
 task 1, lines 19-36:
 //# publish
-Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::o'. Got VMError: {
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::o2'. Got VMError: {
     major_status: FIELD_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
-    location: 0x1::o,
+    location: 0x1::o2,
     indices: [(FunctionDefinition, 0)],
     offsets: [(FunctionDefinitionIndex(0), 3)],
 }
 
 task 2, lines 38-54:
 //# publish
-Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::o'. Got VMError: {
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::o3'. Got VMError: {
     major_status: FIELD_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
-    location: 0x1::o,
+    location: 0x1::o3,
     indices: [(FunctionDefinition, 0)],
     offsets: [(FunctionDefinitionIndex(0), 3)],
 }
 
 task 3, lines 56-74:
 //# publish
-Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::o'. Got VMError: {
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::o4'. Got VMError: {
     major_status: FIELD_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
-    location: 0x1::o,
+    location: 0x1::o4,
     indices: [(FunctionDefinition, 0)],
     offsets: [(FunctionDefinitionIndex(0), 5)],
 }
@@ -56,10 +55,10 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
 
 task 6, lines 120-142:
 //# publish
-Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::invalid'. Got VMError: {
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::invalid2'. Got VMError: {
     major_status: READREF_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
-    location: 0x1::invalid,
+    location: 0x1::invalid2,
     indices: [(FunctionDefinition, 0)],
     offsets: [(FunctionDefinitionIndex(0), 17)],
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/alias_write_after_join.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/alias_write_after_join.mvir
@@ -1,0 +1,33 @@
+// writing to alias after join
+
+//# publish
+
+module 0x2.alias_after_join_reborrow {
+
+t(cond: bool) {
+    let a: u64;
+    let b: u64;
+    let x: &mut u64;
+    let y: &mut u64;
+    let z: &mut u64;
+label l0:
+    a = 0;
+    b = 0;
+    jump_if (move(cond)) l2;
+label l1:
+    x = &mut a;
+    y = &mut b;
+    jump l3;
+label l2:
+    x = &mut b;
+    y = &mut a;
+    jump l3;
+label l3:
+    z = &mut a;
+    *move(z) = 0;
+    *move(x) = 0;
+    *move(y) = 0;
+    return;
+}
+
+}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/alias_write_after_join.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/alias_write_after_join.snap
@@ -1,0 +1,14 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task
+
+task 0, lines 3-33:
+//# publish
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000002::alias_after_join_reborrow'. Got VMError: {
+    major_status: WRITEREF_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0x2::alias_after_join_reborrow,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 20)],
+}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/alias_writes.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/alias_writes.mvir
@@ -1,0 +1,77 @@
+// writing to alias writes should be consistent
+
+//# publish
+
+module 0x2.borrow_local_twice {
+
+t() {
+    let a: u64;
+    let x: &mut u64;
+    let y: &mut u64;
+label b0:
+    a = 0;
+    x = &mut a;
+    y = &mut a;
+    *move(x) = 0;
+    *move(y) = 0;
+    return;
+}
+
+}
+
+//# publish
+
+module 0x3.borrow_local_twice_reverse {
+
+t() {
+    let a: u64;
+    let x: &mut u64;
+    let y: &mut u64;
+label b0:
+    a = 0;
+    x = &mut a;
+    y = &mut a;
+    *move(y) = 0;
+    *move(x) = 0;
+    return;
+}
+
+}
+
+//# publish
+
+module 0x4.borrow_local_and_copy_ref {
+
+t() {
+    let a: u64;
+    let x: &mut u64;
+    let y: &mut u64;
+label b0:
+    a = 0;
+    x = &mut a;
+    y = copy(x);
+    *move(x) = 0;
+    *move(y) = 0;
+    return;
+}
+
+}
+
+//# publish
+
+module 0x5.borrow_local_and_copy_ref_reverse {
+
+t() {
+    let a: u64;
+    let x: &mut u64;
+    let y: &mut u64;
+label b0:
+    a = 0;
+    x = &mut a;
+    y = copy(x);
+    *move(y) = 0;
+    *move(x) = 0;
+    return;
+}
+
+}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/alias_writes.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/alias_writes.snap
@@ -1,0 +1,24 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+task 1, lines 22-39:
+//# publish
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000003::borrow_local_twice_reverse'. Got VMError: {
+    major_status: WRITEREF_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0x3::borrow_local_twice_reverse,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 8)],
+}
+
+task 2, lines 41-58:
+//# publish
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000004::borrow_local_and_copy_ref'. Got VMError: {
+    major_status: WRITEREF_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0x4::borrow_local_and_copy_ref,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 8)],
+}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/extension_after_call.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/extension_after_call.mvir
@@ -1,0 +1,28 @@
+// can write to an extension after a call
+
+//# publish
+
+module 0x2.Tester {
+
+struct Point has copy, drop, store { x: u64, y: u64 }
+struct Box has copy, drop, store { tl: Self.Point, br: Self.Point }
+
+borrow(p: &mut Self.Box): &mut Self.Point {
+label b0:
+    return &mut copy(p).Box::tl;
+}
+
+write(b: &mut Self.Box): &mut Self.Point {
+    let p: &mut Self.Point;
+    let x: &mut u64;
+    let y: &mut u64;
+label b0:
+    p = Self.borrow(copy(b));
+    x = &mut copy(p).Point::x;
+    *move(x) = 0;
+    y = &mut copy(p).Point::y;
+    *move(y) = 0;
+    return move(p);
+}
+
+}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/extension_after_call.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/extension_after_call.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/extension_writes_after_join.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/extension_writes_after_join.mvir
@@ -1,0 +1,30 @@
+// writing to extension after join
+
+//# publish
+
+module 0x2.extension_after_join {
+
+struct S has copy, drop, store { f: u64 }
+
+t(cond: bool, a: &mut Self.S, b: &mut Self.S): &mut Self.S {
+    let x: &mut Self.S;
+    let y: &mut Self.S;
+    let f: &mut u64;
+label l0:
+    jump_if (move(cond)) l2;
+label l1:
+    x = move(a);
+    y = move(b);
+    jump l3;
+label l2:
+    x = move(b);
+    y = move(a);
+    jump l3;
+label l3:
+    f = &mut copy(x).S::f;
+    *copy(y) = S { f: *copy(f) };
+    *copy(f) = 0;
+    return move(y);
+}
+
+}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/extension_writes_after_join.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/extension_writes_after_join.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/multible_mutable_return_values.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/multible_mutable_return_values.mvir
@@ -1,0 +1,26 @@
+// all mutable return values of a call should writable
+
+//# publish
+
+module 0x2.Tester {
+
+struct Point has copy, drop, store { x: u64, y: u64 }
+
+borrow(p: &mut Self.Point): &mut u64 * &mut u64 {
+label b0:
+    return &mut copy(p).Point::x, &mut copy(p).Point::y;
+}
+
+write(p: &mut Self.Point) {
+    let x: &mut u64;
+    let y: &mut u64;
+label b0:
+    x, y = Self.borrow(copy(p));
+    *copy(x) = 0;
+    *copy(y) = 0;
+    *copy(x) = 0;
+    *copy(y) = 0;
+    return;
+}
+
+}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/multible_mutable_return_values.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/multible_mutable_return_values.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/subtree_writes_release.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/subtree_writes_release.mvir
@@ -1,0 +1,33 @@
+// release is lossy in the graph, these writes are safe
+
+//# publish
+
+module 0x2.extension_after_join {
+
+struct Tree has copy, drop, store { l: Self.Sub1, r: Self.Sub1 }
+struct Sub1 has copy, drop, store { l: Self.Sub2, r: Self.Sub2 }
+struct Sub2 has copy, drop, store { l: u64, r: u64 }
+
+t(cond: bool, root: &mut Self.Tree) {
+    let x: &mut Self.Sub1;
+    let y: &mut u64;
+label l0:
+    jump_if (move(cond)) l2;
+label l1:
+    x = &mut copy(root).Tree::l;
+    y = &mut (&mut copy(x).Sub1::l).Sub2::l;
+    jump l3;
+label l2:
+    x = &mut copy(root).Tree::r;
+    y = &mut (&mut copy(x).Sub1::r).Sub2::r;
+    jump l3;
+label l3:
+    _ = move(x);
+    // should be safe root.l.r is not borrowed
+    *(&mut (&mut copy(root).Tree::l).Sub1::r) = Sub2 { l: 0, r: 0 };
+    *move(y) = 0;
+    return;
+}
+
+
+}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/subtree_writes_release.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/subtree_writes_release.snap
@@ -1,0 +1,14 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task
+
+task 0, lines 3-33:
+//# publish
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000002::extension_after_join'. Got VMError: {
+    major_status: WRITEREF_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0x2::extension_after_join,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 26)],
+}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid.mvir
@@ -1,6 +1,5 @@
 //# publish
 module 0x1.Tester {
-    import 0x1.signer;
 
     struct Initializer has key { x: u64, y: u64 }
     struct Point { x: u64, y: u64 }
@@ -48,7 +47,6 @@ module 0x1.Tester {
 
 //# publish
 module 0x1.Tester2 {
-    import 0x1.signer;
 
     struct Initializer has key { x: u64, y: u64 }
     struct Point { x: u64, y: u64 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid.mvir
 ---
 processed 2 tasks
 
-task 0, lines 1-47:
+task 0, lines 1-46:
 //# publish
 Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::Tester'. Got VMError: {
     major_status: FIELD_EXISTS_MUTABLE_BORROW_ERROR,
@@ -14,7 +13,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     offsets: [(FunctionDefinitionIndex(2), 23)],
 }
 
-task 1, lines 49-95:
+task 1, lines 48-93:
 //# publish
 Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::Tester2'. Got VMError: {
     major_status: FREEZEREF_EXISTS_MUTABLE_BORROW_ERROR,

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_extends_mut_arg.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_extends_mut_arg.mvir
@@ -1,0 +1,85 @@
+// tests that function calls require arguments references as disjoint
+
+//# publish
+
+module 0x2.eps1_freeze {
+    struct T has copy { f: u64 }
+
+    eps1(s: &Self.T, s2: &mut Self.T) {
+    label b0:
+        abort 0;
+    }
+
+    // reject call, i extends s
+    t_eps1(s: &mut Self.T) {
+        let i: &Self.T;
+    label l0:
+        i = freeze(copy(s));
+        Self.eps1(move(i), move(s));
+        return;
+    }
+}
+
+//# publish
+
+module 0x3.eps2_freeze {
+    struct T has copy { f: u64 }
+
+    eps2(s2: &mut Self.T, s: &Self.T) {
+    label b0:
+        abort 0;
+    }
+
+    // reject call, i extends s
+    t_eps(s: &mut Self.T) {
+        let i: &Self.T;
+    label l0:
+        i = freeze(copy(s));
+        Self.eps2(move(s), move(i));
+        return;
+    }
+}
+
+//# publish
+
+module 0x4.eps1_reborrow {
+    struct T has copy, drop { f: u64 }
+
+    eps1(s: &Self.T, s2: &mut Self.T) {
+    label b0:
+        abort 0;
+    }
+
+    // reject call, i extends s
+    t_eps1(x: Self.T) {
+        let s: &mut Self.T;
+        let i: &Self.T;
+    label l0:
+        i = &x;
+        s = &mut x;
+        Self.eps1(move(i), move(s));
+        return;
+    }
+}
+
+//# publish
+
+module 0x5.eps2_reborrow {
+    struct T has copy, drop { f: u64 }
+
+    eps2(s2: &mut Self.T, s: &Self.T) {
+    label b0:
+        abort 0;
+    }
+
+    // reject call, i extends s
+    t_eps(x: Self.T) {
+        let s: &mut Self.T;
+        let i: &Self.T;
+    label l0:
+        s = &mut x;
+        i = &x;
+        Self.eps2(move(s), move(i));
+        return;
+    }
+}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_extends_mut_arg.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_extends_mut_arg.snap
@@ -1,0 +1,44 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+task 0, lines 3-21:
+//# publish
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000002::eps1_freeze'. Got VMError: {
+    major_status: CALL_BORROWED_MUTABLE_REFERENCE_ERROR,
+    sub_status: None,
+    location: 0x2::eps1_freeze,
+    indices: [(FunctionDefinition, 1)],
+    offsets: [(FunctionDefinitionIndex(1), 5)],
+}
+
+task 1, lines 23-41:
+//# publish
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000003::eps2_freeze'. Got VMError: {
+    major_status: CALL_BORROWED_MUTABLE_REFERENCE_ERROR,
+    sub_status: None,
+    location: 0x3::eps2_freeze,
+    indices: [(FunctionDefinition, 1)],
+    offsets: [(FunctionDefinitionIndex(1), 5)],
+}
+
+task 2, lines 43-63:
+//# publish
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000004::eps1_reborrow'. Got VMError: {
+    major_status: CALL_BORROWED_MUTABLE_REFERENCE_ERROR,
+    sub_status: None,
+    location: 0x4::eps1_reborrow,
+    indices: [(FunctionDefinition, 1)],
+    offsets: [(FunctionDefinitionIndex(1), 6)],
+}
+
+task 3, lines 65-85:
+//# publish
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000005::eps2_reborrow'. Got VMError: {
+    major_status: BORROWLOC_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0x5::eps2_reborrow,
+    indices: [(FunctionDefinition, 1)],
+    offsets: [(FunctionDefinitionIndex(1), 2)],
+}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_extends_mut_arg_field.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_extends_mut_arg_field.mvir
@@ -1,0 +1,47 @@
+// tests that function calls require arguments references as disjoint
+
+//# publish
+
+module 0x1.Tester {
+    struct T has copy { f: u64 }
+
+    f1(s: &Self.T, f: &mut u64) {
+    label b0:
+        abort 0;
+    }
+
+    // reject call, f extends i
+    t_f1(s: &mut Self.T) {
+        let i: &Self.T;
+        let f: &mut u64;
+    label l0:
+        i = freeze(copy(s));
+        f = &mut copy(s).T::f;
+        Self.f1(move(i), move(f));
+        return;
+    }
+
+}
+
+//# publish
+
+module 0x1.Tester {
+    struct T has copy { f: u64 }
+
+    f2(f: &mut u64, s: &Self.T) {
+    label b0:
+        abort 0;
+    }
+
+    // reject call, f extends i
+    t_f1(s: &mut Self.T) {
+        let i: &Self.T;
+        let f: &mut u64;
+    label l0:
+        i = freeze(copy(s));
+        f = &mut copy(s).T::f;
+        Self.f2(move(f), move(i));
+        return;
+    }
+
+}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_extends_mut_arg_field.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_extends_mut_arg_field.snap
@@ -1,0 +1,24 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 2 tasks
+
+task 0, lines 3-24:
+//# publish
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::Tester'. Got VMError: {
+    major_status: FIELD_EXISTS_MUTABLE_BORROW_ERROR,
+    sub_status: None,
+    location: 0x1::Tester,
+    indices: [(FunctionDefinition, 1)],
+    offsets: [(FunctionDefinitionIndex(1), 4)],
+}
+
+task 1, lines 26-47:
+//# publish
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::Tester'. Got VMError: {
+    major_status: FIELD_EXISTS_MUTABLE_BORROW_ERROR,
+    sub_status: None,
+    location: 0x1::Tester,
+    indices: [(FunctionDefinition, 1)],
+    offsets: [(FunctionDefinitionIndex(1), 4)],
+}


### PR DESCRIPTION
# Description of change

- Additional tests for reference safety passes
- Pulled in from the regex rewrite

According to [changes](https://github.com/MystenLabs/sui/commit/9cb97ff079ba2adc2bc2fd7812e03e15938e9636)

## Links to any relevant issues

Fixes #8265 .

## How the change has been tested

Run tests for bytecode-verifier-transactional-tests

../iota/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/tests.rs