### PR TITLE
feat: bump iota to v1.6.1-rc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,7 +1835,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "const-str",
  "git-version",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "iota"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5439,7 +5439,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-simulator",
  "iota-source-validation",
  "iota-swarm",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "arrow-array 53.1.0",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5602,7 +5602,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -5613,7 +5613,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5664,7 +5664,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -5707,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5725,7 +5725,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-move-build",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5793,7 +5793,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5948,7 +5948,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5981,7 +5981,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6044,7 +6044,7 @@ dependencies = [
  "iota-protocol-config",
  "iota-rest-api",
  "iota-rust-sdk",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-simulator",
  "iota-storage",
  "iota-swarm",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "serde_yaml",
 ]
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6130,7 +6130,7 @@ dependencies = [
  "iota-keys",
  "iota-metrics",
  "iota-network-stack",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-types",
  "parking_lot 0.12.3",
  "prometheus",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6174,7 +6174,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6213,7 +6213,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6273,7 +6273,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6281,7 +6281,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6294,7 +6294,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6332,7 +6332,7 @@ dependencies = [
  "iota-network-stack",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-types",
@@ -6365,7 +6365,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6378,14 +6378,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "axum 0.8.4",
 ]
 
 [[package]]
 name = "iota-http"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "axum 0.8.4",
  "bytes",
@@ -6406,7 +6406,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6468,7 +6468,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6503,7 +6503,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6558,7 +6558,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6577,7 +6577,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6596,7 +6596,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6648,7 +6648,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "bip32",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "iota-kvstore"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6708,7 +6708,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger-signer"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6716,7 +6716,7 @@ dependencies = [
  "bip32",
  "clap",
  "iota-ledger",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "shared-crypto",
  "thiserror 1.0.64",
  "tokio",
@@ -6725,7 +6725,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6739,7 +6739,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-types",
  "move-core-types",
  "object_store 0.10.2",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -6768,7 +6768,7 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6780,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "backoff",
@@ -6801,7 +6801,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6826,7 +6826,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -6865,7 +6865,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6886,7 +6886,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "bin-version",
  "clap",
@@ -6919,7 +6919,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6931,7 +6931,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -6971,7 +6971,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anemo",
  "bcs",
@@ -6999,7 +6999,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7047,7 +7047,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7071,7 +7071,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7083,7 +7083,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7099,13 +7099,13 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -7115,7 +7115,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7136,7 +7136,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -7146,7 +7146,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "clap",
  "insta",
@@ -7161,7 +7161,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7170,7 +7170,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7185,7 +7185,7 @@ dependencies = [
  "hex",
  "hyper 1.4.1",
  "iota-metrics",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-tls",
  "iota-types",
  "itertools 0.13.0",
@@ -7213,7 +7213,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7229,7 +7229,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-transaction-checks",
  "iota-types",
  "jsonrpsee",
@@ -7258,7 +7258,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7287,7 +7287,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-kv"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7314,7 +7314,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7331,7 +7331,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-swarm-config",
  "iota-types",
  "move-core-types",
@@ -7355,7 +7355,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7365,7 +7365,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-types",
  "itertools 0.13.0",
  "serde",
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7479,7 +7479,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7501,7 +7501,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7535,7 +7535,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7562,7 +7562,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "colored",
@@ -7572,7 +7572,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -7594,7 +7594,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7609,7 +7609,7 @@ dependencies = [
  "iota-move",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-source-validation",
  "move-core-types",
  "move-package",
@@ -7630,7 +7630,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7681,7 +7681,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "bcs",
  "clap",
@@ -7709,7 +7709,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "futures",
@@ -7736,7 +7736,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -7764,7 +7764,7 @@ dependencies = [
 
 [[package]]
 name = "iota-synthetic-ingestion"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7781,12 +7781,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -7794,7 +7794,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7816,7 +7816,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -7838,7 +7838,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -7861,7 +7861,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7877,7 +7877,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -7890,7 +7890,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7935,7 +7935,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8010,7 +8010,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8038,7 +8038,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11303,7 +11303,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13088,7 +13088,7 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "bcs",
  "eyre",
@@ -13213,7 +13213,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -13955,7 +13955,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -14042,7 +14042,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -14058,7 +14058,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.6.0-beta",
+ "iota-sdk 1.6.1-rc",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -14875,7 +14875,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -14947,7 +14947,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -14978,7 +14978,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -14988,7 +14988,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "serde",
  "thiserror 1.0.64",
@@ -14996,7 +14996,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "1.6.0-beta"
+version = "1.6.1-rc"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -116,12 +116,12 @@ task 15, lines 64-69:
 //# run-graphql --show-usage --show-headers --show-service-version
 Headers: {
     "content-type": "application/graphql-response+json",
-    "x-iota-rpc-version": "1.6.0-testing-no-sha",
+    "x-iota-rpc-version": "1.6.1-testing-no-sha",
     "vary": "origin, access-control-request-method, access-control-request-headers",
     "access-control-allow-origin": "*",
     "content-length": "157",
 }
-Service version: 1.6.0-testing-no-sha
+Service version: 1.6.1-testing-no-sha
 Response: {
   "data": {
     "checkpoint": {

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "1.6.0-beta"
+    "version": "1.6.1-rc"
   },
   "methods": [
     {


### PR DESCRIPTION
Bump iota to `v1.6.1-rc` in preparation for `testnet` release.