### PR TITLE
upstream(indexer): Modify PruningOptions to point to a toml file of epochs_to_keep and optional per-table overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6455,6 +6455,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "simulacrum",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "tap",
  "telemetry-subscribers",
  "tempfile",
@@ -6463,6 +6465,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.12",
+ "toml 0.7.8",
  "tracing",
  "url",
 ]

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -57,6 +57,9 @@ iota-types.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
 telemetry-subscribers.workspace = true
+toml.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
 
 [features]
 pg_integration = ["dep:rand"]

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -29,12 +29,15 @@ rand = { workspace = true, optional = true }
 secrecy = "0.8.0"
 serde.workspace = true
 serde_with.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
 tap.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
+toml.workspace = true
 tracing.workspace = true
 url.workspace = true
 
@@ -57,9 +60,6 @@ iota-types.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
 telemetry-subscribers.workspace = true
-toml.workspace = true
-strum.workspace = true
-strum_macros.workspace = true
 
 [features]
 pg_integration = ["dep:rand"]

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -235,7 +235,8 @@ pub enum Command {
 
 #[derive(Args, Default, Debug, Clone)]
 pub struct PruningOptions {
-    // Argument left for backward compatibility, users are encouraged to use pruning_config_path
+    /// Argument left for backward compatibility, users are encouraged to use
+    /// pruning_config_path
     #[arg(long, env = "EPOCHS_TO_KEEP")]
     pub epochs_to_keep: Option<u64>,
     /// Path to TOML file containing configuration for retention policies.
@@ -257,25 +258,26 @@ pub struct RetentionConfig {
 }
 
 impl PruningOptions {
-    /// Load default retention policy and overrides from file.
+    /// Loads default retention policy and overrides from file.
     pub fn load_from_file(&self) -> IndexerResult<Option<RetentionConfig>> {
-        if let Some(epochs_to_keep) = self.epochs_to_keep {
+        let Some(config_path) = self.pruning_config_path.as_ref() else {
+            let Some(epochs_to_keep) = self.epochs_to_keep else {
+                return Ok(None);
+            };
             warn!(
                 "Using the deprecated --epochs-to-keep argument for pruning configuration. \
-                Please use --pruning-config-path to specify a TOML configuration file instead."
-            );
-            assert!(
-                self.pruning_config_path.is_none(),
-                "Both --epochs-to-keep and --pruning-config-path cannot be provided at the same time."
+                 Please use --pruning-config-path to specify a TOML configuration file instead."
             );
             return Ok(Some(RetentionConfig::new(
                 epochs_to_keep,
                 Default::default(),
             )));
-        }
+        };
 
-        let Some(config_path) = self.pruning_config_path.as_ref() else {
-            return Ok(None);
+        if self.epochs_to_keep.is_some() {
+            warn!(
+                "The --epochs-to-keep argument will be ignored since --pruning-config-path is also provided."
+            );
         };
 
         let contents = std::fs::read_to_string(config_path)
@@ -302,10 +304,12 @@ impl PruningOptions {
 }
 
 impl RetentionConfig {
-    /// Create a new `RetentionConfig` with the specified default retention and
-    /// overrides. Call `finalize()` on the instance to update the
-    /// `policies` field with the default retention policy for all tables
-    /// that do not have an override specified.
+    /// Creates a new `RetentionConfig` with the specified default retention and
+    /// overrides.
+    ///
+    /// Call `finalize()` on the instance to update the `policies` field with
+    /// the default retention policy for all tables that do not have an
+    /// override specified.
     pub fn new(epochs_to_keep: u64, overrides: HashMap<PrunableTable, u64>) -> Self {
         Self {
             epochs_to_keep,
@@ -323,11 +327,13 @@ impl RetentionConfig {
         Self::new(epochs_to_keep, HashMap::new())
     }
 
-    /// Consumes this struct to produce a full mapping of every prunable table
-    /// and its retention policy. By default, every prunable table will have
-    /// the default retention policy from `epochs_to_keep`. Some tables like
-    /// `objects_history` will observe a different default retention policy.
-    /// These default values are overridden by any entries in `overrides`.
+    /// Consumes the struct and produces a mapping of every prunable table
+    /// and its retention policy.
+    ///
+    /// By default, every prunable table will have the default retention policy
+    /// from `epochs_to_keep`. Some tables like `objects_history` will
+    /// observe a different default retention policy. These default values
+    /// are overridden by any entries in `overrides`.
     pub fn retention_policies(self) -> HashMap<PrunableTable, u64> {
         let RetentionConfig {
             epochs_to_keep,

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -10,6 +10,7 @@ use iota_names::config::IotaNamesConfig;
 use iota_types::base_types::{IotaAddress, ObjectID};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
+use tracing::warn;
 use url::Url;
 
 use crate::{
@@ -234,6 +235,9 @@ pub enum Command {
 
 #[derive(Args, Default, Debug, Clone)]
 pub struct PruningOptions {
+    // Argument left for backward compatibility, users are encouraged to use pruning_config_path
+    #[arg(long, env = "EPOCHS_TO_KEEP")]
+    pub epochs_to_keep: Option<u64>,
     /// Path to TOML file containing configuration for retention policies.
     #[arg(long)]
     pub pruning_config_path: Option<PathBuf>,
@@ -255,6 +259,21 @@ pub struct RetentionConfig {
 impl PruningOptions {
     /// Load default retention policy and overrides from file.
     pub fn load_from_file(&self) -> IndexerResult<Option<RetentionConfig>> {
+        if let Some(epochs_to_keep) = self.epochs_to_keep {
+            warn!(
+                "Using the deprecated --epochs-to-keep argument for pruning configuration. \
+                Please use --pruning-config-path to specify a TOML configuration file instead."
+            );
+            assert!(
+                self.pruning_config_path.is_none(),
+                "Both --epochs-to-keep and --pruning-config-path cannot be provided at the same time."
+            );
+            return Ok(Some(RetentionConfig::new(
+                epochs_to_keep,
+                Default::default(),
+            )));
+        }
+
         let Some(config_path) = self.pruning_config_path.as_ref() else {
             return Ok(None);
         };
@@ -594,7 +613,10 @@ pub mod deprecated {
                         sleep_duration: SnapshotLagConfig::DEFAULT_SLEEP_DURATION_SEC,
                     },
                     pruning_options: PruningOptions {
-                        pruning_config_path: None, // no support for pruning in old CLI
+                        epochs_to_keep: std::env::var("EPOCHS_TO_KEEP")
+                            .map(|s| s.parse::<u64>().ok())
+                            .unwrap_or_else(|_e| None),
+                        pruning_config_path: None,
                     },
                     reset_db: old_conf.reset_db,
                 }
@@ -708,6 +730,7 @@ mod test {
         temp_file.write_all(toml_content.as_bytes()).unwrap();
         let temp_path: PathBuf = temp_file.path().to_path_buf();
         let pruning_options = PruningOptions {
+            epochs_to_keep: None,
             pruning_config_path: Some(temp_path.clone()),
         };
         let retention_config = pruning_options.load_from_file().unwrap().unwrap();
@@ -757,6 +780,7 @@ mod test {
         temp_file.write_all(toml_content.as_bytes()).unwrap();
         let temp_path: PathBuf = temp_file.path().to_path_buf();
         let pruning_options = PruningOptions {
+            epochs_to_keep: None,
             pruning_config_path: Some(temp_path.clone()),
         };
         let retention_config = pruning_options.load_from_file().unwrap().unwrap();

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -2,14 +2,20 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{net::SocketAddr, path::PathBuf};
+use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
 
 use clap::{Args, Parser, Subcommand};
 use iota_names::config::IotaNamesConfig;
 use iota_types::base_types::{IotaAddress, ObjectID};
+use serde::{Deserialize, Serialize};
+use strum::IntoEnumIterator;
 use url::Url;
 
-use crate::{backfill::BackfillKind, db::ConnectionPoolConfig};
+use crate::{backfill::BackfillKind, db::ConnectionPoolConfig, handlers::pruner::PrunableTable};
+
+/// The primary purpose of objects_history is to serve consistency query.
+/// A short retention is sufficient.
+const OBJECTS_HISTORY_EPOCHS_TO_KEEP: u64 = 2;
 
 #[derive(Parser, Clone, Debug)]
 #[command(
@@ -224,8 +230,96 @@ pub enum Command {
 
 #[derive(Args, Default, Debug, Clone)]
 pub struct PruningOptions {
-    #[arg(long, env = "EPOCHS_TO_KEEP")]
-    pub epochs_to_keep: Option<u64>,
+    /// Path to TOML file containing configuration for retention policies.
+    #[arg(long)]
+    pub pruning_config_path: Option<PathBuf>,
+}
+
+/// Represents the default retention policy and overrides for prunable tables.
+/// Instantiated only if `PruningOptions` is provided on indexer start.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetentionConfig {
+    /// Default retention policy for all tables.
+    pub epochs_to_keep: u64,
+    /// A map of tables to their respective retention policies that will
+    /// override the default. Prunable tables not named here will use the
+    /// default retention policy.
+    #[serde(default)]
+    pub overrides: HashMap<PrunableTable, u64>,
+}
+
+impl PruningOptions {
+    /// Load default retention policy and overrides from file.
+    pub fn load_from_file(&self) -> Option<RetentionConfig> {
+        let config_path = self.pruning_config_path.as_ref()?;
+
+        let contents = std::fs::read_to_string(config_path)
+            .expect("Failed to read default retention policy and overrides from file");
+        let retention_with_overrides = toml::de::from_str::<RetentionConfig>(&contents)
+            .expect("Failed to parse into RetentionConfig struct");
+
+        let default_retention = retention_with_overrides.epochs_to_keep;
+
+        assert!(
+            default_retention > 0,
+            "Default retention must be greater than 0"
+        );
+        assert!(
+            retention_with_overrides
+                .overrides
+                .values()
+                .all(|&policy| policy > 0),
+            "All retention overrides must be greater than 0"
+        );
+
+        Some(retention_with_overrides)
+    }
+}
+
+impl RetentionConfig {
+    /// Create a new `RetentionConfig` with the specified default retention and
+    /// overrides. Call `finalize()` on the instance to update the
+    /// `policies` field with the default retention policy for all tables
+    /// that do not have an override specified.
+    pub fn new(epochs_to_keep: u64, overrides: HashMap<PrunableTable, u64>) -> Self {
+        Self {
+            epochs_to_keep,
+            overrides,
+        }
+    }
+
+    pub fn new_with_default_retention_only_for_testing(epochs_to_keep: u64) -> Self {
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            PrunableTable::ObjectsHistory,
+            OBJECTS_HISTORY_EPOCHS_TO_KEEP,
+        );
+
+        Self::new(epochs_to_keep, HashMap::new())
+    }
+
+    /// Consumes this struct to produce a full mapping of every prunable table
+    /// and its retention policy. By default, every prunable table will have
+    /// the default retention policy from `epochs_to_keep`. Some tables like
+    /// `objects_history` will observe a different default retention policy.
+    /// These default values are overridden by any entries in `overrides`.
+    pub fn retention_policies(self) -> HashMap<PrunableTable, u64> {
+        let RetentionConfig {
+            epochs_to_keep,
+            mut overrides,
+        } = self;
+
+        for table in PrunableTable::iter() {
+            let default_retention = match table {
+                PrunableTable::ObjectsHistory => OBJECTS_HISTORY_EPOCHS_TO_KEEP,
+                _ => epochs_to_keep,
+            };
+
+            overrides.entry(table).or_insert(default_retention);
+        }
+
+        overrides
+    }
 }
 
 #[derive(Args, Debug, Clone)]
@@ -494,9 +588,7 @@ pub mod deprecated {
                         sleep_duration: SnapshotLagConfig::DEFAULT_SLEEP_DURATION_SEC,
                     },
                     pruning_options: PruningOptions {
-                        epochs_to_keep: std::env::var("EPOCHS_TO_KEEP")
-                            .map(|s| s.parse::<u64>().ok())
-                            .unwrap_or_else(|_e| None),
+                        pruning_config_path: None, // no support for pruning in old CLI
                     },
                     reset_db: old_conf.reset_db,
                 }
@@ -528,9 +620,13 @@ pub mod deprecated {
 
 #[cfg(test)]
 mod test {
+    use std::io::Write;
+
     use tap::Pipe;
+    use tempfile::NamedTempFile;
 
     use super::*;
+    use crate::handlers::pruner::PrunableTable;
 
     fn parse_args<'a, T>(args: impl IntoIterator<Item = &'a str>) -> Result<T, clap::error::Error>
     where
@@ -592,5 +688,127 @@ mod test {
 
         // fullnode rpc url must be present
         parse_args::<JsonRpcConfig>([]).unwrap_err();
+    }
+
+    #[test]
+    fn pruning_options_with_objects_history_override() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        let toml_content = r#"
+        epochs_to_keep = 5
+        [overrides]
+        objects_history = 10
+        transactions = 20
+        "#;
+        temp_file.write_all(toml_content.as_bytes()).unwrap();
+        let temp_path: PathBuf = temp_file.path().to_path_buf();
+        let pruning_options = PruningOptions {
+            pruning_config_path: Some(temp_path.clone()),
+        };
+        let retention_config = pruning_options.load_from_file().unwrap();
+
+        // Assert the parsed values
+        assert_eq!(retention_config.epochs_to_keep, 5);
+        assert_eq!(
+            retention_config
+                .overrides
+                .get(&PrunableTable::ObjectsHistory)
+                .copied(),
+            Some(10)
+        );
+        assert_eq!(
+            retention_config
+                .overrides
+                .get(&PrunableTable::Transactions)
+                .copied(),
+            Some(20)
+        );
+        assert_eq!(retention_config.overrides.len(), 2);
+
+        let retention_policies = retention_config.retention_policies();
+
+        for table in PrunableTable::iter() {
+            let Some(retention) = retention_policies.get(&table).copied() else {
+                panic!("Expected a retention policy for table {table:?}");
+            };
+
+            match table {
+                PrunableTable::ObjectsHistory => assert_eq!(retention, 10),
+                PrunableTable::Transactions => assert_eq!(retention, 20),
+                _ => assert_eq!(retention, 5),
+            };
+        }
+    }
+
+    #[test]
+    fn pruning_options_no_objects_history_override() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        let toml_content = r#"
+        epochs_to_keep = 5
+        [overrides]
+        tx_affected_addresses = 10
+        transactions = 20
+        "#;
+        temp_file.write_all(toml_content.as_bytes()).unwrap();
+        let temp_path: PathBuf = temp_file.path().to_path_buf();
+        let pruning_options = PruningOptions {
+            pruning_config_path: Some(temp_path.clone()),
+        };
+        let retention_config = pruning_options.load_from_file().unwrap();
+
+        // Assert the parsed values
+        assert_eq!(retention_config.epochs_to_keep, 5);
+        assert_eq!(
+            retention_config
+                .overrides
+                .get(&PrunableTable::TxAffectedAddresses)
+                .copied(),
+            Some(10)
+        );
+        assert_eq!(
+            retention_config
+                .overrides
+                .get(&PrunableTable::Transactions)
+                .copied(),
+            Some(20)
+        );
+        assert_eq!(retention_config.overrides.len(), 2);
+
+        let retention_policies = retention_config.retention_policies();
+
+        for table in PrunableTable::iter() {
+            let Some(retention) = retention_policies.get(&table).copied() else {
+                panic!("Expected a retention policy for table {table:?}");
+            };
+
+            match table {
+                PrunableTable::ObjectsHistory => {
+                    assert_eq!(retention, OBJECTS_HISTORY_EPOCHS_TO_KEEP)
+                }
+                PrunableTable::TxAffectedAddresses => assert_eq!(retention, 10),
+                PrunableTable::Transactions => assert_eq!(retention, 20),
+                _ => assert_eq!(retention, 5),
+            };
+        }
+    }
+
+    #[test]
+    fn test_invalid_pruning_config_file() {
+        let toml_str = r#"
+        epochs_to_keep = 5
+        [overrides]
+        objects_history = 10
+        transactions = 20
+        invalid_table = 30
+        "#;
+
+        let result = toml::from_str::<RetentionConfig>(toml_str);
+        assert!(result.is_err(), "Expected an error, but parsing succeeded");
+
+        if let Err(e) = result {
+            assert!(
+                e.to_string().contains("unknown variant `invalid_table`"),
+                "Error message doesn't mention the invalid table"
+            );
+        }
     }
 }

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -4,6 +4,7 @@
 
 use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
 
+use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
 use iota_names::config::IotaNamesConfig;
 use iota_types::base_types::{IotaAddress, ObjectID};
@@ -11,7 +12,10 @@ use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use url::Url;
 
-use crate::{backfill::BackfillKind, db::ConnectionPoolConfig, handlers::pruner::PrunableTable};
+use crate::{
+    backfill::BackfillKind, db::ConnectionPoolConfig, handlers::pruner::PrunableTable,
+    types::IndexerResult,
+};
 
 /// The primary purpose of objects_history is to serve consistency query.
 /// A short retention is sufficient.
@@ -250,13 +254,15 @@ pub struct RetentionConfig {
 
 impl PruningOptions {
     /// Load default retention policy and overrides from file.
-    pub fn load_from_file(&self) -> Option<RetentionConfig> {
-        let config_path = self.pruning_config_path.as_ref()?;
+    pub fn load_from_file(&self) -> IndexerResult<Option<RetentionConfig>> {
+        let Some(config_path) = self.pruning_config_path.as_ref() else {
+            return Ok(None);
+        };
 
         let contents = std::fs::read_to_string(config_path)
-            .expect("Failed to read default retention policy and overrides from file");
+            .context("Failed to read default retention policy and overrides from file")?;
         let retention_with_overrides = toml::de::from_str::<RetentionConfig>(&contents)
-            .expect("Failed to parse into RetentionConfig struct");
+            .context("Failed to parse into RetentionConfig struct")?;
 
         let default_retention = retention_with_overrides.epochs_to_keep;
 
@@ -272,7 +278,7 @@ impl PruningOptions {
             "All retention overrides must be greater than 0"
         );
 
-        Some(retention_with_overrides)
+        Ok(Some(retention_with_overrides))
     }
 }
 
@@ -704,7 +710,7 @@ mod test {
         let pruning_options = PruningOptions {
             pruning_config_path: Some(temp_path.clone()),
         };
-        let retention_config = pruning_options.load_from_file().unwrap();
+        let retention_config = pruning_options.load_from_file().unwrap().unwrap();
 
         // Assert the parsed values
         assert_eq!(retention_config.epochs_to_keep, 5);
@@ -753,7 +759,7 @@ mod test {
         let pruning_options = PruningOptions {
             pruning_config_path: Some(temp_path.clone()),
         };
-        let retention_config = pruning_options.load_from_file().unwrap();
+        let retention_config = pruning_options.load_from_file().unwrap().unwrap();
 
         // Assert the parsed values
         assert_eq!(retention_config.epochs_to_keep, 5);

--- a/crates/iota-indexer/src/db.rs
+++ b/crates/iota-indexer/src/db.rs
@@ -2,18 +2,20 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
+use std::{collections::HashSet, time::Duration};
 
 use anyhow::anyhow;
 use clap::Args;
 use diesel::{
-    PgConnection,
+    PgConnection, QueryableByName,
     connection::BoxableConnection,
     query_dsl::RunQueryDsl,
     r2d2::{ConnectionManager, Pool, PooledConnection, R2D2Connection},
 };
+use strum::IntoEnumIterator;
+use tracing::info;
 
-use crate::errors::IndexerError;
+use crate::{errors::IndexerError, handlers::pruner::PrunableTable};
 
 pub type ConnectionPool = Pool<ConnectionManager<PgConnection>>;
 pub type PoolConnection = PooledConnection<ConnectionManager<PgConnection>>;
@@ -152,6 +154,53 @@ pub fn reset_database(conn: &mut PoolConnection) -> Result<(), anyhow::Error> {
                 },
             )?;
     }
+    Ok(())
+}
+
+/// Check that prunable tables exist in the database.
+pub async fn check_prunable_tables_valid(conn: &mut PoolConnection) -> Result<(), IndexerError> {
+    info!("Starting compatibility check");
+
+    use diesel::RunQueryDsl;
+
+    let select_parent_tables = r#"
+    SELECT c.relname AS table_name
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    LEFT JOIN pg_partitioned_table pt ON pt.partrelid = c.oid
+    WHERE c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
+        AND n.nspname = 'public'
+        AND (
+            pt.partrelid IS NOT NULL  -- This is a partitioned (parent) table
+            OR NOT EXISTS (  -- This is not a partition (child table)
+                SELECT 1
+                FROM pg_inherits i
+                WHERE i.inhrelid = c.oid
+            )
+        );
+    "#;
+
+    #[derive(QueryableByName)]
+    struct TableName {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        table_name: String,
+    }
+
+    let result: Vec<TableName> = diesel::sql_query(select_parent_tables)
+        .load(conn)
+        .map_err(|e| IndexerError::DbMigration(format!("Failed to fetch tables: {e}")))?;
+
+    let parent_tables_from_db: HashSet<_> = result.into_iter().map(|t| t.table_name).collect();
+
+    for key in PrunableTable::iter() {
+        if !parent_tables_from_db.contains(key.as_ref()) {
+            return Err(IndexerError::Generic(format!(
+                "Invalid retention policy override provided for table {key}: does not exist in the database",
+            )));
+        }
+    }
+
+    info!("Compatibility check passed");
     Ok(())
 }
 

--- a/crates/iota-indexer/src/handlers/pruner.rs
+++ b/crates/iota-indexer/src/handlers/pruner.rs
@@ -146,10 +146,7 @@ impl Pruner {
                         }
                         self.partition_manager
                             .drop_table_partition(table_name.clone(), epoch)?;
-                        info!(
-                            "Batch dropped table partition {} epoch {}",
-                            table_name, epoch
-                        );
+                        info!("Batch dropped table partition {table_name} epoch {epoch}",);
                     }
                 }
             }

--- a/crates/iota-indexer/src/handlers/pruner.rs
+++ b/crates/iota-indexer/src/handlers/pruner.rs
@@ -43,6 +43,7 @@ pub struct Pruner {
 )]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum PrunableTable {
     ObjectsHistory,
     Transactions,

--- a/crates/iota-indexer/src/handlers/pruner.rs
+++ b/crates/iota-indexer/src/handlers/pruner.rs
@@ -4,11 +4,13 @@
 
 use std::{collections::HashMap, time::Duration};
 
+use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 use super::checkpoint_handler::CheckpointHandler;
 use crate::{
+    config::RetentionConfig,
     errors::IndexerError,
     metrics::IndexerMetrics,
     store::{IndexerStore, PgIndexerStore, pg_partition_manager::PgPartitionManager},
@@ -18,24 +20,89 @@ use crate::{
 pub struct Pruner {
     pub store: PgIndexerStore,
     pub partition_manager: PgPartitionManager,
+    // TODO: we can remove this when pruner logic is updated to use `retention_policies`.
     pub epochs_to_keep: u64,
+    pub retention_policies: HashMap<PrunableTable, u64>,
     pub metrics: IndexerMetrics,
 }
 
+/// Enum representing tables that the pruner is allowed to prune. The pruner
+/// will ignore any table that is not listed here.
+#[derive(
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::EnumIter,
+    strum_macros::AsRefStr,
+    Hash,
+    Serialize,
+    Deserialize,
+    Clone,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum PrunableTable {
+    ObjectsHistory,
+    Transactions,
+    Events,
+
+    EventEmitPackage,
+    EventEmitModule,
+    EventSenders,
+    EventStructInstantiation,
+    EventStructModule,
+    EventStructName,
+    EventStructPackage,
+
+    TxAffectedAddresses,
+    TxAffectedObjects,
+    TxCallsPkg,
+    TxCallsMod,
+    TxCallsFun,
+    TxChangedObjects,
+    TxDigests,
+    TxInputObjects,
+    TxKinds,
+    TxRecipients,
+    TxSenders,
+
+    Checkpoints,
+    PrunerCpWatermark,
+}
+
 impl Pruner {
+    /// Instantiates a pruner with default retention and overrides. Pruner will
+    /// finalize the retention policies so there is a value for every
+    /// prunable table.
     pub fn new(
         store: PgIndexerStore,
-        epochs_to_keep: u64,
+        retention_config: RetentionConfig,
         metrics: IndexerMetrics,
     ) -> Result<Self, IndexerError> {
         let blocking_cp = CheckpointHandler::pg_blocking_cp(store.clone()).unwrap();
         let partition_manager = PgPartitionManager::new(blocking_cp.clone())?;
+        let epochs_to_keep = retention_config.epochs_to_keep;
+        let retention_policies = retention_config.retention_policies();
+
         Ok(Self {
             store,
-            partition_manager,
             epochs_to_keep,
+            partition_manager,
+            retention_policies,
             metrics,
         })
+    }
+
+    /// Given a table name, return the number of epochs to keep for that table.
+    /// Return `None` if the table is not prunable.
+    fn table_retention(&self, table_name: &str) -> Option<u64> {
+        if let Ok(variant) = table_name.parse::<PrunableTable>() {
+            self.retention_policies.get(&variant).copied()
+        } else {
+            None
+        }
     }
 
     pub async fn start(&self, cancel: CancellationToken) -> IndexerResult<()> {
@@ -63,30 +130,38 @@ impl Pruner {
                 })
                 .collect();
 
-            let prune_to_epoch = last_seen_max_epoch.saturating_sub(self.epochs_to_keep - 1);
-
             for (table_name, (min_partition, max_partition)) in &table_partitions {
-                if last_seen_max_epoch != *max_partition {
-                    error!(
-                        "Epochs are out of sync for table {table_name}: max_epoch={last_seen_max_epoch}, max_partition={max_partition}",
-                    );
-                }
-                for epoch in *min_partition..prune_to_epoch {
-                    if cancel.is_cancelled() {
-                        info!("Pruner task cancelled.");
-                        return Ok(());
+                if let Some(epochs_to_keep) = self.table_retention(table_name) {
+                    if last_seen_max_epoch != *max_partition {
+                        error!(
+                            "Epochs are out of sync for table {table_name}: max_epoch={last_seen_max_epoch}, max_partition={max_partition}",
+                        );
                     }
-                    self.partition_manager
-                        .drop_table_partition(table_name.clone(), epoch)?;
-                    info!(
-                        "Batch dropped table partition {} epoch {}",
-                        table_name, epoch
-                    );
+                    for epoch in
+                        *min_partition..last_seen_max_epoch.saturating_sub(epochs_to_keep - 1)
+                    {
+                        if cancel.is_cancelled() {
+                            info!("Pruner task cancelled.");
+                            return Ok(());
+                        }
+                        self.partition_manager
+                            .drop_table_partition(table_name.clone(), epoch)?;
+                        info!(
+                            "Batch dropped table partition {} epoch {}",
+                            table_name, epoch
+                        );
+                    }
                 }
             }
 
-            let prune_start_epoch = next_prune_epoch.unwrap_or(min_epoch);
+            // TODO: Once we have the watermarks table, we can iterate through each
+            // row returned from `watermarks`, look it up against
+            // `retention_policies`, and process them independently. This also
+            // means that pruning overrides will only apply for
+            // epoch-partitioned tables right now.
+            let prune_to_epoch = last_seen_max_epoch.saturating_sub(self.epochs_to_keep - 1);
 
+            let prune_start_epoch = next_prune_epoch.unwrap_or(min_epoch);
             for epoch in prune_start_epoch..prune_to_epoch {
                 if cancel.is_cancelled() {
                     info!("Pruner task cancelled.");

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -17,7 +17,7 @@ use tracing::info;
 
 use crate::{
     build_optimistic_json_rpc_server,
-    config::{IngestionConfig, JsonRpcConfig, PruningOptions, SnapshotLagConfig},
+    config::{IngestionConfig, JsonRpcConfig, RetentionConfig, SnapshotLagConfig},
     db::ConnectionPool,
     errors::IndexerError,
     handlers::{
@@ -33,29 +33,12 @@ use crate::{
 pub struct Indexer;
 
 impl Indexer {
-    pub async fn start_writer(
-        config: &IngestionConfig,
-        store: PgIndexerStore,
-        metrics: IndexerMetrics,
-    ) -> Result<(), IndexerError> {
-        let snapshot_config = SnapshotLagConfig::default();
-        Indexer::start_writer_with_config(
-            config,
-            store,
-            metrics,
-            snapshot_config,
-            PruningOptions::default(),
-            CancellationToken::new(),
-        )
-        .await
-    }
-
     pub async fn start_writer_with_config(
         config: &IngestionConfig,
         store: PgIndexerStore,
         metrics: IndexerMetrics,
         snapshot_config: SnapshotLagConfig,
-        pruning_options: PruningOptions,
+        retention_config: Option<RetentionConfig>,
         cancel: CancellationToken,
     ) -> Result<(), IndexerError> {
         info!(
@@ -88,14 +71,10 @@ impl Indexer {
         )
         .await?;
 
-        if let Some(epochs_to_keep) = pruning_options.epochs_to_keep {
-            info!(
-                "Starting indexer pruner with epochs to keep: {}",
-                epochs_to_keep
-            );
-            assert!(epochs_to_keep > 0, "Epochs to keep must be positive");
-            let pruner: Pruner = Pruner::new(store.clone(), epochs_to_keep, metrics.clone())?;
-            spawn_monitored_task!(pruner.start(CancellationToken::new()));
+        if let Some(retention_config) = retention_config {
+            let pruner = Pruner::new(store.clone(), retention_config, metrics.clone())?;
+            let cancel_clone = cancel.clone();
+            spawn_monitored_task!(pruner.start(cancel_clone));
         }
 
         // If we already have chain identifier indexed (i.e. the first checkpoint has

--- a/crates/iota-indexer/src/main.rs
+++ b/crates/iota-indexer/src/main.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<(), IndexerError> {
             pruning_options,
             reset_db,
         } => {
-            let retention_config = pruning_options.load_from_file();
+            let retention_config = pruning_options.load_from_file()?;
             {
                 // Make sure to run all migrations on startup, and also serve as a compatibility
                 // check.

--- a/crates/iota-indexer/src/main.rs
+++ b/crates/iota-indexer/src/main.rs
@@ -9,7 +9,7 @@ use iota_indexer::{
     backfill::runner::BackfillRunner,
     config::{Command, IndexerConfig, deprecated::OldIndexerConfig},
     db::{
-        get_pool_connection, new_connection_pool, reset_database,
+        check_prunable_tables_valid, get_pool_connection, new_connection_pool, reset_database,
         setup_postgres::{check_db_migration_consistency, run_migrations},
     },
     errors::IndexerError,
@@ -71,6 +71,7 @@ async fn main() -> Result<(), IndexerError> {
             pruning_options,
             reset_db,
         } => {
+            let retention_config = pruning_options.load_from_file();
             {
                 // Make sure to run all migrations on startup, and also serve as a compatibility
                 // check.
@@ -80,6 +81,9 @@ async fn main() -> Result<(), IndexerError> {
                 } else {
                     run_migrations(&mut pool_conn)?;
                 }
+                if retention_config.is_some() {
+                    check_prunable_tables_valid(&mut pool_conn).await?;
+                }
             }
 
             let store = PgIndexerStore::new(connection_pool, indexer_metrics.clone());
@@ -88,7 +92,7 @@ async fn main() -> Result<(), IndexerError> {
                 store,
                 indexer_metrics,
                 snapshot_config,
-                pruning_options,
+                retention_config,
                 CancellationToken::new(),
             )
             .await?;

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -12,7 +12,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     IndexerMetrics,
-    config::{IngestionConfig, IotaNamesOptions, PruningOptions, SnapshotLagConfig},
+    config::{IngestionConfig, IotaNamesOptions, RetentionConfig, SnapshotLagConfig},
     db::{ConnectionPool, ConnectionPoolConfig, PoolConnection, new_connection_pool},
     errors::IndexerError,
     indexer::Indexer,
@@ -63,7 +63,7 @@ pub enum IndexerTypeConfig {
     },
     Writer {
         snapshot_config: SnapshotLagConfig,
-        pruning_options: PruningOptions,
+        retention_config: Option<RetentionConfig>,
     },
     AnalyticalWorker,
 }
@@ -81,7 +81,8 @@ impl IndexerTypeConfig {
     ) -> Self {
         Self::Writer {
             snapshot_config: snapshot_config.unwrap_or_default(),
-            pruning_options: PruningOptions { epochs_to_keep },
+            retention_config: epochs_to_keep
+                .map(RetentionConfig::new_with_default_retention_only_for_testing),
         }
     }
 }
@@ -152,7 +153,7 @@ pub async fn start_test_indexer_impl(
         }
         IndexerTypeConfig::Writer {
             snapshot_config,
-            pruning_options,
+            retention_config,
         } => {
             let store_clone = store.clone();
             let mut ingestion_config = IngestionConfig::default();
@@ -168,7 +169,7 @@ pub async fn start_test_indexer_impl(
                     store_clone,
                     indexer_metrics,
                     snapshot_config,
-                    pruning_options,
+                    retention_config,
                     cancel,
                 )
                 .await


### PR DESCRIPTION
# Description of change
Modify `PruningOptions` to point to a toml file that must specify `epochs_to_keep` and an optional [overrides] portion of per-table overrides.

pruner.rs file will define prunable tables. the toml file when parsed into Rust config will warn if it tries to name any variants not supported by indexer code. additionally, there's also a check to make sure that prunable tables actually exist in the db

## Links to any relevant issues

fixes #8457

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
