### PR TITLE
fix(docs): Correct typo in "convenience" in method syntax documentation

### DIFF
--- a/external-crates/move/documentation/book/src/method-syntax.md
+++ b/external-crates/move/documentation/book/src/method-syntax.md
@@ -1,6 +1,6 @@
 # Methods
 
-As a syntactic convience, some functions in Move can be called as "methods" on a value. This is done
+As a syntactic convenience, some functions in Move can be called as "methods" on a value. This is done
 by using the `.` operator to call the function, where the value on the left-hand side of the `.` is
 the first argument to the function (sometimes called the receiver). The type of that value
 statically determines which function is called. This is an important difference from some other


### PR DESCRIPTION
# Description of change

Single typo fix in the docs. Changed word "convience" to the right one "convenience".

## Links to any relevant issues

fixes #[8273](https://github.com/iotaledger/iota/issues/8273)

## How the change has been tested

- No test has been done for this small fix
