### PR TITLE
fix: ptb arguments checking

### DIFF
--- a/crates/iota-types/src/auth_context.rs
+++ b/crates/iota-types/src/auth_context.rs
@@ -3,7 +3,7 @@
 
 use move_binary_format::{CompiledModule, file_format::SignatureToken};
 use move_bytecode_utils::resolve_struct;
-use move_core_types::{ident_str, identifier::IdentStr};
+use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -95,11 +95,7 @@ impl AuthContext {
 
         let (module_addr, module_name, struct_name) = resolve_struct(module, *idx);
 
-        let is_auth_context_type = module_name == AUTH_CONTEXT_MODULE_NAME
-            && module_addr == &IOTA_FRAMEWORK_ADDRESS
-            && struct_name == AUTH_CONTEXT_STRUCT_NAME;
-
-        if is_auth_context_type {
+        if is_auth_context(module_addr, module_name, struct_name) {
             kind
         } else {
             AuthContextKind::None
@@ -115,4 +111,14 @@ pub enum AuthContextKind {
     Mutable,
     // &AuthContext
     Immutable,
+}
+
+pub fn is_auth_context(
+    module_addr: &AccountAddress,
+    module_name: &IdentStr,
+    struct_name: &IdentStr,
+) -> bool {
+    module_addr == &IOTA_FRAMEWORK_ADDRESS
+        && module_name == AUTH_CONTEXT_MODULE_NAME
+        && struct_name == AUTH_CONTEXT_STRUCT_NAME
 }

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -1391,20 +1391,7 @@ mod checked {
             // injected yet.
             let is_last_arg = idx == (args.len() - 1);
             if is_last_arg && is_auth_context(context, non_ref_param_ty)? {
-                assert_invariant!(
-                    context.protocol_config.move_auth(),
-                    "`iota::auth_context::AuthContext` can't be used as a parameter if the `move_auth` feature is disabled"
-                );
-
-                // TODO: Should we try to deserialize?
-                // TODO: Create a MOVE_AUTHENTICATION mode to make sure that `AuthContext` is
-                // used only for authentication?
-                if !matches!(value, Value::Raw(RawValueType::Any, _)) {
-                    return Err(command_argument_error(
-                        CommandArgumentError::TypeMismatch,
-                        idx,
-                    ));
-                }
+                check_auth_context_value(context, idx, &value)?;
             } else {
                 check_param_type::<Mode>(context, idx, &value, non_ref_param_ty)?;
             }
@@ -1515,6 +1502,31 @@ mod checked {
             }
         }
         Ok(())
+    }
+
+    /// Checks that the value represents the `iota::auth_context::AuthContext`
+    /// type.
+    fn check_auth_context_value(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        idx: usize,
+        value: &Value,
+    ) -> Result<(), ExecutionError> {
+        assert_invariant!(
+            context.protocol_config.move_auth(),
+            "`iota::auth_context::AuthContext` can't be used as a parameter if the `move_auth` feature is disabled"
+        );
+
+        // TODO: Should we try to deserialize?
+        // TODO: Create a MOVE_AUTHENTICATION mode to make sure that `AuthContext` is
+        // used only for authentication?
+        if matches!(value, Value::Raw(RawValueType::Any, _)) {
+            return Ok(());
+        }
+
+        Err(command_argument_error(
+            CommandArgumentError::TypeMismatch,
+            idx,
+        ))
     }
 
     fn to_identifier(

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -1389,6 +1389,11 @@ mod checked {
             // functions.
             // It must be the last one in the arguments list since the `TxContext` is not
             // injected yet.
+            //
+            // TODO: We must check the `AuthContext` parameter here because it is added
+            // to the `args` list when the authenticator transaction is created. It leads to
+            // having a more complex validation logic, so we need to refactor this and
+            // inject `AuthContext` in the same way how it is done for `TxContext`.
             let is_last_arg = idx == (args.len() - 1);
             if is_last_arg && is_auth_context(context, non_ref_param_ty)? {
                 check_auth_context_value(context, idx, &value)?;
@@ -1516,9 +1521,8 @@ mod checked {
             "`iota::auth_context::AuthContext` can't be used as a parameter if the `move_auth` feature is disabled"
         );
 
-        // TODO: Should we try to deserialize?
-        // TODO: Create a MOVE_AUTHENTICATION mode to make sure that `AuthContext` is
-        // used only for authentication?
+        // TODO: Consider creating a MOVE_AUTHENTICATION execution mode to make sure
+        // that `AuthContext` is used only for authentication.
         if matches!(value, Value::Raw(RawValueType::Any, _)) {
             return Ok(());
         }

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -15,7 +15,7 @@ mod checked {
     use iota_move_natives::object_runtime::ObjectRuntime;
     use iota_protocol_config::ProtocolConfig;
     use iota_types::{
-        IOTA_FRAMEWORK_ADDRESS,
+        IOTA_FRAMEWORK_ADDRESS, auth_context,
         base_types::{
             IotaAddress, MoveObjectType, ObjectID, RESOLVED_ASCII_STR, RESOLVED_STD_OPTION,
             RESOLVED_UTF8_STR, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME, TxContext,
@@ -1385,7 +1385,29 @@ mod checked {
                     idx,
                 ));
             }
-            check_param_type::<Mode>(context, idx, &value, non_ref_param_ty)?;
+            // We allow passing in the `AuthContext` as an argument to authenticate
+            // functions.
+            // It must be the last one in the arguments list since the `TxContext` is not
+            // injected yet.
+            let is_last_arg = idx == (args.len() - 1);
+            if is_last_arg && is_auth_context(context, non_ref_param_ty)? {
+                assert_invariant!(
+                    context.protocol_config.move_auth(),
+                    "`iota::auth_context::AuthContext` can't be used as a parameter if the `move_auth` feature is disabled"
+                );
+
+                // TODO: Should we try to deserialize?
+                // TODO: Create a MOVE_AUTHENTICATION mode to make sure that `AuthContext` is
+                // used only for authentication?
+                if !matches!(value, Value::Raw(RawValueType::Any, _)) {
+                    return Err(command_argument_error(
+                        CommandArgumentError::TypeMismatch,
+                        idx,
+                    ));
+                }
+            } else {
+                check_param_type::<Mode>(context, idx, &value, non_ref_param_ty)?;
+            }
             let bytes = {
                 let mut v = vec![];
                 value.write_bcs_bytes(&mut v, None)?;
@@ -1403,6 +1425,11 @@ mod checked {
         value: &Value,
         param_ty: &Type,
     ) -> Result<(), ExecutionError> {
+        assert_invariant!(
+            !is_auth_context(context, param_ty)?,
+            "`iota::auth_context::AuthContext` struct is not expected to be used here"
+        );
+
         match value {
             // For dev-spect, allow any BCS bytes. This does mean internal invariants for types can
             // be violated (like for string or Option)
@@ -1566,6 +1593,30 @@ mod checked {
         } else {
             TxContextKind::None
         })
+    }
+
+    // Returns `true` if the type is a Datatype with identifier matching
+    // `AuthContext`.
+    // Returns `false` for all other types or identifiers not matching.
+    pub fn is_auth_context(
+        context: &ExecutionContext<'_, '_, '_>,
+        t: &Type,
+    ) -> Result<bool, ExecutionError> {
+        let Type::Datatype(idx) = t else {
+            return Ok(false);
+        };
+
+        let Some(s) = context.vm.get_runtime().get_type(*idx) else {
+            invariant_violation!("Loaded struct not found")
+        };
+
+        let (module_addr, module_name, struct_name) = get_datatype_ident(&s);
+
+        Ok(auth_context::is_auth_context(
+            module_addr,
+            module_name,
+            struct_name,
+        ))
     }
 
     /// Returns Some(layout) iff it is a primitive, an ID, a String, or an


### PR DESCRIPTION
# Description of change

Fixed the following issue:
```
ErrorObject { code: ServerError(-32002), message: "Transaction execution failed due to issues with transaction inputs, please review the errors and try again:\n- Failed to execute the Move authenticator, reason: \"ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 2, kind: InvalidUsageOfPureArg }, source: Some(\\\"Non-primitive argument at index 2. If it is an object, it must be populated by an object\\\"), command: Some(0) } }\".", data: None }.
```

It is a temporary fix; the solution will be refactored to align with the `TxContext` approach.

## Links to any relevant issues

fixes #8545
