### PR TITLE
feat(iota-names): [cherry-pick] testnet deployment (#8430)

### DIFF
--- a/crates/iota-names/src/config.rs
+++ b/crates/iota-names/src/config.rs
@@ -30,8 +30,7 @@ pub struct IotaNamesConfig {
 impl Default for IotaNamesConfig {
     fn default() -> Self {
         // TODO change to mainnet https://github.com/iotaledger/iota/issues/6532
-        // TODO change to testnet https://github.com/iotaledger/iota/issues/6531
-        Self::devnet()
+        Self::testnet()
     }
 }
 
@@ -65,7 +64,7 @@ impl IotaNamesConfig {
     pub fn from_chain(chain: &Chain) -> Self {
         match chain {
             Chain::Mainnet => todo!("https://github.com/iotaledger/iota/issues/6532"),
-            Chain::Testnet => todo!("https://github.com/iotaledger/iota/issues/6531"),
+            Chain::Testnet => IotaNamesConfig::testnet(),
             Chain::Unknown => IotaNamesConfig::devnet(),
         }
     }
@@ -93,7 +92,33 @@ impl IotaNamesConfig {
 
     // TODO add mainnet https://github.com/iotaledger/iota/issues/6532
 
-    // TODO add testnet https://github.com/iotaledger/iota/issues/6531
+    // Create a config based on the package and object ids published on testnet.
+    pub fn testnet() -> Self {
+        const PACKAGE_ADDRESS: &str =
+            "0x7fff6e95f385349bec98d17121ab2bfa3e134f2f0b1ccefc270313415f7835ea";
+        const OBJECT_ID: &str =
+            "0x7cab491740d51e0d75b26bf9984e49ba2e32a2d0694cabcee605543ed13c7dec";
+        const PAYMENTS_PACKAGE_ADDRESS: &str =
+            "0x6b1b01f4c72786a893191d5c6e73d3012f7529f86fdee3bc8c163323cee08441";
+        const REGISTRY_ID: &str =
+            "0x2dfc6f6d46ba55217425643a59dc85fe4d8ed273a9f74077bd0ee280dbb4f590";
+        const REVERSE_REGISTRY_ID: &str =
+            "0x3550bcacb793ef8b776264665e7c99fa3d897695ed664656aac693cf9cf9b76b";
+
+        let package_address = IotaAddress::from_str(PACKAGE_ADDRESS).unwrap();
+        let object_id = ObjectID::from_str(OBJECT_ID).unwrap();
+        let payments_package_address = IotaAddress::from_str(PAYMENTS_PACKAGE_ADDRESS).unwrap();
+        let registry_id = ObjectID::from_str(REGISTRY_ID).unwrap();
+        let reverse_registry_id = ObjectID::from_str(REVERSE_REGISTRY_ID).unwrap();
+
+        Self::new(
+            package_address,
+            object_id,
+            payments_package_address,
+            registry_id,
+            reverse_registry_id,
+        )
+    }
 
     // Create a config based on the package and object ids published on devnet.
     pub fn devnet() -> Self {


### PR DESCRIPTION
# Description of change

Cherry picks #8430 so that the planned Testnet release on 03/09 includes a working CLI for IOTA Names.

## Links to any relevant issues

Closes https://github.com/iotaledger/iota-names/issues/722

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes