### PR TITLE
fix(explorer): avoid showing results of names with no linked address

### DIFF
--- a/apps/explorer/src/hooks/useSearch.ts
+++ b/apps/explorer/src/hooks/useSearch.ts
@@ -82,7 +82,7 @@ const getResultsForAddress = async (
     if (iotaNamesClient && isNamesEnabled && isValidIotaName(query)) {
         const nameRecord = await iotaNamesClient.getNameRecord(query.toLowerCase());
 
-        if (!nameRecord) return null;
+        if (!nameRecord || !nameRecord.targetAddress) return null;
 
         return [
             {


### PR DESCRIPTION
# Description of change

When searching for a valid name with unset address, the explorer shows a blank result, which redirects to an invalid page if you click on it.

## Links to any relevant issues

Fixes #8395 

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
