### PR TITLE
feat(move-compiler): Add additional arity checks to typing stage

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -4065,6 +4065,7 @@ fn module_call_impl(
         context,
         loc,
         || format!("Invalid call of '{}::{}'", &m, &f),
+        Some(declared),
         parameters.len(),
         argloc,
         args,
@@ -4277,6 +4278,7 @@ fn builtin_call(
         context,
         loc,
         || format!("Invalid call of '{}'", &b_),
+        None,
         params_ty.len(),
         argloc,
         args,
@@ -4319,7 +4321,7 @@ fn syntax_call_return_ty(
     let arg_tys = {
         let msg = || format!("Invalid call of '{}::{}'", &m, &f);
         let arity = parameters.len();
-        make_arg_types(context, loc, msg, arity, argloc, tys)
+        make_arg_types(context, loc, msg, Some(declared), arity, argloc, tys)
     };
     assert!(arg_tys.len() == parameters.len());
     let mut valid = true;
@@ -4375,6 +4377,7 @@ fn vector_pack(
         context,
         eloc,
         || -> String { panic!("ICE. could not create vector args") },
+        None,
         arity,
         argloc,
         args_,
@@ -4416,13 +4419,14 @@ fn call_args<S: std::fmt::Display, F: Fn() -> S>(
     context: &mut Context,
     loc: Loc,
     msg: F,
+    arity_loc: Option<Loc>,
     arity: usize,
     argloc: Loc,
     mut args: Vec<T::Exp>,
 ) -> (Box<T::Exp>, Vec<Type>) {
     use T::UnannotatedExp_ as TE;
     let tys = args.iter().map(|e| e.ty.clone()).collect();
-    let tys = make_arg_types(context, loc, msg, arity, argloc, tys);
+    let tys = make_arg_types(context, loc, msg, arity_loc, arity, argloc, tys);
     let arg = match args.len() {
         0 => T::exp(
             sp(argloc, Type_::Unit),
@@ -4442,12 +4446,13 @@ fn make_arg_types<S: std::fmt::Display, F: Fn() -> S>(
     context: &mut Context,
     loc: Loc,
     msg: F,
+    arity_loc: Option<Loc>,
     arity: usize,
     argloc: Loc,
     mut given: Vec<Type>,
 ) -> Vec<Type> {
     let given_len = given.len();
-    core::check_call_arity(context, loc, msg, None, arity, argloc, given_len);
+    core::check_call_arity(context, loc, msg, arity_loc, arity, argloc, given_len);
     while given.len() < arity {
         given.push(context.error_type(argloc))
     }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_syntax_methods_miscalled.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_syntax_methods_miscalled.snap
@@ -184,6 +184,9 @@ error[E04007]: incompatible types
 error[E04017]: too many arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:120:9
     │
+  8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+    │                       ------ Expected 2 argument(s)
+    ·
 120 │         &v[i, j]
     │         ^^^^^^^^
     │         │ │
@@ -193,6 +196,9 @@ error[E04017]: too many arguments
 error[E04017]: too many arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:120:10
     │
+  8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+    │                       ------ Expected 2 argument(s)
+    ·
 120 │         &v[i, j]
     │          ^^^^^^^
     │          ││
@@ -202,6 +208,9 @@ error[E04017]: too many arguments
 error[E04017]: too many arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:124:9
     │
+ 12 │     native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
+    │                       ---------- Expected 2 argument(s)
+    ·
 124 │         &mut v[i, j]
     │         ^^^^^^^^^^^^
     │         │     │
@@ -211,6 +220,9 @@ error[E04017]: too many arguments
 error[E04017]: too many arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:124:14
     │
+  8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+    │                       ------ Expected 2 argument(s)
+    ·
 124 │         &mut v[i, j]
     │              ^^^^^^^
     │              ││
@@ -220,6 +232,9 @@ error[E04017]: too many arguments
 error[E04017]: too many arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:128:10
     │
+  8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+    │                       ------ Expected 2 argument(s)
+    ·
 128 │         &v[i, j]
     │          ^^^^^^^
     │          ││
@@ -246,6 +261,9 @@ error[E03004]: unbound type
 error[E04017]: too many arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:132:14
     │
+  8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+    │                       ------ Expected 2 argument(s)
+    ·
 132 │         &mut v[i, j]
     │              ^^^^^^^
     │              ││
@@ -266,6 +284,9 @@ error[E04007]: incompatible types
 error[E04016]: too few arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:152:9
     │
+142 │     public fun borrow_s(s: &S, i: u64, j: u64): &u64 {
+    │                -------- Expected 3 argument(s)
+    ·
 152 │         &s[i]
     │         ^^^^^
     │         │ │
@@ -275,6 +296,9 @@ error[E04016]: too few arguments
 error[E04016]: too few arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:152:10
     │
+142 │     public fun borrow_s(s: &S, i: u64, j: u64): &u64 {
+    │                -------- Expected 3 argument(s)
+    ·
 152 │         &s[i]
     │          ^^^^
     │          ││
@@ -284,6 +308,9 @@ error[E04016]: too few arguments
 error[E04016]: too few arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:156:9
     │
+147 │     public fun borrow_s_mut(s: &mut S, i: u64, j: u64): &mut u64 {
+    │                ------------ Expected 3 argument(s)
+    ·
 156 │         &mut s[i]
     │         ^^^^^^^^^
     │         │     │
@@ -293,6 +320,9 @@ error[E04016]: too few arguments
 error[E04016]: too few arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:156:14
     │
+142 │     public fun borrow_s(s: &S, i: u64, j: u64): &u64 {
+    │                -------- Expected 3 argument(s)
+    ·
 156 │         &mut s[i]
     │              ^^^^
     │              ││

--- a/external-crates/move/crates/move-compiler/tests/move_check/borrows/unused_ref.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/borrows/unused_ref.snap
@@ -8,6 +8,9 @@ info:
 error[E04017]: too many arguments
    ┌─ tests/move_check/borrows/unused_ref.move:28:5
    │
+19 │ fun borrow<K: copy + drop + store, V: store>(_x: &X, _k: K): &V {
+   │     ------ Expected 2 argument(s)
+   ·
 28 │     borrow<u64, u64>(&mut x, 0, 0);
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │     │               │

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/module_call.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/module_call.snap
@@ -20,6 +20,9 @@ error[E04007]: incompatible types
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:43:18
    │
+11 │     public fun bing(_: bool, _: address, _: u64) {
+   │                ---- Expected 3 argument(s)
+   ·
 43 │         let () = X::bing(X::baz(X::bar(X::foo())));
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │                  │      │
@@ -38,6 +41,9 @@ error[E04004]: expected a single non-reference type
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:43:26
    │
+ 8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                --- Expected 2 argument(s)
+   ·
 43 │         let () = X::bing(X::baz(X::bar(X::foo())));
    │                          ^^^^^^^^^^^^^^^^^^^^^^^^
    │                          │     │
@@ -59,6 +65,9 @@ error[E04007]: incompatible types
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:44:18
    │
+11 │     public fun bing(_: bool, _: address, _: u64) {
+   │                ---- Expected 3 argument(s)
+   ·
 44 │         let () = X::bing (X::baz (X::bar (X::foo())));
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │                  │       │
@@ -77,6 +86,9 @@ error[E04004]: expected a single non-reference type
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:44:27
    │
+ 8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                --- Expected 2 argument(s)
+   ·
 44 │         let () = X::bing (X::baz (X::bar (X::foo())));
    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
    │                           │      │
@@ -98,6 +110,9 @@ error[E04007]: incompatible types
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:45:18
    │
+11 │     public fun bing(_: bool, _: address, _: u64) {
+   │                ---- Expected 3 argument(s)
+   ·
 45 │         let () = X::bing (X::baz (X::bar(1)));
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │                  │       │
@@ -116,6 +131,9 @@ error[E04004]: expected a single non-reference type
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:45:27
    │
+ 8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                --- Expected 2 argument(s)
+   ·
 45 │         let () = X::bing (X::baz (X::bar(1)));
    │                           ^^^^^^^^^^^^^^^^^^
    │                           │      │
@@ -137,6 +155,9 @@ error[E04007]: incompatible types
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:46:18
    │
+11 │     public fun bing(_: bool, _: address, _: u64) {
+   │                ---- Expected 3 argument(s)
+   ·
 46 │         let () = X::bing (X::baz (@0x0, 1));
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    │                  │       │
@@ -158,6 +179,9 @@ error[E04007]: incompatible types
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:51:18
    │
+25 │     fun bing(_: bool, _: address, _: u64) {
+   │         ---- Expected 3 argument(s)
+   ·
 51 │         let () = bing(baz(bar(foo())));
    │                  ^^^^^^^^^^^^^^^^^^^^^
    │                  │   │
@@ -176,6 +200,9 @@ error[E04004]: expected a single non-reference type
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:51:23
    │
+22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │         --- Expected 2 argument(s)
+   ·
 51 │         let () = bing(baz(bar(foo())));
    │                       ^^^^^^^^^^^^^^^
    │                       │  │
@@ -197,6 +224,9 @@ error[E04007]: incompatible types
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:52:18
    │
+25 │     fun bing(_: bool, _: address, _: u64) {
+   │         ---- Expected 3 argument(s)
+   ·
 52 │         let () = bing (baz (bar (foo())));
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^
    │                  │    │
@@ -215,6 +245,9 @@ error[E04004]: expected a single non-reference type
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:52:24
    │
+22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │         --- Expected 2 argument(s)
+   ·
 52 │         let () = bing (baz (bar (foo())));
    │                        ^^^^^^^^^^^^^^^^^
    │                        │   │
@@ -236,6 +269,9 @@ error[E04007]: incompatible types
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:53:18
    │
+25 │     fun bing(_: bool, _: address, _: u64) {
+   │         ---- Expected 3 argument(s)
+   ·
 53 │         let () = bing (baz (bar(1)));
    │                  ^^^^^^^^^^^^^^^^^^^
    │                  │    │
@@ -254,6 +290,9 @@ error[E04004]: expected a single non-reference type
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:53:24
    │
+22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │         --- Expected 2 argument(s)
+   ·
 53 │         let () = bing (baz (bar(1)));
    │                        ^^^^^^^^^^^^
    │                        │   │
@@ -275,6 +314,9 @@ error[E04007]: incompatible types
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call.move:54:18
    │
+25 │     fun bing(_: bool, _: address, _: u64) {
+   │         ---- Expected 3 argument(s)
+   ·
 54 │         let () = bing (baz (@0x0, 1));
    │                  ^^^^^^^^^^^^^^^^^^^^
    │                  │    │

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/module_call_complicated_rhs.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/module_call_complicated_rhs.snap
@@ -8,6 +8,9 @@ info:
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_complicated_rhs.move:11:9
    │
+ 2 │     fun foo(): u64 { 0 }
+   │         --- Expected 0 argument(s)
+   ·
 11 │         foo (if (cond) () else ());
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │   │
@@ -26,6 +29,9 @@ error[E04004]: expected a single non-reference type
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call_complicated_rhs.move:13:9
    │
+ 6 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │         --- Expected 2 argument(s)
+   ·
 13 │         baz (if (cond) (false, @0x0) else (true, @0x1));
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │   │
@@ -35,6 +41,9 @@ error[E04016]: too few arguments
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_complicated_rhs.move:17:9
    │
+ 2 │     fun foo(): u64 { 0 }
+   │         --- Expected 0 argument(s)
+   ·
 17 │         foo(if (cond) () else ());
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │  │
@@ -53,6 +62,9 @@ error[E04004]: expected a single non-reference type
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call_complicated_rhs.move:19:9
    │
+ 6 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │         --- Expected 2 argument(s)
+   ·
 19 │         baz(if (cond) (false, @0x0) else (true, @0x1));
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │  │
@@ -62,6 +74,9 @@ error[E04016]: too few arguments
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_complicated_rhs.move:23:9
    │
+ 2 │     fun foo(): u64 { 0 }
+   │         --- Expected 0 argument(s)
+   ·
 23 │         foo({});
    │         ^^^^^^^
    │         │  │
@@ -71,6 +86,9 @@ error[E04017]: too many arguments
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_complicated_rhs.move:24:9
    │
+ 2 │     fun foo(): u64 { 0 }
+   │         --- Expected 0 argument(s)
+   ·
 24 │         foo({ let _x = 0; });
    │         ^^^^^^^^^^^^^^^^^^^^
    │         │  │
@@ -89,6 +107,9 @@ error[E04004]: expected a single non-reference type
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call_complicated_rhs.move:31:9
    │
+ 6 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │         --- Expected 2 argument(s)
+   ·
 31 │         baz({ (a, x) });
    │         ^^^^^^^^^^^^^^^
    │         │  │
@@ -107,6 +128,9 @@ error[E04004]: expected a single non-reference type
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call_complicated_rhs.move:32:9
    │
+ 6 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │         --- Expected 2 argument(s)
+   ·
 32 │         baz({ let a = false; (a, x) });
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │  │
@@ -116,6 +140,9 @@ error[E04016]: too few arguments
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_complicated_rhs.move:36:9
    │
+ 2 │     fun foo(): u64 { 0 }
+   │         --- Expected 0 argument(s)
+   ·
 36 │         foo({});
    │         ^^^^^^^
    │         │  │
@@ -125,6 +152,9 @@ error[E04017]: too many arguments
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_complicated_rhs.move:37:9
    │
+ 2 │     fun foo(): u64 { 0 }
+   │         --- Expected 0 argument(s)
+   ·
 37 │         foo({ let _x = 0; });
    │         ^^^^^^^^^^^^^^^^^^^^
    │         │  │
@@ -143,6 +173,9 @@ error[E04004]: expected a single non-reference type
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call_complicated_rhs.move:44:9
    │
+ 6 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │         --- Expected 2 argument(s)
+   ·
 44 │         baz({ (a, x) });
    │         ^^^^^^^^^^^^^^^
    │         │  │
@@ -161,6 +194,9 @@ error[E04004]: expected a single non-reference type
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call_complicated_rhs.move:45:9
    │
+ 6 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │         --- Expected 2 argument(s)
+   ·
 45 │         baz({ let a = false; (a, x) });
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │  │

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/module_call_wrong_arity.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/module_call_wrong_arity.snap
@@ -8,6 +8,9 @@ info:
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:27:9
    │
+ 5 │     public fun foo(): u64 { 0 }
+   │                --- Expected 0 argument(s)
+   ·
 27 │         X::foo(1);
    │         ^^^^^^^^^
    │         │     │
@@ -17,6 +20,9 @@ error[E04017]: too many arguments
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:28:9
    │
+ 5 │     public fun foo(): u64 { 0 }
+   │                --- Expected 0 argument(s)
+   ·
 28 │         X::foo(1, 2);
    │         ^^^^^^^^^^^^
    │         │     │
@@ -26,6 +32,9 @@ error[E04017]: too many arguments
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:29:9
    │
+ 6 │     public fun bar(x: u64): (address, u64) {
+   │                --- Expected 1 argument(s)
+   ·
 29 │         X::bar();
    │         ^^^^^^^^
    │         │     │
@@ -35,6 +44,9 @@ error[E04016]: too few arguments
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:30:9
    │
+ 6 │     public fun bar(x: u64): (address, u64) {
+   │                --- Expected 1 argument(s)
+   ·
 30 │         X::bar(1, 2);
    │         ^^^^^^^^^^^^
    │         │     │
@@ -44,6 +56,9 @@ error[E04017]: too many arguments
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:31:9
    │
+ 9 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                --- Expected 2 argument(s)
+   ·
 31 │         X::baz<u64, u64>();
    │         ^^^^^^^^^^^^^^^^^^
    │         │               │
@@ -53,6 +68,9 @@ error[E04016]: too few arguments
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:32:9
    │
+ 9 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                --- Expected 2 argument(s)
+   ·
 32 │         X::baz<u64, u64>(1);
    │         ^^^^^^^^^^^^^^^^^^^
    │         │               │
@@ -62,6 +80,9 @@ error[E04016]: too few arguments
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:33:9
    │
+ 9 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                --- Expected 2 argument(s)
+   ·
 33 │         X::baz(1, 2, 3);
    │         ^^^^^^^^^^^^^^^
    │         │     │
@@ -71,6 +92,9 @@ error[E04017]: too many arguments
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:37:9
    │
+18 │     fun foo(): u64 { 0 }
+   │         --- Expected 0 argument(s)
+   ·
 37 │         foo(1);
    │         ^^^^^^
    │         │  │
@@ -80,6 +104,9 @@ error[E04017]: too many arguments
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:38:9
    │
+18 │     fun foo(): u64 { 0 }
+   │         --- Expected 0 argument(s)
+   ·
 38 │         foo(1, 2);
    │         ^^^^^^^^^
    │         │  │
@@ -89,6 +116,9 @@ error[E04017]: too many arguments
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:39:9
    │
+19 │     fun bar(x: u64): (address, u64) {
+   │         --- Expected 1 argument(s)
+   ·
 39 │         bar();
    │         ^^^^^
    │         │  │
@@ -98,6 +128,9 @@ error[E04016]: too few arguments
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:40:9
    │
+19 │     fun bar(x: u64): (address, u64) {
+   │         --- Expected 1 argument(s)
+   ·
 40 │         bar(1, 2);
    │         ^^^^^^^^^
    │         │  │
@@ -107,6 +140,9 @@ error[E04017]: too many arguments
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:41:9
    │
+22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │         --- Expected 2 argument(s)
+   ·
 41 │         baz<u64, u64>();
    │         ^^^^^^^^^^^^^^^
    │         │            │
@@ -116,6 +152,9 @@ error[E04016]: too few arguments
 error[E04016]: too few arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:42:9
    │
+22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │         --- Expected 2 argument(s)
+   ·
 42 │         baz<u64, u64>(1);
    │         ^^^^^^^^^^^^^^^^
    │         │            │
@@ -125,6 +164,9 @@ error[E04016]: too few arguments
 error[E04017]: too many arguments
    ┌─ tests/move_check/typing/module_call_wrong_arity.move:43:9
    │
+22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │         --- Expected 2 argument(s)
+   ·
 43 │         baz(1, 2, 3);
    │         ^^^^^^^^^^^^
    │         │  │


### PR DESCRIPTION
# Description of change

Add additional arity diagnostics.

Example: 
```
native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
                  ------ Expected 2 argument(s)
``` 

## Links to any relevant issues

fixes #8318 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
