### PR TITLE
fix(move-compiler): fix assignment optimization

### DIFF
--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/identity_with_struct_unpack.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/identity_with_struct_unpack.move
@@ -1,0 +1,92 @@
+//# init --edition 2024.alpha
+
+//# publish
+
+module 0x42::a;
+
+public struct SingleFieldStruct {
+    f: u32
+}
+
+#[allow(unused_assignment)]
+public fun single_field_struct(value: u32): u32 {
+    let s = SingleFieldStruct{ f: value };
+    let mut value_f = 0;
+    SingleFieldStruct{ f: value_f } = s;
+    value_f
+}
+
+#[allow(unused_assignment)]
+public fun single_field_struct_2(value: u32): u32 {
+    let s = SingleFieldStruct{ f: value };
+    let mut value_f;
+    SingleFieldStruct{ f: value_f } = SingleFieldStruct { f: 0 };
+    SingleFieldStruct{ f: value_f } = s;
+    value_f
+}
+
+public struct Pos(u8, u8)
+
+#[allow(unused_assignment)]
+public fun pos_struct(value: u8): u8 {
+    let p = Pos(value, 0);
+    let mut value_1 = 0;
+    let mut value_2 = 0;
+    Pos(value_1, value_2) = p;
+    value_1
+}
+
+#[allow(unused_assignment)]
+public fun pos_struct_2(value: u8): u8 {
+    let p = Pos(value, 0);
+    let mut value_1;
+    let mut value_2;
+    Pos(value_1, value_2) = Pos(0, 0);
+    Pos(value_1, value_2) = p;
+    value_1
+}
+
+public struct Box { top_left: Pos, bottom_right: Pos }
+
+#[allow(unused_assignment)]
+public fun box(value: u8): u8 {
+    let b = Box { top_left: Pos(value, 0), bottom_right: Pos(0, 0) };
+    let mut top_left_x = 0;
+    let mut top_left_y = 0;
+    let mut bottom_right_x = 0;
+    let mut bottom_right_y = 0;
+    Box {
+        top_left: Pos(top_left_x, top_left_y),
+        bottom_right: Pos(bottom_right_x, bottom_right_y),
+    } = b;
+    top_left_x
+}
+
+#[allow(unused_assignment)]
+public fun box_2(value: u8): u8 {
+    let b = Box { top_left: Pos(value, 0), bottom_right: Pos(0, 0) };
+    let mut top_left_x;
+    let mut top_left_y;
+    let mut bottom_right_x;
+    let mut bottom_right_y;
+    Box {
+        top_left: Pos(top_left_x, top_left_y),
+        bottom_right: Pos(bottom_right_x, bottom_right_y),
+    } = Box { top_left: Pos(0, 0), bottom_right: Pos(0, 0) };
+    Box {
+        top_left: Pos(top_left_x, top_left_y),
+        bottom_right: Pos(bottom_right_x, bottom_right_y),
+    } = b;
+    top_left_x
+}
+
+public fun assert_42() {
+    assert!(single_field_struct(42) == 42);
+    assert!(single_field_struct_2(42) == 42);
+    assert!(pos_struct(42) == 42);
+    assert!(pos_struct_2(42) == 42);
+    assert!(box(42) == 42);
+    assert!(box_2(42) == 42);
+}
+
+//# run 0x42::a::assert_42

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/identity_with_struct_unpack.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/identity_with_struct_unpack.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/eliminate_locals.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/eliminate_locals.rs
@@ -150,7 +150,12 @@ mod count {
     fn lvalue(context: &mut Context, sp!(_, l_): &LValue, substitutable: bool) {
         use LValue_ as L;
         match l_ {
-            L::Ignore | L::Unpack(_, _, _) | L::UnpackVariant(..) => (),
+            L::Ignore => (),
+            L::Unpack(_, _, field_lvalues) | L::UnpackVariant(_, _, _, _, _, field_lvalues) => {
+                for (_field, fl) in field_lvalues {
+                    lvalue(context, fl, /* substitutable */ false);
+                }
+            }
             L::Var { var, .. } => context.assign(var, substitutable),
         }
     }


### PR DESCRIPTION
# Description of change

- Fixed assignment optimization bug reported by https://pi2.network/
- Inlining did not consider assignments from struct unpacks/matches

## A bit details: 
Move compiler’s assignment/ inlining pass in `cfgir/optimize/eliminate_locals.rs` ignored assignments made via struct/enum unpack patterns (including nested fields). Because those assignments weren’t “counted,” the optimizer could incorrectly treat locals as substitutable (inline/kill), producing wrong results when values were assigned through pattern unpacking

Fix is leading to when visiting an lvalue, the pass now recurse into the field lvalues for Unpack / UnpackVariant and marks them non-substitutable, ensuring those locals are recorded as real assignments. New transactional tests demonstrate correctness.

Please check the new provided test for better explanation.

According to [changes](https://github.com/MystenLabs/sui/commit/a9e4c778eb5c1989a1a5e3d2adf981050241ec7f)

## Links to any relevant issues

Fixes #8270 .

## How the change has been tested

Run `cargo nextest run` for move-compiler-transactional-tests