### PR TITLE
fix(iota): Use provided sender over inferred sender

### DIFF
--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -976,7 +976,11 @@ impl IotaClientCommands {
                 gas_data,
                 processing,
             } => {
-                let sender = context.infer_sender(&payment.gas).await?;
+                let sender = if let Some(sender) = processing.sender {
+                    sender
+                } else {
+                    context.infer_sender(&payment.gas).await?
+                };
                 let client = context.get_client().await?;
                 let read_api = client.read_api();
                 let chain_id = read_api.get_chain_identifier().await.ok();
@@ -1129,7 +1133,11 @@ impl IotaClientCommands {
                     .into());
                 }
 
-                let sender = context.infer_sender(&payment.gas).await?;
+                let sender = if let Some(sender) = processing.sender {
+                    sender
+                } else {
+                    context.infer_sender(&payment.gas).await?
+                };
                 let client = context.get_client().await?;
                 let read_api = client.read_api();
                 let chain_id = read_api.get_chain_identifier().await.ok();
@@ -1370,7 +1378,11 @@ impl IotaClientCommands {
                     .move_call_tx_kind(package, &module, &function, type_args, args)
                     .await?;
 
-                let sender = context.infer_sender(&payment.gas).await?;
+                let sender = if let Some(sender) = processing.sender {
+                    sender
+                } else {
+                    context.infer_sender(&payment.gas).await?
+                };
                 let gas_payment = client
                     .transaction_builder()
                     .input_refs(&payment.gas)
@@ -1827,7 +1839,11 @@ impl IotaClientCommands {
                 };
 
                 let client = context.get_client().await?;
-                let sender = context.infer_sender(&payment.gas).await?;
+                let sender = if let Some(sender) = processing.sender {
+                    sender
+                } else {
+                    context.infer_sender(&payment.gas).await?
+                };
                 let gas_payment = client
                     .transaction_builder()
                     .input_refs(&payment.gas)


### PR DESCRIPTION
## Description 

Uses the provided `--sender` if there is one, rather than always inferring it, in the following commands:

- `iota client call`
- `iota client publish`
- `iota client upgrade`
- `iota client serialized-tx-kind`

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Use the provided `--sender` if there is one, rather than always inferring it, for iota client call, publish, upgrade, and serialized-tx-kind.
- [ ] Rust SDK:
- [ ] REST API:
