### PR TITLE
feat(iota-graphql-rpc, iota-json-rpc-types, iota-types, iota-execution): Introduction of ChangeEpochV4 transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7382,7 +7382,7 @@ dependencies = [
 [[package]]
 name = "iota-rust-sdk"
 version = "0.0.0"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=93580286f3714248398d17e4481daf608508856a#93580286f3714248398d17e4481daf608508856a"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2bfa96c72969e3fe5b49979e4abad43e0677c4ba#2bfa96c72969e3fe5b49979e4abad43e0677c4ba"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -438,7 +438,7 @@ iota-rosetta = { path = "crates/iota-rosetta" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
 # core-types with json format for REST API
-iota-sdk2 = { package = "iota-rust-sdk", git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "93580286f3714248398d17e4481daf608508856a", features = ["hash", "serde", "schemars"] }
+iota-sdk2 = { package = "iota-rust-sdk", git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2bfa96c72969e3fe5b49979e4abad43e0677c4ba", features = ["hash", "serde", "schemars"] }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -13,6 +13,7 @@ use iota_types::{
         AuthenticatorStateExpire as NativeAuthenticatorStateExpireTransaction,
         ChangeEpoch as NativeChangeEpochTransaction,
         ChangeEpochV2 as NativeChangeEpochTransactionV2,
+        ChangeEpochV4 as NativeChangeEpochTransactionV4,
         EndOfEpochTransactionKind as NativeEndOfEpochTransactionKind,
     },
 };
