### PR TITLE
fix(docker): Fix build of iota docker container

### DIFF
--- a/docker/iota/Dockerfile
+++ b/docker/iota/Dockerfile
@@ -11,7 +11,7 @@ ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "/iota"
 
 # Install build dependencies, including clang and lld for faster linking
-RUN apt update && apt install -y cmake clang lld protobuf-compiler
+RUN apt update && apt install -y cmake clang lld libudev-dev protobuf-compiler
 
 # Configure Rust to use clang and lld as the linker
 RUN mkdir -p ~/.cargo && \


### PR DESCRIPTION
# Description of change

`docker compose build local-network` was failing because of `Unable to find libudev` 

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/8613

## How the change has been tested

```
$ cd dev-tools/pg-services-local/
$ docker compose build local-network
```

