### PR TITLE
upstream(core): Introduce indexes pruner to authority store

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -981,6 +981,8 @@ pub struct AuthorityStorePruningConfig {
     /// may result in some old versions that will never be pruned.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub enable_compaction_filter: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_epochs_to_retain_for_indexes: Option<u64>,
 }
 
 fn default_num_latest_epoch_dbs_to_retain() -> usize {
@@ -1020,6 +1022,7 @@ impl Default for AuthorityStorePruningConfig {
             num_epochs_to_retain_for_checkpoints: if cfg!(msim) { Some(2) } else { None },
             smooth: true,
             enable_compaction_filter: cfg!(test) || cfg!(msim),
+            num_epochs_to_retain_for_indexes: None,
         }
     }
 }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2909,6 +2909,7 @@ impl AuthorityState {
             store.perpetual_tables.clone(),
             checkpoint_store.clone(),
             rest_index.clone(),
+            indexes.clone(),
             config.authority_store_pruning_config.clone(),
             epoch_store.committee().authority_exists(&name),
             epoch_store.epoch_start_state().epoch_duration_ms(),

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -59,6 +59,7 @@ static PERIODIC_PRUNING_TABLES: Lazy<BTreeSet<String>> = Lazy::new(|| {
     .collect()
 });
 pub const EPOCH_DURATION_MS_FOR_TESTING: u64 = 24 * 60 * 60 * 1000;
+pub const MIN_EPOCHS_TO_RETAIN_FOR_INDEXES: u64 = 7;
 
 /// The `AuthorityStorePruner` manages the pruning process for object stores
 /// within the `AuthorityStore`. It includes a cancellation handle that can be
@@ -569,9 +570,9 @@ impl AuthorityStorePruner {
         if let (Some(mut epochs_to_retain), Some(indexes)) =
             (config.num_epochs_to_retain_for_indexes, indexes)
         {
-            if epochs_to_retain < 7 {
+            if epochs_to_retain < MIN_EPOCHS_TO_RETAIN_FOR_INDEXES {
                 warn!("num_epochs_to_retain_for_indexes is too low. Resetting it to 7");
-                epochs_to_retain = 7;
+                epochs_to_retain = MIN_EPOCHS_TO_RETAIN_FOR_INDEXES;
             }
             let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
             if let Some(cut_time_ms) =

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -41,6 +41,7 @@ use super::authority_store_tables::{AuthorityPerpetualTables, AuthorityPrunerTab
 use crate::{
     authority::authority_store_types::{StoreObject, StoreObjectWrapper},
     checkpoints::{CheckpointStore, CheckpointWatermark},
+    jsonrpc_index::IndexStore,
     rest_index::RestIndexStore,
 };
 
@@ -75,6 +76,7 @@ pub struct AuthorityStorePruningMetrics {
     pub num_pruned_objects: IntCounter,
     pub num_pruned_tombstones: IntCounter,
     pub last_pruned_effects_checkpoint: IntGauge,
+    pub last_pruned_indexes_transaction: IntGauge,
     pub num_epochs_to_retain_for_objects: IntGauge,
     pub num_epochs_to_retain_for_checkpoints: IntGauge,
 }
@@ -106,6 +108,12 @@ impl AuthorityStorePruningMetrics {
             last_pruned_effects_checkpoint: register_int_gauge_with_registry!(
                 "last_pruned_effects_checkpoint",
                 "Last pruned effects checkpoint",
+                registry
+            )
+            .unwrap(),
+            last_pruned_indexes_transaction: register_int_gauge_with_registry!(
+                "last_pruned_indexes_transaction",
+                "Last pruned indexes transaction",
                 registry
             )
             .unwrap(),
@@ -552,6 +560,32 @@ impl AuthorityStorePruner {
         Ok(())
     }
 
+    fn prune_indexes(
+        indexes: Option<&IndexStore>,
+        config: &AuthorityStorePruningConfig,
+        epoch_duration_ms: u64,
+        metrics: &AuthorityStorePruningMetrics,
+    ) -> anyhow::Result<()> {
+        if let (Some(mut epochs_to_retain), Some(indexes)) =
+            (config.num_epochs_to_retain_for_indexes, indexes)
+        {
+            if epochs_to_retain < 7 {
+                warn!("num_epochs_to_retain_for_indexes is too low. Resetting it to 7");
+                epochs_to_retain = 7;
+            }
+            let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
+            if let Some(cut_time_ms) =
+                u64::try_from(now)?.checked_sub(epochs_to_retain * epoch_duration_ms)
+            {
+                let transaction_id = indexes.prune(cut_time_ms)?;
+                metrics
+                    .last_pruned_indexes_transaction
+                    .set(transaction_id as i64);
+            }
+        }
+        Ok(())
+    }
+
     /// Identifies and compacts the next eligible SST file in the
     /// `AuthorityStore` that meets the specified conditions for manual
     /// compaction. This function checks each SST file's metadata, including
@@ -650,6 +684,7 @@ impl AuthorityStorePruner {
         perpetual_db: Arc<AuthorityPerpetualTables>,
         checkpoint_store: Arc<CheckpointStore>,
         rest_index: Option<Arc<RestIndexStore>>,
+        jsonrpc_index: Option<Arc<IndexStore>>,
         pruner_db: Option<Arc<AuthorityPrunerTables>>,
         metrics: Arc<AuthorityStorePruningMetrics>,
         archive_readers: ArchiveReaderBalancer,
@@ -670,6 +705,8 @@ impl AuthorityStorePruner {
         let mut objects_prune_interval =
             tokio::time::interval_at(Instant::now() + pruning_initial_delay, tick_duration);
         let mut checkpoints_prune_interval =
+            tokio::time::interval_at(Instant::now() + pruning_initial_delay, tick_duration);
+        let mut indexes_prune_interval =
             tokio::time::interval_at(Instant::now() + pruning_initial_delay, tick_duration);
 
         let perpetual_db_for_compaction = perpetual_db.clone();
@@ -719,6 +756,11 @@ impl AuthorityStorePruner {
                             error!("Failed to prune checkpoints: {:?}", err);
                         }
                     },
+                    _ = indexes_prune_interval.tick(), if config.num_epochs_to_retain_for_indexes.is_some() => {
+                        if let Err(err) = Self::prune_indexes(jsonrpc_index.as_deref(), &config, epoch_duration_ms, &metrics) {
+                            error!("Failed to prune indexes: {:?}", err);
+                        }
+                    }
                     _ = &mut recv => break,
                 }
             }
@@ -732,6 +774,7 @@ impl AuthorityStorePruner {
         perpetual_db: Arc<AuthorityPerpetualTables>,
         checkpoint_store: Arc<CheckpointStore>,
         rest_index: Option<Arc<RestIndexStore>>,
+        jsonrpc_index: Option<Arc<IndexStore>>,
         mut pruning_config: AuthorityStorePruningConfig,
         is_validator: bool,
         epoch_duration_ms: u64,
@@ -759,6 +802,7 @@ impl AuthorityStorePruner {
                 perpetual_db,
                 checkpoint_store,
                 rest_index,
+                jsonrpc_index,
                 pruner_db,
                 AuthorityStorePruningMetrics::new(registry),
                 archive_readers,

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -7,7 +7,7 @@
 
 use std::{
     cmp::{max, min},
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{
         Arc,
@@ -15,6 +15,7 @@ use std::{
     },
 };
 
+use bincode::Options;
 use either::Either;
 use iota_common::try_iterator_ext::TryIteratorExt;
 use iota_json_rpc_types::{IotaObjectDataFilter, TransactionFilter};
@@ -35,12 +36,19 @@ use iota_types::{
 use itertools::Itertools;
 use move_core_types::language_storage::{ModuleId, StructTag, TypeTag};
 use parking_lot::ArcMutexGuard;
-use prometheus::{IntCounter, Registry, register_int_counter_with_registry};
+use prometheus::{
+    IntCounter, IntCounterVec, Registry, register_int_counter_vec_with_registry,
+    register_int_counter_with_registry,
+};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use tracing::{debug, trace};
+use tracing::{debug, info, trace};
 use typed_store::{
     DBMapUtils, TypedStoreError,
-    rocks::{DBBatch, DBMap, DBOptions, MetricConf, default_db_options, read_size_from_env},
+    rocks::{
+        DBBatch, DBMap, DBMapTableConfigMap, DBOptions, MetricConf, default_db_options,
+        read_size_from_env,
+    },
+    rocksdb::compaction_filter::Decision,
     traits::{Map, TableSummary, TypedStoreDebug},
 };
 
@@ -153,11 +161,9 @@ pub struct IndexStoreCacheUpdates {
 #[derive(DBMapUtils)]
 pub struct IndexStoreTables {
     /// Index from iota address to transactions initiated by that address.
-    #[default_options_override_fn = "transactions_from_addr_table_default_config"]
     transactions_from_addr: DBMap<(IotaAddress, TxSequenceNumber), TransactionDigest>,
 
     /// Index from iota address to transactions that were sent to that address.
-    #[default_options_override_fn = "transactions_to_addr_table_default_config"]
     transactions_to_addr: DBMap<(IotaAddress, TxSequenceNumber), TransactionDigest>,
 
     /// Index from object id to transactions that used that object id as input.
@@ -171,16 +177,13 @@ pub struct IndexStoreTables {
 
     /// Index from package id, module and function identifier to transactions
     /// that used that moce function call as input.
-    #[default_options_override_fn = "transactions_by_move_function_table_default_config"]
     transactions_by_move_function:
         DBMap<(ObjectID, String, String, TxSequenceNumber), TransactionDigest>,
 
     /// Ordering of all indexed transactions.
-    #[default_options_override_fn = "transactions_order_table_default_config"]
     transaction_order: DBMap<TxSequenceNumber, TransactionDigest>,
 
     /// Index from transaction digest to sequence number.
-    #[default_options_override_fn = "transactions_seq_table_default_config"]
     transactions_seq: DBMap<TransactionDigest, TxSequenceNumber>,
 
     /// This is an index of object references to currently existing objects,
@@ -188,10 +191,8 @@ pub struct IndexStoreTables {
     /// the object ID of the object. This composite index allows an
     /// efficient iterator to list all objected currently owned
     /// by a specific user, and their object reference.
-    #[default_options_override_fn = "owner_index_table_default_config"]
     owner_index: DBMap<OwnerIndexKey, ObjectInfo>,
 
-    #[default_options_override_fn = "coin_index_table_default_config"]
     coin_index: DBMap<CoinIndexKey, CoinInfo>,
 
     /// This is an index of object references to currently existing dynamic
@@ -199,26 +200,21 @@ pub struct IndexStoreTables {
     /// parent and the object ID of the dynamic field object. This composite
     /// index allows an efficient iterator to list all objects currently owned
     /// by a specific object, and their object reference.
-    #[default_options_override_fn = "dynamic_field_index_table_default_config"]
     dynamic_field_index: DBMap<DynamicFieldKey, DynamicFieldInfo>,
 
-    #[default_options_override_fn = "index_table_default_config"]
     event_order: DBMap<EventId, EventIndex>,
 
-    #[default_options_override_fn = "index_table_default_config"]
     event_by_move_module: DBMap<(ModuleId, EventId), EventIndex>,
 
-    #[default_options_override_fn = "index_table_default_config"]
     event_by_move_event: DBMap<(StructTag, EventId), EventIndex>,
 
-    #[default_options_override_fn = "index_table_default_config"]
     event_by_event_module: DBMap<(ModuleId, EventId), EventIndex>,
 
-    #[default_options_override_fn = "index_table_default_config"]
     event_by_sender: DBMap<(IotaAddress, EventId), EventIndex>,
 
-    #[default_options_override_fn = "index_table_default_config"]
     event_by_time: DBMap<(u64, EventId), EventIndex>,
+
+    pruner_watermark: DBMap<(), TxSequenceNumber>,
 }
 
 impl IndexStoreTables {
@@ -241,33 +237,89 @@ pub struct IndexStore {
     metrics: Arc<IndexStoreMetrics>,
     max_type_length: u64,
     remove_deprecated_tables: bool,
+    pruner_watermark: Arc<AtomicU64>,
 }
 
-// These functions are used to initialize the DB tables
-fn transactions_order_table_default_config() -> DBOptions {
-    default_db_options().disable_write_throttling()
+struct JsonRpcCompactionMetrics {
+    key_removed: IntCounterVec,
+    key_kept: IntCounterVec,
+    key_error: IntCounterVec,
 }
-fn transactions_seq_table_default_config() -> DBOptions {
-    default_db_options().disable_write_throttling()
+
+impl JsonRpcCompactionMetrics {
+    pub fn new(registry: &Registry) -> Arc<Self> {
+        Arc::new(Self {
+            key_removed: register_int_counter_vec_with_registry!(
+                "json_rpc_compaction_filter_key_removed",
+                "Compaction key removed",
+                &["cf"],
+                registry
+            )
+            .unwrap(),
+            key_kept: register_int_counter_vec_with_registry!(
+                "json_rpc_compaction_filter_key_kept",
+                "Compaction key kept",
+                &["cf"],
+                registry
+            )
+            .unwrap(),
+            key_error: register_int_counter_vec_with_registry!(
+                "json_rpc_compaction_filter_key_error",
+                "Compaction error",
+                &["cf"],
+                registry
+            )
+            .unwrap(),
+        })
+    }
 }
-fn transactions_from_addr_table_default_config() -> DBOptions {
-    default_db_options().disable_write_throttling()
+
+fn compaction_filter_config<T: DeserializeOwned>(
+    name: &str,
+    metrics: Arc<JsonRpcCompactionMetrics>,
+    mut db_options: DBOptions,
+    pruner_watermark: Arc<AtomicU64>,
+    extractor: impl Fn(T) -> TxSequenceNumber + Send + Sync + 'static,
+    by_key: bool,
+) -> DBOptions {
+    let cf = name.to_string();
+    db_options
+        .options
+        .set_compaction_filter(name, move |_, key, value| {
+            let bytes = if by_key { key } else { value };
+            let deserializer = bincode::DefaultOptions::new()
+                .with_big_endian()
+                .with_fixint_encoding();
+            match deserializer.deserialize(bytes) {
+                Ok(key_data) => {
+                    let sequence_number = extractor(key_data);
+                    if sequence_number < pruner_watermark.load(Ordering::Relaxed) {
+                        metrics.key_removed.with_label_values(&[&cf]).inc();
+                        Decision::Remove
+                    } else {
+                        metrics.key_kept.with_label_values(&[&cf]).inc();
+                        Decision::Keep
+                    }
+                }
+                Err(_) => {
+                    metrics.key_error.with_label_values(&[&cf]).inc();
+                    Decision::Keep
+                }
+            }
+        });
+    db_options
 }
-fn transactions_to_addr_table_default_config() -> DBOptions {
-    default_db_options().disable_write_throttling()
+
+fn compaction_filter_config_by_key<T: DeserializeOwned>(
+    name: &str,
+    metrics: Arc<JsonRpcCompactionMetrics>,
+    db_options: DBOptions,
+    pruner_watermark: Arc<AtomicU64>,
+    extractor: impl Fn(T) -> TxSequenceNumber + Send + Sync + 'static,
+) -> DBOptions {
+    compaction_filter_config(name, metrics, db_options, pruner_watermark, extractor, true)
 }
-fn transactions_by_move_function_table_default_config() -> DBOptions {
-    default_db_options().disable_write_throttling()
-}
-fn owner_index_table_default_config() -> DBOptions {
-    default_db_options().disable_write_throttling()
-}
-fn dynamic_field_index_table_default_config() -> DBOptions {
-    default_db_options().disable_write_throttling()
-}
-fn index_table_default_config() -> DBOptions {
-    default_db_options().disable_write_throttling()
-}
+
 fn coin_index_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
@@ -284,13 +336,121 @@ impl IndexStore {
         max_type_length: Option<u64>,
         remove_deprecated_tables: bool,
     ) -> Self {
+        let db_options = default_db_options().disable_write_throttling();
+        let pruner_watermark = Arc::new(AtomicU64::new(0));
+        let compaction_metrics = JsonRpcCompactionMetrics::new(registry);
+        let table_options = DBMapTableConfigMap::new(BTreeMap::from([
+            (
+                "transactions_from_addr".to_string(),
+                compaction_filter_config_by_key(
+                    "transactions_from_addr",
+                    compaction_metrics.clone(),
+                    db_options.clone(),
+                    pruner_watermark.clone(),
+                    |(_, id): (IotaAddress, TxSequenceNumber)| id,
+                ),
+            ),
+            (
+                "transactions_to_addr".to_string(),
+                compaction_filter_config_by_key(
+                    "transactions_to_addr",
+                    compaction_metrics.clone(),
+                    db_options.clone(),
+                    pruner_watermark.clone(),
+                    |(_, sequence_number): (IotaAddress, TxSequenceNumber)| sequence_number,
+                ),
+            ),
+            (
+                "transactions_by_move_function".to_string(),
+                compaction_filter_config_by_key(
+                    "transactions_by_move_function",
+                    compaction_metrics.clone(),
+                    db_options.clone(),
+                    pruner_watermark.clone(),
+                    |(_, _, _, id): (ObjectID, String, String, TxSequenceNumber)| id,
+                ),
+            ),
+            (
+                "transaction_order".to_string(),
+                compaction_filter_config_by_key(
+                    "transaction_order",
+                    compaction_metrics.clone(),
+                    db_options.clone(),
+                    pruner_watermark.clone(),
+                    |sequence_number: TxSequenceNumber| sequence_number,
+                ),
+            ),
+            (
+                "transactions_seq".to_string(),
+                compaction_filter_config(
+                    "transactions_seq",
+                    compaction_metrics.clone(),
+                    db_options.clone(),
+                    pruner_watermark.clone(),
+                    |sequence_number: TxSequenceNumber| sequence_number,
+                    false,
+                ),
+            ),
+            ("coin_index".to_string(), coin_index_table_default_config()),
+            (
+                "event_order".to_string(),
+                compaction_filter_config_by_key(
+                    "event_order",
+                    compaction_metrics.clone(),
+                    db_options.clone(),
+                    pruner_watermark.clone(),
+                    |event_id: EventId| event_id.0,
+                ),
+            ),
+            (
+                "event_by_move_module".to_string(),
+                compaction_filter_config_by_key(
+                    "event_by_move_module",
+                    compaction_metrics.clone(),
+                    db_options.clone(),
+                    pruner_watermark.clone(),
+                    |(_, event_id): (ModuleId, EventId)| event_id.0,
+                ),
+            ),
+            (
+                "event_by_event_module".to_string(),
+                compaction_filter_config_by_key(
+                    "event_by_event_module",
+                    compaction_metrics.clone(),
+                    db_options.clone(),
+                    pruner_watermark.clone(),
+                    |(_, event_id): (ModuleId, EventId)| event_id.0,
+                ),
+            ),
+            (
+                "event_by_sender".to_string(),
+                compaction_filter_config_by_key(
+                    "event_by_sender",
+                    compaction_metrics.clone(),
+                    db_options.clone(),
+                    pruner_watermark.clone(),
+                    |(_, event_id): (IotaAddress, EventId)| event_id.0,
+                ),
+            ),
+            (
+                "event_by_time".to_string(),
+                compaction_filter_config_by_key(
+                    "event_by_time",
+                    compaction_metrics.clone(),
+                    db_options.clone(),
+                    pruner_watermark.clone(),
+                    |(_, event_id): (u64, EventId)| event_id.0,
+                ),
+            ),
+        ]));
         let tables = IndexStoreTables::open_tables_read_write_with_deprecation_option(
             path,
             MetricConf::new("index"),
-            None,
-            None,
+            Some(db_options.options),
+            Some(table_options),
             remove_deprecated_tables,
         );
+
         let metrics = IndexStoreMetrics::new(registry);
         let caches = IndexStoreCaches {
             per_coin_type_balance: ShardedLruCache::new(1_000_000, 1000),
@@ -307,6 +467,12 @@ impl IndexStore {
             .map(|(seq, _)| seq + 1)
             .unwrap_or(0)
             .into();
+        let pruner_watermark_value = tables
+            .pruner_watermark
+            .get(&())
+            .expect("failed to initialize index tables")
+            .unwrap_or(0);
+        pruner_watermark.store(pruner_watermark_value, Ordering::Relaxed);
 
         Self {
             tables,
@@ -315,6 +481,7 @@ impl IndexStore {
             metrics: Arc::new(metrics),
             max_type_length: max_type_length.unwrap_or(128),
             remove_deprecated_tables,
+            pruner_watermark,
         }
     }
 
@@ -1094,6 +1261,32 @@ impl IndexStore {
                     },
                 )
                 .map_err(Into::into)
+        }
+    }
+
+    pub fn prune(&self, cut_time_ms: u64) -> IotaResult<TxSequenceNumber> {
+        match self
+            .tables
+            .event_by_time
+            .reversed_safe_iter_with_bounds(
+                None,
+                Some((cut_time_ms, (TxSequenceNumber::MAX, usize::MAX))),
+            )?
+            .next()
+            .transpose()?
+        {
+            Some(((_, (watermark, _)), _)) => {
+                if let Some(digest) = self.tables.transaction_order.get(&watermark)? {
+                    info!(
+                        "json rpc index pruning. Watermark is {} with digest {}",
+                        watermark, digest
+                    );
+                }
+                self.pruner_watermark.store(watermark, Ordering::Relaxed);
+                self.tables.pruner_watermark.insert(&(), &watermark)?;
+                Ok(watermark)
+            }
+            None => Ok(0),
         }
     }
 

--- a/crates/iota-tool/src/db_tool/index_search.rs
+++ b/crates/iota-tool/src/db_tool/index_search.rs
@@ -7,7 +7,7 @@ use std::{fmt::Debug, path::PathBuf, str::FromStr};
 use anyhow::{anyhow, bail};
 use iota_core::jsonrpc_index::IndexStoreTables;
 use iota_types::{
-    Identifier, TypeTag,
+    Identifier,
     base_types::{IotaAddress, ObjectID, TxSequenceNumber},
     digests::TransactionDigest,
 };
@@ -111,14 +111,6 @@ pub fn search_index(
             get_db_entries!(
                 db_read_only_handle.owner_index,
                 from_addr_oid,
-                start,
-                termination
-            )
-        }
-        "coin_index" => {
-            get_db_entries!(
-                db_read_only_handle.coin_index,
-                from_addr_str_oid,
                 start,
                 termination
             )
@@ -298,20 +290,6 @@ fn from_addr_oid(s: &str) -> Result<(IotaAddress, ObjectID), anyhow::Error> {
     let oid = ObjectID::from_str(tokens[1].trim())?;
 
     Ok((addr, oid))
-}
-
-fn from_addr_str_oid(s: &str) -> Result<(IotaAddress, String, ObjectID), anyhow::Error> {
-    // Remove whitespaces
-    let s = s.trim();
-    let tokens = s.split(',').collect::<Vec<&str>>();
-    if tokens.len() != 3 {
-        bail!("Invalid addr, type tag object id triplet");
-    }
-    let address = IotaAddress::from_str(tokens[0].trim())?;
-    let tag: TypeTag = TypeTag::from_str(tokens[1].trim())?;
-    let oid: ObjectID = ObjectID::from_str(tokens[2].trim())?;
-
-    Ok((address, tag.to_string(), oid))
 }
 
 fn from_oid_oid(s: &str) -> Result<(ObjectID, ObjectID), anyhow::Error> {


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.44.3, v1.45.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/5bc3504d7c1b69433b24a77df54f5fab36500d0f
- Description:
Make indexes prunable.


## Links to any relevant issues

Part of #6153 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Introduce indexes pruner to authority store
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: