### PR TITLE
feat(iota-faucet): address rate limitting 

### DIFF
--- a/crates/iota-faucet/src/faucet/mod.rs
+++ b/crates/iota-faucet/src/faucet/mod.rs
@@ -129,6 +129,19 @@ pub struct FaucetConfig {
 
     #[arg(long, action = clap::ArgAction::Set, default_value_t = false)]
     pub batch_enabled: bool,
+
+    // enable rate limiting
+    #[arg(long, default_value_t = false)]
+    pub enable_rate_limiting: bool,
+
+    // fields for rate limiting
+    // default 12 requests
+    #[arg(long, default_value_t = 12)]
+    pub max_requests_per_window: usize,
+
+    // default: 12 hours
+    #[arg(long, default_value_t = 43200)]
+    pub rate_window_secs: u64,
 }
 
 impl Default for FaucetConfig {
@@ -147,6 +160,9 @@ impl Default for FaucetConfig {
             batch_request_size: 500,
             ttl_expiration: 300,
             batch_enabled: false,
+            enable_rate_limiting: false,
+            max_requests_per_window: 12,
+            rate_window_secs: 12,
         }
     }
 }

--- a/crates/iota-faucet/src/faucet/mod.rs
+++ b/crates/iota-faucet/src/faucet/mod.rs
@@ -80,6 +80,9 @@ pub trait Faucet {
 
     /// Get the status of a batch_send request
     async fn get_batch_send_status(&self, task_id: Uuid) -> Result<BatchSendStatus, FaucetError>;
+
+    /// Apply rate limiting
+    async fn rate_limit(&self, recipient: IotaAddress) -> Result<(), FaucetError>;
 }
 
 pub const DEFAULT_AMOUNT: u64 = 1_000_000_000;
@@ -130,12 +133,9 @@ pub struct FaucetConfig {
     #[arg(long, action = clap::ArgAction::Set, default_value_t = false)]
     pub batch_enabled: bool,
 
-    // enable rate limiting
     #[arg(long, default_value_t = false)]
     pub enable_rate_limiting: bool,
 
-    // fields for rate limiting
-    // default 12 requests
     #[arg(long, default_value_t = 12)]
     pub max_requests_per_window: usize,
 

--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -37,9 +37,9 @@ use tokio::{
         mpsc::{self, Receiver, Sender},
         oneshot,
     },
-    time::{Duration, timeout},
+    time::{Duration, Instant, timeout},
 };
-use tracing::{error, info, warn};
+use tracing::{error, info, warn, debug};
 use ttl_cache::TtlCache;
 use typed_store::Map;
 use uuid::Uuid;
@@ -64,10 +64,14 @@ pub struct SimpleFaucet {
     task_id_cache: Mutex<TtlCache<Uuid, BatchSendStatus>>,
     ttl_expiration: u64,
     coin_amount: u64,
-    request_count: Mutex<HashMap<IotaAddress, u64>>,
+    request_times: Mutex<HashMap<IotaAddress, Vec<Instant>>>,
     /// Shuts down the batch transfer task. Used only in testing.
     #[cfg_attr(not(test), expect(unused))]
     batch_transfer_shutdown: parking_lot::Mutex<Option<oneshot::Sender<()>>>,
+    // rate limiting
+    enable_rate_limiting: bool,
+    max_requests_per_window: usize,
+    rate_window_secs: u64,
 }
 
 /// We do not just derive(Debug) because WalletContext and the WriteAheadLog do
@@ -205,7 +209,11 @@ impl SimpleFaucet {
             ttl_expiration: config.ttl_expiration,
             coin_amount: config.amount,
             batch_transfer_shutdown: parking_lot::Mutex::new(Some(batch_transfer_shutdown)),
-            request_count: Mutex::new(HashMap::new()),
+            // rate limiting
+            request_times: Mutex::new(HashMap::<IotaAddress, Vec<Instant>>::new()),
+            enable_rate_limiting: config.enable_rate_limiting,
+            max_requests_per_window: config.max_requests_per_window,
+            rate_window_secs: config.rate_window_secs,
         };
 
         let arc_faucet = Arc::new(faucet);
