### PR TITLE
fix(iota): fix signing with ledger nano

### DIFF
--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -82,7 +82,6 @@ use prometheus::Registry;
 use reqwest::StatusCode;
 use serde::Serialize;
 use serde_json::{Value, json};
-use shared_crypto::intent::Intent;
 use strum::{Display, EnumString};
 use tabled::{
     builder::Builder as TableBuilder,
@@ -103,6 +102,7 @@ use crate::{
     displays::Pretty,
     key_identity::{KeyIdentity, get_identity_address},
     keytool::Key,
+    signing::sign_transaction,
     upgrade_compatibility::check_compatibility,
     verifier_meter::{AccumulatingMeter, Accumulator},
 };
@@ -3367,16 +3367,13 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
     } else if tx_digest {
         Ok(IotaClientCommandResult::ComputeTransactionDigest(tx_data))
     } else {
-        let keystore = context.config().keystore();
-        let signature =
-            keystore.sign_secure(&tx_data.sender(), &tx_data, Intent::iota_transaction())?;
+        let signature = sign_transaction(context, &tx_data, &tx_data.sender()).await?;
 
         let mut signatures = vec![signature.into()];
 
         if let Some(gas_sponsor) = gas_sponsor {
             if gas_sponsor != signer {
-                let signature =
-                    keystore.sign_secure(&gas_sponsor, &tx_data, Intent::iota_transaction())?;
+                let signature = sign_transaction(context, &tx_data, &gas_sponsor).await?;
 
                 signatures.push(signature.into());
             }

--- a/crates/iota/src/signing.rs
+++ b/crates/iota/src/signing.rs
@@ -8,11 +8,7 @@ use iota_keys::keystore::{AccountKeystore, StoredKey};
 use iota_ledger::Ledger;
 use iota_ledger_signer::LedgerSigner;
 use iota_sdk::wallet_context::WalletContext;
-use iota_types::{
-    base_types::IotaAddress,
-    crypto::Signature,
-    transaction::{TransactionData, TransactionDataAPI},
-};
+use iota_types::{base_types::IotaAddress, crypto::Signature, transaction::TransactionData};
 use serde::Serialize;
 use shared_crypto::intent::Intent;
 
@@ -49,15 +45,15 @@ impl fmt::Display for ExternalKeySource {
 pub(crate) async fn sign_transaction(
     context: &mut WalletContext,
     tx_data: &TransactionData,
+    signer_address: &IotaAddress,
 ) -> Result<Signature> {
     let iota_client = context.get_client().await?;
-    let sender = &tx_data.sender();
 
-    let key = context.config().keystore().get_key(sender)?;
+    let key = context.config().keystore().get_key(signer_address)?;
 
     match key {
         StoredKey::KeyPair(_) => Ok(context.config().keystore().sign_secure(
-            sender,
+            signer_address,
             tx_data,
             Intent::iota_transaction(),
         )?),
@@ -79,7 +75,7 @@ pub(crate) async fn sign_transaction(
                     // pass the transaction sender to the signer to ensure the correct
                     // key is used
                     Ok(signer
-                        .sign_transaction(tx_data, sender)
+                        .sign_transaction(tx_data, signer_address)
                         .await
                         .map(|s| s.signature)?)
                 }

--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -47,7 +47,7 @@ use iota_types::{
     },
     multiaddr::Multiaddr,
     object::Owner,
-    transaction::{CallArg, ObjectArg, Transaction, TransactionData},
+    transaction::{CallArg, ObjectArg, Transaction, TransactionData, TransactionDataAPI},
 };
 use move_core_types::ident_str;
 use serde::Serialize;
@@ -624,7 +624,7 @@ async fn call_0x5(
         construct_unsigned_0x5_txn(context, sender, function, call_args, gas_budget).await?;
     let iota_client = context.get_client().await?;
 
-    let signature = sign_transaction(context, &tx_data).await?;
+    let signature = sign_transaction(context, &tx_data, &tx_data.sender()).await?;
     let transaction = Transaction::from_data(tx_data, vec![signature]);
 
     iota_client


### PR DESCRIPTION
# Description of change

Fix signing with a ledger nano hardware wallet, currently fails with `signature error: sign_secure is not supported for external type: ledger`, broke in https://github.com/iotaledger/iota/pull/7881

## How the change has been tested

` ./run_speculos.sh` in https://github.com/iotaledger/ledger-app-iota
Normal tx:
`LEDGER_SIMULATOR=1 cargo run client pay-iota --recipients 0x1b3669e321893ee49c387a08fc251dbfff37cd2a981e6c473a5b2afde19d363e --amounts 100`
https://explorer.iota.org/txblock/BjfGrQ4JGXdEzsYZqV5gBgAUJzsddv8c6vBfYKaNqaxn?network=devnet
Sponsored tx:
```
LEDGER_SIMULATOR=1 cargo run client ptb \
--make-move-vec "<std::string::String>" "['zero', 'one', 'two']" \
--assign my_string_vec \
--sender @0x111111111504e9350e635d65cd38ccd2c029434c6a3a480d8947a9ba6a15b215 \
--gas-sponsor @0x1b3669e321893ee49c387a08fc251dbfff37cd2a981e6c473a5b2afde19d363e
```
https://explorer.iota.org/txblock/BRVK4bHAcdtH5ZR4oY1vTo2q1vNvSG9CgNA68iYmeycS?network=devnet

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Fix signing with ledger nano hardware wallet
- [ ] Rust SDK:
- [ ] REST API:
