### PR TITLE
refactor(move/move-model-2): Switch maps to IndexMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
  "arrow-schema 54.3.1",
  "chrono",
  "half",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "lexical-core",
  "memchr",
  "num",
@@ -925,7 +925,7 @@ dependencies = [
  "futures-util",
  "handlebars",
  "http 1.3.1",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "lru",
  "mime",
  "multer",
@@ -996,7 +996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ecdaff7c9cffa3614a9f9999bf9ee4c3078fe3ce4d6a6e161736b56febf2de"
 dependencies = [
  "bytes",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "serde",
  "serde_json",
 ]
@@ -3175,7 +3175,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718f6cd8c54ae5249fd42b0c86639df0100b8a86eea2e5f1b915cde2e1481453"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "lalrpop-util",
  "logos",
 ]
@@ -4586,7 +4586,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util 0.7.12",
@@ -4605,7 +4605,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util 0.7.12",
@@ -5239,12 +5239,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -6024,7 +6024,7 @@ dependencies = [
  "fastcrypto",
  "fastcrypto-zkp",
  "futures",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "insta",
  "iota-config",
  "iota-core",
@@ -6517,7 +6517,7 @@ dependencies = [
  "futures",
  "http-body 1.0.1",
  "hyper 1.4.1",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "iota-config",
  "iota-core",
  "iota-json",
@@ -6902,7 +6902,7 @@ dependencies = [
  "fastcrypto",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "iota-protocol-config",
  "iota-types",
  "move-binary-format",
@@ -7684,7 +7684,7 @@ dependencies = [
  "bcs",
  "clap",
  "futures",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "iota-core",
  "iota-json-rpc-types",
  "iota-macros",
@@ -7955,7 +7955,7 @@ dependencies = [
  "fastcrypto-zkp",
  "hex",
  "im",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "iota-enum-compat-util",
  "iota-macros",
  "iota-network-stack",
@@ -9150,7 +9150,7 @@ name = "move-bytecode-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "move-binary-format",
  "move-core-types",
  "petgraph 0.5.1",
@@ -9319,7 +9319,7 @@ dependencies = [
  "clap",
  "codespan",
  "colored",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -9437,6 +9437,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "codespan-reporting",
+ "indexmap 2.11.0",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
@@ -10236,7 +10237,7 @@ name = "openapiv3"
 version = "2.0.0"
 source = "git+https://github.com/bmwill/openapiv3.git?rev=ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963#ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "schemars",
  "serde",
  "serde_json",
@@ -10664,7 +10665,7 @@ dependencies = [
  "data-encoding",
  "getrandom 0.2.15",
  "hmac",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -10832,7 +10833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
 ]
 
 [[package]]
@@ -12864,7 +12865,7 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "itoa",
  "memchr",
  "ryu",
@@ -12923,7 +12924,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -14328,7 +14329,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -14374,7 +14375,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -14387,7 +14388,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -14400,7 +14401,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "toml_datetime",
  "toml_write",
  "winnow 0.7.11",
@@ -14569,7 +14570,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.1",
@@ -16071,7 +16072,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.5.0",
+ "indexmap 2.11.0",
  "memchr",
  "thiserror 1.0.64",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,7 +282,7 @@ hyper = "1"
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-roots", "http1", "http2", "ring", "tls12"] }
 hyper-util = { version = "0.1.4", features = ["tokio", "server-auto", "service"] }
 im = "15"
-indexmap = { version = "2.1.0", features = ["serde"] }
+indexmap = { version = "2.11.0", features = ["serde"] }
 indicatif = "0.17.2"
 insta = { version = "1.21.1", features = ["redactions", "yaml", "json"] }
 integer-encoding = "3.0.1"

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1765,7 +1765,7 @@ name = "move-bytecode-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "move-binary-format",
  "move-core-types",
  "petgraph",
@@ -1948,7 +1948,7 @@ dependencies = [
  "clap 4.5.41",
  "codespan",
  "colored",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -2125,7 +2125,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "codespan-reporting",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
@@ -3289,7 +3289,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3762,7 +3762,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "toml_datetime",
  "winnow",
 ]

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2125,6 +2125,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "codespan-reporting",
+ "indexmap 2.10.0",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -49,7 +49,7 @@ hex = "0.4.3"
 hex-literal = "0.3.4"
 hkdf = "0.10.0"
 im = "15.1.0"
-indexmap = "2.1.0"
+indexmap = "2.8.0"
 inline_colorization = "0.1.6"
 insta = "1.42.0"
 internment = { version = "0.5.0", features = ["arc"] }

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -49,7 +49,7 @@ hex = "0.4.3"
 hex-literal = "0.3.4"
 hkdf = "0.10.0"
 im = "15.1.0"
-indexmap = "2.8.0"
+indexmap = "2.11.0"
 inline_colorization = "0.1.6"
 insta = "1.42.0"
 internment = { version = "0.5.0", features = ["arc"] }

--- a/external-crates/move/crates/move-docgen-tests/tests/move/annotation/a__m.md@collapsed_sections.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/annotation/a__m.md@collapsed_sections.snap
@@ -8,7 +8,6 @@ info:
   no_collapsed_sections: true
   include_dep_diagrams: false
   include_call_diagrams: false
-input_file: crates/move-docgen-tests/tests/move/annotation/Move.toml
 ---
 <a name="a_m"></a>
 
@@ -29,17 +28,6 @@ This is a doc comment above an annotation.
 <a name="@Constants_0"></a>
 
 ## Constants
-
-
-<a name="a_m_Cool"></a>
-
-This is the top doc comment
-This is the middle doc comment
-
-
-<pre><code><b>const</b> <a href="../a/m.md#a_m_Cool">Cool</a>: u32 = 0;
-</code></pre>
-
 
 
 <a name="a_m_Error"></a>
@@ -70,6 +58,17 @@ This is the bottom doc comment
 
 
 <pre><code><b>const</b> <a href="../a/m.md#a_m_Woah">Woah</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="a_m_Cool"></a>
+
+This is the top doc comment
+This is the middle doc comment
+
+
+<pre><code><b>const</b> <a href="../a/m.md#a_m_Cool">Cool</a>: u32 = 0;
 </code></pre>
 
 

--- a/external-crates/move/crates/move-docgen-tests/tests/move/annotation/a__m.md@default.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/annotation/a__m.md@default.snap
@@ -8,7 +8,6 @@ info:
   no_collapsed_sections: false
   include_dep_diagrams: false
   include_call_diagrams: false
-input_file: crates/move-docgen-tests/tests/move/annotation/Move.toml
 ---
 <a name="a_m"></a>
 
@@ -29,17 +28,6 @@ This is a doc comment above an annotation.
 <a name="@Constants_0"></a>
 
 ## Constants
-
-
-<a name="a_m_Cool"></a>
-
-This is the top doc comment
-This is the middle doc comment
-
-
-<pre><code><b>const</b> <a href="../a/m.md#a_m_Cool">Cool</a>: u32 = 0;
-</code></pre>
-
 
 
 <a name="a_m_Error"></a>
@@ -70,6 +58,17 @@ This is the bottom doc comment
 
 
 <pre><code><b>const</b> <a href="../a/m.md#a_m_Woah">Woah</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="a_m_Cool"></a>
+
+This is the top doc comment
+This is the middle doc comment
+
+
+<pre><code><b>const</b> <a href="../a/m.md#a_m_Cool">Cool</a>: u32 = 0;
 </code></pre>
 
 

--- a/external-crates/move/crates/move-docgen-tests/tests/move/const_string/a__m.md@collapsed_sections.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/const_string/a__m.md@collapsed_sections.snap
@@ -8,7 +8,6 @@ info:
   no_collapsed_sections: true
   include_dep_diagrams: false
   include_call_diagrams: false
-input_file: crates/move-docgen-tests/tests/move/const_string/Move.toml
 ---
 <a name="a_m"></a>
 
@@ -39,15 +38,6 @@ This is a doc comment above an error constant that should be rendered as a strin
 
 
 
-<a name="a_m_AStringNotError"></a>
-
-
-
-<pre><code><b>const</b> <a href="../a/m.md#a_m_AStringNotError">AStringNotError</a>: vector&lt;u8&gt; = vector[72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 32, 32, 240, 159, 166, 128, 32, 32, 32];
-</code></pre>
-
-
-
 <a name="a_m_ErrorNotString"></a>
 
 This is a doc comment above an error constant that should not be rendered as a string
@@ -55,6 +45,15 @@ This is a doc comment above an error constant that should not be rendered as a s
 
 <pre><code>#[error]
 <b>const</b> <a href="../a/m.md#a_m_ErrorNotString">ErrorNotString</a>: u64 = 10;
+</code></pre>
+
+
+
+<a name="a_m_AStringNotError"></a>
+
+
+
+<pre><code><b>const</b> <a href="../a/m.md#a_m_AStringNotError">AStringNotError</a>: vector&lt;u8&gt; = vector[72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 32, 32, 240, 159, 166, 128, 32, 32, 32];
 </code></pre>
 
 

--- a/external-crates/move/crates/move-docgen-tests/tests/move/const_string/a__m.md@default.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/const_string/a__m.md@default.snap
@@ -8,7 +8,6 @@ info:
   no_collapsed_sections: false
   include_dep_diagrams: false
   include_call_diagrams: false
-input_file: crates/move-docgen-tests/tests/move/const_string/Move.toml
 ---
 <a name="a_m"></a>
 
@@ -39,15 +38,6 @@ This is a doc comment above an error constant that should be rendered as a strin
 
 
 
-<a name="a_m_AStringNotError"></a>
-
-
-
-<pre><code><b>const</b> <a href="../a/m.md#a_m_AStringNotError">AStringNotError</a>: vector&lt;u8&gt; = vector[72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 32, 32, 240, 159, 166, 128, 32, 32, 32];
-</code></pre>
-
-
-
 <a name="a_m_ErrorNotString"></a>
 
 This is a doc comment above an error constant that should not be rendered as a string
@@ -55,6 +45,15 @@ This is a doc comment above an error constant that should not be rendered as a s
 
 <pre><code>#[error]
 <b>const</b> <a href="../a/m.md#a_m_ErrorNotString">ErrorNotString</a>: u64 = 10;
+</code></pre>
+
+
+
+<a name="a_m_AStringNotError"></a>
+
+
+
+<pre><code><b>const</b> <a href="../a/m.md#a_m_AStringNotError">AStringNotError</a>: vector&lt;u8&gt; = vector[72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 32, 32, 240, 159, 166, 128, 32, 32, 32];
 </code></pre>
 
 

--- a/external-crates/move/crates/move-model-2/Cargo.toml
+++ b/external-crates/move/crates/move-model-2/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+indexmap.workspace = true
 move-binary-format.workspace = true
 move-bytecode-source-map.workspace = true
 move-command-line-common.workspace = true

--- a/external-crates/move/crates/move-model-2/src/compiled.rs
+++ b/external-crates/move/crates/move-model-2/src/compiled.rs
@@ -2,6 +2,7 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use indexmap::IndexMap;
 use move_binary_format::file_format::{
     self, AbilitySet, CodeOffset, CodeUnit, CompiledModule, ConstantPoolIndex, DatatypeHandleIndex,
     DatatypeTyParameter, EnumDefinitionIndex, FieldHandleIndex, FunctionDefinition,
@@ -42,9 +43,9 @@ pub struct Package {
 pub struct Module {
     pub name: Symbol,
     pub package: AccountAddress,
-    pub structs: BTreeMap<Symbol, Struct>,
-    pub enums: BTreeMap<Symbol, Enum>,
-    pub functions: BTreeMap<Symbol, Function>,
+    pub structs: IndexMap<Symbol, Struct>,
+    pub enums: IndexMap<Symbol, Enum>,
+    pub functions: IndexMap<Symbol, Function>,
     pub constants: Vec<Constant>,
     pub module: CompiledModule,
     pub deps: BTreeMap<ModuleId, /* is immediate */ bool>,
@@ -65,7 +66,7 @@ pub struct Enum {
     pub name: Symbol,
     pub abilities: AbilitySet,
     pub type_parameters: Vec<DatatypeTyParameter>,
-    pub variants: BTreeMap<Symbol, Variant>,
+    pub variants: IndexMap<Symbol, Variant>,
     pub def_idx: EnumDefinitionIndex,
 }
 
@@ -485,7 +486,7 @@ impl Module {
                 let struct_ = make_struct(&compiled_module, def, StructDefinitionIndex(idx as u16));
                 (struct_.name, struct_)
             })
-            .collect::<BTreeMap<_, _>>();
+            .collect::<IndexMap<_, _>>();
         let enums = compiled_module
             .enum_defs()
             .iter()
@@ -494,7 +495,7 @@ impl Module {
                 let enum_ = make_enum(&compiled_module, def, EnumDefinitionIndex(idx as u16));
                 (enum_.name, enum_)
             })
-            .collect::<BTreeMap<_, _>>();
+            .collect::<IndexMap<_, _>>();
         let functions = compiled_module
             .function_defs()
             .iter()
@@ -503,7 +504,7 @@ impl Module {
                 let fun = make_fun(&compiled_module, def, FunctionDefinitionIndex(idx as u16));
                 (fun.name, fun)
             })
-            .collect::<BTreeMap<_, _>>();
+            .collect::<IndexMap<_, _>>();
         let constants = compiled_module
             .constant_pool()
             .iter()
@@ -511,6 +512,22 @@ impl Module {
             .map(|(idx, def)| make_constant(&compiled_module, def, ConstantPoolIndex(idx as u16)))
             .collect();
 
+        debug_assert!(structs
+            .values()
+            .enumerate()
+            .all(|(i, s)| i == s.def_idx.0 as usize));
+        debug_assert!(enums
+            .values()
+            .enumerate()
+            .all(|(i, e)| i == e.def_idx.0 as usize
+                && e.variants
+                    .values()
+                    .enumerate()
+                    .all(|(j, v)| j == v.tag as usize)));
+        debug_assert!(functions
+            .values()
+            .enumerate()
+            .all(|(i, f)| i == f.def_idx.0 as usize));
         Self {
             name,
             package,

--- a/external-crates/move/crates/move-model-2/src/model.rs
+++ b/external-crates/move/crates/move-model-2/src/model.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use crate::compiled::{self, ModuleId, QualifiedMemberId, TModuleId};
+use indexmap::IndexMap;
 use move_binary_format::{file_format, CompiledModule};
 use move_bytecode_source_map::source_map::SourceMap;
 use move_compiler::{
@@ -199,6 +200,7 @@ impl Model<WITH_SOURCE> {
             compiled,
             packages,
         };
+        model.check_invariants();
         Ok(model)
     }
 
@@ -226,14 +228,16 @@ impl Model<WITHOUT_SOURCE> {
             .iter()
             .map(|(a, n)| (*n, *a))
             .collect();
-        Self {
+        let model = Self {
             files: [],
             root_package_name: None,
             root_named_address_map,
             info: [],
             compiled,
             packages,
-        }
+        };
+        model.check_invariants();
+        model
     }
 }
 
@@ -294,6 +298,60 @@ impl<const HAS_SOURCE: SourceKind> Model<HAS_SOURCE> {
                 std::mem::transmute::<&Self, &Model<WITHOUT_SOURCE>>(self)
             }),
             _ => unreachable!(),
+        }
+    }
+
+    fn check_invariants(&self) {
+        #[cfg(debug_assertions)]
+        {
+            for (p, package) in &self.packages {
+                for (m, module) in &package.modules {
+                    let compiled = &self.compiled.packages[p].modules[m];
+                    for (idx, s) in module.structs.keys().enumerate() {
+                        let map_idx = module.structs.get_index_of(s).unwrap();
+                        let compiled_map_idx = compiled.structs.get_index_of(s).unwrap();
+                        let compiled_idx = compiled.structs[s].def_idx.0 as usize;
+                        debug_assert_eq!(idx, map_idx);
+                        debug_assert_eq!(idx, compiled_map_idx);
+                        debug_assert_eq!(idx, compiled_idx);
+                    }
+                    for (idx, f) in module.functions.keys().enumerate() {
+                        let map_idx = module.functions.get_index_of(f).unwrap();
+                        debug_assert_eq!(idx, map_idx);
+                        if let Some(compiled_map_idx) = compiled.functions.get_index_of(f) {
+                            let compiled_idx = compiled.functions[f].def_idx.0 as usize;
+                            debug_assert!(idx >= compiled_map_idx);
+                            debug_assert!(idx >= compiled_idx);
+                        }
+                        if HAS_SOURCE == WITH_SOURCE {
+                            let declared_idx = self.info[0]
+                                .module(&module.ident[0])
+                                .functions
+                                .get_(f)
+                                .unwrap()
+                                .index;
+                            debug_assert_eq!(idx, declared_idx);
+                        }
+                    }
+                    for (idx, (e, enum_)) in module.enums.iter().enumerate() {
+                        let map_idx = module.enums.get_index_of(e).unwrap();
+                        let compiled_map_idx = compiled.enums.get_index_of(e).unwrap();
+                        let compiled_idx = compiled.enums[e].def_idx.0 as usize;
+                        debug_assert_eq!(idx, map_idx);
+                        debug_assert_eq!(idx, compiled_map_idx);
+                        debug_assert_eq!(idx, compiled_idx);
+                        for (vidx, v) in enum_.variants.keys().enumerate() {
+                            let map_idx = enum_.variants.get_index_of(v).unwrap();
+                            let compiled_map_idx =
+                                compiled.enums[e].variants.get_index_of(v).unwrap();
+                            let compiled_idx = compiled.enums[e].variants[v].tag as usize;
+                            debug_assert_eq!(vidx, map_idx);
+                            debug_assert_eq!(vidx, compiled_map_idx);
+                            debug_assert_eq!(vidx, compiled_idx);
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -802,10 +860,10 @@ struct PackageData<const HAS_SOURCE: SourceKind> {
 
 struct ModuleData<const HAS_SOURCE: SourceKind> {
     ident: [E::ModuleIdent; HAS_SOURCE],
-    structs: BTreeMap<Symbol, StructData>,
-    enums: BTreeMap<Symbol, EnumData>,
-    functions: BTreeMap<Symbol, FunctionData>,
-    named_constants: [BTreeMap<Symbol, ConstantData>; HAS_SOURCE],
+    structs: IndexMap<Symbol, StructData>,
+    enums: IndexMap<Symbol, EnumData>,
+    functions: IndexMap<Symbol, FunctionData>,
+    named_constants: [IndexMap<Symbol, ConstantData>; HAS_SOURCE],
     // mapping from file_format::ConstantPoolIndex to source constant name, if any
     constant_names: [Vec<Option<Symbol>>; HAS_SOURCE],
 }
@@ -814,7 +872,7 @@ struct StructData {}
 
 struct EnumData {
     #[allow(unused)]
-    variants: BTreeMap<Symbol, VariantData>,
+    variants: IndexMap<Symbol, VariantData>,
 }
 
 struct VariantData {}
@@ -875,50 +933,28 @@ impl ModuleData<WITH_SOURCE> {
         info: &ModuleInfo,
         unit: &NamedCompiledModule,
     ) -> Self {
-        let structs = info
-            .structs
-            .iter()
-            .map(|(_loc, name, _sinfo)| {
-                let name = *name;
-                let (_idx, _struct_def) =
-                    unit.module.find_struct_def_by_name(name.as_str()).unwrap();
-                let struct_ = StructData::new();
-                (name, struct_)
-            })
-            .collect();
-        let enums = info
-            .enums
-            .iter()
-            .map(|(_loc, name, _einfo)| {
-                let name = *name;
-                let (_idx, enum_def) = unit.module.find_enum_def_by_name(name.as_str()).unwrap();
-                let enum_ = EnumData::new(&unit.module, enum_def);
-                (name, enum_)
-            })
-            .collect();
-        let functions = info
-            .functions
-            .iter()
-            .map(|(_loc, name, _finfo)| {
-                let name = *name;
-                // Note, won't be found for macros
-                // let (_idx, _function_def) = unit
-                //     .module
-                //     .find_function_def_by_name(name.as_str())
-                //     .expect(&format!("cannot find fun {name}"));
-                let function = FunctionData::new();
-                (name, function)
-            })
-            .collect();
-        let named_constants = info
-            .constants
-            .iter()
-            .map(|(_loc, name, _cinfo)| {
-                let name = *name;
-                let constant = ConstantData::from_source(&unit.source_map, name);
-                (name, constant)
-            })
-            .collect();
+        let structs = make_map(info.structs.iter().map(|(_loc, name, _sinfo)| {
+            let name = *name;
+            let (idx, _struct_def) = unit.module.find_struct_def_by_name(name.as_str()).unwrap();
+            let struct_ = StructData::new();
+            (idx, name, struct_)
+        }));
+        let enums = make_map(info.enums.iter().map(|(_loc, name, _einfo)| {
+            let name = *name;
+            let (idx, enum_def) = unit.module.find_enum_def_by_name(name.as_str()).unwrap();
+            let enum_ = EnumData::new(&unit.module, enum_def);
+            (idx, name, enum_)
+        }));
+        let functions = make_map(info.functions.iter().map(|(_loc, name, finfo)| {
+            let name = *name;
+            let function = FunctionData::new();
+            (finfo.index, name, function)
+        }));
+        let named_constants = make_map(info.constants.iter().map(|(_loc, name, cinfo)| {
+            let name = *name;
+            let constant = ConstantData::from_source(&unit.source_map, name);
+            (cinfo.index, name, constant)
+        }));
         let constant_names = {
             let idx_to_name_map = unit
                 .source_map
@@ -984,7 +1020,7 @@ impl StructData {
 
 impl EnumData {
     fn new(module: &file_format::CompiledModule, def: &file_format::EnumDefinition) -> Self {
-        let mut variants = BTreeMap::new();
+        let mut variants = IndexMap::new();
         for variant in &def.variants {
             let name = Symbol::from(module.identifier_at(variant.variant_name).as_str());
             let data = VariantData::new();
@@ -1016,4 +1052,15 @@ impl ConstantData {
             .map(file_format::ConstantPoolIndex);
         Self { compiled_index }
     }
+}
+
+fn make_map<I: Ord + Copy, T>(
+    items: impl IntoIterator<Item = (I, Symbol, T)>,
+) -> IndexMap<Symbol, T> {
+    let mut items = items.into_iter().collect::<Vec<_>>();
+    items.sort_by_key(|(idx, _name, _data)| *idx);
+    items
+        .into_iter()
+        .map(|(_idx, name, data)| (name, data))
+        .collect::<IndexMap<_, _>>()
 }

--- a/external-crates/move/crates/move-stdlib/docs/std/bit_vector.md
+++ b/external-crates/move/crates/move-stdlib/docs/std/bit_vector.md
@@ -76,21 +76,21 @@ An invalid length of bitvector was given
 
 
 
+<a name="std_bit_vector_WORD_SIZE"></a>
+
+
+
+<pre><code><b>const</b> <a href="../std/bit_vector.md#std_bit_vector_WORD_SIZE">WORD_SIZE</a>: <a href="../std/u64.md#std_u64">u64</a> = 1;
+</code></pre>
+
+
+
 <a name="std_bit_vector_MAX_SIZE"></a>
 
 The maximum allowed bitvector size
 
 
 <pre><code><b>const</b> <a href="../std/bit_vector.md#std_bit_vector_MAX_SIZE">MAX_SIZE</a>: <a href="../std/u64.md#std_u64">u64</a> = 1024;
-</code></pre>
-
-
-
-<a name="std_bit_vector_WORD_SIZE"></a>
-
-
-
-<pre><code><b>const</b> <a href="../std/bit_vector.md#std_bit_vector_WORD_SIZE">WORD_SIZE</a>: <a href="../std/u64.md#std_u64">u64</a> = 1;
 </code></pre>
 
 

--- a/external-crates/move/crates/move-stdlib/docs/std/fixed_point32.md
+++ b/external-crates/move/crates/move-stdlib/docs/std/fixed_point32.md
@@ -61,6 +61,16 @@ decimal.
 ## Constants
 
 
+<a name="std_fixed_point32_MAX_U64"></a>
+
+> TODO: This is a basic constant and should be provided somewhere centrally in the framework.
+
+
+<pre><code><b>const</b> <a href="../std/fixed_point32.md#std_fixed_point32_MAX_U64">MAX_U64</a>: <a href="../std/u128.md#std_u128">u128</a> = 18446744073709551615;
+</code></pre>
+
+
+
 <a name="std_fixed_point32_EDENOMINATOR"></a>
 
 The denominator provided was zero
@@ -81,16 +91,6 @@ The quotient value would be too large to be held in a <code><a href="../std/u64.
 
 
 
-<a name="std_fixed_point32_EDIVISION_BY_ZERO"></a>
-
-A division by zero was encountered
-
-
-<pre><code><b>const</b> <a href="../std/fixed_point32.md#std_fixed_point32_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>: <a href="../std/u64.md#std_u64">u64</a> = 65540;
-</code></pre>
-
-
-
 <a name="std_fixed_point32_EMULTIPLICATION"></a>
 
 The multiplied value would be too large to be held in a <code><a href="../std/u64.md#std_u64">u64</a></code>
@@ -101,22 +101,22 @@ The multiplied value would be too large to be held in a <code><a href="../std/u6
 
 
 
+<a name="std_fixed_point32_EDIVISION_BY_ZERO"></a>
+
+A division by zero was encountered
+
+
+<pre><code><b>const</b> <a href="../std/fixed_point32.md#std_fixed_point32_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>: <a href="../std/u64.md#std_u64">u64</a> = 65540;
+</code></pre>
+
+
+
 <a name="std_fixed_point32_ERATIO_OUT_OF_RANGE"></a>
 
 The computed ratio when converting to a <code><a href="../std/fixed_point32.md#std_fixed_point32_FixedPoint32">FixedPoint32</a></code> would be unrepresentable
 
 
 <pre><code><b>const</b> <a href="../std/fixed_point32.md#std_fixed_point32_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>: <a href="../std/u64.md#std_u64">u64</a> = 131077;
-</code></pre>
-
-
-
-<a name="std_fixed_point32_MAX_U64"></a>
-
-> TODO: This is a basic constant and should be provided somewhere centrally in the framework.
-
-
-<pre><code><b>const</b> <a href="../std/fixed_point32.md#std_fixed_point32_MAX_U64">MAX_U64</a>: <a href="../std/u128.md#std_u128">u128</a> = 18446744073709551615;
 </code></pre>
 
 

--- a/external-crates/move/crates/move-stdlib/docs/std/string.md
+++ b/external-crates/move/crates/move-stdlib/docs/std/string.md
@@ -70,22 +70,22 @@ format.
 ## Constants
 
 
-<a name="std_string_EInvalidIndex"></a>
-
-Index out of range.
-
-
-<pre><code><b>const</b> <a href="../std/string.md#std_string_EInvalidIndex">EInvalidIndex</a>: <a href="../std/u64.md#std_u64">u64</a> = 2;
-</code></pre>
-
-
-
 <a name="std_string_EInvalidUTF8"></a>
 
 An invalid UTF8 encoding.
 
 
 <pre><code><b>const</b> <a href="../std/string.md#std_string_EInvalidUTF8">EInvalidUTF8</a>: <a href="../std/u64.md#std_u64">u64</a> = 1;
+</code></pre>
+
+
+
+<a name="std_string_EInvalidIndex"></a>
+
+Index out of range.
+
+
+<pre><code><b>const</b> <a href="../std/string.md#std_string_EInvalidIndex">EInvalidIndex</a>: <a href="../std/u64.md#std_u64">u64</a> = 2;
 </code></pre>
 
 

--- a/external-crates/move/crates/move-stdlib/docs/std/type_name.md
+++ b/external-crates/move/crates/move-stdlib/docs/std/type_name.md
@@ -63,16 +63,6 @@ Functionality for converting Move types into values. Use with care!
 ## Constants
 
 
-<a name="std_type_name_ASCII_C"></a>
-
-ASCII Character code for the <code>c</code> (lowercase c) symbol.
-
-
-<pre><code><b>const</b> <a href="../std/type_name.md#std_type_name_ASCII_C">ASCII_C</a>: <a href="../std/u8.md#std_u8">u8</a> = 99;
-</code></pre>
-
-
-
 <a name="std_type_name_ASCII_COLON"></a>
 
 ASCII Character code for the <code>:</code> (colon) symbol.
@@ -83,12 +73,42 @@ ASCII Character code for the <code>:</code> (colon) symbol.
 
 
 
+<a name="std_type_name_ASCII_V"></a>
+
+ASCII Character code for the <code>v</code> (lowercase v) symbol.
+
+
+<pre><code><b>const</b> <a href="../std/type_name.md#std_type_name_ASCII_V">ASCII_V</a>: <a href="../std/u8.md#std_u8">u8</a> = 118;
+</code></pre>
+
+
+
 <a name="std_type_name_ASCII_E"></a>
 
 ASCII Character code for the <code>e</code> (lowercase e) symbol.
 
 
 <pre><code><b>const</b> <a href="../std/type_name.md#std_type_name_ASCII_E">ASCII_E</a>: <a href="../std/u8.md#std_u8">u8</a> = 101;
+</code></pre>
+
+
+
+<a name="std_type_name_ASCII_C"></a>
+
+ASCII Character code for the <code>c</code> (lowercase c) symbol.
+
+
+<pre><code><b>const</b> <a href="../std/type_name.md#std_type_name_ASCII_C">ASCII_C</a>: <a href="../std/u8.md#std_u8">u8</a> = 99;
+</code></pre>
+
+
+
+<a name="std_type_name_ASCII_T"></a>
+
+ASCII Character code for the <code>t</code> (lowercase t) symbol.
+
+
+<pre><code><b>const</b> <a href="../std/type_name.md#std_type_name_ASCII_T">ASCII_T</a>: <a href="../std/u8.md#std_u8">u8</a> = 116;
 </code></pre>
 
 
@@ -109,26 +129,6 @@ ASCII Character code for the <code>r</code> (lowercase r) symbol.
 
 
 <pre><code><b>const</b> <a href="../std/type_name.md#std_type_name_ASCII_R">ASCII_R</a>: <a href="../std/u8.md#std_u8">u8</a> = 114;
-</code></pre>
-
-
-
-<a name="std_type_name_ASCII_T"></a>
-
-ASCII Character code for the <code>t</code> (lowercase t) symbol.
-
-
-<pre><code><b>const</b> <a href="../std/type_name.md#std_type_name_ASCII_T">ASCII_T</a>: <a href="../std/u8.md#std_u8">u8</a> = 116;
-</code></pre>
-
-
-
-<a name="std_type_name_ASCII_V"></a>
-
-ASCII Character code for the <code>v</code> (lowercase v) symbol.
-
-
-<pre><code><b>const</b> <a href="../std/type_name.md#std_type_name_ASCII_V">ASCII_V</a>: <a href="../std/u8.md#std_u8">u8</a> = 118;
 </code></pre>
 
 


### PR DESCRIPTION
# Description of change

- Module members are now ordered by their declared+compiled index

According to [changes](https://github.com/MystenLabs/sui/commit/2c5490ca6ed26de2ad37cbf82345375d2e4a8036#diff-75ca1f519c92cce1c3701cb370477da60ef31bccc0ce0810a82bc65c55ed2494)
## Links to any relevant issues

Fixes #8266 .