@@ -44,6 +45,7 @@ pub(crate) struct EndOfEpochTransaction {
 pub(crate) enum EndOfEpochTransactionKind {
     ChangeEpoch(ChangeEpochTransaction),
     ChangeEpochV2(ChangeEpochTransactionV2),
+    ChangeEpochV4(ChangeEpochTransactionV4),
     AuthenticatorStateCreate(AuthenticatorStateCreateTransaction),
     AuthenticatorStateExpire(AuthenticatorStateExpireTransaction),
 }
@@ -62,6 +64,16 @@ pub(crate) struct ChangeEpochTransaction {
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct ChangeEpochTransactionV2 {
     pub native: NativeChangeEpochTransactionV2,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
+
+// System transaction for advancing the epoch.
+// This version includes the scores field for when
+// the scorer is enabled in the protocol config.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct ChangeEpochTransactionV4 {
+    pub native: NativeChangeEpochTransactionV4,
     /// The checkpoint sequence number this was viewed at.
     pub checkpoint_viewed_at: u64,
 }
@@ -329,6 +341,122 @@ impl ChangeEpochTransactionV2 {
     }
 }
 
+/// A system transaction that updates epoch information on-chain (increments the
+/// current epoch). Executed by the system once per epoch, without using gas.
+/// Epoch change transactions cannot be submitted by users, because validators
+/// will refuse to sign them.
+#[Object]
+impl ChangeEpochTransactionV4 {
+    /// The next (to become) epoch.
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
+        Epoch::query(ctx, Some(self.native.epoch), self.checkpoint_viewed_at)
+            .await
+            .extend()
+    }
+
+    /// The protocol version in effect in the new epoch.
+    async fn protocol_version(&self) -> UInt53 {
+        self.native.protocol_version.as_u64().into()
+    }
+
+    /// The total amount of gas charged for storage during the previous epoch
+    /// (in NANOS).
+    async fn storage_charge(&self) -> BigInt {
+        BigInt::from(self.native.storage_charge)
+    }
+
+    /// The total amount of gas charged for computation during the previous
+    /// epoch (in NANOS).
+    async fn computation_charge(&self) -> BigInt {
+        BigInt::from(self.native.computation_charge)
+    }
+
+    /// The total amount of gas burned for computation during the previous
+    /// epoch (in NANOS).
+    async fn computation_charge_burned(&self) -> BigInt {
+        BigInt::from(self.native.computation_charge_burned)
+    }
+
+    /// The IOTA returned to transaction senders for cleaning up objects (in
+    /// NANOS).
+    async fn storage_rebate(&self) -> BigInt {
+        BigInt::from(self.native.storage_rebate)
+    }
+
+    /// The total gas retained from storage fees, that will not be returned by
+    /// storage rebates when the relevant objects are cleaned up (in NANOS).
+    async fn non_refundable_storage_fee(&self) -> BigInt {
+        BigInt::from(self.native.non_refundable_storage_fee)
+    }
+
+    /// Time at which the next epoch will start.
+    async fn start_timestamp(&self) -> Result<DateTime, Error> {
+        DateTime::from_ms(self.native.epoch_start_timestamp_ms as i64)
+    }
+
+    /// System packages (specifically framework and move stdlib) that are
+    /// written before the new epoch starts, to upgrade them on-chain.
+    /// Validators write these packages out when running the transaction.
+    async fn system_packages(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CPackage>,
+        last: Option<u64>,
+        before: Option<CPackage>,
+    ) -> Result<Connection<String, MovePackage>> {
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+
+        let mut connection = Connection::new(false, false);
+        let Some((prev, next, _, cs)) = page.paginate_consistent_indices(
+            self.native.system_packages.len(),
+            self.checkpoint_viewed_at,
+        )?
+        else {
+            return Ok(connection);
+        };
+
+        connection.has_previous_page = prev;
+        connection.has_next_page = next;
+
+        for c in cs {
+            let (version, modules, deps) = &self.native.system_packages[c.ix];
+            let compiled_modules = modules
+                .iter()
+                .map(|bytes| CompiledModule::deserialize_with_defaults(bytes))
+                .collect::<PartialVMResult<Vec<_>>>()
+                .map_err(|e| Error::Internal(format!("Failed to deserialize system modules: {e}")))
+                .extend()?;
+
+            let native = NativeObject::new_system_package(
+                &compiled_modules,
+                *version,
+                deps.clone(),
+                TransactionDigest::ZERO,
+            );
+
+            let runtime_id = native.id();
+            let object = Object::from_native(IotaAddress::from(runtime_id), native, c.c, None);
+            let package = MovePackage::try_from(&object)
+                .map_err(|_| Error::Internal("Failed to create system package".to_string()))
+                .extend()?;
+
+            connection.edges.push(Edge::new(c.encode_cursor(), package));
+        }
+
+        Ok(connection)
+    }
+
+    /// The validator scores at the end of the epoch.
+    async fn scores(&self) -> Vec<BigInt> {
+        self.native
+            .scores
+            .iter()
+            .map(|s| BigInt::from(*s))
+            .collect()
+    }
+}
+
 #[Object]
 impl AuthenticatorStateExpireTransaction {
     /// Expire JWKs that have a lower epoch than this.
@@ -358,6 +486,10 @@ impl EndOfEpochTransactionKind {
                 checkpoint_viewed_at,
             }),
             N::ChangeEpochV2(ce) => K::ChangeEpochV2(ChangeEpochTransactionV2 {
+                native: ce,
+                checkpoint_viewed_at,
+            }),
+            N::ChangeEpochV4(ce) => K::ChangeEpochV4(ChangeEpochTransactionV4 {
                 native: ce,
                 checkpoint_viewed_at,
             }),

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -35,9 +35,10 @@ use iota_types::{
     signature::GenericSignature,
     storage::{DeleteKind, WriteKind},
     transaction::{
-        Argument, CallArg, ChangeEpoch, ChangeEpochV2, Command, EndOfEpochTransactionKind,
-        GenesisObject, InputObjectKind, ObjectArg, ProgrammableMoveCall, ProgrammableTransaction,
-        SenderSignedData, TransactionData, TransactionDataAPI, TransactionKind,
+        Argument, CallArg, ChangeEpoch, ChangeEpochV2, ChangeEpochV4, Command,
+        EndOfEpochTransactionKind, GenesisObject, InputObjectKind, ObjectArg, ProgrammableMoveCall,
+        ProgrammableTransaction, SenderSignedData, TransactionData, TransactionDataAPI,
+        TransactionKind,
     },
 };
 use move_binary_format::CompiledModule;
