### PR TITLE
feat(gRPC): remain original checkpoint processing logic and enhance release_notes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6412,7 +6412,7 @@ dependencies = [
 
 [[package]]
 name = "iota-grpc-types"
-version = "1.5.0-alpha"
+version = "1.6.0-alpha"
 dependencies = [
  "iota-types",
  "serde",

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -524,6 +524,11 @@ impl CheckpointExecutor {
             }
         }
 
+        if let Some(ref checkpoint_data) = checkpoint_data {
+            self.commit_index_updates_and_enqueue_to_subscription_service(checkpoint_data.clone())
+                .await;
+        }
+
         if !checkpoint.is_last_checkpoint_of_epoch() {
             self.accumulator
                 .accumulate_running_root(epoch_store, checkpoint.sequence_number, checkpoint_acc)
@@ -534,13 +539,6 @@ impl CheckpointExecutor {
             // `broadcast_checkpoint` for the last checkpoint of an epoch
             // is handled specially in `check_epoch_last_checkpoint`
             self.broadcast_checkpoint(checkpoint, all_tx_digests, checkpoint_data.as_ref());
-        }
-
-        // Commit the index updates here to avoid cloning the checkpoint_data because we
-        // need to broadcast_checkpoint
-        if let Some(checkpoint_data) = checkpoint_data {
-            self.commit_index_updates_and_enqueue_to_subscription_service(checkpoint_data)
-                .await;
         }
     }
 
@@ -811,6 +809,13 @@ impl CheckpointExecutor {
                     .await
                     .expect("Finalizing checkpoint cannot fail");
 
+                    if let Some(ref checkpoint_data) = checkpoint_data {
+                        self.commit_index_updates_and_enqueue_to_subscription_service(
+                            checkpoint_data.clone(),
+                        )
+                        .await;
+                    }
+
                     self.checkpoint_store
                         .insert_epoch_last_checkpoint(cur_epoch, checkpoint)
                         .expect("Failed to insert epoch last checkpoint");
@@ -830,15 +835,6 @@ impl CheckpointExecutor {
                         &all_tx_digests,
                         checkpoint_data.as_ref(),
                     );
-
-                    // Commit the index updates here to avoid cloning the checkpoint_data because we
-                    // need to broadcast_checkpoint
-                    if let Some(checkpoint_data) = checkpoint_data {
-                        self.commit_index_updates_and_enqueue_to_subscription_service(
-                            checkpoint_data,
-                        )
-                        .await;
-                    }
 
                     return true;
                 }

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -525,7 +525,7 @@ impl CheckpointExecutor {
         }
 
         if let Some(ref checkpoint_data) = checkpoint_data {
-            self.commit_index_updates_and_enqueue_to_subscription_service(checkpoint_data.clone())
+            self.commit_index_updates_and_enqueue_to_subscription_service(checkpoint_data)
                 .await;
         }
 
@@ -547,7 +547,7 @@ impl CheckpointExecutor {
     /// service
     async fn commit_index_updates_and_enqueue_to_subscription_service(
         &self,
-        checkpoint: CheckpointData,
+        checkpoint: &CheckpointData,
     ) {
         if let Some(rest_index) = &self.state.rest_index {
             rest_index
@@ -811,7 +811,7 @@ impl CheckpointExecutor {
 
                     if let Some(ref checkpoint_data) = checkpoint_data {
                         self.commit_index_updates_and_enqueue_to_subscription_service(
-                            checkpoint_data.clone(),
+                            checkpoint_data,
                         )
                         .await;
                     }

--- a/crates/iota-grpc-api/src/client/checkpoint.rs
+++ b/crates/iota-grpc-api/src/client/checkpoint.rs
@@ -56,7 +56,7 @@ impl CheckpointClient {
         Ok(stream.map(|result| {
             result.and_then(|checkpoint| {
                 Self::deserialize_checkpoint(&checkpoint).map_err(|e| {
-                    tonic::Status::internal(format!("Failed to deserialize checkpoint: {}", e))
+                    tonic::Status::internal(format!("Failed to deserialize checkpoint: {e}"))
                 })
             })
         }))

--- a/crates/iota-grpc-api/src/types.rs
+++ b/crates/iota-grpc-api/src/types.rs
@@ -388,7 +388,7 @@ impl GrpcReader {
                     }
                     Some(Err(RecvError::Closed)) => {
                         // report internal error to the stream and break
-                        Err(Status::internal(format!("Checkpoint {} channel closed.", data_type_name)))?;
+                        Err(Status::internal(format!("Checkpoint {data_type_name} channel closed.")))?;
                         break;
                     }
                     None => {

--- a/crates/iota-grpc-api/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-api/tests/checkpoint_stream.rs
@@ -404,7 +404,7 @@ async fn test_server_and_client_setup<I: Iterator<Item = u64>>(
     .expect("Failed to start gRPC server");
 
     let server_addr = server_handle.address();
-    let client = NodeClient::connect(&format!("http://{}", server_addr))
+    let client = NodeClient::connect(&format!("http://{server_addr}"))
         .await
         .expect("Failed to connect to gRPC server")
         .checkpoint_client()

--- a/scripts/release_notes/release_notes.py
+++ b/scripts/release_notes/release_notes.py
@@ -63,6 +63,7 @@ NOTE_ORDER = [
     "CLI",
     "Rust SDK",
     "REST API",
+    "Internal gRPC API",
 ]
 
 


### PR DESCRIPTION
# Description of change

- Remain the execution order in `process_executed_checkpoint` as the version before adding gRPC support
- Enhance `release_notes` rule to support `Internal gRPC API`
- Fix lint error due to rustc version update

## Links to any relevant issues

No

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
