### PR TITLE
fix(auth_context): serialization uses TypeName instead of TypeInput

### DIFF
--- a/crates/iota-types/src/auth_context.rs
+++ b/crates/iota-types/src/auth_context.rs
@@ -5,7 +5,7 @@ use move_binary_format::{CompiledModule, file_format::SignatureToken};
 use move_bytecode_utils::resolve_struct;
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
 use serde::{
-    Deserialize, Serialize, Serializer,
+    Serialize, Serializer,
     ser::{SerializeStruct, SerializeStructVariant, SerializeTupleVariant},
 };
 
@@ -44,7 +44,7 @@ pub const AUTH_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("AuthContext");
 /// ```
 // Conceptually similar to `TxContext`, but designed specifically for use in the authentication
 // flow.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AuthContext {
     /// The digest of the MoveAuthenticator
     auth_digest: MoveAuthenticatorDigest,
@@ -107,6 +107,11 @@ impl AuthContext {
     }
 }
 
+// TODO: add a deserializer that can handle the Command::MoveCall and
+// Command::MakeMoveVec variants properly. For now, we only need serialization
+// for inclusion in the tx authenticator input, so we implement Serialize only.
+// Alternatively, a custom Command struct could be created for de/serialization
+// purposes or to add new functionalities.
 impl Serialize for AuthContext {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/iota-types/src/auth_context.rs
+++ b/crates/iota-types/src/auth_context.rs
@@ -4,12 +4,16 @@
 use move_binary_format::{CompiledModule, file_format::SignatureToken};
 use move_bytecode_utils::resolve_struct;
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize, Serialize, Serializer,
+    ser::{SerializeStruct, SerializeStructVariant, SerializeTupleVariant},
+};
 
 use crate::{
     IOTA_FRAMEWORK_ADDRESS,
     digests::MoveAuthenticatorDigest,
     transaction::{CallArg, Command, ProgrammableTransaction},
+    type_input::TypeName,
 };
 
 pub const AUTH_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("auth_context");
@@ -40,7 +44,7 @@ pub const AUTH_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("AuthContext");
 /// ```
 // Conceptually similar to `TxContext`, but designed specifically for use in the authentication
 // flow.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct AuthContext {
     /// The digest of the MoveAuthenticator
     auth_digest: MoveAuthenticatorDigest,
@@ -100,6 +104,61 @@ impl AuthContext {
         } else {
             AuthContextKind::None
         }
+    }
+}
+
+impl Serialize for AuthContext {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("AuthContext", 3)?;
+        state.serialize_field("auth_digest", &self.auth_digest)?;
+        state.serialize_field("tx_inputs", &self.tx_inputs)?;
+
+        // Serialize tx_commands as a Vec of enums, matching the original logic
+        struct CommandSer<'a>(&'a Command);
+
+        impl<'a> Serialize for CommandSer<'a> {
+            fn serialize<SC>(&self, serializer: SC) -> Result<SC::Ok, SC::Error>
+            where
+                SC: Serializer,
+            {
+                match self.0 {
+                    Command::MoveCall(m) => {
+                        let mut s =
+                            serializer.serialize_struct_variant("Command", 0, "MoveCall", 5)?;
+                        s.serialize_field("package", &m.package)?;
+                        s.serialize_field("module", &m.module)?;
+                        s.serialize_field("function", &m.function)?;
+                        s.serialize_field(
+                            "type_arguments",
+                            &m.type_arguments
+                                .iter()
+                                .map(|ty| TypeName::from(ty))
+                                .collect::<Vec<_>>(),
+                        )?;
+                        s.serialize_field("arguments", &m.arguments)?;
+                        s.end()
+                    }
+                    Command::MakeMoveVec(ty_opt, vals) => {
+                        let mut s =
+                            serializer.serialize_tuple_variant("Command", 5, "MakeMoveVec", 2)?;
+                        s.serialize_field(&ty_opt.as_ref().map(|ty| TypeName::from(ty)))?;
+                        s.serialize_field(vals)?;
+                        s.end()
+                    }
+                    _ => self.0.serialize(serializer),
+                }
+            }
+        }
+
+        state.serialize_field(
+            "tx_commands",
+            &self.tx_commands.iter().map(CommandSer).collect::<Vec<_>>(),
+        )?;
+
+        state.end()
     }
 }
 

--- a/crates/iota-types/src/type_input.rs
+++ b/crates/iota-types/src/type_input.rs
@@ -13,6 +13,37 @@ use move_core_types::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::parse_iota_type_tag;
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct TypeName {
+    /// String representation of the type. All types are represented
+    /// using their source syntax:
+    /// "u8", "u64", "bool", "address", "vector", and so on for primitive types.
+    /// Struct types are represented as fully qualified type names; e.g.
+    /// `00000000000000000000000000000001::string::String` or
+    /// `0000000000000000000000000000000a::module_name1::type_name1<0000000000000000000000000000000a::module_name2::type_name2<u64>>`
+    /// Addresses are hex-encoded lowercase values of length ADDRESS_LENGTH (16,
+    /// 20, or 32 depending on the Move platform)
+    pub name: String,
+}
+
+impl From<&TypeInput> for TypeName {
+    fn from(value: &TypeInput) -> Self {
+        TypeName {
+            name: value.to_canonical_string(false /* with_prefix */),
+        }
+    }
+}
+
+impl TryFrom<TypeName> for TypeInput {
+    type Error = anyhow::Error;
+
+    fn try_from(value: TypeName) -> Result<Self, Self::Error> {
+        parse_iota_type_tag(&value.name).map(|tag| tag.into())
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub struct StructInput {
     pub address: AccountAddress,


### PR DESCRIPTION
# Description of change

Given that the `AuthContext` Move representation makes use of the `TypeName`, i.e., the string representation of the type, its serializer was implemented to support the conversion from `TypeInput` to `TypeName`.

## Links to any relevant issues

Fixes #8455 issue 3

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
