### PR TITLE
feat(indexer): add streaming support for events and transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3906,6 +3906,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fast_chemail"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6461,6 +6467,7 @@ dependencies = [
  "test-cluster",
  "thiserror 1.0.64",
  "tokio",
+ "tokio-postgres",
  "tokio-stream",
  "tokio-util 0.7.12",
  "tracing",
@@ -11037,6 +11044,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
+name = "postgres-protocol"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ff0abab4a9b844b93ef7b81f1efc0a366062aaef2cd702c76256b5dc075c54"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.9.1",
+ "sha2 0.10.8",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13614,6 +13650,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "stronghold-derive"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14351,6 +14398,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-postgres"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c95d533c83082bb6490e0189acaa0bbeef9084e60471b696ca6988cd0541fb0"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot 0.12.3",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.9.1",
+ "socket2",
+ "tokio",
+ "tokio-util 0.7.12",
+ "whoami",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15070,6 +15143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15089,6 +15168,12 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-segmentation"

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -28,11 +28,13 @@ prometheus.workspace = true
 rand = { workspace = true, optional = true }
 secrecy = "0.8.0"
 serde.workspace = true
+serde_json.workspace = true
 serde_with.workspace = true
 tap.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tokio-postgres = "0.7.13"
 tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
 tracing.workspace = true

--- a/crates/iota-indexer/migrations/pg/2025-09-10-071522_events_and_transactions_triggers/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-09-10-071522_events_and_transactions_triggers/down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS checkpoint_committed_trigger ON checkpoints;
+DROP FUNCTION IF EXISTS notify_checkpoint_committed();

--- a/crates/iota-indexer/migrations/pg/2025-09-10-071522_events_and_transactions_triggers/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-09-10-071522_events_and_transactions_triggers/up.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION notify_checkpoint_committed()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Send notification with just the range - let client query events
+    PERFORM pg_notify('checkpoint_committed',
+        json_build_object(
+            'checkpoint_sequence_number', NEW.sequence_number,
+            'min_tx_sequence_number', NEW.min_tx_sequence_number,
+            'max_tx_sequence_number', NEW.max_tx_sequence_number
+        )::text
+    );
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE TRIGGER checkpoint_committed_trigger
+    AFTER INSERT ON checkpoints
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_checkpoint_committed();

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -869,6 +869,20 @@ impl IndexerReader {
         run_query!(&self.pool, |conn| query.load::<StoredTransaction>(conn))
     }
 
+    pub(crate) fn multi_get_transactions_by_sequence_numbers_range(
+        &self,
+        min_seq: i64,
+        max_seq: i64,
+    ) -> Result<Vec<StoredTransaction>, IndexerError> {
+        use crate::schema::transactions::dsl as txdsl;
+        let query = txdsl::transactions
+            .filter(txdsl::tx_sequence_number.ge(min_seq))
+            .filter(txdsl::tx_sequence_number.le(max_seq))
+            .order(txdsl::tx_sequence_number.asc())
+            .into_boxed();
+        run_query!(&self.pool, |conn| query.load::<StoredTransaction>(conn))
+    }
+
     pub async fn get_owned_objects_in_blocking_task(
         &self,
         address: IotaAddress,

--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -44,6 +44,7 @@ pub mod processors;
 pub(crate) mod rolling;
 pub mod schema;
 pub mod store;
+pub mod stream;
 pub mod system_package_task;
 pub mod test_utils;
 pub mod types;

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -431,7 +431,7 @@ impl StoredTransaction {
         })
     }
 
-    fn try_into_sender_signed_data(&self) -> IndexerResult<SenderSignedData> {
+    pub(crate) fn try_into_sender_signed_data(&self) -> IndexerResult<SenderSignedData> {
         let sender_signed_data: SenderSignedData =
             bcs::from_bytes(&self.raw_transaction).map_err(|e| {
                 IndexerError::PersistentStorageDataCorruption(format!(

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::BTreeMap,
     str::FromStr,
     sync::{Arc, Mutex},
     time::Instant,
@@ -17,7 +17,7 @@ use iota_types::{
     transaction::TransactionDataAPI,
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc::{self, error::TrySendError};
+use tokio::sync::mpsc::{self};
 use tokio_postgres::{AsyncMessage, Client, Config, Connection, NoTls, Socket, tls::NoTlsStream};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, warn};
@@ -31,18 +31,22 @@ use crate::{
     },
 };
 
+/// Buffer size used in the mpsc bounded channels.
 const BUFFER_SIZE: usize = 1000;
+/// Postgres Notify channel name.
 const CHANNEL_NAME: &str = "checkpoint_committed";
 
+/// Active subscribers held in memory.
 type Subscribers<T, F> = Arc<Mutex<BTreeMap<String, Subscriber<T, F>>>>;
 
+/// A single subscriber to which we can send data based on provided filters.
 struct Subscriber<T, F> {
-    sender: mpsc::Sender<T>,
-    lag_buffer: VecDeque<T>,
+    sender: mpsc::Sender<StreamEvent<T>>,
     filter: F,
 }
 
-#[derive(Clone, Debug, Default)]
+/// Filter returned [`StoredEvent`] form the stream.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StreamEventFilter {
     #[default]
     All,
@@ -67,13 +71,14 @@ impl Filter<StoredEvent> for StreamEventFilter {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Module {
     name: String,
     function: Option<String>,
 }
 
-#[derive(Clone, Debug, Default)]
+/// Filter returned [`StoredTransaction`] form the stream.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StreamTransactionFilter {
     #[default]
     All,
@@ -115,42 +120,69 @@ impl Filter<StoredTransaction> for StreamTransactionFilter {
     }
 }
 
+/// Represents a notification about a checkpoint commit in Indexer Database, it
+/// acts as a trigger to request transaction related to that particular
+/// checkpoint.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 struct CheckpointCommitNotification {
+    /// Committed checkpoint sequence number.
     checkpoint_sequence_number: i64,
+    /// the minimum transaction sequence number.
     min_tx_sequence_number: i64,
+    /// the maximum transaction sequence number.
     max_tx_sequence_number: i64,
+}
+
+/// Represents events that can be sent to stream subscribers in a broadcasting
+/// system.
+///
+/// This enum encapsulates the different types of messages that subscribers can
+/// receive when listening to a stream. It handles both normal message delivery
+/// and backpressure scenarios where slow subscribers need to be managed.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum StreamEvent<T> {
+    /// A regular message delivered to an active subscriber.
+    ///
+    /// This variant indicates normal operation where the subscriber is keeping
+    /// up with the message flow and can continue receiving subsequent
+    /// messages. The wrapped data represents the actual payload being
+    /// streamed.
+    Message(T),
+    /// The final message sent to a subscriber that is lagging behind.
+    ///
+    /// This variant is sent when the server detects that a subscriber cannot
+    /// process messages fast enough to keep up with the stream. After sending
+    /// this message, the subscriber will be automatically removed from the
+    /// broadcasting system to prevent memory buildup and maintain overall
+    /// system performance.
+    ///
+    /// The wrapped data represents the last message the subscriber will
+    /// receive, allowing for graceful cleanup or final processing before
+    /// disconnection.
+    ClosingDueToLag(T),
 }
 
 /// A lightweight in-memory fan-out broadcaster that distributes data to
 /// multiple filtered subscribers.
 ///
-/// The `Broadcaster` provides a publish-subscribe pattern where a single data
-/// producer can efficiently distribute items to multiple consumers, each with
-/// their own filtering criteria.
+/// It provides a publish-subscribe pattern where a single data producer can
+/// efficiently distribute items to multiple consumers, each with their own
+/// filtering criteria.
 ///
 /// # Backpressure Handling
+/// The "slow receiver" problem is handled through capacity-based monitoring:
 ///
-/// This broadcaster handles the "slow receiver" problem similarly to tokio's
-/// broadcast channels. When subscribers cannot keep up with the message rate,
-/// the system maintains bounded memory usage while gracefully handling lag.
-///
-/// ## Channel Send Behavior
-/// - **Success**: Message is delivered immediately to the subscriber's channel
-/// - **Channel Full**: Message is added to the subscriber's local lag buffer
-/// - **Channel Closed**: Subscriber is automatically removed from the
-///   subscribers list
-///
-/// ## Lag Buffer
-/// Each subscriber has a local buffer that retains messages when their channel
-/// is full:
-/// - When a subscriber's channel is full, messages are queued in their lag
-///   buffer
-/// - The lag buffer has a hard upper bound on capacity (`BUFFER_SIZE`)
-/// - When the buffer is at capacity and a new message arrives, the **oldest**
-///   message is released to free up space for the new message
-/// - On the next broadcast iteration, buffered messages are sent first
-///   (oldest-to-newest) before new messages
+/// - **Normal Operation**: When a subscriber's channel has capacity > 1,
+///   messages are sent as [`StreamEvent::Message`] allowing continued
+///   subscription
+/// - **Backpressure Detection**: When capacity drops to 1 (channel nearly
+///   full), the subscriber is marked as lagging behind the message production
+///   rate
+/// - **Graceful Termination**: Lagging subscribers receive their final message
+///   wrapped in [`StreamEvent::ClosingDueToLag`] and are automatically removed
+///   from the subscriber list
+/// - **System Protection**: This prevents unbounded memory growth and maintains
+///   overall broadcaster performance by avoiding blocking on slow consumers
 ///
 /// # Filtering
 ///
@@ -169,9 +201,10 @@ where
     /// Creates a new broadcaster that consumes items from the provided
     /// receiver.
     ///
-    /// This method spawns a background task that continuously reads from `rx`
-    /// and distributes items to all registered subscribers. The broadcaster
-    /// begins processing immediately upon creation.
+    /// This method spawns a background task that continuously reads from
+    /// [`mpsc::Receiver`] and distributes items to all registered
+    /// subscribers. The broadcaster begins processing immediately upon
+    /// creation.
     fn new(mut rx: mpsc::Receiver<T>) -> Self {
         let streamer = Self {
             subscribers: Default::default(),
@@ -197,28 +230,32 @@ where
             });
 
             for (id, subscriber) in subscribers_snapshot.iter_mut() {
+                if subscriber.sender.is_closed() {
+                    warn!(
+                        subscription_id = id,
+                        "Subscriber closed connection, removing"
+                    );
+                    to_remove.push(id.clone());
+                    continue;
+                }
+
                 if !(subscriber.filter.matches(&data)) {
                     continue;
                 }
-                Self::push_bounded(&mut subscriber.lag_buffer, data.clone());
-                while let Some(data) = subscriber.lag_buffer.pop_front() {
-                    match subscriber.sender.try_send(data) {
-                        Ok(_) => {
-                            debug!(subscription_id = id, "Streaming data to subscriber.");
-                        }
-                        Err(TrySendError::Full(returned_data)) => {
-                            warn!(subscription_id = id, "Lagging behind");
-                            Self::push_bounded(&mut subscriber.lag_buffer, returned_data);
-                        }
-                        Err(TrySendError::Closed(_)) => {
-                            warn!(
-                                subscription_id = id,
-                                "Sender half dropped, removing subscriber"
-                            );
-                            to_remove.push(id.clone());
-                        }
-                    }
-                }
+
+                let data = if subscriber.sender.capacity() > 1 {
+                    StreamEvent::Message(data.clone())
+                } else {
+                    warn!(
+                        subscription_id = id,
+                        "Lagging behind, sending last message and removing"
+                    );
+                    to_remove.push(id.clone());
+                    StreamEvent::ClosingDueToLag(data.clone())
+                };
+
+                // since we checked the capacity we can ignore the result
+                let _ = subscriber.sender.try_send(data);
             }
             to_remove
         };
@@ -234,21 +271,12 @@ where
         }
     }
 
-    /// Pushes a message to the lag buffer. If the buffer is at capacity,
-    /// the oldest message is released to free up space for the new message.
-    fn push_bounded(lag_buff: &mut VecDeque<T>, data: T) {
-        if lag_buff.len() >= BUFFER_SIZE {
-            lag_buff.pop_front();
-        }
-        lag_buff.push_back(data);
-    }
-
     /// Creates a new subscription to the broadcast stream with the specified
     /// filter.
     ///
     /// Each call to `subscribe` creates an independent stream that:
     /// - Receives only items that match the provided filter
-    /// - Has its own bounded channel buffer (`BUFFER_SIZE` capacity)
+    /// - Has its own bounded channel buffer ([`BUFFER_SIZE`] capacity)
     /// - Operates independently of other subscribers
     /// - Is automatically removed if it's disconnected
     ///
@@ -265,21 +293,16 @@ where
     ///     }
     /// });
     /// ```
