### PR TITLE
chore: Allow `RUSTSEC-2025-0055`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -55,6 +55,8 @@ ignore = [
   "RUSTSEC-2024-0436",
   # backoff is unmaintained
   "RUSTSEC-2025-0012",
+  # Logging user input may result in poisoning logs with ANSI escape sequences
+  "RUSTSEC-2025-0055",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/external-crates/move/deny.toml
+++ b/external-crates/move/deny.toml
@@ -54,6 +54,8 @@ ignore = [
   "RUSTSEC-2024-0384",
   # `paste` is unmaintained
   "RUSTSEC-2024-0436",
+  # Logging user input may result in poisoning logs with ANSI escape sequences
+  "RUSTSEC-2025-0055",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
# Description of change

Update `tracing-subscriber` to avoid [`RUSTSEC-2025-0055`](https://rustsec.org/advisories/RUSTSEC-2025-0055).