@@ -551,6 +552,9 @@ impl IotaTransactionBlockKind {
                             EndOfEpochTransactionKind::ChangeEpochV2(e) => {
                                 IotaEndOfEpochTransactionKind::ChangeEpochV2(e.into())
                             }
+                            EndOfEpochTransactionKind::ChangeEpochV4(e) => {
+                                IotaEndOfEpochTransactionKind::ChangeEpochV4(e.into())
+                            }
                             EndOfEpochTransactionKind::AuthenticatorStateCreate => {
                                 IotaEndOfEpochTransactionKind::AuthenticatorStateCreate
                             }
@@ -629,6 +633,9 @@ impl IotaTransactionBlockKind {
                             }
                             EndOfEpochTransactionKind::ChangeEpochV2(e) => {
                                 IotaEndOfEpochTransactionKind::ChangeEpochV2(e.into())
+                            }
+                            EndOfEpochTransactionKind::ChangeEpochV4(e) => {
+                                IotaEndOfEpochTransactionKind::ChangeEpochV4(e.into())
                             }
                             EndOfEpochTransactionKind::AuthenticatorStateCreate => {
                                 IotaEndOfEpochTransactionKind::AuthenticatorStateCreate
@@ -730,6 +737,46 @@ impl From<ChangeEpochV2> for IotaChangeEpochV2 {
             computation_charge_burned: e.computation_charge_burned,
             storage_rebate: e.storage_rebate,
             epoch_start_timestamp_ms: e.epoch_start_timestamp_ms,
+        }
+    }
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct IotaChangeEpochV4 {
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub epoch: EpochId,
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub storage_charge: u64,
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub computation_charge: u64,
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub computation_charge_burned: u64,
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub storage_rebate: u64,
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub epoch_start_timestamp_ms: u64,
+    #[schemars(with = "Vec<BigInt<u64>>")]
+    #[serde_as(as = "Vec<BigInt<u64>>")]
+    pub scores: Vec<u64>,
+}
+
+impl From<ChangeEpochV4> for IotaChangeEpochV4 {
+    fn from(e: ChangeEpochV4) -> Self {
+        Self {
+            epoch: e.epoch,
+            storage_charge: e.storage_charge,
+            computation_charge: e.computation_charge,
+            computation_charge_burned: e.computation_charge_burned,
+            storage_rebate: e.storage_rebate,
+            epoch_start_timestamp_ms: e.epoch_start_timestamp_ms,
+            scores: e.scores,
         }
     }
 }
@@ -1686,6 +1733,7 @@ pub struct IotaEndOfEpochTransaction {
 pub enum IotaEndOfEpochTransactionKind {
     ChangeEpoch(IotaChangeEpoch),
     ChangeEpochV2(IotaChangeEpochV2),
+    ChangeEpochV4(IotaChangeEpochV4),
     AuthenticatorStateCreate,
     AuthenticatorStateExpire(IotaAuthenticatorStateExpire),
 }

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -13,7 +13,7 @@
 use fastcrypto::traits::ToFromBytes;
 use iota_sdk2::types::{
     object::{MovePackage, MoveStruct},
-    transaction::{ChangeEpoch, ChangeEpochV2},
+    transaction::{ChangeEpoch, ChangeEpochV2, ChangeEpochV4},
     *,
 };
 use move_core_types::language_storage::ModuleId;
@@ -621,6 +621,29 @@ impl From<crate::transaction::EndOfEpochTransactionKind> for EndOfEpochTransacti
                         .collect(),
                 })
             }
+
+            crate::transaction::EndOfEpochTransactionKind::ChangeEpochV4(change_epoch_v4) => {
+                EndOfEpochTransactionKind::ChangeEpochV4(ChangeEpochV4 {
+                    epoch: change_epoch_v4.epoch,
+                    protocol_version: change_epoch_v4.protocol_version.as_u64(),
+                    storage_charge: change_epoch_v4.storage_charge,
+                    computation_charge: change_epoch_v4.computation_charge,
+                    computation_charge_burned: change_epoch_v4.computation_charge_burned,
+                    storage_rebate: change_epoch_v4.storage_rebate,
+                    non_refundable_storage_fee: change_epoch_v4.non_refundable_storage_fee,
+                    epoch_start_timestamp_ms: change_epoch_v4.epoch_start_timestamp_ms,
+                    system_packages: change_epoch_v4
+                        .system_packages
+                        .into_iter()
+                        .map(|(version, modules, dependencies)| SystemPackage {
+                            version: version.value(),
+                            modules,
+                            dependencies: dependencies.into_iter().map(Into::into).collect(),
+                        })
+                        .collect(),
+                    scores: change_epoch_v4.scores,
+                })
+            }
             crate::transaction::EndOfEpochTransactionKind::AuthenticatorStateCreate => {
                 EndOfEpochTransactionKind::AuthenticatorStateCreate
             }
@@ -682,6 +705,30 @@ impl From<EndOfEpochTransactionKind> for crate::transaction::EndOfEpochTransacti
                             )
                         })
                         .collect(),
