### PR TITLE
upstream(node): Convert several tests to simtest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6992,6 +6992,8 @@ dependencies = [
  "iota-macros",
  "iota-metrics",
  "iota-network-stack",
+ "iota-protocol-config",
+ "iota-simulator",
  "iota-storage",
  "iota-swarm-config",
  "iota-types",

--- a/crates/iota-network/Cargo.toml
+++ b/crates/iota-network/Cargo.toml
@@ -50,5 +50,9 @@ tokio = { workspace = true, features = ["test-util"] }
 
 # internal dependencies
 iota-macros.workspace = true
+iota-protocol-config.workspace = true
 iota-swarm-config.workspace = true
 telemetry-subscribers.workspace = true
+
+[target.'cfg(msim)'.dependencies]
+iota-simulator.workspace = true

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeSet;
 
 use fastcrypto::{groups::bls12381, serde_helpers::ToFromByteArray};
 use fastcrypto_tbls::{mocked_dkg, nodes};
+use iota_macros::sim_test;
 use iota_swarm_config::test_utils::CommitteeFixture;
 use iota_types::{
     base_types::ConciseableName,
@@ -19,7 +20,7 @@ use crate::{randomness::*, utils};
 type PkG = bls12381::G2Element;
 type EncG = bls12381::G2Element;
 
-#[tokio::test]
+#[sim_test]
 async fn test_multiple_epochs() {
     telemetry_subscribers::init_for_testing();
     let committee_fixture = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
@@ -140,7 +141,7 @@ async fn test_multiple_epochs() {
     assert!(rounds_seen.contains(&RandomnessRound(1)));
 }
 
-#[tokio::test]
+#[sim_test]
 async fn test_record_own_partial_sigs() {
     telemetry_subscribers::init_for_testing();
     let committee_fixture = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
@@ -216,7 +217,7 @@ async fn test_record_own_partial_sigs() {
     }
 }
 
-#[tokio::test]
+#[sim_test]
 async fn test_receive_full_sig() {
     telemetry_subscribers::init_for_testing();
     let committee_fixture = CommitteeFixture::generate(rand::rngs::OsRng, 0, 8);
@@ -300,7 +301,7 @@ async fn test_receive_full_sig() {
     assert_ne!(0, bytes.len());
 }
 
-#[tokio::test]
+#[sim_test]
 async fn test_restart_recovery() {
     telemetry_subscribers::init_for_testing();
     let committee_fixture = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
@@ -370,7 +371,7 @@ async fn test_restart_recovery() {
     }
 }
 
-#[tokio::test]
+#[sim_test]
 async fn test_byzantine_peer_handling() {
     telemetry_subscribers::init_for_testing();
     let committee_fixture = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.44.3, v1.45.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/8e168f4ccf985d1a8a9298faaa1c2a873b4cd822
- Description:
Convert several tests to simtest (for speedup and flakiness improvement)


## Links to any relevant issues

Part of #6153 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
