### PR TITLE
fix(explorer): Use `href` for the `link` field in the explorer object view

### DIFF
--- a/apps/explorer/src/pages/object-result/views/ObjectView.tsx
+++ b/apps/explorer/src/pages/object-result/views/ObjectView.tsx
@@ -299,7 +299,7 @@ export function ObjectView({ data }: ObjectViewProps): JSX.Element {
                     <div className="flex-1">
                         <DisplayStats
                             label="Link"
-                            value={<Link to={display.link}>{display.link}</Link>}
+                            value={<Link href={display.link}>{display.link}</Link>}
                         />
                     </div>
                 )}


### PR DESCRIPTION
Fixes https://explorer.iota.org/object/0xf698c966b6c11d2c8093a8b3e2bd0f55f700deaf33d6b23b31890093f40d6ca7