### PR TITLE
upstream(core): Migrate unbounded_iter callsites

### DIFF
--- a/crates/iota-analytics-indexer/src/package_store.rs
+++ b/crates/iota-analytics-indexer/src/package_store.rs
@@ -6,7 +6,7 @@ use std::{path::Path, sync::Arc};
 
 use async_trait::async_trait;
 use iota_package_resolver::{
-    Package, PackageStore, PackageStoreWithLruCache, Result, error::Error as PackageResolverError,
+    Package, PackageStore, PackageStoreWithLruCache, error::Error as PackageResolverError,
 };
 use iota_rest_api::Client;
 use iota_types::{base_types::ObjectID, object::Object};
@@ -51,7 +51,7 @@ impl PackageStoreTables {
             None,
         ))
     }
-    pub(crate) fn update(&self, package: &Object) -> Result<()> {
+    pub(crate) fn update(&self, package: &Object) -> iota_package_resolver::Result<()> {
         let mut batch = self.packages.batch();
         batch
             .insert_batch(&self.packages, std::iter::once((package.id(), package)))
@@ -79,7 +79,7 @@ impl LocalDBPackageStore {
         }
     }
 
-    pub fn update(&self, object: &Object) -> Result<()> {
+    pub fn update(&self, object: &Object) -> iota_package_resolver::Result<()> {
         let Some(_package) = object.data.try_as_package() else {
             return Ok(());
         };
@@ -87,7 +87,7 @@ impl LocalDBPackageStore {
         Ok(())
     }
 
-    pub async fn get(&self, id: AccountAddress) -> Result<Object> {
+    pub async fn get(&self, id: AccountAddress) -> iota_package_resolver::Result<Object> {
         let object = if let Some(object) = self
             .package_store_tables
             .packages
@@ -110,7 +110,7 @@ impl LocalDBPackageStore {
 
 #[async_trait]
 impl PackageStore for LocalDBPackageStore {
-    async fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>> {
+    async fn fetch(&self, id: AccountAddress) -> iota_package_resolver::Result<Arc<Package>> {
         let object = self.get(id).await?;
         Ok(Arc::new(Package::read_from_object(&object)?))
     }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3309,7 +3309,9 @@ impl AuthorityState {
         );
 
         if cfg!(debug_assertions) {
-            cur_epoch_store.check_all_executed_transactions_in_checkpoint();
+            cur_epoch_store
+                .check_all_executed_transactions_in_checkpoint()
+                .expect("failed to check all executed transactions in checkpoint");
         }
 
         self.get_reconfig_api()
@@ -5143,7 +5145,7 @@ impl AuthorityState {
             expensive_safety_check_config,
             cur_epoch_store.get_chain_identifier(),
             epoch_last_checkpoint,
-        );
+        )?;
         self.epoch_store.store(new_epoch_store.clone());
         Ok(new_epoch_store)
     }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -730,11 +730,12 @@ impl AuthorityEpochTables {
         Ok(state)
     }
 
-    pub fn get_all_pending_consensus_transactions(&self) -> Vec<ConsensusTransaction> {
-        self.pending_consensus_transactions
-            .unbounded_iter()
-            .map(|(_k, v)| v)
-            .collect()
+    pub fn get_all_pending_consensus_transactions(&self) -> IotaResult<Vec<ConsensusTransaction>> {
+        Ok(self
+            .pending_consensus_transactions
+            .safe_iter()
+            .map(|item| item.map(|(_k, v)| v))
+            .collect::<Result<Vec<_>, _>>()?)
     }
 
     pub fn reset_db_for_execution_since_genesis(&self) -> IotaResult {
@@ -852,19 +853,19 @@ impl AuthorityPerEpochStore {
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
         chain_identifier: ChainIdentifier,
         highest_executed_checkpoint: CheckpointSequenceNumber,
-    ) -> Arc<Self> {
+    ) -> IotaResult<Arc<Self>> {
         let current_time = Instant::now();
         let epoch_id = committee.epoch;
 
         let tables = AuthorityEpochTables::open(epoch_id, parent_path, db_options.clone());
         let end_of_publish =
-            StakeAggregator::from_iter(committee.clone(), tables.end_of_publish.unbounded_iter());
+            StakeAggregator::from_iter(committee.clone(), tables.end_of_publish.safe_iter())?;
         let reconfig_state = tables
             .load_reconfig_state()
             .expect("Load reconfig state at initialization cannot fail");
 
         let epoch_alive_notify = NotifyOnce::new();
-        let pending_consensus_transactions = tables.get_all_pending_consensus_transactions();
+        let pending_consensus_transactions = tables.get_all_pending_consensus_transactions()?;
         let pending_consensus_certificates: HashSet<_> = pending_consensus_transactions
             .iter()
             .filter_map(|transaction| {
@@ -950,7 +951,8 @@ impl AuthorityPerEpochStore {
 
         let mut jwk_aggregator = JwkAggregator::new(committee.clone());
 
-        for ((authority, id, jwk), _) in tables.pending_jwks.unbounded_iter() {
+        for item in tables.pending_jwks.safe_iter() {
+            let ((authority, id, jwk), _) = item?;
             jwk_aggregator.insert(authority, (id, jwk));
         }
 
@@ -997,7 +999,7 @@ impl AuthorityPerEpochStore {
         });
 
         s.update_buffer_stake_metric();
-        s
+        Ok(s)
     }
 
     pub fn tables(&self) -> IotaResult<Arc<AuthorityEpochTables>> {
@@ -1082,7 +1084,7 @@ impl AuthorityPerEpochStore {
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
         chain_identifier: ChainIdentifier,
         previous_epoch_last_checkpoint: CheckpointSequenceNumber,
-    ) -> Arc<Self> {
+    ) -> IotaResult<Arc<Self>> {
         assert_eq!(self.epoch() + 1, new_committee.epoch);
         self.record_reconfig_halt_duration_metric();
         self.record_epoch_total_duration_metric();
@@ -1126,6 +1128,7 @@ impl AuthorityPerEpochStore {
             self.chain_identifier,
             previous_epoch_last_checkpoint,
         )
+        .expect("failed to create new authority per epoch store")
     }
 
     pub fn committee(&self) -> &Arc<Committee> {
@@ -1488,9 +1491,9 @@ impl AuthorityPerEpochStore {
         Ok(self
             .tables()?
             .pending_execution
-            .unbounded_iter()
-            .map(|(_, cert)| cert.into())
-            .collect())
+            .safe_iter()
+            .map(|item| item.map(|(_, cert)| cert.into()))
+            .collect::<Result<Vec<_>, _>>()?)
     }
 
     /// Called when transaction outputs are committed to disk
@@ -1526,6 +1529,7 @@ impl AuthorityPerEpochStore {
         self.tables()
             .expect("recovery should not cross epoch boundary")
             .get_all_pending_consensus_transactions()
+            .expect("failed to get pending consensus transactions")
     }
 
     #[cfg(test)]
@@ -4344,18 +4348,18 @@ impl AuthorityPerEpochStore {
         self.signature_verifier.clear_signature_cache();
     }
 
-    pub(crate) fn check_all_executed_transactions_in_checkpoint(&self) {
+    pub(crate) fn check_all_executed_transactions_in_checkpoint(&self) -> IotaResult<()> {
         let tables = self.tables().unwrap();
 
         info!("Verifying that all executed transactions are in a checkpoint");
 
-        let mut executed_iter = tables.executed_in_epoch.unbounded_iter();
-        let mut checkpointed_iter = tables.executed_transactions_to_checkpoint.unbounded_iter();
+        let mut executed_iter = tables.executed_in_epoch.safe_iter();
+        let mut checkpointed_iter = tables.executed_transactions_to_checkpoint.safe_iter();
 
         // verify that the two iterators (which are both sorted) are identical
         loop {
-            let executed = executed_iter.next();
-            let checkpointed = checkpointed_iter.next();
+            let executed = executed_iter.next().transpose()?;
+            let checkpointed = checkpointed_iter.next().transpose()?;
             match (executed, checkpointed) {
                 (Some((left, ())), Some((right, _))) => {
                     if left != right {
@@ -4364,7 +4368,7 @@ impl AuthorityPerEpochStore {
                         );
                     }
                 }
-                (None, None) => break,
+                (None, None) => break Ok(()),
                 (left, right) => panic!(
                     "Executed transactions and checkpointed transactions do not match: {left:?} {right:?}"
                 ),

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -1655,18 +1655,6 @@ impl AuthorityStore {
         Ok(())
     }
 
-    #[cfg(msim)]
-    pub fn remove_all_versions_of_object(&self, object_id: ObjectID) {
-        let entries: Vec<_> = self
-            .perpetual_tables
-            .objects
-            .unbounded_iter()
-            .filter_map(|(key, _)| if key.0 == object_id { Some(key) } else { None })
-            .collect();
-        info!("Removing all versions of object: {:?}", entries);
-        self.perpetual_tables.objects.multi_remove(entries).unwrap();
-    }
-
     // Counts the number of versions exist in object store for `object_id`. This
     // includes tombstone.
     #[cfg(msim)]

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -889,9 +889,9 @@ mod tests {
             &ReadWriteOptions::default(),
             false,
         )?;
-        let iter = objects.unbounded_iter();
-        for (k, _v) in iter {
-            after_pruning.insert(k);
+        let iter = objects.safe_iter();
+        for item in iter {
+            after_pruning.insert(item?.0);
         }
         Ok(after_pruning)
     }

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -438,12 +438,12 @@ impl AuthorityPerpetualTables {
     }
 
     pub fn database_is_empty(&self) -> IotaResult<bool> {
-        Ok(self.objects.unbounded_iter().next().is_none())
+        Ok(self.objects.safe_iter().next().is_none())
     }
 
     pub fn iter_live_object_set(&self) -> LiveSetIter<'_> {
         LiveSetIter {
-            iter: self.objects.unbounded_iter(),
+            iter: self.objects.safe_iter(),
             tables: self,
             prev: None,
         }
@@ -458,7 +458,7 @@ impl AuthorityPerpetualTables {
         let upper_bound = upper_bound.as_ref().map(ObjectKey::max_for_id);
 
         LiveSetIter {
-            iter: self.objects.iter_with_bounds(lower_bound, upper_bound),
+            iter: self.objects.safe_iter_with_bounds(lower_bound, upper_bound),
             tables: self,
             prev: None,
         }
@@ -555,7 +555,7 @@ impl ObjectStore for AuthorityPerpetualTables {
 
 pub struct LiveSetIter<'a> {
     iter:
-        <DBMap<ObjectKey, StoreObjectWrapper> as Map<'a, ObjectKey, StoreObjectWrapper>>::Iterator,
+        <DBMap<ObjectKey, StoreObjectWrapper> as Map<'a, ObjectKey, StoreObjectWrapper>>::SafeIterator,
     tables: &'a AuthorityPerpetualTables,
     prev: Option<(ObjectKey, StoreObjectWrapper)>,
 }
@@ -620,7 +620,7 @@ impl Iterator for LiveSetIter<'_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if let Some((next_key, next_value)) = self.iter.next() {
+            if let Some(Ok((next_key, next_value))) = self.iter.next() {
                 let prev = self.prev.take();
                 self.prev = Some((next_key, next_value));
 

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -304,7 +304,8 @@ impl<'a> TestAuthorityBuilder<'a> {
                 .get_highest_executed_checkpoint_seq_number()
                 .unwrap()
                 .unwrap_or(0),
-        );
+        )
+        .expect("failed to create authority per epoch store");
         let committee_store = Arc::new(CommitteeStore::new(
             path.join("epochs"),
             &genesis_committee,

--- a/crates/iota-core/src/authority/transaction_deferral.rs
+++ b/crates/iota-core/src/authority/transaction_deferral.rs
@@ -141,8 +141,8 @@ mod object_cost_tests {
         }
 
         let mut previous_future_round = 0;
-        for (key, _) in db.deferred_certs.unbounded_iter() {
-            match key {
+        for item in db.deferred_certs.safe_iter() {
+            match item.unwrap().0 {
                 DeferralKey::Randomness { .. } => (),
                 DeferralKey::ConsensusRound { future_round, .. } => {
                     assert!(previous_future_round <= future_round);

--- a/crates/iota-core/src/epoch/committee_store.rs
+++ b/crates/iota-core/src/epoch/committee_store.rs
@@ -51,7 +51,10 @@ impl CommitteeStore {
             tables,
             cache: RwLock::new(HashMap::new()),
         };
-        if store.database_is_empty() {
+        if store
+            .database_is_empty()
+            .expect("CommitteeStore initialization failed")
+        {
             store
                 .init_genesis_committee(genesis_committee.clone())
                 .expect("Init genesis committee data must not fail");
@@ -133,7 +136,13 @@ impl CommitteeStore {
             .map_err(Into::into)
     }
 
-    fn database_is_empty(&self) -> bool {
-        self.tables.committee_map.unbounded_iter().next().is_none()
+    fn database_is_empty(&self) -> IotaResult<bool> {
+        Ok(self
+            .tables
+            .committee_map
+            .safe_iter()
+            .next()
+            .transpose()?
+            .is_none())
     }
 }

--- a/crates/iota-core/src/stake_aggregator.rs
+++ b/crates/iota-core/src/stake_aggregator.rs
@@ -12,12 +12,13 @@ use iota_types::{
     base_types::{AuthorityName, ConciseableName},
     committee::{Committee, CommitteeTrait, StakeUnit},
     crypto::{AuthorityQuorumSignInfo, AuthoritySignInfo, AuthoritySignInfoTrait},
-    error::IotaError,
+    error::{IotaError, IotaResult},
     message_envelope::{Envelope, Message},
 };
 use serde::Serialize;
 use shared_crypto::intent::Intent;
 use tracing::warn;
+use typed_store::TypedStoreError;
 
 /// StakeAggregator allows us to keep track of the total stake of a set of
 /// validators. STRENGTH indicates whether we want a strong quorum (2f+1) or a
@@ -44,15 +45,16 @@ impl<S: Clone + Eq, const STRENGTH: bool> StakeAggregator<S, STRENGTH> {
         }
     }
 
-    pub fn from_iter<I: Iterator<Item = (AuthorityName, S)>>(
+    pub fn from_iter<I: Iterator<Item = Result<(AuthorityName, S), TypedStoreError>>>(
         committee: Arc<Committee>,
         data: I,
-    ) -> Self {
+    ) -> IotaResult<Self> {
         let mut this = Self::new(committee);
-        for (authority, s) in data {
+        for item in data {
+            let (authority, s) = item?;
             this.insert_generic(authority, s);
         }
-        this
+        Ok(this)
     }
 
     /// A generic version of inserting arbitrary type of V (e.g. void type).

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -519,7 +519,9 @@ where
                 info!("Skipping loading pending transactions from pending_tx_log.");
                 return;
             }
-            let pending_txes = pending_tx_log.load_all_pending_transactions();
+            let pending_txes = pending_tx_log
+                .load_all_pending_transactions()
+                .expect("failed to load all pending transactions");
             info!(
                 "Recovering {} pending transactions from pending_tx_log.",
                 pending_txes.len()
@@ -561,7 +563,7 @@ where
         });
     }
 
-    pub fn load_all_pending_transactions(&self) -> Vec<VerifiedTransaction> {
+    pub fn load_all_pending_transactions(&self) -> IotaResult<Vec<VerifiedTransaction>> {
         self.pending_tx_log.load_all_pending_transactions()
     }
 }

--- a/crates/iota-core/src/verify_indexes.rs
+++ b/crates/iota-core/src/verify_indexes.rs
@@ -52,7 +52,8 @@ pub fn verify_indexes(store: &dyn AccumulatorStore, indexes: Arc<IndexStore>) ->
     tracing::info!("Live objects set is prepared, about to verify indexes");
 
     // Verify Owner Index
-    for (key, info) in indexes.tables().owner_index().unbounded_iter() {
+    for item in indexes.tables().owner_index().safe_iter() {
+        let (key, info) = item?;
         let calculated_info = owner_index.remove(&key).ok_or_else(|| {
             anyhow!(
                 "owner_index: found extra, unexpected entry {:?}",
@@ -73,7 +74,8 @@ pub fn verify_indexes(store: &dyn AccumulatorStore, indexes: Arc<IndexStore>) ->
     tracing::info!("Owner index is good");
 
     // Verify Coin Index
-    for (key, info) in indexes.tables().coin_index().unbounded_iter() {
+    for item in indexes.tables().coin_index().safe_iter() {
+        let (key, info) = item?;
         let calculated_info = coin_index.remove(&key).ok_or_else(|| {
             anyhow!(
                 "coin_index: found extra, unexpected entry {:?}",

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -150,7 +150,7 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
 
     // Because the tx did not go through, we expect to see it in the WAL log
     let pending_txes: Vec<_> = orchestrator
-        .load_all_pending_transactions()
+        .load_all_pending_transactions()?
         .into_iter()
         .map(|t| t.into_inner())
         .collect();
@@ -172,7 +172,7 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
     // done before response is returned and we will not need the sleep.
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
     // The tx should be erased in wal log.
-    let pending_txes = orchestrator.load_all_pending_transactions();
+    let pending_txes = orchestrator.load_all_pending_transactions()?;
     assert!(pending_txes.is_empty());
 
     Ok(())

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -599,7 +599,7 @@ impl IotaNode {
                 .get_highest_executed_checkpoint_seq_number()
                 .expect("checkpoint store read cannot fail")
                 .unwrap_or(0),
-        );
+        )?;
 
         info!("created epoch store");
 

--- a/crates/iota-storage/src/write_path_pending_tx_log.rs
+++ b/crates/iota-storage/src/write_path_pending_tx_log.rs
@@ -91,12 +91,13 @@ impl WritePathPendingTransactionLog {
         write_batch.write().map_err(IotaError::from)
     }
 
-    pub fn load_all_pending_transactions(&self) -> Vec<VerifiedTransaction> {
-        self.pending_transactions
+    pub fn load_all_pending_transactions(&self) -> IotaResult<Vec<VerifiedTransaction>> {
+        Ok(self
+            .pending_transactions
             .logs
-            .unbounded_iter()
-            .map(|(_tx_digest, tx)| VerifiedTransaction::from(tx))
-            .collect()
+            .safe_iter()
+            .map(|item| item.map(|(_tx_digest, tx)| VerifiedTransaction::from(tx)))
+            .collect::<Result<Vec<_>, _>>()?)
     }
 }
 
@@ -129,11 +130,11 @@ mod tests {
                 .unwrap()
         );
 
-        let loaded_txes = pending_txes.load_all_pending_transactions();
+        let loaded_txes = pending_txes.load_all_pending_transactions()?;
         assert_eq!(vec![tx], loaded_txes);
 
         pending_txes.finish_transaction(&tx_digest).unwrap();
-        let loaded_txes = pending_txes.load_all_pending_transactions();
+        let loaded_txes = pending_txes.load_all_pending_transactions()?;
         assert!(loaded_txes.is_empty());
 
         // It's ok to finish an already finished transaction
@@ -152,7 +153,7 @@ mod tests {
             );
         }
         let loaded_tx_digests: HashSet<_> = pending_txes
-            .load_all_pending_transactions()
+            .load_all_pending_transactions()?
             .iter()
             .map(|t| *t.digest())
             .collect();
@@ -165,7 +166,7 @@ mod tests {
             pending_txes.finish_transaction(tx.digest()).unwrap();
         }
         let loaded_tx_digests: HashSet<_> = pending_txes
-            .load_all_pending_transactions()
+            .load_all_pending_transactions()?
             .iter()
             .map(|t| *t.digest())
             .collect();

--- a/crates/iota-tool/src/db_tool/db_dump.rs
+++ b/crates/iota-tool/src/db_tool/db_dump.rs
@@ -167,9 +167,9 @@ pub fn print_table_metadata(
     Ok(())
 }
 
-pub fn duplicate_objects_summary(db_path: PathBuf) -> (usize, usize, usize, usize) {
+pub fn duplicate_objects_summary(db_path: PathBuf) -> anyhow::Result<(usize, usize, usize, usize)> {
     let perpetual_tables = AuthorityPerpetualTables::open_readonly(&db_path);
-    let iter = perpetual_tables.objects.unbounded_iter();
+    let iter = perpetual_tables.objects.safe_iter();
     let mut total_count = 0;
     let mut duplicate_count = 0;
     let mut total_bytes = 0;
@@ -178,7 +178,8 @@ pub fn duplicate_objects_summary(db_path: PathBuf) -> (usize, usize, usize, usiz
     let mut object_id: ObjectID = ObjectID::random();
     let mut data: HashMap<Vec<u8>, usize> = HashMap::new();
 
-    for (key, value) in iter {
+    for item in iter {
+        let (key, value) = item?;
         if let StoreObject::Value(store_object) = value.migrate().into_inner() {
             if let StoreData::Move(object) = store_object.data {
                 if object_id != key.0 {
@@ -195,7 +196,7 @@ pub fn duplicate_objects_summary(db_path: PathBuf) -> (usize, usize, usize, usiz
             }
         }
     }
-    (total_count, duplicate_count, total_bytes, duplicated_bytes)
+    Ok((total_count, duplicate_count, total_bytes, duplicated_bytes))
 }
 
 pub fn compact(db_path: PathBuf) -> anyhow::Result<()> {

--- a/crates/iota-tool/src/db_tool/mod.rs
+++ b/crates/iota-tool/src/db_tool/mod.rs
@@ -233,7 +233,7 @@ pub fn print_db_all_tables(db_path: PathBuf) -> anyhow::Result<()> {
 
 pub fn print_db_duplicates_summary(db_path: PathBuf) -> anyhow::Result<()> {
     let (total_count, duplicate_count, total_bytes, duplicated_bytes) =
-        duplicate_objects_summary(db_path);
+        duplicate_objects_summary(db_path)?;
     println!(
         "Total objects = {total_count}, duplicated objects = {duplicate_count}, total bytes = {total_bytes}, duplicated bytes = {duplicated_bytes}"
     );

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -283,7 +283,8 @@ impl SimulatorStore for PersistedStore {
 
     fn owned_objects(&self, owner: IotaAddress) -> Box<dyn Iterator<Item = Object> + '_> {
         Box::new(self.read_write.live_objects
-            .unbounded_iter()
+            .safe_iter()
+            .map(|result| result.expect("rocksdb iteration failed"))
             .flat_map(|(id, version)| self.get_object_at_version(&id, version))
             .filter(
                 move |object| matches!(object.owner, Owner::AddressOwner(addr) if addr == owner),

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -465,11 +465,11 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     #(
                         stringify!(#field_names) => {
                             typed_store::traits::Map::try_catch_up_with_primary(&self.#field_names)?;
-                            typed_store::traits::Map::unbounded_iter(&self.#field_names)
+                            typed_store::traits::Map::safe_iter(&self.#field_names)
                                 .skip((page_number * (page_size) as usize))
                                 .take(page_size as usize)
-                                .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
-                                .collect::<std::collections::BTreeMap<_, _>>()
+                                .map(|result| result.map(|(k, v)| (format!("{:?}", k), format!("{:?}", v))))
+                                .collect::<eyre::Result<std::collections::BTreeMap<_, _>, _>>()?
                         }
                     )*
 
@@ -502,7 +502,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     #(
                         stringify!(#field_names) => {
                             typed_store::traits::Map::try_catch_up_with_primary(&self.#field_names)?;
-                            typed_store::traits::Map::unbounded_iter(&self.#field_names).count()
+                            typed_store::traits::Map::safe_iter(&self.#field_names).count()
                         }
                     )*
 

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -502,7 +502,9 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     #(
                         stringify!(#field_names) => {
                             typed_store::traits::Map::try_catch_up_with_primary(&self.#field_names)?;
-                            typed_store::traits::Map::safe_iter(&self.#field_names).count()
+                            typed_store::traits::Map::safe_iter(&self.#field_names)
+                                .collect::<Result<Vec<_>, _>>()?
+                                .len()
                         }
                     )*
 

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1532,7 +1532,7 @@ where
     /// overridden in the config), so please use this function with caution
     #[instrument(level = "trace", skip_all, err)]
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
-        let first_key = self.unbounded_iter().next().map(|(k, _v)| k);
+        let first_key = self.safe_iter().next().transpose()?.map(|(k, _v)| k);
         let last_key = self
             .reversed_safe_iter_with_bounds(None, None)?
             .next()
@@ -1550,24 +1550,6 @@ where
         self.safe_iter().next().is_none()
     }
 
-    /// Returns an unbounded iterator visiting each key-value pair in the map.
-    /// This is potentially unsafe as it can perform a full table scan
-    fn unbounded_iter(&'a self) -> Self::Iterator {
-        let db_iter = self
-            .rocksdb
-            .raw_iterator_cf(&self.cf(), self.opts.readopts());
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        Iter::new(
-            self.cf.clone(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
-    }
-
     /// Returns an iterator visiting each key-value pair in the map. By proving
     /// bounds of the scan range, RocksDB scan avoid unnecessary scans.
     /// Lower bound is inclusive, while upper bound is exclusive.
@@ -1577,23 +1559,6 @@ where
         upper_bound: Option<K>,
     ) -> Self::Iterator {
         let readopts = self.create_read_options_with_bounds(lower_bound, upper_bound);
-        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        Iter::new(
-            self.cf.clone(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
-    }
-
-    /// Similar to `iter_with_bounds` but allows specifying
-    /// inclusivity/exclusivity of ranges explicitly. TODO: find better name
-    fn range_iter(&'a self, range: impl RangeBounds<K>) -> Self::Iterator {
-        let readopts = self.create_read_options_with_range(range);
         let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
         let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
         Iter::new(

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -42,15 +42,12 @@ impl<K: DeserializeOwned, V: DeserializeOwned> Iterator for TestIteratorWrapper<
 }
 
 // Creates an Iterator based on `use_safe_iter` on `db`.
-fn get_iter<K, V>(db: &DBMap<K, V>, use_safe_iter: bool) -> TestIteratorWrapper<'_, K, V>
+fn get_iter<K, V>(db: &DBMap<K, V>, _: bool) -> TestIteratorWrapper<'_, K, V>
 where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
-    match use_safe_iter {
-        true => TestIteratorWrapper::SafeIter(db.safe_iter()),
-        false => TestIteratorWrapper::Iter(db.unbounded_iter()),
-    }
+    TestIteratorWrapper::SafeIter(db.safe_iter())
 }
 
 fn get_reverse_iter<K, V>(
@@ -87,16 +84,12 @@ where
 fn get_range_iter<K, V>(
     db: &DBMap<K, V>,
     range: impl RangeBounds<K>,
-    use_safe_iter: bool,
 ) -> TestIteratorWrapper<'_, K, V>
 where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
-    match use_safe_iter {
-        true => TestIteratorWrapper::SafeIter(db.safe_range_iter(range)),
-        false => TestIteratorWrapper::Iter(db.range_iter(range)),
-    }
+    TestIteratorWrapper::SafeIter(db.safe_range_iter(range))
 }
 
 #[tokio::test]
@@ -589,7 +582,7 @@ async fn test_iter_with_bounds(#[values(true, false)] use_safe_iter: bool) {
 
 #[rstest]
 #[tokio::test]
-async fn test_range_iter(#[values(true, false)] use_safe_iter: bool) {
+async fn test_range_iter() {
     let db = open_map(temp_dir(), None);
 
     // Add [1, 50) and (50, 100) in the db
@@ -600,28 +593,28 @@ async fn test_range_iter(#[values(true, false)] use_safe_iter: bool) {
     }
 
     // Tests basic range iterating with inclusive end.
-    let db_iter = get_range_iter(&db, 10..=20, use_safe_iter);
+    let db_iter = get_range_iter(&db, 10..=20);
     assert_eq!(
         (10..21).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
         db_iter.collect::<Vec<_>>()
     );
 
     // Tests range with min start and exclusive end.
-    let db_iter = get_range_iter(&db, ..20, use_safe_iter);
+    let db_iter = get_range_iter(&db, ..20);
     assert_eq!(
         (1..20).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
         db_iter.collect::<Vec<_>>()
     );
 
     // Tests range with max end.
-    let db_iter = get_range_iter(&db, 60.., use_safe_iter);
+    let db_iter = get_range_iter(&db, 60..);
     assert_eq!(
         (60..100).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
         db_iter.collect::<Vec<_>>()
     );
 
     // Skip to first key in the bound (bound is [1, 49))
-    let db_iter = get_range_iter(&db, 1..49, use_safe_iter);
+    let db_iter = get_range_iter(&db, 1..49);
     assert_eq!(
         (1..49).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
         db_iter.collect::<Vec<_>>()

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -270,19 +270,11 @@ where
         locked.is_empty()
     }
 
-    fn unbounded_iter(&'a self) -> Self::Iterator {
-        unimplemented!("unimplemented API");
-    }
-
     fn iter_with_bounds(
         &'a self,
         _lower_bound: Option<K>,
         _upper_bound: Option<K>,
     ) -> Self::Iterator {
-        unimplemented!("unimplemented API");
-    }
-
-    fn range_iter(&'a self, _range: impl RangeBounds<K>) -> Self::Iterator {
         unimplemented!("unimplemented API");
     }
 

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -51,18 +51,10 @@ where
     /// Returns true if the map is empty, otherwise false.
     fn is_empty(&self) -> bool;
 
-    /// Returns an unbounded iterator visiting each key-value pair in the map.
-    /// This is potentially unsafe as it can perform a full table scan
-    fn unbounded_iter(&'a self) -> Self::Iterator;
-
     /// Returns an iterator visiting each key-value pair within the specified
     /// bounds in the map.
     fn iter_with_bounds(&'a self, lower_bound: Option<K>, upper_bound: Option<K>)
     -> Self::Iterator;
-
-    /// Similar to `iter_with_bounds` but allows specifying
-    /// inclusivity/exclusivity of ranges explicitly. TODO: find better name
-    fn range_iter(&'a self, range: impl RangeBounds<K>) -> Self::Iterator;
 
     /// Same as `iter` but performs status check.
     fn safe_iter(&'a self) -> Self::SafeIterator;


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.44.3, v1.45.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/ab6eaa148bda22aee12b87c2eb06b5d63ad5a440
- Description:
  * migrates unbounded_iter call sites to safe_iter
  * removes unused range_iter method
  * deprecates iterator_cf method


## Links to any relevant issues

Part of #6153 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
