### PR TITLE
feat(graphql-rpc): Read optimistic transactions in graphql

### DIFF
--- a/.changeset/smooth-readers-tell.md
+++ b/.changeset/smooth-readers-tell.md
@@ -1,0 +1,6 @@
+---
+'@iota/graphql-transport': minor
+'@iota/iota-sdk': minor
+---
+
+Add a new `waitMode` in `waitForTransaction`

--- a/crates/iota-graphql-rpc/README.md
+++ b/crates/iota-graphql-rpc/README.md
@@ -147,3 +147,15 @@ In order to re-generate the GraphQL schema ([schema.graphql](schema.graphql)), r
 ```sh
 cargo run --bin iota-graphql-rpc generate-schema
 ```
+
+If the snapshot tests are failing:
+
+```sh
+cargo nextest run -p iota-graphql-rpc -- test_schema_sdl_export
+```
+
+snapshot changes can be reviewed and accepted by running:
+
+```sh
+cargo insta review
+```

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -603,14 +603,13 @@ type Coin implements IMoveObject & IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -780,14 +779,13 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -1600,7 +1598,16 @@ referred to as its address). This includes Move objects and packages.
 interface IObject {
 	version: UInt53!
 	"""
-	The current status of the object as read from the off-chain store. The possible states are: NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or system package upgrade transaction. LIVE, the version returned is the most recent for the object, and it is not deleted or wrapped at that version. HISTORICAL, the object was referenced at a specific version or checkpoint, so is fetched from historical tables and may not be the latest version of the object. WRAPPED_OR_DELETED, the object is deleted or wrapped and only partial information can be loaded.
+	
+	            The current status of the object as read from the off-chain store. The
+	            possible states are:
+	            - NOT_INDEXED: The object is loaded from serialized data, such as the
+	            contents of a genesis or system package upgrade transaction.
+	            - INDEXED: The object is retrieved from the off-chain index and
+	            represents the most recent or historical state of the object.
+	            - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	            information can be loaded.
+	        
 	"""
 	status: ObjectKind!
 	"""
@@ -2157,14 +2164,13 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2364,14 +2370,13 @@ type MovePackage implements IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2738,13 +2743,13 @@ type Mutation {
 	that was not possible. A transaction is final when its effects are
 	guaranteed on chain (it cannot be revoked).
 	
-	There may be a delay between transaction finality and when GraphQL
-	requests (including the request that issued the transaction) reflect
-	its effects. As a result, queries that depend on indexing the state
-	of the chain (e.g. contents of output objects, address-level balance
-	information at the time of the transaction), must wait for indexing to
-	catch up by polling for the transaction digest using
-	`Query.transactionBlock`.
+	Transaction effects are now available immediately after execution
+	through `Query.transactionBlock`. However, other queries that depend
+	on the chain’s indexed state (e.g., address-level balance updates)
+	may still lag until the transaction has been checkpointed.
+	To confirm that a transaction has been included in a checkpoint, query
+	`Query.transactionBlock` and check whether the `effects.checkpoint`
+	field is set (or `null` if not yet checkpointed).
 	"""
 	executeTransactionBlock(txBytes: String!, signatures: [String!]!): ExecutionResult!
 }
@@ -2793,14 +2798,13 @@ type NameRegistration implements IMoveObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2980,14 +2984,13 @@ type Object implements IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -4104,14 +4107,13 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""

--- a/crates/iota-graphql-rpc/src/mutation.rs
+++ b/crates/iota-graphql-rpc/src/mutation.rs
@@ -60,13 +60,13 @@ impl Mutation {
     /// that was not possible. A transaction is final when its effects are
     /// guaranteed on chain (it cannot be revoked).
     ///
-    /// There may be a delay between transaction finality and when GraphQL
-    /// requests (including the request that issued the transaction) reflect
-    /// its effects. As a result, queries that depend on indexing the state
-    /// of the chain (e.g. contents of output objects, address-level balance
-    /// information at the time of the transaction), must wait for indexing to
-    /// catch up by polling for the transaction digest using
-    /// `Query.transactionBlock`.
+    /// Transaction effects are now available immediately after execution
+    /// through `Query.transactionBlock`. However, other queries that depend
+    /// on the chain’s indexed state (e.g., address-level balance updates)
+    /// may still lag until the transaction has been checkpointed.
+    /// To confirm that a transaction has been included in a checkpoint, query
+    /// `Query.transactionBlock` and check whether the `effects.checkpoint`
+    /// field is set (or `null` if not yet checkpointed).
     async fn execute_transaction_block(
         &self,
         ctx: &Context<'_>,

--- a/crates/iota-graphql-rpc/src/types/coin.rs
+++ b/crates/iota-graphql-rpc/src/types/coin.rs
@@ -164,14 +164,13 @@ impl Coin {
     }
 
     /// The current status of the object as read from the off-chain store. The
-    /// possible states are: NOT_INDEXED, the object is loaded from
-    /// serialized data, such as the contents of a genesis or system package
-    /// upgrade transaction. LIVE, the version returned is the most recent for
-    /// the object, and it is not deleted or wrapped at that version.
-    /// HISTORICAL, the object was referenced at a specific version or
-    /// checkpoint, so is fetched from historical tables and may not be the
-    /// latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-    /// or wrapped and only partial information can be loaded."
+    /// possible states are:
+    /// - NOT_INDEXED: The object is loaded from serialized data, such as the
+    ///   contents of a genesis or system package upgrade transaction.
+    /// - INDEXED: The object is retrieved from the off-chain index and
+    ///   represents the most recent or historical state of the object.
+    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(&self.super_.super_).status().await
     }

--- a/crates/iota-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/iota-graphql-rpc/src/types/coin_metadata.rs
@@ -157,14 +157,13 @@ impl CoinMetadata {
     }
 
     /// The current status of the object as read from the off-chain store. The
-    /// possible states are: NOT_INDEXED, the object is loaded from
-    /// serialized data, such as the contents of a genesis or system package
-    /// upgrade transaction. LIVE, the version returned is the most recent for
-    /// the object, and it is not deleted or wrapped at that version.
-    /// HISTORICAL, the object was referenced at a specific version or
-    /// checkpoint, so is fetched from historical tables and may not be the
-    /// latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-    /// or wrapped and only partial information can be loaded."
+    /// possible states are:
+    /// - NOT_INDEXED: The object is loaded from serialized data, such as the
+    ///   contents of a genesis or system package upgrade transaction.
+    /// - INDEXED: The object is retrieved from the off-chain index and
+    ///   represents the most recent or historical state of the object.
+    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(&self.super_.super_).status().await
     }

--- a/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
+++ b/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
@@ -206,14 +206,13 @@ impl NameRegistration {
     }
 
     /// The current status of the object as read from the off-chain store. The
-    /// possible states are: NOT_INDEXED, the object is loaded from
-    /// serialized data, such as the contents of a genesis or system package
-    /// upgrade transaction. LIVE, the version returned is the most recent for
-    /// the object, and it is not deleted or wrapped at that version.
-    /// HISTORICAL, the object was referenced at a specific version or
-    /// checkpoint, so is fetched from historical tables and may not be the
-    /// latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-    /// or wrapped and only partial information can be loaded."
+    /// possible states are:
+    /// - NOT_INDEXED: The object is loaded from serialized data, such as the
+    ///   contents of a genesis or system package upgrade transaction.
+    /// - INDEXED: The object is retrieved from the off-chain index and
+    ///   represents the most recent or historical state of the object.
+    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(&self.super_.super_).status().await
     }