@@ -900,18 +908,69 @@ impl Faucet for SimpleFaucet {
     ) -> Result<FaucetReceipt, FaucetError> {
         info!(?recipient, uuid = ?id, ?amounts, "Getting faucet requests");
 
-        // Check the in-memory block list before proceeding.
-        let mut counts = self.request_count.lock().await;
-        let count = counts.entry(recipient.clone()).or_insert(0);
-        *count += 1;
-        if *count >= 100 {
-            info!("{:?} {} {}", recipient, *count, "Blocked");
-            return Err(FaucetError::BatchSendQueueFull);
+        // If rate limiting is enabled, perform the rate check.
+        if self.enable_rate_limiting {
+            let mut request_times = self.request_times.lock().await;
+            let entries = request_times.entry(recipient.clone()).or_insert_with(Vec::new);
+
+            // Define the time window based on configuration.
+            let window = Duration::from_secs(self.rate_window_secs);
+            let now = Instant::now();
+
+            // Debug: log the state before pruning.
+            debug!(
+                "Before pruning, recipient {:?} has {} request(s): {:?}",
+                recipient,
+                entries.len(),
+                entries
+            );
+
+            // Remove timestamps older than the configured window.
+            entries.retain(|&timestamp| now.duration_since(timestamp) < window);
+
+            // Debug: log the state after pruning.
+            debug!(
+                "After pruning, recipient {:?} has {} request(s): {:?}",
+                recipient,
+                entries.len(),
+                entries
+            );
+
+            // Check if the number of requests in the window exceeds the configured limit.
+            if entries.len() >= self.max_requests_per_window {
+                info!(
+                    "{:?} has {} requests in the past {} seconds; blocking.",
+                    recipient,
+                    entries.len(),
+                    self.rate_window_secs
+                );
+                return Err(FaucetError::BatchSendQueueFull);
+            }
+
+            // Debug: log before recording the new request.
+            debug!(
+                "Allowing a new request for recipient {:?}; current count: {}",
+                recipient,
+                entries.len()
+            );
+
+            // Record the current request.
+            entries.push(now);
+
+            // Debug: log the state after adding the new request.
+            debug!(
+                "After adding request, recipient {:?} has {} request(s): {:?}",
+                recipient,
+                entries.len(),
+                entries
+            );
+
+            // Release the lock.
+            drop(request_times);
         }
 
-        info!("{:?} {} {}", recipient, *count, "Allowed");
-        drop(counts);
 
+        // Continue with transaction processing if rate limiting is either disabled or the check passed.
         let (digest, coin_ids) = self.transfer_gases(amounts, recipient, id).await?;
 
         info!(uuid = ?id, ?recipient, ?digest, "PayIota txn succeeded");

--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -64,6 +64,7 @@ pub struct SimpleFaucet {
     task_id_cache: Mutex<TtlCache<Uuid, BatchSendStatus>>,
     ttl_expiration: u64,
     coin_amount: u64,
+    request_count: Mutex<HashMap<IotaAddress, u64>>,
     /// Shuts down the batch transfer task. Used only in testing.
     #[cfg_attr(not(test), expect(unused))]
     batch_transfer_shutdown: parking_lot::Mutex<Option<oneshot::Sender<()>>>,
@@ -204,6 +205,7 @@ impl SimpleFaucet {
             ttl_expiration: config.ttl_expiration,
             coin_amount: config.amount,
             batch_transfer_shutdown: parking_lot::Mutex::new(Some(batch_transfer_shutdown)),
+            request_count: Mutex::new(HashMap::new()),
         };
 
         let arc_faucet = Arc::new(faucet);
@@ -897,6 +899,18 @@ impl Faucet for SimpleFaucet {
         amounts: &[u64],
     ) -> Result<FaucetReceipt, FaucetError> {
         info!(?recipient, uuid = ?id, ?amounts, "Getting faucet requests");
+
+        // Check the in-memory block list before proceeding.
+        let mut counts = self.request_count.lock().await;
+        let count = counts.entry(recipient.clone()).or_insert(0);
+        *count += 1;
+        if *count >= 100 {
+            info!("{:?} {} {}", recipient, *count, "Blocked");
+            return Err(FaucetError::BatchSendQueueFull);
+        }
+
+        info!("{:?} {} {}", recipient, *count, "Allowed");
+        drop(counts);
 
         let (digest, coin_ids) = self.transfer_gases(amounts, recipient, id).await?;
 

--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -917,24 +917,8 @@ impl Faucet for SimpleFaucet {
             let window = Duration::from_secs(self.rate_window_secs);
             let now = Instant::now();
 
-            // Debug: log the state before pruning.
-            debug!(
-                "Before pruning, recipient {:?} has {} request(s): {:?}",
-                recipient,
-                entries.len(),
-                entries
-            );
-
             // Remove timestamps older than the configured window.
             entries.retain(|&timestamp| now.duration_since(timestamp) < window);
-
-            // Debug: log the state after pruning.
-            debug!(
-                "After pruning, recipient {:?} has {} request(s): {:?}",
-                recipient,
-                entries.len(),
-                entries
-            );
 
             // Check if the number of requests in the window exceeds the configured limit.
             if entries.len() >= self.max_requests_per_window {
@@ -956,14 +940,6 @@ impl Faucet for SimpleFaucet {
 
             // Record the current request.
             entries.push(now);
-
-            // Debug: log the state after adding the new request.
-            debug!(
-                "After adding request, recipient {:?} has {} request(s): {:?}",
-                recipient,
-                entries.len(),
-                entries
-            );
 
             // Release the lock.
             drop(request_times);

--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -5,7 +5,7 @@
 #[cfg(test)]
 use std::collections::HashSet;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     fmt,
     path::Path,
     sync::{Arc, Weak},
@@ -43,8 +43,6 @@ use tracing::{debug, error, info, warn};
 use ttl_cache::TtlCache;
 use typed_store::Map;
 use uuid::Uuid;
-
-use std::collections::VecDeque;
 
 use super::write_ahead_log::WriteAheadLog;
 use crate::{
@@ -963,7 +961,8 @@ impl Faucet for SimpleFaucet {
             drop(request_times);
         }
 
-        // Continue with transaction processing if rate limiting is either disabled or the check passed.
+        // Continue with transaction processing if rate limiting is either disabled or
+        // the check passed.
         let (digest, coin_ids) = self.transfer_gases(amounts, recipient, id).await?;
 
         info!(uuid = ?id, ?recipient, ?digest, "PayIota txn succeeded");

--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -39,10 +39,12 @@ use tokio::{
     },
     time::{Duration, Instant, timeout},
 };
-use tracing::{error, info, warn, debug};
+use tracing::{debug, error, info, warn};
 use ttl_cache::TtlCache;
 use typed_store::Map;
 use uuid::Uuid;
+
+use std::collections::VecDeque;
 
 use super::write_ahead_log::WriteAheadLog;
 use crate::{
@@ -64,7 +66,7 @@ pub struct SimpleFaucet {
     task_id_cache: Mutex<TtlCache<Uuid, BatchSendStatus>>,
     ttl_expiration: u64,
     coin_amount: u64,
-    request_times: Mutex<HashMap<IotaAddress, Vec<Instant>>>,
+    request_times: Mutex<HashMap<IotaAddress, VecDeque<Instant>>>,
     /// Shuts down the batch transfer task. Used only in testing.
     #[cfg_attr(not(test), expect(unused))]
     batch_transfer_shutdown: parking_lot::Mutex<Option<oneshot::Sender<()>>>,
@@ -102,6 +104,8 @@ const DEFAULT_GAS_COMPUTATION_BUCKET: u64 = 10_000_000;
 const LOCK_TIMEOUT: Duration = Duration::from_secs(10);
 const RECV_TIMEOUT: Duration = Duration::from_secs(5);
 const BATCH_TIMEOUT: Duration = Duration::from_secs(10);
+
+const MAX_TRACKED_ADDRESSES: usize = 100_000;
 
 impl SimpleFaucet {
     pub async fn new(
@@ -210,7 +214,7 @@ impl SimpleFaucet {
             coin_amount: config.amount,
             batch_transfer_shutdown: parking_lot::Mutex::new(Some(batch_transfer_shutdown)),
             // rate limiting
-            request_times: Mutex::new(HashMap::<IotaAddress, Vec<Instant>>::new()),
+            request_times: Mutex::new(HashMap::<IotaAddress, VecDeque<Instant>>::new()),
             enable_rate_limiting: config.enable_rate_limiting,
             max_requests_per_window: config.max_requests_per_window,
             rate_window_secs: config.rate_window_secs,
@@ -911,11 +915,25 @@ impl Faucet for SimpleFaucet {
         // If rate limiting is enabled, perform the rate check.
         if self.enable_rate_limiting {
             let mut request_times = self.request_times.lock().await;
-            let entries = request_times.entry(recipient.clone()).or_insert_with(Vec::new);
 
             // Define the time window based on configuration.
             let window = Duration::from_secs(self.rate_window_secs);
             let now = Instant::now();
+
+            // clean map
+            if request_times.len() >= MAX_TRACKED_ADDRESSES {
+                request_times.retain(|_, times| {
+                    times.retain(|&t| now.duration_since(t) < window);
+                    !times.is_empty()
+                });
+                if request_times.len() >= MAX_TRACKED_ADDRESSES
+                    && !request_times.contains_key(&recipient)
+                {
+                    return Err(FaucetError::BatchSendQueueFull);
+                }
+            }
+
+            let entries = request_times.entry(recipient).or_insert_with(VecDeque::new);
 
             // Remove timestamps older than the configured window.
             entries.retain(|&timestamp| now.duration_since(timestamp) < window);
@@ -939,12 +957,11 @@ impl Faucet for SimpleFaucet {
             );
 
             // Record the current request.
-            entries.push(now);
+            entries.push_back(now);
 
             // Release the lock.
             drop(request_times);
         }
-
 
         // Continue with transaction processing if rate limiting is either disabled or the check passed.
         let (digest, coin_ids) = self.transfer_gases(amounts, recipient, id).await?;

--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -902,6 +902,55 @@ impl SimpleFaucet {
 
 #[async_trait]
 impl Faucet for SimpleFaucet {
+    async fn rate_limit(&self, recipient: IotaAddress) -> Result<(), FaucetError> {
+        let mut request_times = self.request_times.lock().await;
+
+        // Define the time window based on configuration.
+        let window = Duration::from_secs(self.rate_window_secs);
+        let now = Instant::now();
+
+        // clean map
+        if request_times.len() >= MAX_TRACKED_ADDRESSES {
+            request_times.retain(|_, times| {
+                times.retain(|&t| now.duration_since(t) < window);
+                !times.is_empty()
+            });
+            if request_times.len() >= MAX_TRACKED_ADDRESSES
+                && !request_times.contains_key(&recipient)
+            {
+                return Err(FaucetError::BatchSendQueueFull);
+            }
+        }
+
+        let entries = request_times.entry(recipient).or_insert_with(VecDeque::new);
+
+        // Remove timestamps older than the configured window.
+        entries.retain(|&timestamp| now.duration_since(timestamp) < window);
+
+        // Check if the number of requests in the window exceeds the configured limit.
+        if entries.len() >= self.max_requests_per_window {
+            info!(
+                "{:?} has {} requests in the past {} seconds; blocking.",
+                recipient,
+                entries.len(),
+                self.rate_window_secs
+            );
+            return Err(FaucetError::BatchSendQueueFull);
+        }
+
+        // Debug: log before recording the new request.
+        debug!(
+            "Allowing a new request for recipient {:?}; current count: {}",
+            recipient,
+            entries.len()
+        );
+
+        // Record the current request.
+        entries.push_back(now);
+
+        Ok(())
+    }
+
     async fn send(
         &self,
         id: Uuid,
@@ -912,53 +961,7 @@ impl Faucet for SimpleFaucet {
 
         // If rate limiting is enabled, perform the rate check.
         if self.enable_rate_limiting {
-            let mut request_times = self.request_times.lock().await;
-
-            // Define the time window based on configuration.
-            let window = Duration::from_secs(self.rate_window_secs);
-            let now = Instant::now();
-
-            // clean map
-            if request_times.len() >= MAX_TRACKED_ADDRESSES {
-                request_times.retain(|_, times| {
-                    times.retain(|&t| now.duration_since(t) < window);
-                    !times.is_empty()
-                });
-                if request_times.len() >= MAX_TRACKED_ADDRESSES
-                    && !request_times.contains_key(&recipient)
-                {
-                    return Err(FaucetError::BatchSendQueueFull);
-                }
-            }
-
-            let entries = request_times.entry(recipient).or_insert_with(VecDeque::new);
-
-            // Remove timestamps older than the configured window.
-            entries.retain(|&timestamp| now.duration_since(timestamp) < window);
-
-            // Check if the number of requests in the window exceeds the configured limit.
-            if entries.len() >= self.max_requests_per_window {
-                info!(
-                    "{:?} has {} requests in the past {} seconds; blocking.",
-                    recipient,
-                    entries.len(),
-                    self.rate_window_secs
-                );
-                return Err(FaucetError::BatchSendQueueFull);
-            }
-
-            // Debug: log before recording the new request.
-            debug!(
-                "Allowing a new request for recipient {:?}; current count: {}",
-                recipient,
-                entries.len()
-            );
-
-            // Record the current request.
-            entries.push_back(now);
-
-            // Release the lock.
-            drop(request_times);
+            self.rate_limit(recipient).await?;
         }
 
         // Continue with transaction processing if rate limiting is either disabled or


### PR DESCRIPTION
# Description of change

Introduces rate-limit per address for the faucet.

There are three new parameters:

`--enable-rate-limiting`
Enable per-recipient rate limiting. Disabled by default.

`--max-requests-per-window <N> (default: 12)`
Maximum number of requests allowed per recipient within the sliding window.

`--rate-window-secs <SECONDS> (default: 43200)`
Size of the sliding window, in seconds (e.g. 43200 = 12 hours).

## How the change has been tested

- [X] Tested on Testnet for a 3 months

### Release Notes

- [X] Faucet / `iota-tools`
