### PR TITLE
feat(consensus): use u8 for authorityindex

### DIFF
--- a/crates/starfish/config/src/committee.rs
+++ b/crates/starfish/config/src/committee.rs
@@ -22,6 +22,7 @@ pub type Stake = u64;
 
 /// Committee is the set of authorities that participate in the consensus
 /// protocol for this epoch. Its configuration is stored and computed on chain.
+/// Committee size is currently limited to 256 as AuthorityIndex is u8.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Committee {
     /// The epoch number of this committee
@@ -32,7 +33,8 @@ pub struct Committee {
     quorum_threshold: Stake,
     /// The validity threshold (f+1).
     validity_threshold: Stake,
-    /// Protocol and network info of each authority.
+    /// Protocol and network info of each authority. Max number limited to
+    /// u8::MAX (256)
     authorities: Vec<Authority>,
     /// transaction data in a block is divided into info_length equal
     /// parts(shards) that are encoded into n shards with erasure correcting
@@ -44,7 +46,7 @@ impl Committee {
     pub fn new(epoch: Epoch, authorities: Vec<Authority>) -> Self {
         assert!(!authorities.is_empty(), "Committee cannot be empty!");
         assert!(
-            authorities.len() < u32::MAX as usize,
+            authorities.len() < u8::MAX as usize,
             "Too many authorities ({})!",
             authorities.len()
         );
@@ -103,7 +105,7 @@ impl Committee {
         self.authorities
             .iter()
             .enumerate()
-            .map(|(i, a)| (AuthorityIndex(i as u32), a))
+            .map(|(i, a)| (AuthorityIndex(i as u8), a))
     }
 
     // -----------------------------------------------------------------------
@@ -123,7 +125,7 @@ impl Committee {
     /// Returns None if index is out of bound.
     pub fn to_authority_index(&self, index: usize) -> Option<AuthorityIndex> {
         if index < self.authorities.len() {
-            Some(AuthorityIndex(index as u32))
+            Some(AuthorityIndex(index as u8))
         } else {
             None
         }
@@ -165,7 +167,7 @@ pub struct Authority {
 
 /// Each authority is uniquely identified by its AuthorityIndex in the
 /// Committee. AuthorityIndex is between 0 (inclusive) and the total number of
-/// authorities (exclusive).
+/// authorities (exclusive) limited by `u8` to 255.
 ///
 /// NOTE: for safety, invalid AuthorityIndex should be impossible to create. So
 /// AuthorityIndex should not be created or incremented outside of this file.
@@ -173,7 +175,7 @@ pub struct Authority {
 #[derive(
     Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Debug, Default, Hash, Serialize, Deserialize,
 )]
-pub struct AuthorityIndex(u32);
+pub struct AuthorityIndex(u8);
 
 impl AuthorityIndex {
     // Minimum committee size is 1, so 0 index is always valid.
@@ -181,21 +183,21 @@ impl AuthorityIndex {
 
     // Only for scanning rows in the database. Invalid elsewhere.
     pub const MIN: Self = Self::ZERO;
-    pub const MAX: Self = Self(u32::MAX);
+    pub const MAX: Self = Self(u8::MAX);
 
     pub fn value(&self) -> usize {
         self.0 as usize
     }
 }
 
-impl From<u32> for AuthorityIndex {
-    fn from(value: u32) -> Self {
+impl From<u8> for AuthorityIndex {
+    fn from(value: u8) -> Self {
         Self(value)
     }
 }
 
 impl AuthorityIndex {
-    pub fn new_for_test(index: u32) -> Self {
+    pub fn new_for_test(index: u8) -> Self {
         Self(index)
     }
 }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1475,7 +1475,7 @@ mod tests {
                 VerifiedBlockHeader::new_for_test(
                     TestBlockHeader::new(
                         (i / committee_size + 1) as u32,
-                        (i % committee_size) as u32,
+                        (i % committee_size) as u8,
                     )
                     .build(),
                 )
@@ -2878,7 +2878,7 @@ mod tests {
             .map(|header| header.reference())
             .collect::<Vec<_>>();
         for validator in 0..validators {
-            let test_block_header = TestBlockHeader::new(rounds + 1, validator as u32)
+            let test_block_header = TestBlockHeader::new(rounds + 1, validator as u8)
                 .set_commit_votes(commit_refs.clone())
                 .set_ancestors(refs_to_headers_from_prev_round.clone())
                 .set_timestamp_ms(
@@ -2903,7 +2903,7 @@ mod tests {
                 .map(|header| header.reference())
                 .collect::<Vec<_>>();
             for validator in 0..validators {
-                let test_block_header = TestBlockHeader::new(round, validator as u32)
+                let test_block_header = TestBlockHeader::new(round, validator as u8)
                     .set_ancestors(refs_to_headers_from_prev_round.clone())
                     .set_timestamp_ms(round as u64 * 1000 + (validator + round as usize + 1) as u64)
                     .build();

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -971,7 +971,7 @@ pub struct TestBlockHeader {
 }
 
 impl TestBlockHeader {
-    pub fn new(round: Round, author: u32) -> Self {
+    pub fn new(round: Round, author: u8) -> Self {
         Self {
             block_header: BlockHeaderV1 {
                 round,
@@ -987,7 +987,7 @@ impl TestBlockHeader {
         }
     }
 
-    pub fn new_with_transaction(round: Round, author: u32, tx: u8) -> Self {
+    pub fn new_with_transaction(round: Round, author: u8, tx: u8) -> Self {
         Self {
             block_header: BlockHeaderV1 {
                 round,

--- a/crates/starfish/core/src/block_manager.rs
+++ b/crates/starfish/core/src/block_manager.rs
@@ -1119,7 +1119,7 @@ mod tests {
 
         let mut ancestor_blocks = vec![];
         for i in 0..num_authorities {
-            let test_block = TestBlockHeader::new(10, i as u32)
+            let test_block = TestBlockHeader::new(10, i as u8)
                 .set_timestamp_ms(1000 + 100 * i as BlockTimestampMs)
                 .build();
             ancestor_blocks.push(VerifiedBlockHeader::new_for_test(test_block));

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -868,14 +868,14 @@ mod tests {
 
         // Populate fully connected test blocks for round 0 ~ 3, authorities 0 ~ 3.
         let first_wave_rounds: u32 = WAVE_LENGTH;
-        let num_authorities: u32 = 4;
+        let num_authorities: u8 = 4;
 
         let mut blocks = Vec::new();
         let (first_round_references, first_round_blocks): (Vec<_>, Vec<_>) = context
             .committee
             .authorities()
             .map(|index| {
-                let author_idx = index.0.value() as u32;
+                let author_idx = index.0.value() as u8;
                 let tx = index.0.value() as u8;
                 let block = TestBlockHeader::new_with_transaction(0, author_idx, tx).build();
                 VerifiedBlock::new_with_transaction_for_test(block, tx)
@@ -907,7 +907,7 @@ mod tests {
                 let base_ts = round as BlockTimestampMs * 1000;
                 let block = VerifiedBlock::new_for_test(
                     TestBlockHeader::new(round, author)
-                        .set_timestamp_ms(base_ts + (author + round) as u64)
+                        .set_timestamp_ms(base_ts + (author as u32 + round) as u64)
                         .set_ancestors(ancestors.clone())
                         .set_acknowledgments(ancestors.clone())
                         .build(),
@@ -949,7 +949,7 @@ mod tests {
         assert_eq!(subdag.timestamp_ms, leader_block.timestamp_ms());
         assert_eq!(
             subdag.blocks.len(),
-            (num_authorities * WAVE_LENGTH) as usize + 1
+            (num_authorities as u32 * WAVE_LENGTH) as usize + 1
         );
         assert_eq!(subdag.commit_ref, commit.reference());
         assert_eq!(subdag.committed_transaction_refs, first_round_references);
@@ -970,14 +970,14 @@ mod tests {
 
         // Populate fully connected test blocks for round 0 ~ 3, authorities 0 ~ 3.
         let first_wave_rounds: u32 = WAVE_LENGTH;
-        let num_authorities: u32 = 4;
+        let num_authorities: u8 = 4;
 
         let mut blocks = Vec::new();
         let (first_round_references, first_round_headers): (Vec<_>, Vec<_>) = context
             .committee
             .authorities()
             .map(|index| {
-                let author_idx = index.0.value() as u32;
+                let author_idx = index.0.value() as u8;
                 let block = TestBlockHeader::new(0, author_idx).build();
                 VerifiedBlockHeader::new_for_test(block)
             })
@@ -996,7 +996,7 @@ mod tests {
                 let base_ts = round as BlockTimestampMs * 1000;
                 let block = VerifiedBlockHeader::new_for_test(
                     TestBlockHeader::new(round, author)
-                        .set_timestamp_ms(base_ts + (author + round) as u64)
+                        .set_timestamp_ms(base_ts + (author as u32 + round) as u64)
                         .set_ancestors(ancestors.clone())
                         .set_acknowledgments(ancestors.clone())
                         .build(),
@@ -1034,7 +1034,7 @@ mod tests {
         assert_eq!(pending_subdag.timestamp_ms, leader_block.timestamp_ms());
         assert_eq!(
             pending_subdag.blocks.len(),
-            (num_authorities * WAVE_LENGTH) as usize + 1
+            (num_authorities as u32 * WAVE_LENGTH) as usize + 1
         );
         assert_eq!(pending_subdag.commit_ref, commit.reference());
         assert_eq!(

--- a/crates/starfish/core/src/commit_vote_monitor.rs
+++ b/crates/starfish/core/src/commit_vote_monitor.rs
@@ -85,7 +85,7 @@ mod test {
             .map(|i| {
                 VerifiedBlockHeader::new_for_test(
                     TestBlockHeader::new(10, i)
-                        .set_commit_votes(vec![CommitRef::new(5 + i, CommitDigest::MIN)])
+                        .set_commit_votes(vec![CommitRef::new(5 + i as u32, CommitDigest::MIN)])
                         .build(),
                 )
             })
@@ -103,8 +103,8 @@ mod test {
                 VerifiedBlockHeader::new_for_test(
                     TestBlockHeader::new(11, i)
                         .set_commit_votes(vec![
-                            CommitRef::new(6 + i, CommitDigest::MIN),
-                            CommitRef::new(7 + i, CommitDigest::MIN),
+                            CommitRef::new(6 + i as u32, CommitDigest::MIN),
+                            CommitRef::new(7 + i as u32, CommitDigest::MIN),
                         ])
                         .build(),
                 )

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1185,7 +1185,7 @@ pub(crate) fn create_cores(context: Context, authorities: Vec<Stake>) -> Vec<Cor
     let mut cores = Vec::new();
 
     for index in 0..authorities.len() {
-        let own_index = AuthorityIndex::new_for_test(index as u32);
+        let own_index = AuthorityIndex::new_for_test(index as u8);
         let core = CoreTextFixture::new(context.clone(), authorities.clone(), own_index, false);
         cores.push(core);
     }
@@ -1436,7 +1436,7 @@ mod test {
             };
 
             for (index, _authority) in context.committee.authorities().skip(authorities_to_skip) {
-                let block = TestBlockHeader::new(round, index.value() as u32)
+                let block = TestBlockHeader::new(round, index.value() as u8)
                     .set_ancestors(last_round_blocks.iter().map(|b| b.reference()).collect())
                     .build();
                 this_round_blocks.push(VerifiedBlock::new_for_test(block));

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1623,7 +1623,7 @@ mod test {
         // Populate test blocks for round 1 ~ 10, authorities 0 ~ 2.
         let num_rounds: u32 = 10;
         let non_existent_round: u32 = 100;
-        let num_authorities: u32 = 3;
+        let num_authorities: u8 = 3;
         let num_blocks_per_slot: usize = 3;
         let mut blocks = BTreeMap::new();
         for round in 1..=num_rounds {
@@ -1896,7 +1896,7 @@ mod test {
 
         // Create test blocks for round 1 ~ 10
         let num_rounds: u32 = 10;
-        let num_authorities: u32 = 4;
+        let num_authorities: u8 = 4;
         let mut block_headers = Vec::new();
 
         for round in 1..=num_rounds {
@@ -1929,7 +1929,7 @@ mod test {
         let result = dag_state.contains_block_headers(block_refs.clone());
 
         // Ensure everything is found
-        let mut expected = vec![true; (num_rounds * num_authorities) as usize];
+        let mut expected = vec![true; (num_rounds * num_authorities as u32) as usize];
         assert_eq!(result, expected);
 
         // Now try to ask also for one block ref that is neither in cache nor in store
@@ -1953,7 +1953,7 @@ mod test {
         /// Only keep elements up to 2 rounds before the last committed round
         const CACHED_ROUNDS: Round = 2;
 
-        let num_authorities: u32 = 4;
+        let num_authorities: u8 = 4;
         let (mut context, _) = Context::new_for_test(num_authorities as usize);
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
 
@@ -2006,7 +2006,7 @@ mod test {
                 BlockHeaderDigest::default(),
             ),
         );
-        let mut expected = vec![true; (num_rounds * num_authorities) as usize];
+        let mut expected = vec![true; (num_rounds * num_authorities as u32) as usize];
         expected.insert(3, false);
 
         // Attempt to check the same for via the contains slot method
@@ -2072,7 +2072,7 @@ mod test {
 
         // Create test blocks for round 1 ~ 10
         let num_rounds: u32 = 10;
-        let num_authorities: u32 = 4;
+        let num_authorities: u8 = 4;
         let mut block_headers = Vec::new();
 
         for round in 1..=num_rounds {
@@ -2244,8 +2244,9 @@ mod test {
         let mut all_blocks = Vec::new();
         for author in 1..=3 {
             for round in 10..(10 + author) {
-                let block =
-                    VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, author).build());
+                let block = VerifiedBlockHeader::new_for_test(
+                    TestBlockHeader::new(round, author as u8).build(),
+                );
                 all_blocks.push(block.clone());
                 dag_state.accept_block_header(block);
             }
@@ -2528,8 +2529,9 @@ mod test {
         let mut all_blocks = Vec::new();
         for author in 1..=3 {
             for round in 1..=author {
-                let block =
-                    VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, author).build());
+                let block = VerifiedBlockHeader::new_for_test(
+                    TestBlockHeader::new(round, author as u8).build(),
+                );
                 all_blocks.push(block.clone());
                 dag_state.accept_block_header(block);
             }
@@ -2681,7 +2683,7 @@ mod test {
 
         // Create test blocks for round 1 ~ 10
         let num_rounds: u32 = 10;
-        let num_authorities: u32 = 4;
+        let num_authorities: u8 = 4;
         let mut blocks = Vec::new();
 
         for round in 1..=num_rounds {
@@ -2717,7 +2719,7 @@ mod test {
         let result = dag_state.contains_transactions(block_refs.clone());
 
         // Ensure everything is found
-        let mut expected = vec![true; (num_rounds * num_authorities) as usize];
+        let mut expected = vec![true; (num_rounds * num_authorities as u32) as usize];
         assert_eq!(result, expected);
 
         // Now try to ask also for one block ref that is neither in cache nor in store

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -137,7 +137,7 @@ impl LeaderSchedule {
             // TODO: we need to differentiate the leader strategy in tests, so for
             // some type of testing (ex sim tests) we can use the staked approach.
             if #[cfg(test)] {
-                let leader = AuthorityIndex::new_for_test((round + leader_offset) % self.context.committee.size() as u32);
+                let leader = AuthorityIndex::new_for_test(((round + leader_offset) % self.context.committee.size() as u32) as u8);
                 let table = self.leader_swap_table.read();
                 table.swap(leader, round, leader_offset).unwrap_or(leader)
             } else {
@@ -716,14 +716,14 @@ mod tests {
 
         // Populate fully connected test blocks for round 0 ~ 4, authorities 0 ~ 3.
         let max_round: u32 = 4;
-        let num_authorities: u32 = 4;
+        let num_authorities: u8 = 4;
 
         let mut blocks = Vec::new();
         let (genesis_references, genesis): (Vec<_>, Vec<_>) = context
             .committee
             .authorities()
             .map(|index| {
-                let author_idx = index.0.value() as u32;
+                let author_idx = index.0.value() as u8;
                 let block = TestBlockHeader::new(0, author_idx).build();
                 VerifiedBlockHeader::new_for_test(block)
             })
@@ -739,7 +739,7 @@ mod tests {
                 let base_ts = round as BlockTimestampMs * 1000;
                 let block = VerifiedBlockHeader::new_for_test(
                     TestBlockHeader::new(round, author)
-                        .set_timestamp_ms(base_ts + (author + round) as u64)
+                        .set_timestamp_ms(base_ts + (author as u32 + round) as u64)
                         .set_ancestors(ancestors.clone())
                         .build(),
                 );

--- a/crates/starfish/core/src/test_dag.rs
+++ b/crates/starfish/core/src/test_dag.rs
@@ -52,7 +52,7 @@ pub(crate) fn build_dag(
             .committee
             .authorities()
             .map(|authority| {
-                let author_idx = authority.0.value() as u32;
+                let author_idx = authority.0.value() as u8;
                 // Test the case where a block from round R+1 has smaller timestamp than a block
                 // from round R.
                 let ts = round as BlockTimestampMs / 2 * num_authorities as BlockTimestampMs
@@ -84,7 +84,7 @@ pub(crate) fn build_dag_layer(
     let mut references = Vec::new();
     for (authority, ancestors) in connections {
         let round = ancestors.first().unwrap().round + 1;
-        let author = authority.value() as u32;
+        let author = authority.value() as u8;
         let block = VerifiedBlockHeader::new_for_test(
             TestBlockHeader::new(round, author)
                 .set_ancestors(ancestors)

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -560,7 +560,7 @@ impl DagBuilder {
         let mut references = Vec::new();
 
         for (authority, ancestors) in connections {
-            let author = authority.value() as u32;
+            let author = authority.value() as u8;
             let base_ts = round as BlockTimestampMs * 1000;
             let block = VerifiedBlockHeader::new_for_test(
                 TestBlockHeader::new(round, author)
@@ -1044,7 +1044,7 @@ impl<'a> LayerBuilder<'a> {
             let num_blocks = self.num_blocks_to_create(authority);
 
             for num_block in 0..num_blocks {
-                let author = authority.value() as u32;
+                let author = authority.value() as u8;
                 let base_ts = match self.timestamp_delay_ms {
                     Some(delay) => (round as BlockTimestampMs * 1000) + delay,
                     None => round as BlockTimestampMs * 1000,
@@ -1068,7 +1068,7 @@ impl<'a> LayerBuilder<'a> {
                             .cloned()
                             .unwrap_or_default(),
                     )
-                    .set_timestamp_ms(base_ts + (author + round + num_block) as u64)
+                    .set_timestamp_ms(base_ts + (author as u32 + round + num_block) as u64)
                     .set_commitment(commitment)
                     .build();
                 let block_header =

--- a/crates/starfish/core/src/test_dag_parser.rs
+++ b/crates/starfish/core/src/test_dag_parser.rs
@@ -59,7 +59,7 @@ fn parse_genesis(input: &str) -> IResult<&str, u32> {
 fn parse_authority_index(input: &str) -> IResult<&str, AuthorityIndex> {
     map_res(anychar, |c: char| {
         if c.is_ascii_uppercase() {
-            Ok((c as u32 - 'A' as u32).into())
+            Ok((c as u8 - b'A').into())
         } else {
             Err(nom::Err::Error(()))
         }
@@ -164,7 +164,7 @@ fn parse_author_and_connections(
         terminated(
             pair(
                 map(terminated(anychar, tag("->")), |author: char| {
-                    AuthorityIndex::from(author as u32 - 'A' as u32)
+                    AuthorityIndex::from(author as u8 - b'A')
                 }),
                 parse_pair_of_ancestor_selections,
             ),

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -210,7 +210,7 @@ async fn direct_skip_no_leader() {
         .committee
         .authorities()
         .map(|index| {
-            let author_idx = index.0.value() as u32;
+            let author_idx = index.0.value() as u8;
             let block = TestBlockHeader::new(0, author_idx).build();
             VerifiedBlockHeader::new_for_test(block).reference()
         })

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -190,7 +190,7 @@ struct AuthorityTestFixture {
     block_manager: BlockManager,
 }
 
-fn authority_setup(num_authorities: usize, authority_index: u32) -> AuthorityTestFixture {
+fn authority_setup(num_authorities: usize, authority_index: u8) -> AuthorityTestFixture {
     let context = Arc::new(
         Context::new_for_test(num_authorities)
             .0

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -331,7 +331,7 @@ async fn direct_skip_missing_leader_block() {
     if let DecidedLeader::Skip(leader) = sequence[2] {
         assert_eq!(
             leader.authority,
-            AuthorityIndex::new_for_test(leader_round_3),
+            AuthorityIndex::new_for_test(leader_round_3 as u8),
         );
         assert_eq!(leader.round, leader_round_3);
     } else {
@@ -490,7 +490,7 @@ async fn indirect_skip() {
             assert_eq!(block.round(), (idx + 1) as Round);
             assert_eq!(
                 block.author(),
-                AuthorityIndex::new_for_test((idx + 1) as u32 % 4)
+                AuthorityIndex::new_for_test((idx + 1) as u8 % 4)
             );
         } else if let DecidedLeader::Skip(ref slot) = decided_leader {
             assert_eq!(slot.round, 4 as Round);

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1093,7 +1093,7 @@ mod tests {
         );
 
         // Create some test transactions
-        let block_round_author: Vec<(Round, u32)> = vec![(1, 1), (2, 1), (3, 2)];
+        let block_round_author: Vec<(Round, u8)> = vec![(1, 1), (2, 1), (3, 2)];
 
         let mut block_headers = Vec::with_capacity(block_round_author.len());
 
@@ -1191,7 +1191,7 @@ mod tests {
 
         // Create block round author pairs
         let block_round_authors = (1..LIVE_FETCH_TRANSACTIONS_CONCURRENCY * 2 + 1)
-            .map(|i| (i as Round, 1u32))
+            .map(|i| (i as Round, 1u8))
             .collect::<Vec<_>>();
 
         let mut block_headers = Vec::with_capacity(block_round_authors.len());
@@ -1299,7 +1299,7 @@ mod tests {
         );
 
         // Create some test transactions
-        let block_round_author: Vec<(Round, u32)> = vec![(1, 0), (2, 1), (3, 2)];
+        let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
 
         let mut block_headers = Vec::with_capacity(block_round_author.len());
 
@@ -1415,7 +1415,7 @@ mod tests {
         );
 
         // Create some test transactions
-        let block_round_author: Vec<(Round, u32)> = vec![(1, 0), (2, 1), (3, 2)];
+        let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
 
         let mut block_headers = Vec::with_capacity(block_round_author.len());
 
@@ -1520,7 +1520,7 @@ mod tests {
         );
 
         // Create some test transactions
-        let block_round_author: Vec<(Round, u32)> = vec![(1, 0), (2, 1), (3, 2)];
+        let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
 
         let mut block_headers = Vec::with_capacity(block_round_author.len());
 
@@ -1627,7 +1627,7 @@ mod tests {
         );
 
         // Create some test transactions
-        let block_round_author: Vec<(Round, u32)> = vec![(1, 0), (2, 1), (3, 2)];
+        let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
 
         let mut block_headers = Vec::with_capacity(block_round_author.len());
 
@@ -1734,7 +1734,7 @@ mod tests {
         );
 
         // Create some test transactions
-        let block_round_author: Vec<(Round, u32)> = vec![(1, 0), (2, 1), (3, 2)];
+        let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
 
         let mut block_headers = Vec::with_capacity(block_round_author.len());
 

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -67,7 +67,7 @@ mod test {
             };
             let node = AuthorityNode::new(config);
 
-            if index != AuthorityIndex::new_for_test(NUM_OF_AUTHORITIES as u32 - 1) {
+            if index != AuthorityIndex::new_for_test(NUM_OF_AUTHORITIES as u8 - 1) {
                 node.start().await.unwrap();
                 node.spawn_committed_subdag_consumer().unwrap();
 


### PR DESCRIPTION
# Description of change

Use `u8` instead of `u32` for `AuthorityIndex` in `BlockHeader` to compress bandwidth.

## Links to any relevant issues

fixes #8590 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
