### PR TITLE
upstream(iota-data-ingestion-core): disable inotify for macos

### DIFF
--- a/crates/iota-data-ingestion-core/src/reader/fetch.rs
+++ b/crates/iota-data-ingestion-core/src/reader/fetch.rs
@@ -13,9 +13,9 @@ use std::{
 use iota_rest_api::{CheckpointData, Client};
 use iota_storage::blob::Blob;
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
-use notify::{RecursiveMode, Watcher};
+#[cfg(not(target_os = "macos"))]
+use notify::{RecommendedWatcher, RecursiveMode};
 use object_store::{ObjectStore, path::Path as ObjectStorePath};
-use tokio::sync::mpsc;
 use tracing::{debug, info};
 
 use crate::{
@@ -142,32 +142,31 @@ pub(crate) trait LocalRead {
         }
         Ok(())
     }
+}
 
-    /// Sets up an inotify watcher on the given path and returns the watcher and
-    /// a receiver for notifications.
-    ///
-    /// This function creates the directory if it does not exist, sets up a
-    /// notify watcher, and returns both the watcher and a receiver that
-    /// yields a unit value `()` whenever a filesystem event occurs.
-    fn setup_directory_watcher(&self) -> (notify::RecommendedWatcher, mpsc::Receiver<()>) {
-        let (inotify_sender, inotify_recv) = mpsc::channel(1);
-        std::fs::create_dir_all(self.path()).expect("failed to create a directory");
-        let mut watcher = notify::recommended_watcher(move |res| {
-            if let Err(err) = res {
-                eprintln!("watch error: {err:?}");
-            }
-            inotify_sender
-                .blocking_send(())
-                .expect("Failed to send inotify update");
-        })
-        .expect("Failed to init inotify");
+/// Sets up an inotify watcher on the given path and returns the watcher. The
+/// Receiver yields a unit value `()` whenever a filesystem event occurs
+/// in the watched directory
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn init_watcher(
+    inotify_sender: tokio::sync::mpsc::Sender<()>,
+    path: &Path,
+) -> RecommendedWatcher {
+    use notify::Watcher;
 
-        watcher
-            .watch(self.path(), RecursiveMode::NonRecursive)
-            .expect("Inotify watcher failed");
-
-        (watcher, inotify_recv)
-    }
+    let mut watcher = notify::recommended_watcher(move |res| {
+        if let Err(err) = res {
+            eprintln!("watch error: {err:?}");
+        }
+        inotify_sender
+            .blocking_send(())
+            .expect("Failed to send inotify update");
+    })
+    .expect("Failed to init inotify");
+    watcher
+        .watch(path, RecursiveMode::NonRecursive)
+        .expect("Inotify watcher failed");
+    watcher
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/iota-data-ingestion-core/src/reader/v1.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v1.rs
@@ -4,6 +4,7 @@
 
 use std::{
     collections::BTreeMap,
+    fs,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -26,6 +27,8 @@ use tokio::{
 };
 use tracing::{debug, error, info};
 
+#[cfg(not(target_os = "macos"))]
+use crate::reader::fetch::init_watcher;
 use crate::{
     IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS, create_remote_store_client,
     reader::fetch::{
@@ -303,7 +306,12 @@ impl CheckpointReader {
     }
 
     pub async fn run(mut self) -> IngestionResult<()> {
-        let (_watcher, mut inotify_recv) = self.setup_directory_watcher();
+        let (_inotify_sender, mut inotify_recv) = mpsc::channel::<()>(1);
+        fs::create_dir_all(self.path()).expect("failed to create a directory");
+
+        #[cfg(not(target_os = "macos"))]
+        let _watcher = init_watcher(_inotify_sender, self.path());
+
         self.data_limiter.gc(self.last_pruned_watermark);
         self.gc_processed_files(self.last_pruned_watermark)
             .expect("Failed to clean the directory");

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -30,6 +30,8 @@ use tokio::{
 };
 use tracing::{debug, error, info};
 
+#[cfg(not(target_os = "macos"))]
+use crate::reader::fetch::init_watcher;
 use crate::{
     IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS, create_remote_store_client,
     history::reader::HistoricalReader,
@@ -451,7 +453,12 @@ impl CheckpointReaderActor {
 
     /// Run the main loop of the checkpoint reader actor.
     async fn run(mut self) {
-        let (_watcher, mut inotify_rx) = self.setup_directory_watcher();
+        let (_inotify_tx, mut inotify_rx) = mpsc::channel::<()>(1);
+        std::fs::create_dir_all(self.path()).expect("failed to create a directory");
+
+        #[cfg(not(target_os = "macos"))]
+        let _watcher = init_watcher(_inotify_tx, self.path());
+
         self.data_limiter.gc(self.last_pruned_watermark);
         self.gc_processed_files(self.last_pruned_watermark)
             .expect("Failed to clean the directory");


### PR DESCRIPTION
# Description of change

This PR adds an upstream patch to fix `macOS` deadlock issues in tests by disabling `inotify `file watching.

## Links to any relevant issues

fixes #8582 

## How the change has been tested

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Ran `iota-data-ingestion-core` and `iota-indexer` tests
```shell
cargo test -p iota-data-ingestion-core
```
```shell
cargo test -p iota-indexer --profile simulator --features shared_test_runtime
```
Noticed that when running indexer tests  it does not make the tests hang on macos, previously very rarely it could hang.
- Built a docker image to simulate a different os (Linux) to test the remaining code, the image was built successfully.
- Ran `Build IOTA binaries` Github Action to make sure that the change will not impact the build of binaries for different OS.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.