-    fn subscribe(&self, filter: F) -> impl Stream<Item = T> {
+    fn subscribe(&self, filter: F) -> impl Stream<Item = StreamEvent<T>> {
         let mut subscribers = self.subscribers.lock().unwrap_or_else(|poisoned| {
             error!("Subscribers mutex poisoned, recovering...");
             self.subscribers.clear_poison();
             poisoned.into_inner()
         });
-
-        let (tx, rx) = mpsc::channel::<T>(BUFFER_SIZE);
+        let (tx, rx) = mpsc::channel::<StreamEvent<T>>(BUFFER_SIZE);
         subscribers.insert(
             ObjectID::random().to_string(),
-            Subscriber {
-                sender: tx,
-                lag_buffer: VecDeque::with_capacity(BUFFER_SIZE),
-                filter,
-            },
+            Subscriber { sender: tx, filter },
         );
         ReceiverStream::new(rx)
     }
@@ -315,12 +338,19 @@ where
 /// ```
 ///
 /// # Backpressure Handling
+/// The "slow receiver" problem is handled through capacity-based monitoring:
 ///
-/// This implementation handles the "slow receiver" problem by maintaining
-/// bounded memory usage per subscriber. When a subscriber cannot keep up with
-/// the message rate, older unprocessed messages are released to make room for
-/// newer ones, preventing memory exhaustion while allowing the subscriber to
-/// continue receiving recent data.
+/// - **Normal Operation**: When a subscriber's channel has capacity > 1,
+///   messages are sent as [`StreamEvent::Message`] allowing continued
+///   subscription
+/// - **Backpressure Detection**: When capacity drops to 1 (channel nearly
+///   full), the subscriber is marked as lagging behind the message production
+///   rate
+/// - **Graceful Termination**: Lagging subscribers receive their final message
+///   wrapped in [`StreamEvent::ClosingDueToLag`] and are automatically removed
+///   from the subscriber list
+/// - **System Protection**: This prevents unbounded memory growth and maintains
+///   overall broadcaster performance by avoiding blocking on slow consumers
 pub struct IndexerStreamer {
     events_broadcaster: Broadcaster<StoredEvent, StreamEventFilter>,
     transactions_broadcaster: Broadcaster<StoredTransaction, StreamTransactionFilter>,
@@ -363,9 +393,13 @@ impl IndexerStreamer {
     /// won't be affected by the processing speed of other subscribers.
     ///
     /// # Note
-    /// If the subscriber's channel exceeds its internal capacity due to slow
-    /// processing, older unprocessed events will be replaced with newer ones
-    /// to maintain bounded memory usage.
+    /// If the subscriber cannot keep up with the event production rate (slow
+    /// subscriber problem), it will automatically receive a final
+    /// [`StreamEvent::ClosingDueToLag`] message and be disconnected to prevent
+    /// system-wide performance degradation. Subscribers can resubscribe at any
+    /// time to resume receiving events, but **any messages that occurred during
+    /// the disconnection period will be lost** - the new subscription will only
+    /// receive events from the point of resubscription forward.
     ///
     /// # Example
     ///
@@ -373,12 +407,22 @@ impl IndexerStreamer {
     /// let events = streamer.subscribe_events(StreamEventFilter::All).unwrap();
     /// tokio::spawn(async move {
     ///     use futures::StreamExt;
-    ///     while let Some(event) = events.next().await {
-    ///         println!("Event: {}", event.event_type);
+    ///     while let Some(stream_event) = events.next().await {
+    ///         match stream_event {
+    ///             StreamEvent::Message(ev) => {
+    ///                 println!("Transaction: {ev:?}");
+    ///             }
+    ///             StreamEvent::ClosingDueToLag(last_ev) => {
+    ///                 println!("Last Transaction: {last_ev:?}");
+    ///             }
+    ///         }
     ///     }
     /// });
     /// ```
-    pub fn subscribe_events(&self, filter: StreamEventFilter) -> impl Stream<Item = StoredEvent> {
+    pub fn subscribe_events(
+        &self,
+        filter: StreamEventFilter,
+    ) -> impl Stream<Item = StreamEvent<StoredEvent>> {
         self.events_broadcaster.subscribe(filter)
     }
 
@@ -389,9 +433,13 @@ impl IndexerStreamer {
     /// won't be affected by the processing speed of other subscribers.
     ///
     /// # Note
-    /// If the subscriber's channel exceeds its internal capacity due to slow
-    /// processing, older unprocessed events will be replaced with newer ones
-    /// to maintain bounded memory usage.
+    /// If the subscriber cannot keep up with the event production rate (slow
+    /// subscriber problem), it will automatically receive a final
+    /// [`StreamEvent::ClosingDueToLag`] message and be disconnected to prevent
+    /// system-wide performance degradation. Subscribers can resubscribe at any
+    /// time to resume receiving events, but **any messages that occurred during
+    /// the disconnection period will be lost** - the new subscription will only
+    /// receive events from the point of resubscription forward.
     ///
     /// # Example
     ///
@@ -400,15 +448,22 @@ impl IndexerStreamer {
     /// let txs = streamer.subscribe_transactions(filter).unwrap();
     /// tokio::spawn(async move {
     ///     use futures::StreamExt;
-    ///     while let Some(tx) = txs.next().await {
-    ///         println!("Transaction: {}", hex::encode(&tx.transaction_digest));
+    ///     while let Some(stream_event) = txs.next().await {
+    ///         match stream_event {
+    ///             StreamEvent::Message(tx) => {
+    ///                 println!("Transaction: {tx:?}");
+    ///             }
+    ///             StreamEvent::ClosingDueToLag(last_tx) => {
+    ///                 println!("Last Transaction: {last_tx:?}");
+    ///             }
+    ///         }
     ///     }
     /// });
     /// ```
     pub fn subscribe_transactions(
         &self,
         filter: StreamTransactionFilter,
-    ) -> impl Stream<Item = StoredTransaction> {
+    ) -> impl Stream<Item = StreamEvent<StoredTransaction>> {
         self.transactions_broadcaster.subscribe(filter)
     }
 

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -256,8 +256,8 @@ impl IndexerStreamer {
 
     /// Subscribe to a stream of [`StoredTransaction`].
     ///
-    /// By default all events are received, it's possible to filter on client
-    /// side by using [`StreamTransactionFilter`] type.
+    /// By default all transactions are received, it's possible to filter on
+    /// client side by using [`StreamTransactionFilter`] type.
     ///
     /// # Note
     /// Since under the hood a [`tokio::sync::broadcast`] channel is used the
@@ -397,8 +397,13 @@ impl IndexerStreamer {
                         Err(_) => None,
                     }
                 }
-                Ok(_) => None, // Not a notification message, skip
-                Err(e) => Some(Err(IndexerError::Generic(format!(
+                // not a notification message, skip
+                Ok(AsyncMessage::Notice(msg)) => {
+                    tracing::warn!("received a postgres notice: {msg}");
+                    None
+                }
+                Ok(_) => None,
+                Err(e) => Some(Err(IndexerError::PostgresRead(format!(
                     "database connection error: {e}"
                 )))),
             }

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -529,7 +529,7 @@ impl IndexerStreamer {
                 );
 
                 let instant = Instant::now();
-                Self::publish_tx_and_events(transactions, &event_tx, &transaction_tx)?;
+                Self::publish_tx_and_events(transactions, &event_tx, &transaction_tx).await?;
                 let duration = instant.elapsed();
                 debug!("broadcast data took: {duration:?}");
             }
@@ -538,19 +538,23 @@ impl IndexerStreamer {
         Ok(())
     }
 
-    fn publish_tx_and_events(
+    async fn publish_tx_and_events(
         transactions: Vec<StoredTransaction>,
         event_tx: &mpsc::Sender<StoredEvent>,
         transaction_tx: &mpsc::Sender<StoredTransaction>,
     ) -> Result<(), IndexerError> {
         for tx in transactions {
             for event in Self::stored_events_from_transaction(&tx)? {
-                if let Err(e) = event_tx.try_send(event) {
-                    error!("failed to queue event: {e}");
+                if event_tx.send(event).await.is_err() {
+                    return Err(IndexerError::ChannelClosed(
+                        "failed to send event, receiver half dropped".into(),
+                    ));
                 }
             }
-            if let Err(e) = transaction_tx.try_send(tx) {
-                error!("failed to queue transaction: {e}");
+            if transaction_tx.send(tx).await.is_err() {
+                return Err(IndexerError::ChannelClosed(
+                    "failed to send transaction, receiver half dropped".into(),
+                ));
             }
         }
         Ok(())

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -131,20 +131,24 @@ struct CheckpointCommitNotification {
 ///
 /// # Backpressure Handling
 ///
+/// This broadcaster handles the "slow receiver" problem similarly to tokio's
+/// broadcast channels. When subscribers cannot keep up with the message rate,
+/// the system maintains bounded memory usage while gracefully handling lag.
+///
 /// ## Channel Send Behavior
 /// - **Success**: Message is delivered immediately to the subscriber's channel
 /// - **Channel Full**: Message is added to the subscriber's local lag buffer
-///   (ring buffer)
 /// - **Channel Closed**: Subscriber is automatically removed from the
 ///   subscribers list
 ///
-/// ## Lag Buffer (Ring Buffer)
-/// Each subscriber has a local `VecDeque` buffer that acts as a ring buffer:
+/// ## Lag Buffer
+/// Each subscriber has a local buffer that retains messages when their channel
+/// is full:
 /// - When a subscriber's channel is full, messages are queued in their lag
 ///   buffer
-/// - The lag buffer has a capacity limit (typically 2x the channel buffer size)
-/// - When the lag buffer exceeds capacity, the **oldest** messages are dropped
-///   to make room for newer ones
+/// - The lag buffer has a hard upper bound on capacity (`BUFFER_SIZE`)
+/// - When the buffer is at capacity and a new message arrives, the **oldest**
+///   message is released to free up space for the new message
 /// - On the next broadcast iteration, buffered messages are sent first
 ///   (oldest-to-newest) before new messages
 ///
@@ -188,6 +192,7 @@ where
             let mut to_remove = vec![];
             let mut subscribers_snapshot = subscribers.lock().unwrap_or_else(|poisoned| {
                 error!("Subscribers mutex poisoned, recovering...");
+                subscribers.clear_poison();
                 poisoned.into_inner()
             });
 
@@ -195,7 +200,7 @@ where
                 if !(subscriber.filter.matches(&data)) {
                     continue;
                 }
-                Self::ring_buffer_push(&mut subscriber.lag_buffer, data.clone());
+                Self::push_bounded(&mut subscriber.lag_buffer, data.clone());
                 while let Some(data) = subscriber.lag_buffer.pop_front() {
                     match subscriber.sender.try_send(data) {
                         Ok(_) => {
@@ -203,7 +208,7 @@ where
                         }
                         Err(TrySendError::Full(returned_data)) => {
                             warn!(subscription_id = id, "Lagging behind");
-                            Self::ring_buffer_push(&mut subscriber.lag_buffer, returned_data);
+                            Self::push_bounded(&mut subscriber.lag_buffer, returned_data);
                         }
                         Err(TrySendError::Closed(_)) => {
                             warn!(
@@ -220,6 +225,7 @@ where
         if !to_remove.is_empty() {
             let mut subscribers = subscribers.lock().unwrap_or_else(|poisoned| {
                 error!("Subscribers mutex poisoned, recovering...");
+                subscribers.clear_poison();
                 poisoned.into_inner()
             });
             for sub in to_remove {
@@ -228,8 +234,10 @@ where
         }
     }
 
-    fn ring_buffer_push(lag_buff: &mut VecDeque<T>, data: T) {
-        if lag_buff.capacity() > BUFFER_SIZE {
+    /// Pushes a message to the lag buffer. If the buffer is at capacity,
+    /// the oldest message is released to free up space for the new message.
+    fn push_bounded(lag_buff: &mut VecDeque<T>, data: T) {
+        if lag_buff.len() >= BUFFER_SIZE {
             lag_buff.pop_front();
         }
         lag_buff.push_back(data);
@@ -260,6 +268,7 @@ where
     fn subscribe(&self, filter: F) -> impl Stream<Item = T> {
         let mut subscribers = self.subscribers.lock().unwrap_or_else(|poisoned| {
             error!("Subscribers mutex poisoned, recovering...");
+            self.subscribers.clear_poison();
             poisoned.into_inner()
         });
 
@@ -307,10 +316,11 @@ where
 ///
 /// # Backpressure Handling
 ///
-/// Slow consumers that cannot keep up with the data rate are automatically
-/// pruned to prevent blocking other subscribers. Each subscriber has a bounded
-/// channel with `BUFFER_SIZE` capacity. A maximum of `MAX_SUBSCRIBERS`
-/// concurrent subscriptions is enforced to prevent memory exhaustion.
+/// This implementation handles the "slow receiver" problem by maintaining
+/// bounded memory usage per subscriber. When a subscriber cannot keep up with
+/// the message rate, older unprocessed messages are released to make room for
+/// newer ones, preventing memory exhaustion while allowing the subscriber to
+/// continue receiving recent data.
 pub struct IndexerStreamer {
     events_broadcaster: Broadcaster<StoredEvent, StreamEventFilter>,
     transactions_broadcaster: Broadcaster<StoredTransaction, StreamTransactionFilter>,

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use anyhow::Context;
-use futures::{Stream, StreamExt, stream};
+use futures::{Stream, StreamExt, TryFutureExt, stream};
 use iota_json_rpc_types::{Filter, IotaTransactionKind};
 use iota_types::{
     base_types::{IotaAddress, ObjectID},
@@ -367,6 +367,8 @@ where
 pub struct IndexerStreamer {
     events_broadcaster: Broadcaster<StoredEvent, StreamEventFilter>,
     transactions_broadcaster: Broadcaster<StoredTransaction, StreamTransactionFilter>,
+    // To receive notifications from the database we must keep the client alive.
+    _client: Client,
 }
 
 impl IndexerStreamer {
@@ -385,17 +387,28 @@ impl IndexerStreamer {
         let (event_tx, event_rx) = mpsc::channel(BUFFER_SIZE);
         let (transaction_tx, transaction_rx) = mpsc::channel(BUFFER_SIZE);
 
-        tokio::spawn(Self::process_checkpoint_notifications(
-            client,
-            connection,
-            indexer_reader,
-            event_tx,
-            transaction_tx,
-        ));
+        // the database connection must be spawned into a separate task in order to
+        // communicate with the database.
+        tokio::spawn({
+            Self::process_checkpoint_notifications(
+                connection,
+                indexer_reader,
+                event_tx,
+                transaction_tx,
+            )
+            .inspect_err(|e| error!("failed to process checkpoint notification: {e}"))
+        });
+
+        // listen for notifications on a specific channel.
+        client
+            .execute(&format!("LISTEN {CHANNEL_NAME};"), &[])
+            .await
+            .context("failed to listen to channel notifications")?;
 
         Ok(Self {
             events_broadcaster: Broadcaster::new(event_rx),
             transactions_broadcaster: Broadcaster::new(transaction_rx),
+            _client: client,
         })
     }
 
@@ -483,69 +496,52 @@ impl IndexerStreamer {
     }
 
     async fn process_checkpoint_notifications(
-        client: Client,
         mut connection: Connection<Socket, NoTlsStream>,
         indexer_reader: IndexerReader,
         event_tx: mpsc::Sender<StoredEvent>,
         transaction_tx: mpsc::Sender<StoredTransaction>,
     ) -> Result<(), IndexerError> {
-        let connection_task = async move {
-            // create a stream from the connection that forwards messages to the channel.
-            let mut stream =
-                stream::poll_fn(move |cx| connection.poll_message(cx)).ready_chunks(BUFFER_SIZE);
+        // Batch checkpoints in smaller chunks to prevent subscriber overload.
+        // Large batches (1000 checkpoints = ~4000-5000 transactions) would cause
+        // immediate subscriber lag. Smaller batches (~10 checkpoints = ~40-50 tx) keep
+        // pace.
+        let buffer_size = BUFFER_SIZE / 100;
+        // create a stream from the connection that forwards messages to the channel.
+        let mut stream =
+            stream::poll_fn(move |cx| connection.poll_message(cx)).ready_chunks(buffer_size);
 
-            while let Some(messages) = stream.next().await {
-                let messages = messages
-                    .into_iter()
-                    .collect::<Result<Vec<AsyncMessage>, _>>()
-                    .map_err(|e| {
-                        IndexerError::Generic(format!("database connection error: {e}"))
-                    })?;
+        while let Some(messages) = stream.next().await {
+            let mut filtered_messages = Self::filter_checkpoint_notifications(messages);
 
-                let mut filtered_messages = Self::filter_checkpoint_notifications(&messages);
+            let first = filtered_messages.next().transpose()?;
+            let last = filtered_messages.last().transpose()?;
 
-                if let Some((first, last)) = filtered_messages
-                    .next()
-                    .map(|first| (first, filtered_messages.last().unwrap_or(first)))
-                {
-                    debug!(notification = ?last);
+            if let Some((first, last)) = first.map(|f| (f, last.unwrap_or(f))) {
+                debug!(notification = ?last);
 
-                    let instant = Instant::now();
-                    let transactions: Vec<StoredTransaction> = indexer_reader
-                        .spawn_blocking(move |this| {
-                            this.multi_get_transactions_by_sequence_numbers_range(
-                                first.min_tx_sequence_number,
-                                last.max_tx_sequence_number,
-                            )
-                        })
-                        .await?;
+                let instant = Instant::now();
+                let transactions: Vec<StoredTransaction> = indexer_reader
+                    .spawn_blocking(move |this| {
+                        this.multi_get_transactions_by_sequence_numbers_range(
+                            first.min_tx_sequence_number,
+                            last.max_tx_sequence_number,
+                        )
+                    })
+                    .await?;
 
-                    let duration = instant.elapsed();
-                    debug!(
-                        "transactions query took: {duration:?}, tx: {}",
-                        transactions.len()
-                    );
+                let duration = instant.elapsed();
+                debug!(
+                    "transactions query took: {duration:?}, tx: {}",
+                    transactions.len()
+                );
 
-                    let instant = Instant::now();
-                    Self::publish_tx_and_events(transactions, &event_tx, &transaction_tx).await?;
-                    let duration = instant.elapsed();
-                    debug!("broadcast data took: {duration:?}");
-                }
+                let instant = Instant::now();
+                Self::publish_tx_and_events(transactions, &event_tx, &transaction_tx).await?;
+                let duration = instant.elapsed();
+                debug!("broadcast data took: {duration:?}");
             }
-
-            Ok::<(), IndexerError>(())
-        };
-
-        // spawn the connection handler.
-        let handle = tokio::spawn(connection_task);
-
-        // listen for notifications on a specific channel.
-        client
-            .execute(&format!("LISTEN {CHANNEL_NAME};"), &[])
-            .await
-            .context("failed to listen to channel notifications")?;
-
-        handle.await?
+        }
+        Ok(())
     }
 
     async fn publish_tx_and_events(
@@ -573,13 +569,21 @@ impl IndexerStreamer {
     /// Filters and parses database notifications into
     /// [`CheckpointCommitNotification`] from PostgreSQL messages.
     fn filter_checkpoint_notifications(
-        messages: &[AsyncMessage],
-    ) -> impl Iterator<Item = CheckpointCommitNotification> + '_ {
-        messages.iter().filter_map(|msg| match msg {
-            AsyncMessage::Notification(n) => {
-                serde_json::from_str::<CheckpointCommitNotification>(n.payload()).ok()
+        messages: Vec<Result<AsyncMessage, tokio_postgres::Error>>,
+    ) -> impl Iterator<Item = Result<CheckpointCommitNotification, IndexerError>> {
+        messages.into_iter().filter_map(|msg_result| {
+            match msg_result {
+                Ok(AsyncMessage::Notification(n)) => {
+                    match serde_json::from_str::<CheckpointCommitNotification>(n.payload()) {
+                        Ok(notification) => Some(Ok(notification)),
+                        Err(_) => None,
+                    }
+                }
+                Ok(_) => None, // Not a notification message, skip
+                Err(e) => Some(Err(IndexerError::Generic(format!(
+                    "database connection error: {e}"
+                )))),
             }
-            _ => None,
         })
     }
 

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -28,7 +28,38 @@ use crate::{
 
 /// Buffer size used in the bounded channels.
 const BUFFER_SIZE: usize = 1000;
-/// Transaction batch size to send to subscribers.
+/// The maximum number of checkpoint notifications to batch together for
+/// processing.
+///
+/// This controls how many PostgreSQL NOTIFY messages are collected before
+/// resolving transaction bounds and fetching data from the database. Each
+/// notification represents a committed checkpoint containing one or more
+/// transactions.
+///
+/// **Performance Trade-offs:**
+/// - **Higher values**: Reduce database query frequency but increase latency
+///   and memory usage per batch
+/// - **Lower values**: Increase responsiveness but may cause more frequent
+///   database queries for small checkpoints
+///
+/// The value of 10 provides a good balance between throughput and latency
+/// for typical checkpoint sizes.
+const CHECKPOINT_NOTIFICATION_CHUNK_SIZE: usize = 10;
+/// The maximum number of transactions to send to subscribers in a single batch.
+///
+/// This controls how many transactions are processed and broadcast together
+/// when streaming data to subscribers. Large checkpoints (e.g., genesis with
+/// thousands of transactions) are automatically split into multiple batches
+/// of this size to maintain consistent performance.
+///
+/// **Performance Trade-offs:**
+/// - **Too small**: May fall behind the indexer commit rate, causing the
+///   streaming service to lag behind real-time data ingestion
+/// - **Too large**: May overwhelm subscribers with large batches, causing them
+///   to lag or drop messages due to slow processing
+///
+/// The value of 50 provides good balance between indexer synchronization
+/// and subscriber responsiveness for typical workloads.
 const TRANSACTION_BATCH_SIZE: i64 = 50;
 /// Postgres Notify channel name.
 const CHANNEL_NAME: &str = "checkpoint_committed";
@@ -266,7 +297,8 @@ impl IndexerStreamer {
         transaction_tx: broadcast::Sender<StoredTransaction>,
     ) -> Result<(), IndexerError> {
         // create a stream from the connection that forwards messages to the channel.
-        let mut stream = stream::poll_fn(move |cx| connection.poll_message(cx)).ready_chunks(10);
+        let mut stream = stream::poll_fn(move |cx| connection.poll_message(cx))
+            .ready_chunks(CHECKPOINT_NOTIFICATION_CHUNK_SIZE);
 
         while let Some(messages) = stream.next().await {
             if let Some((min_tx_sequence_number, max_tx_sequence_number)) =

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -73,8 +73,8 @@ impl Filter<StoredEvent> for StreamEventFilter {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Module {
-    name: String,
-    function: Option<String>,
+    pub name: String,
+    pub function: Option<String>,
 }
 
 /// Filter returned [`StoredTransaction`] form the stream.

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::BTreeMap,
+    collections::HashMap,
+    fmt::Display,
     str::FromStr,
     sync::{Arc, Mutex},
     time::Instant,
@@ -37,12 +38,27 @@ const BUFFER_SIZE: usize = 1000;
 const CHANNEL_NAME: &str = "checkpoint_committed";
 
 /// Active subscribers held in memory.
-type Subscribers<T, F> = Arc<Mutex<BTreeMap<String, Subscriber<T, F>>>>;
+type Subscribers<T, F> = Arc<Mutex<HashMap<SubscriberId, Subscriber<T, F>>>>;
 
 /// A single subscriber to which we can send data based on provided filters.
 struct Subscriber<T, F> {
-    sender: mpsc::Sender<StreamEvent<T>>,
+    sender: mpsc::Sender<StreamPayload<T>>,
     filter: F,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+struct SubscriberId(ObjectID);
+
+impl SubscriberId {
+    pub fn new() -> Self {
+        SubscriberId(ObjectID::random())
+    }
+}
+
+impl Display for SubscriberId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 /// Filter returned [`StoredEvent`] form the stream.
@@ -123,13 +139,13 @@ impl Filter<StoredTransaction> for StreamTransactionFilter {
 /// Represents a notification about a checkpoint commit in Indexer Database, it
 /// acts as a trigger to request transaction related to that particular
 /// checkpoint.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 struct CheckpointCommitNotification {
     /// Committed checkpoint sequence number.
     checkpoint_sequence_number: i64,
-    /// the minimum transaction sequence number.
+    /// The minimum transaction sequence number.
     min_tx_sequence_number: i64,
-    /// the maximum transaction sequence number.
+    /// The maximum transaction sequence number.
     max_tx_sequence_number: i64,
 }
 
@@ -140,7 +156,7 @@ struct CheckpointCommitNotification {
 /// receive when listening to a stream. It handles both normal message delivery
 /// and backpressure scenarios where slow subscribers need to be managed.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum StreamEvent<T> {
+pub enum StreamPayload<T> {
     /// A regular message delivered to an active subscriber.
     ///
     /// This variant indicates normal operation where the subscriber is keeping
@@ -173,14 +189,14 @@ pub enum StreamEvent<T> {
 /// The "slow receiver" problem is handled through capacity-based monitoring:
 ///
 /// - **Normal Operation**: When a subscriber's channel has capacity > 1,
-///   messages are sent as [`StreamEvent::Message`] allowing continued
+///   messages are sent as [`StreamPayload::Message`] allowing continued
 ///   subscription
 /// - **Backpressure Detection**: When capacity drops to 1 (channel nearly
 ///   full), the subscriber is marked as lagging behind the message production
 ///   rate
 /// - **Graceful Termination**: Lagging subscribers receive their final message
-///   wrapped in [`StreamEvent::ClosingDueToLag`] and are automatically removed
-///   from the subscriber list
+///   wrapped in [`StreamPayload::ClosingDueToLag`] and are automatically
+///   removed from the subscriber list
 /// - **System Protection**: This prevents unbounded memory growth and maintains
 ///   overall broadcaster performance by avoiding blocking on slow consumers
 ///
@@ -224,7 +240,7 @@ where
         let to_remove = {
             let mut to_remove = vec![];
             let mut subscribers_snapshot = subscribers.lock().unwrap_or_else(|poisoned| {
-                error!("Subscribers mutex poisoned, recovering...");
+                error!("subscribers mutex poisoned, recovering...");
                 subscribers.clear_poison();
                 poisoned.into_inner()
             });
@@ -232,10 +248,10 @@ where
             for (id, subscriber) in subscribers_snapshot.iter_mut() {
                 if subscriber.sender.is_closed() {
                     warn!(
-                        subscription_id = id,
-                        "Subscriber closed connection, removing"
+                        subscription_id = id.to_string(),
+                        "subscriber closed connection, removing"
                     );
-                    to_remove.push(id.clone());
+                    to_remove.push(*id);
                     continue;
                 }
 
@@ -244,14 +260,14 @@ where
                 }
 
                 let data = if subscriber.sender.capacity() > 1 {
-                    StreamEvent::Message(data.clone())
+                    StreamPayload::Message(data.clone())
                 } else {
                     warn!(
-                        subscription_id = id,
-                        "Lagging behind, sending last message and removing"
+                        subscription_id = id.to_string(),
+                        "lagging behind, sending last message and removing"
                     );
-                    to_remove.push(id.clone());
-                    StreamEvent::ClosingDueToLag(data.clone())
+                    to_remove.push(*id);
+                    StreamPayload::ClosingDueToLag(data.clone())
                 };
 
                 // since we checked the capacity we can ignore the result
@@ -261,7 +277,7 @@ where
         };
         if !to_remove.is_empty() {
             let mut subscribers = subscribers.lock().unwrap_or_else(|poisoned| {
-                error!("Subscribers mutex poisoned, recovering...");
+                error!("subscribers mutex poisoned, recovering...");
                 subscribers.clear_poison();
                 poisoned.into_inner()
             });
@@ -293,17 +309,14 @@ where
     ///     }
     /// });
     /// ```
-    fn subscribe(&self, filter: F) -> impl Stream<Item = StreamEvent<T>> {
+    fn subscribe(&self, filter: F) -> impl Stream<Item = StreamPayload<T>> {
         let mut subscribers = self.subscribers.lock().unwrap_or_else(|poisoned| {
-            error!("Subscribers mutex poisoned, recovering...");
+            error!("subscribers mutex poisoned, recovering...");
             self.subscribers.clear_poison();
             poisoned.into_inner()
         });
-        let (tx, rx) = mpsc::channel::<StreamEvent<T>>(BUFFER_SIZE);
-        subscribers.insert(
-            ObjectID::random().to_string(),
-            Subscriber { sender: tx, filter },
-        );
+        let (tx, rx) = mpsc::channel::<StreamPayload<T>>(BUFFER_SIZE);
+        subscribers.insert(SubscriberId::new(), Subscriber { sender: tx, filter });
         ReceiverStream::new(rx)
     }
 }
@@ -341,14 +354,14 @@ where
 /// The "slow receiver" problem is handled through capacity-based monitoring:
 ///
 /// - **Normal Operation**: When a subscriber's channel has capacity > 1,
-///   messages are sent as [`StreamEvent::Message`] allowing continued
+///   messages are sent as [`StreamPayload::Message`] allowing continued
 ///   subscription
 /// - **Backpressure Detection**: When capacity drops to 1 (channel nearly
 ///   full), the subscriber is marked as lagging behind the message production
 ///   rate
 /// - **Graceful Termination**: Lagging subscribers receive their final message
-///   wrapped in [`StreamEvent::ClosingDueToLag`] and are automatically removed
-///   from the subscriber list
+///   wrapped in [`StreamPayload::ClosingDueToLag`] and are automatically
+///   removed from the subscriber list
 /// - **System Protection**: This prevents unbounded memory growth and maintains
 ///   overall broadcaster performance by avoiding blocking on slow consumers
 pub struct IndexerStreamer {
@@ -395,11 +408,12 @@ impl IndexerStreamer {
     /// # Note
     /// If the subscriber cannot keep up with the event production rate (slow
     /// subscriber problem), it will automatically receive a final
-    /// [`StreamEvent::ClosingDueToLag`] message and be disconnected to prevent
-    /// system-wide performance degradation. Subscribers can resubscribe at any
-    /// time to resume receiving events, but **any messages that occurred during
-    /// the disconnection period will be lost** - the new subscription will only
-    /// receive events from the point of resubscription forward.
+    /// [`StreamPayload::ClosingDueToLag`] message and be disconnected to
+    /// prevent system-wide performance degradation. Subscribers can
+    /// resubscribe at any time to resume receiving events, but **any
+    /// messages that occurred during the disconnection period will be
+    /// lost** - the new subscription will only receive events from the
+    /// point of resubscription forward.
     ///
     /// # Example
     ///
@@ -409,10 +423,10 @@ impl IndexerStreamer {
     ///     use futures::StreamExt;
     ///     while let Some(stream_event) = events.next().await {
     ///         match stream_event {
-    ///             StreamEvent::Message(ev) => {
+    ///             StreamPayload::Message(ev) => {
     ///                 println!("Transaction: {ev:?}");
     ///             }
-    ///             StreamEvent::ClosingDueToLag(last_ev) => {
+    ///             StreamPayload::ClosingDueToLag(last_ev) => {
     ///                 println!("Last Transaction: {last_ev:?}");
     ///             }
     ///         }
@@ -422,7 +436,7 @@ impl IndexerStreamer {
     pub fn subscribe_events(
         &self,
         filter: StreamEventFilter,
-    ) -> impl Stream<Item = StreamEvent<StoredEvent>> {
+    ) -> impl Stream<Item = StreamPayload<StoredEvent>> {
         self.events_broadcaster.subscribe(filter)
     }
 
@@ -435,11 +449,12 @@ impl IndexerStreamer {
     /// # Note
     /// If the subscriber cannot keep up with the event production rate (slow
     /// subscriber problem), it will automatically receive a final
-    /// [`StreamEvent::ClosingDueToLag`] message and be disconnected to prevent
-    /// system-wide performance degradation. Subscribers can resubscribe at any
-    /// time to resume receiving events, but **any messages that occurred during
-    /// the disconnection period will be lost** - the new subscription will only
-    /// receive events from the point of resubscription forward.
+    /// [`StreamPayload::ClosingDueToLag`] message and be disconnected to
+    /// prevent system-wide performance degradation. Subscribers can
+    /// resubscribe at any time to resume receiving events, but **any
+    /// messages that occurred during the disconnection period will be
+    /// lost** - the new subscription will only receive events from the
+    /// point of resubscription forward.
     ///
     /// # Example
     ///
@@ -450,10 +465,10 @@ impl IndexerStreamer {
     ///     use futures::StreamExt;
     ///     while let Some(stream_event) = txs.next().await {
     ///         match stream_event {
-    ///             StreamEvent::Message(tx) => {
+    ///             StreamPayload::Message(tx) => {
     ///                 println!("Transaction: {tx:?}");
     ///             }
-    ///             StreamEvent::ClosingDueToLag(last_tx) => {
+    ///             StreamPayload::ClosingDueToLag(last_tx) => {
     ///                 println!("Last Transaction: {last_tx:?}");
     ///             }
     ///         }
@@ -463,7 +478,7 @@ impl IndexerStreamer {
     pub fn subscribe_transactions(
         &self,
         filter: StreamTransactionFilter,
-    ) -> impl Stream<Item = StreamEvent<StoredTransaction>> {
+    ) -> impl Stream<Item = StreamPayload<StoredTransaction>> {
         self.transactions_broadcaster.subscribe(filter)
     }
 
@@ -474,68 +489,63 @@ impl IndexerStreamer {
         event_tx: mpsc::Sender<StoredEvent>,
         transaction_tx: mpsc::Sender<StoredTransaction>,
     ) -> Result<(), IndexerError> {
-        // Create a channel for receiving messages
-        let (tx, rx) = mpsc::channel(BUFFER_SIZE);
-
-        // Create a stream from the connection that forwards messages to the channel
-        let stream = stream::poll_fn(move |cx| connection.poll_message(cx));
         let connection_task = async move {
-            let mut stream = stream;
-            while let Some(message) = stream.next().await {
-                match message {
-                    Ok(msg) => {
-                        if tx.send(msg).await.is_err() {
-                            error!("notification receiver dropped");
-                            break;
-                        }
-                    }
-                    Err(e) => {
-                        error!("connection error: {e}");
-                        break;
-                    }
+            // create a stream from the connection that forwards messages to the channel.
+            let mut stream =
+                stream::poll_fn(move |cx| connection.poll_message(cx)).ready_chunks(BUFFER_SIZE);
+
+            while let Some(messages) = stream.next().await {
+                let messages = messages
+                    .into_iter()
+                    .collect::<Result<Vec<AsyncMessage>, _>>()
+                    .map_err(|e| {
+                        IndexerError::Generic(format!("database connection error: {e}"))
+                    })?;
+
+                let mut filtered_messages = Self::filter_checkpoint_notifications(&messages);
+
+                if let Some((first, last)) = filtered_messages
+                    .next()
+                    .map(|first| (first, filtered_messages.last().unwrap_or(first)))
+                {
+                    debug!(notification = ?last);
+
+                    let instant = Instant::now();
+                    let transactions: Vec<StoredTransaction> = indexer_reader
+                        .spawn_blocking(move |this| {
+                            this.multi_get_transactions_by_sequence_numbers_range(
+                                first.min_tx_sequence_number,
+                                last.max_tx_sequence_number,
+                            )
+                        })
+                        .await?;
+
+                    let duration = instant.elapsed();
+                    debug!(
+                        "transactions query took: {duration:?}, tx: {}",
+                        transactions.len()
+                    );
+
+                    let instant = Instant::now();
+                    Self::publish_tx_and_events(transactions, &event_tx, &transaction_tx).await?;
+                    let duration = instant.elapsed();
+                    debug!("broadcast data took: {duration:?}");
                 }
             }
+
+            Ok::<(), IndexerError>(())
         };
 
-        // Spawn the connection handler
-        tokio::spawn(connection_task);
+        // spawn the connection handler.
+        let handle = tokio::spawn(connection_task);
 
-        // Listen for notifications on a specific channel
+        // listen for notifications on a specific channel.
         client
             .execute(&format!("LISTEN {CHANNEL_NAME};"), &[])
             .await
             .context("failed to listen to channel notifications")?;
 
-        let mut notification_stream = ReceiverStream::new(rx).ready_chunks(BUFFER_SIZE);
-
-        while let Some(messages) = notification_stream.next().await {
-            if let Some((first, last)) = Self::first_and_last_checkpoint_notifications(&messages) {
-                debug!(notification = ?last);
-
-                let instant = Instant::now();
-                let transactions: Vec<StoredTransaction> = indexer_reader
-                    .spawn_blocking(move |this| {
-                        this.multi_get_transactions_by_sequence_numbers_range(
-                            first.min_tx_sequence_number,
-                            last.max_tx_sequence_number,
-                        )
-                    })
-                    .await?;
-
-                let duration = instant.elapsed();
-                debug!(
-                    "transactions query took: {duration:?}, tx: {}",
-                    transactions.len()
-                );
-
-                let instant = Instant::now();
-                Self::publish_tx_and_events(transactions, &event_tx, &transaction_tx).await?;
-                let duration = instant.elapsed();
-                debug!("broadcast data took: {duration:?}");
-            }
-        }
-
-        Ok(())
+        handle.await?
     }
 
     async fn publish_tx_and_events(
@@ -560,38 +570,24 @@ impl IndexerStreamer {
         Ok(())
     }
 
-    fn first_and_last_checkpoint_notifications(
+    /// Filters and parses database notifications into
+    /// [`CheckpointCommitNotification`] from PostgreSQL messages.
+    fn filter_checkpoint_notifications(
         messages: &[AsyncMessage],
-    ) -> Option<(CheckpointCommitNotification, CheckpointCommitNotification)> {
-        let mut first: Option<CheckpointCommitNotification> = None;
-        let mut last: Option<CheckpointCommitNotification> = None;
-
-        for msg in messages {
-            match msg {
-                AsyncMessage::Notification(n) => {
-                    match serde_json::from_str::<CheckpointCommitNotification>(n.payload()) {
-                        Ok(parsed) => {
-                            first.get_or_insert(parsed.clone());
-                            last = Some(parsed);
-                        }
-                        Err(e) => {
-                            error!("failed parsing checkpoint notification: {e}");
-                        }
-                    }
-                }
-                AsyncMessage::Notice(notice) => {
-                    warn!("received PostgreSQL notice: {}", notice.message());
-                }
-                _ => {}
+    ) -> impl Iterator<Item = CheckpointCommitNotification> + '_ {
+        messages.iter().filter_map(|msg| match msg {
+            AsyncMessage::Notification(n) => {
+                serde_json::from_str::<CheckpointCommitNotification>(n.payload()).ok()
             }
-        }
-
-        first.and_then(|f| last.map(|l| (f, l)))
+            _ => None,
+        })
     }
 
+    /// Extract [`StoredEvent`]'s from [`StoredTransaction`].
     fn stored_events_from_transaction(
         tx: &StoredTransaction,
     ) -> Result<Vec<StoredEvent>, IndexerError> {
+        let with_prefix = true;
         let native_events: Vec<Event> = stored_events_to_events(tx.events.clone())?;
         let stored = native_events
             .into_iter()
@@ -603,7 +599,7 @@ impl IndexerStreamer {
                 senders: vec![Some(native.sender.to_vec())],
                 package: native.package_id.to_vec(),
                 module: native.transaction_module.to_string(),
-                event_type: native.type_.to_canonical_string(/* with_prefix */ true),
+                event_type: native.type_.to_canonical_string(with_prefix),
                 timestamp_ms: tx.timestamp_ms,
                 bcs: native.contents.clone(),
             })

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -268,7 +268,7 @@ where
             ObjectID::random().to_string(),
             Subscriber {
                 sender: tx,
-                lag_buffer: VecDeque::with_capacity(BUFFER_SIZE * 2),
+                lag_buffer: VecDeque::with_capacity(BUFFER_SIZE),
                 filter,
             },
         );

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -26,7 +26,7 @@ use crate::{
     },
 };
 
-/// Buffer size used in the mpsc bounded channels.
+/// Buffer size used in the bounded channels.
 const BUFFER_SIZE: usize = 1000;
 /// Postgres Notify channel name.
 const CHANNEL_NAME: &str = "checkpoint_committed";

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     str::FromStr,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex},
     time::Instant,
 };
 
@@ -17,7 +17,7 @@ use iota_types::{
     transaction::TransactionDataAPI,
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::{self, error::TrySendError};
 use tokio_postgres::{AsyncMessage, Client, Config, Connection, NoTls, Socket, tls::NoTlsStream};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, warn};
@@ -29,14 +29,18 @@ use crate::{
         events::StoredEvent,
         transactions::{StoredTransaction, stored_events_to_events},
     },
-    types::IndexerResult,
 };
 
 const BUFFER_SIZE: usize = 1000;
-const MAX_SUBSCRIBERS: usize = 100;
 const CHANNEL_NAME: &str = "checkpoint_committed";
 
-type Subscribers<T, F> = Arc<RwLock<BTreeMap<String, (mpsc::Sender<T>, F)>>>;
+type Subscribers<T, F> = Arc<Mutex<BTreeMap<String, Subscriber<T, F>>>>;
+
+struct Subscriber<T, F> {
+    sender: mpsc::Sender<T>,
+    lag_buffer: VecDeque<T>,
+    filter: F,
+}
 
 #[derive(Clone, Debug, Default)]
 pub enum StreamEventFilter {
@@ -112,10 +116,10 @@ impl Filter<StoredTransaction> for StreamTransactionFilter {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct CheckpointCommitNotification {
-    pub checkpoint_sequence_number: i64,
-    pub min_tx_sequence_number: i64,
-    pub max_tx_sequence_number: i64,
+struct CheckpointCommitNotification {
+    checkpoint_sequence_number: i64,
+    min_tx_sequence_number: i64,
+    max_tx_sequence_number: i64,
 }
 
 /// A lightweight in-memory fan-out broadcaster that distributes data to
@@ -127,15 +131,22 @@ pub struct CheckpointCommitNotification {
 ///
 /// # Backpressure Handling
 ///
-/// The broadcaster implements automatic subscriber pruning for backpressure
-/// management:
-/// - Each subscriber has a bounded channel with `BUFFER_SIZE` capacity
-/// - Maximum of `MAX_SUBSCRIBERS` concurrent subscribers allowed
-/// - When a subscriber's channel is full, `try_send` fails immediately
-/// - Failed subscribers are automatically removed from the subscriber list
-/// - New subscriptions are rejected when at maximum capacity
-/// - This prevents slow consumers from stalling the entire broadcast system and
-///   prevents OOM
+/// ## Channel Send Behavior
+/// - **Success**: Message is delivered immediately to the subscriber's channel
+/// - **Channel Full**: Message is added to the subscriber's local lag buffer
+///   (ring buffer)
+/// - **Channel Closed**: Subscriber is automatically removed from the
+///   subscribers list
+///
+/// ## Lag Buffer (Ring Buffer)
+/// Each subscriber has a local `VecDeque` buffer that acts as a ring buffer:
+/// - When a subscriber's channel is full, messages are queued in their lag
+///   buffer
+/// - The lag buffer has a capacity limit (typically 2x the channel buffer size)
+/// - When the lag buffer exceeds capacity, the **oldest** messages are dropped
+///   to make room for newer ones
+/// - On the next broadcast iteration, buffered messages are sent first
+///   (oldest-to-newest) before new messages
 ///
 /// # Filtering
 ///
@@ -157,7 +168,7 @@ where
     /// This method spawns a background task that continuously reads from `rx`
     /// and distributes items to all registered subscribers. The broadcaster
     /// begins processing immediately upon creation.
-    pub fn new(mut rx: mpsc::Receiver<T>) -> Self {
+    fn new(mut rx: mpsc::Receiver<T>) -> Self {
         let streamer = Self {
             subscribers: Default::default(),
         };
@@ -166,44 +177,62 @@ where
 
         tokio::spawn(async move {
             while let Some(data) = rx.recv().await {
-                Self::send_to_all_subscribers(subscribers.clone(), data).await;
+                Self::send_to_all_subscribers(subscribers.clone(), data);
             }
         });
         streamer
     }
 
-    async fn send_to_all_subscribers(subscribers: Subscribers<T, F>, data: T) {
+    fn send_to_all_subscribers(subscribers: Subscribers<T, F>, data: T) {
         let to_remove = {
             let mut to_remove = vec![];
-            let subscribers_snapshot = subscribers
-                .read()
-                .expect("failed to acquire read subscribers lock");
+            let mut subscribers_snapshot = subscribers.lock().unwrap_or_else(|poisoned| {
+                error!("Subscribers mutex poisoned, recovering...");
+                poisoned.into_inner()
+            });
 
-            for (id, (subscriber, filter)) in subscribers_snapshot.iter() {
-                if !(filter.matches(&data)) {
+            for (id, subscriber) in subscribers_snapshot.iter_mut() {
+                if !(subscriber.filter.matches(&data)) {
                     continue;
                 }
-                match subscriber.try_send(data.clone()) {
-                    Ok(_) => {
-                        debug!(subscription_id = id, "Streaming data to subscriber.");
-                    }
-                    Err(e) => {
-                        warn!(
-                            subscription_id = id,
-                            "Error when streaming data, removing subscriber. Error: {e}"
-                        );
-                        to_remove.push(id.clone());
+                Self::ring_buffer_push(&mut subscriber.lag_buffer, data.clone());
+                while let Some(data) = subscriber.lag_buffer.pop_front() {
+                    match subscriber.sender.try_send(data) {
+                        Ok(_) => {
+                            debug!(subscription_id = id, "Streaming data to subscriber.");
+                        }
+                        Err(TrySendError::Full(returned_data)) => {
+                            warn!(subscription_id = id, "Lagging behind");
+                            Self::ring_buffer_push(&mut subscriber.lag_buffer, returned_data);
+                        }
+                        Err(TrySendError::Closed(_)) => {
+                            warn!(
+                                subscription_id = id,
+                                "Sender half dropped, removing subscriber"
+                            );
+                            to_remove.push(id.clone());
+                        }
                     }
                 }
             }
             to_remove
         };
         if !to_remove.is_empty() {
-            let mut subscribers = subscribers.write().unwrap();
+            let mut subscribers = subscribers.lock().unwrap_or_else(|poisoned| {
+                error!("Subscribers mutex poisoned, recovering...");
+                poisoned.into_inner()
+            });
             for sub in to_remove {
                 subscribers.remove(&sub);
             }
         }
+    }
+
+    fn ring_buffer_push(lag_buff: &mut VecDeque<T>, data: T) {
+        if lag_buff.capacity() > BUFFER_SIZE {
+            lag_buff.pop_front();
+        }
+        lag_buff.push_back(data);
     }
 
     /// Creates a new subscription to the broadcast stream with the specified
@@ -213,13 +242,7 @@ where
     /// - Receives only items that match the provided filter
     /// - Has its own bounded channel buffer (`BUFFER_SIZE` capacity)
     /// - Operates independently of other subscribers
-    /// - Is automatically removed if it becomes slow or disconnected
-    ///
-    /// # Subscriber Limit
-    ///
-    /// To prevent memory exhaustion, the broadcaster enforces a maximum of
-    /// `MAX_SUBSCRIBERS` concurrent subscriptions. When this limit is reached,
-    /// new subscription attempts will be rejected.
+    /// - Is automatically removed if it's disconnected
     ///
     /// # Example
     ///
@@ -234,24 +257,22 @@ where
     ///     }
     /// });
     /// ```
-    pub fn subscribe(&self, filter: F) -> IndexerResult<impl Stream<Item = T>> {
-        let mut subscribers = self
-            .subscribers
-            .write()
-            .expect("failed to acquire write subscribers lock");
-
-        // Check subscriber limit
-        if subscribers.len() > MAX_SUBSCRIBERS {
-            warn!(
-                "maximum subscribers ({}) reached, rejecting new subscription",
-                MAX_SUBSCRIBERS
-            );
-            return Err(IndexerError::Generic("maximum subscribers reached".into()));
-        }
+    fn subscribe(&self, filter: F) -> impl Stream<Item = T> {
+        let mut subscribers = self.subscribers.lock().unwrap_or_else(|poisoned| {
+            error!("Subscribers mutex poisoned, recovering...");
+            poisoned.into_inner()
+        });
 
         let (tx, rx) = mpsc::channel::<T>(BUFFER_SIZE);
-        subscribers.insert(ObjectID::random().to_string(), (tx, filter));
-        Ok(ReceiverStream::new(rx))
+        subscribers.insert(
+            ObjectID::random().to_string(),
+            Subscriber {
+                sender: tx,
+                lag_buffer: VecDeque::with_capacity(BUFFER_SIZE * 2),
+                filter,
+            },
+        );
+        ReceiverStream::new(rx)
     }
 }
 
@@ -331,6 +352,11 @@ impl IndexerStreamer {
     /// provided filter. Each subscriber gets its own independent stream and
     /// won't be affected by the processing speed of other subscribers.
     ///
+    /// # Note
+    /// If the subscriber's channel exceeds its internal capacity due to slow
+    /// processing, older unprocessed events will be replaced with newer ones
+    /// to maintain bounded memory usage.
+    ///
     /// # Example
     ///
     /// ```rust,ignore
@@ -342,10 +368,7 @@ impl IndexerStreamer {
     ///     }
     /// });
     /// ```
-    pub fn subscribe_events(
-        &self,
-        filter: StreamEventFilter,
-    ) -> IndexerResult<impl Stream<Item = StoredEvent>> {
+    pub fn subscribe_events(&self, filter: StreamEventFilter) -> impl Stream<Item = StoredEvent> {
         self.events_broadcaster.subscribe(filter)
     }
 
@@ -354,6 +377,11 @@ impl IndexerStreamer {
     /// Creates a new subscription that will receive transactions matching the
     /// provided filter. Each subscriber gets its own independent stream and
     /// won't be affected by the processing speed of other subscribers.
+    ///
+    /// # Note
+    /// If the subscriber's channel exceeds its internal capacity due to slow
+    /// processing, older unprocessed events will be replaced with newer ones
+    /// to maintain bounded memory usage.
     ///
     /// # Example
     ///
@@ -370,7 +398,7 @@ impl IndexerStreamer {
     pub fn subscribe_transactions(
         &self,
         filter: StreamTransactionFilter,
-    ) -> IndexerResult<impl Stream<Item = StoredTransaction>> {
+    ) -> impl Stream<Item = StoredTransaction> {
         self.transactions_broadcaster.subscribe(filter)
     }
 

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -85,9 +85,9 @@ impl Filter<StoredEvent> for StreamEventFilter {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Module {
-    pub name: String,
-    pub function: Option<String>,
+pub struct ModuleFunction {
+    pub module_name: String,
+    pub function_name: Option<String>,
 }
 
 /// Filter returned [`StoredTransaction`] form the stream.
@@ -97,7 +97,7 @@ pub enum StreamTransactionFilter {
     SigningAddress(IotaAddress),
     Function {
         package: ObjectID,
-        module: Option<Module>,
+        module: Option<ModuleFunction>,
     },
 }
 
@@ -116,11 +116,11 @@ impl Filter<StoredTransaction> for StreamTransactionFilter {
                         .move_calls()
                         .iter()
                         .any(|(p, m, f)| match module {
-                            Some(module) => {
-                                let Some(ref function) = module.function else {
-                                    return *p == package && *m == module.name;
+                            Some(module_function) => {
+                                let Some(ref function) = module_function.function_name else {
+                                    return *p == package && *m == module_function.module_name;
                                 };
-                                *p == package && *m == module.name && *f == function
+                                *p == package && *m == module_function.module_name && *f == function
                             }
                             None => *p == package,
                         })

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -28,6 +28,8 @@ use crate::{
 
 /// Buffer size used in the bounded channels.
 const BUFFER_SIZE: usize = 1000;
+/// Transaction batch size to send to subscribers.
+const TRANSACTION_BATCH_SIZE: i64 = 50;
 /// Postgres Notify channel name.
 const CHANNEL_NAME: &str = "checkpoint_committed";
 
@@ -263,46 +265,74 @@ impl IndexerStreamer {
         event_tx: broadcast::Sender<StoredEvent>,
         transaction_tx: broadcast::Sender<StoredTransaction>,
     ) -> Result<(), IndexerError> {
-        // Batch checkpoints in smaller chunks to prevent subscriber overload.
-        // Large batches (1000 checkpoints = ~4000-5000 transactions) would cause
-        // immediate subscriber lag. Smaller batches (~10 checkpoints = ~40-50 tx) keep
-        // pace.
-        let buffer_size = BUFFER_SIZE / 100;
         // create a stream from the connection that forwards messages to the channel.
-        let mut stream =
-            stream::poll_fn(move |cx| connection.poll_message(cx)).ready_chunks(buffer_size);
+        let mut stream = stream::poll_fn(move |cx| connection.poll_message(cx)).ready_chunks(10);
 
         while let Some(messages) = stream.next().await {
-            let mut filtered_messages = Self::filter_checkpoint_notifications(messages);
+            if let Some((min_tx_sequence_number, max_tx_sequence_number)) =
+                Self::resolve_tx_bounds(messages)?
+            {
+                let mut start = min_tx_sequence_number;
 
-            let first = filtered_messages.next().transpose()?;
-            let last = filtered_messages.last().transpose()?;
+                while start <= max_tx_sequence_number {
+                    let end = (start + TRANSACTION_BATCH_SIZE - 1).min(max_tx_sequence_number);
 
-            if let Some((first, last)) = first.map(|f| (f, last.unwrap_or(f))) {
-                debug!(notification = ?last);
-
-                let instant = Instant::now();
-                let transactions: Vec<StoredTransaction> = indexer_reader
-                    .spawn_blocking(move |this| {
-                        this.multi_get_transactions_by_sequence_numbers_range(
-                            first.min_tx_sequence_number,
-                            last.max_tx_sequence_number,
-                        )
-                    })
+                    Self::process_transaction_batch(
+                        start,
+                        end,
+                        &indexer_reader,
+                        &event_tx,
+                        &transaction_tx,
+                    )
                     .await?;
 
-                let duration = instant.elapsed();
-                debug!(
-                    "transactions query took: {duration:?}, tx: {}",
-                    transactions.len()
-                );
-
-                let instant = Instant::now();
-                Self::publish_tx_and_events(transactions, &event_tx, &transaction_tx).await?;
-                let duration = instant.elapsed();
-                debug!("broadcast data took: {duration:?}");
+                    start = end + 1;
+                }
             }
         }
+        Ok(())
+    }
+
+    fn resolve_tx_bounds(
+        messages: Vec<Result<AsyncMessage, tokio_postgres::Error>>,
+    ) -> Result<Option<(i64, i64)>, IndexerError> {
+        let mut filtered_messages = Self::filter_checkpoint_notifications(messages);
+
+        let first = filtered_messages.next().transpose()?;
+        let last = filtered_messages.last().transpose()?;
+
+        Ok(first.map(|f| {
+            (
+                f.min_tx_sequence_number,
+                last.unwrap_or(f).max_tx_sequence_number,
+            )
+        }))
+    }
+
+    async fn process_transaction_batch(
+        start: i64,
+        end: i64,
+        indexer_reader: &IndexerReader,
+        event_tx: &broadcast::Sender<StoredEvent>,
+        transaction_tx: &broadcast::Sender<StoredTransaction>,
+    ) -> Result<(), IndexerError> {
+        let instant = Instant::now();
+        let transactions: Vec<StoredTransaction> = indexer_reader
+            .spawn_blocking(move |this| {
+                this.multi_get_transactions_by_sequence_numbers_range(start, end)
+            })
+            .await?;
+
+        debug!(
+            "transactions query took: {:?}, tx: {}",
+            instant.elapsed(),
+            transactions.len()
+        );
+
+        let instant = Instant::now();
+        Self::publish_tx_and_events(transactions, event_tx, transaction_tx).await?;
+        debug!("broadcast data took: {:?}", instant.elapsed());
+
         Ok(())
     }
 

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -1,0 +1,516 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::BTreeMap,
+    str::FromStr,
+    sync::{Arc, RwLock},
+    time::Instant,
+};
+
+use anyhow::Context;
+use futures::{Stream, StreamExt, stream};
+use iota_json_rpc_types::{Filter, IotaTransactionKind};
+use iota_types::{
+    base_types::{IotaAddress, ObjectID},
+    event::Event,
+    transaction::TransactionDataAPI,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio_postgres::{AsyncMessage, Client, Config, Connection, NoTls, Socket, tls::NoTlsStream};
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::{debug, error, warn};
+
+use crate::{
+    errors::IndexerError,
+    indexer_reader::IndexerReader,
+    models::{
+        events::StoredEvent,
+        transactions::{StoredTransaction, stored_events_to_events},
+    },
+    types::IndexerResult,
+};
+
+const BUFFER_SIZE: usize = 1000;
+const MAX_SUBSCRIBERS: usize = 100;
+const CHANNEL_NAME: &str = "checkpoint_committed";
+
+type Subscribers<T, F> = Arc<RwLock<BTreeMap<String, (mpsc::Sender<T>, F)>>>;
+
+#[derive(Clone, Debug, Default)]
+pub enum StreamEventFilter {
+    #[default]
+    All,
+    EmittingPackage(ObjectID),
+    EmittingModule {
+        package: ObjectID,
+        module: String,
+    },
+}
+
+impl Filter<StoredEvent> for StreamEventFilter {
+    fn matches(&self, event: &StoredEvent) -> bool {
+        match self {
+            StreamEventFilter::All => true,
+            StreamEventFilter::EmittingPackage(pkg_addr) => {
+                event.package.as_slice() == pkg_addr.as_ref()
+            }
+            StreamEventFilter::EmittingModule { package, module } => {
+                event.package.as_slice() == package.as_ref() && event.module == *module
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Module {
+    name: String,
+    function: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub enum StreamTransactionFilter {
+    #[default]
+    All,
+    Kind(IotaTransactionKind),
+    SigningAddress(IotaAddress),
+    Function {
+        package: ObjectID,
+        module: Option<Module>,
+    },
+}
+
+impl Filter<StoredTransaction> for StreamTransactionFilter {
+    fn matches(&self, transaction: &StoredTransaction) -> bool {
+        match self {
+            StreamTransactionFilter::All => true,
+            StreamTransactionFilter::Kind(kind) => transaction.transaction_kind == *kind as i16,
+            StreamTransactionFilter::SigningAddress(address) => transaction
+                .try_into_sender_signed_data()
+                .map(|data| data.transaction_data().sender() == *address)
+                .unwrap_or_default(),
+            StreamTransactionFilter::Function { package, module } => transaction
+                .try_into_sender_signed_data()
+                .map(|data| {
+                    data.transaction_data()
+                        .move_calls()
+                        .iter()
+                        .any(|(p, m, f)| match module {
+                            Some(module) => {
+                                let Some(ref function) = module.function else {
+                                    return *p == package && *m == module.name;
+                                };
+                                *p == package && *m == module.name && *f == function
+                            }
+                            None => *p == package,
+                        })
+                })
+                .unwrap_or_default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CheckpointCommitNotification {
+    pub checkpoint_sequence_number: i64,
+    pub min_tx_sequence_number: i64,
+    pub max_tx_sequence_number: i64,
+}
+
+/// A lightweight in-memory fan-out broadcaster that distributes data to
+/// multiple filtered subscribers.
+///
+/// The `Broadcaster` provides a publish-subscribe pattern where a single data
+/// producer can efficiently distribute items to multiple consumers, each with
+/// their own filtering criteria.
+///
+/// # Backpressure Handling
+///
+/// The broadcaster implements automatic subscriber pruning for backpressure
+/// management:
+/// - Each subscriber has a bounded channel with `BUFFER_SIZE` capacity
+/// - Maximum of `MAX_SUBSCRIBERS` concurrent subscribers allowed
+/// - When a subscriber's channel is full, `try_send` fails immediately
+/// - Failed subscribers are automatically removed from the subscriber list
+/// - New subscriptions are rejected when at maximum capacity
+/// - This prevents slow consumers from stalling the entire broadcast system and
+///   prevents OOM
+///
+/// # Filtering
+///
+/// Each subscriber can specify a filter that implements the `Filter<T>` trait.
+/// Only items that match the subscriber's filter are sent to their channel.
+/// Filtering happens after data retrieval but before channel transmission.
+struct Broadcaster<T, F: Filter<T>> {
+    subscribers: Subscribers<T, F>,
+}
+
+impl<T, F> Broadcaster<T, F>
+where
+    T: Clone + Send + 'static,
+    F: Filter<T> + Send + Sync + 'static,
+{
+    /// Creates a new broadcaster that consumes items from the provided
+    /// receiver.
+    ///
+    /// This method spawns a background task that continuously reads from `rx`
+    /// and distributes items to all registered subscribers. The broadcaster
+    /// begins processing immediately upon creation.
+    pub fn new(mut rx: mpsc::Receiver<T>) -> Self {
+        let streamer = Self {
+            subscribers: Default::default(),
+        };
+
+        let subscribers = streamer.subscribers.clone();
+
+        tokio::spawn(async move {
+            while let Some(data) = rx.recv().await {
+                Self::send_to_all_subscribers(subscribers.clone(), data).await;
+            }
+        });
+        streamer
+    }
+
+    async fn send_to_all_subscribers(subscribers: Subscribers<T, F>, data: T) {
+        let to_remove = {
+            let mut to_remove = vec![];
+            let subscribers_snapshot = subscribers
+                .read()
+                .expect("failed to acquire read subscribers lock");
+
+            for (id, (subscriber, filter)) in subscribers_snapshot.iter() {
+                if !(filter.matches(&data)) {
+                    continue;
+                }
+                match subscriber.try_send(data.clone()) {
+                    Ok(_) => {
+                        debug!(subscription_id = id, "Streaming data to subscriber.");
+                    }
+                    Err(e) => {
+                        warn!(
+                            subscription_id = id,
+                            "Error when streaming data, removing subscriber. Error: {e}"
+                        );
+                        to_remove.push(id.clone());
+                    }
+                }
+            }
+            to_remove
+        };
+        if !to_remove.is_empty() {
+            let mut subscribers = subscribers.write().unwrap();
+            for sub in to_remove {
+                subscribers.remove(&sub);
+            }
+        }
+    }
+
+    /// Creates a new subscription to the broadcast stream with the specified
+    /// filter.
+    ///
+    /// Each call to `subscribe` creates an independent stream that:
+    /// - Receives only items that match the provided filter
+    /// - Has its own bounded channel buffer (`BUFFER_SIZE` capacity)
+    /// - Operates independently of other subscribers
+    /// - Is automatically removed if it becomes slow or disconnected
+    ///
+    /// # Subscriber Limit
+    ///
+    /// To prevent memory exhaustion, the broadcaster enforces a maximum of
+    /// `MAX_SUBSCRIBERS` concurrent subscriptions. When this limit is reached,
+    /// new subscription attempts will be rejected.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use futures::StreamExt;
+    ///
+    /// // Attempt to subscribe
+    /// let stream = broadcaster.subscribe(MyFilter::All).unwrap();
+    /// tokio::spawn(async move {
+    ///     while let Some(item) = stream.next().await {
+    ///         process_item(item).await;
+    ///     }
+    /// });
+    /// ```
+    pub fn subscribe(&self, filter: F) -> IndexerResult<impl Stream<Item = T>> {
+        let mut subscribers = self
+            .subscribers
+            .write()
+            .expect("failed to acquire write subscribers lock");
+
+        // Check subscriber limit
+        if subscribers.len() > MAX_SUBSCRIBERS {
+            warn!(
+                "maximum subscribers ({}) reached, rejecting new subscription",
+                MAX_SUBSCRIBERS
+            );
+            return Err(IndexerError::Generic("maximum subscribers reached".into()));
+        }
+
+        let (tx, rx) = mpsc::channel::<T>(BUFFER_SIZE);
+        subscribers.insert(ObjectID::random().to_string(), (tx, filter));
+        Ok(ReceiverStream::new(rx))
+    }
+}
+
+/// Provides filtered, real-time streams of transactions
+/// and events from the IOTA Indexer by listening to PostgreSQL NOTIFY
+/// messages triggered when new checkpoints are committed to the indexer
+/// database.
+///
+/// The streamer consists of:
+/// - A PostgreSQL connection listening for `checkpoint_committed` notifications
+/// - Internal broadcasters that fan-out data to multiple subscribers
+/// - Configurable filters for events and transactions
+/// - Automatic subscriber management with backpressure handling
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// use iota_indexer::stream::{IndexerStreamer, StreamEventFilter, StreamTransactionFilter};
+///
+/// // Create a new streamer
+/// let streamer = IndexerStreamer::new(db_url, indexer_reader).await?;
+///
+/// // Subscribe to all events
+/// let events = streamer.subscribe_events(StreamEventFilter::All).unwrap()
+/// tokio::spawn(async move {
+///     use futures::StreamExt;
+///     while let Some(event) = events.next().await {
+///         println!("New event: {:?}", event);
+///     }
+/// });
+/// ```
+///
+/// # Backpressure Handling
+///
+/// Slow consumers that cannot keep up with the data rate are automatically
+/// pruned to prevent blocking other subscribers. Each subscriber has a bounded
+/// channel with `BUFFER_SIZE` capacity. A maximum of `MAX_SUBSCRIBERS`
+/// concurrent subscriptions is enforced to prevent memory exhaustion.
+pub struct IndexerStreamer {
+    events_broadcaster: Broadcaster<StoredEvent, StreamEventFilter>,
+    transactions_broadcaster: Broadcaster<StoredTransaction, StreamTransactionFilter>,
+}
+
+impl IndexerStreamer {
+    /// Creates a new `IndexerStreamer` instance.
+    ///
+    /// This method establishes a connection to PostgreSQL, sets up the
+    /// notification listener, and spawns the background task that processes
+    /// checkpoint notifications.
+    pub async fn new(db_url: &str, indexer_reader: IndexerReader) -> Result<Self, IndexerError> {
+        let (client, connection) = Config::from_str(db_url)
+            .map_err(|e| IndexerError::Generic(format!("failed to parse Postgresdb url: {e}")))?
+            .connect(NoTls)
+            .await
+            .context("Failed to connect to Postgres")?;
+
+        let (event_tx, event_rx) = mpsc::channel(BUFFER_SIZE);
+        let (transaction_tx, transaction_rx) = mpsc::channel(BUFFER_SIZE);
+
+        tokio::spawn(Self::process_checkpoint_notifications(
+            client,
+            connection,
+            indexer_reader,
+            event_tx,
+            transaction_tx,
+        ));
+
+        Ok(Self {
+            events_broadcaster: Broadcaster::new(event_rx),
+            transactions_broadcaster: Broadcaster::new(transaction_rx),
+        })
+    }
+
+    /// Subscribe to a filtered stream of blockchain events.
+    ///
+    /// Creates a new subscription that will receive events matching the
+    /// provided filter. Each subscriber gets its own independent stream and
+    /// won't be affected by the processing speed of other subscribers.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let events = streamer.subscribe_events(StreamEventFilter::All).unwrap();
+    /// tokio::spawn(async move {
+    ///     use futures::StreamExt;
+    ///     while let Some(event) = events.next().await {
+    ///         println!("Event: {}", event.event_type);
+    ///     }
+    /// });
+    /// ```
+    pub fn subscribe_events(
+        &self,
+        filter: StreamEventFilter,
+    ) -> IndexerResult<impl Stream<Item = StoredEvent>> {
+        self.events_broadcaster.subscribe(filter)
+    }
+
+    /// Subscribe to a filtered stream of blockchain transactions.
+    ///
+    /// Creates a new subscription that will receive transactions matching the
+    /// provided filter. Each subscriber gets its own independent stream and
+    /// won't be affected by the processing speed of other subscribers.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let filter = StreamTransactionFilter::Kind(IotaTransactionKind::ProgrammableTransaction);
+    /// let txs = streamer.subscribe_transactions(filter).unwrap();
+    /// tokio::spawn(async move {
+    ///     use futures::StreamExt;
+    ///     while let Some(tx) = txs.next().await {
+    ///         println!("Transaction: {}", hex::encode(&tx.transaction_digest));
+    ///     }
+    /// });
+    /// ```
+    pub fn subscribe_transactions(
+        &self,
+        filter: StreamTransactionFilter,
+    ) -> IndexerResult<impl Stream<Item = StoredTransaction>> {
+        self.transactions_broadcaster.subscribe(filter)
+    }
+
+    async fn process_checkpoint_notifications(
+        client: Client,
+        mut connection: Connection<Socket, NoTlsStream>,
+        indexer_reader: IndexerReader,
+        event_tx: mpsc::Sender<StoredEvent>,
+        transaction_tx: mpsc::Sender<StoredTransaction>,
+    ) -> Result<(), IndexerError> {
+        // Create a channel for receiving messages
+        let (tx, rx) = mpsc::channel(BUFFER_SIZE);
+
+        // Create a stream from the connection that forwards messages to the channel
+        let stream = stream::poll_fn(move |cx| connection.poll_message(cx));
+        let connection_task = async move {
+            let mut stream = stream;
+            while let Some(message) = stream.next().await {
+                match message {
+                    Ok(msg) => {
+                        if tx.send(msg).await.is_err() {
+                            error!("notification receiver dropped");
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        error!("connection error: {e}");
+                        break;
+                    }
+                }
+            }
+        };
+
+        // Spawn the connection handler
+        tokio::spawn(connection_task);
+
+        // Listen for notifications on a specific channel
+        client
+            .execute(&format!("LISTEN {CHANNEL_NAME};"), &[])
+            .await
+            .context("failed to listen to channel notifications")?;
+
+        let mut notification_stream = ReceiverStream::new(rx).ready_chunks(BUFFER_SIZE);
+
+        while let Some(messages) = notification_stream.next().await {
+            if let Some((first, last)) = Self::first_and_last_checkpoint_notifications(&messages) {
+                debug!(notification = ?last);
+
+                let instant = Instant::now();
+                let transactions: Vec<StoredTransaction> = indexer_reader
+                    .spawn_blocking(move |this| {
+                        this.multi_get_transactions_by_sequence_numbers_range(
+                            first.min_tx_sequence_number,
+                            last.max_tx_sequence_number,
+                        )
+                    })
+                    .await?;
+
+                let duration = instant.elapsed();
+                debug!(
+                    "transactions query took: {duration:?}, tx: {}",
+                    transactions.len()
+                );
+
+                let instant = Instant::now();
+                Self::publish_tx_and_events(transactions, &event_tx, &transaction_tx)?;
+                let duration = instant.elapsed();
+                debug!("broadcast data took: {duration:?}");
+            }
+        }
+
+        Ok(())
+    }
+
+    fn publish_tx_and_events(
+        transactions: Vec<StoredTransaction>,
+        event_tx: &mpsc::Sender<StoredEvent>,
+        transaction_tx: &mpsc::Sender<StoredTransaction>,
+    ) -> Result<(), IndexerError> {
+        for tx in transactions {
+            for event in Self::stored_events_from_transaction(&tx)? {
+                if let Err(e) = event_tx.try_send(event) {
+                    error!("failed to queue event: {e}");
+                }
+            }
+            if let Err(e) = transaction_tx.try_send(tx) {
+                error!("failed to queue transaction: {e}");
+            }
+        }
+        Ok(())
+    }
+
+    fn first_and_last_checkpoint_notifications(
+        messages: &[AsyncMessage],
+    ) -> Option<(CheckpointCommitNotification, CheckpointCommitNotification)> {
+        let mut first: Option<CheckpointCommitNotification> = None;
+        let mut last: Option<CheckpointCommitNotification> = None;
+
+        for msg in messages {
+            match msg {
+                AsyncMessage::Notification(n) => {
+                    match serde_json::from_str::<CheckpointCommitNotification>(n.payload()) {
+                        Ok(parsed) => {
+                            first.get_or_insert(parsed.clone());
+                            last = Some(parsed);
+                        }
+                        Err(e) => {
+                            error!("failed parsing checkpoint notification: {e}");
+                        }
+                    }
+                }
+                AsyncMessage::Notice(notice) => {
+                    warn!("received PostgreSQL notice: {}", notice.message());
+                }
+                _ => {}
+            }
+        }
+
+        first.and_then(|f| last.map(|l| (f, l)))
+    }
+
+    fn stored_events_from_transaction(
+        tx: &StoredTransaction,
+    ) -> Result<Vec<StoredEvent>, IndexerError> {
+        let native_events: Vec<Event> = stored_events_to_events(tx.events.clone())?;
+        let stored = native_events
+            .into_iter()
+            .enumerate()
+            .map(|(idx, native)| StoredEvent {
+                tx_sequence_number: tx.tx_sequence_number,
+                event_sequence_number: idx as i64,
+                transaction_digest: tx.transaction_digest.clone(),
+                senders: vec![Some(native.sender.to_vec())],
+                package: native.package_id.to_vec(),
+                module: native.transaction_module.to_string(),
+                event_type: native.type_.to_canonical_string(/* with_prefix */ true),
+                timestamp_ms: tx.timestamp_ms,
+                bcs: native.contents.clone(),
+            })
+            .collect();
+        Ok(stored)
+    }
+}

--- a/crates/iota-indexer/src/stream.rs
+++ b/crates/iota-indexer/src/stream.rs
@@ -1,13 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::HashMap,
-    fmt::Display,
-    str::FromStr,
-    sync::{Arc, Mutex},
-    time::Instant,
-};
+use std::{str::FromStr, time::Instant};
 
 use anyhow::Context;
 use futures::{Stream, StreamExt, TryFutureExt, stream};
@@ -18,10 +12,10 @@ use iota_types::{
     transaction::TransactionDataAPI,
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc::{self};
+use tokio::sync::broadcast;
 use tokio_postgres::{AsyncMessage, Client, Config, Connection, NoTls, Socket, tls::NoTlsStream};
-use tokio_stream::wrappers::ReceiverStream;
-use tracing::{debug, error, warn};
+use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
+use tracing::{debug, error};
 
 use crate::{
     errors::IndexerError,
@@ -37,46 +31,16 @@ const BUFFER_SIZE: usize = 1000;
 /// Postgres Notify channel name.
 const CHANNEL_NAME: &str = "checkpoint_committed";
 
-/// Active subscribers held in memory.
-type Subscribers<T, F> = Arc<Mutex<HashMap<SubscriberId, Subscriber<T, F>>>>;
-
-/// A single subscriber to which we can send data based on provided filters.
-struct Subscriber<T, F> {
-    sender: mpsc::Sender<StreamPayload<T>>,
-    filter: F,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-struct SubscriberId(ObjectID);
-
-impl SubscriberId {
-    pub fn new() -> Self {
-        SubscriberId(ObjectID::random())
-    }
-}
-
-impl Display for SubscriberId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 /// Filter returned [`StoredEvent`] form the stream.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StreamEventFilter {
-    #[default]
-    All,
     EmittingPackage(ObjectID),
-    EmittingModule {
-        package: ObjectID,
-        module: String,
-    },
+    EmittingModule { package: ObjectID, module: String },
 }
 
 impl Filter<StoredEvent> for StreamEventFilter {
     fn matches(&self, event: &StoredEvent) -> bool {
         match self {
-            StreamEventFilter::All => true,
             StreamEventFilter::EmittingPackage(pkg_addr) => {
                 event.package.as_slice() == pkg_addr.as_ref()
             }
@@ -94,10 +58,8 @@ pub struct Module {
 }
 
 /// Filter returned [`StoredTransaction`] form the stream.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StreamTransactionFilter {
-    #[default]
-    All,
     Kind(IotaTransactionKind),
     SigningAddress(IotaAddress),
     Function {
@@ -109,7 +71,6 @@ pub enum StreamTransactionFilter {
 impl Filter<StoredTransaction> for StreamTransactionFilter {
     fn matches(&self, transaction: &StoredTransaction) -> bool {
         match self {
-            StreamTransactionFilter::All => true,
             StreamTransactionFilter::Kind(kind) => transaction.transaction_kind == *kind as i16,
             StreamTransactionFilter::SigningAddress(address) => transaction
                 .try_into_sender_signed_data()
@@ -149,178 +110,6 @@ struct CheckpointCommitNotification {
     max_tx_sequence_number: i64,
 }
 
-/// Represents events that can be sent to stream subscribers in a broadcasting
-/// system.
-///
-/// This enum encapsulates the different types of messages that subscribers can
-/// receive when listening to a stream. It handles both normal message delivery
-/// and backpressure scenarios where slow subscribers need to be managed.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum StreamPayload<T> {
-    /// A regular message delivered to an active subscriber.
-    ///
-    /// This variant indicates normal operation where the subscriber is keeping
-    /// up with the message flow and can continue receiving subsequent
-    /// messages. The wrapped data represents the actual payload being
-    /// streamed.
-    Message(T),
-    /// The final message sent to a subscriber that is lagging behind.
-    ///
-    /// This variant is sent when the server detects that a subscriber cannot
-    /// process messages fast enough to keep up with the stream. After sending
-    /// this message, the subscriber will be automatically removed from the
-    /// broadcasting system to prevent memory buildup and maintain overall
-    /// system performance.
-    ///
-    /// The wrapped data represents the last message the subscriber will
-    /// receive, allowing for graceful cleanup or final processing before
-    /// disconnection.
-    ClosingDueToLag(T),
-}
-
-/// A lightweight in-memory fan-out broadcaster that distributes data to
-/// multiple filtered subscribers.
-///
-/// It provides a publish-subscribe pattern where a single data producer can
-/// efficiently distribute items to multiple consumers, each with their own
-/// filtering criteria.
-///
-/// # Backpressure Handling
-/// The "slow receiver" problem is handled through capacity-based monitoring:
-///
-/// - **Normal Operation**: When a subscriber's channel has capacity > 1,
-///   messages are sent as [`StreamPayload::Message`] allowing continued
-///   subscription
-/// - **Backpressure Detection**: When capacity drops to 1 (channel nearly
-///   full), the subscriber is marked as lagging behind the message production
-///   rate
-/// - **Graceful Termination**: Lagging subscribers receive their final message
-///   wrapped in [`StreamPayload::ClosingDueToLag`] and are automatically
-///   removed from the subscriber list
-/// - **System Protection**: This prevents unbounded memory growth and maintains
-///   overall broadcaster performance by avoiding blocking on slow consumers
-///
-/// # Filtering
-///
-/// Each subscriber can specify a filter that implements the `Filter<T>` trait.
-/// Only items that match the subscriber's filter are sent to their channel.
-/// Filtering happens after data retrieval but before channel transmission.
-struct Broadcaster<T, F: Filter<T>> {
-    subscribers: Subscribers<T, F>,
-}
-
-impl<T, F> Broadcaster<T, F>
-where
-    T: Clone + Send + 'static,
-    F: Filter<T> + Send + Sync + 'static,
-{
-    /// Creates a new broadcaster that consumes items from the provided
-    /// receiver.
-    ///
-    /// This method spawns a background task that continuously reads from
-    /// [`mpsc::Receiver`] and distributes items to all registered
-    /// subscribers. The broadcaster begins processing immediately upon
-    /// creation.
-    fn new(mut rx: mpsc::Receiver<T>) -> Self {
-        let streamer = Self {
-            subscribers: Default::default(),
-        };
-
-        let subscribers = streamer.subscribers.clone();
-
-        tokio::spawn(async move {
-            while let Some(data) = rx.recv().await {
-                Self::send_to_all_subscribers(subscribers.clone(), data);
-            }
-        });
-        streamer
-    }
-
-    fn send_to_all_subscribers(subscribers: Subscribers<T, F>, data: T) {
-        let to_remove = {
-            let mut to_remove = vec![];
-            let mut subscribers_snapshot = subscribers.lock().unwrap_or_else(|poisoned| {
-                error!("subscribers mutex poisoned, recovering...");
-                subscribers.clear_poison();
-                poisoned.into_inner()
-            });
-
-            for (id, subscriber) in subscribers_snapshot.iter_mut() {
-                if subscriber.sender.is_closed() {
-                    warn!(
-                        subscription_id = id.to_string(),
-                        "subscriber closed connection, removing"
-                    );
-                    to_remove.push(*id);
-                    continue;
-                }
-
-                if !(subscriber.filter.matches(&data)) {
-                    continue;
-                }
-
-                let data = if subscriber.sender.capacity() > 1 {
-                    StreamPayload::Message(data.clone())
-                } else {
-                    warn!(
-                        subscription_id = id.to_string(),
-                        "lagging behind, sending last message and removing"
-                    );
-                    to_remove.push(*id);
-                    StreamPayload::ClosingDueToLag(data.clone())
-                };
-
-                // since we checked the capacity we can ignore the result
-                let _ = subscriber.sender.try_send(data);
-            }
-            to_remove
-        };
-        if !to_remove.is_empty() {
-            let mut subscribers = subscribers.lock().unwrap_or_else(|poisoned| {
-                error!("subscribers mutex poisoned, recovering...");
-                subscribers.clear_poison();
-                poisoned.into_inner()
-            });
-            for sub in to_remove {
-                subscribers.remove(&sub);
-            }
-        }
-    }
-
-    /// Creates a new subscription to the broadcast stream with the specified
-    /// filter.
-    ///
-    /// Each call to `subscribe` creates an independent stream that:
-    /// - Receives only items that match the provided filter
-    /// - Has its own bounded channel buffer ([`BUFFER_SIZE`] capacity)
-    /// - Operates independently of other subscribers
-    /// - Is automatically removed if it's disconnected
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// use futures::StreamExt;
-    ///
-    /// // Attempt to subscribe
-    /// let stream = broadcaster.subscribe(MyFilter::All).unwrap();
-    /// tokio::spawn(async move {
-    ///     while let Some(item) = stream.next().await {
-    ///         process_item(item).await;
-    ///     }
-    /// });
-    /// ```
-    fn subscribe(&self, filter: F) -> impl Stream<Item = StreamPayload<T>> {
-        let mut subscribers = self.subscribers.lock().unwrap_or_else(|poisoned| {
-            error!("subscribers mutex poisoned, recovering...");
-            self.subscribers.clear_poison();
-            poisoned.into_inner()
-        });
-        let (tx, rx) = mpsc::channel::<StreamPayload<T>>(BUFFER_SIZE);
-        subscribers.insert(SubscriberId::new(), Subscriber { sender: tx, filter });
-        ReceiverStream::new(rx)
-    }
-}
-
 /// Provides filtered, real-time streams of transactions
 /// and events from the IOTA Indexer by listening to PostgreSQL NOTIFY
 /// messages triggered when new checkpoints are committed to the indexer
@@ -328,20 +117,19 @@ where
 ///
 /// The streamer consists of:
 /// - A PostgreSQL connection listening for `checkpoint_committed` notifications
-/// - Internal broadcasters that fan-out data to multiple subscribers
-/// - Configurable filters for events and transactions
-/// - Automatic subscriber management with backpressure handling
+/// - Internal broadcasters that fan-out data to multiple subscribers using a
+///   [`tokio::sync::broadcast`] channels
 ///
 /// # Usage
 ///
 /// ```rust,ignore
-/// use iota_indexer::stream::{IndexerStreamer, StreamEventFilter, StreamTransactionFilter};
+/// use iota_indexer::stream::{IndexerStreamer, StreamTransactionFilter};
 ///
 /// // Create a new streamer
 /// let streamer = IndexerStreamer::new(db_url, indexer_reader).await?;
 ///
 /// // Subscribe to all events
-/// let events = streamer.subscribe_events(StreamEventFilter::All).unwrap()
+/// let events = streamer.subscribe_events().unwrap()
 /// tokio::spawn(async move {
 ///     use futures::StreamExt;
 ///     while let Some(event) = events.next().await {
@@ -349,24 +137,9 @@ where
 ///     }
 /// });
 /// ```
-///
-/// # Backpressure Handling
-/// The "slow receiver" problem is handled through capacity-based monitoring:
-///
-/// - **Normal Operation**: When a subscriber's channel has capacity > 1,
-///   messages are sent as [`StreamPayload::Message`] allowing continued
-///   subscription
-/// - **Backpressure Detection**: When capacity drops to 1 (channel nearly
-///   full), the subscriber is marked as lagging behind the message production
-///   rate
-/// - **Graceful Termination**: Lagging subscribers receive their final message
-///   wrapped in [`StreamPayload::ClosingDueToLag`] and are automatically
-///   removed from the subscriber list
-/// - **System Protection**: This prevents unbounded memory growth and maintains
-///   overall broadcaster performance by avoiding blocking on slow consumers
 pub struct IndexerStreamer {
-    events_broadcaster: Broadcaster<StoredEvent, StreamEventFilter>,
-    transactions_broadcaster: Broadcaster<StoredTransaction, StreamTransactionFilter>,
+    event_tx: broadcast::Sender<StoredEvent>,
+    transaction_tx: broadcast::Sender<StoredTransaction>,
     // To receive notifications from the database we must keep the client alive.
     _client: Client,
 }
@@ -384,8 +157,8 @@ impl IndexerStreamer {
             .await
             .context("Failed to connect to Postgres")?;
 
-        let (event_tx, event_rx) = mpsc::channel(BUFFER_SIZE);
-        let (transaction_tx, transaction_rx) = mpsc::channel(BUFFER_SIZE);
+        let (event_tx, _) = broadcast::channel(BUFFER_SIZE);
+        let (transaction_tx, _) = broadcast::channel(BUFFER_SIZE);
 
         // the database connection must be spawned into a separate task in order to
         // communicate with the database.
@@ -393,8 +166,8 @@ impl IndexerStreamer {
             Self::process_checkpoint_notifications(
                 connection,
                 indexer_reader,
-                event_tx,
-                transaction_tx,
+                event_tx.clone(),
+                transaction_tx.clone(),
             )
             .inspect_err(|e| error!("failed to process checkpoint notification: {e}"))
         });
@@ -406,41 +179,37 @@ impl IndexerStreamer {
             .context("failed to listen to channel notifications")?;
 
         Ok(Self {
-            events_broadcaster: Broadcaster::new(event_rx),
-            transactions_broadcaster: Broadcaster::new(transaction_rx),
+            event_tx,
+            transaction_tx,
             _client: client,
         })
     }
 
-    /// Subscribe to a filtered stream of blockchain events.
+    /// Subscribe to a stream of [`StoredEvent`].
     ///
-    /// Creates a new subscription that will receive events matching the
-    /// provided filter. Each subscriber gets its own independent stream and
-    /// won't be affected by the processing speed of other subscribers.
+    /// By default all events are received, it's possible to filter on client
+    /// side by using [`StreamEventFilter`] type.
     ///
     /// # Note
-    /// If the subscriber cannot keep up with the event production rate (slow
-    /// subscriber problem), it will automatically receive a final
-    /// [`StreamPayload::ClosingDueToLag`] message and be disconnected to
-    /// prevent system-wide performance degradation. Subscribers can
-    /// resubscribe at any time to resume receiving events, but **any
-    /// messages that occurred during the disconnection period will be
-    /// lost** - the new subscription will only receive events from the
-    /// point of resubscription forward.
+    /// Since under the hood a [`tokio::sync::broadcast`] channel is used the
+    /// slow subscriber problem will be handled according to [documentation](https://docs.rs/tokio/latest/tokio/sync/broadcast/index.html#lagging)
     ///
     /// # Example
     ///
     /// ```rust,ignore
-    /// let events = streamer.subscribe_events(StreamEventFilter::All).unwrap();
+    /// let event_stream = streamer.subscribe_events().unwrap();
     /// tokio::spawn(async move {
     ///     use futures::StreamExt;
-    ///     while let Some(stream_event) = events.next().await {
-    ///         match stream_event {
-    ///             StreamPayload::Message(ev) => {
-    ///                 println!("Transaction: {ev:?}");
+    ///     while let Some(ev) = event_stream.next().await {
+    ///         match ev {
+    ///             Ok(ev) => {
+    ///                 if !StreamEventFilter::matches(&ev) {
+    ///                     continue;
+    ///                 };
+    ///                 println!("Received event: {ev:?}");
     ///             }
-    ///             StreamPayload::ClosingDueToLag(last_ev) => {
-    ///                 println!("Last Transaction: {last_ev:?}");
+    ///             Err(BroadcastStreamRecvError::Lagged(num)) => {
+    ///                 println!("Lagged by {num} events");
     ///             }
     ///         }
     ///     }
@@ -448,58 +217,51 @@ impl IndexerStreamer {
     /// ```
     pub fn subscribe_events(
         &self,
-        filter: StreamEventFilter,
-    ) -> impl Stream<Item = StreamPayload<StoredEvent>> {
-        self.events_broadcaster.subscribe(filter)
+    ) -> impl Stream<Item = Result<StoredEvent, BroadcastStreamRecvError>> {
+        BroadcastStream::new(self.event_tx.subscribe())
     }
 
-    /// Subscribe to a filtered stream of blockchain transactions.
+    /// Subscribe to a stream of [`StoredTransaction`].
     ///
-    /// Creates a new subscription that will receive transactions matching the
-    /// provided filter. Each subscriber gets its own independent stream and
-    /// won't be affected by the processing speed of other subscribers.
+    /// By default all events are received, it's possible to filter on client
+    /// side by using [`StreamTransactionFilter`] type.
     ///
     /// # Note
-    /// If the subscriber cannot keep up with the event production rate (slow
-    /// subscriber problem), it will automatically receive a final
-    /// [`StreamPayload::ClosingDueToLag`] message and be disconnected to
-    /// prevent system-wide performance degradation. Subscribers can
-    /// resubscribe at any time to resume receiving events, but **any
-    /// messages that occurred during the disconnection period will be
-    /// lost** - the new subscription will only receive events from the
-    /// point of resubscription forward.
+    /// Since under the hood a [`tokio::sync::broadcast`] channel is used the
+    /// slow subscriber problem will be handled according to [documentation](https://docs.rs/tokio/latest/tokio/sync/broadcast/index.html#lagging)
     ///
     /// # Example
     ///
     /// ```rust,ignore
     /// let filter = StreamTransactionFilter::Kind(IotaTransactionKind::ProgrammableTransaction);
-    /// let txs = streamer.subscribe_transactions(filter).unwrap();
+    /// let tx_stream = streamer.subscribe_transactions().unwrap();
     /// tokio::spawn(async move {
     ///     use futures::StreamExt;
-    ///     while let Some(stream_event) = txs.next().await {
-    ///         match stream_event {
-    ///             StreamPayload::Message(tx) => {
+    ///     while let Some(tx) = tx_stream.next().await {
+    ///         match tx {
+    ///             Ok(tx) => {
+    ///                 if !filter.matches(&tx) {
+    ///                     continue;
+    ///                 };
     ///                 println!("Transaction: {tx:?}");
     ///             }
-    ///             StreamPayload::ClosingDueToLag(last_tx) => {
-    ///                 println!("Last Transaction: {last_tx:?}");
+    ///             Err(BroadcastStreamRecvError::Lagged(num)) => {
+    ///                 println!("Lagged by {num} transactions");
     ///             }
     ///         }
     ///     }
     /// });
-    /// ```
     pub fn subscribe_transactions(
         &self,
-        filter: StreamTransactionFilter,
-    ) -> impl Stream<Item = StreamPayload<StoredTransaction>> {
-        self.transactions_broadcaster.subscribe(filter)
+    ) -> impl Stream<Item = Result<StoredTransaction, BroadcastStreamRecvError>> {
+        BroadcastStream::new(self.transaction_tx.subscribe())
     }
 
     async fn process_checkpoint_notifications(
         mut connection: Connection<Socket, NoTlsStream>,
         indexer_reader: IndexerReader,
-        event_tx: mpsc::Sender<StoredEvent>,
-        transaction_tx: mpsc::Sender<StoredTransaction>,
+        event_tx: broadcast::Sender<StoredEvent>,
+        transaction_tx: broadcast::Sender<StoredTransaction>,
     ) -> Result<(), IndexerError> {
         // Batch checkpoints in smaller chunks to prevent subscriber overload.
         // Large batches (1000 checkpoints = ~4000-5000 transactions) would cause
@@ -546,22 +308,16 @@ impl IndexerStreamer {
 
     async fn publish_tx_and_events(
         transactions: Vec<StoredTransaction>,
-        event_tx: &mpsc::Sender<StoredEvent>,
-        transaction_tx: &mpsc::Sender<StoredTransaction>,
+        event_tx: &broadcast::Sender<StoredEvent>,
+        transaction_tx: &broadcast::Sender<StoredTransaction>,
     ) -> Result<(), IndexerError> {
+        // we ignore errors here because we may receive an error if no subscribers are
+        // registered which may happen.
         for tx in transactions {
             for event in Self::stored_events_from_transaction(&tx)? {
-                if event_tx.send(event).await.is_err() {
-                    return Err(IndexerError::ChannelClosed(
-                        "failed to send event, receiver half dropped".into(),
-                    ));
-                }
+                _ = event_tx.send(event);
             }
-            if transaction_tx.send(tx).await.is_err() {
-                return Err(IndexerError::ChannelClosed(
-                    "failed to send transaction, receiver half dropped".into(),
-                ));
-            }
+            _ = transaction_tx.send(tx);
         }
         Ok(())
     }


### PR DESCRIPTION
# Description of change

This PR is the first iteration attempt to provide streaming support for the `iota-indexer` as a library componente. Currently it supports streaming of `StoredEvents` and `StoredTransactions`. It also supports filters.

## Links to any relevant issues

fixes #8315 

## How the change has been tested
created a separated binary which used the `iota-indexer` as a library, used `testnet` network as source of checkpoints for synchronization, subscribed to incoming events, applied different filter to assert that they were respected.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [x] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

### Release Notes
- [x] Indexer: Add streaming support for `events` and `transactions`.