--- a/crates/iota-graphql-rpc/src/types/move_object.rs
+++ b/crates/iota-graphql-rpc/src/types/move_object.rs
@@ -227,14 +227,13 @@ impl MoveObject {
     }
 
     /// The current status of the object as read from the off-chain store. The
-    /// possible states are: NOT_INDEXED, the object is loaded from
-    /// serialized data, such as the contents of a genesis or system package
-    /// upgrade transaction. LIVE, the version returned is the most recent for
-    /// the object, and it is not deleted or wrapped at that version.
-    /// HISTORICAL, the object was referenced at a specific version or
-    /// checkpoint, so is fetched from historical tables and may not be the
-    /// latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-    /// or wrapped and only partial information can be loaded."
+    /// possible states are:
+    /// - NOT_INDEXED: The object is loaded from serialized data, such as the
+    ///   contents of a genesis or system package upgrade transaction.
+    /// - INDEXED: The object is retrieved from the off-chain index and
+    ///   represents the most recent or historical state of the object.
+    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(&self.super_).status().await
     }

--- a/crates/iota-graphql-rpc/src/types/move_package.rs
+++ b/crates/iota-graphql-rpc/src/types/move_package.rs
@@ -312,14 +312,13 @@ impl MovePackage {
     }
 
     /// The current status of the object as read from the off-chain store. The
-    /// possible states are: NOT_INDEXED, the object is loaded from
-    /// serialized data, such as the contents of a genesis or system package
-    /// upgrade transaction. LIVE, the version returned is the most recent for
-    /// the object, and it is not deleted or wrapped at that version.
-    /// HISTORICAL, the object was referenced at a specific version or
-    /// checkpoint, so is fetched from historical tables and may not be the
-    /// latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-    /// or wrapped and only partial information can be loaded."
+    /// possible states are:
+    /// - NOT_INDEXED: The object is loaded from serialized data, such as the
+    ///   contents of a genesis or system package upgrade transaction.
+    /// - INDEXED: The object is retrieved from the off-chain index and
+    ///   represents the most recent or historical state of the object.
+    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(&self.super_).status().await
     }

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -260,14 +260,16 @@ pub(crate) struct HistoricalObjectCursor {
     field(
         name = "status",
         ty = "ObjectStatus",
-        desc = "The current status of the object as read from the off-chain store. The possible \
-                states are: NOT_INDEXED, the object is loaded from serialized data, such as the \
-                contents of a genesis or system package upgrade transaction. LIVE, the version \
-                returned is the most recent for the object, and it is not deleted or wrapped at \
-                that version. HISTORICAL, the object was referenced at a specific version or \
-                checkpoint, so is fetched from historical tables and may not be the latest version \
-                of the object. WRAPPED_OR_DELETED, the object is deleted or wrapped and only \
-                partial information can be loaded."
+        desc = r#"
+            The current status of the object as read from the off-chain store. The
+            possible states are:
+            - NOT_INDEXED: The object is loaded from serialized data, such as the
+            contents of a genesis or system package upgrade transaction.
+            - INDEXED: The object is retrieved from the off-chain index and
+            represents the most recent or historical state of the object.
+            - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+            information can be loaded.
+        "#
     ),
     field(
         name = "digest",
@@ -465,14 +467,13 @@ impl Object {
     }
 
     /// The current status of the object as read from the off-chain store. The
-    /// possible states are: NOT_INDEXED, the object is loaded from
-    /// serialized data, such as the contents of a genesis or system package
-    /// upgrade transaction. LIVE, the version returned is the most recent for
-    /// the object, and it is not deleted or wrapped at that version.
-    /// HISTORICAL, the object was referenced at a specific version or
-    /// checkpoint, so is fetched from historical tables and may not be the
-    /// latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-    /// or wrapped and only partial information can be loaded."
+    /// possible states are:
+    /// - NOT_INDEXED: The object is loaded from serialized data, such as the
+    ///   contents of a genesis or system package upgrade transaction.
+    /// - INDEXED: The object is retrieved from the off-chain index and
+    ///   represents the most recent or historical state of the object.
+    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(self).status().await
     }
@@ -1055,6 +1056,43 @@ impl Object {
             }),
         }
     }
+
+    pub(crate) fn try_from_stored_object(
+        stored_object: StoredObject,
+        checkpoint_viewed_at: u64,
+    ) -> Result<Self, Error> {
+        let address = addr(&stored_object.object_id)?;
+
+        let native_object = bcs::from_bytes(&stored_object.serialized_object)
+            .map_err(|_| Error::Internal(format!("Failed to deserialize object {address}")))?;
+
+        let root_version = version_for_dynamic_fields(&native_object);
+
+        let stored_history_like = StoredHistoryObject {
+            object_id: stored_object.object_id,
+            object_version: stored_object.object_version,
+            object_digest: Some(stored_object.object_digest),
+            object_status: NativeObjectStatus::Active as i16,
+            checkpoint_sequence_number: checkpoint_viewed_at as i64,
+            serialized_object: Some(stored_object.serialized_object),
+            object_type: stored_object.object_type,
+            object_type_package: stored_object.object_type_package,
+            object_type_module: stored_object.object_type_module,
+            object_type_name: stored_object.object_type_name,
+            owner_type: Some(stored_object.owner_type),
+            owner_id: stored_object.owner_id,
+            coin_type: stored_object.coin_type,
+            coin_balance: stored_object.coin_balance,
+            df_kind: stored_object.df_kind,
+        };
+
+        Ok(Self {
+            address,
+            kind: ObjectKind::Indexed(native_object, stored_history_like),
+            checkpoint_viewed_at,
+            root_version,
+        })
+    }
 }
 
 /// We're deliberately choosing to use a child object's version as the root