+                })
+            }
+            EndOfEpochTransactionKind::ChangeEpochV4(change_epoch_v4) => {
+                Self::ChangeEpochV4(crate::transaction::ChangeEpochV4 {
+                    epoch: change_epoch_v4.epoch,
+                    protocol_version: change_epoch_v4.protocol_version.into(),
+                    storage_charge: change_epoch_v4.storage_charge,
+                    computation_charge: change_epoch_v4.computation_charge,
+                    computation_charge_burned: change_epoch_v4.computation_charge_burned,
+                    storage_rebate: change_epoch_v4.storage_rebate,
+                    non_refundable_storage_fee: change_epoch_v4.non_refundable_storage_fee,
+                    epoch_start_timestamp_ms: change_epoch_v4.epoch_start_timestamp_ms,
+                    system_packages: change_epoch_v4
+                        .system_packages
+                        .into_iter()
+                        .map(|package| {
+                            (
+                                package.version.into(),
+                                package.modules,
+                                package.dependencies.into_iter().map(Into::into).collect(),
+                            )
+                        })
+                        .collect(),
+                    scores: change_epoch_v4.scores,
                 })
             }
             EndOfEpochTransactionKind::AuthenticatorStateCreate => Self::AuthenticatorStateCreate,
@@ -1312,6 +1359,11 @@ impl From<ExecutionError> for crate::execution_status::ExecutionFailureStatus {
                                 secondary_idx: subresult,
                             }
                         }
+                        // TO DO: check this error. This mapping is currently a placeholder
+                        CommandArgumentError::InvalidArgumentArity { .. } => {
+                            InternalCmdArgErr::InvalidGasCoinUsage
+                        }
+
                         CommandArgumentError::InvalidResultArity { result } => {
                             InternalCmdArgErr::InvalidResultArity { result_idx: result }
                         }

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -235,6 +235,38 @@ pub struct ChangeEpochV2 {
     /// their package ID), and a list of their transitive dependencies.
     pub system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>,
 }
+// System transaction for advancing the epoch.
+// This version includes the scores field for when
+// the scorer is enabled in the protocol config.
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct ChangeEpochV4 {
+    /// The next (to become) epoch ID.
+    pub epoch: EpochId,
+    /// The protocol version in effect in the new epoch.
+    pub protocol_version: ProtocolVersion,
+    /// The total amount of gas charged for storage during the epoch.
+    pub storage_charge: u64,
+    /// The total amount of gas charged for computation during the epoch.
+    pub computation_charge: u64,
+    /// The burned component of the total computation/execution costs.
+    pub computation_charge_burned: u64,
+    /// The amount of storage rebate refunded to the txn senders.
+    pub storage_rebate: u64,
+    /// The non-refundable storage fee.
+    pub non_refundable_storage_fee: u64,
+    /// Unix timestamp when epoch started
+    pub epoch_start_timestamp_ms: u64,
+    /// System packages (specifically framework and move stdlib) that are
+    /// written before the new epoch starts. This tracks framework upgrades
+    /// on chain. When executing the ChangeEpochV4 txn, the validator must
+    /// write out the modules below.  Modules are provided with the version they
+    /// will be upgraded to, their modules in serialized form (which include
+    /// their package ID), and a list of their transitive dependencies.
+    pub system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>,
+    /// Scores relative to the previous epoch. Each value corresponds to one
+    /// authority, using the same index that in the last epoch's committee.
+    pub scores: Vec<u64>,
+}
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct GenesisTransaction {
@@ -346,6 +378,7 @@ pub enum TransactionKind {
 pub enum EndOfEpochTransactionKind {
     ChangeEpoch(ChangeEpoch),
     ChangeEpochV2(ChangeEpochV2),
+    ChangeEpochV4(ChangeEpochV4),
     AuthenticatorStateCreate,
     AuthenticatorStateExpire(AuthenticatorStateExpire),
 }
@@ -397,6 +430,32 @@ impl EndOfEpochTransactionKind {
         })
     }
 
+    pub fn new_change_epoch_v4(
+        next_epoch: EpochId,
+        protocol_version: ProtocolVersion,
+        storage_charge: u64,
+        computation_charge: u64,
+        computation_charge_burned: u64,
+        storage_rebate: u64,
+        non_refundable_storage_fee: u64,
+        epoch_start_timestamp_ms: u64,
+        system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>,
+        scores: Vec<u64>,
+    ) -> Self {
+        Self::ChangeEpochV4(ChangeEpochV4 {
+            epoch: next_epoch,
+            protocol_version,
+            storage_charge,
+            computation_charge,
+            computation_charge_burned,
+            storage_rebate,
+            non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            system_packages,
+            scores,
+        })
+    }
+
     pub fn new_authenticator_state_expire(
         min_epoch: u64,
         authenticator_obj_initial_shared_version: SequenceNumber,
@@ -427,6 +486,13 @@ impl EndOfEpochTransactionKind {
                     mutable: true,
                 }]
             }
