### PR TITLE
feat(move-analyzer): disable building of `move-analyzer` binary in external crates

### DIFF
--- a/external-crates/move/crates/move-analyzer/Cargo.toml
+++ b/external-crates/move/crates/move-analyzer/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 license = "Apache-2.0"
 publish = false
 description = "A language server for Move"
+# `move-analyzer` binary built directly out of this crate
+# should not be used "as is", as it's sits somewhere
+# in the middle between supporting Sui and not supporting it (fully)
+autobins = false
 
 [dependencies]
 anyhow.workspace = true

--- a/external-crates/move/crates/move-analyzer/Cargo.toml
+++ b/external-crates/move/crates/move-analyzer/Cargo.toml
@@ -3,8 +3,8 @@ name = "move-analyzer"
 version = "1.0.0"
 authors = ["IOTA Foundation <info@iota.org>"]
 # `move-analyzer` binary built directly out of this crate
-# should not be used "as is", as it's sits somewhere
-# in the middle between supporting Sui and not supporting it (fully)
+# should not be used "as is", as it sits somewhere
+# in the middle between supporting IOTA and not supporting it (fully)
 autobins = false
 edition = "2021"
 license = "Apache-2.0"

--- a/external-crates/move/crates/move-analyzer/Cargo.toml
+++ b/external-crates/move/crates/move-analyzer/Cargo.toml
@@ -2,14 +2,14 @@
 name = "move-analyzer"
 version = "1.0.0"
 authors = ["IOTA Foundation <info@iota.org>"]
-edition = "2021"
-license = "Apache-2.0"
-publish = false
-description = "A language server for Move"
 # `move-analyzer` binary built directly out of this crate
 # should not be used "as is", as it's sits somewhere
 # in the middle between supporting Sui and not supporting it (fully)
 autobins = false
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+description = "A language server for Move"
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
# Description of change

For full Iota support, `move-analyzer` binary should be built with the
following command:
```shell
cargo install --git https://github.com/iotaledger/iota iota-move-lsp
```

However, prior to this PR, it was also possible to build it with the
following command which resulted in a binary that lacked some of the
features (e.g., support for implicit deps):
```shell
cargo install --git https://github.com/iotaledger/iota move-analyzer
````

This was confusing, particularly for people that use `move-analyzer`
binary to support editors other than VSCode. Hence the decision to only
allow creation of a binary from `iota-move-lsp` crate.

## Links to any relevant issues

fixes #8322 