@@ -1401,14 +1439,7 @@ impl Loader<OptimisticKey> for Db {
         let mut missing_keys = Vec::new();
         for key in keys {
             if let Some(stored) = id_version_to_stored.get(&(key.id, key.version)) {
-                let object = Object::from_native(
-                    key.id,
-                    bcs::from_bytes(&stored.serialized_object).map_err(|_| {
-                        Error::Internal(format!("Failed to deserialize object {}", key.id))
-                    })?,
-                    u64::MAX,
-                    None,
-                );
+                let object = Object::try_from_stored_object(stored.clone(), u64::MAX)?;
                 result.insert(*key, object);
             } else {
                 missing_keys.push(*key);

--- a/crates/iota-graphql-rpc/src/types/stake.rs
+++ b/crates/iota-graphql-rpc/src/types/stake.rs
@@ -173,14 +173,13 @@ impl StakedIota {
     }
 
     /// The current status of the object as read from the off-chain store. The
-    /// possible states are: NOT_INDEXED, the object is loaded from
-    /// serialized data, such as the contents of a genesis or system package
-    /// upgrade transaction. LIVE, the version returned is the most recent for
-    /// the object, and it is not deleted or wrapped at that version.
-    /// HISTORICAL, the object was referenced at a specific version or
-    /// checkpoint, so is fetched from historical tables and may not be the
-    /// latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-    /// or wrapped and only partial information can be loaded."
+    /// possible states are:
+    /// - NOT_INDEXED: The object is loaded from serialized data, such as the
+    ///   contents of a genesis or system package upgrade transaction.
+    /// - INDEXED: The object is retrieved from the off-chain index and
+    ///   represents the most recent or historical state of the object.
+    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(&self.super_.super_).status().await
     }

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -7,11 +7,11 @@ use std::collections::{BTreeMap, HashMap};
 use async_graphql::{connection::CursorType, dataloader::Loader, *};
 use connection::Edge;
 use cursor::TxLookup;
-use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
+use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
 use fastcrypto::encoding::{Base58, Encoding};
 use iota_indexer::{
     models::transactions::{OptimisticTransaction, StoredTransaction},
-    schema::{transactions, tx_digests},
+    schema::{optimistic_transactions, transactions, tx_digests, tx_global_order},
 };
 use iota_json_rpc_api::ReadApiClient;
 use iota_types::{
@@ -495,11 +495,15 @@ impl Loader<DigestKey> for Db {
         &self,
         keys: &[DigestKey],
     ) -> Result<HashMap<DigestKey, TransactionBlock>, Error> {
+        use optimistic_transactions::dsl as opt_tx;
         use transactions::dsl as tx;
         use tx_digests::dsl as ds;
+        use tx_global_order::dsl as tx_global;
 
         let digests: Vec<_> = keys.iter().map(|k| k.digest.to_vec()).collect();
+        let digests_clone = digests.clone();
 
+        // First, fetch from the main transactions table
         let transactions: Vec<StoredTransaction> = self
             .execute(move |conn| {
                 conn.results(move || {
@@ -513,36 +517,75 @@ impl Loader<DigestKey> for Db {
             })
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch transactions: {e}")))?;
-
-        let transaction_digest_to_stored: BTreeMap<_, _> = transactions
+        let transaction_digest_to_stored: BTreeMap<Vec<u8>, StoredTransaction> = transactions
             .into_iter()
-            .map(|tx| Ok((tx.transaction_digest.clone(), tx)))
-            .collect::<Result<BTreeMap<_, _>, Error>>()?;
+            .map(|tx| (tx.transaction_digest.clone(), tx))
+            .collect();
+
+        // Fetch from optimistic_transactions table for any missing digests
+        let missing_digests: Vec<Vec<u8>> = digests_clone
+            .into_iter()
+            .filter(|digest| !transaction_digest_to_stored.contains_key(digest))
+            .collect();
+        let optimistic_transactions: Vec<OptimisticTransaction> = if missing_digests.is_empty() {
+            Vec::new()
+        } else {
+            self.execute(move |conn| {
+                conn.results(move || {
+                    opt_tx::optimistic_transactions
+                        .inner_join(
+                            tx_global::tx_global_order.on(opt_tx::global_sequence_number
+                                .eq(tx_global::global_sequence_number)
+                                .and(
+                                    opt_tx::optimistic_sequence_number
+                                        .eq(tx_global::optimistic_sequence_number),
+                                )),
+                        )
+                        // Filter by digest on tx_global_order table because it is indexed by
+                        // digest, optimistic_transactions table is not
+                        .filter(tx_global::tx_digest.eq_any(missing_digests.clone()))
+                        .select(OptimisticTransaction::as_select())
+                })
+            })
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to fetch optimistic transactions: {e}")))?
+        };
+        let transaction_digest_to_optimistic: BTreeMap<Vec<u8>, OptimisticTransaction> =
+            optimistic_transactions
+                .into_iter()
+                .map(|opt_tx| (opt_tx.transaction_digest.clone(), opt_tx))
+                .collect();
 
         let mut results = HashMap::new();
         for key in keys {
-            let Some(stored) = transaction_digest_to_stored
-                .get(key.digest.as_slice())
-                .cloned()
-            else {
-                continue;
-            };
+            let digest_bytes = key.digest.as_slice();
 
-            // Filter by key's checkpoint viewed at here. Doing this in memory because it
-            // should be quite rare that this query actually filters something,
-            // but encoding it in SQL is complicated.
-            if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
-                continue;
+            if let Some(stored) = transaction_digest_to_stored.get(digest_bytes) {
+                // Filter by key's checkpoint viewed at here. Doing this in memory because it
+                // should be quite rare that this query actually filters something,
+                // but encoding it in SQL is complicated.
+                if (key.checkpoint_viewed_at as i64) < stored.checkpoint_sequence_number {
+                    continue;
+                }
+
+                let inner = TransactionBlockInner::try_from(stored.clone())?;
+                results.insert(
+                    *key,
+                    TransactionBlock {
+                        inner,
+                        checkpoint_viewed_at: key.checkpoint_viewed_at,
+                    },
+                );
+            } else if let Some(optimistic) = transaction_digest_to_optimistic.get(digest_bytes) {
+                let inner = TransactionBlockInner::try_from(optimistic.clone())?;
+                results.insert(
+                    *key,
+                    TransactionBlock {
+                        inner,
+                        checkpoint_viewed_at: u64::MAX,
+                    },
+                );
             }
-
-            let inner = TransactionBlockInner::try_from(stored)?;
-            results.insert(
-                *key,
-                TransactionBlock {
-                    inner,
-                    checkpoint_viewed_at: key.checkpoint_viewed_at,
-                },
-            );
         }
 
         Ok(results)

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -501,7 +501,6 @@ impl Loader<DigestKey> for Db {
         use tx_global_order::dsl as tx_global;
 
         let digests: Vec<_> = keys.iter().map(|k| k.digest.to_vec()).collect();
-        let digests_clone = digests.clone();
 
         // First, fetch from the main transactions table
         let transactions: Vec<StoredTransaction> = self
@@ -517,70 +516,78 @@ impl Loader<DigestKey> for Db {
             })
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch transactions: {e}")))?;
+
         let transaction_digest_to_stored: BTreeMap<Vec<u8>, StoredTransaction> = transactions
             .into_iter()
             .map(|tx| (tx.transaction_digest.clone(), tx))
             .collect();
 
-        // Fetch from optimistic_transactions table for any missing digests
-        let missing_digests: Vec<Vec<u8>> = digests_clone
-            .into_iter()
-            .filter(|digest| !transaction_digest_to_stored.contains_key(digest))
-            .collect();
-        let optimistic_transactions: Vec<OptimisticTransaction> = if missing_digests.is_empty() {
-            Vec::new()
-        } else {
-            self.execute(move |conn| {
-                conn.results(move || {
-                    opt_tx::optimistic_transactions
-                        .inner_join(
-                            tx_global::tx_global_order.on(opt_tx::global_sequence_number
-                                .eq(tx_global::global_sequence_number)
-                                .and(
-                                    opt_tx::optimistic_sequence_number
-                                        .eq(tx_global::optimistic_sequence_number),
-                                )),
-                        )
-                        // Filter by digest on tx_global_order table because it is indexed by
-                        // digest, optimistic_transactions table is not
-                        .filter(tx_global::tx_digest.eq_any(missing_digests.clone()))
-                        .select(OptimisticTransaction::as_select())
-                })
-            })
-            .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch optimistic transactions: {e}")))?
-        };
-        let transaction_digest_to_optimistic: BTreeMap<Vec<u8>, OptimisticTransaction> =
-            optimistic_transactions
-                .into_iter()
-                .map(|opt_tx| (opt_tx.transaction_digest.clone(), opt_tx))
-                .collect();
-
+        // Process stored transactions and collect missing digests
         let mut results = HashMap::new();
+        let mut missing_digests = Vec::new();
+
         for key in keys {
             let digest_bytes = key.digest.as_slice();
 
-            let tx_block = if let Some(stored) = transaction_digest_to_stored.get(digest_bytes) {
-                // Filter by key's checkpoint viewed at here. Doing this in memory because it
-                // should be quite rare that this query actually filters something,
-                // but encoding it in SQL is complicated.
-                if (key.checkpoint_viewed_at as i64) < stored.checkpoint_sequence_number {
-                    continue;
+            match transaction_digest_to_stored.get(digest_bytes) {
+                Some(stored)
+                    if (key.checkpoint_viewed_at as i64) >= stored.checkpoint_sequence_number =>
+                {
+                    // Filter by key's checkpoint viewed at here. Doing this in memory because it
+                    // should be quite rare that this query actually filters something,
+                    // but encoding it in SQL is complicated.
+                    let tx_block = TransactionBlock {
+                        inner: TransactionBlockInner::try_from(stored.clone())?,
+                        checkpoint_viewed_at: key.checkpoint_viewed_at,
+                    };
+                    results.insert(*key, tx_block);
                 }
+                _ => {
+                    missing_digests.push(key.digest.to_vec());
+                }
+            }
+        }
 
-                TransactionBlock {
-                    inner: TransactionBlockInner::try_from(stored.clone())?,
-                    checkpoint_viewed_at: key.checkpoint_viewed_at,
+        if !missing_digests.is_empty() {
+            let optimistic_transactions: Vec<OptimisticTransaction> = self
+                .execute(move |conn| {
+                    conn.results(move || {
+                        opt_tx::optimistic_transactions
+                            .inner_join(
+                                tx_global::tx_global_order.on(opt_tx::global_sequence_number
+                                    .eq(tx_global::global_sequence_number)
+                                    .and(
+                                        opt_tx::optimistic_sequence_number
+                                            .eq(tx_global::optimistic_sequence_number),
+                                    )),
+                            )
+                            // Filter by digest on tx_global_order table because it is indexed by
+                            // digest, optimistic_transactions table is not
+                            .filter(tx_global::tx_digest.eq_any(missing_digests.clone()))
+                            .select(OptimisticTransaction::as_select())
+                    })
+                })
+                .await
+                .map_err(|e| {
+                    Error::Internal(format!("Failed to fetch optimistic transactions: {e}"))
+                })?;
+
+            let transaction_digest_to_optimistic: BTreeMap<Vec<u8>, OptimisticTransaction> =
+                optimistic_transactions
+                    .into_iter()
+                    .map(|opt_tx| (opt_tx.transaction_digest.clone(), opt_tx))
+                    .collect();
+
+            for key in keys {
+                let digest_bytes = key.digest.as_slice();
+                if let Some(optimistic) = transaction_digest_to_optimistic.get(digest_bytes) {
+                    let tx_block = TransactionBlock {
+                        inner: TransactionBlockInner::try_from(optimistic.clone())?,
+                        checkpoint_viewed_at: u64::MAX,
+                    };
+                    results.insert(*key, tx_block);
                 }
-            } else if let Some(optimistic) = transaction_digest_to_optimistic.get(digest_bytes) {
-                TransactionBlock {
-                    inner: TransactionBlockInner::try_from(optimistic.clone())?,
-                    checkpoint_viewed_at: u64::MAX,
-                }
-            } else {
-                continue;
-            };
-            results.insert(*key, tx_block);
+            }
         }
 
         Ok(results)

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -560,7 +560,7 @@ impl Loader<DigestKey> for Db {
         for key in keys {
             let digest_bytes = key.digest.as_slice();
 
-            if let Some(stored) = transaction_digest_to_stored.get(digest_bytes) {
+            let tx_block = if let Some(stored) = transaction_digest_to_stored.get(digest_bytes) {
                 // Filter by key's checkpoint viewed at here. Doing this in memory because it
                 // should be quite rare that this query actually filters something,
                 // but encoding it in SQL is complicated.
@@ -568,24 +568,19 @@ impl Loader<DigestKey> for Db {
                     continue;
                 }
 
-                let inner = TransactionBlockInner::try_from(stored.clone())?;
-                results.insert(
-                    *key,
-                    TransactionBlock {
-                        inner,
-                        checkpoint_viewed_at: key.checkpoint_viewed_at,
-                    },
-                );
+                TransactionBlock {
+                    inner: TransactionBlockInner::try_from(stored.clone())?,
+                    checkpoint_viewed_at: key.checkpoint_viewed_at,
+                }
             } else if let Some(optimistic) = transaction_digest_to_optimistic.get(digest_bytes) {
-                let inner = TransactionBlockInner::try_from(optimistic.clone())?;
-                results.insert(
-                    *key,
-                    TransactionBlock {
-                        inner,
-                        checkpoint_viewed_at: u64::MAX,
-                    },
-                );
-            }
+                TransactionBlock {
+                    inner: TransactionBlockInner::try_from(optimistic.clone())?,
+                    checkpoint_viewed_at: u64::MAX,
+                }
+            } else {
+                continue;
+            };
+            results.insert(*key, tx_block);
         }
 
         Ok(results)

--- a/crates/iota-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/iota-graphql-rpc/tests/e2e_tests.rs
@@ -33,12 +33,15 @@ mod tests {
     async fn mutation_execute_transaction(
         client: &SimpleClient,
         signed_tx: &Transaction,
+        response_fields: &str,
     ) -> GraphqlResponse {
         let (tx_bytes, sigs) = signed_tx.to_tx_bytes_and_signatures();
         let tx_bytes = tx_bytes.encoded();
         let sigs = sigs.iter().map(|sig| sig.encoded()).collect::<Vec<_>>();
 
-        let mutation = r#"{ executeTransactionBlock(txBytes: $tx,  signatures: $sigs) { effects { transactionBlock { digest } } errors}}"#;
+        let mutation = format!(
+            "{{ executeTransactionBlock(txBytes: $tx, signatures: $sigs) {{ {response_fields} }} }}"
+        );
 
         let variables = vec![
             GraphqlQueryVariable {
@@ -53,7 +56,7 @@ mod tests {
             },
         ];
         client
-            .execute_mutation_to_graphql(mutation.to_string(), variables)
+            .execute_mutation_to_graphql(mutation, variables)
             .await
             .unwrap()
     }
@@ -366,9 +369,11 @@ mod tests {
 
         let tx = cluster.build_transfer_iota_for_test().await;
         let signed_tx = cluster.sign_transaction(&tx);
-        let raw_response = mutation_execute_transaction(&cluster.graphql_client, &signed_tx)
-            .await
-            .response_body_json();
+        let response_fields = "effects { transactionBlock { digest } } errors";
+        let raw_response =
+            mutation_execute_transaction(&cluster.graphql_client, &signed_tx, response_fields)
+                .await
+                .response_body_json();
         let response = &raw_response["data"]["executeTransactionBlock"];
 
         let digest = response["effects"]["transactionBlock"]["digest"]
@@ -412,52 +417,112 @@ mod tests {
             iota_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
                 .await;
 
+        let addresses = cluster.validator_fullnode_handle.wallet.get_addresses();
+        let sender = addresses[0];
+
+        let tx_block_gql_fields = r#"
+            digest
+            sender {
+              address
+            }
+            effects {
+              status
+              errors
+              objectChanges {
+                edges {
+                  node {
+                    inputState {
+                        version
+                        status
+                        bcs
+                    }
+                    outputState {
+                        version
+                        status
+                        bcs
+                    }
+                    idCreated
+                    idDeleted
+                  }
+                }
+              }
+              balanceChanges {
+                edges {
+                  node {
+                    coinType {
+                      repr
+                    }
+                    amount
+                  }
+                }
+              }
+            }
+            "#;
+
+        let response_fields =
+            format!("effects {{ transactionBlock {{ {tx_block_gql_fields} }} }} errors");
+
         let tx = cluster.build_transfer_iota_for_test().await;
         let signed_tx = cluster.sign_transaction(&tx);
         let original_digest = signed_tx.digest();
-        let raw_response = mutation_execute_transaction(&cluster.graphql_client, &signed_tx)
-            .await
-            .response_body_json();
-        let response = &raw_response["data"]["executeTransactionBlock"];
-
-        let digest = response["effects"]["transactionBlock"]["digest"]
-            .as_str()
-            .unwrap();
-        assert!(raw_response["errors"].is_null());
+        let raw_response =
+            mutation_execute_transaction(&cluster.graphql_client, &signed_tx, &response_fields)
+                .await
+                .response_body_json();
+        let execute_transaction_block_res = &raw_response["data"]["executeTransactionBlock"];
+        let mutation_tx_data = &execute_transaction_block_res["effects"]["transactionBlock"];
+        let sender_read = mutation_tx_data["sender"]["address"].as_str().unwrap();
+        let digest = mutation_tx_data["digest"].as_str().unwrap();
+        assert!(execute_transaction_block_res["errors"].is_null());
         assert_eq!(digest, original_digest.to_string());
+        assert_eq!(sender_read, sender.to_string());
 
-        // Wait for the transaction to be committed and indexed
-        sleep(Duration::from_secs(10)).await;
-        // Query the transaction
-        let query = r#"
-            {
-                transactionBlock(digest: $dig){
-                    indexedOnNode
-                    sender {
-                        address
-                    }
-                }
-            }
-        "#;
-
+        // Query the transaction immediately after execution (optimistic indexing)
+        // Use the same fields as in the mutation
+        let query = format!(
+            r#"
+                {{
+                    transactionBlock(digest: $dig){{
+                        {tx_block_gql_fields}
+                    }}
+                }}
+            "#,
+        );
         let variables = vec![GraphqlQueryVariable {
             name: "dig".to_string(),
             ty: "String!".to_string(),
             value: json!(digest),
         }];
-        let raw_response = cluster
+
+        let immediate_res = cluster
             .graphql_client
-            .execute_to_graphql(query.to_string(), true, variables, vec![])
+            .execute_to_graphql(query.to_string(), true, variables.clone(), vec![])
             .await
             .unwrap()
-            .response_body_json();
+            .response_body()
+            .data
+            .clone()
+            .into_json()
+            .unwrap();
+        let immediate_tx_data = &immediate_res["transactionBlock"];
 
-        let tx = &raw_response["data"]["transactionBlock"];
+        // Wait 10 seconds for transaction to be checkpointed
+        sleep(Duration::from_secs(10)).await;
+        let checkpointed_res = cluster
+            .graphql_client
+            .execute_to_graphql(query.to_string(), true, variables.clone(), vec![])
+            .await
+            .unwrap()
+            .response_body()
+            .data
+            .clone()
+            .into_json()
+            .unwrap();
+        let checkpointed_tx_data = &checkpointed_res["transactionBlock"];
 
-        let sender_read = tx["sender"]["address"].as_str().unwrap();
-        assert_eq!(sender_read, signed_tx.sender_address().to_string());
-        let indexed_on_node = tx.get("indexedOnNode").unwrap().as_bool().unwrap();
-        assert!(indexed_on_node);
+        // All 3 responses should be identical: mutation, optimistic and checkpointed
+        assert_eq!(mutation_tx_data, immediate_tx_data);
+        assert_eq!(immediate_tx_data, checkpointed_tx_data);
 
         // Check that optimistic indexing happened
         let digest_bytes = Base58::decode(digest).unwrap();

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -607,14 +607,13 @@ type Coin implements IMoveObject & IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -784,14 +783,13 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -1604,7 +1602,16 @@ referred to as its address). This includes Move objects and packages.
 interface IObject {
 	version: UInt53!
 	"""
-	The current status of the object as read from the off-chain store. The possible states are: NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or system package upgrade transaction. LIVE, the version returned is the most recent for the object, and it is not deleted or wrapped at that version. HISTORICAL, the object was referenced at a specific version or checkpoint, so is fetched from historical tables and may not be the latest version of the object. WRAPPED_OR_DELETED, the object is deleted or wrapped and only partial information can be loaded.
+	
+	            The current status of the object as read from the off-chain store. The
+	            possible states are:
+	            - NOT_INDEXED: The object is loaded from serialized data, such as the
+	            contents of a genesis or system package upgrade transaction.
+	            - INDEXED: The object is retrieved from the off-chain index and
+	            represents the most recent or historical state of the object.
+	            - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	            information can be loaded.
+	        
 	"""
 	status: ObjectKind!
 	"""
@@ -2161,14 +2168,13 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2368,14 +2374,13 @@ type MovePackage implements IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2742,13 +2747,13 @@ type Mutation {
 	that was not possible. A transaction is final when its effects are
 	guaranteed on chain (it cannot be revoked).
 	
-	There may be a delay between transaction finality and when GraphQL
-	requests (including the request that issued the transaction) reflect
-	its effects. As a result, queries that depend on indexing the state
-	of the chain (e.g. contents of output objects, address-level balance
-	information at the time of the transaction), must wait for indexing to
-	catch up by polling for the transaction digest using
-	`Query.transactionBlock`.
+	Transaction effects are now available immediately after execution
+	through `Query.transactionBlock`. However, other queries that depend
+	on the chain’s indexed state (e.g., address-level balance updates)
+	may still lag until the transaction has been checkpointed.
+	To confirm that a transaction has been included in a checkpoint, query
+	`Query.transactionBlock` and check whether the `effects.checkpoint`
+	field is set (or `null` if not yet checkpointed).
 	"""
 	executeTransactionBlock(txBytes: String!, signatures: [String!]!): ExecutionResult!
 }
@@ -2797,14 +2802,13 @@ type NameRegistration implements IMoveObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2984,14 +2988,13 @@ type Object implements IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -4108,14 +4111,13 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""

--- a/sdk/graphql-transport/src/generated/queries.ts
+++ b/sdk/graphql-transport/src/generated/queries.ts
@@ -828,14 +828,13 @@ export type Coin = IMoveObject & IObject & IOwner & {
   stakedIotas: StakedIotaConnection;
   /**
    * The current status of the object as read from the off-chain store. The
-   * possible states are: NOT_INDEXED, the object is loaded from
-   * serialized data, such as the contents of a genesis or system package
-   * upgrade transaction. LIVE, the version returned is the most recent for
-   * the object, and it is not deleted or wrapped at that version.
-   * HISTORICAL, the object was referenced at a specific version or
-   * checkpoint, so is fetched from historical tables and may not be the
-   * latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-   * or wrapped and only partial information can be loaded."
+   * possible states are:
+   * - NOT_INDEXED: The object is loaded from serialized data, such as the
+   * contents of a genesis or system package upgrade transaction.
+   * - INDEXED: The object is retrieved from the off-chain index and
+   * represents the most recent or historical state of the object.
+   * - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+   * information can be loaded.
    */
   status: ObjectKind;
   /**
@@ -1076,14 +1075,13 @@ export type CoinMetadata = IMoveObject & IObject & IOwner & {
   stakedIotas: StakedIotaConnection;
   /**
    * The current status of the object as read from the off-chain store. The
-   * possible states are: NOT_INDEXED, the object is loaded from
-   * serialized data, such as the contents of a genesis or system package
-   * upgrade transaction. LIVE, the version returned is the most recent for
-   * the object, and it is not deleted or wrapped at that version.
-   * HISTORICAL, the object was referenced at a specific version or
-   * checkpoint, so is fetched from historical tables and may not be the
-   * latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-   * or wrapped and only partial information can be loaded."
+   * possible states are:
+   * - NOT_INDEXED: The object is loaded from serialized data, such as the
+   * contents of a genesis or system package upgrade transaction.
+   * - INDEXED: The object is retrieved from the off-chain index and
+   * represents the most recent or historical state of the object.
+   * - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+   * information can be loaded.
    */
   status: ObjectKind;
   /**
@@ -1887,7 +1885,16 @@ export type IObject = {
   previousTransactionBlock?: Maybe<TransactionBlock>;
   /** The transaction blocks that sent objects to this object. */
   receivedTransactionBlocks: TransactionBlockConnection;
-  /** The current status of the object as read from the off-chain store. The possible states are: NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or system package upgrade transaction. LIVE, the version returned is the most recent for the object, and it is not deleted or wrapped at that version. HISTORICAL, the object was referenced at a specific version or checkpoint, so is fetched from historical tables and may not be the latest version of the object. WRAPPED_OR_DELETED, the object is deleted or wrapped and only partial information can be loaded. */
+  /**
+   * The current status of the object as read from the off-chain store. The
+   * possible states are:
+   * - NOT_INDEXED: The object is loaded from serialized data, such as the
+   * contents of a genesis or system package upgrade transaction.
+   * - INDEXED: The object is retrieved from the off-chain index and
+   * represents the most recent or historical state of the object.
+   * - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+   * information can be loaded.
+   */
   status: ObjectKind;
   storageRebate?: Maybe<Scalars['BigInt']['output']>;
   version: Scalars['UInt53']['output'];
@@ -2562,14 +2569,13 @@ export type MoveObject = IMoveObject & IObject & IOwner & {
   stakedIotas: StakedIotaConnection;
   /**
    * The current status of the object as read from the off-chain store. The
-   * possible states are: NOT_INDEXED, the object is loaded from
-   * serialized data, such as the contents of a genesis or system package
-   * upgrade transaction. LIVE, the version returned is the most recent for
-   * the object, and it is not deleted or wrapped at that version.
-   * HISTORICAL, the object was referenced at a specific version or
-   * checkpoint, so is fetched from historical tables and may not be the
-   * latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-   * or wrapped and only partial information can be loaded."
+   * possible states are:
+   * - NOT_INDEXED: The object is loaded from serialized data, such as the
+   * contents of a genesis or system package upgrade transaction.
+   * - INDEXED: The object is retrieved from the off-chain index and
+   * represents the most recent or historical state of the object.
+   * - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+   * information can be loaded.
    */
   status: ObjectKind;
   /**
@@ -2872,14 +2878,13 @@ export type MovePackage = IObject & IOwner & {
   stakedIotas: StakedIotaConnection;
   /**
    * The current status of the object as read from the off-chain store. The
-   * possible states are: NOT_INDEXED, the object is loaded from
-   * serialized data, such as the contents of a genesis or system package
-   * upgrade transaction. LIVE, the version returned is the most recent for
-   * the object, and it is not deleted or wrapped at that version.
-   * HISTORICAL, the object was referenced at a specific version or
-   * checkpoint, so is fetched from historical tables and may not be the
-   * latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-   * or wrapped and only partial information can be loaded."
+   * possible states are:
+   * - NOT_INDEXED: The object is loaded from serialized data, such as the
+   * contents of a genesis or system package upgrade transaction.
+   * - INDEXED: The object is retrieved from the off-chain index and
+   * represents the most recent or historical state of the object.
+   * - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+   * information can be loaded.
    */
   status: ObjectKind;
   /**
@@ -3224,13 +3229,13 @@ export type Mutation = {
    * that was not possible. A transaction is final when its effects are
    * guaranteed on chain (it cannot be revoked).
    *
-   * There may be a delay between transaction finality and when GraphQL
-   * requests (including the request that issued the transaction) reflect
-   * its effects. As a result, queries that depend on indexing the state
-   * of the chain (e.g. contents of output objects, address-level balance
-   * information at the time of the transaction), must wait for indexing to
-   * catch up by polling for the transaction digest using
-   * `Query.transactionBlock`.
+   * Transaction effects are now available immediately after execution
+   * through `Query.transactionBlock`. However, other queries that depend
+   * on the chain’s indexed state (e.g., address-level balance updates)
+   * may still lag until the transaction has been checkpointed.
+   * To confirm that a transaction has been included in a checkpoint, query
+   * `Query.transactionBlock` and check whether the `effects.checkpoint`
+   * field is set (or `null` if not yet checkpointed).
    */
   executeTransactionBlock: ExecutionResult;
 };
@@ -3367,14 +3372,13 @@ export type NameRegistration = IMoveObject & IOwner & {
   stakedIotas: StakedIotaConnection;
   /**
    * The current status of the object as read from the off-chain store. The
-   * possible states are: NOT_INDEXED, the object is loaded from
-   * serialized data, such as the contents of a genesis or system package
-   * upgrade transaction. LIVE, the version returned is the most recent for
-   * the object, and it is not deleted or wrapped at that version.
-   * HISTORICAL, the object was referenced at a specific version or
-   * checkpoint, so is fetched from historical tables and may not be the
-   * latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-   * or wrapped and only partial information can be loaded."
+   * possible states are:
+   * - NOT_INDEXED: The object is loaded from serialized data, such as the
+   * contents of a genesis or system package upgrade transaction.
+   * - INDEXED: The object is retrieved from the off-chain index and
+   * represents the most recent or historical state of the object.
+   * - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+   * information can be loaded.
    */
   status: ObjectKind;
   /**
@@ -3603,14 +3607,13 @@ export type Object = IObject & IOwner & {
   stakedIotas: StakedIotaConnection;
   /**
    * The current status of the object as read from the off-chain store. The
-   * possible states are: NOT_INDEXED, the object is loaded from
-   * serialized data, such as the contents of a genesis or system package
-   * upgrade transaction. LIVE, the version returned is the most recent for
-   * the object, and it is not deleted or wrapped at that version.
-   * HISTORICAL, the object was referenced at a specific version or
-   * checkpoint, so is fetched from historical tables and may not be the
-   * latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-   * or wrapped and only partial information can be loaded."
+   * possible states are:
+   * - NOT_INDEXED: The object is loaded from serialized data, such as the
+   * contents of a genesis or system package upgrade transaction.
+   * - INDEXED: The object is retrieved from the off-chain index and
+   * represents the most recent or historical state of the object.
+   * - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+   * information can be loaded.
    */
   status: ObjectKind;
   /**
@@ -5023,14 +5026,13 @@ export type StakedIota = IMoveObject & IObject & IOwner & {
   stakedIotas: StakedIotaConnection;
   /**
    * The current status of the object as read from the off-chain store. The
-   * possible states are: NOT_INDEXED, the object is loaded from
-   * serialized data, such as the contents of a genesis or system package
-   * upgrade transaction. LIVE, the version returned is the most recent for
-   * the object, and it is not deleted or wrapped at that version.
-   * HISTORICAL, the object was referenced at a specific version or
-   * checkpoint, so is fetched from historical tables and may not be the
-   * latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-   * or wrapped and only partial information can be loaded."
+   * possible states are:
+   * - NOT_INDEXED: The object is loaded from serialized data, such as the
+   * contents of a genesis or system package upgrade transaction.
+   * - INDEXED: The object is retrieved from the off-chain index and
+   * represents the most recent or historical state of the object.
+   * - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+   * information can be loaded.
    */
   status: ObjectKind;
   /**

--- a/sdk/graphql-transport/test/compatibility.test.ts
+++ b/sdk/graphql-transport/test/compatibility.test.ts
@@ -17,6 +17,55 @@ import { IotaClientGraphQLTransport } from '../src/transport';
 const DEFAULT_GRAPHQL_URL = import.meta.env.DEFAULT_GRAPHQL_URL ?? 'http:127.0.0.1:9125';
 const LOCALNET_INDEXER = 'http:127.0.0.1:9124';
 
+async function waitForTransactionCheckpointed(
+    transactionDigest: string,
+    timeout = 30 * 1000,
+    pollInterval = 100,
+): Promise<void> {
+    const graphQLClient = new IotaClient({
+        transport: new IotaClientGraphQLTransport({
+            url: DEFAULT_GRAPHQL_URL,
+        }),
+    });
+
+    const timeoutSignal = AbortSignal.timeout(timeout);
+    const timeoutPromise = new Promise((_, reject) => {
+        timeoutSignal.addEventListener('abort', () => reject(timeoutSignal.reason));
+    });
+
+    timeoutPromise.catch(() => {
+        // Swallow unhandled rejections that might be thrown after early return
+    });
+
+    while (!timeoutSignal.aborted) {
+        try {
+            const transactionBlock = await graphQLClient.getTransactionBlock({
+                digest: transactionDigest,
+                options: {
+                    showEffects: true,
+                },
+            });
+
+            if (transactionBlock.checkpoint !== null && transactionBlock.checkpoint !== undefined) {
+                return;
+            }
+        } catch (error) {
+            console.log(`Error fetching transaction block: ${error}`);
+        }
+
+        // Wait for either the next poll interval, or the timeout
+        await Promise.race([
+            new Promise((resolve) => setTimeout(resolve, pollInterval)),
+            timeoutPromise,
+        ]);
+    }
+
+    timeoutSignal.throwIfAborted();
+
+    // This should never happen, but adding it just in case
+    throw new Error('Unexpected error while waiting for transaction checkpoint.');
+}
+
 describe('GraphQL IotaClient compatibility', () => {
     let toolbox: TestToolbox;
     let transactionBlockDigest: string;
@@ -58,7 +107,7 @@ describe('GraphQL IotaClient compatibility', () => {
         transactionBlockDigest = result.digest;
 
         await toolbox.client.waitForTransaction({ digest: transactionBlockDigest });
-        await graphQLClient.waitForTransaction({ digest: transactionBlockDigest });
+        await waitForTransactionCheckpointed(transactionBlockDigest);
     });
 
     test('getRpcApiVersion', async () => {
@@ -90,16 +139,6 @@ describe('GraphQL IotaClient compatibility', () => {
         expect(graphQLCoins).toEqual(rpcCoins);
     });
 
-    test('getBalance', async () => {
-        const rpcCoins = await toolbox.client.getBalance({
-            owner: toolbox.address(),
-        });
-        const graphQLCoins = await graphQLClient!.getBalance({
-            owner: toolbox.address(),
-        });
-
-        expect(graphQLCoins).toEqual(rpcCoins);
-    });
     test('getBalance', async () => {
         const rpcBalance = await toolbox.client.getBalance({
             owner: toolbox.address(),
@@ -625,9 +664,6 @@ describe('GraphQL IotaClient compatibility', () => {
                 showRawInput: true,
             },
         });
-
-        await toolbox.client.waitForTransaction({ digest: transaction.digest });
-        await graphQLClient.waitForTransaction({ digest: transaction.digest });
 
         const {
             checkpoint: gCheckpoint,

--- a/sdk/graphql-transport/test/compatibility.test.ts
+++ b/sdk/graphql-transport/test/compatibility.test.ts
@@ -17,55 +17,6 @@ import { IotaClientGraphQLTransport } from '../src/transport';
 const DEFAULT_GRAPHQL_URL = import.meta.env.DEFAULT_GRAPHQL_URL ?? 'http:127.0.0.1:9125';
 const LOCALNET_INDEXER = 'http:127.0.0.1:9124';
 
-async function waitForTransactionCheckpointed(
-    transactionDigest: string,
-    timeout = 30 * 1000,
-    pollInterval = 100,
-): Promise<void> {
-    const graphQLClient = new IotaClient({
-        transport: new IotaClientGraphQLTransport({
-            url: DEFAULT_GRAPHQL_URL,
-        }),
-    });
-
-    const timeoutSignal = AbortSignal.timeout(timeout);
-    const timeoutPromise = new Promise((_, reject) => {
-        timeoutSignal.addEventListener('abort', () => reject(timeoutSignal.reason));
-    });
-
-    timeoutPromise.catch(() => {
-        // Swallow unhandled rejections that might be thrown after early return
-    });
-
-    while (!timeoutSignal.aborted) {
-        try {
-            const transactionBlock = await graphQLClient.getTransactionBlock({
-                digest: transactionDigest,
-                options: {
-                    showEffects: true,
-                },
-            });
-
-            if (transactionBlock.checkpoint !== null && transactionBlock.checkpoint !== undefined) {
-                return;
-            }
-        } catch (error) {
-            console.log(`Error fetching transaction block: ${error}`);
-        }
-
-        // Wait for either the next poll interval, or the timeout
-        await Promise.race([
-            new Promise((resolve) => setTimeout(resolve, pollInterval)),
-            timeoutPromise,
-        ]);
-    }
-
-    timeoutSignal.throwIfAborted();
-
-    // This should never happen, but adding it just in case
-    throw new Error('Unexpected error while waiting for transaction checkpoint.');
-}
-
 describe('GraphQL IotaClient compatibility', () => {
     let toolbox: TestToolbox;
     let transactionBlockDigest: string;
@@ -106,8 +57,10 @@ describe('GraphQL IotaClient compatibility', () => {
 
         transactionBlockDigest = result.digest;
 
-        await toolbox.client.waitForTransaction({ digest: transactionBlockDigest });
-        await waitForTransactionCheckpointed(transactionBlockDigest);
+        await toolbox.client.waitForTransaction({
+            digest: transactionBlockDigest,
+            waitMode: 'checkpoint',
+        });
     });
 
     test('getRpcApiVersion', async () => {
@@ -856,7 +809,7 @@ describe('GraphQL IotaClient compatibility', () => {
         const [coin] = tx.splitCoins(tx.gas, [1]);
         tx.transferObjects([coin], toolbox.address());
 
-        const transaction = await graphQLClient!.signAndExecuteTransaction({
+        let transaction = await graphQLClient!.signAndExecuteTransaction({
             transaction: tx as Transaction,
             signer: toolbox.keypair,
             options: {
@@ -870,37 +823,24 @@ describe('GraphQL IotaClient compatibility', () => {
             },
         });
 
-        expect(
-            await toolbox.client.isTransactionIndexedOnNode({ digest: transaction.digest }),
-        ).toEqual(false);
-        expect(
-            await graphQLClient.isTransactionIndexedOnNode({ digest: transaction.digest }),
-        ).toEqual(false);
+        transaction = await toolbox.client.waitForTransaction({
+            digest: transaction.digest,
+            waitMode: 'indexed-on-node',
+        });
+        transaction = await graphQLClient.waitForTransaction({
+            digest: transaction.digest,
+            waitMode: 'indexed-on-node',
+        });
 
-        await toolbox.client.waitForTransaction({ digest: transaction.digest });
-
-        let result = null;
-        for (const _ of Array.from({ length: 5 })) {
-            try {
-                result = await toolbox.client.isTransactionIndexedOnNode({
-                    digest: transaction.digest,
-                });
-                if (result) {
-                    break;
-                } else {
-                    await new Promise((r) => {
-                        setTimeout(r, 2000);
-                    });
-                }
-
-                // eslint-disable-next-line no-empty
-            } catch (e) {}
-        }
-        expect(result).toEqual(true);
-
-        await graphQLClient.waitForTransaction({ digest: transaction.digest });
-        expect(
-            await graphQLClient.isTransactionIndexedOnNode({ digest: transaction.digest }),
-        ).toEqual(true);
+        transaction = await toolbox.client.waitForTransaction({
+            digest: transaction.digest,
+            waitMode: 'checkpoint',
+        });
+        expect(transaction.checkpoint).toBeDefined();
+        transaction = await graphQLClient.waitForTransaction({
+            digest: transaction.digest,
+            waitMode: 'checkpoint',
+        });
+        expect(transaction.checkpoint).toBeDefined();
     });
 });

--- a/sdk/typescript/src/client/client.ts
+++ b/sdk/typescript/src/client/client.ts
@@ -919,6 +919,7 @@ export class IotaClient {
         signal,
         timeout = 60 * 1000,
         pollInterval = 2 * 1000,
+        waitMode,
         ...input
     }: {
         /** An optional abort signal that can be used to cancel */
@@ -927,6 +928,10 @@ export class IotaClient {
         timeout?: number;
         /** The amount of time to wait between checks for the transaction block. Defaults to 2 seconds. */
         pollInterval?: number;
+        /** Whether to wait the transaction to have been checkpointed or indexed on the node.
+         * A transaction might be indexed but not checkpointed yet, but a checkpointed transaction is guaranteed to be indexed.
+         */
+        waitMode?: 'checkpoint' | 'indexed-on-node';
     } & Parameters<IotaClient['getTransactionBlock']>[0]): Promise<IotaTransactionBlockResponse> {
         const timeoutSignal = AbortSignal.timeout(timeout);
         const timeoutPromise = new Promise((_, reject) => {
@@ -939,14 +944,32 @@ export class IotaClient {
 
         while (!timeoutSignal.aborted) {
             signal?.throwIfAborted();
-            try {
-                return await this.getTransactionBlock(input);
-            } catch (e) {
+            const wait = async () => {
                 // Wait for either the next poll interval, or the timeout.
                 await Promise.race([
                     new Promise((resolve) => setTimeout(resolve, pollInterval)),
                     timeoutPromise,
                 ]);
+            };
+            try {
+                if (waitMode === 'indexed-on-node') {
+                    const isIndexedOnNode = await this.isTransactionIndexedOnNode({
+                        digest: input.digest,
+                    });
+                    if (isIndexedOnNode) {
+                        return await this.getTransactionBlock(input);
+                    }
+                } else if (waitMode === 'checkpoint') {
+                    const transaction = await this.getTransactionBlock(input);
+                    if (transaction.checkpoint) {
+                        return transaction;
+                    }
+                } else {
+                    return await this.getTransactionBlock(input);
+                }
+                await wait();
+            } catch (e) {
+                await wait();
             }
         }
 

--- a/sdk/typescript/src/graphql/generated/2025.2/schema.graphql
+++ b/sdk/typescript/src/graphql/generated/2025.2/schema.graphql
@@ -603,14 +603,13 @@ type Coin implements IMoveObject & IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -780,14 +779,13 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -1600,7 +1598,16 @@ referred to as its address). This includes Move objects and packages.
 interface IObject {
 	version: UInt53!
 	"""
-	The current status of the object as read from the off-chain store. The possible states are: NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or system package upgrade transaction. LIVE, the version returned is the most recent for the object, and it is not deleted or wrapped at that version. HISTORICAL, the object was referenced at a specific version or checkpoint, so is fetched from historical tables and may not be the latest version of the object. WRAPPED_OR_DELETED, the object is deleted or wrapped and only partial information can be loaded.
+	
+	            The current status of the object as read from the off-chain store. The
+	            possible states are:
+	            - NOT_INDEXED: The object is loaded from serialized data, such as the
+	            contents of a genesis or system package upgrade transaction.
+	            - INDEXED: The object is retrieved from the off-chain index and
+	            represents the most recent or historical state of the object.
+	            - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	            information can be loaded.
+	        
 	"""
 	status: ObjectKind!
 	"""
@@ -2157,14 +2164,13 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2364,14 +2370,13 @@ type MovePackage implements IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2738,13 +2743,13 @@ type Mutation {
 	that was not possible. A transaction is final when its effects are
 	guaranteed on chain (it cannot be revoked).
 	
-	There may be a delay between transaction finality and when GraphQL
-	requests (including the request that issued the transaction) reflect
-	its effects. As a result, queries that depend on indexing the state
-	of the chain (e.g. contents of output objects, address-level balance
-	information at the time of the transaction), must wait for indexing to
-	catch up by polling for the transaction digest using
-	`Query.transactionBlock`.
+	Transaction effects are now available immediately after execution
+	through `Query.transactionBlock`. However, other queries that depend
+	on the chain’s indexed state (e.g., address-level balance updates)
+	may still lag until the transaction has been checkpointed.
+	To confirm that a transaction has been included in a checkpoint, query
+	`Query.transactionBlock` and check whether the `effects.checkpoint`
+	field is set (or `null` if not yet checkpointed).
 	"""
 	executeTransactionBlock(txBytes: String!, signatures: [String!]!): ExecutionResult!
 }
@@ -2793,14 +2798,13 @@ type NameRegistration implements IMoveObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2980,14 +2984,13 @@ type Object implements IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -4104,14 +4107,13 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
+	possible states are:
+	- NOT_INDEXED: The object is loaded from serialized data, such as the
+	contents of a genesis or system package upgrade transaction.
+	- INDEXED: The object is retrieved from the off-chain index and
+	represents the most recent or historical state of the object.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
+	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""


### PR DESCRIPTION
# Description of change

Transaction effects are now available immediately after execution through `Query.transactionBlock`.
However, other queries that depend on the chain’s indexed state (e.g., address-level balance updates) may still lag until the transaction has been checkpointed.
To confirm that a transaction has been included in a checkpoint, user can query `Query.transactionBlock` and check whether the `effects.checkpoint` field is set (or `null` if not yet checkpointed).

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/8418

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [x] GraphQL:
    Transaction effects are now available immediately after execution via `Query.transactionBlock`.
    Note that other queries relying on the chain’s indexed state (such as address-level balance updates) may still show a delay until the transaction is checkpointed.
    To verify checkpoint inclusion, query `Query.transactionBlock` and check the `effects.checkpoint` field — it will be `null` until the transaction has been checkpointed.
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
