### PR TITLE
fix(move-compiler): auto-completion for unresolved method chains

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -3905,7 +3905,9 @@ fn method_call(
     let (m, f, fty, usage) =
         match method_call_resolve(context, call_loc, &edotted, method, ty_args_opt) {
             ResolvedMethodCall::Resolved(m, f, fty, usage) => (*m, f, fty, usage),
-            ResolvedMethodCall::UnknownName if context.env().ide_mode() => {
+            ResolvedMethodCall::InvalidBaseType | ResolvedMethodCall::UnknownName
+                if context.env().ide_mode() =>
+            {
                 // Even if the method name fails to resolve, we want autocomplete information.
                 edotted.autocomplete_last = Some(method.loc);
                 let err_ty = context.error_type(call_loc);

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types@ide.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types@ide.snap
@@ -1,5 +1,9 @@
 ---
 source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
 ---
 warning[W09009]: unused struct field
    ┌─ tests/move_2024/ide_mode/macro_types.move:10:9
@@ -37,13 +41,13 @@ note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/macro_types.move:19:29
    │
 19 │             collection.items.push_back(content);
-   │                             ^ Possible dot names: 'std::vector::all', 'std::vector::any', 'std::vector::append', 'std::vector::borrow', 'std::vector::borrow_mut', 'std::vector::contains', 'std::vector::count', 'std::vector::destroy', 'std::vector::destroy_empty', 'std::vector::do', 'std::vector::do_mut', 'std::vector::do_ref', 'std::vector::filter', 'std::vector::find_index', 'std::vector::fold', 'std::vector::index_of', 'std::vector::insert', 'std::vector::is_empty', 'std::vector::length', 'std::vector::map', 'std::vector::map_ref', 'std::vector::partition', 'std::vector::pop_back', 'std::vector::push_back', 'std::vector::remove', 'std::vector::reverse', 'std::vector::swap', 'std::vector::swap_remove', 'std::ascii::to_ascii_string', 'std::string::to_string', 'std::ascii::try_to_ascii_string', 'std::string::try_to_string', 'std::vector::zip_do', 'std::vector::zip_do_mut', 'std::vector::zip_do_ref', 'std::vector::zip_do_reverse', 'std::vector::zip_map', or 'std::vector::zip_map_ref'
+   │                             ^ Possible dot names: 'std::vector::all', 'std::vector::any', 'std::vector::append', 'std::vector::borrow', 'std::vector::borrow_mut', 'std::vector::contains', 'std::vector::count', 'std::vector::destroy', 'std::vector::destroy_empty', 'std::vector::do', 'std::vector::do_mut', 'std::vector::do_ref', 'std::vector::filter', 'std::vector::find_index', 'std::vector::flatten', 'std::vector::fold', 'std::vector::index_of', 'std::vector::insert', 'std::vector::is_empty', 'std::vector::length', 'std::vector::map', 'std::vector::map_ref', 'std::vector::partition', 'std::vector::pop_back', 'std::vector::push_back', 'std::vector::remove', 'std::vector::reverse', 'std::vector::swap', 'std::vector::swap_remove', 'std::ascii::to_ascii_string', 'std::string::to_string', 'std::ascii::try_to_ascii_string', 'std::string::try_to_string', 'std::vector::zip_do', 'std::vector::zip_do_mut', 'std::vector::zip_do_ref', 'std::vector::zip_do_reverse', 'std::vector::zip_map', or 'std::vector::zip_map_ref'
 
 note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/macro_types.move:19:30
    │
 19 │             collection.items.push_back(content);
-   │                              ^^^^^^^^^ Possible dot names: 'std::vector::all', 'std::vector::any', 'std::vector::append', 'std::vector::borrow', 'std::vector::borrow_mut', 'std::vector::contains', 'std::vector::count', 'std::vector::destroy', 'std::vector::destroy_empty', 'std::vector::do', 'std::vector::do_mut', 'std::vector::do_ref', 'std::vector::filter', 'std::vector::find_index', 'std::vector::fold', 'std::vector::index_of', 'std::vector::insert', 'std::vector::is_empty', 'std::vector::length', 'std::vector::map', 'std::vector::map_ref', 'std::vector::partition', 'std::vector::pop_back', 'std::vector::push_back', 'std::vector::remove', 'std::vector::reverse', 'std::vector::swap', 'std::vector::swap_remove', 'std::ascii::to_ascii_string', 'std::string::to_string', 'std::ascii::try_to_ascii_string', 'std::string::try_to_string', 'std::vector::zip_do', 'std::vector::zip_do_mut', 'std::vector::zip_do_ref', 'std::vector::zip_do_reverse', 'std::vector::zip_map', or 'std::vector::zip_map_ref'
+   │                              ^^^^^^^^^ Possible dot names: 'std::vector::all', 'std::vector::any', 'std::vector::append', 'std::vector::borrow', 'std::vector::borrow_mut', 'std::vector::contains', 'std::vector::count', 'std::vector::destroy', 'std::vector::destroy_empty', 'std::vector::do', 'std::vector::do_mut', 'std::vector::do_ref', 'std::vector::filter', 'std::vector::find_index', 'std::vector::flatten', 'std::vector::fold', 'std::vector::index_of', 'std::vector::insert', 'std::vector::is_empty', 'std::vector::length', 'std::vector::map', 'std::vector::map_ref', 'std::vector::partition', 'std::vector::pop_back', 'std::vector::push_back', 'std::vector::remove', 'std::vector::reverse', 'std::vector::swap', 'std::vector::swap_remove', 'std::ascii::to_ascii_string', 'std::string::to_string', 'std::ascii::try_to_ascii_string', 'std::string::try_to_string', 'std::vector::zip_do', 'std::vector::zip_do_mut', 'std::vector::zip_do_ref', 'std::vector::zip_do_reverse', 'std::vector::zip_map', or 'std::vector::zip_map_ref'
 
 note[I15003]: IDE expanded lambda
    ┌─ tests/move_2024/ide_mode/macro_types.move:37:13

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/wrong_completion_before_dot_call.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/wrong_completion_before_dot_call.move
@@ -1,0 +1,20 @@
+#[allow(ide_path_autocomplete)]
+module a::m {
+
+    public struct SomeStruct {
+        some_field: u64,
+    }
+
+    public fun bar(_some_struct: &SomeStruct):u64 {
+        42
+    }
+
+    public fun foo(some_struct: &mut SomeStruct): u64 {
+        // Auto-completion after some_struct. did not work here before,
+        // but it worked if the other some_struct access
+        // is not a dot call but rather a field access
+        some_struct.
+        some_struct.bar()
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/wrong_completion_before_dot_call.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/wrong_completion_before_dot_call.snap
@@ -1,0 +1,19 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+warning[W10007]: issue with attribute value
+  ┌─ tests/move_2024/ide_mode/wrong_completion_before_dot_call.move:1:9
+  │
+1 │ #[allow(ide_path_autocomplete)]
+  │         ^^^^^^^^^^^^^^^^^^^^^ Unknown warning filter 'ide_path_autocomplete'
+
+error[E03010]: unbound field
+   ┌─ tests/move_2024/ide_mode/wrong_completion_before_dot_call.move:16:9
+   │  
+16 │ ╭         some_struct.
+17 │ │         some_struct.bar()
+   │ ╰───────────────────^ Unbound field 'some_struct' in 'a::m::SomeStruct'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/wrong_completion_before_dot_call@ide.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/wrong_completion_before_dot_call@ide.snap
@@ -1,0 +1,25 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E03010]: unbound field
+   ┌─ tests/move_2024/ide_mode/wrong_completion_before_dot_call.move:16:9
+   │  
+16 │ ╭         some_struct.
+17 │ │         some_struct.bar()
+   │ ╰───────────────────^ Unbound field 'some_struct' in 'a::m::SomeStruct'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/wrong_completion_before_dot_call.move:16:20
+   │
+16 │         some_struct.
+   │                    ^ Possible dot names: 'a::m::bar', 'a::m::foo', or 'some_field'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/wrong_completion_before_dot_call.move:17:9
+   │
+17 │         some_struct.bar()
+   │         ^^^^^^^^^^^ Possible dot names: 'a::m::bar', 'a::m::foo', or 'some_field'


### PR DESCRIPTION
# Description of change

When method's access chain was incorrect, no auto-completion was
generated even for correctly typed prefix of this chain, such as in this
example:
```move
    public struct SomeStruct {
        some_field: u64,
    }

    public fun bar(_some_struct: &SomeStruct):u64 {
        42
    }

    public fun foo(some_struct: &mut SomeStruct): u64 {
        some_struct.
        some_struct.bar()
    }
```
Additionally, this behavior was inconsistent with the auto-completion
behavior for a similar chain but ending in a (supposed) field access
instead of a method call, where auto-completion for the dot following
the first `some_struct` would be generated:
```move
    public fun foo(some_struct: &mut SomeStruct): u64 {
        some_struct.
        some_struct.some_field
    }
```

> [!NOTE]  
> The version hasn't been updated in this PR; it will be updated later when we are ready to release the extension.
> The `macro_types@ide.snap` is updated since it is broken in the base branch.

## Links to any relevant issues

fixes #8264 

