### PR TITLE
fix(node): Fix node peer discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6989,7 +6989,6 @@ dependencies = [
  "futures",
  "governor",
  "iota-archival",
- "iota-common",
  "iota-config",
  "iota-macros",
  "iota-metrics",

--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -926,6 +926,7 @@ mod test {
             })
             .with_submit_delay_step_override_millis(3000)
             .with_num_unpruned_validators(default_num_of_unpruned_validators)
+            .with_disabled_address_verification_cooldown() // Disable cooldown for tests with node crashes
             .build()
             .await
             .into()

--- a/crates/iota-config/src/p2p.rs
+++ b/crates/iota-config/src/p2p.rs
@@ -336,7 +336,7 @@ pub struct DiscoveryConfig {
 
 impl DiscoveryConfig {
     pub fn interval_period(&self) -> Duration {
-        const INTERVAL_PERIOD_MS: u64 = 5_000; // 5 seconds
+        const INTERVAL_PERIOD_MS: u64 = 10_000; // 10 seconds
 
         Duration::from_millis(self.interval_period_ms.unwrap_or(INTERVAL_PERIOD_MS))
     }

--- a/crates/iota-config/src/p2p.rs
+++ b/crates/iota-config/src/p2p.rs
@@ -311,6 +311,12 @@ pub struct DiscoveryConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub peers_to_query: Option<usize>,
 
+    /// Timeout for individual peer query requests in discovery protocol.
+    ///
+    /// If unspecified, this will default to `1` second.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_query_timeout_sec: Option<u64>,
+
     /// Per-peer rate-limit (in requests/sec) for the GetKnownPeers RPC.
     ///
     /// If unspecified, this will default to no limit.
@@ -332,6 +338,42 @@ pub struct DiscoveryConfig {
     /// peers in the network.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub allowlisted_peers: Vec<AllowlistedPeer>,
+
+    /// Maximum number of concurrent address verification attempts.
+    /// This prevents overwhelming the network when verifying many peers at
+    /// once.
+    ///
+    /// If unspecified, this will default to `10`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_concurrent_address_verifications: Option<usize>,
+
+    /// Timeout for individual address verification attempts.
+    ///
+    /// If unspecified, this will default to `3` seconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_verification_timeout_sec: Option<u64>,
+
+    /// Total timeout for all address verification attempts to prevent DoS
+    /// attacks.
+    ///
+    /// If unspecified, this will default to `8` seconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_verification_total_timeout_sec: Option<u64>,
+
+    /// Cooldown period in seconds for peers whose address verification failed.
+    /// During this period, new peer info from the same peer will be ignored.
+    /// Set to 0 to disable the cooldown feature entirely.
+    ///
+    /// If unspecified, this will default to `600` seconds (10 minutes).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_verification_failure_cooldown_sec: Option<u64>,
+
+    /// Interval for cleaning up old entries from the verification failure
+    /// cooldown list.
+    ///
+    /// If unspecified, this will default to `300` seconds (5 minutes).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cooldown_cleanup_interval_sec: Option<u64>,
 }
 
 impl DiscoveryConfig {
@@ -354,9 +396,68 @@ impl DiscoveryConfig {
         self.peers_to_query.unwrap_or(PEERS_TO_QUERY)
     }
 
+    pub fn peer_query_timeout(&self) -> Duration {
+        const PEER_QUERY_TIMEOUT_SEC: u64 = 1;
+
+        Duration::from_secs(
+            self.peer_query_timeout_sec
+                .unwrap_or(PEER_QUERY_TIMEOUT_SEC),
+        )
+    }
+
     pub fn access_type(&self) -> AccessType {
         // defaults None to Public
         self.access_type.unwrap_or(AccessType::Public)
+    }
+
+    pub fn max_concurrent_address_verifications(&self) -> usize {
+        const MAX_CONCURRENT_ADDRESS_VERIFICATIONS: usize = 10;
+
+        self.max_concurrent_address_verifications
+            .unwrap_or(MAX_CONCURRENT_ADDRESS_VERIFICATIONS)
+    }
+
+    pub fn address_verification_timeout(&self) -> Duration {
+        const ADDRESS_VERIFICATION_TIMEOUT_SEC: u64 = 3;
+
+        Duration::from_secs(
+            self.address_verification_timeout_sec
+                .unwrap_or(ADDRESS_VERIFICATION_TIMEOUT_SEC),
+        )
+    }
+
+    pub fn address_verification_total_timeout(&self) -> Duration {
+        const ADDRESS_VERIFICATION_TOTAL_TIMEOUT_SEC: u64 = 8;
+
+        Duration::from_secs(
+            self.address_verification_total_timeout_sec
+                .unwrap_or(ADDRESS_VERIFICATION_TOTAL_TIMEOUT_SEC),
+        )
+    }
+
+    pub fn address_verification_failure_cooldown(&self) -> Duration {
+        const ADDRESS_VERIFICATION_FAILURE_COOLDOWN_SEC: u64 = 600; // 10 minutes
+
+        Duration::from_secs(
+            self.address_verification_failure_cooldown_sec
+                .unwrap_or(ADDRESS_VERIFICATION_FAILURE_COOLDOWN_SEC),
+        )
+    }
+
+    pub fn cooldown_cleanup_interval(&self) -> Duration {
+        const COOLDOWN_CLEANUP_INTERVAL_SEC: u64 = 300; // 5 minutes
+
+        Duration::from_secs(
+            self.cooldown_cleanup_interval_sec
+                .unwrap_or(COOLDOWN_CLEANUP_INTERVAL_SEC),
+        )
+    }
+
+    /// Returns true if address verification cooldown is enabled (cooldown > 0)
+    pub fn is_address_verification_cooldown_enabled(&self) -> bool {
+        self.address_verification_failure_cooldown_sec
+            .unwrap_or(600)
+            > 0
     }
 }
 

--- a/crates/iota-network/Cargo.toml
+++ b/crates/iota-network/Cargo.toml
@@ -30,7 +30,6 @@ tracing.workspace = true
 
 # internal dependencies
 iota-archival.workspace = true
-iota-common.workspace = true
 iota-config.workspace = true
 iota-macros.workspace = true
 iota-metrics.workspace = true

--- a/crates/iota-network/src/discovery/builder.rs
+++ b/crates/iota-network/src/discovery/builder.rs
@@ -89,7 +89,6 @@ impl Builder {
             connected_peers: HashMap::default(),
             known_peers: HashMap::default(),
             address_verification_cooldown: HashMap::default(),
-            last_cooldown_cleanup: std::time::Instant::now(),
         }
         .pipe(RwLock::new)
         .pipe(Arc::new);

--- a/crates/iota-network/src/discovery/builder.rs
+++ b/crates/iota-network/src/discovery/builder.rs
@@ -88,6 +88,8 @@ impl Builder {
             our_info: None,
             connected_peers: HashMap::default(),
             known_peers: HashMap::default(),
+            address_verification_cooldown: HashMap::default(),
+            last_cooldown_cleanup: std::time::Instant::now(),
         }
         .pipe(RwLock::new)
         .pipe(Arc::new);

--- a/crates/iota-network/src/discovery/mod.rs
+++ b/crates/iota-network/src/discovery/mod.rs
@@ -802,8 +802,9 @@ fn verify_peer_infos(
                             true // Cooldown expired
                         } else {
                             debug!(
-                                "Peer {} is in verification failure cooldown (failed {:.1}s ago, cooldown: {:.1}s)",
+                                "Peer {} ({}) is in verification failure cooldown (failed {:.1}s ago, cooldown: {:.1}s)",
                                 peer_info.peer_id,
+                                peer_info.addresses.iter().map(|a| a.to_string()).collect::<Vec<_>>().join(", "),
                                 time_since_failure.as_secs_f32(),
                                 cooldown_duration.as_secs_f32()
                             );
@@ -905,7 +906,7 @@ async fn verify_addresses_of_peers(
     config: &DiscoveryConfig,
 ) -> (
     Vec<(VerifiedEnvelope<NodeInfo, Ed25519Signature>, Vec<Multiaddr>)>,
-    Vec<PeerId>,
+    Vec<NodeInfo>,
 ) {
     let peers_count = peers.len();
     let verification_stream = futures::stream::iter(peers.into_iter().map(|verified_peer_info| {
@@ -952,10 +953,16 @@ async fn verify_addresses_of_peers(
     for (verified_peer_info, verified_addresses) in address_verification_results {
         if verified_addresses.is_empty() {
             info!(
-                "Rejecting peer {} due to failed address verification for all addresses",
-                verified_peer_info.peer_id
+                "Rejecting peer {} ({}) due to failed address verification for all addresses",
+                verified_peer_info.peer_id,
+                verified_peer_info
+                    .addresses
+                    .iter()
+                    .map(|a| a.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             );
-            failed_peers.push(verified_peer_info.peer_id);
+            failed_peers.push(verified_peer_info.data().to_owned());
         } else {
             verified_peers.push((verified_peer_info, verified_addresses));
         }
@@ -1052,7 +1059,7 @@ async fn update_known_peers(
     }
 
     // Verify addresses for peers that need verification
-    let (mut verified_peers, failed_peer_ids) = match peers_with_addresses_to_verify.is_empty() {
+    let (mut verified_peers, failed_peer_infos) = match peers_with_addresses_to_verify.is_empty() {
         false => verify_addresses_of_peers(network, peers_with_addresses_to_verify, config).await,
         true => Default::default(),
     };
@@ -1061,7 +1068,7 @@ async fn update_known_peers(
     // peers, we're done
     if verified_peers.is_empty()
         && peers_to_update_directly.is_empty()
-        && failed_peer_ids.is_empty()
+        && failed_peer_infos.is_empty()
     {
         return;
     }
@@ -1097,13 +1104,19 @@ async fn update_known_peers(
 
         // Add all failed peers to verification failure cooldown (if enabled)
         if config.is_address_verification_cooldown_enabled() {
-            for peer_id in failed_peer_ids {
+            for peer_info in failed_peer_infos {
                 state_guard
                     .address_verification_cooldown
-                    .insert(peer_id, now_instant);
+                    .insert(peer_info.peer_id, now_instant);
                 debug!(
-                    "Added peer {} to verification failure cooldown for {:.1}s",
-                    peer_id,
+                    "Added peer {} ({}) to verification failure cooldown for {:.1}s",
+                    peer_info.peer_id,
+                    peer_info
+                        .addresses
+                        .iter()
+                        .map(|a| a.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
                     config.address_verification_failure_cooldown().as_secs_f32()
                 );
             }

--- a/crates/iota-network/src/discovery/mod.rs
+++ b/crates/iota-network/src/discovery/mod.rs
@@ -5,7 +5,7 @@
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
     sync::{Arc, RwLock},
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use anemo::{
@@ -31,15 +31,10 @@ use tokio::{
 };
 use tracing::{debug, info, trace};
 
-const TIMEOUT: Duration = Duration::from_secs(1);
 const ONE_DAY_MILLISECONDS: u64 = 24 * 60 * 60 * 1_000;
 const MAX_ADDRESS_LENGTH: usize = 300;
 const MAX_PEERS_TO_SEND: usize = 200;
 const MAX_ADDRESSES_PER_PEER: usize = 2;
-const ADDRESS_VERIFICATION_TIMEOUT: Duration = Duration::from_secs(3);
-const ADDRESS_VERIFICATION_TOTAL_TIMEOUT: Duration = Duration::from_secs(8); // Overall timeout for verify_address_ownership to prevent DoS attacks
-const ADDRESS_VERIFICATION_FAILURE_COOLDOWN: Duration = Duration::from_secs(10 * 60); // 10 minutes cooldown
-const COOLDOWN_CLEANUP_INTERVAL: Duration = Duration::from_secs(5 * 60); // Clean up cooldown list every 5 minutes
 
 // Includes the generated Discovery code from the OUT_DIR
 mod generated {
@@ -350,6 +345,7 @@ impl DiscoveryEventLoop {
                         self.state.clone(),
                         self.metrics.clone(),
                         self.allowlisted_peers.clone(),
+                        self.discovery_config.clone(),
                     ));
                 }
             }
@@ -465,7 +461,11 @@ impl DiscoveryEventLoop {
 /// attacks. Tries all addresses individually and returns the list of
 /// addresses that were successfully verified.
 /// This should only be used for not-yet-connected peers.
-async fn verify_address_ownership(network: &Network, peer_info: &SignedNodeInfo) -> Vec<Multiaddr> {
+async fn verify_address_ownership(
+    network: &Network,
+    peer_info: &SignedNodeInfo,
+    config: &DiscoveryConfig,
+) -> Vec<Multiaddr> {
     // Try each address individually and collect the ones that work
     let verification_futures: Vec<_> = peer_info
         .addresses
@@ -478,7 +478,7 @@ async fn verify_address_ownership(network: &Network, peer_info: &SignedNodeInfo)
                 if let Ok(anemo_address) = address.to_anemo_address() {
                     // Try to connect to the claimed address with the claimed peer_id
                     match tokio::time::timeout(
-                        ADDRESS_VERIFICATION_TIMEOUT,
+                        config.address_verification_timeout(),
                         network.connect_with_peer_id(anemo_address, peer_id),
                     )
                     .await
@@ -615,10 +615,11 @@ async fn query_peer_for_their_known_peers(
     state: Arc<RwLock<State>>,
     metrics: Metrics,
     allowlisted_peers: Arc<HashMap<PeerId, Option<Multiaddr>>>,
+    config: Arc<DiscoveryConfig>,
 ) {
     let mut client = DiscoveryClient::new(peer);
 
-    let request = Request::new(()).with_timeout(TIMEOUT);
+    let request = Request::new(()).with_timeout(config.peer_query_timeout());
     let found_peers = client
         .get_known_peers_v2(request)
         .await
@@ -650,6 +651,7 @@ async fn query_peer_for_their_known_peers(
             metrics,
             deduplicate_peers(limited_peers),
             allowlisted_peers,
+            &config,
         )
         .await;
     }
@@ -672,12 +674,14 @@ async fn query_connected_peers_for_their_known_peers(
         .flat_map(|id| network.peer(id))
         .choose_multiple(&mut rand::thread_rng(), config.peers_to_query());
 
+    let peer_query_timeout = config.peer_query_timeout();
+
     // Queries the selected neighbors for their known peers in parallel.
     let found_peers = peers_to_query
         .into_iter()
         .map(DiscoveryClient::new)
         .map(|mut client| async move {
-            let request = Request::new(()).with_timeout(TIMEOUT);
+            let request = Request::new(()).with_timeout(peer_query_timeout);
             client
                 .get_known_peers_v2(request)
                 .await
@@ -713,15 +717,25 @@ async fn query_connected_peers_for_their_known_peers(
         metrics,
         deduplicate_peers(found_peers),
         allowlisted_peers,
+        &config,
     )
     .await;
 }
 
 /// Cleans up old entries from the verification failure cooldown list
-fn cleanup_verification_failure_cooldown(state: &Arc<RwLock<State>>, now_instant: Instant) {
+fn cleanup_verification_failure_cooldown(
+    state: &Arc<RwLock<State>>,
+    now_instant: Instant,
+    config: &DiscoveryConfig,
+) {
+    // Skip cleanup if cooldown is disabled
+    if !config.is_address_verification_cooldown_enabled() {
+        return;
+    }
+
     // Only run cleanup if enough time has passed since the last cleanup
     if now_instant.duration_since(state.read().unwrap().last_cooldown_cleanup)
-        < COOLDOWN_CLEANUP_INTERVAL
+        < config.cooldown_cleanup_interval()
     {
         return;
     }
@@ -731,11 +745,11 @@ fn cleanup_verification_failure_cooldown(state: &Arc<RwLock<State>>, now_instant
 
     // Remove entries that have exceeded the cooldown period
     let initial_size = state_guard.address_verification_cooldown.len();
+    let cooldown_duration = config.address_verification_failure_cooldown();
     state_guard
         .address_verification_cooldown
         .retain(|peer_id, &mut failure_instant| {
-            let should_retain =
-                now_instant.duration_since(failure_instant) < ADDRESS_VERIFICATION_FAILURE_COOLDOWN;
+            let should_retain = now_instant.duration_since(failure_instant) < cooldown_duration;
             if !should_retain {
                 debug!(
                     "Removing peer {} from verification failure cooldown",
@@ -759,6 +773,7 @@ fn verify_peer_infos(
     found_peers: Vec<Envelope<NodeInfo, Ed25519Signature>>,
     allowlisted_peers: Arc<HashMap<PeerId, Option<Multiaddr>>>,
     now_instant: Instant,
+    config: &DiscoveryConfig,
 ) -> Vec<VerifiedSignedNodeInfo> {
     let now_unix = now_unix();
 
@@ -771,20 +786,26 @@ fn verify_peer_infos(
         let filtered_peers: Vec<_> = found_peers
             .into_iter()
             .filter(|peer_info| {
+                // Skip cooldown check if it's disabled
+                if !config.is_address_verification_cooldown_enabled() {
+                    return true;
+                }
+
                 // Check if this peer is in the address verification cooldown.
                 // Even if the signature is not checked yet, it would be pointless to verify if
                 // that peer_id is marked for cooldown.
                 match state_guard.address_verification_cooldown.get(&peer_info.peer_id) {
                     Some(&failure_instant) => {
                         let time_since_failure = now_instant.duration_since(failure_instant);
-                        if time_since_failure >= ADDRESS_VERIFICATION_FAILURE_COOLDOWN {
+                        let cooldown_duration = config.address_verification_failure_cooldown();
+                        if time_since_failure >= cooldown_duration {
                             true // Cooldown expired
                         } else {
                             debug!(
                                 "Peer {} is in verification failure cooldown (failed {:.1}s ago, cooldown: {:.1}s)",
                                 peer_info.peer_id,
                                 time_since_failure.as_secs_f32(),
-                                ADDRESS_VERIFICATION_FAILURE_COOLDOWN.as_secs_f32()
+                                cooldown_duration.as_secs_f32()
                             );
                             false // Still in cooldown
                         }
@@ -877,10 +898,11 @@ fn verify_peer_infos(
 /// - A list of peers along with their successfully verified addresses
 /// - A list of peer IDs that failed verification (to be added to cooldown)
 ///
-/// Times out after ADDRESS_VERIFICATION_TOTAL_TIMEOUT to prevent DOS attacks.
+/// Times out after the configured total timeout to prevent DOS attacks.
 async fn verify_addresses_of_peers(
     network: &Network,
     peers: Vec<VerifiedEnvelope<NodeInfo, Ed25519Signature>>,
+    config: &DiscoveryConfig,
 ) -> (
     Vec<(VerifiedEnvelope<NodeInfo, Ed25519Signature>, Vec<Multiaddr>)>,
     Vec<PeerId>,
@@ -889,16 +911,17 @@ async fn verify_addresses_of_peers(
     let verification_stream = futures::stream::iter(peers.into_iter().map(|verified_peer_info| {
         let network = network.clone();
         async move {
-            let valid_addresses = verify_address_ownership(&network, &verified_peer_info).await;
+            let valid_addresses =
+                verify_address_ownership(&network, &verified_peer_info, config).await;
             (verified_peer_info, valid_addresses)
         }
     }))
-    .buffer_unordered(10); // Limit concurrent verifications to avoid overwhelming the network
+    .buffer_unordered(config.max_concurrent_address_verifications()); // Limit concurrent verifications to avoid overwhelming the network
 
     let mut address_verification_results = Vec::with_capacity(peers_count);
     let mut verification_stream = std::pin::Pin::new(Box::new(verification_stream));
 
-    match tokio::time::timeout(ADDRESS_VERIFICATION_TOTAL_TIMEOUT, async {
+    match tokio::time::timeout(config.address_verification_total_timeout(), async {
         while let Some(result) = verification_stream.next().await {
             address_verification_results.push(result);
         }
@@ -914,7 +937,7 @@ async fn verify_addresses_of_peers(
         Err(_) => {
             debug!(
                 "Address verification timed out after {}s, but collected {} partial results out of {} peers",
-                ADDRESS_VERIFICATION_TOTAL_TIMEOUT.as_secs(),
+                config.address_verification_total_timeout().as_secs(),
                 address_verification_results.len(),
                 peers_count
             );
@@ -952,16 +975,22 @@ async fn update_known_peers(
     metrics: Metrics,
     found_peers: Vec<SignedNodeInfo>,
     allowlisted_peers: Arc<HashMap<PeerId, Option<Multiaddr>>>,
+    config: &DiscoveryConfig,
 ) {
     let now_instant = Instant::now();
 
     // Clean up old entries from the verification failure cooldown
-    cleanup_verification_failure_cooldown(&state, now_instant);
+    cleanup_verification_failure_cooldown(&state, now_instant, config);
 
     // Verify all peer infos and filter out invalid ones, filter by latest timestamp
     // per peer_id. This does not verify address ownership yet.
-    let verified_peer_infos =
-        verify_peer_infos(&state, found_peers, allowlisted_peers.clone(), now_instant);
+    let verified_peer_infos = verify_peer_infos(
+        &state,
+        found_peers,
+        allowlisted_peers.clone(),
+        now_instant,
+        config,
+    );
 
     if verified_peer_infos.is_empty() {
         // No verified peers to process, we're done
@@ -1024,7 +1053,7 @@ async fn update_known_peers(
 
     // Verify addresses for peers that need verification
     let (mut verified_peers, failed_peer_ids) = match peers_with_addresses_to_verify.is_empty() {
-        false => verify_addresses_of_peers(network, peers_with_addresses_to_verify).await,
+        false => verify_addresses_of_peers(network, peers_with_addresses_to_verify, config).await,
         true => Default::default(),
     };
 
@@ -1066,16 +1095,18 @@ async fn update_known_peers(
         // acquisition.
         let mut state_guard = state.write().unwrap();
 
-        // Add all failed peers to verification failure cooldown
-        for peer_id in failed_peer_ids {
-            state_guard
-                .address_verification_cooldown
-                .insert(peer_id, now_instant);
-            debug!(
-                "Added peer {} to verification failure cooldown for {:.1}s",
-                peer_id,
-                ADDRESS_VERIFICATION_FAILURE_COOLDOWN.as_secs_f32()
-            );
+        // Add all failed peers to verification failure cooldown (if enabled)
+        if config.is_address_verification_cooldown_enabled() {
+            for peer_id in failed_peer_ids {
+                state_guard
+                    .address_verification_cooldown
+                    .insert(peer_id, now_instant);
+                debug!(
+                    "Added peer {} to verification failure cooldown for {:.1}s",
+                    peer_id,
+                    config.address_verification_failure_cooldown().as_secs_f32()
+                );
+            }
         }
 
         // First insert/update the peers that didn't need verification

--- a/crates/iota-network/src/discovery/mod.rs
+++ b/crates/iota-network/src/discovery/mod.rs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::Entry},
     sync::{Arc, RwLock},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anemo::{
@@ -36,6 +36,10 @@ const ONE_DAY_MILLISECONDS: u64 = 24 * 60 * 60 * 1_000;
 const MAX_ADDRESS_LENGTH: usize = 300;
 const MAX_PEERS_TO_SEND: usize = 200;
 const MAX_ADDRESSES_PER_PEER: usize = 2;
+const ADDRESS_VERIFICATION_TIMEOUT: Duration = Duration::from_secs(3);
+const ADDRESS_VERIFICATION_TOTAL_TIMEOUT: Duration = Duration::from_secs(8); // Overall timeout for verify_address_ownership to prevent DoS attacks
+const ADDRESS_VERIFICATION_FAILURE_COOLDOWN: Duration = Duration::from_secs(10 * 60); // 10 minutes cooldown
+const COOLDOWN_CLEANUP_INTERVAL: Duration = Duration::from_secs(5 * 60); // Clean up cooldown list every 5 minutes
 
 // Includes the generated Discovery code from the OUT_DIR
 mod generated {
@@ -62,6 +66,12 @@ struct State {
     our_info: Option<SignedNodeInfo>,
     connected_peers: HashMap<PeerId, ()>,
     known_peers: HashMap<PeerId, VerifiedSignedNodeInfo>,
+    /// Cooldown list for peers whose address verification failed recently
+    /// Maps PeerId to the instant when the verification failed.
+    /// Can't be spoofed because the peer_id is part of the signed info.
+    address_verification_cooldown: HashMap<PeerId, Instant>,
+    /// Instant of the last cooldown cleanup
+    last_cooldown_cleanup: Instant,
 }
 
 /// The information necessary to dial another peer.
@@ -336,6 +346,7 @@ impl DiscoveryEventLoop {
                     // Queries the new node for any peers.
                     self.tasks.spawn(query_peer_for_their_known_peers(
                         peer,
+                        self.network.clone(),
                         self.state.clone(),
                         self.metrics.clone(),
                         self.allowlisted_peers.clone(),
@@ -397,19 +408,17 @@ impl DiscoveryEventLoop {
         // Selects a subset of known peers to dial if we're not connected to enough
         // peers.
         let state = self.state.read().unwrap();
-        let eligible = state
+        let eligible: Vec<_> = state
             .known_peers
-            .clone()
-            .into_iter()
-            .filter(|(peer_id, info)| {
-                peer_id != &self.network.peer_id() &&
-                !info.addresses.is_empty() // Peer has addresses we can dial
-                && !state.connected_peers.contains_key(peer_id) // We're not already connected
-                && !self.pending_dials.contains_key(peer_id) // There is no
-                // pending dial to
-                // this node
+            .iter()
+            .filter(|(&peer_id, info)| {
+                peer_id != self.network.peer_id()
+                    && !info.addresses.is_empty() // Peer has addresses we can dial
+                    && !state.connected_peers.contains_key(&peer_id) // We're not already connected
+                    && !self.pending_dials.contains_key(&peer_id) // There is no pending dial to this node
             })
-            .collect::<Vec<_>>();
+            .map(|(&peer_id, info)| (peer_id, info.clone()))
+            .collect();
 
         // No need to connect to any more peers if we're already connected to a bunch
         let number_of_connections = state.connected_peers.len();
@@ -451,6 +460,63 @@ impl DiscoveryEventLoop {
     }
 }
 
+/// Verifies that a peer actually controls the addresses they claim by
+/// attempting to establish a connection. This prevents address spoofing
+/// attacks. Tries all addresses individually and returns the list of
+/// addresses that were successfully verified.
+/// This should only be used for not-yet-connected peers.
+async fn verify_address_ownership(network: &Network, peer_info: &SignedNodeInfo) -> Vec<Multiaddr> {
+    // Try each address individually and collect the ones that work
+    let verification_futures: Vec<_> = peer_info
+        .addresses
+        .iter()
+        .map(|address| {
+            let network = network.clone();
+            let peer_id = peer_info.peer_id;
+            let address = address.clone();
+            Box::pin(async move {
+                if let Ok(anemo_address) = address.to_anemo_address() {
+                    // Try to connect to the claimed address with the claimed peer_id
+                    match tokio::time::timeout(
+                        ADDRESS_VERIFICATION_TIMEOUT,
+                        network.connect_with_peer_id(anemo_address, peer_id),
+                    )
+                    .await
+                    {
+                        Ok(Ok(_connection)) => {
+                            debug!(
+                                "Address verification succeeded for peer {} at address {}",
+                                peer_id, address
+                            );
+
+                            // Disconnect immediately since this was just for verification
+                            let _ = network.disconnect(peer_id);
+                            return Some(address);
+                        }
+                        Ok(Err(e)) => {
+                            debug!(
+                                "Address verification failed for peer {} at address {}: {}",
+                                peer_id, address, e
+                            );
+                        }
+                        Err(_timeout) => {
+                            debug!(
+                                "Address verification timed out for peer {} at address {}",
+                                peer_id, address
+                            );
+                        }
+                    }
+                }
+                None
+            })
+        })
+        .collect();
+
+    // Wait for all verification attempts to complete and collect successful ones
+    let results = futures::future::join_all(verification_futures).await;
+    results.into_iter().flatten().collect()
+}
+
 async fn try_to_connect_to_peer(network: Network, info: NodeInfo) {
     debug!("Connecting to peer {info:?}");
     for multiaddr in &info.addresses {
@@ -462,8 +528,7 @@ async fn try_to_connect_to_peer(network: Network, info: NodeInfo) {
                 .tap_err(|e| {
                     debug!(
                         "error dialing {} at address '{}': {e}",
-                        info.peer_id.short_display(4),
-                        multiaddr
+                        info.peer_id, multiaddr
                     )
                 })
                 .is_ok()
@@ -503,8 +568,50 @@ async fn try_to_connect_to_seed_peers(
     .await;
 }
 
+/// Deduplicates peer infos based on their serialized representation (including
+/// signature). First groups by PeerId for efficiency, then uses BCS
+/// serialization only when there are multiple entries for the same peer.
+fn deduplicate_peers(peers: Vec<SignedNodeInfo>) -> Vec<SignedNodeInfo> {
+    let peers_count = peers.len();
+
+    // First group by PeerId - much more efficient than always serializing
+    let peer_groups = peers.into_iter().fold(
+        HashMap::<PeerId, Vec<SignedNodeInfo>>::with_capacity(peers_count),
+        |mut acc, peer_info| {
+            acc.entry(peer_info.peer_id).or_default().push(peer_info);
+            acc
+        },
+    );
+
+    let mut peers_deduplicated = Vec::with_capacity(peer_groups.len());
+
+    for (_, peer_infos) in peer_groups {
+        match peer_infos.len() {
+            1 => {
+                // No duplicates for this peer - just take the single entry
+                peers_deduplicated.push(peer_infos.into_iter().next().unwrap());
+            }
+            _ => {
+                // Multiple entries for this peer - deduplicate using BCS serialization
+                let peer_deduplicated: HashMap<Vec<u8>, SignedNodeInfo> = peer_infos
+                    .into_iter()
+                    .map(|peer_info| {
+                        let key =
+                            bcs::to_bytes(&peer_info).expect("BCS serialization should not fail");
+                        (key, peer_info)
+                    })
+                    .collect();
+                peers_deduplicated.extend(peer_deduplicated.into_values());
+            }
+        }
+    }
+
+    peers_deduplicated
+}
+
 async fn query_peer_for_their_known_peers(
     peer: Peer,
+    network: Network,
     state: Arc<RwLock<State>>,
     metrics: Metrics,
     allowlisted_peers: Arc<HashMap<PeerId, Option<Multiaddr>>>,
@@ -528,8 +635,23 @@ async fn query_peer_for_their_known_peers(
                 known_peers
             },
         );
+
     if let Some(found_peers) = found_peers {
-        update_known_peers(state, metrics, found_peers, allowlisted_peers);
+        // Limit each client to MAX_PEERS_TO_SEND (+1 because of the own_info from the
+        // peer)
+        let limited_peers = found_peers
+            .into_iter()
+            .take(MAX_PEERS_TO_SEND + 1)
+            .collect::<Vec<_>>();
+
+        update_known_peers(
+            &network,
+            state,
+            metrics,
+            deduplicate_peers(limited_peers),
+            allowlisted_peers,
+        )
+        .await;
     }
 }
 
@@ -569,7 +691,12 @@ async fn query_connected_peers_for_their_known_peers(
                         if !own_info.addresses.is_empty() {
                             known_peers.push(own_info)
                         }
+                        // Limit each client to MAX_PEERS_TO_SEND (+1 because of the own_info from
+                        // the peer)
                         known_peers
+                            .into_iter()
+                            .take(MAX_PEERS_TO_SEND + 1)
+                            .collect::<Vec<_>>()
                     },
                 )
         })
@@ -580,26 +707,100 @@ async fn query_connected_peers_for_their_known_peers(
         .collect::<Vec<_>>()
         .await;
 
-    update_known_peers(state, metrics, found_peers, allowlisted_peers);
+    update_known_peers(
+        &network,
+        state,
+        metrics,
+        deduplicate_peers(found_peers),
+        allowlisted_peers,
+    )
+    .await;
 }
 
-/// Updates the known peers list with the found peers. The found peer is ignored
-/// if it is too old or too far in the future from our clock.
-/// If a peer is already known, the NodeInfo is updated, otherwise the peer is
-/// inserted.
-fn update_known_peers(
-    state: Arc<RwLock<State>>,
-    metrics: Metrics,
-    found_peers: Vec<SignedNodeInfo>,
-    allowlisted_peers: Arc<HashMap<PeerId, Option<Multiaddr>>>,
-) {
-    use std::collections::hash_map::Entry;
+/// Cleans up old entries from the verification failure cooldown list
+fn cleanup_verification_failure_cooldown(state: &Arc<RwLock<State>>, now_instant: Instant) {
+    // Only run cleanup if enough time has passed since the last cleanup
+    if now_instant.duration_since(state.read().unwrap().last_cooldown_cleanup)
+        < COOLDOWN_CLEANUP_INTERVAL
+    {
+        return;
+    }
 
+    let mut state_guard = state.write().unwrap();
+    state_guard.last_cooldown_cleanup = now_instant;
+
+    // Remove entries that have exceeded the cooldown period
+    let initial_size = state_guard.address_verification_cooldown.len();
+    state_guard
+        .address_verification_cooldown
+        .retain(|peer_id, &mut failure_instant| {
+            let should_retain =
+                now_instant.duration_since(failure_instant) < ADDRESS_VERIFICATION_FAILURE_COOLDOWN;
+            if !should_retain {
+                debug!(
+                    "Removing peer {} from verification failure cooldown",
+                    peer_id
+                );
+            }
+            should_retain
+        });
+
+    let removed_count = initial_size - state_guard.address_verification_cooldown.len();
+    if removed_count > 0 {
+        debug!(
+            "Cleaned up {} entries from verification failure cooldown",
+            removed_count
+        );
+    }
+}
+
+fn verify_peer_infos(
+    state: &Arc<RwLock<State>>,
+    found_peers: Vec<Envelope<NodeInfo, Ed25519Signature>>,
+    allowlisted_peers: Arc<HashMap<PeerId, Option<Multiaddr>>>,
+    now_instant: Instant,
+) -> Vec<VerifiedSignedNodeInfo> {
     let now_unix = now_unix();
-    let our_peer_id = state.read().unwrap().our_info.clone().unwrap().peer_id;
-    let known_peers = &mut state.write().unwrap().known_peers;
-    // only take the first MAX_PEERS_TO_SEND peers
-    for peer_info in found_peers.into_iter().take(MAX_PEERS_TO_SEND) {
+
+    // Acquire read lock once to get our peer ID and filter peers by cooldown
+    let (our_peer_id, found_peers) = {
+        let state_guard = state.read().unwrap();
+        let our_peer_id = state_guard.our_info.clone().unwrap().peer_id;
+
+        // Filter out peers that are in cooldown while holding the lock
+        let filtered_peers: Vec<_> = found_peers
+            .into_iter()
+            .filter(|peer_info| {
+                // Check if this peer is in the address verification cooldown.
+                // Even if the signature is not checked yet, it would be pointless to verify if
+                // that peer_id is marked for cooldown.
+                match state_guard.address_verification_cooldown.get(&peer_info.peer_id) {
+                    Some(&failure_instant) => {
+                        let time_since_failure = now_instant.duration_since(failure_instant);
+                        if time_since_failure >= ADDRESS_VERIFICATION_FAILURE_COOLDOWN {
+                            true // Cooldown expired
+                        } else {
+                            debug!(
+                                "Peer {} is in verification failure cooldown (failed {:.1}s ago, cooldown: {:.1}s)",
+                                peer_info.peer_id,
+                                time_since_failure.as_secs_f32(),
+                                ADDRESS_VERIFICATION_FAILURE_COOLDOWN.as_secs_f32()
+                            );
+                            false // Still in cooldown
+                        }
+                    }
+                    None => true, // Not in cooldown
+                }
+            })
+            .collect();
+
+        (our_peer_id, filtered_peers)
+    };
+
+    let mut latest_verified_peer_infos: HashMap<PeerId, VerifiedSignedNodeInfo> =
+        HashMap::with_capacity(found_peers.len());
+
+    for peer_info in found_peers.into_iter() {
         // Skip peers whose timestamp is too far in the future from our clock
         // or that are too old
         if peer_info.timestamp_ms > now_unix.saturating_add(30 * 1_000) // 30 seconds
@@ -608,6 +809,7 @@ fn update_known_peers(
             continue;
         }
 
+        // Skip our own info
         if peer_info.peer_id == our_peer_id {
             continue;
         }
@@ -619,13 +821,15 @@ fn update_known_peers(
             continue;
         }
 
-        // Skip entries that have too many addresses as a means to cap the size of a
-        // node's info
-        if peer_info.addresses.len() > MAX_ADDRESSES_PER_PEER {
+        // Skip entries that have no or too many addresses as a means to cap the size of
+        // a node's info. This also means we don't update entries when peers remove all
+        // their addresses. Those entries will eventually be removed after
+        // ONE_DAY_MILLISECONDS.
+        if peer_info.addresses.is_empty() || peer_info.addresses.len() > MAX_ADDRESSES_PER_PEER {
             continue;
         }
 
-        // verify that all addresses provided are valid anemo addresses
+        // Verify that all addresses provided are valid anemo addresses
         if !peer_info
             .addresses
             .iter()
@@ -633,6 +837,8 @@ fn update_known_peers(
         {
             continue;
         }
+
+        // Verify the signature
         let Ok(public_key) = Ed25519PublicKey::from_bytes(&peer_info.peer_id.0) else {
             debug_fatal!(
                 // This should never happen.
@@ -650,28 +856,321 @@ fn update_known_peers(
             // TODO: consider denylisting the source of bad NodeInfo from future requests.
             continue;
         }
-        let peer = VerifiedSignedNodeInfo::new_from_verified(peer_info);
+        let verified_peer_info = VerifiedSignedNodeInfo::new_from_verified(peer_info);
 
-        match known_peers.entry(peer.peer_id) {
-            // Updates the NodeInfo of the peer if it exists.
-            Entry::Occupied(mut o) => {
-                if peer.timestamp_ms > o.get().timestamp_ms {
-                    if o.get().addresses.is_empty() && !peer.addresses.is_empty() {
-                        metrics.inc_num_peers_with_external_address();
+        // Keep only the latest entry for each peer_id based on timestamp
+        latest_verified_peer_infos
+            .entry(verified_peer_info.peer_id)
+            .and_modify(|existing| {
+                if verified_peer_info.timestamp_ms > existing.timestamp_ms {
+                    *existing = verified_peer_info.clone();
+                }
+            })
+            .or_insert(verified_peer_info);
+    }
+
+    latest_verified_peer_infos.into_values().collect()
+}
+
+/// Verifies the addresses of the given peers by attempting to connect to them.
+/// Returns a tuple containing:
+/// - A list of peers along with their successfully verified addresses
+/// - A list of peer IDs that failed verification (to be added to cooldown)
+///
+/// Times out after ADDRESS_VERIFICATION_TOTAL_TIMEOUT to prevent DOS attacks.
+async fn verify_addresses_of_peers(
+    network: &Network,
+    peers: Vec<VerifiedEnvelope<NodeInfo, Ed25519Signature>>,
+) -> (
+    Vec<(VerifiedEnvelope<NodeInfo, Ed25519Signature>, Vec<Multiaddr>)>,
+    Vec<PeerId>,
+) {
+    let peers_count = peers.len();
+    let verification_stream = futures::stream::iter(peers.into_iter().map(|verified_peer_info| {
+        let network = network.clone();
+        async move {
+            let valid_addresses = verify_address_ownership(&network, &verified_peer_info).await;
+            (verified_peer_info, valid_addresses)
+        }
+    }))
+    .buffer_unordered(10); // Limit concurrent verifications to avoid overwhelming the network
+
+    let mut address_verification_results = Vec::with_capacity(peers_count);
+    let mut verification_stream = std::pin::Pin::new(Box::new(verification_stream));
+
+    match tokio::time::timeout(ADDRESS_VERIFICATION_TOTAL_TIMEOUT, async {
+        while let Some(result) = verification_stream.next().await {
+            address_verification_results.push(result);
+        }
+    })
+    .await
+    {
+        Ok(_) => {
+            debug!(
+                "Address verification completed successfully for {} peers",
+                address_verification_results.len()
+            );
+        }
+        Err(_) => {
+            debug!(
+                "Address verification timed out after {}s, but collected {} partial results out of {} peers",
+                ADDRESS_VERIFICATION_TOTAL_TIMEOUT.as_secs(),
+                address_verification_results.len(),
+                peers_count
+            );
+        }
+    };
+
+    // Collect all verified peers with their verified addresses and peers that
+    // failed verification
+    let mut verified_peers = Vec::new();
+    let mut failed_peers = Vec::new();
+
+    for (verified_peer_info, verified_addresses) in address_verification_results {
+        if verified_addresses.is_empty() {
+            info!(
+                "Rejecting peer {} due to failed address verification for all addresses",
+                verified_peer_info.peer_id
+            );
+            failed_peers.push(verified_peer_info.peer_id);
+        } else {
+            verified_peers.push((verified_peer_info, verified_addresses));
+        }
+    }
+
+    (verified_peers, failed_peers)
+}
+
+/// Updates the known peers list with the found peers. The found peer is ignored
+/// if it is too old or too far in the future from our clock.
+/// If a peer is already known, the NodeInfo is updated, otherwise the peer is
+/// inserted if at least one address is verified.
+/// New or changed addresses are verified to prevent spoofing attacks.
+async fn update_known_peers(
+    network: &Network,
+    state: Arc<RwLock<State>>,
+    metrics: Metrics,
+    found_peers: Vec<SignedNodeInfo>,
+    allowlisted_peers: Arc<HashMap<PeerId, Option<Multiaddr>>>,
+) {
+    let now_instant = Instant::now();
+
+    // Clean up old entries from the verification failure cooldown
+    cleanup_verification_failure_cooldown(&state, now_instant);
+
+    // Verify all peer infos and filter out invalid ones, filter by latest timestamp
+    // per peer_id. This does not verify address ownership yet.
+    let verified_peer_infos =
+        verify_peer_infos(&state, found_peers, allowlisted_peers.clone(), now_instant);
+
+    if verified_peer_infos.is_empty() {
+        // No verified peers to process, we're done
+        return;
+    }
+
+    // We need to loop over the verified peers and compare them to the existing
+    // known peers. If the timestamp is newer and the addresses have changed, we
+    // need to verify the new addresses and handle potential address conflicts
+    // with existing entries afterwards. If the timestamp is newer but the
+    // addresses are the same, we can just update the timestamp without
+    // verification.
+    let mut peers_to_update_directly = Vec::new();
+    let mut peers_with_addresses_to_verify = Vec::new();
+    {
+        let state_guard = state.read().unwrap();
+        for verified_peer_info in verified_peer_infos {
+            // Skip address verification for allowlisted peers (they are trusted)
+            let is_allowlisted = allowlisted_peers.contains_key(&verified_peer_info.peer_id);
+            let is_connected = state_guard
+                .connected_peers
+                .contains_key(&verified_peer_info.peer_id);
+
+            match state_guard.known_peers.get(&verified_peer_info.peer_id) {
+                Some(existing_peer) => {
+                    // Existing peer, check if the timestamp is newer, otherwise ignore
+                    if verified_peer_info.timestamp_ms > existing_peer.timestamp_ms {
+                        // Check if the addresses have changed
+                        if verified_peer_info.addresses != existing_peer.addresses {
+                            if is_allowlisted || is_connected {
+                                // Allowlisted or connected peers are trusted, skip verification
+                                peers_to_update_directly.push(verified_peer_info);
+                            } else {
+                                // Addresses have changed, we need to verify.
+                                peers_with_addresses_to_verify.push(verified_peer_info);
+                            }
+                        } else {
+                            // Only timestamp changed, no need to verify addresses
+                            peers_to_update_directly.push(verified_peer_info);
+                        }
                     }
-                    if !o.get().addresses.is_empty() && peer.addresses.is_empty() {
-                        metrics.dec_num_peers_with_external_address();
+                }
+                None => {
+                    if is_allowlisted {
+                        // Allowlisted can be added without verification
+                        peers_to_update_directly.push(verified_peer_info);
+                    } else {
+                        // Unknown peer, always verify
+                        peers_with_addresses_to_verify.push(verified_peer_info);
                     }
-                    o.insert(peer);
                 }
             }
-            // Inserts the peer if it doesn't exist.
-            Entry::Vacant(v) => {
-                if !peer.addresses.is_empty() {
+        }
+    }
+
+    if peers_to_update_directly.is_empty() && peers_with_addresses_to_verify.is_empty() {
+        // No peers to update or verify, we're done
+        return;
+    }
+
+    // Verify addresses for peers that need verification
+    let (mut verified_peers, failed_peer_ids) = match peers_with_addresses_to_verify.is_empty() {
+        false => verify_addresses_of_peers(network, peers_with_addresses_to_verify).await,
+        true => Default::default(),
+    };
+
+    // If we have neither verified peers nor peers to update directly, nor failed
+    // peers, we're done
+    if verified_peers.is_empty()
+        && peers_to_update_directly.is_empty()
+        && failed_peer_ids.is_empty()
+    {
+        return;
+    }
+
+    {
+        // First check if multiple verified peers claim the same address
+        let mut address_to_peer: HashMap<Multiaddr, VerifiedSignedNodeInfo> =
+            HashMap::with_capacity(verified_peers.len() * MAX_ADDRESSES_PER_PEER);
+        let mut new_peers_to_reject = HashSet::new();
+        for (new_peer_info, verified_addresses) in &verified_peers {
+            for address in verified_addresses {
+                match address_to_peer.entry(address.clone()) {
+                    // Replaces the peer if the new one is newer.
+                    Entry::Occupied(mut existing_entry) => {
+                        if new_peer_info.timestamp_ms > existing_entry.get().timestamp_ms {
+                            new_peers_to_reject.insert(existing_entry.get().peer_id);
+                            existing_entry.insert(new_peer_info.clone());
+                        } else {
+                            new_peers_to_reject.insert(new_peer_info.peer_id);
+                        }
+                    }
+                    // Inserts the peer if it doesn't exist.
+                    Entry::Vacant(v) => {
+                        v.insert(new_peer_info.clone());
+                    }
+                }
+            }
+        }
+
+        // Update the known peers state with all changes in a single write lock
+        // acquisition.
+        let mut state_guard = state.write().unwrap();
+
+        // Add all failed peers to verification failure cooldown
+        for peer_id in failed_peer_ids {
+            state_guard
+                .address_verification_cooldown
+                .insert(peer_id, now_instant);
+            debug!(
+                "Added peer {} to verification failure cooldown for {:.1}s",
+                peer_id,
+                ADDRESS_VERIFICATION_FAILURE_COOLDOWN.as_secs_f32()
+            );
+        }
+
+        // First insert/update the peers that didn't need verification
+        for peer in peers_to_update_directly {
+            insert_or_update_peer(&mut state_guard, peer, &metrics);
+        }
+
+        if !address_to_peer.is_empty() {
+            // Remove existing peers that have conflicting addresses with the new peers, if
+            // their timestamp is older than the new peer's timestamp. (Skip
+            // connected peers).
+            // Also reject new peers that lost address conflicts or with existing peers
+
+            let mut peers_to_remove = Vec::new();
+            for (peer_id, peer_info) in state_guard.known_peers.iter() {
+                // Skip connected peers as we don't want to disconnect them anyway
+                if state_guard.connected_peers.contains_key(peer_id) {
+                    continue;
+                }
+
+                for address in &peer_info.addresses {
+                    if let Some(new_peer_info) = address_to_peer.get(address) {
+                        // if the peer_id is the same, we will update it later
+                        if new_peer_info.peer_id != *peer_id {
+                            // Conflict detected
+                            if new_peer_info.timestamp_ms > peer_info.timestamp_ms {
+                                debug!(
+                                    "Address conflict: newer peer {} replaces older peer {} for address {}",
+                                    new_peer_info.peer_id, peer_id, address
+                                );
+                                // New peer wins - remove old peer
+                                peers_to_remove.push(*peer_id);
+                                if !peer_info.addresses.is_empty() {
+                                    metrics.dec_num_peers_with_external_address();
+                                }
+                                break; // No need to check other addresses of this peer
+                            } else {
+                                // Existing peer wins - reject this new peer
+                                debug!(
+                                    "Address conflict: existing peer {} keeps address {} over older peer {}",
+                                    peer_id, address, new_peer_info.peer_id
+                                );
+                                new_peers_to_reject.insert(new_peer_info.peer_id);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Remove the peers that lost conflicts
+            for peer_id in peers_to_remove {
+                state_guard.known_peers.remove(&peer_id);
+            }
+        }
+
+        if !new_peers_to_reject.is_empty() {
+            // Remove new peers that lost address conflicts
+            verified_peers
+                .retain(|(peer_info, _)| !new_peers_to_reject.contains(&peer_info.peer_id));
+        }
+
+        // Insert/update the remaining verified peers
+        for (verified_peer, _) in verified_peers {
+            insert_or_update_peer(&mut state_guard, verified_peer, &metrics);
+        }
+    }
+}
+
+/// Inserts or updates a peer in the known peers list.
+/// If the peer already exists, its NodeInfo is updated only if the new one has
+/// a newer timestamp.
+fn insert_or_update_peer(
+    state_guard: &mut std::sync::RwLockWriteGuard<'_, State>,
+    peer: VerifiedSignedNodeInfo,
+    metrics: &Metrics,
+) {
+    match state_guard.known_peers.entry(peer.peer_id) {
+        // Updates the NodeInfo of the peer if it exists.
+        Entry::Occupied(mut existing_entry) => {
+            if peer.timestamp_ms > existing_entry.get().timestamp_ms {
+                if existing_entry.get().addresses.is_empty() && !peer.addresses.is_empty() {
                     metrics.inc_num_peers_with_external_address();
                 }
-                v.insert(peer);
+                if !existing_entry.get().addresses.is_empty() && peer.addresses.is_empty() {
+                    metrics.dec_num_peers_with_external_address();
+                }
+                existing_entry.insert(peer);
             }
+        }
+        // Inserts the peer if it doesn't exist.
+        Entry::Vacant(v) => {
+            if !peer.addresses.is_empty() {
+                metrics.inc_num_peers_with_external_address();
+            }
+            v.insert(peer);
         }
     }
 }

--- a/crates/iota-network/src/discovery/mod.rs
+++ b/crates/iota-network/src/discovery/mod.rs
@@ -14,7 +14,6 @@ use anemo::{
 };
 use fastcrypto::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use futures::StreamExt;
-use iota_common::debug_fatal;
 use iota_config::p2p::{AccessType, DiscoveryConfig, P2pConfig, SeedPeer};
 use iota_types::{
     crypto::{NetworkKeyPair, Signer, ToFromBytes, VerifyingKey},
@@ -65,8 +64,6 @@ struct State {
     /// Maps PeerId to the instant when the verification failed.
     /// Can't be spoofed because the peer_id is part of the signed info.
     address_verification_cooldown: HashMap<PeerId, Instant>,
-    /// Instant of the last cooldown cleanup
-    last_cooldown_cleanup: Instant,
 }
 
 /// The information necessary to dial another peer.
@@ -148,6 +145,8 @@ impl DiscoveryEventLoop {
         self.configure_preferred_peers();
 
         let mut interval = tokio::time::interval(self.discovery_config.interval_period());
+        let mut cleanup_interval =
+            tokio::time::interval(self.discovery_config.cooldown_cleanup_interval());
         let mut peer_events = {
             let (subscriber, _peers) = self.network.subscribe().unwrap();
             subscriber
@@ -158,6 +157,9 @@ impl DiscoveryEventLoop {
                 now = interval.tick() => {
                     let now_unix = now_unix();
                     self.handle_tick(now.into_std(), now_unix);
+                }
+                now = cleanup_interval.tick() => {
+                    cleanup_verification_failure_cooldown(&self.state, now.into_std(), &self.discovery_config);
                 }
                 peer_event = peer_events.recv() => {
                     self.handle_peer_event(peer_event);
@@ -476,6 +478,16 @@ async fn verify_address_ownership(
             let address = address.clone();
             Box::pin(async move {
                 if let Ok(anemo_address) = address.to_anemo_address() {
+                    // Check again if we're connected before attempting verification
+                    // to handle race conditions where connection happens during verification
+                    if network.peer(peer_id).is_some() {
+                        debug!(
+                            "Peer {} connected during verification, trusting address {}",
+                            peer_id, address
+                        );
+                        return Some(address);
+                    }
+
                     // Try to connect to the claimed address with the claimed peer_id
                     match tokio::time::timeout(
                         config.address_verification_timeout(),
@@ -568,45 +580,42 @@ async fn try_to_connect_to_seed_peers(
     .await;
 }
 
-/// Deduplicates peer infos based on their serialized representation (including
-/// signature). First groups by PeerId for efficiency, then uses BCS
-/// serialization only when there are multiple entries for the same peer.
-fn deduplicate_peers(peers: Vec<SignedNodeInfo>) -> Vec<SignedNodeInfo> {
-    let peers_count = peers.len();
+/// Wrapper for SignedNodeInfo that implements Hash based on all fields (data +
+/// signature)
+#[derive(Clone, Debug)]
+struct HashableSignedNodeInfo(SignedNodeInfo);
 
-    // First group by PeerId - much more efficient than always serializing
-    let peer_groups = peers.into_iter().fold(
-        HashMap::<PeerId, Vec<SignedNodeInfo>>::with_capacity(peers_count),
-        |mut acc, peer_info| {
-            acc.entry(peer_info.peer_id).or_default().push(peer_info);
-            acc
-        },
-    );
-
-    let mut peers_deduplicated = Vec::with_capacity(peer_groups.len());
-
-    for (_, peer_infos) in peer_groups {
-        match peer_infos.len() {
-            1 => {
-                // No duplicates for this peer - just take the single entry
-                peers_deduplicated.push(peer_infos.into_iter().next().unwrap());
-            }
-            _ => {
-                // Multiple entries for this peer - deduplicate using BCS serialization
-                let peer_deduplicated: HashMap<Vec<u8>, SignedNodeInfo> = peer_infos
-                    .into_iter()
-                    .map(|peer_info| {
-                        let key =
-                            bcs::to_bytes(&peer_info).expect("BCS serialization should not fail");
-                        (key, peer_info)
-                    })
-                    .collect();
-                peers_deduplicated.extend(peer_deduplicated.into_values());
-            }
-        }
+impl std::hash::Hash for HashableSignedNodeInfo {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.peer_id.hash(state);
+        self.0.addresses.hash(state);
+        self.0.timestamp_ms.hash(state);
+        state.write_isize(self.0.access_type as isize);
+        self.0.auth_sig().as_bytes().hash(state);
     }
+}
 
-    peers_deduplicated
+impl PartialEq for HashableSignedNodeInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.peer_id == other.0.peer_id
+            && self.0.addresses == other.0.addresses
+            && self.0.timestamp_ms == other.0.timestamp_ms
+            && self.0.access_type == other.0.access_type
+            && self.0.auth_sig() == other.0.auth_sig()
+    }
+}
+
+impl Eq for HashableSignedNodeInfo {}
+
+/// Deduplicates peer infos based on their complete content (data + signature)
+fn deduplicate_peers(peers: Vec<SignedNodeInfo>) -> Vec<SignedNodeInfo> {
+    peers
+        .into_iter()
+        .map(HashableSignedNodeInfo)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .map(|wrapped| wrapped.0)
+        .collect()
 }
 
 async fn query_peer_for_their_known_peers(
@@ -630,6 +639,8 @@ async fn query_peer_for_their_known_peers(
                  own_info,
                  mut known_peers,
              }| {
+                // Limit each client to MAX_PEERS_TO_SEND
+                known_peers.truncate(MAX_PEERS_TO_SEND);
                 if !own_info.addresses.is_empty() {
                     known_peers.push(own_info)
                 }
@@ -638,18 +649,11 @@ async fn query_peer_for_their_known_peers(
         );
 
     if let Some(found_peers) = found_peers {
-        // Limit each client to MAX_PEERS_TO_SEND (+1 because of the own_info from the
-        // peer)
-        let limited_peers = found_peers
-            .into_iter()
-            .take(MAX_PEERS_TO_SEND + 1)
-            .collect::<Vec<_>>();
-
         update_known_peers(
             &network,
             state,
             metrics,
-            deduplicate_peers(limited_peers),
+            deduplicate_peers(found_peers),
             allowlisted_peers,
             &config,
         )
@@ -692,15 +696,12 @@ async fn query_connected_peers_for_their_known_peers(
                          own_info,
                          mut known_peers,
                      }| {
+                        // Limit each client to MAX_PEERS_TO_SEND
+                        known_peers.truncate(MAX_PEERS_TO_SEND);
                         if !own_info.addresses.is_empty() {
                             known_peers.push(own_info)
                         }
-                        // Limit each client to MAX_PEERS_TO_SEND (+1 because of the own_info from
-                        // the peer)
                         known_peers
-                            .into_iter()
-                            .take(MAX_PEERS_TO_SEND + 1)
-                            .collect::<Vec<_>>()
                     },
                 )
         })
@@ -733,37 +734,40 @@ fn cleanup_verification_failure_cooldown(
         return;
     }
 
-    // Only run cleanup if enough time has passed since the last cleanup
-    if now_instant.duration_since(state.read().unwrap().last_cooldown_cleanup)
-        < config.cooldown_cleanup_interval()
-    {
-        return;
-    }
+    // First, check with a read lock to see if there are any entries to remove
+    let peers_to_remove: Vec<PeerId> = {
+        let state_guard = state.read().unwrap();
+        let cooldown_duration = config.address_verification_failure_cooldown();
 
-    let mut state_guard = state.write().unwrap();
-    state_guard.last_cooldown_cleanup = now_instant;
+        state_guard
+            .address_verification_cooldown
+            .iter()
+            .filter_map(|(&peer_id, &failure_instant)| {
+                if now_instant.duration_since(failure_instant) >= cooldown_duration {
+                    Some(peer_id)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    };
 
-    // Remove entries that have exceeded the cooldown period
-    let initial_size = state_guard.address_verification_cooldown.len();
-    let cooldown_duration = config.address_verification_failure_cooldown();
-    state_guard
-        .address_verification_cooldown
-        .retain(|peer_id, &mut failure_instant| {
-            let should_retain = now_instant.duration_since(failure_instant) < cooldown_duration;
-            if !should_retain {
-                debug!(
-                    "Removing peer {} from verification failure cooldown",
-                    peer_id
-                );
-            }
-            should_retain
-        });
+    // Only acquire write lock if we actually have entries to remove
+    if !peers_to_remove.is_empty() {
+        let mut state_guard = state.write().unwrap();
 
-    let removed_count = initial_size - state_guard.address_verification_cooldown.len();
-    if removed_count > 0 {
+        // Remove the expired entries
+        for peer_id in &peers_to_remove {
+            state_guard.address_verification_cooldown.remove(peer_id);
+            debug!(
+                "Removing peer {} from verification failure cooldown",
+                peer_id
+            );
+        }
+
         debug!(
             "Cleaned up {} entries from verification failure cooldown",
-            removed_count
+            peers_to_remove.len()
         );
     }
 }
@@ -862,7 +866,7 @@ fn verify_peer_infos(
 
         // Verify the signature
         let Ok(public_key) = Ed25519PublicKey::from_bytes(&peer_info.peer_id.0) else {
-            debug_fatal!(
+            debug!(
                 // This should never happen.
                 "Failed to convert anemo PeerId {:?} to Ed25519PublicKey",
                 peer_info.peer_id
@@ -985,9 +989,6 @@ async fn update_known_peers(
     config: &DiscoveryConfig,
 ) {
     let now_instant = Instant::now();
-
-    // Clean up old entries from the verification failure cooldown
-    cleanup_verification_failure_cooldown(&state, now_instant, config);
 
     // Verify all peer infos and filter out invalid ones, filter by latest timestamp
     // per peer_id. This does not verify address ownership yet.

--- a/crates/iota-network/src/discovery/server.rs
+++ b/crates/iota-network/src/discovery/server.rs
@@ -34,26 +34,45 @@ impl Discovery for Server {
             .ok_or_else(|| anemo::rpc::Status::internal("own_info has not been initialized yet"))?;
 
         let mut rng = rand::thread_rng();
-        // Prefer connected peers
-        let mut known_peers = state
+
+        // Create a hashmap with all known peers that are not private
+        let non_private_peers: std::collections::HashMap<_, _> = state
             .known_peers
             .iter()
             .filter_map(|(peer_id, peer_info)| {
-                (peer_info.access_type != AccessType::Private
-                    && state.connected_peers.contains_key(peer_id))
-                .then_some(peer_info.inner().clone())
+                (peer_info.access_type != AccessType::Private)
+                    .then_some((*peer_id, peer_info.inner().clone()))
+            })
+            .collect();
+
+        let mut known_peers = Vec::new();
+
+        // Step 1: Add connected peers (highest priority)
+        let mut connected_peers: Vec<_> = non_private_peers
+            .iter()
+            .filter_map(|(peer_id, peer_info)| {
+                state
+                    .connected_peers
+                    .contains_key(peer_id)
+                    .then_some(peer_info.clone())
             })
             .choose_multiple(&mut rng, MAX_PEERS_TO_SEND);
-        let mut known_not_connected_peers = state
-            .known_peers
-            .iter()
-            .filter_map(|(peer_id, peer_info)| {
-                (peer_info.access_type != AccessType::Private
-                    && !state.connected_peers.contains_key(peer_id))
-                .then_some(peer_info.inner().clone())
-            })
-            .choose_multiple(&mut rng, MAX_PEERS_TO_SEND - known_peers.len());
-        known_peers.append(&mut known_not_connected_peers);
+        known_peers.append(&mut connected_peers);
+
+        // Step 2: Add not connected peers with addresses (lower priority)
+        if known_peers.len() < MAX_PEERS_TO_SEND {
+            let mut not_connected_with_addresses: Vec<_> = non_private_peers
+                .iter()
+                .filter_map(|(peer_id, peer_info)| {
+                    (!state.connected_peers.contains_key(peer_id)
+                        && !peer_info.addresses.is_empty())
+                    .then_some(peer_info.clone())
+                })
+                .choose_multiple(&mut rng, MAX_PEERS_TO_SEND - known_peers.len());
+            known_peers.append(&mut not_connected_with_addresses);
+        }
+
+        // Shuffle the known peers to obfuscate network topology
         known_peers.shuffle(&mut rng);
 
         Ok(Response::new(GetKnownPeersResponseV2 {

--- a/crates/iota-network/src/discovery/tests.rs
+++ b/crates/iota-network/src/discovery/tests.rs
@@ -262,12 +262,14 @@ async fn update_peers_for_test(
     state: Arc<RwLock<State>>,
     peers: Vec<SignedNodeInfo>,
 ) {
+    let config = DiscoveryConfig::default();
     update_known_peers(
         network,
         state,
         Metrics::disabled(),
         peers,
         Arc::new(HashMap::new()),
+        &config,
     )
     .await;
 }

--- a/crates/iota-network/src/discovery/tests.rs
+++ b/crates/iota-network/src/discovery/tests.rs
@@ -13,6 +13,149 @@ use tokio::time::timeout;
 use super::*;
 use crate::utils::{build_network_with_address_and_anemo_config, build_network_with_anemo_config};
 
+///////////////////////////////////////////////
+// Helper functions for common test patterns //
+///////////////////////////////////////////////
+
+fn assert_peers(
+    self_name: &str,
+    network: &Network,
+    state: &Arc<RwLock<State>>,
+    expected_network_known_peers: HashSet<PeerId>,
+    expected_network_connected_peers: HashSet<PeerId>,
+    expected_discovery_known_peers: HashSet<PeerId>,
+    expected_discovery_connected_peers: HashSet<PeerId>,
+) {
+    let actual = network
+        .known_peers()
+        .get_all()
+        .iter()
+        .map(|pi| pi.peer_id)
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        actual, expected_network_known_peers,
+        "{self_name} network known peers mismatch. Expected: {expected_network_known_peers:#?}, actual: {actual:#?}",
+    );
+    let actual = network.peers().iter().copied().collect::<HashSet<_>>();
+    assert_eq!(
+        actual, expected_network_connected_peers,
+        "{self_name} network connected peers mismatch. Expected: {expected_network_connected_peers:#?}, actual: {actual:#?}",
+    );
+    let actual = state
+        .read()
+        .unwrap()
+        .known_peers
+        .keys()
+        .cloned()
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        actual, expected_discovery_known_peers,
+        "{self_name} discovery known peers mismatch. Expected: {expected_discovery_known_peers:#?}, actual: {actual:#?}",
+    );
+
+    let actual = state
+        .read()
+        .unwrap()
+        .connected_peers
+        .keys()
+        .cloned()
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        actual, expected_discovery_connected_peers,
+        "{self_name} discovery connected peers mismatch. Expected: {expected_discovery_connected_peers:#?}, actual: {actual:#?}",
+    );
+}
+
+fn unwrap_new_peer_event(event: PeerEvent) -> PeerId {
+    match event {
+        PeerEvent::NewPeer(peer_id) => peer_id,
+        e => panic!("unexpected event: {e:?}"),
+    }
+}
+
+fn local_allowlisted_peer(peer_id: PeerId, port: Option<u16>) -> AllowlistedPeer {
+    AllowlistedPeer {
+        peer_id,
+        address: port.map(|port| format!("/dns/localhost/udp/{port}").parse().unwrap()),
+    }
+}
+
+fn set_up_network_with_trusted_peer_change_rx(
+    p2p_config: P2pConfig,
+    address: Option<anemo::types::Address>,
+    trusted_peer_change_rx: watch::Receiver<TrustedPeerChangeEvent>,
+) -> (
+    UnstartedDiscovery,
+    DiscoveryServer<impl Discovery>,
+    Network,
+    NetworkKeyPair,
+) {
+    let anemo_config = p2p_config.anemo_config.clone().unwrap_or_default();
+
+    let (discovery, server) = Builder::new(trusted_peer_change_rx)
+        .config(p2p_config)
+        .build();
+
+    let (network, keypair) = match address {
+        Some(addr) => build_network_with_address_and_anemo_config(
+            |router| router.add_rpc_service(server.clone()),
+            addr,
+            anemo_config,
+        ),
+        None => build_network_with_anemo_config(
+            |router| router.add_rpc_service(server.clone()),
+            anemo_config,
+        ),
+    };
+
+    (discovery, server, network, keypair)
+}
+
+fn set_up_network(
+    p2p_config: P2pConfig,
+    address: Option<anemo::types::Address>,
+) -> (
+    UnstartedDiscovery,
+    DiscoveryServer<impl Discovery>,
+    Network,
+    NetworkKeyPair,
+) {
+    set_up_network_with_trusted_peer_change_rx(p2p_config, address, create_test_channel().1)
+}
+
+fn start_network(
+    discovery: UnstartedDiscovery,
+    network: Network,
+    keypair: NetworkKeyPair,
+) -> (DiscoveryEventLoop, Handle, Arc<RwLock<State>>) {
+    let (mut event_loop, handle) = discovery.build(network.clone(), keypair);
+    event_loop.config.external_address = Some(local_multiaddr_from_network(&network));
+    let state = event_loop.state.clone();
+    (event_loop, handle, state)
+}
+
+fn create_test_channel() -> (
+    watch::Sender<TrustedPeerChangeEvent>,
+    watch::Receiver<TrustedPeerChangeEvent>,
+) {
+    let (tx, rx) = watch::channel(TrustedPeerChangeEvent {
+        new_committee: vec![],
+        old_committee: vec![],
+    });
+    (tx, rx)
+}
+
+/// Helper to create multiaddr from network's port
+fn local_multiaddr_from_network(network: &Network) -> Multiaddr {
+    format!("/dns/localhost/udp/{}", network.local_addr().port())
+        .parse()
+        .unwrap()
+}
+
+///////////
+// Tests //
+///////////
+
 #[tokio::test]
 async fn get_known_peers() -> Result<()> {
     let config = P2pConfig::default();
@@ -683,145 +826,6 @@ async fn test_access_types() {
         HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_9]),
         HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_9]),
     );
-}
-
-///////////////////////////////////////////////
-// Helper functions for common test patterns //
-///////////////////////////////////////////////
-
-fn assert_peers(
-    self_name: &str,
-    network: &Network,
-    state: &Arc<RwLock<State>>,
-    expected_network_known_peers: HashSet<PeerId>,
-    expected_network_connected_peers: HashSet<PeerId>,
-    expected_discovery_known_peers: HashSet<PeerId>,
-    expected_discovery_connected_peers: HashSet<PeerId>,
-) {
-    let actual = network
-        .known_peers()
-        .get_all()
-        .iter()
-        .map(|pi| pi.peer_id)
-        .collect::<HashSet<_>>();
-    assert_eq!(
-        actual, expected_network_known_peers,
-        "{self_name} network known peers mismatch. Expected: {expected_network_known_peers:#?}, actual: {actual:#?}",
-    );
-    let actual = network.peers().iter().copied().collect::<HashSet<_>>();
-    assert_eq!(
-        actual, expected_network_connected_peers,
-        "{self_name} network connected peers mismatch. Expected: {expected_network_connected_peers:#?}, actual: {actual:#?}",
-    );
-    let actual = state
-        .read()
-        .unwrap()
-        .known_peers
-        .keys()
-        .cloned()
-        .collect::<HashSet<_>>();
-    assert_eq!(
-        actual, expected_discovery_known_peers,
-        "{self_name} discovery known peers mismatch. Expected: {expected_discovery_known_peers:#?}, actual: {actual:#?}",
-    );
-
-    let actual = state
-        .read()
-        .unwrap()
-        .connected_peers
-        .keys()
-        .cloned()
-        .collect::<HashSet<_>>();
-    assert_eq!(
-        actual, expected_discovery_connected_peers,
-        "{self_name} discovery connected peers mismatch. Expected: {expected_discovery_connected_peers:#?}, actual: {actual:#?}",
-    );
-}
-
-fn unwrap_new_peer_event(event: PeerEvent) -> PeerId {
-    match event {
-        PeerEvent::NewPeer(peer_id) => peer_id,
-        e => panic!("unexpected event: {e:?}"),
-    }
-}
-
-fn local_allowlisted_peer(peer_id: PeerId, port: Option<u16>) -> AllowlistedPeer {
-    AllowlistedPeer {
-        peer_id,
-        address: port.map(|port| format!("/dns/localhost/udp/{port}").parse().unwrap()),
-    }
-}
-
-fn set_up_network_with_trusted_peer_change_rx(
-    p2p_config: P2pConfig,
-    address: Option<anemo::types::Address>,
-    trusted_peer_change_rx: watch::Receiver<TrustedPeerChangeEvent>,
-) -> (
-    UnstartedDiscovery,
-    DiscoveryServer<impl Discovery>,
-    Network,
-    NetworkKeyPair,
-) {
-    let anemo_config = p2p_config.anemo_config.clone().unwrap_or_default();
-
-    let (discovery, server) = Builder::new(trusted_peer_change_rx)
-        .config(p2p_config)
-        .build();
-
-    let (network, keypair) = match address {
-        Some(addr) => build_network_with_address_and_anemo_config(
-            |router| router.add_rpc_service(server.clone()),
-            addr,
-            anemo_config,
-        ),
-        None => build_network_with_anemo_config(
-            |router| router.add_rpc_service(server.clone()),
-            anemo_config,
-        ),
-    };
-
-    (discovery, server, network, keypair)
-}
-
-fn set_up_network(
-    p2p_config: P2pConfig,
-    address: Option<anemo::types::Address>,
-) -> (
-    UnstartedDiscovery,
-    DiscoveryServer<impl Discovery>,
-    Network,
-    NetworkKeyPair,
-) {
-    set_up_network_with_trusted_peer_change_rx(p2p_config, address, create_test_channel().1)
-}
-
-fn start_network(
-    discovery: UnstartedDiscovery,
-    network: Network,
-    keypair: NetworkKeyPair,
-) -> (DiscoveryEventLoop, Handle, Arc<RwLock<State>>) {
-    let (mut event_loop, handle) = discovery.build(network.clone(), keypair);
-    event_loop.config.external_address = Some(local_multiaddr_from_network(&network));
-    let state = event_loop.state.clone();
-    (event_loop, handle, state)
-}
-
-fn create_test_channel() -> (
-    watch::Sender<TrustedPeerChangeEvent>,
-    watch::Receiver<TrustedPeerChangeEvent>,
-) {
-    let (tx, rx) = watch::channel(TrustedPeerChangeEvent {
-        new_committee: vec![],
-        old_committee: vec![],
-    });
-    (tx, rx)
-}
-
-/// Helper to create multiaddr from network's port
-fn local_multiaddr_from_network(network: &Network) -> Multiaddr {
-    format!("/dns/localhost/udp/{}", network.local_addr().port())
-        .parse()
-        .unwrap()
 }
 
 #[tokio::test]

--- a/crates/iota-network/src/discovery/tests.rs
+++ b/crates/iota-network/src/discovery/tests.rs
@@ -2,26 +2,28 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Duration};
 
 use anemo::{Result, types::PeerAffinity};
-use fastcrypto::ed25519::Ed25519PublicKey;
+use fastcrypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
 use futures::stream::FuturesUnordered;
 use iota_config::p2p::AllowlistedPeer;
 use tokio::time::timeout;
 
 use super::*;
-use crate::utils::{build_network_and_key, build_network_with_anemo_config};
+use crate::utils::{build_network_with_address_and_anemo_config, build_network_with_anemo_config};
 
 #[tokio::test]
 async fn get_known_peers() -> Result<()> {
     let config = P2pConfig::default();
-    let (UnstartedDiscovery { state, .. }, server) = Builder::new(create_test_channel().1)
-        .config(config)
-        .build_internal();
+
+    let (discovery, server, network, key) = set_up_network(config, None);
+    let key_for_signing = key.copy();
+    let (_event_loop, _handle, state) = start_network(discovery, network.clone(), key);
 
     // Err when own_info not set
     server
+        .inner()
         .get_known_peers_v2(Request::new(()))
         .await
         .unwrap_err();
@@ -33,11 +35,12 @@ async fn get_known_peers() -> Result<()> {
         timestamp_ms: now_unix(),
         access_type: AccessType::Public,
     };
-    state.write().unwrap().our_info = Some(SignedNodeInfo::new_from_data_and_sig(
-        our_info.clone(),
-        Ed25519Signature::default(),
-    ));
+
+    let signed_our_info = our_info.clone().sign(&key_for_signing);
+    state.write().unwrap().our_info = Some(signed_our_info);
+
     let response = server
+        .inner()
         .get_known_peers_v2(Request::new(()))
         .await
         .unwrap()
@@ -46,20 +49,22 @@ async fn get_known_peers() -> Result<()> {
     assert!(response.known_peers.is_empty());
 
     // Normal response with some known peers
-    let other_peer = NodeInfo {
+    let address_other: Multiaddr = "/dns/localhost/udp/1234".parse()?;
+    let peer_info_other = NodeInfo {
         peer_id: PeerId([13; 32]),
-        addresses: Vec::new(),
+        addresses: vec![address_other],
         timestamp_ms: now_unix(),
         access_type: AccessType::Public,
     };
     state.write().unwrap().known_peers.insert(
-        other_peer.peer_id,
+        peer_info_other.peer_id,
         VerifiedSignedNodeInfo::new_unchecked(SignedNodeInfo::new_from_data_and_sig(
-            other_peer.clone(),
+            peer_info_other.clone(),
             Ed25519Signature::default(),
         )),
     );
     let response = server
+        .inner()
         .get_known_peers_v2(Request::new(()))
         .await
         .unwrap()
@@ -71,7 +76,7 @@ async fn get_known_peers() -> Result<()> {
             .into_iter()
             .map(|peer| peer.into_data())
             .collect::<Vec<_>>(),
-        vec![other_peer]
+        vec![peer_info_other]
     );
 
     Ok(())
@@ -80,19 +85,18 @@ async fn get_known_peers() -> Result<()> {
 #[tokio::test]
 async fn make_connection_to_seed_peer() -> Result<()> {
     let mut config = P2pConfig::default();
-    let (builder, server) = Builder::new(create_test_channel().1)
-        .config(config.clone())
-        .build();
-    let (network_1, key_1) = build_network_and_key(|router| router.add_rpc_service(server));
-    let (_event_loop_1, _handle_1) = builder.build(network_1.clone(), key_1);
+
+    let (discovery_1, _server_1, network_1, key_1) = set_up_network(config.clone(), None);
+    let (_event_loop_1, _handle_1, _state_1) = start_network(discovery_1, network_1.clone(), key_1);
 
     config.seed_peers.push(SeedPeer {
         peer_id: None,
-        address: format!("/dns/localhost/udp/{}", network_1.local_addr().port()).parse()?,
+        address: local_multiaddr_from_network(&network_1),
     });
-    let (builder, server) = Builder::new(create_test_channel().1).config(config).build();
-    let (network_2, key_2) = build_network_and_key(|router| router.add_rpc_service(server));
-    let (mut event_loop_2, _handle_2) = builder.build(network_2.clone(), key_2);
+
+    let (discovery_2, _server_2, network_2, key_2) = set_up_network(config.clone(), None);
+    let (mut event_loop_2, _handle_2, _state_2) =
+        start_network(discovery_2, network_2.clone(), key_2);
 
     let (mut subscriber_1, _) = network_1.subscribe()?;
     let (mut subscriber_2, _) = network_2.subscribe()?;
@@ -114,19 +118,18 @@ async fn make_connection_to_seed_peer() -> Result<()> {
 #[tokio::test]
 async fn make_connection_to_seed_peer_with_peer_id() -> Result<()> {
     let mut config = P2pConfig::default();
-    let (builder, server) = Builder::new(create_test_channel().1)
-        .config(config.clone())
-        .build();
-    let (network_1, key_1) = build_network_and_key(|router| router.add_rpc_service(server));
-    let (_event_loop_1, _handle_1) = builder.build(network_1.clone(), key_1);
+
+    let (discovery_1, _server_1, network_1, key_1) = set_up_network(config.clone(), None);
+    let (_event_loop_1, _handle_1, _state_1) = start_network(discovery_1, network_1.clone(), key_1);
 
     config.seed_peers.push(SeedPeer {
         peer_id: Some(network_1.peer_id()),
-        address: format!("/dns/localhost/udp/{}", network_1.local_addr().port()).parse()?,
+        address: local_multiaddr_from_network(&network_1),
     });
-    let (builder, server) = Builder::new(create_test_channel().1).config(config).build();
-    let (network_2, key_2) = build_network_and_key(|router| router.add_rpc_service(server));
-    let (mut event_loop_2, _handle_2) = builder.build(network_2.clone(), key_2);
+
+    let (discovery_2, _server_2, network_2, key_2) = set_up_network(config, None);
+    let (mut event_loop_2, _handle_2, _state_2) =
+        start_network(discovery_2, network_2.clone(), key_2);
 
     let (mut subscriber_1, _) = network_1.subscribe()?;
     let (mut subscriber_2, _) = network_2.subscribe()?;
@@ -147,30 +150,22 @@ async fn make_connection_to_seed_peer_with_peer_id() -> Result<()> {
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn three_nodes_can_connect_via_discovery() -> Result<()> {
-    // Setup the peer that will be the seed for the other two
     let mut config = P2pConfig::default();
-    let (builder, server) = Builder::new(create_test_channel().1)
-        .config(config.clone())
-        .build();
-    let (network_1, key_1) = build_network_and_key(|router| router.add_rpc_service(server));
-    let (event_loop_1, _handle_1) = builder.build(network_1.clone(), key_1);
+
+    // Setup the peer that will be the seed for the other two
+    let (discovery_1, _server_1, network_1, key_1) = set_up_network(config.clone(), None);
+    let (event_loop_1, _handle_1, _state_1) = start_network(discovery_1, network_1.clone(), key_1);
 
     config.seed_peers.push(SeedPeer {
         peer_id: Some(network_1.peer_id()),
-        address: format!("/dns/localhost/udp/{}", network_1.local_addr().port()).parse()?,
+        address: local_multiaddr_from_network(&network_1),
     });
-    let (builder, server) = Builder::new(create_test_channel().1)
-        .config(config.clone())
-        .build();
-    let (network_2, key_2) = build_network_and_key(|router| router.add_rpc_service(server));
-    let (mut event_loop_2, _handle_2) = builder.build(network_2.clone(), key_2);
-    // Set an external_address address for node 2 so that it can share its address
-    event_loop_2.config.external_address =
-        Some(format!("/dns/localhost/udp/{}", network_2.local_addr().port()).parse()?);
 
-    let (builder, server) = Builder::new(create_test_channel().1).config(config).build();
-    let (network_3, key_3) = build_network_and_key(|router| router.add_rpc_service(server));
-    let (event_loop_3, _handle_3) = builder.build(network_3.clone(), key_3);
+    let (discovery_2, _server_2, network_2, key_2) = set_up_network(config.clone(), None);
+    let (event_loop_2, _handle_2, _state_2) = start_network(discovery_2, network_2.clone(), key_2);
+
+    let (discovery_3, _server_3, network_3, key_3) = set_up_network(config, None);
+    let (event_loop_3, _handle_3, _state_3) = start_network(discovery_3, network_3.clone(), key_3);
 
     let (mut subscriber_1, _) = network_1.subscribe()?;
     let (mut subscriber_2, _) = network_2.subscribe()?;
@@ -181,48 +176,89 @@ async fn three_nodes_can_connect_via_discovery() -> Result<()> {
     tokio::spawn(event_loop_2.start());
     tokio::spawn(event_loop_3.start());
 
+    // advance the internal tokio time, so that the "handle_tick"'s are called
+    tokio::time::sleep(Duration::from_secs(15)).await;
+
     let peer_id_1 = network_1.peer_id();
     let peer_id_2 = network_2.peer_id();
     let peer_id_3 = network_3.peer_id();
 
-    // Get two events from node and make sure they're all connected
-    let peers_1 = [subscriber_1.recv().await?, subscriber_1.recv().await?]
-        .into_iter()
-        .map(unwrap_new_peer_event)
-        .collect::<HashSet<_>>();
-    assert!(peers_1.contains(&peer_id_2));
-    assert!(peers_1.contains(&peer_id_3));
+    let mut connected_peers_1 = Vec::new();
+    let mut connected_peers_2 = Vec::new();
+    let mut connected_peers_3 = Vec::new();
 
-    let peers_2 = [subscriber_2.recv().await?, subscriber_2.recv().await?]
-        .into_iter()
-        .map(unwrap_new_peer_event)
-        .collect::<HashSet<_>>();
-    assert!(peers_2.contains(&peer_id_1));
-    assert!(peers_2.contains(&peer_id_3));
+    // Collect all events from each subscriber and filter for NewPeer events
+    tokio::time::timeout(Duration::from_secs(1), async {
+        // Keep collecting until we have at least 2 NewPeer events per node or timeout
+        loop {
+            tokio::select! {
+                event = subscriber_1.recv() => {
+                    if let Ok(PeerEvent::NewPeer(peer_id)) = event {
+                        connected_peers_1.push(peer_id);
+                    }
+                }
+                event = subscriber_2.recv() => {
+                    if let Ok(PeerEvent::NewPeer(peer_id)) = event {
+                        connected_peers_2.push(peer_id);
+                    }
+                }
+                event = subscriber_3.recv() => {
+                    if let Ok(PeerEvent::NewPeer(peer_id)) = event {
+                        connected_peers_3.push(peer_id);
+                    }
+                }
+                _ = tokio::time::sleep(Duration::from_millis(100)) => {
+                    if connected_peers_1.len() >= 2 && connected_peers_2.len() >= 2 && connected_peers_3.len() >= 2 {
+                        break;
+                    }
+                }
+            }
+        }
+    }).await?;
 
-    let peers_3 = [subscriber_3.recv().await?, subscriber_3.recv().await?]
-        .into_iter()
-        .map(unwrap_new_peer_event)
-        .collect::<HashSet<_>>();
-    assert!(peers_3.contains(&peer_id_1));
-    assert!(peers_3.contains(&peer_id_2));
+    // Check that each node is connected to the other two
+    assert!(
+        connected_peers_1.contains(&peer_id_2),
+        "Node 1 should be connected to node 2"
+    );
+    assert!(
+        connected_peers_1.contains(&peer_id_3),
+        "Node 1 should be connected to node 3"
+    );
+
+    assert!(
+        connected_peers_2.contains(&peer_id_1),
+        "Node 2 should be connected to node 1"
+    );
+    assert!(
+        connected_peers_2.contains(&peer_id_3),
+        "Node 2 should be connected to node 3"
+    );
+
+    assert!(
+        connected_peers_3.contains(&peer_id_1),
+        "Node 3 should be connected to node 1"
+    );
+    assert!(
+        connected_peers_3.contains(&peer_id_2),
+        "Node 3 should be connected to node 2"
+    );
 
     Ok(())
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn peers_are_added_from_reconfig_channel() -> Result<()> {
-    let (tx_1, rx_1) = create_test_channel();
     let config = P2pConfig::default();
-    let (builder, server) = Builder::new(rx_1).config(config.clone()).build();
-    let (network_1, key_1) = build_network_and_key(|router| router.add_rpc_service(server));
-    let (event_loop_1, _handle_1) = builder.build(network_1.clone(), key_1);
 
-    let (builder, server) = Builder::new(create_test_channel().1)
-        .config(config.clone())
-        .build();
-    let (network_2, key_2) = build_network_and_key(|router| router.add_rpc_service(server));
-    let (event_loop_2, _handle_2) = builder.build(network_2.clone(), key_2);
+    let (tx_1, rx_1) = create_test_channel();
+
+    let (discovery_1, _server_1, network_1, key_1) =
+        set_up_network_with_trusted_peer_change_rx(config.clone(), None, rx_1);
+    let (event_loop_1, _handle_1, _state_1) = start_network(discovery_1, network_1.clone(), key_1);
+
+    let (discovery_2, _server_2, network_2, key_2) = set_up_network(config.clone(), None);
+    let (event_loop_2, _handle_2, _state_2) = start_network(discovery_2, network_2.clone(), key_2);
 
     let (mut subscriber_1, _) = network_1.subscribe()?;
     let (mut subscriber_2, _) = network_2.subscribe()?;
@@ -248,9 +284,7 @@ async fn peers_are_added_from_reconfig_channel() -> Result<()> {
     // We send peer 1 a new peer info (peer 2) in the channel.
     let peer_2_network_pubkey =
         Ed25519PublicKey(ed25519_consensus::VerificationKey::try_from(peer_id_2.0).unwrap());
-    let peer2_addr: Multiaddr = format!("/dns/localhost/udp/{}", network_2.local_addr().port())
-        .parse()
-        .unwrap();
+    let peer2_addr: Multiaddr = local_multiaddr_from_network(&network_2);
     tx_1.send(TrustedPeerChangeEvent {
         new_committee: vec![PeerInfo {
             peer_id: PeerId(peer_2_network_pubkey.0.to_bytes()),
@@ -322,44 +356,49 @@ async fn test_access_types() {
     };
 
     // Node 1, public
-    let (builder_1, network_1, key_1) = set_up_network(default_p2p_config.clone());
+    let (discovery_1, _server_1, network_1, key_1) =
+        set_up_network(default_p2p_config.clone(), None);
 
     let mut config = default_p2p_config.clone();
     config.seed_peers.push(SeedPeer {
         peer_id: Some(network_1.peer_id()),
-        address: format!("/dns/localhost/udp/{}", network_1.local_addr().port())
-            .parse()
-            .unwrap(),
+        address: local_multiaddr_from_network(&network_1),
     });
 
     // Node 2, public, seed: Node 1, allowlist: Node 7, Node 8
-    let (mut builder_2, network_2, key_2) = set_up_network(config.clone());
+    let (mut discovery_2, _server_2, network_2, key_2) = set_up_network(config.clone(), None);
 
     // Node 3, private, seed: Node 1
-    let (mut builder_3, network_3, key_3) = set_up_network(config.clone());
+    let (mut discovery_3, _server_3, network_3, key_3) = set_up_network(config.clone(), None);
 
     // Node 4, private, allowlist: Node 3, 5, and 6
-    let (mut builder_4, network_4, key_4) = set_up_network(P2pConfig::default());
+    let (mut discovery_4, _server_4, network_4, key_4) = set_up_network(P2pConfig::default(), None);
 
     // Node 5, private, allowlisted: Node 3 and Node 4
-    let (builder_5, network_5, key_5) = {
+    let (discovery_5, _server_5, network_5, key_5) = {
         let mut private_discovery_config = default_private_discovery_config.clone();
         private_discovery_config.allowlisted_peers = vec![
             // Intitially 5 does not know how to contact 3 or 4.
             local_allowlisted_peer(network_3.peer_id(), None),
             local_allowlisted_peer(network_4.peer_id(), Some(network_4.local_addr().port())),
         ];
-        set_up_network(P2pConfig::default().set_discovery_config(private_discovery_config))
+        set_up_network(
+            P2pConfig::default().set_discovery_config(private_discovery_config),
+            None,
+        )
     };
 
     // Node 6, private, allowlisted: Node 4
-    let (builder_6, network_6, key_6) = {
+    let (discovery_6, _server_6, network_6, key_6) = {
         let mut private_discovery_config = default_private_discovery_config.clone();
         private_discovery_config.allowlisted_peers = vec![local_allowlisted_peer(
             network_4.peer_id(),
             Some(network_4.local_addr().port()),
         )];
-        set_up_network(P2pConfig::default().set_discovery_config(private_discovery_config))
+        set_up_network(
+            P2pConfig::default().set_discovery_config(private_discovery_config),
+            None,
+        )
     };
 
     // Node 3: Add Node 4 and Node 5 to allowlist
@@ -368,7 +407,7 @@ async fn test_access_types() {
         local_allowlisted_peer(network_4.peer_id(), Some(network_4.local_addr().port())),
         local_allowlisted_peer(network_5.peer_id(), Some(network_5.local_addr().port())),
     ];
-    builder_3.config.discovery = Some(private_discovery_config);
+    discovery_3.config.discovery = Some(private_discovery_config);
 
     // Node 4: Add Node 3, Node 5, and Node 6 to allowlist
     let mut private_discovery_config = default_private_discovery_config.clone();
@@ -377,18 +416,20 @@ async fn test_access_types() {
         local_allowlisted_peer(network_5.peer_id(), None),
         local_allowlisted_peer(network_6.peer_id(), None),
     ];
-    builder_4.config.discovery = Some(private_discovery_config);
+    discovery_4.config.discovery = Some(private_discovery_config);
 
     // Node 7, private, allowlisted: Node 2, Node 8
-    let (mut builder_7, network_7, key_7) = set_up_network(
+    let (mut discovery_7, _server_7, network_7, key_7) = set_up_network(
         P2pConfig::default().set_discovery_config(default_private_discovery_config.clone()),
+        None,
     );
 
     // Node 9, public
-    let (builder_9, network_9, key_9) = set_up_network(default_p2p_config.clone());
+    let (discovery_9, _server_9, network_9, key_9) =
+        set_up_network(default_p2p_config.clone(), None);
 
     // Node 8, private, allowlisted: Node 7, Node 9
-    let (builder_8, network_8, key_8) = {
+    let (discovery_8, _server_8, network_8, key_8) = {
         let mut private_discovery_config = default_private_discovery_config.clone();
         private_discovery_config.allowlisted_peers = vec![
             local_allowlisted_peer(network_7.peer_id(), Some(network_7.local_addr().port())),
@@ -398,7 +439,10 @@ async fn test_access_types() {
         let mut anemo_config = anemo::Config::default();
         anemo_config.max_concurrent_connections = Some(0);
         p2p_config.anemo_config = Some(anemo_config);
-        set_up_network(p2p_config.set_discovery_config(private_discovery_config))
+        set_up_network(
+            p2p_config.set_discovery_config(private_discovery_config),
+            None,
+        )
     };
 
     // Node 2, Add Node 7 and Node 8 to allowlist
@@ -407,7 +451,7 @@ async fn test_access_types() {
         local_allowlisted_peer(network_7.peer_id(), None),
         local_allowlisted_peer(network_8.peer_id(), None),
     ];
-    builder_2.config.discovery = Some(discovery_config);
+    discovery_2.config.discovery = Some(discovery_config);
 
     // Node 7: Add Node 2, and Node 8 to allowlist
     let mut private_discovery_config = default_private_discovery_config.clone();
@@ -415,29 +459,25 @@ async fn test_access_types() {
         local_allowlisted_peer(network_2.peer_id(), Some(network_2.local_addr().port())),
         local_allowlisted_peer(network_8.peer_id(), Some(network_8.local_addr().port())),
     ];
-    builder_7.config.discovery = Some(private_discovery_config);
+    discovery_7.config.discovery = Some(private_discovery_config);
 
     // Node 10, private, seed: 9
-    let (builder_10, network_10, key_10) = {
+    let (discovery_10, _server_10, network_10, key_10) = {
         let mut p2p_config = default_p2p_config.clone();
         p2p_config.seed_peers.push(SeedPeer {
             peer_id: Some(network_9.peer_id()),
-            address: format!("/dns/localhost/udp/{}", network_9.local_addr().port())
-                .parse()
-                .unwrap(),
+            address: local_multiaddr_from_network(&network_9),
         });
         p2p_config.discovery = Some(default_private_discovery_config.clone());
-        set_up_network(p2p_config.clone())
+        set_up_network(p2p_config.clone(), None)
     };
 
     // Node 11, private, seed: 1, allow: 7, 8
-    let (builder_11, network_11, key_11) = {
+    let (discovery_11, _server_11, network_11, key_11) = {
         let mut p2p_config = default_p2p_config.clone();
         p2p_config.seed_peers.push(SeedPeer {
             peer_id: Some(network_1.peer_id()),
-            address: format!("/dns/localhost/udp/{}", network_1.local_addr().port())
-                .parse()
-                .unwrap(),
+            address: local_multiaddr_from_network(&network_1),
         });
         let mut private_discovery_config = default_private_discovery_config.clone();
         private_discovery_config.allowlisted_peers = vec![
@@ -445,22 +485,22 @@ async fn test_access_types() {
             local_allowlisted_peer(network_7.peer_id(), None),
         ];
         p2p_config.discovery = Some(private_discovery_config);
-        set_up_network(p2p_config)
+        set_up_network(p2p_config, None)
     };
 
-    let (event_loop_1, _handle_1, state_1) = start_network(builder_1, network_1.clone(), key_1);
-    let (event_loop_2, _handle_2, state_2) = start_network(builder_2, network_2.clone(), key_2);
-    let (event_loop_3, _handle_3, state_3) = start_network(builder_3, network_3.clone(), key_3);
-    let (event_loop_4, _handle_4, state_4) = start_network(builder_4, network_4.clone(), key_4);
-    let (event_loop_5, _handle_5, state_5) = start_network(builder_5, network_5.clone(), key_5);
-    let (event_loop_6, _handle_6, state_6) = start_network(builder_6, network_6.clone(), key_6);
-    let (event_loop_7, _handle_7, state_7) = start_network(builder_7, network_7.clone(), key_7);
-    let (event_loop_8, _handle_8, state_8) = start_network(builder_8, network_8.clone(), key_8);
-    let (event_loop_9, _handle_9, state_9) = start_network(builder_9, network_9.clone(), key_9);
+    let (event_loop_1, _handle_1, state_1) = start_network(discovery_1, network_1.clone(), key_1);
+    let (event_loop_2, _handle_2, state_2) = start_network(discovery_2, network_2.clone(), key_2);
+    let (event_loop_3, _handle_3, state_3) = start_network(discovery_3, network_3.clone(), key_3);
+    let (event_loop_4, _handle_4, state_4) = start_network(discovery_4, network_4.clone(), key_4);
+    let (event_loop_5, _handle_5, state_5) = start_network(discovery_5, network_5.clone(), key_5);
+    let (event_loop_6, _handle_6, state_6) = start_network(discovery_6, network_6.clone(), key_6);
+    let (event_loop_7, _handle_7, state_7) = start_network(discovery_7, network_7.clone(), key_7);
+    let (event_loop_8, _handle_8, state_8) = start_network(discovery_8, network_8.clone(), key_8);
+    let (event_loop_9, _handle_9, state_9) = start_network(discovery_9, network_9.clone(), key_9);
     let (event_loop_10, _handle_10, state_10) =
-        start_network(builder_10, network_10.clone(), key_10);
+        start_network(discovery_10, network_10.clone(), key_10);
     let (event_loop_11, _handle_11, state_11) =
-        start_network(builder_11, network_11.clone(), key_11);
+        start_network(discovery_11, network_11.clone(), key_11);
 
     // Start all the event loops
     tokio::spawn(event_loop_1.start());
@@ -645,6 +685,10 @@ async fn test_access_types() {
     );
 }
 
+///////////////////////////////////////////////
+// Helper functions for common test patterns //
+///////////////////////////////////////////////
+
 fn assert_peers(
     self_name: &str,
     network: &Network,
@@ -708,27 +752,56 @@ fn local_allowlisted_peer(peer_id: PeerId, port: Option<u16>) -> AllowlistedPeer
     }
 }
 
-fn set_up_network(p2p_config: P2pConfig) -> (UnstartedDiscovery, Network, NetworkKeyPair) {
+fn set_up_network_with_trusted_peer_change_rx(
+    p2p_config: P2pConfig,
+    address: Option<anemo::types::Address>,
+    trusted_peer_change_rx: watch::Receiver<TrustedPeerChangeEvent>,
+) -> (
+    UnstartedDiscovery,
+    DiscoveryServer<impl Discovery>,
+    Network,
+    NetworkKeyPair,
+) {
     let anemo_config = p2p_config.anemo_config.clone().unwrap_or_default();
-    let (builder, server) = Builder::new(create_test_channel().1)
+
+    let (discovery, server) = Builder::new(trusted_peer_change_rx)
         .config(p2p_config)
         .build();
-    let (network, keypair) =
-        build_network_with_anemo_config(|router| router.add_rpc_service(server), anemo_config);
-    (builder, network, keypair)
+
+    let (network, keypair) = match address {
+        Some(addr) => build_network_with_address_and_anemo_config(
+            |router| router.add_rpc_service(server.clone()),
+            addr,
+            anemo_config,
+        ),
+        None => build_network_with_anemo_config(
+            |router| router.add_rpc_service(server.clone()),
+            anemo_config,
+        ),
+    };
+
+    (discovery, server, network, keypair)
+}
+
+fn set_up_network(
+    p2p_config: P2pConfig,
+    address: Option<anemo::types::Address>,
+) -> (
+    UnstartedDiscovery,
+    DiscoveryServer<impl Discovery>,
+    Network,
+    NetworkKeyPair,
+) {
+    set_up_network_with_trusted_peer_change_rx(p2p_config, address, create_test_channel().1)
 }
 
 fn start_network(
-    builder: UnstartedDiscovery,
+    discovery: UnstartedDiscovery,
     network: Network,
     keypair: NetworkKeyPair,
 ) -> (DiscoveryEventLoop, Handle, Arc<RwLock<State>>) {
-    let (mut event_loop, handle) = builder.build(network.clone(), keypair);
-    event_loop.config.external_address = Some(
-        format!("/dns/localhost/udp/{}", network.local_addr().port())
-            .parse()
-            .unwrap(),
-    );
+    let (mut event_loop, handle) = discovery.build(network.clone(), keypair);
+    event_loop.config.external_address = Some(local_multiaddr_from_network(&network));
     let state = event_loop.state.clone();
     (event_loop, handle, state)
 }
@@ -744,10 +817,17 @@ fn create_test_channel() -> (
     (tx, rx)
 }
 
+/// Helper to create multiaddr from network's port
+fn local_multiaddr_from_network(network: &Network) -> Multiaddr {
+    format!("/dns/localhost/udp/{}", network.local_addr().port())
+        .parse()
+        .unwrap()
+}
+
 #[tokio::test]
 async fn test_handle_trusted_peer_change_event() -> Result<()> {
-    fn mock_multiaddr(id: u16) -> Multiaddr {
-        format!("/dns/mockhost/udp/{id}").parse().unwrap()
+    fn mock_multiaddr(port: u16) -> Multiaddr {
+        format!("/dns/mockhost/udp/{port}").parse().unwrap()
     }
 
     // Create mock peers, good enough for the test
@@ -789,9 +869,10 @@ async fn test_handle_trusted_peer_change_event() -> Result<()> {
 
     // Setup test network and discovery event loop
     let (tx, mut rx) = create_test_channel();
-    let (builder, server) = Builder::new(rx.clone()).config(config).build();
-    let (network, key) = build_network_and_key(|router| router.add_rpc_service(server));
-    let (event_loop, _handle) = builder.build(network.clone(), key);
+    let (discovery, _server, network, key) =
+        set_up_network_with_trusted_peer_change_rx(config.clone(), None, rx.clone());
+    let (event_loop, _handle, _state) = start_network(discovery, network.clone(), key);
+
     let mut peer0 = peers[0].clone();
     peer0.peer_id = network.peer_id();
     peer0.address = vec![

--- a/crates/iota-network/src/discovery/tests.rs
+++ b/crates/iota-network/src/discovery/tests.rs
@@ -252,8 +252,6 @@ fn expire_peer_cooldown(state: &Arc<RwLock<State>>, peer_id: &PeerId) {
     if let Some(failure_time) = state_guard.address_verification_cooldown.get_mut(peer_id) {
         *failure_time = std::time::Instant::now() - Duration::from_secs(15 * 60); // 15 minutes ago
     }
-    // Also update last cleanup time to ensure cleanup runs
-    state_guard.last_cooldown_cleanup = std::time::Instant::now() - Duration::from_secs(10 * 60);
 }
 
 /// Helper to update known peers and return the result for testing
@@ -1460,7 +1458,7 @@ async fn test_address_conflict_resolution_with_existing_peers() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_address_verification_cooldown_and_cleanup() -> Result<()> {
     // This test checks the address verification cooldown mechanism.
 
@@ -1476,8 +1474,11 @@ async fn test_address_verification_cooldown_and_cleanup() -> Result<()> {
     }
     .sign(&key);
 
-    let (_event_loop, _handle, state) = start_network(discovery, network.clone(), key);
+    let (event_loop, _handle, state) = start_network(discovery, network.clone(), key);
     state.write().unwrap().our_info = Some(signed_peer_info);
+
+    // Start the event loop to handle cleanup intervals
+    tokio::spawn(event_loop.start());
 
     // Create a peer with an unreachable address that will fail verification
     let (network_other, key_other) = build_network_and_key(|router| router);
@@ -1541,6 +1542,10 @@ async fn test_address_verification_cooldown_and_cleanup() -> Result<()> {
     // Step 3: Wait for cooldown to pass, re-add peer with valid address
     expire_peer_cooldown(&state, &peer_id_other);
 
+    // Advance time to trigger the cleanup interval (default is 5 minutes = 300
+    // seconds) Add a bit extra to ensure the cleanup runs
+    tokio::time::sleep(Duration::from_secs(500)).await;
+
     update_peers_for_test(&network, state.clone(), vec![signed_peer_info_valid_other]).await;
 
     // Verify peer is processed normally after cooldown expires
@@ -1555,6 +1560,240 @@ async fn test_address_verification_cooldown_and_cleanup() -> Result<()> {
         &peer_id_other,
         false,
         "Peer should not be in verification failure cooldown",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_peer_deduplication() -> Result<()> {
+    // This test verifies that the deduplicate_peers function correctly handles
+    // each field in NodeInfo individually
+
+    // Create test keypairs
+    let key1 = NetworkKeyPair::generate(&mut rand::thread_rng());
+    let key2 = NetworkKeyPair::generate(&mut rand::thread_rng());
+
+    let peer_id1 = anemo::PeerId(key1.public().as_bytes().try_into().unwrap());
+    let peer_id2 = anemo::PeerId(key2.public().as_bytes().try_into().unwrap());
+
+    let address1: Multiaddr = "/dns/localhost/udp/1111".parse()?;
+    let address2: Multiaddr = "/dns/localhost/udp/2222".parse()?;
+
+    let timestamp1 = now_unix();
+
+    // Base peer info for testing
+    let peer_info_base = NodeInfo {
+        peer_id: peer_id1,
+        addresses: vec![address1.clone()],
+        timestamp_ms: timestamp1,
+        access_type: AccessType::Public,
+    };
+    let signed_peer_base = peer_info_base.clone().sign(&key1);
+    let signed_peer_base_different_key = peer_info_base.sign(&key2); // Same data, different signature
+
+    let peer_info_other = NodeInfo {
+        peer_id: peer_id2,
+        addresses: vec![address2.clone()],
+        timestamp_ms: timestamp1 + 1000,
+        access_type: AccessType::Private,
+    };
+    let signed_peer_other = peer_info_other.sign(&key2);
+
+    let peer_info_different_id = NodeInfo {
+        peer_id: peer_id2, // Different peer ID
+        addresses: vec![address1.clone()],
+        timestamp_ms: timestamp1,
+        access_type: AccessType::Public,
+    };
+    let signed_peer_different_id = peer_info_different_id.sign(&key1);
+
+    let peer_info_different_address = NodeInfo {
+        peer_id: peer_id1,
+        addresses: vec![address2.clone()],
+        timestamp_ms: timestamp1,
+        access_type: AccessType::Public,
+    };
+    let signed_peer_different_address = peer_info_different_address.sign(&key1);
+
+    let peer_info_multiple_addresses = NodeInfo {
+        peer_id: peer_id1,
+        addresses: vec![address1.clone(), address2.clone()],
+        timestamp_ms: timestamp1,
+        access_type: AccessType::Public,
+    };
+    let signed_peer_multiple_addresses = peer_info_multiple_addresses.sign(&key1);
+
+    let peer_info_reordered_addresses = NodeInfo {
+        peer_id: peer_id1,
+        addresses: vec![address2.clone(), address1.clone()],
+        timestamp_ms: timestamp1,
+        access_type: AccessType::Public,
+    };
+    let signed_peer_reordered_addresses = peer_info_reordered_addresses.sign(&key1);
+
+    let peer_info_empty_addresses = NodeInfo {
+        peer_id: peer_id1,
+        addresses: vec![],
+        timestamp_ms: timestamp1,
+        access_type: AccessType::Public,
+    };
+    let signed_peer_empty_addresses = peer_info_empty_addresses.sign(&key1);
+
+    let peer_info_different_timestamp = NodeInfo {
+        peer_id: peer_id1,
+        addresses: vec![address1.clone()],
+        timestamp_ms: timestamp1 + 1000, // Different timestamp
+        access_type: AccessType::Public,
+    };
+    let signed_peer_different_timestamp = peer_info_different_timestamp.sign(&key1);
+
+    let peer_info_different_access_type = NodeInfo {
+        peer_id: peer_id1,
+        addresses: vec![address1.clone()],
+        timestamp_ms: timestamp1,
+        access_type: AccessType::Private, // Different access type
+    };
+    let signed_peer_different_access_type = peer_info_different_access_type.sign(&key1);
+
+    // Test Case 1: Identical peers (same data, same signature) SHOULD be
+    // deduplicated
+    let identical_peers = vec![signed_peer_base.clone(), signed_peer_base.clone()];
+    let result = deduplicate_peers(identical_peers);
+    assert_eq!(
+        result.len(),
+        1,
+        "Identical peers should be deduplicated to 1 peer"
+    );
+
+    // Test Case 2: Different peer_id field should NOT be deduplicated
+    let different_id_peers = vec![signed_peer_base.clone(), signed_peer_different_id];
+    let result = deduplicate_peers(different_id_peers);
+    assert_eq!(
+        result.len(),
+        2,
+        "Peers with different peer_id should NOT be deduplicated"
+    );
+
+    // Test Case 3: Different single address should NOT be deduplicated
+    let different_address_peers = vec![signed_peer_base.clone(), signed_peer_different_address];
+    let result = deduplicate_peers(different_address_peers);
+    assert_eq!(
+        result.len(),
+        2,
+        "Peers with different single address should NOT be deduplicated"
+    );
+
+    // Test Case 4: Different number of addresses should NOT be deduplicated
+    let multiple_addresses_peers = vec![
+        signed_peer_base.clone(),
+        signed_peer_multiple_addresses.clone(),
+    ];
+    let result = deduplicate_peers(multiple_addresses_peers);
+    assert_eq!(
+        result.len(),
+        2,
+        "Peers with different number of addresses should NOT be deduplicated"
+    );
+
+    // Test Case 5: Different address order should NOT be deduplicated
+    let reordered_addresses_peers = vec![
+        signed_peer_multiple_addresses,
+        signed_peer_reordered_addresses,
+    ];
+    let result = deduplicate_peers(reordered_addresses_peers);
+    assert_eq!(
+        result.len(),
+        2,
+        "Peers with different address order should NOT be deduplicated"
+    );
+
+    // Test Case 6: Empty addresses vs non-empty addresses should NOT be
+    // deduplicated
+    let empty_addresses_peers = vec![signed_peer_base.clone(), signed_peer_empty_addresses];
+    let result = deduplicate_peers(empty_addresses_peers);
+    assert_eq!(
+        result.len(),
+        2,
+        "Peers with empty vs non-empty addresses should NOT be deduplicated"
+    );
+
+    // Test Case 7: Different timestamp_ms field should NOT be deduplicated
+    let different_timestamp_peers = vec![
+        signed_peer_base.clone(),
+        signed_peer_different_timestamp.clone(),
+    ];
+    let result = deduplicate_peers(different_timestamp_peers);
+    assert_eq!(
+        result.len(),
+        2,
+        "Peers with different timestamp_ms should NOT be deduplicated"
+    );
+
+    // Test Case 8: Different access_type field should NOT be deduplicated
+    let different_access_type_peers =
+        vec![signed_peer_base.clone(), signed_peer_different_access_type];
+    let result = deduplicate_peers(different_access_type_peers);
+    assert_eq!(
+        result.len(),
+        2,
+        "Peers with different access_type should NOT be deduplicated"
+    );
+
+    // Test Case 9: Different signature (same data, different key) should NOT be
+    // deduplicated
+    let different_signature_peers = vec![signed_peer_base.clone(), signed_peer_base_different_key];
+    let result = deduplicate_peers(different_signature_peers);
+    assert_eq!(
+        result.len(),
+        2,
+        "Peers with same data but different signatures should NOT be deduplicated"
+    );
+
+    // Test Case 10: Edge cases
+    // Empty input should return empty output
+    let empty_result = deduplicate_peers(vec![]);
+    assert_eq!(
+        empty_result.len(),
+        0,
+        "Empty input should return empty output"
+    );
+
+    // Single peer should return single peer
+    let single_input = vec![signed_peer_base.clone()];
+    let single_result = deduplicate_peers(single_input);
+    assert_eq!(
+        single_result.len(),
+        1,
+        "Single input should return single output"
+    );
+
+    // Multiple identical peers should return single peer
+    let multiple_identical = vec![
+        signed_peer_base.clone(),
+        signed_peer_base.clone(),
+        signed_peer_base.clone(),
+    ];
+    let multiple_identical_result = deduplicate_peers(multiple_identical);
+    assert_eq!(
+        multiple_identical_result.len(),
+        1,
+        "Multiple identical peers should be deduplicated to 1 peer"
+    );
+
+    // Test Case 11: Mixed scenario with multiple duplicates and unique peers
+    let mixed_peers = vec![
+        signed_peer_base.clone(),                // Original
+        signed_peer_base.clone(),                // Duplicate of original
+        signed_peer_different_timestamp.clone(), // Different (timestamp)
+        signed_peer_different_timestamp,         // Duplicate of different
+        signed_peer_other,                       // Completely unique
+    ];
+    let mixed_result = deduplicate_peers(mixed_peers);
+    assert_eq!(
+        mixed_result.len(),
+        3,
+        "Mixed duplicates and unique peers should result in 3 unique entries"
     );
 
     Ok(())

--- a/crates/iota-network/src/discovery/tests.rs
+++ b/crates/iota-network/src/discovery/tests.rs
@@ -7,11 +7,14 @@ use std::{collections::HashSet, time::Duration};
 use anemo::{Result, types::PeerAffinity};
 use fastcrypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
 use futures::stream::FuturesUnordered;
-use iota_config::p2p::AllowlistedPeer;
+use iota_config::{local_ip_utils, p2p::AllowlistedPeer};
 use tokio::time::timeout;
 
 use super::*;
-use crate::utils::{build_network_with_address_and_anemo_config, build_network_with_anemo_config};
+use crate::utils::{
+    build_network_and_key, build_network_with_address_and_anemo_config,
+    build_network_with_anemo_config,
+};
 
 ///////////////////////////////////////////////
 // Helper functions for common test patterns //
@@ -145,11 +148,128 @@ fn create_test_channel() -> (
     (tx, rx)
 }
 
+fn multiaddr_with_available_local_port(address_format: &str) -> Multiaddr {
+    let port = local_ip_utils::get_available_port(&local_ip_utils::localhost_for_testing());
+    address_format
+        .replace("{}", &port.to_string())
+        .parse()
+        .unwrap()
+}
+
 /// Helper to create multiaddr from network's port
 fn local_multiaddr_from_network(network: &Network) -> Multiaddr {
     format!("/dns/localhost/udp/{}", network.local_addr().port())
         .parse()
         .unwrap()
+}
+
+fn assert_known_peers_count(
+    state: &Arc<RwLock<State>>,
+    expected_count: usize,
+    message_format: &str,
+) {
+    let state_guard = state.read().unwrap();
+    assert_eq!(
+        state_guard.known_peers.len(),
+        expected_count,
+        "{}",
+        message_format.replace("{}", &state_guard.known_peers.len().to_string()),
+    );
+}
+
+/// Helper to assert peer is in known_peers
+fn assert_peer_in_known_peers(
+    state: &Arc<RwLock<State>>,
+    peer_id: &PeerId,
+    should_be_known: bool,
+    message_format: &str,
+) {
+    let state_guard = state.read().unwrap();
+    if should_be_known {
+        assert!(
+            state_guard.known_peers.contains_key(peer_id),
+            "{}",
+            message_format.replace("{}", &peer_id.to_string()),
+        );
+    } else {
+        assert!(
+            !state_guard.known_peers.contains_key(peer_id),
+            "{}",
+            message_format.replace("{}", &peer_id.to_string()),
+        );
+    }
+}
+
+fn assert_known_peer_address(
+    state: &Arc<RwLock<State>>,
+    peer_id: &PeerId,
+    expected_address: &Multiaddr,
+    message_format: &str,
+) {
+    let state_guard = state.read().unwrap();
+
+    if let Some(peer_info) = state_guard.known_peers.get(peer_id) {
+        assert!(
+            peer_info.addresses.contains(expected_address),
+            "{}",
+            message_format.replace("{}", &peer_id.to_string()),
+        );
+    } else {
+        panic!("Peer {peer_id} not found in known_peers");
+    }
+}
+
+/// Helper to assert peer is in cooldown
+fn assert_peer_in_cooldown(
+    state: &Arc<RwLock<State>>,
+    peer_id: &PeerId,
+    should_be_in_cooldown: bool,
+    message_format: &str,
+) {
+    let state_guard = state.read().unwrap();
+    if should_be_in_cooldown {
+        assert!(
+            state_guard
+                .address_verification_cooldown
+                .contains_key(peer_id),
+            "{}",
+            message_format.replace("{}", &peer_id.to_string()),
+        );
+    } else {
+        assert!(
+            !state_guard
+                .address_verification_cooldown
+                .contains_key(peer_id),
+            "{}",
+            message_format.replace("{}", &peer_id.to_string()),
+        );
+    }
+}
+
+/// Helper to manually expire a peer's cooldown for testing
+fn expire_peer_cooldown(state: &Arc<RwLock<State>>, peer_id: &PeerId) {
+    let mut state_guard = state.write().unwrap();
+    if let Some(failure_time) = state_guard.address_verification_cooldown.get_mut(peer_id) {
+        *failure_time = std::time::Instant::now() - Duration::from_secs(15 * 60); // 15 minutes ago
+    }
+    // Also update last cleanup time to ensure cleanup runs
+    state_guard.last_cooldown_cleanup = std::time::Instant::now() - Duration::from_secs(10 * 60);
+}
+
+/// Helper to update known peers and return the result for testing
+async fn update_peers_for_test(
+    network: &Network,
+    state: Arc<RwLock<State>>,
+    peers: Vec<SignedNodeInfo>,
+) {
+    update_known_peers(
+        network,
+        state,
+        Metrics::disabled(),
+        peers,
+        Arc::new(HashMap::new()),
+    )
+    .await;
 }
 
 ///////////
@@ -970,6 +1090,470 @@ async fn test_handle_trusted_peer_change_event() -> Result<()> {
     assert_eq!(known_peers[0].peer_id, updated_peers[1].peer_id); // allowlisted and updated
     assert_eq!(known_peers[0].address.len(), 2);
     assert_eq!(known_peers[1].peer_id, peers[2].peer_id); // seed peer
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_address_spoofing_prevention() -> Result<()> {
+    // This test verifies that our address verification prevents malicious actors
+    // from spamming the discovery with multiple peer entries using the same address
+    // but different private keys, or with non-existent addresses.
+
+    let config = P2pConfig::default();
+
+    let (discovery_victim, _server_victim, network_victim, key_victim) =
+        set_up_network(config.clone(), None);
+    let (event_loop_victim, _handle_victim, _state_victim) =
+        start_network(discovery_victim, network_victim.clone(), key_victim);
+
+    // Start the victim node discovery event loop (this is the node that will
+    // receive the attack)
+    tokio::spawn(event_loop_victim.start());
+
+    // Create a legitimate node that will be spoofed
+    let (discovery_legitimate, _server_legitimate, network_legitimate, key_legitimate) =
+        set_up_network(config.clone(), None);
+    let key_legitimate_for_signing = key_legitimate.copy(); // Keep a copy for signing
+    let (mut event_loop_legitimate, _handle_legitimate, _state_legitimate) = start_network(
+        discovery_legitimate,
+        network_legitimate.clone(),
+        key_legitimate,
+    );
+
+    // Set an external address for the legitimate node - use the actual listening
+    // address
+    let address_legitimate = local_multiaddr_from_network(&network_legitimate);
+    event_loop_legitimate.config.external_address = Some(address_legitimate.clone());
+
+    // Start the legitimate node discovery event loop
+    tokio::spawn(event_loop_legitimate.start());
+
+    // Wait for nodes to start up
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let start_timestamp_ms = now_unix();
+
+    // Create legitimate NodeInfo - use the same key that was used to create the
+    // network
+    let signed_peer_info_legitimate = NodeInfo {
+        peer_id: network_legitimate.peer_id(),
+        addresses: vec![address_legitimate.clone()],
+        timestamp_ms: start_timestamp_ms,
+        access_type: AccessType::Public,
+    }
+    .sign(&key_legitimate_for_signing); // Use the actual network key, not a random one
+
+    // ATTACK VECTOR 1: Multiple malicious entries with the SAME address but
+    // different peer IDs. This simulates the attack where a malicious actor
+    // creates multiple "fake" nodes claiming to be at the same address but with
+    // different valid keys
+    let mut malicious_peers = Vec::new();
+
+    for i in 0..5 {
+        // Create different keypairs (different private keys) for each malicious peer
+        let malicious_key = NetworkKeyPair::generate(&mut rand::thread_rng());
+        let malicious_peer_id =
+            anemo::PeerId(malicious_key.public().as_bytes().try_into().unwrap());
+        let timestamp_malicious = start_timestamp_ms + i + 100;
+
+        let signed_peer_info_malicious = NodeInfo {
+            peer_id: malicious_peer_id,
+            addresses: vec![address_legitimate.clone()], // SAME address as legitimate node
+            timestamp_ms: timestamp_malicious,           /* Make sure these have newer timestamps
+                                                          * than legitimate */
+            access_type: AccessType::Public,
+        }
+        .sign(&malicious_key); // Sign with the matching key to pass signature verification
+
+        malicious_peers.push(signed_peer_info_malicious);
+    }
+
+    // ATTACK VECTOR 2: Peer ID spoofing with non-existent address
+    // Malicious actor claims to be a legitimate peer but at a fake
+    // non-existing/non-reachable address
+    let fake_address: Multiaddr = "/dns/localhost/udp/54321".parse()?;
+    let key_malicious_2 = NetworkKeyPair::generate(&mut rand::thread_rng());
+    let peer_id_malicious_2 =
+        anemo::PeerId(key_malicious_2.public().as_bytes().try_into().unwrap());
+    let timestamp_malicious_2 = start_timestamp_ms + 1000; // Newer timestamp
+    let signed_peer_info_spoof_fake_addr = NodeInfo {
+        peer_id: peer_id_malicious_2,
+        addresses: vec![fake_address.clone()], // non-existent address
+        timestamp_ms: timestamp_malicious_2,
+        access_type: AccessType::Public,
+    }
+    .sign(&key_malicious_2);
+
+    malicious_peers.push(signed_peer_info_spoof_fake_addr);
+
+    // ATTACK VECTOR 3: Peer ID spoofing with real existing address of another node
+    // Create another legitimate node to use as the "malicious_address"
+    let (discovery_malicious_3, _server_malicious_3, network_malicious_3, key_malicious_3) =
+        set_up_network(config.clone(), None);
+    let key_malicious_3_for_signing = key_malicious_3.copy(); // Keep a copy for signing
+    let (event_loop_malicious_3, _handle_malicious_3) =
+        discovery_malicious_3.build(network_malicious_3.clone(), key_malicious_3);
+
+    // Start the malicious node discovery event loop
+    tokio::spawn(event_loop_malicious_3.start());
+
+    // Wait for it to start up
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let timestamp_malicious_3 = start_timestamp_ms + 2000; // Even newer timestamp
+    let address_malicious_3 = local_multiaddr_from_network(&network_malicious_3);
+    let signed_peer_info_spoof_real_addr = NodeInfo {
+        peer_id: network_legitimate.peer_id(), // SAME peer ID as legitimate peer!
+        addresses: vec![address_malicious_3.clone()], // But address of malicious_address
+        timestamp_ms: timestamp_malicious_3,   // Even newer timestamp
+        access_type: AccessType::Public,
+    }
+    .sign(&key_malicious_3_for_signing); // Signed with wrong key - this should fail signature verification
+
+    malicious_peers.push(signed_peer_info_spoof_real_addr);
+
+    // Get the victim's state before the attack
+    let (discovery_victim, _server_victim, network_victim, key_victim) =
+        set_up_network(config, None);
+
+    // Set up the victim's own info to avoid unwrap panics
+    let signed_peer_info_victim = NodeInfo {
+        peer_id: network_victim.peer_id(),
+        addresses: Vec::new(),
+        timestamp_ms: start_timestamp_ms,
+        access_type: AccessType::Public,
+    }
+    .sign(&key_victim);
+
+    let (_event_loop_victim, _handle_victim, state_victim) =
+        start_network(discovery_victim, network_victim.clone(), key_victim);
+    state_victim.write().unwrap().our_info = Some(signed_peer_info_victim);
+
+    // Simulate what happens when the victim receives these peers through discovery
+    // This would normally happen when a malicious node sends these as "known peers"
+    let mut attack_peers = vec![signed_peer_info_legitimate];
+    attack_peers.extend(malicious_peers.clone());
+
+    update_peers_for_test(&network_victim, state_victim.clone(), attack_peers).await;
+
+    // Verify that address deduplication and verification work together correctly
+    let known_peers = state_victim.read().unwrap().known_peers.clone();
+
+    // Address verification should reject malicious peers (wrong peer ID at address,
+    // non-existent address) and keep verified ones only
+    assert_eq!(
+        known_peers.len(),
+        1,
+        "Should have exactly 1 peer (the legitimate one) after filtering out malicious peers. Found {} peers: {:?}",
+        known_peers.len(),
+        known_peers.keys().collect::<Vec<_>>()
+    );
+
+    // Verify it's the legitimate peer that survived
+    assert!(
+        known_peers.contains_key(&network_legitimate.peer_id()),
+        "The legitimate peer should be the one that survived"
+    );
+
+    // Check that if the legitimate peer ID is in known_peers, it has the correct
+    // address
+    if let Some(surviving_peer) = known_peers.get(&network_legitimate.peer_id()) {
+        assert_eq!(
+            surviving_peer.addresses,
+            vec![address_legitimate.clone()],
+            "The surviving peer should have the legitimate address, not a spoofed one"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_address_conflict_resolution_with_existing_peers() -> Result<()> {
+    // Test that address conflicts between new peers and existing entries are
+    // resolved correctly
+
+    let config = P2pConfig::default();
+
+    let start_timestamp_ms = now_unix();
+    let timestamp_peer_1 = start_timestamp_ms + 100;
+    let timestamp_peer_2 = start_timestamp_ms + 200;
+    let timestamp_peer_3 = start_timestamp_ms + 150; // Older than 2 but newer than 1
+
+    // Setup a network to act as the victim receiving conflicting peer info
+    let address_victim: Multiaddr = multiaddr_with_available_local_port("/dns/localhost/udp/{}");
+    let (discovery_victim, _server_victim, network_victim, key_victim) = set_up_network(
+        config.clone(),
+        Some(address_victim.clone().to_anemo_address().unwrap()),
+    );
+
+    let signed_peer_info_victim = NodeInfo {
+        peer_id: network_victim.peer_id(),
+        addresses: vec![address_victim],
+        timestamp_ms: start_timestamp_ms,
+        access_type: AccessType::Public,
+    }
+    .sign(&key_victim);
+
+    let (_event_loop_victim, _handle_victim, state_victim) =
+        start_network(discovery_victim, network_victim.clone(), key_victim);
+    state_victim.write().unwrap().our_info = Some(signed_peer_info_victim);
+
+    // Create network 1 first
+    let (discovery_1, _server_1, network_1, key_1) = set_up_network(config.clone(), None);
+    let key_1_for_signing = key_1.copy();
+    let (event_loop_1, handle_1, _state_1) = start_network(discovery_1, network_1.clone(), key_1);
+    let peer_id_1 = network_1.peer_id();
+
+    // Get the address that network 1 is using
+    let shared_socket_addr = network_1.local_addr();
+    let shared_address = local_multiaddr_from_network(&network_1);
+
+    let signed_peer_info_1 = NodeInfo {
+        peer_id: peer_id_1,
+        addresses: vec![shared_address.clone()],
+        timestamp_ms: timestamp_peer_1,
+        access_type: AccessType::Public,
+    }
+    .sign(&key_1_for_signing);
+
+    // Add peer 1 to state using normal update process (should pass verification)
+    update_peers_for_test(
+        &network_victim,
+        state_victim.clone(),
+        vec![signed_peer_info_1],
+    )
+    .await;
+
+    // Verify peer 1 was added
+    {
+        assert_known_peers_count(
+            &state_victim,
+            1,
+            "Should have exactly 1 peer after adding peer 1 but got {}",
+        );
+        assert_peer_in_known_peers(
+            &state_victim,
+            &peer_id_1,
+            true,
+            "Peer 1 should be added initially",
+        );
+        assert_known_peer_address(
+            &state_victim,
+            &peer_id_1,
+            &shared_address,
+            "Peer 1 should have the correct address",
+        );
+    }
+
+    // Shutdown network 1 to free up the address
+    drop(event_loop_1);
+    drop(handle_1);
+    drop(network_1);
+    tokio::time::sleep(Duration::from_millis(300)).await; // Give it time to shut down
+
+    // Create network 2 with the same address that 1 was using
+    let (discovery_2, _server_2, network_2, key_2) =
+        set_up_network(config.clone(), Some(shared_socket_addr.into()));
+    let key_2_for_signing = key_2.copy();
+    let (event_loop_2, handle_2, _state_2) = start_network(discovery_2, network_2.clone(), key_2);
+    let peer_id_2 = network_2.peer_id();
+
+    let signed_peer_info_2 = NodeInfo {
+        peer_id: peer_id_2,
+        addresses: vec![shared_address.clone()], // Same address as peer 1
+        timestamp_ms: timestamp_peer_2,
+        access_type: AccessType::Public,
+    }
+    .sign(&key_2_for_signing);
+
+    // Add peer 2 - this should trigger conflict resolution
+    update_peers_for_test(
+        &network_victim,
+        state_victim.clone(),
+        vec![signed_peer_info_2],
+    )
+    .await;
+
+    // Verify conflict resolution: peer 2 should remain (newer), peer 1 should be
+    // removed
+    {
+        assert_known_peers_count(
+            &state_victim,
+            1,
+            "Should have exactly 1 peer after conflict resolution but got {}",
+        );
+        assert_peer_in_known_peers(
+            &state_victim,
+            &peer_id_1,
+            false,
+            "Older peer 1 should be removed due to address conflict",
+        );
+        assert_peer_in_known_peers(
+            &state_victim,
+            &peer_id_2,
+            true,
+            "Newer peer 2 should be kept",
+        );
+        assert_known_peer_address(
+            &state_victim,
+            &peer_id_2,
+            &shared_address,
+            "Peer 2 should have the correct address",
+        );
+    }
+
+    // Now test the reverse: add peer 3 with an older timestamp than 2 (should be
+    // rejected) Shutdown network 2 first to free up the address for peer 3
+    drop(event_loop_2);
+    drop(handle_2);
+    drop(network_2);
+    tokio::time::sleep(Duration::from_millis(300)).await; // Give it time to shut down
+
+    // Create network 3 with the same address
+    let (discovery_3, _server_3, network_3, key_3) =
+        set_up_network(config.clone(), Some(shared_socket_addr.into()));
+    let key_3_for_signing = key_3.copy();
+    let (_event_loop_3, _handle_3, _state_3) = start_network(discovery_3, network_3.clone(), key_3);
+    let peer_id_3 = network_3.peer_id();
+
+    let signed_peer_info_3 = NodeInfo {
+        peer_id: peer_id_3,
+        addresses: vec![shared_address.clone()], // Same address again
+        timestamp_ms: timestamp_peer_3,
+        access_type: AccessType::Public,
+    }
+    .sign(&key_3_for_signing);
+
+    // Add peer 3 - this should be rejected since 2 (newer) is already present
+    update_peers_for_test(
+        &network_victim,
+        state_victim.clone(),
+        vec![signed_peer_info_3],
+    )
+    .await;
+
+    // Verify that peer 2 is still there and peer 3 was rejected
+    {
+        assert_known_peers_count(
+            &state_victim,
+            1,
+            "Should still have exactly 1 peer after attempting to add older peer 3 but got {}",
+        );
+        assert_peer_in_known_peers(
+            &state_victim,
+            &peer_id_2,
+            true,
+            "Newer peer 2 should still be kept",
+        );
+        assert_peer_in_known_peers(
+            &state_victim,
+            &peer_id_3,
+            false,
+            "Older peer 3 should be rejected due to address conflict",
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_address_verification_cooldown_and_cleanup() -> Result<()> {
+    // This test checks the address verification cooldown mechanism.
+
+    // Create a test network and state
+    let (discovery, _server, network, key) = set_up_network(P2pConfig::default(), None);
+
+    // Set up the nodes's own info to avoid unwrap panics
+    let signed_peer_info = NodeInfo {
+        peer_id: network.peer_id(),
+        addresses: Vec::new(),
+        timestamp_ms: now_unix(),
+        access_type: AccessType::Public,
+    }
+    .sign(&key);
+
+    let (_event_loop, _handle, state) = start_network(discovery, network.clone(), key);
+    state.write().unwrap().our_info = Some(signed_peer_info);
+
+    // Create a peer with an unreachable address that will fail verification
+    let (network_other, key_other) = build_network_and_key(|router| router);
+    let peer_id_other = network_other.peer_id();
+
+    // Step 1: Add peer with unreachable address, check that it's in cooldown
+    let peer_info_other = NodeInfo {
+        peer_id: peer_id_other,
+        addresses: vec!["/ip4/192.0.2.1/udp/12345".parse().unwrap()], // Unreachable address
+        timestamp_ms: now_unix(),
+        access_type: AccessType::Public,
+    };
+    let signed_peer_info_other = peer_info_other.sign(&key_other);
+
+    update_peers_for_test(&network, state.clone(), vec![signed_peer_info_other]).await;
+
+    // Verify peer is in cooldown after failed verification
+    assert_peer_in_known_peers(
+        &state,
+        &peer_id_other,
+        false,
+        "Peer should not be in known_peers after failed verification",
+    );
+    assert_peer_in_cooldown(
+        &state,
+        &peer_id_other,
+        true,
+        "Peer should be in verification failure cooldown",
+    );
+
+    // Step 2: Re-add same peer with valid address (should be filtered by cooldown)
+    let peer_info_valid_other = NodeInfo {
+        peer_id: peer_id_other,                                        // Same peer ID
+        addresses: vec![local_multiaddr_from_network(&network_other)], // Valid address
+        timestamp_ms: now_unix() + 1000,                               // Newer timestamp
+        access_type: AccessType::Public,
+    };
+    let signed_peer_info_valid_other = peer_info_valid_other.sign(&key_other);
+
+    update_peers_for_test(
+        &network,
+        state.clone(),
+        vec![signed_peer_info_valid_other.clone()],
+    )
+    .await;
+
+    // Verify peer is still filtered out by cooldown
+    assert_peer_in_known_peers(
+        &state,
+        &peer_id_other,
+        false,
+        "Peer should still not be in known_peers due to cooldown",
+    );
+    assert_peer_in_cooldown(
+        &state,
+        &peer_id_other,
+        true,
+        "Peer should be in verification failure cooldown",
+    );
+
+    // Step 3: Wait for cooldown to pass, re-add peer with valid address
+    expire_peer_cooldown(&state, &peer_id_other);
+
+    update_peers_for_test(&network, state.clone(), vec![signed_peer_info_valid_other]).await;
+
+    // Verify peer is processed normally after cooldown expires
+    assert_peer_in_known_peers(
+        &state,
+        &peer_id_other,
+        true,
+        "Peer should be in known_peers after cooldown",
+    );
+    assert_peer_in_cooldown(
+        &state,
+        &peer_id_other,
+        false,
+        "Peer should not be in verification failure cooldown",
+    );
 
     Ok(())
 }

--- a/crates/iota-network/src/utils.rs
+++ b/crates/iota-network/src/utils.rs
@@ -4,14 +4,14 @@
 
 #[cfg(test)]
 pub fn build_network(f: impl FnOnce(anemo::Router) -> anemo::Router) -> anemo::Network {
-    build_network_impl(f, None).0
+    build_network_impl(f, "localhost:0".into(), None).0
 }
 
 #[cfg(test)]
 pub fn build_network_and_key(
     f: impl FnOnce(anemo::Router) -> anemo::Router,
 ) -> (anemo::Network, iota_types::crypto::NetworkKeyPair) {
-    build_network_impl(f, None)
+    build_network_impl(f, "localhost:0".into(), None)
 }
 
 #[cfg(test)]
@@ -19,19 +19,37 @@ pub fn build_network_with_anemo_config(
     f: impl FnOnce(anemo::Router) -> anemo::Router,
     anemo_config: anemo::Config,
 ) -> (anemo::Network, iota_types::crypto::NetworkKeyPair) {
-    build_network_impl(f, Some(anemo_config))
+    build_network_impl(f, "localhost:0".into(), Some(anemo_config))
+}
+
+#[cfg(test)]
+pub fn build_network_with_address(
+    f: impl FnOnce(anemo::Router) -> anemo::Router,
+    address: anemo::types::Address,
+) -> (anemo::Network, iota_types::crypto::NetworkKeyPair) {
+    build_network_impl(f, address, None)
+}
+
+#[cfg(test)]
+pub fn build_network_with_address_and_anemo_config(
+    f: impl FnOnce(anemo::Router) -> anemo::Router,
+    address: anemo::types::Address,
+    anemo_config: anemo::Config,
+) -> (anemo::Network, iota_types::crypto::NetworkKeyPair) {
+    build_network_impl(f, address, Some(anemo_config))
 }
 
 #[cfg(test)]
 fn build_network_impl(
     f: impl FnOnce(anemo::Router) -> anemo::Router,
+    address: anemo::types::Address,
     anemo_config: Option<anemo::Config>,
 ) -> (anemo::Network, iota_types::crypto::NetworkKeyPair) {
     use fastcrypto::traits::KeyPair;
 
     let keypair = iota_types::crypto::NetworkKeyPair::generate(&mut rand::thread_rng());
     let router = f(anemo::Router::new());
-    let network = anemo::Network::bind("localhost:0")
+    let network = anemo::Network::bind(address)
         .private_key(keypair.copy().private().0.to_bytes())
         .config(anemo_config.unwrap_or_default())
         .server_name("test")

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -19,7 +19,7 @@ use iota_config::{
         default_enable_index_processing, default_end_of_epoch_broadcast_channel_capacity,
         default_zklogin_oauth_providers,
     },
-    p2p::{P2pConfig, SeedPeer, StateSyncConfig},
+    p2p::{DiscoveryConfig, P2pConfig, SeedPeer, StateSyncConfig},
     verifier_signing_config::VerifierSigningConfig,
 };
 use iota_names::config::IotaNamesConfig;
@@ -52,6 +52,7 @@ pub struct ValidatorConfigBuilder {
     firewall_config: Option<RemoteFirewallConfig>,
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
+    discovery_config: Option<DiscoveryConfig>,
 }
 
 impl ValidatorConfigBuilder {
@@ -129,6 +130,11 @@ impl ValidatorConfigBuilder {
         self
     }
 
+    pub fn with_discovery_config(mut self, discovery_config: DiscoveryConfig) -> Self {
+        self.discovery_config = Some(discovery_config);
+        self
+    }
+
     pub fn build_without_genesis(self, validator: ValidatorGenesisConfig) -> NodeConfig {
         let key_path = get_key_path(&validator.authority_key_pair);
         let config_directory = self
@@ -166,6 +172,8 @@ impl ValidatorConfigBuilder {
                 checkpoint_content_timeout_ms: Some(10_000),
                 ..Default::default()
             }),
+            // Use discovery config if provided
+            discovery: self.discovery_config,
             ..Default::default()
         };
 
@@ -295,6 +303,7 @@ pub struct FullnodeConfigBuilder {
     disable_pruning: bool,
     iota_names_config: Option<IotaNamesConfig>,
     grpc_api_config: Option<iota_grpc_api::Config>,
+    discovery_config: Option<DiscoveryConfig>,
 }
 
 impl FullnodeConfigBuilder {
@@ -425,6 +434,11 @@ impl FullnodeConfigBuilder {
         self
     }
 
+    pub fn with_discovery_config(mut self, discovery_config: DiscoveryConfig) -> Self {
+        self.discovery_config = Some(discovery_config);
+        self
+    }
+
     pub fn build_from_parts<R: rand::RngCore + rand::CryptoRng>(
         self,
         rng: &mut R,
@@ -479,6 +493,8 @@ impl FullnodeConfigBuilder {
                     checkpoint_content_timeout_ms: Some(10_000),
                     ..Default::default()
                 }),
+                // Use discovery config if provided
+                discovery: self.discovery_config,
                 ..Default::default()
             }
         };

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -16,6 +16,7 @@ use futures::future::try_join_all;
 use iota_config::{
     ExecutionCacheConfig, ExecutionCacheType, IOTA_GENESIS_FILENAME, NodeConfig,
     node::{AuthorityOverloadConfig, DBCheckpointConfig, RunWithRange},
+    p2p::DiscoveryConfig,
 };
 use iota_grpc_api;
 use iota_macros::nondeterministic;
@@ -73,6 +74,7 @@ pub struct SwarmBuilder<R = OsRng> {
     disable_fullnode_pruning: bool,
     iota_names_config: Option<IotaNamesConfig>,
     fullnode_grpc_api_config: Option<iota_grpc_api::Config>,
+    disable_address_verification_cooldown: bool,
 }
 
 impl SwarmBuilder {
@@ -106,6 +108,7 @@ impl SwarmBuilder {
             disable_fullnode_pruning: false,
             iota_names_config: None,
             fullnode_grpc_api_config: None,
+            disable_address_verification_cooldown: false,
         }
     }
 }
@@ -141,6 +144,7 @@ impl<R> SwarmBuilder<R> {
             disable_fullnode_pruning: self.disable_fullnode_pruning,
             iota_names_config: self.iota_names_config,
             fullnode_grpc_api_config: self.fullnode_grpc_api_config,
+            disable_address_verification_cooldown: self.disable_address_verification_cooldown,
         }
     }
 
@@ -349,6 +353,14 @@ impl<R> SwarmBuilder<R> {
         self.iota_names_config = Some(iota_names_config);
         self
     }
+
+    /// Disable address verification cooldown for test environments where nodes
+    /// frequently restart. This prevents nodes from being blocked from
+    /// reconnecting after crashes/restarts.
+    pub fn with_disabled_address_verification_cooldown(mut self) -> Self {
+        self.disable_address_verification_cooldown = true;
+        self
+    }
 }
 
 impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
@@ -362,7 +374,7 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
 
         let ingest_data = self.data_ingestion_dir.clone();
 
-        let network_config = self.network_config.unwrap_or_else(|| {
+        let mut network_config = self.network_config.unwrap_or_else(|| {
             let mut config_builder = ConfigBuilder::new(dir.as_ref());
 
             if let Some(genesis_config) = self.genesis_config {
@@ -427,6 +439,19 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             network_config
         });
 
+        if self.disable_address_verification_cooldown {
+            for validator in &mut network_config.validator_configs {
+                if let Some(ref mut discovery_config) = validator.p2p_config.discovery {
+                    discovery_config.address_verification_failure_cooldown_sec = Some(0);
+                } else {
+                    validator.p2p_config.discovery = Some(DiscoveryConfig {
+                        address_verification_failure_cooldown_sec: Some(0),
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+
         let mut nodes: HashMap<_, _> = network_config
             .validator_configs()
             .iter()
@@ -448,6 +473,16 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             .with_fw_config(self.fullnode_fw_config)
             .with_disable_pruning(self.disable_fullnode_pruning)
             .with_iota_names_config(self.iota_names_config);
+
+        if self.disable_address_verification_cooldown {
+            let discovery_config = DiscoveryConfig {
+                address_verification_failure_cooldown_sec: Some(0),
+                ..Default::default()
+            };
+
+            fullnode_config_builder =
+                fullnode_config_builder.with_discovery_config(discovery_config);
+        }
 
         if let Some(spvc) = &self.fullnode_supported_protocol_versions_config {
             let supported_versions = match spvc {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1006,6 +1006,7 @@ pub struct TestClusterBuilder {
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
     validator_state_accumulator_config: StateAccumulatorV1EnabledConfig,
+    disable_address_verification_cooldown: bool,
 }
 
 impl TestClusterBuilder {
@@ -1038,6 +1039,7 @@ impl TestClusterBuilder {
             max_submit_position: None,
             submit_delay_step_override_millis: None,
             validator_state_accumulator_config: StateAccumulatorV1EnabledConfig::Global(true),
+            disable_address_verification_cooldown: false,
         }
     }
 
@@ -1263,6 +1265,14 @@ impl TestClusterBuilder {
         self
     }
 
+    /// Disable address verification cooldown for test environments where nodes
+    /// frequently restart. This prevents nodes from being blocked from
+    /// reconnecting after crashes/restarts.
+    pub fn with_disabled_address_verification_cooldown(mut self) -> Self {
+        self.disable_address_verification_cooldown = true;
+        self
+    }
+
     pub async fn build(mut self) -> TestCluster {
         // We can add a faucet account to the `GenesisConfig` if there was no
         // `NetworkConfig` provided. Only either a `GenesisConfig` or a
@@ -1420,6 +1430,9 @@ impl TestClusterBuilder {
         }
         if let Some(config) = &self.fullnode_grpc_api_config {
             builder = builder.with_fullnode_grpc_api_config(config.clone());
+        }
+        if self.disable_address_verification_cooldown {
+            builder = builder.with_disabled_address_verification_cooldown();
         }
 
         let mut swarm = builder.build();

--- a/setups/fullnode/docker/README.md
+++ b/setups/fullnode/docker/README.md
@@ -1,3 +1,3 @@
 # Use Docker to Run an IOTA Full Node Locally
 
-The instructions to run a Full Node with Docker can be found [here](https://docs.iota.org/operator/fullnode/docker).
+The instructions to run a Full Node with Docker can be found [here](https://docs.iota.org/operator/full-node/docker).


### PR DESCRIPTION
# Description of change

There are two problems in the node discovery:
1. Only the first 200 entries of a `GetKnownPeers` response are evaluated, but the `own_info` of a node is pushed as the last element, resulting in it being cut from the updates of other nodes. Nodes are never able to update their own info in the whole network if there are more than 200 known peers.
2. New entries are not checked for valid addresses, so the list might contain old entries.

This PR adds a check for valid addresses, before adding the peers to the known peers list.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes