### PR TITLE
feat(consensus, iota-core, iota-protocol-config): Add scorer protocol config

### DIFF
--- a/consensus/core/src/scorer.rs
+++ b/consensus/core/src/scorer.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use consensus_config::AuthorityIndex;
+use iota_protocol_config::ProtocolConfig;
 use itertools::izip;
 
 use crate::{
@@ -22,16 +23,28 @@ use crate::{
 /// and the evictions that happen in storage. It also holds the partial scores
 /// for each authority, which are then added to EndOfPublishV2 and used to
 /// calculate a final score.
+enum ScorerVersion {
+    // Initial version of the scorer.
+    V1,
+    // Future versions can be added here.
+}
 pub struct Scorer {
     scoring_metrics: ValidatorScoringMetrics,
     partial_scores: PartialScores,
+    #[allow(dead_code)]
+    version: ScorerVersion,
 }
 
 impl Scorer {
-    pub fn new(committee_size: usize) -> Self {
+    pub fn new(committee_size: usize, protocol_config: &ProtocolConfig) -> Self {
+        let version = match protocol_config.scorer_version_as_option() {
+            None | Some(1) => ScorerVersion::V1,
+            _ => panic!("Unsupported scorer version"),
+        };
         Self {
             scoring_metrics: ValidatorScoringMetrics::new(committee_size),
             partial_scores: PartialScores::new(committee_size),
+            version,
         }
     }
 
@@ -595,7 +608,7 @@ fn is_from_commit_syncer(err: &ConsensusError) -> bool {
 #[cfg(test)]
 impl Scorer {
     pub(crate) fn new_dummy_for_tests(committee_size: usize) -> Self {
-        Self::new(committee_size)
+        Self::new(committee_size, &ProtocolConfig::get_for_min_version())
     }
 }
 

--- a/consensus/core/src/scorer.rs
+++ b/consensus/core/src/scorer.rs
@@ -18,16 +18,17 @@ use crate::{
     storage::StorageScoringMetrics,
 };
 
-/// The Scorer holds the scoring metrics for all authorities in the committee,
-/// which is updated according to the blocks received
-/// and the evictions that happen in storage. It also holds the partial scores
-/// for each authority, which are then added to EndOfPublishV2 and used to
-/// calculate a final score.
 enum ScorerVersion {
     // Initial version of the scorer.
     V1,
     // Future versions can be added here.
 }
+
+/// The Scorer holds the scoring metrics for all authorities in the committee,
+/// which is updated according to the blocks received
+/// and the evictions that happen in storage. It also holds the partial scores
+/// for each authority, which are then added to EndOfPublishV2 and used to
+/// calculate a final score.
 pub struct Scorer {
     scoring_metrics: ValidatorScoringMetrics,
     partial_scores: PartialScores,
@@ -37,6 +38,8 @@ pub struct Scorer {
 
 impl Scorer {
     pub fn new(committee_size: usize, protocol_config: &ProtocolConfig) -> Self {
+        // If protocol_config.scorer_version is None, we use ScorerVersion::V1 but still
+        // send EndOfPublish messages (as opposed to EndOfPublishV2).
         let version = match protocol_config.scorer_version_as_option() {
             None | Some(1) => ScorerVersion::V1,
             _ => panic!("Unsupported scorer version"),

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -954,7 +954,7 @@ impl AuthorityPerEpochStore {
         let s = Arc::new(Self {
             name,
             committee,
-            protocol_config,
+            protocol_config: protocol_config.clone(),
             tables: ArcSwapOption::new(Some(Arc::new(tables))),
             consensus_output_cache,
             consensus_quarantine: RwLock::new(ConsensusOutputQuarantine::new(
@@ -986,7 +986,7 @@ impl AuthorityPerEpochStore {
             jwk_aggregator,
             randomness_manager: OnceCell::new(),
             randomness_reporter: OnceCell::new(),
-            scorer: Arc::new(Scorer::new(committee_size)),
+            scorer: Arc::new(Scorer::new(committee_size, &protocol_config)),
         });
 
         s.update_buffer_stake_metric();

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -732,10 +732,7 @@ impl SequencedConsensusTransaction {
 
     pub fn is_end_of_publish_v1(&self) -> bool {
         if let SequencedConsensusTransactionKind::External(ref transaction) = self.transaction {
-            matches!(
-                transaction.kind,
-                ConsensusTransactionKind::EndOfPublish(..)
-            )
+            matches!(transaction.kind, ConsensusTransactionKind::EndOfPublish(..))
         } else {
             false
         }

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -72,7 +72,6 @@ pub const MAX_PROTOCOL_VERSION: u64 = 12;
 //             Add additional linkage checks
 // Version 11: Framework fix regarding candidate validator commission rate.
 // Version 12: Enable the gas price feedback mechanism in all networks.
-// Version 13: Score integration with consensus.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1108,7 +1107,10 @@ pub struct ProtocolConfig {
     /// `0` then the garbage collection is disabled.
     consensus_gc_depth: Option<u32>,
 
-    // Scorer version
+    /// Scorer version. When set to `None`, scores are not included in
+    /// EndOfEpoch messages. When set to `Some(version)`, scores are
+    /// included in the EndOfEpochV2 messages, where `version` determines
+    /// the scoring formulas to be used.
     scorer_version: Option<u64>,
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -317,10 +317,6 @@ struct FeatureFlags {
     // If true enable additional multisig checks.
     #[serde(skip_serializing_if = "is_false")]
     additional_multisig_checks: bool,
-
-    // If true enable score based reward distribution.
-    #[serde(skip_serializing_if = "is_false")]
-    score_based_rewards: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1108,9 +1104,10 @@ pub struct ProtocolConfig {
     consensus_gc_depth: Option<u32>,
 
     /// Scorer version. When set to `None`, scores are not included in
-    /// EndOfEpoch messages. When set to `Some(version)`, scores are
-    /// included in the EndOfEpochV2 messages, where `version` determines
-    /// the scoring formulas to be used.
+    /// EndOfEpoch messages. When set to `Some(version)`, scores are included in
+    /// the EndOfEpochV2 messages, where `version` determines the scoring
+    /// formulas to be used and whether rewards are adjusted based on the scores
+    /// or not.
     scorer_version: Option<u16>,
 }
 
@@ -1331,10 +1328,6 @@ impl ProtocolConfig {
         // TODO: this will eventually be the max of some number of other
         // parameters.
         0
-    }
-
-    pub fn score_based_rewards(&self) -> bool {
-        self.feature_flags.score_based_rewards
     }
 }
 
@@ -2308,10 +2301,6 @@ impl ProtocolConfig {
     pub fn set_congestion_control_gas_price_feedback_mechanism_for_testing(&mut self, val: bool) {
         self.feature_flags
             .congestion_control_gas_price_feedback_mechanism = val;
-    }
-
-    pub fn set_score_based_rewards_for_testing(&mut self, val: bool) {
-        self.feature_flags.score_based_rewards = val;
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -318,6 +318,10 @@ struct FeatureFlags {
     // If true enable additional multisig checks.
     #[serde(skip_serializing_if = "is_false")]
     additional_multisig_checks: bool,
+
+    // If true enable score based reward distribution.
+    #[serde(skip_serializing_if = "is_false")]
+    score_based_rewards: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1326,6 +1330,10 @@ impl ProtocolConfig {
         // parameters.
         0
     }
+
+    pub fn score_based_rewards(&self) -> bool {
+        self.feature_flags.score_based_rewards
+    }
 }
 
 #[cfg(not(msim))]
@@ -2141,6 +2149,7 @@ impl ProtocolConfig {
                 }
                 13 => {
                     cfg.scorer_version = Some(1);
+                    cfg.feature_flags.score_based_rewards = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-pub const MAX_PROTOCOL_VERSION: u64 = 13;
+pub const MAX_PROTOCOL_VERSION: u64 = 12;
 
 // Record history of protocol version allocations here:
 //
@@ -2147,10 +2147,6 @@ impl ProtocolConfig {
                     cfg.feature_flags
                         .congestion_control_gas_price_feedback_mechanism = true;
                 }
-                13 => {
-                    cfg.scorer_version = Some(1);
-                    cfg.feature_flags.score_based_rewards = true;
-                }
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.
@@ -2310,6 +2306,10 @@ impl ProtocolConfig {
     pub fn set_congestion_control_gas_price_feedback_mechanism_for_testing(&mut self, val: bool) {
         self.feature_flags
             .congestion_control_gas_price_feedback_mechanism = val;
+    }
+
+    pub fn set_score_based_rewards_for_testing(&mut self, val: bool) {
+        self.feature_flags.score_based_rewards = val;
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-pub const MAX_PROTOCOL_VERSION: u64 = 12;
+pub const MAX_PROTOCOL_VERSION: u64 = 13;
 
 // Record history of protocol version allocations here:
 //
@@ -72,6 +72,7 @@ pub const MAX_PROTOCOL_VERSION: u64 = 12;
 //             Add additional linkage checks
 // Version 11: Framework fix regarding candidate validator commission rate.
 // Version 12: Enable the gas price feedback mechanism in all networks.
+// Version 13: Score integration with consensus.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1102,6 +1103,9 @@ pub struct ProtocolConfig {
     /// Configures the garbage collection depth for consensus. When is unset or
     /// `0` then the garbage collection is disabled.
     consensus_gc_depth: Option<u32>,
+
+    // Scorer version
+    scorer_version: Option<u64>,
 }
 
 // feature flags
@@ -1878,6 +1882,8 @@ impl ProtocolConfig {
             max_committee_members_count: None,
 
             consensus_gc_depth: None,
+
+            scorer_version: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };
@@ -2132,6 +2138,9 @@ impl ProtocolConfig {
                     // cancelled due to congestion in all networks
                     cfg.feature_flags
                         .congestion_control_gas_price_feedback_mechanism = true;
+                }
+                13 => {
+                    cfg.scorer_version = Some(1);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1111,7 +1111,7 @@ pub struct ProtocolConfig {
     /// EndOfEpoch messages. When set to `Some(version)`, scores are
     /// included in the EndOfEpochV2 messages, where `version` determines
     /// the scoring formulas to be used.
-    scorer_version: Option<u64>,
+    scorer_version: Option<u16>,
 }
 
 // feature flags

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -1360,7 +1360,7 @@ impl From<ExecutionError> for crate::execution_status::ExecutionFailureStatus {
                             }
                         }
                         // TO DO: check this error. This mapping is currently a placeholder
-                        CommandArgumentError::InvalidArgumentArity { .. } => {
+                        CommandArgumentError::InvalidArgumentArity => {
                             InternalCmdArgErr::InvalidGasCoinUsage
                         }
 


### PR DESCRIPTION
```mermaid
---
config:
  gitGraph:
    {parallelCommits: true,
    mainBranchName: 'Feature',
    rotateCommitLabel: true}
---
gitGraph
   commit id: "Initial commit"
   commit id: "Add ChangeEpochV4" tag: "#8522  "
   commit id: "Add Scorer" tag: "#8530"
   commit id: "Add EndOfPublishV2" tag: "#8529 "
   checkout Feature
   branch mergedbranch
   commit id: "Add protocol configs"
      branch process-EOPV2
   commit id: "EndOfPublishV2 processing"
    checkout mergedbranch
    branch advance-epoch
   commit id: "add advance_epoch_v4"
    checkout mergedbranch
    branch send-EOPV2
   commit id: "EndOfPublishV2 dissemination"
 checkout Feature
    merge mergedbranch tag: "THIS PR"
```

# Description of change

Adds the protocol configs to be used for the score integration to consensus.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): New protocol configs relative to scores
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
