### PR TITLE
feat(tx-test-runner): Add dev inspect and dry run tests

### DIFF
--- a/crates/iota-adapter-transactional-tests/tests/dev_inspect/arbitrary_args.move
+++ b/crates/iota-adapter-transactional-tests/tests/dev_inspect/arbitrary_args.move
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// arbitrary struct input allowed for dev inspect
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m {
+    public struct S has key {
+        id: UID,
+        setting: u64,
+    }
+
+    public fun take_s(s: S) {
+        let S { id, .. } = s;
+        id.delete();
+    }
+}
+
+//# programmable --sender A --inputs struct(@empty,0) --dev-inspect
+//> 0: test::m::take_s(Input(0));

--- a/crates/iota-adapter-transactional-tests/tests/dev_inspect/arbitrary_args.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dev_inspect/arbitrary_args.snap
@@ -1,0 +1,20 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 9-21:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4461200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 23-24:
+//# programmable --sender A --inputs struct(@empty,0) --dev-inspect
+//> 0: test::m::take_s(Input(0));
+mutated: object(_)
+unwrapped_then_deleted: object(_)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 980400,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/dev_inspect/conservation.move
+++ b/crates/iota-adapter-transactional-tests/tests/dev_inspect/conservation.move
@@ -1,0 +1,21 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// conservation checks disabled for dev inspect
+
+//# init --addresses test=0x0 --accounts A B
+
+//# publish
+
+module test::m {
+    use iota::iota::IOTA;
+    use iota::coin::Coin;
+
+    public fun transfer_back(c: Coin<IOTA>, ctx: &mut TxContext) {
+        iota::transfer::public_transfer(c, tx_context::sender(ctx))
+    }
+}
+
+//# programmable --sender A --inputs struct(@empty,1) --dev-inspect
+//> 0: test::m::transfer_back(Input(0));

--- a/crates/iota-adapter-transactional-tests/tests/dev_inspect/conservation.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dev_inspect/conservation.snap
@@ -1,0 +1,20 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 9-18:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4826000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 20-21:
+//# programmable --sender A --inputs struct(@empty,1) --dev-inspect
+//> 0: test::m::transfer_back(Input(0));
+mutated: object(_)
+unwrapped: object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/dev_inspect/entry_checks.move
+++ b/crates/iota-adapter-transactional-tests/tests/dev_inspect/entry_checks.move
@@ -1,0 +1,21 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// entry checks disabled during dev inspect
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m {
+    public fun return_u64(): u64 {
+        0
+    }
+    entry fun entry_take_u64(_n: u64) {
+    }
+}
+
+//# programmable --sender A --dev-inspect
+//> 0: test::m::return_u64();
+//> 1: test::m::entry_take_u64(Result(0));

--- a/crates/iota-adapter-transactional-tests/tests/dev_inspect/entry_checks.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dev_inspect/entry_checks.snap
@@ -1,0 +1,20 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 9-17:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3708800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 19-21:
+//# programmable --sender A --dev-inspect
+//> 0: test::m::return_u64();
+//> 1: test::m::entry_take_u64(Result(0));
+Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction } in command 1
+Execution Error: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction } in command 1

--- a/crates/iota-adapter-transactional-tests/tests/dev_inspect/unused_value_without_drop.move
+++ b/crates/iota-adapter-transactional-tests/tests/dev_inspect/unused_value_without_drop.move
@@ -1,0 +1,19 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// dev inspect should not trigger unused value without drop error
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m {
+    public struct Object has key, store { id: UID }
+
+    public fun return_object(ctx: &mut TxContext): Object {
+        Object { id: object::new(ctx) }
+    }
+}
+
+//# programmable --sender A --dev-inspect
+//> 0: test::m::return_object();

--- a/crates/iota-adapter-transactional-tests/tests/dev_inspect/unused_value_without_drop.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dev_inspect/unused_value_without_drop.snap
@@ -1,0 +1,19 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 9-16:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4719600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 18-19:
+//# programmable --sender A --dev-inspect
+//> 0: test::m::return_object();
+mutated: object(_)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 980400,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/arbitrary_args.move
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/arbitrary_args.move
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// arbitrary struct input disallowed for dry run
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m {
+    public struct S has key {
+        id: UID,
+        setting: u64,
+    }
+
+    public fun take_s(s: S) {
+        let S { id, .. } = s;
+        id.delete();
+    }
+}
+
+
+//# programmable --sender A --inputs struct(@empty,0) --dry-run
+//> 0: test::m::take_s(Input(0));

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/arbitrary_args.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/arbitrary_args.snap
@@ -1,0 +1,19 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 9-21:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4461200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 24-25:
+//# programmable --sender A --inputs struct(@empty,0) --dry-run
+//> 0: test::m::take_s(Input(0));
+Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: InvalidUsageOfPureArg } in command 0
+Execution Error: CommandArgumentError { arg_idx: 0, kind: InvalidUsageOfPureArg } in command 0

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/conservation.move
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/conservation.move
@@ -1,0 +1,21 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// conservation checks enabled for dry run
+
+//# init --addresses test=0x0 --accounts A B
+
+//# publish
+
+module test::m {
+    use iota::iota::IOTA;
+    use iota::coin::Coin;
+
+    public fun transfer_back(c: Coin<IOTA>, ctx: &mut TxContext) {
+        iota::transfer::public_transfer(c, tx_context::sender(ctx))
+    }
+}
+
+//# programmable --sender A --inputs struct(@empty,1) --dry-run
+//> 0: test::m::transfer_back(Input(0));

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/conservation.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/conservation.snap
@@ -1,0 +1,19 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 9-18:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4826000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 20-21:
+//# programmable --sender A --inputs struct(@empty,1) --dry-run
+//> 0: test::m::transfer_back(Input(0));
+Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: InvalidUsageOfPureArg } in command 0
+Execution Error: CommandArgumentError { arg_idx: 0, kind: InvalidUsageOfPureArg } in command 0

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/entry_checks.move
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/entry_checks.move
@@ -1,0 +1,21 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// entry checks maintained during dry run
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m {
+    public fun return_u64(): u64 {
+        0
+    }
+    entry fun entry_take_u64(_n: u64) {
+    }
+}
+
+//# programmable --sender A --dry-run
+//> 0: test::m::return_u64();
+//> 1: test::m::entry_take_u64(Result(0));

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/entry_checks.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/entry_checks.snap
@@ -1,0 +1,20 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 9-17:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3708800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 19-21:
+//# programmable --sender A --dry-run
+//> 0: test::m::return_u64();
+//> 1: test::m::entry_take_u64(Result(0));
+Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction } in command 1
+Execution Error: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction } in command 1

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/gas_missing.move
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/gas_missing.move
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Test basic coin transfer
+
+//# init --addresses test=0x0 --accounts A B C
+
+//# publish
+
+/// gas heavy function
+module test::m {
+
+
+    public struct Obj has key {
+        id: object::UID,
+        contents: vector<u8>
+
+    }
+
+    public entry fun large_vector(n: u64, ctx: &mut TxContext) {
+        let mut v: vector<u64> = vector::empty();
+        let mut i = 0;
+        while (i < n) {
+            vector::push_back(&mut v, i);
+            i = i + 1;
+        };
+
+        transfer::transfer(Obj { id: object::new(ctx), contents: vector::empty() }, tx_context::sender(ctx))
+    }
+}
+
+// Move all A coins to B
+//# programmable --sender A --inputs @B
+//> TransferObjects([Gas], Input(0))
+
+// Return a small amount of coin to A
+//# programmable --sender B --inputs 2 @A
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+// Account A now has 3,0
+//# view-object 3,0
+
+// Not enough gas for large_vector()
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 3,0
+//> 0: test::m::large_vector(Input(0));
+
+// Give A enough gas to send transaction after rebates, it should still fail
+//# programmable --sender B --inputs 2499999999 @A
+//> SplitCoins(Gas, [Input(0), Input(0)]);
+//> TransferObjects([NestedResult(0,0), NestedResult(0,1)], Input(1))
+
+// Account A now has 6,0 6,1 that are 2 gas short of the needed amount
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 6,0 --gas-payment 6,1
+//> 0: test::m::large_vector(Input(0));
+
+// Include 3,0 in the gas payment, it should succeed
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 6,0 --gas-payment 6,1 --gas-payment 3,0
+//> 0: test::m::large_vector(Input(0));

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/gas_missing.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/gas_missing.snap
@@ -1,0 +1,73 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 9-33:
+//# publish
+created: object(1,0)
+mutated: object(0,3)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5738000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 34-37:
+//# programmable --sender A --inputs @B
+//> TransferObjects([Gas], Input(0))
+// Return a small amount of coin to A
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 980400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 38-42:
+//# programmable --sender B --inputs 2 @A
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+// Account A now has 3,0
+created: object(3,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 4, lines 43-45:
+//# view-object 3,0
+Owner: Account Address ( A )
+Version: 2
+Contents: iota::coin::Coin<iota::iota::IOTA> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    balance: iota::balance::Balance<iota::iota::IOTA> {
+        value: 2u64,
+    },
+}
+
+task 5, lines 46-49:
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 3,0
+//> 0: test::m::large_vector(Input(0));
+// Give A enough gas to send transaction after rebates, it should still fail
+Error: Error checking transaction input objects: GasBalanceTooLow { gas_balance: 2, needed_gas_amount: 5000000000 }
+
+task 6, lines 50-54:
+//# programmable --sender B --inputs 2499999999 @A
+//> SplitCoins(Gas, [Input(0), Input(0)]);
+//> TransferObjects([NestedResult(0,0), NestedResult(0,1)], Input(1))
+// Account A now has 6,0 6,1 that are 2 gas short of the needed amount
+created: object(6,0), object(6,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2941200,  storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 7, lines 55-58:
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 6,0 --gas-payment 6,1
+//> 0: test::m::large_vector(Input(0));
+// Include 3,0 in the gas payment, it should succeed
+Error: Error checking transaction input objects: GasBalanceTooLow { gas_balance: 4999999998, needed_gas_amount: 5000000000 }
+
+task 8, lines 59-60:
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 6,0 --gas-payment 6,1 --gas-payment 3,0
+//> 0: test::m::large_vector(Input(0));
+created: object(8,0)
+mutated: object(6,0)
+deleted: object(3,0), object(6,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2204000,  storage_rebate: 2941200, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/unused_value_without_drop.move
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/unused_value_without_drop.move
@@ -1,0 +1,19 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// dry run should trigger unused value without drop error
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m {
+    public struct Object has key, store { id: UID }
+
+    public fun return_object(ctx: &mut TxContext): Object {
+        Object { id: object::new(ctx) }
+    }
+}
+
+//# programmable --sender A --dry-run
+//> 0: test::m::return_object();

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/unused_value_without_drop.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/unused_value_without_drop.snap
@@ -1,0 +1,19 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 9-16:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4719600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 18-19:
+//# programmable --sender A --dry-run
+//> 0: test::m::return_object();
+Error: Transaction Effects Status: UnusedValueWithoutDrop { result_idx: 0, secondary_idx: 0 }
+Execution Error: UnusedValueWithoutDrop { result_idx: 0, secondary_idx: 0 }

--- a/crates/iota-adapter-transactional-tests/tests/upgrade/basic.move
+++ b/crates/iota-adapter-transactional-tests/tests/upgrade/basic.move
@@ -10,6 +10,11 @@ module Test::M1 {
     public fun f1() { }
 }
 
+//# upgrade --package Test --upgrade-capability 1,1 --sender A --dry-run
+module Test::M1 {
+    fun init(_ctx: &mut TxContext) { }
+}
+
 //# upgrade --package Test --upgrade-capability 1,1 --sender A
 module Test::M1 {
     fun init(_ctx: &mut TxContext) { }

--- a/crates/iota-adapter-transactional-tests/tests/upgrade/basic.snap
+++ b/crates/iota-adapter-transactional-tests/tests/upgrade/basic.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 3 tasks
+processed 4 tasks
 
 init:
 A: object(0,0)
@@ -13,6 +13,11 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5631600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2, lines 13-16:
+//# upgrade --package Test --upgrade-capability 1,1 --sender A --dry-run
+Error: Transaction Effects Status: PackageUpgradeError { upgrade_error: IncompatibleUpgrade } in command 1
+Execution Error: PackageUpgradeError { upgrade_error: IncompatibleUpgrade } in command 1
+
+task 3, lines 18-21:
 //# upgrade --package Test --upgrade-capability 1,1 --sender A
 Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }

--- a/crates/iota-transactional-test-runner/src/args.rs
+++ b/crates/iota-transactional-test-runner/src/args.rs
@@ -125,7 +125,7 @@ pub struct ProgrammableTransactionCommand {
     #[arg(long)]
     pub gas_price: Option<u64>,
     #[clap(long = "gas-payment", value_parser = parse_fake_id)]
-    pub gas_payment: Option<FakeID>,
+    pub gas_payment: Option<Vec<FakeID>>,
     #[arg(long = "dev-inspect")]
     pub dev_inspect: bool,
     #[clap(long = "dry-run")]
@@ -151,6 +151,8 @@ pub struct UpgradePackageCommand {
     pub sender: String,
     #[arg(long)]
     pub gas_budget: Option<u64>,
+    #[clap(long = "dry-run")]
+    pub dry_run: bool,
     #[arg(long)]
     pub syntax: Option<SyntaxChoice>,
     #[arg(long, default_value="compatible", value_parser = parse_policy)]

--- a/crates/iota-transactional-test-runner/src/args.rs
+++ b/crates/iota-transactional-test-runner/src/args.rs
@@ -151,7 +151,7 @@ pub struct UpgradePackageCommand {
     pub sender: String,
     #[arg(long)]
     pub gas_budget: Option<u64>,
-    #[clap(long = "dry-run")]
+    #[arg(long)]
     pub dry_run: bool,
     #[arg(long)]
     pub syntax: Option<SyntaxChoice>,

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -490,7 +490,7 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                 builder.publish_immutable(modules_bytes, dependencies);
             };
             let pt = builder.finish();
-            TransactionData::new_programmable(sender, vec![gas], pt, gas_budget, gas_price)
+            TransactionData::new_programmable(sender, gas, pt, gas_budget, gas_price)
         };
         let transaction = self.sign_txn(sender, data);
         let summary = self.execute_txn(transaction).await?;
@@ -753,7 +753,7 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                         rec_arg,
                     ));
                     let pt = builder.finish();
-                    TransactionData::new_programmable(sender, vec![gas], pt, gas_budget, gas_price)
+                    TransactionData::new_programmable(sender, gas, pt, gas_budget, gas_price)
                 });
                 let summary = self.execute_txn(transaction).await?;
                 let output = self.object_summary_output(&summary, /* summarize */ false);
@@ -832,11 +832,11 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                     let transaction = self.sign_sponsor_txn(
                         sender,
                         sponsor,
-                        gas_payment,
+                        gas_payment.unwrap_or_default(),
                         |sender, sponsor, gas| {
                             TransactionData::new_programmable_allow_sponsor(
                                 sender,
-                                vec![gas],
+                                gas,
                                 ProgrammableTransaction { inputs, commands },
                                 gas_budget,
                                 gas_price,
@@ -851,11 +851,11 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                     let sender = self.get_sender(sender);
                     let sponsor = sponsor.map_or(sender, |a| self.get_sender(Some(a)));
 
-                    let payment = self.get_payment(sponsor, gas_payment);
+                    let payments = self.get_payments(sponsor, gas_payment.unwrap_or_default());
 
                     let transaction = TransactionData::new_programmable(
                         sender.address,
-                        vec![payment],
+                        payments,
                         ProgrammableTransaction { inputs, commands },
                         gas_budget,
                         gas_price,
@@ -884,6 +884,7 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                 dependencies,
                 sender,
                 gas_budget,
+                dry_run,
                 syntax,
                 policy,
                 gas_price,
@@ -971,6 +972,7 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                             dependencies,
                             sender,
                             gas_budget,
+                            dry_run,
                             policy,
                             gas_price,
                         ).await?;
@@ -1366,6 +1368,7 @@ impl IotaTestAdapter {
         dependencies: Vec<String>,
         sender: String,
         gas_budget: Option<u64>,
+        dry_run: bool,
         policy: u8,
         gas_price: u64,
     ) -> anyhow::Result<Option<String>> {
@@ -1413,12 +1416,22 @@ impl IotaTestAdapter {
 
         let pt = builder.finish();
 
-        let data = |sender, gas| {
-            TransactionData::new_programmable(sender, vec![gas], pt, gas_budget, gas_price)
+        let summary = if dry_run {
+            let transaction = TransactionData::new_programmable(
+                self.get_sender(Some(sender)).address,
+                vec![],
+                pt,
+                gas_budget,
+                gas_price,
+            );
+            self.dry_run(transaction).await?
+        } else {
+            let data = |sender, gas| {
+                TransactionData::new_programmable(sender, gas, pt, gas_budget, gas_price)
+            };
+            let transaction = self.sign_txn(Some(sender), data);
+            self.execute_txn(transaction).await?
         };
-
-        let transaction = self.sign_txn(Some(sender), data);
-        let summary = self.execute_txn(transaction).await?;
         let created_package = summary
             .created
             .iter()
@@ -1453,47 +1466,58 @@ impl IotaTestAdapter {
             // sender
             IotaAddress,
             // gas
-            ObjectRef,
+            Vec<ObjectRef>,
         ) -> TransactionData,
     ) -> Transaction {
-        self.sign_sponsor_txn(sender, None, None, move |sender, _, gas| {
+        self.sign_sponsor_txn(sender, None, vec![], move |sender, _, gas| {
             txn_data(sender, gas)
         })
     }
 
-    fn get_payment(&self, sponsor: &TestAccount, payment: Option<FakeID>) -> ObjectRef {
-        let payment = if let Some(payment) = payment {
-            self.fake_to_real_object_id(payment)
-                .expect("Could not find specified payment object")
+    fn get_payments(&self, sponsor: &TestAccount, payments: Vec<FakeID>) -> Vec<ObjectRef> {
+        let payments = if payments.is_empty() {
+            vec![sponsor.gas]
         } else {
-            sponsor.gas
+            payments
+                .into_iter()
+                .map(|payment| {
+                    self.fake_to_real_object_id(payment)
+                        .expect("Could not find specified payment object")
+                })
+                .collect::<Vec<ObjectID>>()
         };
 
-        self.get_object(&payment, None)
-            .unwrap()
-            .compute_object_reference()
+        payments
+            .into_iter()
+            .map(|payment| {
+                self.get_object(&payment, None)
+                    .unwrap()
+                    .compute_object_reference()
+            })
+            .collect()
     }
 
     fn sign_sponsor_txn(
         &self,
         sender: Option<String>,
         sponsor: Option<String>,
-        payment: Option<FakeID>,
+        payment: Vec<FakeID>,
         txn_data: impl FnOnce(
             // sender
             IotaAddress,
             // sponsor
             IotaAddress,
             // gas
-            ObjectRef,
+            Vec<ObjectRef>,
         ) -> TransactionData,
     ) -> Transaction {
         let sender = self.get_sender(sender);
         let sponsor = sponsor.map_or(sender, |a| self.get_sender(Some(a)));
 
-        let payment_ref = self.get_payment(sponsor, payment);
+        let payment_refs = self.get_payments(sponsor, payment);
 
-        let data = txn_data(sender.address, sponsor.address, payment_ref);
+        let data = txn_data(sender.address, sponsor.address, payment_refs);
+
         if sender.address == sponsor.address {
             to_sender_signed_transaction(data, &sender.key_pair)
         } else {
@@ -1546,7 +1570,7 @@ impl IotaTestAdapter {
                 arguments,
             ));
             let pt = builder.finish();
-            TransactionData::new_programmable(sender, vec![gas], pt, gas_budget, gas_price)
+            TransactionData::new_programmable(sender, gas, pt, gas_budget, gas_price)
         };
         Ok(self.sign_txn(sender, data))
     }


### PR DESCRIPTION
# Description of change

Upstream commit left out from the previous cycle: #8255

Ensures expected dry run behavior for:
- arbitrary args
- conservation
- entry check
- unused value without drop
- gas tests

adds to test runner: 
- dry-run for upgrades option
- multiple gas payments

context: https://github.com/MystenLabs/sui/pull/20109

## Links to any relevant issues

Fixes #8586

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
