### PR TITLE
feat(json-rpc): add new method isTransactionIndexedOnNode

### DIFF
--- a/crates/iota-indexer/src/apis/read_api.rs
+++ b/crates/iota-indexer/src/apis/read_api.rs
@@ -6,7 +6,9 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use iota_json_rpc::{IotaRpcModule, error::IotaRpcInputError};
-use iota_json_rpc_api::{QUERY_MAX_RESULT_LIMIT, ReadApiServer, internal_error};
+use iota_json_rpc_api::{
+    QUERY_MAX_RESULT_LIMIT, ReadApiClient, ReadApiServer, error_object_from_rpc, internal_error,
+};
 use iota_json_rpc_types::{
     Checkpoint, CheckpointId, CheckpointPage, IotaEvent, IotaGetPastObjectRequest, IotaObjectData,
     IotaObjectDataOptions, IotaObjectResponse, IotaPastObjectResponse,
@@ -21,18 +23,22 @@ use iota_types::{
     iota_serde::BigInt,
     object::{ObjectRead, PastObjectRead},
 };
-use jsonrpsee::{RpcModule, core::RpcResult};
+use jsonrpsee::{RpcModule, core::RpcResult, http_client::HttpClient};
 
 use crate::{errors::IndexerError, indexer_reader::IndexerReader, models::objects::StoredObject};
 
 #[derive(Clone)]
 pub(crate) struct ReadApi {
     inner: IndexerReader,
+    fullnode_client: HttpClient,
 }
 
 impl ReadApi {
-    pub fn new(inner: IndexerReader) -> Self {
-        Self { inner }
+    pub fn new(inner: IndexerReader, fullnode_client: HttpClient) -> Self {
+        Self {
+            inner,
+            fullnode_client,
+        }
     }
 
     async fn get_checkpoint(&self, id: CheckpointId) -> Result<Checkpoint, IndexerError> {
@@ -231,6 +237,13 @@ impl ReadApiServer for ReadApi {
     async fn get_total_transaction_blocks(&self) -> RpcResult<BigInt<u64>> {
         let checkpoint = self.get_latest_checkpoint().await?;
         Ok(BigInt::from(checkpoint.network_total_transactions))
+    }
+
+    async fn is_transaction_indexed_on_node(&self, digest: TransactionDigest) -> RpcResult<bool> {
+        self.fullnode_client
+            .is_transaction_indexed_on_node(digest)
+            .await
+            .map_err(error_object_from_rpc)
     }
 
     async fn get_transaction_block(

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -16,7 +16,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::{
-    build_optimistic_json_rpc_server,
+    build_json_rpc_server,
     config::{IngestionConfig, JsonRpcConfig, RetentionConfig, SnapshotLagConfig},
     db::ConnectionPool,
     errors::IndexerError,
@@ -143,10 +143,9 @@ impl Indexer {
             env!("CARGO_PKG_VERSION")
         );
         let indexer_reader = IndexerReader::new(connection_pool);
-        let handle =
-            build_optimistic_json_rpc_server(store, registry, indexer_reader, config, metrics)
-                .await
-                .expect("Json rpc server should not run into errors upon start.");
+        let handle = build_json_rpc_server(store, registry, indexer_reader, config, metrics)
+            .await
+            .expect("Json rpc server should not run into errors upon start.");
         tokio::spawn(async move { handle.stopped().await })
             .await
             .expect("Rpc server task failed");

--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -48,18 +48,15 @@ pub mod system_package_task;
 pub mod test_utils;
 pub mod types;
 
-async fn build_common_json_rpc_server(
+pub async fn build_json_rpc_server(
+    store: PgIndexerStore,
     prometheus_registry: &Registry,
     reader: IndexerReader,
     config: &JsonRpcConfig,
-    register_api_fn: impl FnOnce(JsonRpcServerBuilder) -> Result<JsonRpcServerBuilder, IndexerError>,
+    metrics: IndexerMetrics,
 ) -> Result<ServerHandle, IndexerError> {
-    let mut builder = register_api_fn(JsonRpcServerBuilder::new(
-        env!("CARGO_PKG_VERSION"),
-        prometheus_registry,
-        None,
-        None,
-    ))?;
+    let mut builder =
+        JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), prometheus_registry, None, None);
 
     let fullnode_client = get_http_client(&config.rpc_client_url)?;
     // Register common modules
@@ -70,13 +67,17 @@ async fn build_common_json_rpc_server(
     builder.register_module(TransactionBuilderApi::new(reader.clone()))?;
     builder.register_module(MoveUtilsApi::new(reader.clone()))?;
     builder.register_module(GovernanceReadApi::new(reader.clone()))?;
-    builder.register_module(ReadApi::new(reader.clone(), fullnode_client))?;
+    builder.register_module(ReadApi::new(reader.clone(), fullnode_client.clone()))?;
     builder.register_module(CoinReadApi::new(reader.clone())?)?;
     builder.register_module(ExtendedApi::new(reader.clone()))?;
+    builder.register_module(OptimisticWriteApi::new(
+        WriteApi::new(fullnode_client),
+        OptimisticTransactionExecutor::new(&config.rpc_client_url, reader.clone(), store, metrics),
+    ))?;
 
     let cancel = CancellationToken::new();
     let system_package_task =
-        SystemPackageTask::new(reader.clone(), cancel.clone(), Duration::from_secs(10));
+        SystemPackageTask::new(reader, cancel.clone(), Duration::from_secs(10));
 
     tracing::info!("Starting system package task");
     spawn_monitored_task!(async move { system_package_task.run().await });
@@ -84,42 +85,6 @@ async fn build_common_json_rpc_server(
     Ok(builder
         .start(config.rpc_address, None, ServerType::Http, Some(cancel))
         .await?)
-}
-
-pub async fn build_json_rpc_server(
-    prometheus_registry: &Registry,
-    reader: IndexerReader,
-    config: &JsonRpcConfig,
-) -> Result<ServerHandle, IndexerError> {
-    build_common_json_rpc_server(prometheus_registry, reader, config, |mut builder| {
-        let http_client = get_http_client(&config.rpc_client_url)?;
-        builder.register_module(WriteApi::new(http_client))?;
-        Ok(builder)
-    })
-    .await
-}
-
-pub async fn build_optimistic_json_rpc_server(
-    store: PgIndexerStore,
-    prometheus_registry: &Registry,
-    reader: IndexerReader,
-    config: &JsonRpcConfig,
-    metrics: IndexerMetrics,
-) -> Result<ServerHandle, IndexerError> {
-    build_common_json_rpc_server(
-        prometheus_registry,
-        reader.clone(),
-        config,
-        |mut builder| {
-            let http_client = get_http_client(&config.rpc_client_url)?;
-            builder.register_module(OptimisticWriteApi::new(
-                WriteApi::new(http_client),
-                OptimisticTransactionExecutor::new(&config.rpc_client_url, reader, store, metrics),
-            ))?;
-            Ok(builder)
-        },
-    )
-    .await
 }
 
 fn get_http_client(rpc_client_url: &str) -> Result<HttpClient, IndexerError> {

--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -61,6 +61,7 @@ async fn build_common_json_rpc_server(
         None,
     ))?;
 
+    let fullnode_client = get_http_client(&config.rpc_client_url)?;
     // Register common modules
     builder.register_module(IndexerApi::new(
         reader.clone(),
@@ -69,7 +70,7 @@ async fn build_common_json_rpc_server(
     builder.register_module(TransactionBuilderApi::new(reader.clone()))?;
     builder.register_module(MoveUtilsApi::new(reader.clone()))?;
     builder.register_module(GovernanceReadApi::new(reader.clone()))?;
-    builder.register_module(ReadApi::new(reader.clone()))?;
+    builder.register_module(ReadApi::new(reader.clone(), fullnode_client))?;
     builder.register_module(CoinReadApi::new(reader.clone())?)?;
     builder.register_module(ExtendedApi::new(reader.clone()))?;
 

--- a/crates/iota-json-rpc-api/src/read.rs
+++ b/crates/iota-json-rpc-api/src/read.rs
@@ -21,6 +21,15 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 #[open_rpc(namespace = "iota", tag = "Read API")]
 #[rpc(server, client, namespace = "iota")]
 pub trait ReadApi {
+    /// Return if the transaction has been indexed on the fullnode.
+    #[rustfmt::skip]
+    #[method(name = "isTransactionIndexedOnNode")]
+    async fn is_transaction_indexed_on_node(
+        &self,
+        /// the digest of the queried transaction
+        digest: TransactionDigest,
+    ) -> RpcResult<bool>;
+
     /// Return the transaction response object.
     #[rustfmt::skip]
     #[method(name = "getTransactionBlock")]

--- a/crates/iota-json-rpc-tests/tests/read_api.rs
+++ b/crates/iota-json-rpc-tests/tests/read_api.rs
@@ -551,6 +551,27 @@ async fn get_transaction_block() {
 }
 
 #[sim_test]
+async fn is_transaction_present() {
+    let cluster = TestClusterBuilder::new().build().await;
+    let address = cluster.get_address_0();
+
+    let (object_ids, gas) = get_objects_to_mutate(&cluster, address).await;
+
+    let transaction = cluster
+        .transfer_object(address, address, object_ids[0], gas, None)
+        .await
+        .unwrap();
+
+    assert!(
+        cluster
+            .rpc_client()
+            .is_transaction_indexed_on_node(transaction.digest)
+            .await
+            .unwrap()
+    );
+}
+
+#[sim_test]
 async fn get_transaction_block_with_full_content() {
     get_transaction_block_with_options(IotaTransactionBlockResponseOptions::full_content()).await;
 }

--- a/crates/iota-json-rpc-tests/tests/read_api.rs
+++ b/crates/iota-json-rpc-tests/tests/read_api.rs
@@ -26,6 +26,7 @@ use iota_types::{
     quorum_driver_types::ExecuteTransactionRequestType,
     transaction::CallArg,
 };
+use rand::{SeedableRng, rngs::StdRng};
 use test_cluster::{TestCluster, TestClusterBuilder};
 
 trait MatchesResponseOptions {
@@ -548,6 +549,21 @@ async fn get_transaction_block_timestamp() {
 #[sim_test]
 async fn get_transaction_block() {
     get_transaction_block_with_options(IotaTransactionBlockResponseOptions::default()).await;
+}
+
+#[sim_test]
+async fn is_transaction_not_present() {
+    let cluster = TestClusterBuilder::new().build().await;
+    let rng = StdRng::from_seed([1; 32]);
+    let digest = TransactionDigest::generate(rng);
+
+    assert!(
+        !cluster
+            .rpc_client()
+            .is_transaction_indexed_on_node(digest)
+            .await
+            .unwrap()
+    );
 }
 
 #[sim_test]

--- a/crates/iota-json-rpc/src/read_api.rs
+++ b/crates/iota-json-rpc/src/read_api.rs
@@ -728,6 +728,12 @@ impl ReadApiServer for ReadApi {
     }
 
     #[instrument(skip(self))]
+    async fn is_transaction_indexed_on_node(&self, digest: TransactionDigest) -> RpcResult<bool> {
+        let transaction = self.get_transaction_block(digest, None).await?;
+        Ok(transaction.digest == digest)
+    }
+
+    #[instrument(skip(self))]
     async fn get_transaction_block(
         &self,
         digest: TransactionDigest,

--- a/crates/iota-json-rpc/src/read_api.rs
+++ b/crates/iota-json-rpc/src/read_api.rs
@@ -729,8 +729,27 @@ impl ReadApiServer for ReadApi {
 
     #[instrument(skip(self))]
     async fn is_transaction_indexed_on_node(&self, digest: TransactionDigest) -> RpcResult<bool> {
-        let transaction = self.get_transaction_block(digest, None).await?;
-        Ok(transaction.digest == digest)
+        let transaction = async move {
+            let transaction_kv_store = self.transaction_kv_store.clone();
+            let mut transactions = spawn_monitored_task!(async move {
+                let ret = transaction_kv_store
+                    .multi_get_tx(&[digest])
+                    .await
+                    .map_err(|err| {
+                        debug!(tx_digest=?digest, "Failed to get transaction: {:?}", err);
+                        Error::from(err)
+                    });
+                add_server_timing("tx_kv_lookup");
+                ret
+            })
+            .await??;
+            Ok(transactions
+                .pop()
+                .expect("there should be one tx lookup response"))
+        }
+        .trace()
+        .await?;
+        Ok(transaction.map(|tx| *tx.digest()) == Some(digest))
     }
 
     #[instrument(skip(self))]

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -2404,7 +2404,7 @@
           "params": [
             {
               "name": "digest",
-              "value": "5SiFuQtEKK9PWceY9bffdjhz4tcKzsfnCotr7LNNC7R9"
+              "value": "Gox564afxEVubGFZPXbDSCiirfN1QYVdMR3pivs34HoC"
             }
           ],
           "result": {

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -2374,6 +2374,47 @@
       ]
     },
     {
+      "name": "iota_isTransactionIndexedOnNode",
+      "tags": [
+        {
+          "name": "Read API"
+        }
+      ],
+      "description": "Return if the transaction has been indexed on the fullnode.",
+      "params": [
+        {
+          "name": "digest",
+          "description": "the digest of the queried transaction",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/TransactionDigest"
+          }
+        }
+      ],
+      "result": {
+        "name": "bool",
+        "required": true,
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "examples": [
+        {
+          "name": "Returns if the transaction has been indexed on the fullnode.",
+          "params": [
+            {
+              "name": "digest",
+              "value": "5SiFuQtEKK9PWceY9bffdjhz4tcKzsfnCotr7LNNC7R9"
+            }
+          ],
+          "result": {
+            "name": "Result",
+            "value": true
+          }
+        }
+      ]
+    },
+    {
       "name": "iota_multiGetObjects",
       "tags": [
         {

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -90,6 +90,7 @@ impl RpcExampleProvider {
             self.get_past_object_example(),
             self.get_owned_objects(),
             self.get_total_transaction_blocks(),
+            self.iota_is_transaction_indexed_on_node(),
             self.get_transaction_block(),
             self.query_transaction_blocks(),
             self.get_events(),
@@ -517,6 +518,18 @@ impl RpcExampleProvider {
                 "Gets total number of transactions on the network.",
                 vec![],
                 json!("2451485"),
+            )],
+        )
+    }
+
+    fn iota_is_transaction_indexed_on_node(&mut self) -> Examples {
+        let digest = TransactionDigest::random();
+        Examples::new(
+            "iota_isTransactionIndexedOnNode",
+            vec![ExamplePairing::new(
+                "Returns if the transaction has been indexed on the fullnode.",
+                vec![("digest", json!(digest))],
+                json!(true),
             )],
         )
     }

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -523,7 +523,7 @@ impl RpcExampleProvider {
     }
 
     fn iota_is_transaction_indexed_on_node(&mut self) -> Examples {
-        let digest = TransactionDigest::random();
+        let digest = TransactionDigest::generate(self.rng.clone());
         Examples::new(
             "iota_isTransactionIndexedOnNode",
             vec![ExamplePairing::new(


### PR DESCRIPTION
# Description of change

This patch adds a new endpoint `iota_isTransactionIndexedOnNode`

## Links to any relevant issues

Fixes #8526

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [x] JSON-RPC: A new method `iota_isTransactionIndexedOnNode` is added that allows clients and dapps to optionally poll the fullnode to verify that a transaction has been indexed. The latter is a necessary condition so that any dependent transaction is executed successfully. The new method complements the recent advancements in the Indexer JSON-RPC API that  indexes transactions after execution without waiting for a checkpoint to include them. 
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
