### PR TITLE
fix(starfish): fix restart authority test

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -323,6 +323,7 @@ mod tests {
     #![allow(non_snake_case)]
 
     use std::{
+        cmp::max,
         collections::{BTreeMap, BTreeSet},
         sync::Arc,
         time::Duration,
@@ -423,7 +424,7 @@ mod tests {
             authorities.push(authority);
         }
 
-        const NUM_TRANSACTIONS: u8 = 15;
+        const NUM_TRANSACTIONS: u8 = 24;
         let mut submitted_transactions = BTreeSet::<Vec<u8>>::new();
         for i in 0..NUM_TRANSACTIONS {
             let txn = vec![i; 16];
@@ -475,7 +476,7 @@ mod tests {
             .await;
 
         // Add some new transactions while authority 0 is down.
-        const BIG_NUM_TRANSACTIONS: u8 = 100;
+        const BIG_NUM_TRANSACTIONS: u8 = 120;
         for i in NUM_TRANSACTIONS..BIG_NUM_TRANSACTIONS {
             let txn = vec![i; 16];
             submitted_transactions.insert(txn.clone());
@@ -536,7 +537,8 @@ mod tests {
                         for block in &committed_subdag.blocks {
                             if block.round() > GENESIS_ROUND {
                                 let author_index = block.author();
-                                last_round_committed_blocks[author_index] = block.round();
+                                last_round_committed_blocks[author_index] =
+                                    max(last_round_committed_blocks[author_index], block.round());
                             }
                         }
 
@@ -551,6 +553,7 @@ mod tests {
                             }
                         }
                         let commit_index = committed_subdag.commit_ref.index;
+                        assert!(last_committed_index[index] < commit_index);
                         last_committed_index[index] = commit_index;
                         consumer_monitors[index].set_highest_handled_commit(commit_index);
                     } else {
@@ -571,7 +574,7 @@ mod tests {
         let max_commit_index = last_committed_index.iter().max().unwrap();
         assert!(
             max_commit_index - min_commit_index < 5,
-            "Commit indices are not close enough: min = {min_commit_index}, max = {max_commit_index}",
+            "Commit indices are not close enough: min = {min_commit_index}, max = {max_commit_index}, all = {last_committed_index:?}"
         );
 
         // Expect that all transactions were submitted and processed.
@@ -586,7 +589,7 @@ mod tests {
         let max_round = last_round_committed_blocks.iter().max().unwrap();
         assert!(
             max_round - min_round < 5,
-            "Committed block rounds are not close enough: min = {min_round}, max = {max_round}",
+            "Committed block rounds are not close enough: min = {min_round}, max = {max_round}, all = {last_round_committed_blocks:?}"
         );
     }
 

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -523,7 +523,7 @@ mod tests {
         let mut last_committed_index = vec![0; num_of_authorities];
         let mut last_round_committed_blocks = vec![0; num_of_authorities];
         loop {
-            if start_time.elapsed() > Duration::from_secs(30) {
+            if start_time.elapsed() > Duration::from_secs(40) {
                 break;
             }
             for (index, receiver) in output_receivers.iter_mut().enumerate() {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1462,8 +1462,11 @@ impl DagState {
             let recent_refs = &mut self.recent_headers_refs_by_authority[authority_index];
 
             // Evict everything below split_key
-            let split_key =
-                BlockRef::new(eviction_round + 1, authority_index, BlockHeaderDigest::MIN);
+            let split_key = BlockRef::new(
+                eviction_round + 1,
+                authority_index,
+                BlockHeaderDigest::MIN,
+            );
 
             let to_keep = recent_refs.split_off(&split_key);
             let evicted = std::mem::replace(recent_refs, to_keep);

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1462,11 +1462,8 @@ impl DagState {
             let recent_refs = &mut self.recent_headers_refs_by_authority[authority_index];
 
             // Evict everything below split_key
-            let split_key = BlockRef::new(
-                eviction_round + 1,
-                authority_index,
-                BlockHeaderDigest::MIN,
-            );
+            let split_key =
+                BlockRef::new(eviction_round + 1, authority_index, BlockHeaderDigest::MIN);
 
             let to_keep = recent_refs.split_off(&split_key);
             let evicted = std::mem::replace(recent_refs, to_keep);

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -225,7 +225,14 @@ impl SynchronizerHandle {
         let mut tasks = self.tasks.lock().await;
         tasks.abort_all();
         while let Some(result) = tasks.join_next().await {
-            result?
+            match result {
+                // task finished successfully
+                Ok(_) => (),
+                // task was cancelled, which is expected on shutdown
+                Err(e) if e.is_cancelled() => (),
+                // propagate other errors (e.g. panics)
+                Err(e) => return Err(e),
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
# Description of change

PR makes small changes and adds new checks in test_restart_authority_committee. The timeout is increased because otherwise, transactions are not synchronised in time.
Also ignores warnings about cancelled processes at synchronizer shutdown.

## Links to any relevant issues

fixes #8486 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

