### PR TITLE
fix: allow missing checkpoints in server init

### DIFF
--- a/crates/iota-grpc-api/src/types.rs
+++ b/crates/iota-grpc-api/src/types.rs
@@ -10,8 +10,9 @@ use iota_grpc_types::{
 };
 use iota_json_rpc_types::{EventFilter, IotaEvent};
 use iota_types::{
-    full_checkpoint_content::CheckpointData, messages_checkpoint::CertifiedCheckpointSummary,
-    storage::RestStateReader,
+    full_checkpoint_content::CheckpointData,
+    messages_checkpoint::CertifiedCheckpointSummary,
+    storage::{RestStateReader, error::Kind},
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::{Receiver, Sender, error::RecvError};
@@ -234,7 +235,16 @@ pub struct RestStateReaderAdapter {
 
 impl GrpcStateReader for RestStateReaderAdapter {
     fn get_latest_checkpoint_sequence_number(&self) -> Option<u64> {
-        Some(*self.inner.get_latest_checkpoint().sequence_number())
+        match self.inner.try_get_latest_checkpoint() {
+            Ok(checkpoint) => Some(*checkpoint.sequence_number()),
+            Err(e) => match e.kind() {
+                // Expected during server initialization when no checkpoints have been executed yet
+                // Return None to indicate service is not ready rather than panicking
+                Kind::Missing => None,
+                // Unexpected storage errors
+                _ => panic!("Unexpected storage error: {e}"),
+            },
+        }
     }
 
     fn get_checkpoint_summary(&self, seq: u64) -> Option<CertifiedCheckpointSummary> {

--- a/crates/iota-grpc-api/tests/checkpoint_e2e.rs
+++ b/crates/iota-grpc-api/tests/checkpoint_e2e.rs
@@ -34,11 +34,7 @@ async fn setup_test_cluster_and_client() -> (TestCluster, CheckpointClient) {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn e2e_stream_checkpoints() {
-    let (cluster, mut client) = setup_test_cluster_and_client().await;
-
-    //  Ensures the checkpoint executor is properly initialized and running before
-    // the gRPC streaming
-    cluster.wait_for_checkpoint(0, None).await;
+    let (_cluster, mut client) = setup_test_cluster_and_client().await;
 
     // Request all checkpoints using the higher-level GrpcNodeClient API
     let mut stream = client
@@ -154,11 +150,7 @@ async fn test_get_epoch_first_checkpoint_sequence_number() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_stream_full_checkpoint_data() {
-    let (cluster, mut client) = setup_test_cluster_and_client().await;
-
-    //  Ensures the checkpoint executor is properly initialized and running before
-    // the gRPC streaming
-    cluster.wait_for_checkpoint(0, None).await;
+    let (_cluster, mut client) = setup_test_cluster_and_client().await;
 
     let mut stream = client
         .stream_checkpoints(None, Some(2), true)

--- a/crates/iota-grpc-api/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-api/tests/checkpoint_stream.rs
@@ -136,11 +136,6 @@ impl iota_types::storage::ReadStore for MockRestStateReader {
         }
     }
 
-    fn get_latest_checkpoint(&self) -> VerifiedCheckpoint {
-        self.try_get_latest_checkpoint()
-            .expect("storage access failed")
-    }
-
     fn try_get_highest_verified_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -46,12 +46,6 @@ pub trait ReadStore: ObjectStore {
     /// available for the returned checkpoint.
     fn try_get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint>;
 
-    /// Non-fallible version of `try_get_latest_checkpoint`.
-    fn get_latest_checkpoint(&self) -> VerifiedCheckpoint {
-        self.try_get_latest_checkpoint()
-            .expect("storage access failed")
-    }
-
     /// Get the latest available checkpoint sequence number. This is the
     /// sequence number of the latest executed checkpoint.
     fn try_get_latest_checkpoint_sequence_number(&self) -> Result<CheckpointSequenceNumber> {

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -46,6 +46,12 @@ pub trait ReadStore: ObjectStore {
     /// available for the returned checkpoint.
     fn try_get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint>;
 
+    /// Non-fallible version of `try_get_latest_checkpoint`.
+    fn get_latest_checkpoint(&self) -> VerifiedCheckpoint {
+        self.try_get_latest_checkpoint()
+            .expect("storage access failed")
+    }
+
     /// Get the latest available checkpoint sequence number. This is the
     /// sequence number of the latest executed checkpoint.
     fn try_get_latest_checkpoint_sequence_number(&self) -> Result<CheckpointSequenceNumber> {


### PR DESCRIPTION
# Description of change

During server initialization it is expected that no checkpoints have been executed yet. In the case we just return `None` to indicate service is not ready rather than panicking.

## Links to any relevant issues

None

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes