### PR TITLE
feat(indexer): Prune optimistic transactions table

### DIFF
--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -7,6 +7,7 @@ use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 use iota_graphql_rpc_client::simple_client::SimpleClient;
 pub use iota_indexer::config::SnapshotLagConfig;
 use iota_indexer::{
+    config::PruningOptions,
     errors::IndexerError,
     store::{PgIndexerStore, indexer_store::IndexerStore},
     test_utils::{IndexerTypeConfig, force_delete_database, start_test_indexer_impl},
@@ -140,7 +141,13 @@ pub async fn serve_executor(
         true,
         None,
         format!("http://{executor_server_url}"),
-        IndexerTypeConfig::writer_mode(snapshot_config.clone(), epochs_to_keep),
+        IndexerTypeConfig::writer_mode(
+            snapshot_config.clone(),
+            Some(PruningOptions {
+                epochs_to_keep,
+                ..Default::default()
+            }),
+        ),
         Some(data_ingestion_path),
         cancellation_token.clone(),
     )

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -626,7 +626,7 @@ pub mod deprecated {
                             .unwrap_or_else(|_e| None),
                         optimistic_pruner_batch_size: std::env::var("OPTIMISTIC_PRUNER_BATCH_SIZE")
                             .map(|s| s.parse::<u64>().ok())
-                            .unwrap_or_else(|_e| None),
+                            .unwrap_or_default(),
                         pruning_config_path: None,
                     },
                     reset_db: old_conf.reset_db,

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -242,6 +242,8 @@ pub struct PruningOptions {
     /// Path to TOML file containing configuration for retention policies.
     #[arg(long)]
     pub pruning_config_path: Option<PathBuf>,
+    #[arg(long, env = "OPTIMISTIC_PRUNER_BATCH_SIZE")]
+    pub optimistic_pruner_batch_size: Option<u64>,
 }
 
 /// Represents the default retention policy and overrides for prunable tables.
@@ -622,6 +624,9 @@ pub mod deprecated {
                         epochs_to_keep: std::env::var("EPOCHS_TO_KEEP")
                             .map(|s| s.parse::<u64>().ok())
                             .unwrap_or_else(|_e| None),
+                        optimistic_pruner_batch_size: std::env::var("OPTIMISTIC_PRUNER_BATCH_SIZE")
+                            .map(|s| s.parse::<u64>().ok())
+                            .unwrap_or_else(|_e| None),
                         pruning_config_path: None,
                     },
                     reset_db: old_conf.reset_db,
@@ -738,6 +743,7 @@ mod test {
         let pruning_options = PruningOptions {
             epochs_to_keep: None,
             pruning_config_path: Some(temp_path.clone()),
+            optimistic_pruner_batch_size: None,
         };
         let retention_config = pruning_options.load_from_file().unwrap().unwrap();
 
@@ -788,6 +794,7 @@ mod test {
         let pruning_options = PruningOptions {
             epochs_to_keep: None,
             pruning_config_path: Some(temp_path.clone()),
+            optimistic_pruner_batch_size: None,
         };
         let retention_config = pruning_options.load_from_file().unwrap().unwrap();
 

--- a/crates/iota-indexer/src/handlers/mod.rs
+++ b/crates/iota-indexer/src/handlers/mod.rs
@@ -24,6 +24,7 @@ use crate::{
 pub mod checkpoint_handler;
 pub mod committer;
 pub mod objects_snapshot_handler;
+pub mod optimistic_pruner;
 pub mod pruner;
 pub mod tx_processor;
 

--- a/crates/iota-indexer/src/handlers/optimistic_pruner.rs
+++ b/crates/iota-indexer/src/handlers/optimistic_pruner.rs
@@ -54,8 +54,8 @@ impl OptimisticPruner {
             }
 
             match self.prune_single_batch().await {
-                Ok(pruning_occured) => {
-                    pruning_in_progress = pruning_occured;
+                Ok(pruning_occurred) => {
+                    pruning_in_progress = pruning_occurred;
                 }
                 Err(err) => {
                     pruning_in_progress = false;

--- a/crates/iota-indexer/src/handlers/optimistic_pruner.rs
+++ b/crates/iota-indexer/src/handlers/optimistic_pruner.rs
@@ -4,7 +4,7 @@
 use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use super::checkpoint_handler::CheckpointHandler;
 use crate::{
@@ -44,21 +44,17 @@ impl OptimisticPruner {
     pub async fn start(&self, cancel: CancellationToken) -> IndexerResult<()> {
         info!("Starting Optimistic Pruner task...");
         let mut pruning_in_progress = false;
-        let mut last_pruned_id = (-1, -1);
 
         while !cancel.is_cancelled() {
             if !pruning_in_progress {
                 // let's not spam the DB if there's no pruning to be done
-                tokio::time::sleep(Duration::from_secs(1)).await;
+                tokio::time::sleep(Duration::from_secs(3)).await;
             }
             pruning_in_progress = false;
 
-            match self.prune_single_batch(last_pruned_id).await {
-                Ok(pruned_to) => {
-                    if pruned_to > last_pruned_id {
-                        pruning_in_progress = true;
-                    }
-                    last_pruned_id = pruned_to;
+            match self.prune_single_batch().await {
+                Ok(pruning_occured) => {
+                    pruning_in_progress = pruning_occured;
                 }
                 Err(err) => {
                     warn!("Failed to prune optimistic transaction batch: {err}");
@@ -71,15 +67,17 @@ impl OptimisticPruner {
         Ok(())
     }
 
-    async fn prune_single_batch(&self, last_pruned_id: (i64, i64)) -> IndexerResult<(i64, i64)> {
+    async fn prune_single_batch(&self) -> IndexerResult<bool> {
+        let whole_batch_timer = self.metrics.optimistic_pruner_batch_duration.start_timer();
+
         let current_epoch = self
             .store
             .get_latest_epoch_id_in_blocking_worker()
             .await?
             .unwrap_or(0);
         if current_epoch < EPOCHS_TO_KEEP {
-            debug!("No epochs available for pruning");
-            return Ok(last_pruned_id);
+            info!("No epochs available for optimistic pruning");
+            return Ok(false);
         }
 
         let prune_to_epoch = current_epoch.saturating_sub(EPOCHS_TO_KEEP);
@@ -97,37 +95,29 @@ impl OptimisticPruner {
             .store
             .get_global_order_for_tx_seq_in_blocking_worker(epoch_end_tx)
             .await?;
-        let prune_to = self
-            .store
-            .get_nth_smallest_optimistic_tx_global_order_in_blocking_worker(
-                self.optimistic_pruner_batch_size - 1,
-            )
-            .await?;
 
-        debug!(
-            "Last tx for epoch {prune_to_epoch} has global order {epoch_end_global_order:?}, \
-             next pruning batch ends at {prune_to:?}"
+        let rows_pruned = {
+            let _delete_timer = self
+                .metrics
+                .optimistic_pruner_delete_query_duration
+                .start_timer();
+            self.store
+                .prune_optimistic_transactions_up_to_in_blocking_worker(
+                    epoch_end_global_order,
+                    self.optimistic_pruner_batch_size as i64,
+                )
+                .await?
+        };
+        self.metrics
+            .optimistic_pruner_total_rows_pruned
+            .inc_by(rows_pruned as u64);
+        let elapsed = whole_batch_timer.stop_and_record();
+        info!(
+            "Pruned {rows_pruned} optimistic transactions with limit at {epoch_end_global_order:?} in {elapsed:?} seconds"
         );
 
-        if let Some(prune_to) = prune_to {
-            let prune_to = std::cmp::min(prune_to, epoch_end_global_order);
-            if prune_to <= last_pruned_id {
-                debug!(
-                    "No new optimistic transactions to prune, already pruned to {last_pruned_id:?}"
-                );
-                return Ok(last_pruned_id);
-            }
-            let rows_pruned = self
-                .store
-                .prune_optimistic_transactions_up_to_in_blocking_worker(prune_to)
-                .await?;
-            self.metrics
-                .last_pruned_optimistic_global_seq_num
-                .set(prune_to.0);
-            info!("Pruned {rows_pruned} optimistic transactions up to global order {prune_to:?}",);
-            return Ok(prune_to);
-        }
-
-        Ok(last_pruned_id)
+        // brief pause to give DB time to vacuum deleted rows
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        Ok(rows_pruned > 0)
     }
 }

--- a/crates/iota-indexer/src/handlers/optimistic_pruner.rs
+++ b/crates/iota-indexer/src/handlers/optimistic_pruner.rs
@@ -17,8 +17,8 @@ use crate::{
 // Keeping current and previous epoch ensures we will not prune just executed
 // txs on epoch boundary
 const EPOCHS_TO_KEEP: u64 = 2;
-const PRUNING_NOT_IN_PROGRESS_DELAY: Duration = Duration::from_secs(3);
-const DELETE_ROWS_DELAY: Duration = Duration::from_millis(200);
+const CHECK_EPOCH_CHANGE_INTERVAL: Duration = Duration::from_secs(3);
+const DELAY_BETWEEN_BATCHES: Duration = Duration::from_millis(200);
 
 pub struct OptimisticPruner {
     pub store: PgIndexerStore,
@@ -50,7 +50,7 @@ impl OptimisticPruner {
         while !cancel.is_cancelled() {
             if !pruning_in_progress {
                 // let's not spam the DB if there's no pruning to be done
-                tokio::time::sleep(PRUNING_NOT_IN_PROGRESS_DELAY).await;
+                tokio::time::sleep(CHECK_EPOCH_CHANGE_INTERVAL).await;
             }
 
             match self.prune_single_batch().await {
@@ -117,8 +117,8 @@ impl OptimisticPruner {
             "Pruned {rows_pruned} optimistic transactions with limit at {epoch_end_global_order:?} in {elapsed:?} seconds"
         );
 
-        // brief pause to give DB time to vacuum deleted rows
-        tokio::time::sleep(DELETE_ROWS_DELAY).await;
+        // brief pause to relieve the I/O pressure on the DB
+        tokio::time::sleep(DELAY_BETWEEN_BATCHES).await;
         Ok(rows_pruned > 0)
     }
 }

--- a/crates/iota-indexer/src/handlers/optimistic_pruner.rs
+++ b/crates/iota-indexer/src/handlers/optimistic_pruner.rs
@@ -101,7 +101,8 @@ impl OptimisticPruner {
         Ok(())
     }
 
-    /// Prunes optimistic transactions in batches until there are no more rows to delete.
+    /// Prunes optimistic transactions in batches until there are no more rows
+    /// to delete.
     async fn prune_in_batches(
         &self,
         epoch_end_global_order: TxGlobalOrderCursor,
@@ -160,8 +161,8 @@ impl OptimisticPruner {
         Ok(Some(epoch_end_global_order))
     }
 
-    /// Deletes a single batch of optimistic transactions up to the given global order.
-    /// Returns the number of deleted rows.
+    /// Deletes a single batch of optimistic transactions up to the given global
+    /// order. Returns the number of deleted rows.
     async fn prune_single_batch(
         &self,
         epoch_end_global_order: TxGlobalOrderCursor,

--- a/crates/iota-indexer/src/handlers/optimistic_pruner.rs
+++ b/crates/iota-indexer/src/handlers/optimistic_pruner.rs
@@ -10,7 +10,9 @@ use super::checkpoint_handler::CheckpointHandler;
 use crate::{
     errors::IndexerError,
     metrics::IndexerMetrics,
-    store::{IndexerStore, PgIndexerStore, pg_partition_manager::PgPartitionManager},
+    store::{
+        IndexerStore, PgIndexerStore, TxGlobalOrderCursor, pg_partition_manager::PgPartitionManager,
+    },
     types::IndexerResult,
 };
 
@@ -45,40 +47,89 @@ impl OptimisticPruner {
 
     pub async fn start(&self, cancel: CancellationToken) {
         info!("Starting Optimistic Pruner task...");
-        let mut pruning_in_progress = false;
+        let mut last_processed_epoch = None;
 
         while !cancel.is_cancelled() {
-            if !pruning_in_progress {
-                // let's not spam the DB if there's no pruning to be done
-                tokio::time::sleep(CHECK_EPOCH_CHANGE_INTERVAL).await;
-            }
+            tokio::time::sleep(CHECK_EPOCH_CHANGE_INTERVAL).await;
 
-            match self.prune_single_batch().await {
-                Ok(pruning_occurred) => {
-                    pruning_in_progress = pruning_occurred;
-                }
+            let current_epoch = match self.get_current_epoch().await {
+                Ok(epoch) => epoch,
                 Err(err) => {
-                    pruning_in_progress = false;
-                    warn!("Failed to prune optimistic transaction batch: {err}");
+                    warn!("Failed to get current epoch: {err}");
                     continue;
                 }
             };
+
+            if last_processed_epoch != Some(current_epoch) {
+                info!("Epoch change detected: {last_processed_epoch:?} -> {current_epoch}");
+
+                if let Err(err) = self.prune_up_to_epoch(current_epoch).await {
+                    warn!("Failed to prune up to epoch {current_epoch}: {err}");
+                    continue;
+                }
+
+                last_processed_epoch = Some(current_epoch);
+            }
         }
 
         info!("Optimistic Pruner task cancelled.");
     }
 
-    async fn prune_single_batch(&self) -> IndexerResult<bool> {
-        let whole_batch_timer = self.metrics.optimistic_pruner_batch_duration.start_timer();
+    /// Prunes optimistic transactions up to the given epoch if needed.
+    /// Returns Ok(()) if pruning was completed or skipped successfully.
+    async fn prune_up_to_epoch(&self, current_epoch: u64) -> IndexerResult<()> {
+        match self.get_pruning_threshold(current_epoch).await? {
+            Some(epoch_end_global_order) => {
+                info!(
+                    "Starting pruning for epoch {current_epoch} up to global order {epoch_end_global_order:?}"
+                );
 
-        let current_epoch = self
+                self.prune_in_batches(epoch_end_global_order).await?;
+            }
+            None => {
+                info!("No pruning needed for epoch {current_epoch}");
+            }
+        }
+        Ok(())
+    }
+
+    /// Prunes optimistic transactions in batches until there are no more rows to delete.
+    async fn prune_in_batches(
+        &self,
+        epoch_end_global_order: TxGlobalOrderCursor,
+    ) -> IndexerResult<()> {
+        loop {
+            let rows_deleted = self.prune_single_batch(epoch_end_global_order).await?;
+            if rows_deleted == 0 {
+                info!(
+                    "Finished pruning optimistic transactions in batches up to {epoch_end_global_order:?}"
+                );
+                break;
+            }
+            // brief pause to relieve the I/O pressure on the DB
+            tokio::time::sleep(DELAY_BETWEEN_BATCHES).await;
+        }
+        Ok(())
+    }
+
+    /// Gets the current epoch from the database.
+    async fn get_current_epoch(&self) -> IndexerResult<u64> {
+        Ok(self
             .store
             .get_latest_epoch_id_in_blocking_worker()
             .await?
-            .unwrap_or(0);
+            .unwrap_or(0))
+    }
+
+    /// Calculates the pruning threshold for a given epoch.
+    /// Returns None if no pruning should occur for this epoch.
+    async fn get_pruning_threshold(
+        &self,
+        current_epoch: u64,
+    ) -> IndexerResult<Option<TxGlobalOrderCursor>> {
         if current_epoch < EPOCHS_TO_KEEP {
             info!("No epochs available for optimistic pruning");
-            return Ok(false);
+            return Ok(None);
         }
 
         let prune_to_epoch = current_epoch.saturating_sub(EPOCHS_TO_KEEP);
@@ -91,34 +142,41 @@ impl OptimisticPruner {
                     "no network total transactions found for epoch {prune_to_epoch}"
                 ))
             })?;
+
         let epoch_end_tx = total_txs as i64 - 1;
         let epoch_end_global_order = self
             .store
             .get_global_order_for_tx_seq_in_blocking_worker(epoch_end_tx)
             .await?;
 
-        let rows_pruned = {
-            let _delete_timer = self
-                .metrics
-                .optimistic_pruner_delete_query_duration
-                .start_timer();
-            self.store
-                .prune_optimistic_transactions_up_to_in_blocking_worker(
-                    epoch_end_global_order,
-                    self.optimistic_pruner_batch_size as i64,
-                )
-                .await?
-        };
+        Ok(Some(epoch_end_global_order))
+    }
+
+    /// Deletes a single batch of optimistic transactions up to the given global order.
+    /// Returns the number of deleted rows.
+    async fn prune_single_batch(
+        &self,
+        epoch_end_global_order: TxGlobalOrderCursor,
+    ) -> IndexerResult<u64> {
+        let whole_batch_timer = self.metrics.optimistic_pruner_batch_duration.start_timer();
+
+        let rows_pruned = self
+            .store
+            .prune_optimistic_transactions_up_to_in_blocking_worker(
+                epoch_end_global_order,
+                self.optimistic_pruner_batch_size as i64,
+            )
+            .await?;
+
         self.metrics
             .optimistic_pruner_total_rows_pruned
             .inc_by(rows_pruned as u64);
+
         let elapsed = whole_batch_timer.stop_and_record();
         info!(
             "Pruned {rows_pruned} optimistic transactions with limit at {epoch_end_global_order:?} in {elapsed:?} seconds"
         );
 
-        // brief pause to relieve the I/O pressure on the DB
-        tokio::time::sleep(DELAY_BETWEEN_BATCHES).await;
-        Ok(rows_pruned > 0)
+        Ok(rows_pruned as u64)
     }
 }

--- a/crates/iota-indexer/src/handlers/optimistic_pruner.rs
+++ b/crates/iota-indexer/src/handlers/optimistic_pruner.rs
@@ -19,7 +19,15 @@ use crate::{
 // Keeping current and previous epoch ensures we will not prune just executed
 // txs on epoch boundary
 const EPOCHS_TO_KEEP: u64 = 2;
+
+// short epoch change detection time for testing
+#[cfg(any(feature = "shared_test_runtime", feature = "pg_integration"))]
 const CHECK_EPOCH_CHANGE_INTERVAL: Duration = Duration::from_secs(3);
+
+// longer epoch change detection time for production builds
+#[cfg(not(any(feature = "shared_test_runtime", feature = "pg_integration")))]
+const CHECK_EPOCH_CHANGE_INTERVAL: Duration = Duration::from_secs(3600); // 1 hour
+
 const DELAY_BETWEEN_BATCHES: Duration = Duration::from_millis(200);
 
 pub struct OptimisticPruner {

--- a/crates/iota-indexer/src/handlers/optimistic_pruner.rs
+++ b/crates/iota-indexer/src/handlers/optimistic_pruner.rs
@@ -17,6 +17,8 @@ use crate::{
 // Keeping current and previous epoch ensures we will not prune just executed
 // txs on epoch boundary
 const EPOCHS_TO_KEEP: u64 = 2;
+const PRUNING_NOT_IN_PROGRESS_DELAY: Duration = Duration::from_secs(3);
+const DELETE_ROWS_DELAY: Duration = Duration::from_millis(200);
 
 pub struct OptimisticPruner {
     pub store: PgIndexerStore,
@@ -31,7 +33,7 @@ impl OptimisticPruner {
         optimistic_pruner_batch_size: u64,
         metrics: IndexerMetrics,
     ) -> Result<Self, IndexerError> {
-        let blocking_cp = CheckpointHandler::pg_blocking_cp(store.clone()).unwrap();
+        let blocking_cp = CheckpointHandler::pg_blocking_cp(store.clone())?;
         let partition_manager = PgPartitionManager::new(blocking_cp.clone())?;
         Ok(Self {
             store,
@@ -41,22 +43,22 @@ impl OptimisticPruner {
         })
     }
 
-    pub async fn start(&self, cancel: CancellationToken) -> IndexerResult<()> {
+    pub async fn start(&self, cancel: CancellationToken) {
         info!("Starting Optimistic Pruner task...");
         let mut pruning_in_progress = false;
 
         while !cancel.is_cancelled() {
             if !pruning_in_progress {
                 // let's not spam the DB if there's no pruning to be done
-                tokio::time::sleep(Duration::from_secs(3)).await;
+                tokio::time::sleep(PRUNING_NOT_IN_PROGRESS_DELAY).await;
             }
-            pruning_in_progress = false;
 
             match self.prune_single_batch().await {
                 Ok(pruning_occured) => {
                     pruning_in_progress = pruning_occured;
                 }
                 Err(err) => {
+                    pruning_in_progress = false;
                     warn!("Failed to prune optimistic transaction batch: {err}");
                     continue;
                 }
@@ -64,7 +66,6 @@ impl OptimisticPruner {
         }
 
         info!("Optimistic Pruner task cancelled.");
-        Ok(())
     }
 
     async fn prune_single_batch(&self) -> IndexerResult<bool> {
@@ -87,7 +88,7 @@ impl OptimisticPruner {
             .await?
             .ok_or_else(|| {
                 IndexerError::PostgresRead(format!(
-                    "No network total transactions found for epoch {prune_to_epoch}"
+                    "no network total transactions found for epoch {prune_to_epoch}"
                 ))
             })?;
         let epoch_end_tx = total_txs as i64 - 1;
@@ -117,7 +118,7 @@ impl OptimisticPruner {
         );
 
         // brief pause to give DB time to vacuum deleted rows
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        tokio::time::sleep(DELETE_ROWS_DELAY).await;
         Ok(rows_pruned > 0)
     }
 }

--- a/crates/iota-indexer/src/handlers/optimistic_pruner.rs
+++ b/crates/iota-indexer/src/handlers/optimistic_pruner.rs
@@ -1,0 +1,133 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use super::checkpoint_handler::CheckpointHandler;
+use crate::{
+    errors::IndexerError,
+    metrics::IndexerMetrics,
+    store::{IndexerStore, PgIndexerStore, pg_partition_manager::PgPartitionManager},
+    types::IndexerResult,
+};
+
+// Keeping current and previous epoch ensures we will not prune just executed
+// txs on epoch boundary
+const EPOCHS_TO_KEEP: u64 = 2;
+
+pub struct OptimisticPruner {
+    pub store: PgIndexerStore,
+    pub partition_manager: PgPartitionManager,
+    pub optimistic_pruner_batch_size: u64,
+    pub metrics: IndexerMetrics,
+}
+
+impl OptimisticPruner {
+    pub fn new(
+        store: PgIndexerStore,
+        optimistic_pruner_batch_size: u64,
+        metrics: IndexerMetrics,
+    ) -> Result<Self, IndexerError> {
+        let blocking_cp = CheckpointHandler::pg_blocking_cp(store.clone()).unwrap();
+        let partition_manager = PgPartitionManager::new(blocking_cp.clone())?;
+        Ok(Self {
+            store,
+            partition_manager,
+            optimistic_pruner_batch_size,
+            metrics,
+        })
+    }
+
+    pub async fn start(&self, cancel: CancellationToken) -> IndexerResult<()> {
+        info!("Starting Optimistic Pruner task...");
+        let mut pruning_in_progress = false;
+        let mut last_pruned_id = (-1, -1);
+
+        while !cancel.is_cancelled() {
+            if !pruning_in_progress {
+                // let's not spam the DB if there's no pruning to be done
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            pruning_in_progress = false;
+
+            match self.prune_single_batch(last_pruned_id).await {
+                Ok(pruned_to) => {
+                    if pruned_to > last_pruned_id {
+                        pruning_in_progress = true;
+                    }
+                    last_pruned_id = pruned_to;
+                }
+                Err(err) => {
+                    warn!("Failed to prune optimistic transaction batch: {err}");
+                    continue;
+                }
+            };
+        }
+
+        info!("Optimistic Pruner task cancelled.");
+        Ok(())
+    }
+
+    async fn prune_single_batch(&self, last_pruned_id: (i64, i64)) -> IndexerResult<(i64, i64)> {
+        let current_epoch = self
+            .store
+            .get_latest_epoch_id_in_blocking_worker()
+            .await?
+            .unwrap_or(0);
+        if current_epoch < EPOCHS_TO_KEEP {
+            debug!("No epochs available for pruning");
+            return Ok(last_pruned_id);
+        }
+
+        let prune_to_epoch = current_epoch.saturating_sub(EPOCHS_TO_KEEP);
+        let total_txs = self
+            .store
+            .get_network_total_transactions_by_end_of_epoch(prune_to_epoch)
+            .await?
+            .ok_or_else(|| {
+                IndexerError::PostgresRead(format!(
+                    "No network total transactions found for epoch {prune_to_epoch}"
+                ))
+            })?;
+        let epoch_end_tx = total_txs as i64 - 1;
+        let epoch_end_global_order = self
+            .store
+            .get_global_order_for_tx_seq_in_blocking_worker(epoch_end_tx)
+            .await?;
+        let prune_to = self
+            .store
+            .get_nth_smallest_optimistic_tx_global_order_in_blocking_worker(
+                self.optimistic_pruner_batch_size - 1,
+            )
+            .await?;
+
+        debug!(
+            "Last tx for epoch {prune_to_epoch} has global order {epoch_end_global_order:?}, \
+             next pruning batch ends at {prune_to:?}"
+        );
+
+        if let Some(prune_to) = prune_to {
+            let prune_to = std::cmp::min(prune_to, epoch_end_global_order);
+            if prune_to <= last_pruned_id {
+                debug!(
+                    "No new optimistic transactions to prune, already pruned to {last_pruned_id:?}"
+                );
+                return Ok(last_pruned_id);
+            }
+            let rows_pruned = self
+                .store
+                .prune_optimistic_transactions_up_to_in_blocking_worker(prune_to)
+                .await?;
+            self.metrics
+                .last_pruned_optimistic_global_seq_num
+                .set(prune_to.0);
+            info!("Pruned {rows_pruned} optimistic transactions up to global order {prune_to:?}",);
+            return Ok(prune_to);
+        }
+
+        Ok(last_pruned_id)
+    }
+}

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -80,7 +80,7 @@ impl Indexer {
 
         if let Some(optimistic_pruner_batch_size) = optimistic_pruner_batch_size {
             info!("Starting indexer optimistic tables pruner");
-            let optimistic_pruner: OptimisticPruner = OptimisticPruner::new(
+            let optimistic_pruner = OptimisticPruner::new(
                 store.clone(),
                 optimistic_pruner_batch_size,
                 metrics.clone(),

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -22,7 +22,7 @@ use crate::{
     errors::IndexerError,
     handlers::{
         checkpoint_handler::new_handlers, objects_snapshot_handler::start_objects_snapshot_handler,
-        pruner::Pruner,
+        optimistic_pruner::OptimisticPruner, pruner::Pruner,
     },
     indexer_reader::IndexerReader,
     metrics::IndexerMetrics,
@@ -39,6 +39,7 @@ impl Indexer {
         metrics: IndexerMetrics,
         snapshot_config: SnapshotLagConfig,
         retention_config: Option<RetentionConfig>,
+        optimistic_pruner_batch_size: Option<u64>,
         cancel: CancellationToken,
     ) -> Result<(), IndexerError> {
         info!(
@@ -75,6 +76,19 @@ impl Indexer {
             let pruner = Pruner::new(store.clone(), retention_config, metrics.clone())?;
             let cancel_clone = cancel.clone();
             spawn_monitored_task!(pruner.start(cancel_clone));
+        }
+
+        if let Some(optimistic_pruner_batch_size) = optimistic_pruner_batch_size {
+            info!("Starting indexer optimistic tables pruner");
+            let optimistic_pruner: OptimisticPruner = OptimisticPruner::new(
+                store.clone(),
+                optimistic_pruner_batch_size,
+                metrics.clone(),
+            )?;
+            let cancellation_token_for_optimistic_pruner = cancel.child_token();
+            spawn_monitored_task!(
+                optimistic_pruner.start(cancellation_token_for_optimistic_pruner)
+            );
         }
 
         // If we already have chain identifier indexed (i.e. the first checkpoint has

--- a/crates/iota-indexer/src/main.rs
+++ b/crates/iota-indexer/src/main.rs
@@ -93,6 +93,7 @@ async fn main() -> Result<(), IndexerError> {
                 indexer_metrics,
                 snapshot_config,
                 retention_config,
+                pruning_options.optimistic_pruner_batch_size,
                 CancellationToken::new(),
             )
             .await?;

--- a/crates/iota-indexer/src/metrics.rs
+++ b/crates/iota-indexer/src/metrics.rs
@@ -180,7 +180,6 @@ pub struct IndexerMetrics {
     pub epoch_pruning_latency: Histogram, // not used
     pub optimistic_pruner_total_rows_pruned: IntCounter,
     pub optimistic_pruner_batch_duration: Histogram,
-    pub optimistic_pruner_delete_query_duration: Histogram,
 }
 
 impl IndexerMetrics {
@@ -815,13 +814,6 @@ impl IndexerMetrics {
             optimistic_pruner_batch_duration: register_histogram_with_registry!(
                 "optimistic_pruner_batch_duration",
                 "Time spent processing single optimistic pruner batch",
-                DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-                .unwrap(),
-            optimistic_pruner_delete_query_duration: register_histogram_with_registry!(
-                "optimistic_pruner_delete_query_duration",
-                "Time spent executing final DELETE query by optimistic pruner",
                 DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )

--- a/crates/iota-indexer/src/metrics.rs
+++ b/crates/iota-indexer/src/metrics.rs
@@ -178,6 +178,7 @@ pub struct IndexerMetrics {
     pub last_pruned_checkpoint: IntGauge,
     pub last_pruned_transaction: IntGauge,
     pub epoch_pruning_latency: Histogram, // not used
+    pub last_pruned_optimistic_global_seq_num: IntGauge,
 }
 
 impl IndexerMetrics {
@@ -801,6 +802,11 @@ impl IndexerMetrics {
             last_pruned_transaction: register_int_gauge_with_registry!(
                 "last_pruned_transaction",
                 "Last pruned transaction sequence number",
+                registry,
+            ).unwrap(),
+            last_pruned_optimistic_global_seq_num: register_int_gauge_with_registry!(
+                "last_pruned_optimistic_global_seq_num",
+                "Last pruned optimistic global sequence number",
                 registry,
             ).unwrap(),
             epoch_pruning_latency: register_histogram_with_registry!(

--- a/crates/iota-indexer/src/metrics.rs
+++ b/crates/iota-indexer/src/metrics.rs
@@ -178,7 +178,9 @@ pub struct IndexerMetrics {
     pub last_pruned_checkpoint: IntGauge,
     pub last_pruned_transaction: IntGauge,
     pub epoch_pruning_latency: Histogram, // not used
-    pub last_pruned_optimistic_global_seq_num: IntGauge,
+    pub optimistic_pruner_total_rows_pruned: IntCounter,
+    pub optimistic_pruner_batch_duration: Histogram,
+    pub optimistic_pruner_delete_query_duration: Histogram,
 }
 
 impl IndexerMetrics {
@@ -804,11 +806,26 @@ impl IndexerMetrics {
                 "Last pruned transaction sequence number",
                 registry,
             ).unwrap(),
-            last_pruned_optimistic_global_seq_num: register_int_gauge_with_registry!(
-                "last_pruned_optimistic_global_seq_num",
-                "Last pruned optimistic global sequence number",
+            optimistic_pruner_total_rows_pruned: register_int_counter_with_registry!(
+                "optimistic_pruner_total_rows_pruned",
+                "Total number of rows pruned by optimistic pruner",
                 registry,
-            ).unwrap(),
+            )
+                .unwrap(),
+            optimistic_pruner_batch_duration: register_histogram_with_registry!(
+                "optimistic_pruner_batch_duration",
+                "Time spent processing single optimistic pruner batch",
+                DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            optimistic_pruner_delete_query_duration: register_histogram_with_registry!(
+                "optimistic_pruner_delete_query_duration",
+                "Time spent executing final DELETE query by optimistic pruner",
+                DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
             epoch_pruning_latency: register_histogram_with_registry!(
                 "epoch_pruning_latency",
                 "Time spent in pruning one epoch",

--- a/crates/iota-indexer/src/store/mod.rs
+++ b/crates/iota-indexer/src/store/mod.rs
@@ -5,7 +5,7 @@
 pub(crate) use indexer_analytics_store::IndexerAnalyticalStore;
 pub(crate) use indexer_store::*;
 pub use pg_indexer_analytical_store::PgIndexerAnalyticalStore;
-pub use pg_indexer_store::PgIndexerStore;
+pub use pg_indexer_store::{PgIndexerStore, TxGlobalOrderCursor};
 
 mod indexer_analytics_store;
 pub mod indexer_store;

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -7,7 +7,8 @@ use std::{any::Any as StdAny, collections::BTreeMap, time::Duration};
 
 use async_trait::async_trait;
 use diesel::{
-    ExpressionMethods, OptionalExtension, PgConnection, QueryDsl, RunQueryDsl,
+    BoolExpressionMethods, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl,
+    RunQueryDsl,
     dsl::{max, min},
     sql_types::{Array, BigInt, Bytea, Nullable, SmallInt, Text},
     upsert::excluded,
@@ -47,9 +48,12 @@ use crate::{
     },
     on_conflict_do_update, on_conflict_do_update_with_condition, persist_chunk_into_table,
     persist_chunk_into_table_in_existing_connection, read_only_blocking,
-    rolling::transform::{
-        CheckpointObjectChanges, LiveObject, RemovedObject,
-        retain_latest_objects_from_checkpoint_batch,
+    rolling::{
+        error::IndexerResult,
+        transform::{
+            CheckpointObjectChanges, LiveObject, RemovedObject,
+            retain_latest_objects_from_checkpoint_batch,
+        },
     },
     schema::{
         chain_identifier, checkpoints, display, epochs, event_emit_module, event_emit_package,
@@ -153,6 +157,13 @@ impl PgIndexerStore {
 
     pub fn blocking_cp(&self) -> ConnectionPool {
         self.blocking_cp.clone()
+    }
+
+    pub(crate) async fn get_latest_epoch_id_in_blocking_worker(
+        &self,
+    ) -> Result<Option<u64>, IndexerError> {
+        self.execute_in_blocking_worker(move |this| this.get_latest_epoch_id())
+            .await
     }
 
     pub fn get_latest_epoch_id(&self) -> Result<Option<u64>, IndexerError> {
@@ -262,7 +273,9 @@ impl PgIndexerStore {
                 .first::<(i64, Option<i64>)>(conn)
                 .map(|(min, max)| (min as u64, max.map(|v| v as u64)))
         })
-        .context("Failed reading checkpoint range from PostgresDB")
+        .context(
+            format!("Failed reading checkpoint range from PostgresDB for epoch {epoch}").as_str(),
+        )
     }
 
     fn get_transaction_range_for_checkpoint(
@@ -279,7 +292,100 @@ impl PgIndexerStore {
                 .first::<(i64, i64)>(conn)
                 .map(|(min, max)| (min as u64, max as u64))
         })
-        .context("Failed reading transaction range from PostgresDB")
+        .context(
+            format!("Failed reading transaction range from PostgresDB for checkpoint {checkpoint}")
+                .as_str(),
+        )
+    }
+
+    pub(crate) async fn get_global_order_for_tx_seq_in_blocking_worker(
+        &self,
+        tx_seq: i64,
+    ) -> Result<(i64, i64), IndexerError> {
+        self.execute_in_blocking_worker(move |this| this.get_global_order_for_tx_seq(tx_seq))
+            .await
+    }
+
+    fn get_global_order_for_tx_seq(&self, tx_seq: i64) -> Result<(i64, i64), IndexerError> {
+        read_only_blocking!(&self.blocking_cp, |conn| {
+            tx_global_order::dsl::tx_global_order
+                .select((
+                    tx_global_order::global_sequence_number,
+                    tx_global_order::optimistic_sequence_number,
+                ))
+                .filter(tx_global_order::chk_tx_sequence_number.eq(tx_seq))
+                .first::<(i64, i64)>(conn)
+        })
+        .context(
+            format!("Failed reading global sequence number from PostgresDB for tx seq {tx_seq}")
+                .as_str(),
+        )
+    }
+
+    pub(crate) async fn get_nth_smallest_optimistic_tx_global_order_in_blocking_worker(
+        &self,
+        n: u64,
+    ) -> Result<Option<(i64, i64)>, IndexerError> {
+        self.execute_in_blocking_worker(move |this| {
+            this.get_nth_smallest_optimistic_tx_global_order(n)
+        })
+        .await
+    }
+
+    fn get_nth_smallest_optimistic_tx_global_order(
+        &self,
+        n: u64,
+    ) -> Result<Option<(i64, i64)>, IndexerError> {
+        read_only_blocking!(&self.blocking_cp, |conn| {
+            optimistic_transactions::dsl::optimistic_transactions
+                .select((
+                    optimistic_transactions::global_sequence_number,
+                    optimistic_transactions::optimistic_sequence_number,
+                ))
+                .order((
+                    optimistic_transactions::global_sequence_number.asc(),
+                    optimistic_transactions::optimistic_sequence_number.asc(),
+                ))
+                .offset(n as i64)
+                .first::<(i64, i64)>(conn)
+                .optional()
+        })
+        .context(format!("Failed reading Nth smallest optimistic tx global sequence number from PostgresDB for N: {n}").as_str())
+    }
+
+    pub(crate) async fn prune_optimistic_transactions_up_to_in_blocking_worker(
+        &self,
+        to: (i64, i64),
+    ) -> IndexerResult<usize> {
+        self.execute_in_blocking_worker(move |this| this.prune_optimistic_transactions_up_to(to))
+            .await
+    }
+
+    fn prune_optimistic_transactions_up_to(&self, to: (i64, i64)) -> IndexerResult<usize> {
+        let (to_global_sequence_num, to_optimistic_sequence_num) = to;
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                diesel::delete(
+                    optimistic_transactions::dsl::optimistic_transactions.filter(
+                        optimistic_transactions::global_sequence_number
+                            .lt(to_global_sequence_num)
+                            .or(optimistic_transactions::global_sequence_number
+                                .eq(to_global_sequence_num)
+                                .and(
+                                    optimistic_transactions::optimistic_sequence_number
+                                        .le(to_optimistic_sequence_num),
+                                )),
+                    ),
+                )
+                .execute(conn)
+                .map_err(IndexerError::from)
+                .context(
+                    format!("Failed to prune optimistic_transactions table to {to:?}").as_str(),
+                )
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
     }
 
     fn get_latest_object_snapshot_checkpoint_sequence_number(
@@ -1581,7 +1687,7 @@ impl PgIndexerStore {
                 .select(epochs::network_total_transactions)
                 .get_result::<Option<i64>>(conn)
         })
-        .context("Failed to get network total transactions in epoch")
+        .context(format!("Failed to get network total transactions in epoch {epoch}").as_str())
         .map(|option| option.map(|v| v as u64))
     }
 

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -78,21 +78,6 @@ pub struct TxGlobalOrderCursor {
     pub optimistic_sequence_number: i64,
 }
 
-impl TxGlobalOrderCursor {
-    pub fn new(global_sequence_number: i64, optimistic_sequence_number: i64) -> Self {
-        Self {
-            global_sequence_number,
-            optimistic_sequence_number,
-        }
-    }
-}
-
-impl From<(i64, i64)> for TxGlobalOrderCursor {
-    fn from((global_sequence_number, optimistic_sequence_number): (i64, i64)) -> Self {
-        Self::new(global_sequence_number, optimistic_sequence_number)
-    }
-}
-
 #[macro_export]
 macro_rules! chunk {
     ($data: expr, $size: expr) => {{
@@ -344,7 +329,11 @@ impl PgIndexerStore {
             format!("failed reading global sequence number from PostgresDB for tx seq {tx_seq}")
                 .as_str(),
         )?;
-        Ok(result.into())
+        let (global_sequence_number, optimistic_sequence_number) = result;
+        Ok(TxGlobalOrderCursor {
+            global_sequence_number,
+            optimistic_sequence_number,
+        })
     }
 
     pub(crate) async fn prune_optimistic_transactions_up_to_in_blocking_worker(

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -71,6 +71,28 @@ use crate::{
     },
 };
 
+/// A cursor representing the global order position of transaction according to tx_global_order table
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TxGlobalOrderCursor {
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
+}
+
+impl TxGlobalOrderCursor {
+    pub fn new(global_sequence_number: i64, optimistic_sequence_number: i64) -> Self {
+        Self {
+            global_sequence_number,
+            optimistic_sequence_number,
+        }
+    }
+}
+
+impl From<(i64, i64)> for TxGlobalOrderCursor {
+    fn from((global_sequence_number, optimistic_sequence_number): (i64, i64)) -> Self {
+        Self::new(global_sequence_number, optimistic_sequence_number)
+    }
+}
+
 #[macro_export]
 macro_rules! chunk {
     ($data: expr, $size: expr) => {{
@@ -300,13 +322,16 @@ impl PgIndexerStore {
     pub(crate) async fn get_global_order_for_tx_seq_in_blocking_worker(
         &self,
         tx_seq: i64,
-    ) -> Result<(i64, i64), IndexerError> {
+    ) -> Result<TxGlobalOrderCursor, IndexerError> {
         self.execute_in_blocking_worker(move |this| this.get_global_order_for_tx_seq(tx_seq))
             .await
     }
 
-    fn get_global_order_for_tx_seq(&self, tx_seq: i64) -> Result<(i64, i64), IndexerError> {
-        read_only_blocking!(&self.blocking_cp, |conn| {
+    fn get_global_order_for_tx_seq(
+        &self,
+        tx_seq: i64,
+    ) -> Result<TxGlobalOrderCursor, IndexerError> {
+        let result = read_only_blocking!(&self.blocking_cp, |conn| {
             tx_global_order::dsl::tx_global_order
                 .select((
                     tx_global_order::global_sequence_number,
@@ -318,12 +343,13 @@ impl PgIndexerStore {
         .context(
             format!("failed reading global sequence number from PostgresDB for tx seq {tx_seq}")
                 .as_str(),
-        )
+        )?;
+        Ok(result.into())
     }
 
     pub(crate) async fn prune_optimistic_transactions_up_to_in_blocking_worker(
         &self,
-        to: (i64, i64),
+        to: TxGlobalOrderCursor,
         limit: i64,
     ) -> IndexerResult<usize> {
         self.execute_in_blocking_worker(move |this| {
@@ -334,28 +360,28 @@ impl PgIndexerStore {
 
     fn prune_optimistic_transactions_up_to(
         &self,
-        to: (i64, i64),
+        to: TxGlobalOrderCursor,
         limit: i64,
     ) -> IndexerResult<usize> {
-        let (to_global_sequence_num, to_optimistic_sequence_num) = to;
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
-                let sql = "\
-                    WITH ids_to_delete AS (\
-                         SELECT global_sequence_number, optimistic_sequence_number \
-                         FROM optimistic_transactions \
-                         WHERE (global_sequence_number, optimistic_sequence_number) <= ($1, $2) \
-                         ORDER BY global_sequence_number, optimistic_sequence_number \
-                         FOR UPDATE LIMIT $3 \
-                     ) \
-                     DELETE FROM optimistic_transactions ot \
-                     USING ids_to_delete \
-                     WHERE (ot.global_sequence_number, ot.optimistic_sequence_number) = \
-                           (ids_to_delete.global_sequence_number, ids_to_delete.optimistic_sequence_number)";
+                let sql = r#"
+                    WITH ids_to_delete AS (
+                         SELECT global_sequence_number, optimistic_sequence_number
+                         FROM optimistic_transactions
+                         WHERE (global_sequence_number, optimistic_sequence_number) <= ($1, $2)
+                         ORDER BY global_sequence_number, optimistic_sequence_number
+                         FOR UPDATE LIMIT $3
+                     )
+                     DELETE FROM optimistic_transactions ot
+                     USING ids_to_delete
+                     WHERE (ot.global_sequence_number, ot.optimistic_sequence_number) =
+                           (ids_to_delete.global_sequence_number, ids_to_delete.optimistic_sequence_number)
+                "#;
                 diesel::sql_query(sql)
-                    .bind::<BigInt, _>(to_global_sequence_num)
-                    .bind::<BigInt, _>(to_optimistic_sequence_num)
+                    .bind::<BigInt, _>(to.global_sequence_number)
+                    .bind::<BigInt, _>(to.optimistic_sequence_number)
                     .bind::<BigInt, _>(limit)
                     .execute(conn)
                     .map_err(IndexerError::from)

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -7,8 +7,7 @@ use std::{any::Any as StdAny, collections::BTreeMap, time::Duration};
 
 use async_trait::async_trait;
 use diesel::{
-    BoolExpressionMethods, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl,
-    RunQueryDsl,
+    ExpressionMethods, OptionalExtension, PgConnection, QueryDsl, RunQueryDsl,
     dsl::{max, min},
     sql_types::{Array, BigInt, Bytea, Nullable, SmallInt, Text},
     upsert::excluded,
@@ -322,67 +321,47 @@ impl PgIndexerStore {
         )
     }
 
-    pub(crate) async fn get_nth_smallest_optimistic_tx_global_order_in_blocking_worker(
+    pub(crate) async fn prune_optimistic_transactions_up_to_in_blocking_worker(
         &self,
-        n: u64,
-    ) -> Result<Option<(i64, i64)>, IndexerError> {
+        to: (i64, i64),
+        limit: i64,
+    ) -> IndexerResult<usize> {
         self.execute_in_blocking_worker(move |this| {
-            this.get_nth_smallest_optimistic_tx_global_order(n)
+            this.prune_optimistic_transactions_up_to(to, limit)
         })
         .await
     }
 
-    fn get_nth_smallest_optimistic_tx_global_order(
-        &self,
-        n: u64,
-    ) -> Result<Option<(i64, i64)>, IndexerError> {
-        read_only_blocking!(&self.blocking_cp, |conn| {
-            optimistic_transactions::dsl::optimistic_transactions
-                .select((
-                    optimistic_transactions::global_sequence_number,
-                    optimistic_transactions::optimistic_sequence_number,
-                ))
-                .order((
-                    optimistic_transactions::global_sequence_number.asc(),
-                    optimistic_transactions::optimistic_sequence_number.asc(),
-                ))
-                .offset(n as i64)
-                .first::<(i64, i64)>(conn)
-                .optional()
-        })
-        .context(format!("Failed reading Nth smallest optimistic tx global sequence number from PostgresDB for N: {n}").as_str())
-    }
-
-    pub(crate) async fn prune_optimistic_transactions_up_to_in_blocking_worker(
+    fn prune_optimistic_transactions_up_to(
         &self,
         to: (i64, i64),
+        limit: i64,
     ) -> IndexerResult<usize> {
-        self.execute_in_blocking_worker(move |this| this.prune_optimistic_transactions_up_to(to))
-            .await
-    }
-
-    fn prune_optimistic_transactions_up_to(&self, to: (i64, i64)) -> IndexerResult<usize> {
         let (to_global_sequence_num, to_optimistic_sequence_num) = to;
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
-                diesel::delete(
-                    optimistic_transactions::dsl::optimistic_transactions.filter(
-                        optimistic_transactions::global_sequence_number
-                            .lt(to_global_sequence_num)
-                            .or(optimistic_transactions::global_sequence_number
-                                .eq(to_global_sequence_num)
-                                .and(
-                                    optimistic_transactions::optimistic_sequence_number
-                                        .le(to_optimistic_sequence_num),
-                                )),
-                    ),
-                )
-                .execute(conn)
-                .map_err(IndexerError::from)
-                .context(
-                    format!("Failed to prune optimistic_transactions table to {to:?}").as_str(),
-                )
+                let sql = "\
+                    WITH ids_to_delete AS (\
+                         SELECT global_sequence_number, optimistic_sequence_number \
+                         FROM optimistic_transactions \
+                         WHERE (global_sequence_number, optimistic_sequence_number) <= ($1, $2) \
+                         ORDER BY global_sequence_number, optimistic_sequence_number \
+                         FOR UPDATE LIMIT $3 \
+                     ) \
+                     DELETE FROM optimistic_transactions ot \
+                     USING ids_to_delete \
+                     WHERE (ot.global_sequence_number, ot.optimistic_sequence_number) = \
+                           (ids_to_delete.global_sequence_number, ids_to_delete.optimistic_sequence_number)";
+                diesel::sql_query(sql)
+                    .bind::<BigInt, _>(to_global_sequence_num)
+                    .bind::<BigInt, _>(to_optimistic_sequence_num)
+                    .bind::<BigInt, _>(limit)
+                    .execute(conn)
+                    .map_err(IndexerError::from)
+                    .context(
+                        format!("Failed to prune optimistic_transactions table to {to:?} with limit {limit}").as_str(),
+                    )
             },
             PG_DB_COMMIT_SLEEP_DURATION
         )

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -273,7 +273,7 @@ impl PgIndexerStore {
                 .map(|(min, max)| (min as u64, max.map(|v| v as u64)))
         })
         .context(
-            format!("Failed reading checkpoint range from PostgresDB for epoch {epoch}").as_str(),
+            format!("failed reading checkpoint range from PostgresDB for epoch {epoch}").as_str(),
         )
     }
 
@@ -292,7 +292,7 @@ impl PgIndexerStore {
                 .map(|(min, max)| (min as u64, max as u64))
         })
         .context(
-            format!("Failed reading transaction range from PostgresDB for checkpoint {checkpoint}")
+            format!("failed reading transaction range from PostgresDB for checkpoint {checkpoint}")
                 .as_str(),
         )
     }
@@ -316,7 +316,7 @@ impl PgIndexerStore {
                 .first::<(i64, i64)>(conn)
         })
         .context(
-            format!("Failed reading global sequence number from PostgresDB for tx seq {tx_seq}")
+            format!("failed reading global sequence number from PostgresDB for tx seq {tx_seq}")
                 .as_str(),
         )
     }
@@ -360,7 +360,7 @@ impl PgIndexerStore {
                     .execute(conn)
                     .map_err(IndexerError::from)
                     .context(
-                        format!("Failed to prune optimistic_transactions table to {to:?} with limit {limit}").as_str(),
+                        format!("failed to prune optimistic_transactions table to {to:?} with limit {limit}").as_str(),
                     )
             },
             PG_DB_COMMIT_SLEEP_DURATION
@@ -1666,7 +1666,7 @@ impl PgIndexerStore {
                 .select(epochs::network_total_transactions)
                 .get_result::<Option<i64>>(conn)
         })
-        .context(format!("Failed to get network total transactions in epoch {epoch}").as_str())
+        .context(format!("failed to get network total transactions in epoch {epoch}").as_str())
         .map(|option| option.map(|v| v as u64))
     }
 

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -71,7 +71,8 @@ use crate::{
     },
 };
 
-/// A cursor representing the global order position of transaction according to tx_global_order table
+/// A cursor representing the global order position of transaction according to
+/// tx_global_order table
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TxGlobalOrderCursor {
     pub global_sequence_number: i64,
@@ -363,9 +364,9 @@ impl PgIndexerStore {
                          ORDER BY global_sequence_number, optimistic_sequence_number
                          FOR UPDATE LIMIT $3
                      )
-                     DELETE FROM optimistic_transactions ot
+                     DELETE FROM optimistic_transactions otx
                      USING ids_to_delete
-                     WHERE (ot.global_sequence_number, ot.optimistic_sequence_number) =
+                     WHERE (otx.global_sequence_number, otx.optimistic_sequence_number) =
                            (ids_to_delete.global_sequence_number, ids_to_delete.optimistic_sequence_number)
                 "#;
                 diesel::sql_query(sql)

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -2,17 +2,19 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::config::PruningOptions;
+use std::path::PathBuf;
+
 use diesel::{QueryableByName, connection::SimpleConnection, sql_types::BigInt};
 use iota_json_rpc_types::IotaTransactionBlockResponse;
 use iota_metrics::init_metrics;
-use std::path::PathBuf;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
     IndexerMetrics,
-    config::{IngestionConfig, IotaNamesOptions, RetentionConfig, SnapshotLagConfig},
+    config::{
+        IngestionConfig, IotaNamesOptions, PruningOptions, RetentionConfig, SnapshotLagConfig,
+    },
     db::{ConnectionPool, ConnectionPoolConfig, PoolConnection, new_connection_pool},
     errors::IndexerError,
     indexer::Indexer,

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -2,11 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
-
+use crate::config::PruningOptions;
 use diesel::{QueryableByName, connection::SimpleConnection, sql_types::BigInt};
 use iota_json_rpc_types::IotaTransactionBlockResponse;
 use iota_metrics::init_metrics;
+use std::path::PathBuf;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -64,6 +64,7 @@ pub enum IndexerTypeConfig {
     Writer {
         snapshot_config: SnapshotLagConfig,
         retention_config: Option<RetentionConfig>,
+        optimistic_pruner_batch_size: Option<u64>,
     },
     AnalyticalWorker,
 }
@@ -77,12 +78,17 @@ impl IndexerTypeConfig {
 
     pub fn writer_mode(
         snapshot_config: Option<SnapshotLagConfig>,
-        epochs_to_keep: Option<u64>,
+        pruning_options: Option<PruningOptions>,
     ) -> Self {
         Self::Writer {
             snapshot_config: snapshot_config.unwrap_or_default(),
-            retention_config: epochs_to_keep
-                .map(RetentionConfig::new_with_default_retention_only_for_testing),
+            retention_config: pruning_options.as_ref().and_then(|pruning_options| {
+                pruning_options
+                    .epochs_to_keep
+                    .map(RetentionConfig::new_with_default_retention_only_for_testing)
+            }),
+            optimistic_pruner_batch_size: pruning_options
+                .and_then(|pruning_options| pruning_options.optimistic_pruner_batch_size),
         }
     }
 }
@@ -154,6 +160,7 @@ pub async fn start_test_indexer_impl(
         IndexerTypeConfig::Writer {
             snapshot_config,
             retention_config,
+            optimistic_pruner_batch_size,
         } => {
             let store_clone = store.clone();
             let mut ingestion_config = IngestionConfig::default();
@@ -170,6 +177,7 @@ pub async fn start_test_indexer_impl(
                     indexer_metrics,
                     snapshot_config,
                     retention_config,
+                    optimistic_pruner_batch_size,
                     cancel,
                 )
                 .await

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -8,14 +8,17 @@ use std::{
     time::Duration,
 };
 
+use diesel::{QueryDsl, RunQueryDsl};
 use fastcrypto::traits::Signer;
 use iota_config::local_ip_utils::{get_available_port, new_local_tcp_socket_for_testing};
 use iota_indexer::{
-    config::{IotaNamesOptions, JsonRpcConfig, SnapshotLagConfig},
+    config::{IotaNamesOptions, JsonRpcConfig, PruningOptions, SnapshotLagConfig},
     db::{ConnectionPoolConfig, new_connection_pool},
     errors::IndexerError,
     indexer::Indexer,
     metrics::IndexerMetrics,
+    read_only_blocking,
+    schema::optimistic_transactions,
     store::{PgIndexerStore, indexer_store::IndexerStore},
     test_utils::{DBInitHook, IndexerTypeConfig, create_pg_store, db_url, start_test_indexer},
 };
@@ -119,7 +122,7 @@ impl SimulacrumTestSetup {
 pub async fn start_test_cluster_with_read_write_indexer(
     database_name: Option<&str>,
     builder_modifier: Option<Box<dyn FnOnce(TestClusterBuilder) -> TestClusterBuilder>>,
-    epochs_to_keep: Option<u64>,
+    pruning_options: Option<PruningOptions>,
 ) -> (TestCluster, PgIndexerStore, HttpClient) {
     let mut builder = TestClusterBuilder::new();
 
@@ -136,7 +139,7 @@ pub async fn start_test_cluster_with_read_write_indexer(
         true,
         None,
         cluster.rpc_url().to_string(),
-        IndexerTypeConfig::writer_mode(None, epochs_to_keep),
+        IndexerTypeConfig::writer_mode(None, pruning_options),
         None,
     )
     .await;
@@ -212,6 +215,43 @@ pub async fn indexer_wait_for_object(
     })
     .await
     .expect("Timeout waiting for indexer to catchup to given object's sequence number");
+}
+
+pub async fn get_optimistic_transactions_count(pg_store: &PgIndexerStore) -> u64 {
+    let blocking_cp = pg_store.blocking_cp();
+    tokio::task::spawn_blocking(move || {
+        read_only_blocking!(&blocking_cp, |conn| {
+            optimistic_transactions::table
+                .count()
+                .get_result::<i64>(conn)
+        })
+    })
+    .await
+    .unwrap()
+    .unwrap() as u64
+}
+
+pub async fn indexer_wait_for_optimistic_transactions_count(
+    pg_store: &PgIndexerStore,
+    expected_transactions_count: u64,
+) {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            let optimistic_transactions_count = get_optimistic_transactions_count(pg_store).await;
+            if optimistic_transactions_count == expected_transactions_count {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("Timeout waiting for indexer to prune optimistic transactions");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // check once again, to ensure match was not accidental
+    let optimistic_transactions_count = get_optimistic_transactions_count(pg_store).await;
+    assert_eq!(optimistic_transactions_count, expected_transactions_count);
 }
 
 /// Wait for the indexer to prune the given checkpoint number

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -5,6 +5,7 @@ use std::{fs::File, path::Path, str::FromStr, sync::Arc, time::Duration};
 
 use hex::FromHex;
 use iota_indexer::{
+    config::PruningOptions,
     models::transactions::StoredTransaction,
     store::package_resolver::IndexerStorePackageResolver,
     test_utils::{TestDatabase, db_url},
@@ -1959,7 +1960,10 @@ fn get_chain_identifier_with_pruning_enabled() {
         let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
             Some("test_get_chain_identifier_with_pruning_enabled"),
             None,
-            Some(1),
+            Some(PruningOptions {
+                epochs_to_keep: Some(1),
+                ..Default::default()
+            }),
         )
         .await;
 

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -10,8 +10,8 @@ use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, expression::SelectableHel
 use fastcrypto::encoding::Base64;
 use futures::{StreamExt, TryStreamExt, stream::FuturesUnordered};
 use iota_indexer::{
-    errors::IndexerError, models::transactions::TxGlobalOrder, read_only_blocking,
-    schema::tx_global_order,
+    config::PruningOptions, errors::IndexerError, models::transactions::TxGlobalOrder,
+    read_only_blocking, schema::tx_global_order, types::IndexerResult,
 };
 use iota_json::{call_args, type_args};
 use iota_json_rpc_api::{
@@ -42,8 +42,12 @@ use move_core_types::{identifier::IdentStr, language_storage::StructTag};
 
 use crate::{
     coin_api::execute_move_call,
-    common::{ApiTestSetup, indexer_wait_for_checkpoint, indexer_wait_for_object},
+    common::{
+        ApiTestSetup, indexer_wait_for_checkpoint, indexer_wait_for_object,
+        indexer_wait_for_optimistic_transactions_count, start_test_cluster_with_read_write_indexer,
+    },
 };
+
 type TxBytes = Base64;
 type Signatures = Vec<Base64>;
 
@@ -873,6 +877,79 @@ fn test_repeatedly_update_display() {
             assert_eq!(actual_description, new_bear_description);
         }
     });
+}
+
+#[tokio::test]
+async fn test_optimistic_tables_pruning() -> IndexerResult<()> {
+    let optimistic_pruner_batch_size = 5;
+    let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
+        Some("test_optimistic_tables_pruning"),
+        None,
+        Some(PruningOptions {
+            epochs_to_keep: Some(2),
+            pruning_config_path: None,
+            optimistic_pruner_batch_size: Some(optimistic_pruner_batch_size),
+        }),
+    )
+    .await;
+    indexer_wait_for_checkpoint(store, 1).await;
+
+    // arbitrary numbers, just need to be > optimistic_pruner_batch_size
+    let txs_epoch_1 = 16;
+    let txs_epoch_2 = 22;
+    let txs_epoch_3 = 18;
+
+    let (sender, sender_kp): (_, AccountKeyPair) = get_key_pair();
+
+    let gas = cluster
+        .fund_address_and_return_gas(
+            cluster.get_reference_gas_price().await,
+            Some(10_000_000_000),
+            sender,
+        )
+        .await;
+    indexer_wait_for_object(client, gas.0, gas.1).await;
+
+    let (_, package_id) = deploy_basics_pkg(sender, &sender_kp, client).await;
+    let (_, counter_obj) = create_counter_object(sender, &sender_kp, client, &package_id)
+        .await
+        .unwrap();
+    cluster.force_new_epoch().await;
+
+    // deploy pkg tx and create counter obj tx
+    indexer_wait_for_optimistic_transactions_count(store, 2).await;
+
+    for _ in 0..txs_epoch_1 {
+        let res = increment_counter(sender, &sender_kp, client, &package_id, &counter_obj, None)
+            .await
+            .unwrap();
+        assert_eq!(res.status_ok(), Some(true));
+    }
+    indexer_wait_for_optimistic_transactions_count(store, txs_epoch_1 + 2).await;
+    cluster.force_new_epoch().await;
+    indexer_wait_for_optimistic_transactions_count(store, txs_epoch_1).await;
+
+    for _ in 0..txs_epoch_2 {
+        let res = increment_counter(sender, &sender_kp, client, &package_id, &counter_obj, None)
+            .await
+            .unwrap();
+        assert_eq!(res.status_ok(), Some(true));
+    }
+    indexer_wait_for_optimistic_transactions_count(store, txs_epoch_1 + txs_epoch_2).await;
+    cluster.force_new_epoch().await;
+    indexer_wait_for_optimistic_transactions_count(store, txs_epoch_2).await;
+
+    for _ in 0..txs_epoch_3 {
+        let res = increment_counter(sender, &sender_kp, client, &package_id, &counter_obj, None)
+            .await
+            .unwrap();
+        assert_eq!(res.status_ok(), Some(true));
+    }
+    indexer_wait_for_optimistic_transactions_count(store, txs_epoch_2 + txs_epoch_3).await;
+    cluster.force_new_epoch().await;
+    indexer_wait_for_optimistic_transactions_count(store, txs_epoch_3).await;
+
+    Ok(())
 }
 
 pub(crate) async fn create_basic_object(


### PR DESCRIPTION
# Description of change

This PR introduces pruner for optimistic_transactions table.
The pruner is disabled by default, unless OPTIMISTIC_PRUNER_BATCH_SIZE env var is set to some value.

## Links to any relevant issues

fixes: https://github.com/iotaledger/iota/issues/5930

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [x] Restart of indexer synchronization locally without resetting the database.
- [x] Restart of indexer synchronization on a production-like database.
- [x] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

