### PR TITLE
upstream(core): Deprecate skip_to_last/reverse methods in starfish rocksdb_store.rs

### DIFF
--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -372,12 +372,10 @@ impl Store for RocksDBStore {
         let mut refs = std::collections::VecDeque::new();
         for kv in self
             .digests_by_authorities
-            .safe_range_iter((
-                Included((author, Round::MIN, BlockHeaderDigest::MIN)),
-                Included((author, before_round, BlockHeaderDigest::MAX)),
-            ))
-            .skip_to_last()
-            .reverse()
+            .reversed_safe_iter_with_bounds(
+                Some((author, Round::MIN, BlockHeaderDigest::MIN)),
+                Some((author, before_round, BlockHeaderDigest::MAX)),
+            )?
             .take(num_of_rounds as usize)
         {
             let ((author, round, digest), _) = kv?;
@@ -394,7 +392,11 @@ impl Store for RocksDBStore {
     }
 
     fn read_last_commit(&self) -> ConsensusResult<Option<TrustedCommit>> {
-        let Some(result) = self.commits.safe_iter().skip_to_last().next() else {
+        let Some(result) = self
+            .commits
+            .reversed_safe_iter_with_bounds(None, None)?
+            .next()
+        else {
             return Ok(None);
         };
         let ((_index, digest), serialized) = result?;
@@ -436,7 +438,11 @@ impl Store for RocksDBStore {
     }
 
     fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>> {
-        let Some(result) = self.commit_info.safe_iter().skip_to_last().next() else {
+        let Some(result) = self
+            .commit_info
+            .reversed_safe_iter_with_bounds(None, None)?
+            .next()
+        else {
             return Ok(None);
         };
         let (key, commit_info) = result.map_err(ConsensusError::RocksDBFailure)?;


### PR DESCRIPTION
## Description
Apply upstream changes in https://github.com/iotaledger/iota/pull/8143 to starfish.

## Links to any relevant issues
Part of #5727 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes