### PR TITLE
fix(graphql): increase gas coin amount for dry runs

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -72,6 +72,7 @@ use iota_types::{
     execution_status::ExecutionStatus,
     fp_ensure,
     gas::{GasCostSummary, IotaGasStatus},
+    gas_coin::NANOS_PER_IOTA,
     inner_temporary_store::{
         InnerTemporaryStore, ObjectMap, PackageStoreWithFallback, TemporaryModuleResolver, TxCoins,
         WrittenObjects,
@@ -344,7 +345,8 @@ const GAS_LATENCY_RATIO_BUCKETS: &[f64] = &[
     3000.0, 4000.0, 5000.0, 6000.0, 7000.0, 8000.0, 9000.0, 10000.0, 50000.0, 100000.0, 1000000.0,
 ];
 
-pub const DEV_INSPECT_GAS_COIN_VALUE: u64 = 1_000_000_000_000;
+/// Gas coin value used in dev-inspect and dry-runs if no gas coin was provided.
+pub const SIMULATION_GAS_COIN_VALUE: u64 = 1_000_000_000 * NANOS_PER_IOTA; // 1B IOTA
 
 impl AuthorityMetrics {
     pub fn new(registry: &prometheus::Registry) -> AuthorityMetrics {
@@ -1773,13 +1775,13 @@ impl AuthorityState {
         let reference_gas_price = epoch_store.reference_gas_price();
         let ((gas_status, checked_input_objects), mock_gas) = if transaction.gas().is_empty() {
             let sender = transaction.gas_owner();
-            // use a 1B iota coin
-            const NANOS_TO_IOTA: u64 = 1_000_000_000;
-            const DRY_RUN_IOTA: u64 = 1_000_000_000;
-            let max_coin_value = NANOS_TO_IOTA * DRY_RUN_IOTA;
             let gas_object_id = ObjectID::random();
             let gas_object = Object::new_move(
-                MoveObject::new_gas_coin(OBJECT_START_VERSION, gas_object_id, max_coin_value),
+                MoveObject::new_gas_coin(
+                    OBJECT_START_VERSION,
+                    gas_object_id,
+                    SIMULATION_GAS_COIN_VALUE,
+                ),
                 Owner::AddressOwner(sender),
                 TransactionDigest::genesis_marker(),
             );
@@ -1964,13 +1966,13 @@ impl AuthorityState {
         let mut gas_object_refs = transaction.gas().to_vec();
         let ((gas_status, checked_input_objects), mock_gas) = if transaction.gas().is_empty() {
             let sender = transaction.gas_owner();
-            // use a 1B iota coin
-            const NANOS_TO_IOTA: u64 = 1_000_000_000;
-            const DRY_RUN_IOTA: u64 = 1_000_000_000;
-            let max_coin_value = NANOS_TO_IOTA * DRY_RUN_IOTA;
             let gas_object_id = ObjectID::MAX;
             let gas_object = Object::new_move(
-                MoveObject::new_gas_coin(OBJECT_START_VERSION, gas_object_id, max_coin_value),
+                MoveObject::new_gas_coin(
+                    OBJECT_START_VERSION,
+                    gas_object_id,
+                    SIMULATION_GAS_COIN_VALUE,
+                ),
                 Owner::AddressOwner(sender),
                 TransactionDigest::genesis_marker(),
             );
@@ -2127,7 +2129,7 @@ impl AuthorityState {
 
         // Create and use a dummy gas object if there is no gas object provided.
         let dummy_gas_object = Object::new_gas_with_balance_and_owner_for_testing(
-            DEV_INSPECT_GAS_COIN_VALUE,
+            SIMULATION_GAS_COIN_VALUE,
             transaction.gas_owner(),
         );
 

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -807,7 +807,7 @@ async fn test_dev_inspect_gas_coin_argument() {
     check_coin_value(
         arg_value,
         arg_type,
-        DEV_INSPECT_GAS_COIN_VALUE - protocol_config.max_tx_gas() - amount,
+        SIMULATION_GAS_COIN_VALUE - protocol_config.max_tx_gas() - amount,
     );
 
     assert_eq!(return_values.len(), 1);


### PR DESCRIPTION
# Description of change

Increase the gas coin amount for the created gas coin that's used in dry runs with graphql. It was just 1_000 IOTA and therefore caused issues with insufficient funds. Now it's 1_000_000_000 IOTA, the same value as used for dry runs and more than any account controls in the mainnet, this should be sufficient large. Using something like u64::MAX -1 doesn't work, because if there are then other coins in a transaction, this would exceed u64 and result in an overflow error.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/8440

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [x] GraphQL: Increased dry run amount from 1_000 to 1_000_000_000 IOTA
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
