### PR TITLE
feat(workflows): enable iota-names feature for release builds

### DIFF
--- a/binary-build-list.json
+++ b/binary-build-list.json
@@ -1,6 +1,6 @@
 {
   "release_binaries": {
-    "iota": ["indexer", "gen-completions", "tracing"],
+    "iota": ["indexer", "iota-names", "gen-completions", "tracing"],
     "iota-node": [],
     "iota-tool": [],
     "iota-faucet": [],

--- a/scripts/homebrew/template.rb
+++ b/scripts/homebrew/template.rb
@@ -42,7 +42,7 @@ class Iota < Formula
     def install
         if @@arch == "source"
             ENV["GIT_REVISION"] = ""
-            system "cargo", "build", "--release", "--bin", "iota", "--bin", "iota-tool", "-F", "indexer,gen-completions,tracing"
+            system "cargo", "build", "--release", "--bin", "iota", "--bin", "iota-tool", "-F", "indexer,iota-names,gen-completions,tracing"
             bin.install "target/release/iota" => "iota"
             bin.install "target/release/iota-tool" => "iota-tool"
         else


### PR DESCRIPTION
# Description of change

Enable iota-names feature for release builds.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Release binaries now include IOTA-Names CLI commands
- [ ] Rust SDK:
- [ ] REST API:
