### PR TITLE
feat(graphql): add isIndexedOnNode field for transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6327,6 +6327,7 @@ dependencies = [
  "iota-graphql-rpc-headers",
  "iota-indexer",
  "iota-json-rpc",
+ "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-metrics",
  "iota-names",

--- a/crates/iota-graphql-rpc/Cargo.toml
+++ b/crates/iota-graphql-rpc/Cargo.toml
@@ -54,6 +54,7 @@ iota-graphql-rpc-client.workspace = true
 iota-graphql-rpc-headers.workspace = true
 iota-indexer.workspace = true
 iota-json-rpc.workspace = true
+iota-json-rpc-api.workspace = true
 iota-json-rpc-types.workspace = true
 iota-metrics.workspace = true
 iota-names.workspace = true

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -4371,6 +4371,10 @@ type TransactionBlock {
 	and Base64 encoded.
 	"""
 	bcs: Base64
+	"""
+	Returns whether the transaction has been indexed on the fullnode.
+	"""
+	indexedOnNode: Boolean
 }
 
 type TransactionBlockConnection {

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -3576,6 +3576,10 @@ type Query {
 	"""
 	dryRunTransactionBlock(txBytes: String!, txMeta: TransactionMetadata, skipChecks: Boolean): DryRunResult!
 	"""
+	Check if a transaction is indexed on the fullnode.
+	"""
+	isTransactionIndexedOnNode(digest: String!): Boolean!
+	"""
 	Look up an Owner by its IotaAddress.
 	
 	`rootVersion` represents the version of the root object in some nested
@@ -4373,6 +4377,17 @@ type TransactionBlock {
 	bcs: Base64
 	"""
 	Returns whether the transaction has been indexed on the fullnode.
+	
+	This makes a request to the fullnode if the transaction is not part of
+	a checkpoint to resolve the index status on the node.
+	
+	However, as this relies on the transaction data being already
+	constructed or fetched from the backing database, it only makes
+	sense to be used with `Mutation.executeTransactionBlock` on the
+	resulting effects.
+	
+	Otherwise, it is recommended that you use
+	`Query.isTransactionIndexedOnNode` for optimal performance.
 	"""
 	indexedOnNode: Boolean
 }

--- a/crates/iota-graphql-rpc/src/mutation.rs
+++ b/crates/iota-graphql-rpc/src/mutation.rs
@@ -8,7 +8,6 @@ use fastcrypto::{
     traits::ToFromBytes,
 };
 use iota_json_rpc_types::IotaTransactionBlockResponseOptions;
-use iota_sdk::IotaClient;
 use iota_types::{
     effects::TransactionEffects as NativeTransactionEffects,
     event::Event as NativeEvent,

--- a/crates/iota-graphql-rpc/src/mutation.rs
+++ b/crates/iota-graphql-rpc/src/mutation.rs
@@ -18,6 +18,7 @@ use iota_types::{
 
 use crate::{
     error::Error,
+    server::builder::get_fullnode_client,
     types::{
         execution_result::ExecutionResult,
         transaction_block_effects::{TransactionBlockEffects, TransactionBlockEffectsKind},
@@ -53,14 +54,7 @@ impl Mutation {
         tx_bytes: String,
         signatures: Vec<String>,
     ) -> Result<ExecutionResult> {
-        let iota_sdk_client: &Option<IotaClient> = ctx
-            .data()
-            .map_err(|_| Error::Internal("Unable to fetch IOTA SDK client".to_string()))
-            .extend()?;
-        let iota_sdk_client = iota_sdk_client
-            .as_ref()
-            .ok_or_else(|| Error::Internal("IOTA SDK client not initialized".to_string()))
-            .extend()?;
+        let iota_sdk_client = get_fullnode_client(ctx)?;
         let tx_data = bcs::from_bytes(
             &Base64::decode(&tx_bytes)
                 .map_err(|e| {

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use async_graphql::{
-    EmptySubscription, Schema, SchemaBuilder,
+    Context, EmptySubscription, ResultExt, Schema, SchemaBuilder,
     extensions::{ApolloTracing, ExtensionFactory, Tracing},
 };
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
@@ -31,7 +31,7 @@ use iota_indexer::db::{get_pool_connection, setup_postgres::check_db_migration_c
 use iota_metrics::spawn_monitored_task;
 use iota_network_stack::callback::{CallbackLayer, MakeCallbackHandler, ResponseHandler};
 use iota_package_resolver::{PackageStoreWithLruCache, Resolver};
-use iota_sdk::IotaClientBuilder;
+use iota_sdk::{IotaClient, IotaClientBuilder};
 use tokio::{join, net::TcpListener, sync::OnceCell};
 use tokio_util::sync::CancellationToken;
 use tower::{Layer, Service};
@@ -532,6 +532,19 @@ fn schema_builder() -> SchemaBuilder<Query, Mutation, EmptySubscription> {
         .register_output_type::<IObject>()
         .register_output_type::<IOwner>()
         .register_output_type::<IMoveDatatype>()
+}
+
+pub(crate) fn get_fullnode_client<'ctx>(
+    ctx: &'ctx Context<'_>,
+) -> async_graphql::Result<&'ctx IotaClient> {
+    let iota_sdk_client: &Option<IotaClient> = ctx
+        .data()
+        .map_err(|_| Error::Internal("Unable to fetch IOTA SDK client".to_string()))
+        .extend()?;
+    iota_sdk_client
+        .as_ref()
+        .ok_or_else(|| Error::Internal("IOTA SDK client not initialized".to_string()))
+        .extend()
 }
 
 /// Return the string representation of the schema used by this server.

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -12,7 +12,10 @@ use iota_indexer::{
     test_utils::{IndexerTypeConfig, force_delete_database, start_test_indexer_impl},
 };
 use iota_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
-use iota_types::storage::RestStateReader;
+use iota_types::{
+    storage::RestStateReader,
+    transaction::{Transaction, TransactionData},
+};
 use test_cluster::{TestCluster, TestClusterBuilder};
 use tokio::{join, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -352,6 +355,25 @@ impl Cluster {
     pub async fn cleanup_resources(self) {
         self.cancellation_token.cancel();
         let _ = join!(self.graphql_server_join_handle, self.indexer_join_handle);
+    }
+
+    /// Build a transaction that transfers IOTA for testing.
+    pub async fn build_transfer_iota_for_test(&self) -> TransactionData {
+        let addresses = self.validator_fullnode_handle.wallet.get_addresses();
+
+        let recipient = addresses[1];
+        self.validator_fullnode_handle
+            .test_transaction_builder()
+            .await
+            .transfer_iota(Some(1_000), recipient)
+            .build()
+    }
+
+    /// Sign a transaction.
+    pub fn sign_transaction(&self, transaction: &TransactionData) -> Transaction {
+        self.validator_fullnode_handle
+            .wallet
+            .sign_transaction(transaction)
     }
 }
 

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -357,7 +357,7 @@ impl Cluster {
         let _ = join!(self.graphql_server_join_handle, self.indexer_join_handle);
     }
 
-    /// Build a transaction that transfers IOTA for testing.
+    /// Builds a transaction that transfers IOTA for testing.
     pub async fn build_transfer_iota_for_test(&self) -> TransactionData {
         let addresses = self.validator_fullnode_handle.wallet.get_addresses();
 
@@ -369,7 +369,7 @@ impl Cluster {
             .build()
     }
 
-    /// Sign a transaction.
+    /// Signs a transaction.
     pub fn sign_transaction(&self, transaction: &TransactionData) -> Transaction {
         self.validator_fullnode_handle
             .wallet

--- a/crates/iota-graphql-rpc/src/types/digest.rs
+++ b/crates/iota-graphql-rpc/src/types/digest.rs
@@ -75,6 +75,12 @@ impl From<TransactionDigest> for Digest {
     }
 }
 
+impl From<Digest> for TransactionDigest {
+    fn from(digest: Digest) -> Self {
+        Self::new(digest.0)
+    }
+}
+
 impl fmt::Display for Digest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Base58::encode(self.0))

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -20,7 +20,7 @@ use crate::{
     connection::ScanConnection,
     error::Error,
     mutation::Mutation,
-    server::watermark_task::Watermark,
+    server::{builder::get_fullnode_client, watermark_task::Watermark},
     types::{
         address::Address,
         available_range::AvailableRange,
@@ -108,14 +108,7 @@ impl Query {
     ) -> Result<DryRunResult> {
         let skip_checks = skip_checks.unwrap_or(false);
 
-        let iota_sdk_client: &Option<IotaClient> = ctx
-            .data()
-            .map_err(|_| Error::Internal("Unable to fetch IOTA SDK client".to_string()))
-            .extend()?;
-        let iota_sdk_client = iota_sdk_client
-            .as_ref()
-            .ok_or_else(|| Error::Internal("IOTA SDK client not initialized".to_string()))
-            .extend()?;
+        let iota_sdk_client = get_fullnode_client(ctx)?;
 
         let (sender_address, tx_kind, gas_price, gas_sponsor, gas_budget, gas_objects) =
             if let Some(TransactionMetadata {

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 
 use async_graphql::{connection::Connection, *};
 use fastcrypto::encoding::{Base64, Encoding};
+use iota_json_rpc_api::ReadApiClient;
 use iota_json_rpc_types::DevInspectArgs;
 use iota_types::{
     TypeTag,
@@ -175,6 +176,19 @@ impl Query {
             .await?;
 
         DryRunResult::try_from(res).extend()
+    }
+
+    /// Check if a transaction is indexed on the fullnode.
+    async fn is_transaction_indexed_on_node(
+        &self,
+        ctx: &Context<'_>,
+        digest: Digest,
+    ) -> Result<bool> {
+        let fullnode_client = get_fullnode_client(ctx)?;
+        Ok(fullnode_client
+            .http()
+            .is_transaction_indexed_on_node(digest.into())
+            .await?)
     }
 
     /// Look up an Owner by its IotaAddress.

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -7,7 +7,6 @@ use std::str::FromStr;
 use async_graphql::{connection::Connection, *};
 use fastcrypto::encoding::{Base64, Encoding};
 use iota_json_rpc_types::DevInspectArgs;
-use iota_sdk::IotaClient;
 use iota_types::{
     TypeTag,
     gas_coin::GAS,

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -88,6 +88,16 @@ pub(crate) enum TransactionBlockInner {
     },
 }
 
+impl TransactionBlockInner {
+    /// Returns if the transaction is included in a checkpoint.
+    fn is_checkpointed(&self) -> bool {
+        let TransactionBlockInner::Stored { stored_tx, .. } = &self else {
+            return false;
+        };
+        stored_tx.checkpoint_sequence_number >= 0
+    }
+}
+
 /// An input filter selecting for either system or programmable transactions.
 #[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) enum TransactionBlockKindInput {
@@ -235,11 +245,14 @@ impl TransactionBlock {
 
     /// Returns whether the transaction has been indexed on the fullnode.
     async fn indexed_on_node(&self, ctx: &Context<'_>) -> Result<Option<bool>> {
-        let fullnode_client = get_fullnode_client(ctx)?;
+        if self.inner.is_checkpointed() {
+            return Ok(Some(true));
+        }
         let Some(digest) = self.native_signed_data().map(|d| d.digest()) else {
             // dry-run transactions are never indexed
             return Ok(Some(false));
         };
+        let fullnode_client = get_fullnode_client(ctx)?;
         Ok(Some(
             fullnode_client
                 .http()

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -13,6 +13,7 @@ use iota_indexer::{
     models::transactions::StoredTransaction,
     schema::{transactions, tx_digests},
 };
+use iota_json_rpc_api::ReadApiClient;
 use iota_types::{
     base_types::IotaAddress as NativeIotaAddress,
     effects::TransactionEffects as NativeTransactionEffects,
@@ -30,7 +31,7 @@ use crate::{
     connection::ScanConnection,
     data::{self, DataLoader, Db, DbConnection, QueryExecutor},
     error::Error,
-    server::watermark_task::Watermark,
+    server::{builder::get_fullnode_client, watermark_task::Watermark},
     types::{
         address::Address,
         base64::Base64,
@@ -230,6 +231,21 @@ impl TransactionBlock {
             // Dry run transaction does not have signatures so no sender signed data.
             TransactionBlockInner::DryRun { .. } => None,
         }
+    }
+
+    /// Returns whether the transaction has been indexed on the fullnode.
+    async fn indexed_on_node(&self, ctx: &Context<'_>) -> Result<Option<bool>> {
+        let fullnode_client = get_fullnode_client(ctx)?;
+        let Some(digest) = self.native_signed_data().map(|d| d.digest()) else {
+            // dry-run transactions are never indexed
+            return Ok(Some(false));
+        };
+        Ok(Some(
+            fullnode_client
+                .http()
+                .is_transaction_indexed_on_node(digest)
+                .await?,
+        ))
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -244,6 +244,17 @@ impl TransactionBlock {
     }
 
     /// Returns whether the transaction has been indexed on the fullnode.
+    ///
+    /// This makes a request to the fullnode if the transaction is not part of
+    /// a checkpoint to resolve the index status on the node.
+    ///
+    /// However, as this relies on the transaction data being already
+    /// constructed or fetched from the backing database, it only makes
+    /// sense to be used with `Mutation.executeTransactionBlock` on the
+    /// resulting effects.
+    ///
+    /// Otherwise, it is recommended that you use
+    /// `Query.isTransactionIndexedOnNode` for optimal performance.
     async fn indexed_on_node(&self, ctx: &Context<'_>) -> Result<Option<bool>> {
         if self.inner.is_checkpointed() {
             return Ok(Some(true));

--- a/crates/iota-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/iota-graphql-rpc/tests/e2e_tests.rs
@@ -377,6 +377,7 @@ mod tests {
         let query = r#"
             {
                 transactionBlock(digest: $dig){
+                    indexedOnNode
                     sender {
                         address
                     }
@@ -396,9 +397,9 @@ mod tests {
             .unwrap();
 
         let binding = res.response_body().data.clone().into_json().unwrap();
-        let sender_read = binding
-            .get("transactionBlock")
-            .unwrap()
+        let tx = binding.get("transactionBlock").unwrap();
+
+        let sender_read = tx
             .get("sender")
             .unwrap()
             .get("address")
@@ -406,6 +407,8 @@ mod tests {
             .as_str()
             .unwrap();
         assert_eq!(sender_read, sender.to_string());
+        let indexed_on_node = tx.get("indexedOnNode").unwrap().as_bool().unwrap();
+        assert!(indexed_on_node);
         cluster.cleanup_resources().await
     }
 
@@ -560,6 +563,7 @@ mod tests {
         let query = r#"{ dryRunTransactionBlock(txBytes: $tx) {
                 transaction {
                     digest
+                    indexedOnNode
                     sender {
                         address
                     }
@@ -609,13 +613,12 @@ mod tests {
         let binding = res.response_body().data.clone().into_json().unwrap();
         let res = binding.get("dryRunTransactionBlock").unwrap();
 
-        let digest = res.get("transaction").unwrap().get("digest").unwrap();
+        let tx = res.get("transaction").unwrap();
+        let digest = tx.get("digest").unwrap();
         // Dry run txn does not have digest
         assert!(digest.is_null());
         assert!(res.get("error").unwrap().is_null());
-        let sender_read = res
-            .get("transaction")
-            .unwrap()
+        let sender_read = tx
             .get("sender")
             .unwrap()
             .get("address")
@@ -623,6 +626,8 @@ mod tests {
             .as_str()
             .unwrap();
         assert_eq!(sender_read, sender.to_string());
+        let indexed_on_node = tx.get("indexedOnNode").unwrap().as_bool().unwrap();
+        assert!(!indexed_on_node);
         assert!(res.get("results").unwrap().is_array());
         cluster.cleanup_resources().await
     }

--- a/crates/iota-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/iota-graphql-rpc/tests/e2e_tests.rs
@@ -12,11 +12,12 @@ mod tests {
         config::ConnectionConfig,
         test_infra::cluster::{DEFAULT_INTERNAL_DATA_SOURCE_PORT, ExecutorCluster},
     };
+    use iota_graphql_rpc_client::{response::GraphqlResponse, simple_client::SimpleClient};
     use iota_types::{
         IOTA_FRAMEWORK_ADDRESS, IOTA_FRAMEWORK_PACKAGE_ID, STARDUST_ADDRESS,
-        digests::ChainIdentifier,
+        digests::{ChainIdentifier, TransactionDigest},
         gas_coin::GAS,
-        transaction::{CallArg, ObjectArg, TransactionDataAPI},
+        transaction::{CallArg, ObjectArg, Transaction, TransactionDataAPI},
     };
     use rand::{SeedableRng, rngs::StdRng};
     use serde_json::json;
@@ -24,6 +25,51 @@ mod tests {
     use simulacrum::Simulacrum;
     use tempfile::tempdir;
     use tokio::time::sleep;
+
+    async fn mutation_execute_transaction(
+        client: &SimpleClient,
+        signed_tx: &Transaction,
+    ) -> GraphqlResponse {
+        let (tx_bytes, sigs) = signed_tx.to_tx_bytes_and_signatures();
+        let tx_bytes = tx_bytes.encoded();
+        let sigs = sigs.iter().map(|sig| sig.encoded()).collect::<Vec<_>>();
+
+        let mutation = r#"{ executeTransactionBlock(txBytes: $tx,  signatures: $sigs) { effects { transactionBlock { digest } } errors}}"#;
+
+        let variables = vec![
+            GraphqlQueryVariable {
+                name: "tx".to_string(),
+                ty: "String!".to_string(),
+                value: json!(tx_bytes),
+            },
+            GraphqlQueryVariable {
+                name: "sigs".to_string(),
+                ty: "[String!]!".to_string(),
+                value: json!(sigs),
+            },
+        ];
+        client
+            .execute_mutation_to_graphql(mutation.to_string(), variables)
+            .await
+            .unwrap()
+    }
+
+    async fn query_is_transaction_indexed_on_node(client: &SimpleClient, digest: &str) -> bool {
+        let query = "{ isTransactionIndexedOnNode(digest: $digest) }";
+        let variables = vec![GraphqlQueryVariable {
+            name: "digest".to_string(),
+            ty: "String!".to_string(),
+            value: json!(digest),
+        }];
+        let resp = client
+            .execute_to_graphql(query.to_string(), false, variables.clone(), vec![])
+            .await
+            .unwrap()
+            .response_body_json();
+        resp["data"]["isTransactionIndexedOnNode"]
+            .as_bool()
+            .unwrap()
+    }
 
     async fn prep_executor_cluster() -> (ConnectionConfig, ExecutorCluster) {
         let rng = StdRng::from_seed([12; 32]);
@@ -309,66 +355,71 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn test_transaction_execution() {
-        let _guard = telemetry_subscribers::TelemetryConfig::new()
-            .with_env()
-            .init();
-
+    async fn test_transaction_is_indexed_on_node() {
         let cluster =
             iota_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
                 .await;
 
-        let addresses = cluster.validator_fullnode_handle.wallet.get_addresses();
-
-        let sender = addresses[0];
-        let recipient = addresses[1];
-        let tx = cluster
-            .validator_fullnode_handle
-            .test_transaction_builder()
+        let tx = cluster.build_transfer_iota_for_test().await;
+        let signed_tx = cluster.sign_transaction(&tx);
+        let raw_response = mutation_execute_transaction(&cluster.graphql_client, &signed_tx)
             .await
-            .transfer_iota(Some(1_000), recipient)
-            .build();
-        let signed_tx = cluster
-            .validator_fullnode_handle
-            .wallet
-            .sign_transaction(&tx);
-        let original_digest = signed_tx.digest();
-        let (tx_bytes, sigs) = signed_tx.to_tx_bytes_and_signatures();
-        let tx_bytes = tx_bytes.encoded();
-        let sigs = sigs.iter().map(|sig| sig.encoded()).collect::<Vec<_>>();
+            .response_body_json();
+        let response = &raw_response["data"]["executeTransactionBlock"];
 
-        let mutation = r#"{ executeTransactionBlock(txBytes: $tx,  signatures: $sigs) { effects { transactionBlock { digest } } errors}}"#;
-
-        let variables = vec![
-            GraphqlQueryVariable {
-                name: "tx".to_string(),
-                ty: "String!".to_string(),
-                value: json!(tx_bytes),
-            },
-            GraphqlQueryVariable {
-                name: "sigs".to_string(),
-                ty: "[String!]!".to_string(),
-                value: json!(sigs),
-            },
-        ];
-        let res = cluster
-            .graphql_client
-            .execute_mutation_to_graphql(mutation.to_string(), variables)
-            .await
-            .unwrap();
-        let binding = res.response_body().data.clone().into_json().unwrap();
-        let res = binding.get("executeTransactionBlock").unwrap();
-
-        let digest = res
-            .get("effects")
-            .unwrap()
-            .get("transactionBlock")
-            .unwrap()
-            .get("digest")
-            .unwrap()
+        let digest = response["effects"]["transactionBlock"]["digest"]
             .as_str()
             .unwrap();
-        assert!(res.get("errors").unwrap().is_null());
+
+        // wait for the transaction to be indexed on the node
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if !query_is_transaction_indexed_on_node(&cluster.graphql_client, digest).await {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                } else {
+                    break;
+                }
+            }
+        })
+        .await
+        .unwrap();
+
+        cluster.cleanup_resources().await
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_transaction_not_indexed_on_node() {
+        let cluster =
+            iota_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
+                .await;
+        let digest = TransactionDigest::generate(StdRng::from_seed([12; 32])).to_string();
+
+        assert!(
+            !query_is_transaction_indexed_on_node(&cluster.graphql_client, digest.as_str()).await
+        );
+        cluster.cleanup_resources().await
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_transaction_execution() {
+        let cluster =
+            iota_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
+                .await;
+
+        let tx = cluster.build_transfer_iota_for_test().await;
+        let signed_tx = cluster.sign_transaction(&tx);
+        let original_digest = signed_tx.digest();
+        let raw_response = mutation_execute_transaction(&cluster.graphql_client, &signed_tx)
+            .await
+            .response_body_json();
+        let response = &raw_response["data"]["executeTransactionBlock"];
+
+        let digest = response["effects"]["transactionBlock"]["digest"]
+            .as_str()
+            .unwrap();
+        assert!(raw_response["errors"].is_null());
         assert_eq!(digest, original_digest.to_string());
 
         // Wait for the transaction to be committed and indexed
@@ -390,25 +441,20 @@ mod tests {
             ty: "String!".to_string(),
             value: json!(digest),
         }];
-        let res = cluster
+        let raw_response = cluster
             .graphql_client
             .execute_to_graphql(query.to_string(), true, variables, vec![])
             .await
-            .unwrap();
-
-        let binding = res.response_body().data.clone().into_json().unwrap();
-        let tx = binding.get("transactionBlock").unwrap();
-
-        let sender_read = tx
-            .get("sender")
             .unwrap()
-            .get("address")
-            .unwrap()
-            .as_str()
-            .unwrap();
-        assert_eq!(sender_read, sender.to_string());
+            .response_body_json();
+
+        let tx = &raw_response["data"]["transactionBlock"];
+
+        let sender_read = tx["sender"]["address"].as_str().unwrap();
+        assert_eq!(sender_read, signed_tx.sender_address().to_string());
         let indexed_on_node = tx.get("indexedOnNode").unwrap().as_bool().unwrap();
         assert!(indexed_on_node);
+
         cluster.cleanup_resources().await
     }
 
@@ -548,17 +594,9 @@ mod tests {
             iota_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
                 .await;
 
-        let addresses = cluster.validator_fullnode_handle.wallet.get_addresses();
-
-        let sender = addresses[0];
-        let recipient = addresses[1];
-        let tx = cluster
-            .validator_fullnode_handle
-            .test_transaction_builder()
-            .await
-            .transfer_iota(Some(1_000), recipient)
-            .build();
+        let tx = cluster.build_transfer_iota_for_test().await;
         let tx_bytes = Base64::encode(bcs::to_bytes(&tx).unwrap());
+        let sender = tx.sender();
 
         let query = r#"{ dryRunTransactionBlock(txBytes: $tx) {
                 transaction {

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -4375,6 +4375,10 @@ type TransactionBlock {
 	and Base64 encoded.
 	"""
 	bcs: Base64
+	"""
+	Returns whether the transaction has been indexed on the fullnode.
+	"""
+	indexedOnNode: Boolean
 }
 
 type TransactionBlockConnection {

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3580,6 +3580,10 @@ type Query {
 	"""
 	dryRunTransactionBlock(txBytes: String!, txMeta: TransactionMetadata, skipChecks: Boolean): DryRunResult!
 	"""
+	Check if a transaction is indexed on the fullnode.
+	"""
+	isTransactionIndexedOnNode(digest: String!): Boolean!
+	"""
 	Look up an Owner by its IotaAddress.
 	
 	`rootVersion` represents the version of the root object in some nested
@@ -4377,6 +4381,17 @@ type TransactionBlock {
 	bcs: Base64
 	"""
 	Returns whether the transaction has been indexed on the fullnode.
+	
+	This makes a request to the fullnode if the transaction is not part of
+	a checkpoint to resolve the index status on the node.
+	
+	However, as this relies on the transaction data being already
+	constructed or fetched from the backing database, it only makes
+	sense to be used with `Mutation.executeTransactionBlock` on the
+	resulting effects.
+	
+	Otherwise, it is recommended that you use
+	`Query.isTransactionIndexedOnNode` for optimal performance.
 	"""
 	indexedOnNode: Boolean
 }


### PR DESCRIPTION
# Description of change

This patch adds a new `bool` field `isIndexedOnNode` on `TransactionBlock`.

## Links to any relevant issues

Fixes #8592 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [x] GraphQL: Adds a new `Query.isTransactionIndexedOnNode` method that can be used to poll the backing fullnode
to verify that a transaction is indexed locally. This patch also introduces an additional field `TransactionBlock.indexedOnNode` that can be used in a similar way to ask for the index status of transactions just executed.
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