+            Self::ChangeEpochV4(_) => {
+                vec![InputObjectKind::SharedMoveObject {
+                    id: IOTA_SYSTEM_STATE_OBJECT_ID,
+                    initial_shared_version: IOTA_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                    mutable: true,
+                }]
+            }
             Self::AuthenticatorStateCreate => vec![],
             Self::AuthenticatorStateExpire(expire) => {
                 vec![InputObjectKind::SharedMoveObject {
@@ -444,6 +510,9 @@ impl EndOfEpochTransactionKind {
                 Either::Left(vec![SharedInputObject::IOTA_SYSTEM_OBJ].into_iter())
             }
             Self::ChangeEpochV2(_) => {
+                Either::Left(vec![SharedInputObject::IOTA_SYSTEM_OBJ].into_iter())
+            }
+            Self::ChangeEpochV4(_) => {
                 Either::Left(vec![SharedInputObject::IOTA_SYSTEM_OBJ].into_iter())
             }
             Self::AuthenticatorStateExpire(expire) => Either::Left(
@@ -473,6 +542,11 @@ impl EndOfEpochTransactionKind {
                         "protocol defined base fee required".to_string(),
                     ));
                 }
+            }
+            Self::ChangeEpochV4(_) => {
+                return Err(UserInputError::Unsupported(
+                    "ChangeEpochV4 is not yet supported".to_string(),
+                ));
             }
             Self::AuthenticatorStateCreate | Self::AuthenticatorStateExpire(_) => {
                 if !config.enable_jwk_consensus_updates() {
@@ -1214,6 +1288,9 @@ impl TransactionKind {
                         Some((e.computation_charge + e.storage_charge, e.storage_rebate))
                     }
                     EndOfEpochTransactionKind::ChangeEpochV2(e) => {
+                        Some((e.computation_charge + e.storage_charge, e.storage_rebate))
+                    }
+                    EndOfEpochTransactionKind::ChangeEpochV4(e) => {
                         Some((e.computation_charge + e.storage_charge, e.storage_rebate))
                     }
                     _ => panic!("final end-of-epoch txn must be ChangeEpoch"),

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -707,6 +707,12 @@ mod checked {
                             )?;
                             return Ok(Mode::empty_results());
                         }
+                        EndOfEpochTransactionKind::ChangeEpochV4(_change_epoch_v4) => {
+                            return Err(ExecutionError::new(
+                                ExecutionErrorKind::FeatureNotYetSupported,
+                                Some("ChangeEpochV4 is not supported".to_string().into()),
+                            ));
+                        }
                         EndOfEpochTransactionKind::AuthenticatorStateCreate => {
                             assert!(protocol_config.enable_jwk_consensus_updates());
                             builder = setup_authenticator_state_create(builder);


### PR DESCRIPTION
```mermaid
---
config:
  gitGraph:
    {parallelCommits: true,
    mainBranchName: 'Feature',
    rotateCommitLabel: true}
---
gitGraph
   commit id: "Initial commit"
   branch Scorer
   commit id: "Add Scorer type"
   checkout Feature
    branch EndOfPublishV2
   commit id: "Add EndOfPublishV2 type"
   checkout Feature
    branch ChangeEpochV4
   commit id: "Add ChangeEpochV4 type"
   checkout Feature
   branch mergedbranch
   merge ChangeEpochV4 id: "Merge ChangeEpochV4"
   merge EndOfPublishV2 id: "Merge EndOfPublishV2" 
    merge Scorer id: "Merge Scorer"
   commit id: "Add protocol configs"
      branch process-EOPV2
   commit id: "EndOfPublishV2 processing"
    checkout mergedbranch
    branch advance-epoch
   commit id: "add advance_epoch_v4"
    checkout mergedbranch
    branch send-EOPV2
   commit id: "EndOfPublishV2 dissemination"
checkout Feature
    merge ChangeEpochV4 tag: "THIS PR"

```


TO DOs:
- https://github.com/iotaledger/iota/blob/8dd86822b2143026cbec6abce810afa5de96f7dd/crates/iota-types/src/iota_sdk_types_conversions.rs#L1362

# Description of change

Introduces the ChangeEpochV4 type, which includes a vector of scores relative to each authority behavior in the ending epoch.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Introduces the ChangeEpochV4 type
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
