### PR TITLE
feat(Starfish): send Merkle root as transaction commitment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12226,6 +12226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
+name = "rs_merkle"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb09b49230ba22e8c676e7b75dfe2887dea8121f18b530ae0ba519ce442d2b21"
+dependencies = [
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "rsa"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13576,6 +13585,7 @@ dependencies = [
  "insta",
  "iota-network-stack",
  "rand 0.8.5",
+ "rs_merkle",
  "serde",
  "shared-crypto",
 ]
@@ -13611,6 +13621,7 @@ dependencies = [
  "quinn-proto",
  "rand 0.8.5",
  "reed-solomon-simd",
+ "rs_merkle",
  "rstest",
  "rustls 0.23.28",
  "serde",

--- a/crates/starfish/config/Cargo.toml
+++ b/crates/starfish/config/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 # external dependencies
 fastcrypto.workspace = true
 rand.workspace = true
+rs_merkle = "1.5.0"
 serde.workspace = true
 
 # internal dependencies

--- a/crates/starfish/config/src/crypto.rs
+++ b/crates/starfish/config/src/crypto.rs
@@ -20,9 +20,9 @@ use fastcrypto::{
     hash::{Blake2b256, HashFunction},
     traits::{KeyPair as _, Signer as _, ToFromBytes as _, VerifyingKey as _},
 };
+use rs_merkle::Hasher;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::INTENT_PREFIX_LENGTH;
-
 /// Network key is used for TLS and as the network identity of the authority.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct NetworkPublicKey(ed25519::Ed25519PublicKey);
@@ -172,5 +172,18 @@ impl AuthorityKeyPair {
 /// Defines algorithm and format of block and commit digests.
 // TODO: change Blake2b256 to Blake3 when starting optimizations
 pub type DefaultHashFunction = Blake2b256;
+
+#[derive(Clone)]
+pub struct DefaultHashFunctionWrapper;
+
+impl Hasher for DefaultHashFunctionWrapper {
+    type Hash = [u8; DefaultHashFunction::OUTPUT_SIZE];
+    fn hash(data: &[u8]) -> [u8; DefaultHashFunction::OUTPUT_SIZE] {
+        let mut hasher = DefaultHashFunction::new();
+        hasher.update(data);
+        hasher.finalize().into()
+    }
+}
+
 pub const DIGEST_LENGTH: usize = DefaultHashFunction::OUTPUT_SIZE;
 pub const INTENT_MESSAGE_LENGTH: usize = INTENT_PREFIX_LENGTH + DIGEST_LENGTH;

--- a/crates/starfish/core/Cargo.toml
+++ b/crates/starfish/core/Cargo.toml
@@ -31,6 +31,7 @@ prost.workspace = true
 quinn-proto.workspace = true
 rand.workspace = true
 reed-solomon-simd = { version = "3.0.1" }
+rs_merkle = "1.5.0"
 rustls.workspace = true
 serde.workspace = true
 strum_macros.workspace = true

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -8,7 +8,6 @@ use iota_protocol_config::ProtocolConfig;
 use itertools::Itertools;
 use parking_lot::RwLock;
 use prometheus::Registry;
-use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::{AuthorityIndex, Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
 use tracing::{info, warn};
 

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -390,7 +390,7 @@ mod tests {
     /// with the rest of the committee.
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_restart_authority_committee(#[values(4, 6, 8)] num_of_authorities: usize) {
+    async fn test_restart_authority_committee(#[values(4, 6)] num_of_authorities: usize) {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -8,6 +8,7 @@ use iota_protocol_config::ProtocolConfig;
 use itertools::Itertools;
 use parking_lot::RwLock;
 use prometheus::Registry;
+use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::{AuthorityIndex, Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
 use tracing::{info, warn};
 

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -523,7 +523,7 @@ mod tests {
         let mut last_committed_index = vec![0; num_of_authorities];
         let mut last_round_committed_blocks = vec![0; num_of_authorities];
         loop {
-            if start_time.elapsed() > Duration::from_secs(40) {
+            if start_time.elapsed() > Duration::from_secs(60) {
                 break;
             }
             for (index, receiver) in output_receivers.iter_mut().enumerate() {

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1322,7 +1322,7 @@ mod tests {
 
         let result = authority_service
             .handle_subscribed_block_bundle(
-                context.committee.to_authority_index(0).unwrap(),
+                context.committee.to_authority_index(1).unwrap(),
                 serialized_block_bundle.clone(),
                 &mut encoder,
             )

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1125,6 +1125,7 @@ mod tests {
     use futures::StreamExt;
     use iota_metrics::monitored_mpsc::unbounded_channel;
     use parking_lot::{Mutex, RwLock};
+    use reed_solomon_simd::ReedSolomonEncoder;
     use starfish_config::{AuthorityIndex, Parameters};
     use tokio::{sync::broadcast, time::sleep};
 
@@ -1254,6 +1255,10 @@ mod tests {
             dag_state,
             store,
         ));
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         // Test rejecting block with time drift.
         let now = context.clock.timestamp_utc_ms();
@@ -1264,21 +1269,15 @@ mod tests {
                 .build(),
         );
 
-        let service = authority_service.clone();
         let serialized_block_bundle = SerializedBlockBundle::try_from(input_block.clone()).unwrap();
-        let bundle_clone = serialized_block_bundle.clone();
-        let service_clone = service.clone();
-        let context_clone = context.clone();
-        let handle = tokio::spawn(async move {
-            service_clone
-                .handle_subscribed_block_bundle(
-                    context_clone.committee.to_authority_index(0).unwrap(),
-                    bundle_clone,
-                )
-                .await
-        });
 
-        let result = handle.await.unwrap(); // unwrap JoinError
+        let result = authority_service
+            .handle_subscribed_block_bundle(
+                context.committee.to_authority_index(0).unwrap(),
+                serialized_block_bundle.clone(),
+                &mut encoder,
+            )
+            .await;
 
         match result {
             Err(ConsensusError::BlockRejected { reason, .. }) => {
@@ -1291,10 +1290,11 @@ mod tests {
         // block but wait
         sleep(max_drift / 2).await;
         tokio::spawn(async move {
-            service
+            authority_service
                 .handle_subscribed_block_bundle(
                     context.committee.to_authority_index(0).unwrap(),
                     serialized_block_bundle,
+                    &mut encoder,
                 )
                 .await
                 .unwrap();
@@ -1349,6 +1349,10 @@ mod tests {
             dag_state,
             store,
         ));
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         let input_block = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 0).build());
 
@@ -1356,19 +1360,14 @@ mod tests {
         let serialized_block_bundle = SerializedBlockBundle::try_from(input_block.clone()).unwrap();
 
         // Test sending a block from wrong peer
-        let bundle_clone = serialized_block_bundle.clone();
-        let service_clone = service.clone();
-        let context_clone = context.clone();
-        let handle = tokio::spawn(async move {
-            service_clone
-                .handle_subscribed_block_bundle(
-                    context_clone.committee.to_authority_index(1).unwrap(),
-                    bundle_clone,
-                )
-                .await
-        });
 
-        let result = handle.await.unwrap(); // unwrap JoinError
+        let result = authority_service
+            .handle_subscribed_block_bundle(
+                context.committee.to_authority_index(0).unwrap(),
+                serialized_block_bundle.clone(),
+                &mut encoder,
+            )
+            .await;
 
         if let Err(ConsensusError::UnexpectedAuthority { .. }) = result {
             // everything is fine
@@ -1382,6 +1381,7 @@ mod tests {
                 .handle_subscribed_block_bundle(
                     context.committee.to_authority_index(0).unwrap(),
                     serialized_block_bundle,
+                    &mut encoder,
                 )
                 .await
                 .unwrap();
@@ -1433,6 +1433,10 @@ mod tests {
             dag_state,
             store,
         ));
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         let input_block = VerifiedBlock::new_for_test(
             TestBlockHeader::new(1, 0)
@@ -1445,23 +1449,16 @@ mod tests {
                 .build(),
         );
 
-        let service = authority_service.clone();
         let serialized_block_bundle = SerializedBlockBundle::try_from(input_block.clone()).unwrap();
 
         // Test sending a block with wrong transaction commitment
-        let bundle_clone = serialized_block_bundle.clone();
-        let service_clone = service.clone();
-        let context_clone = context.clone();
-        let handle = tokio::spawn(async move {
-            service_clone
-                .handle_subscribed_block_bundle(
-                    context_clone.committee.to_authority_index(0).unwrap(),
-                    bundle_clone,
-                )
-                .await
-        });
-
-        let result = handle.await.unwrap(); // unwrap JoinError
+        let result = authority_service
+            .handle_subscribed_block_bundle(
+                context.committee.to_authority_index(0).unwrap(),
+                serialized_block_bundle,
+                &mut encoder,
+            )
+            .await;
 
         if let Err(ConsensusError::TransactionCommitmentFailure { .. }) = result {
             // everything is fine
@@ -1512,6 +1509,10 @@ mod tests {
             dag_state,
             store,
         ));
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         let input_block = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 0).build());
         let num_of_block_headers = MAX_HEADERS_PER_BUNDLE + 1;
@@ -1538,19 +1539,13 @@ mod tests {
         let service = authority_service.clone();
 
         // Send a bundle with too many headers
-        let bundle_clone = serialized_big_block_bundle.clone();
-        let service_clone = service.clone();
-        let context_clone = context.clone();
-        let handle = tokio::spawn(async move {
-            service_clone
-                .handle_subscribed_block_bundle(
-                    context_clone.committee.to_authority_index(0).unwrap(),
-                    bundle_clone,
-                )
-                .await
-        });
-
-        let result = handle.await.unwrap(); // unwrap JoinError
+        let result = authority_service
+            .handle_subscribed_block_bundle(
+                context.committee.to_authority_index(0).unwrap(),
+                serialized_big_block_bundle,
+                &mut encoder,
+            )
+            .await;
 
         if let Err(ConsensusError::TooManyHeadersInABundle { .. }) = result {
             // everything is fine
@@ -1569,19 +1564,13 @@ mod tests {
         .unwrap();
 
         // Send a bundle with too many headers
-        let bundle_clone = serialized_block_bundle_with_big_round.clone();
-        let service_clone = service.clone();
-        let context_clone = context.clone();
-        let handle = tokio::spawn(async move {
-            service_clone
-                .handle_subscribed_block_bundle(
-                    context_clone.committee.to_authority_index(0).unwrap(),
-                    bundle_clone,
-                )
-                .await
-        });
-
-        let result = handle.await.unwrap(); // unwrap JoinError
+        let result = authority_service
+            .handle_subscribed_block_bundle(
+                context.committee.to_authority_index(0).unwrap(),
+                serialized_block_bundle_with_big_round,
+                &mut encoder,
+            )
+            .await;
 
         if let Err(ConsensusError::TooBigHeaderRoundInABundle { .. }) = result {
             // everything is fine
@@ -1609,6 +1598,7 @@ mod tests {
                 .handle_subscribed_block_bundle(
                     context.committee.to_authority_index(0).unwrap(),
                     serialized_block_bundle,
+                    &mut encoder,
                 )
                 .await
                 .unwrap();
@@ -2043,6 +2033,11 @@ mod tests {
             dag_state.clone(),
             store,
         ));
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
+
         let protocol_keypairs = key_pairs.iter().map(|kp| kp.1.clone()).collect();
         let mut dag_builder =
             DagBuilder::new(context.clone()).set_protocol_keypair(protocol_keypairs);
@@ -2083,6 +2078,7 @@ mod tests {
                     .handle_subscribed_block_bundle(
                         context.committee.to_authority_index(peer).unwrap(),
                         serialized_block_bundle,
+                        &mut encoder,
                     )
                     .await
                     .expect("bundle is expected to be processed successfully");
@@ -2184,6 +2180,11 @@ mod tests {
             dag_state.clone(),
             store,
         ));
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
+
         let protocol_keypairs = key_pairs.iter().map(|kp| kp.1.clone()).collect();
         let mut dag_builder =
             DagBuilder::new(context.clone()).set_protocol_keypair(protocol_keypairs);
@@ -2216,6 +2217,7 @@ mod tests {
                     .handle_subscribed_block_bundle(
                         context.committee.to_authority_index(peer).unwrap(),
                         serialized_block_bundle,
+                        &mut encoder,
                     )
                     .await
                     .expect("bundle is expected to be processed successfully");

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1317,7 +1317,9 @@ mod tests {
         let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
             .expect("We should expect correct creation of the ReedSolomonEncoder");
 
-        let input_block = VerifiedBlock::new_for_test(TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build());
+        let input_block = VerifiedBlock::new_for_test(
+            TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build(),
+        );
 
         let service = authority_service.clone();
         let serialized_block_bundle = SerializedBlockBundle::try_from(input_block.clone()).unwrap();
@@ -1404,9 +1406,11 @@ mod tests {
         let input_block = VerifiedBlock::new_for_test(
             TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder)
                 .set_commitment(
-                    TransactionsCommitment::compute_transactions_commitment(&Bytes::from_static(
-                        b"dummy data"
-                    ), &context, &mut encoder)
+                    TransactionsCommitment::compute_transactions_commitment(
+                        &Bytes::from_static(b"dummy data"),
+                        &context,
+                        &mut encoder,
+                    )
                     .unwrap(),
                 )
                 .build(),
@@ -1477,7 +1481,9 @@ mod tests {
         let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
             .expect("We should expect correct creation of the ReedSolomonEncoder");
 
-        let input_block = VerifiedBlock::new_for_test(TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build());
+        let input_block = VerifiedBlock::new_for_test(
+            TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build(),
+        );
         let num_of_block_headers = MAX_HEADERS_PER_BUNDLE + 1;
         let mut headers = (0..num_of_block_headers)
             .map(|i| {
@@ -1545,7 +1551,13 @@ mod tests {
 
         // Create a block with a big round
         let input_block = VerifiedBlock::new_for_test(
-            TestBlockHeader::new_with_commitment(MAX_HEADERS_PER_BUNDLE as u32 + 1, 0, &context, &mut encoder).build(),
+            TestBlockHeader::new_with_commitment(
+                MAX_HEADERS_PER_BUNDLE as u32 + 1,
+                0,
+                &context,
+                &mut encoder,
+            )
+            .build(),
         );
 
         let block_bundle = BlockBundle {
@@ -2384,8 +2396,12 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 signed_block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions, &context, &mut encoder)
-                    .unwrap()
+                TransactionsCommitment::compute_transactions_commitment(
+                    &serialized_transactions,
+                    &context,
+                    &mut encoder
+                )
+                .unwrap()
             );
 
             let verified_block_header =
@@ -2445,8 +2461,12 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 signed_block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions, &context, &mut encoder)
-                    .unwrap()
+                TransactionsCommitment::compute_transactions_commitment(
+                    &serialized_transactions,
+                    &context,
+                    &mut encoder
+                )
+                .unwrap()
             );
 
             let verified_block_header =
@@ -3111,8 +3131,12 @@ mod tests {
                 .expect("We expect to find the header with such block_ref");
             assert_eq!(
                 block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions, &context, &mut encoder)
-                    .unwrap()
+                TransactionsCommitment::compute_transactions_commitment(
+                    &serialized_transactions,
+                    &context,
+                    &mut encoder
+                )
+                .unwrap()
             );
         }
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -50,44 +50,6 @@ use crate::{
 
 pub(crate) const COMMIT_LAG_MULTIPLIER: u32 = 5;
 
-pub trait TransactionsCommitmentComputer {
-    async fn compute_transactions_commitment(
-        &self,
-        serialized_transactions: &Bytes,
-        encoder: &mut ReedSolomonEncoder,
-    ) -> ConsensusResult<TransactionsCommitment>;
-}
-
-impl<C: CoreThreadDispatcher> TransactionsCommitmentComputer for AuthorityService<C> {
-    async fn compute_transactions_commitment(
-        &self,
-        serialized_transactions: &Bytes,
-        encoder: &mut ReedSolomonEncoder,
-    ) -> ConsensusResult<TransactionsCommitment> {
-        let info_length = self.context.committee.info_length();
-        let parity_length = self.context.committee.size() - info_length;
-        assert!(
-            serialized_transactions.len() % info_length == 0,
-            "Serialized transactions length must be divisible by info length"
-        );
-        // Compute transaction commitment that will be included in the block header
-        let sharded_transactions: Vec<Shard> = serialized_transactions
-            .chunks(serialized_transactions.len() / info_length)
-            .map(|chunk| chunk.to_vec())
-            .collect();
-
-        let encoded_shards = encoder
-            .encode_shards(sharded_transactions, info_length, parity_length)
-            .expect("We should expect correct encoding of the shards");
-
-        let transactions_commitment = TransactionsCommitment::compute_merkle_root(&encoded_shards)
-            .expect(
-                "We should expect correct computation of the Merkle root for encoded transactions",
-            );
-        Ok(transactions_commitment)
-    }
-}
-
 const MAX_FILTER_SIZE: u32 = 10000;
 
 struct FilterForHeaders {
@@ -241,10 +203,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         if signed_block_header.transactions_commitment()
-            != self
-                .compute_transactions_commitment(&serialized_transactions, encoder)
-                .await
-                .expect("we should expect correct computation of the transactions commitment")
+            != TransactionsCommitment::compute_transactions_commitment(
+                &serialized_transactions,
+                &self.context,
+                encoder,
+            )
+            .expect("we should expect correct computation of the transactions commitment")
         {
             return Err(ConsensusError::TransactionCommitmentFailure {
                 round: signed_block_header.round(),
@@ -1441,9 +1405,9 @@ mod tests {
         let input_block = VerifiedBlock::new_for_test(
             TestBlockHeader::new(1, 0)
                 .set_commitment(
-                    TransactionsCommitment::compute_transactions_commitment_for_test(
-                        &Bytes::from_static(b"dummy data"),
-                    )
+                    TransactionsCommitment::compute_transactions_commitment(&Bytes::from_static(
+                        b"dummy data",
+                    ))
                     .unwrap(),
                 )
                 .build(),
@@ -2415,10 +2379,8 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 signed_block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment_for_test(
-                    &serialized_transactions
-                )
-                .unwrap()
+                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                    .unwrap()
             );
 
             let verified_block_header =
@@ -2478,10 +2440,8 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 signed_block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment_for_test(
-                    &serialized_transactions
-                )
-                .unwrap()
+                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                    .unwrap()
             );
 
             let verified_block_header =
@@ -3142,10 +3102,8 @@ mod tests {
                 .expect("We expect to find the header with such block_ref");
             assert_eq!(
                 block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment_for_test(
-                    &serialized_transactions
-                )
-                .unwrap()
+                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                    .unwrap()
             );
         }
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -54,6 +54,7 @@ pub trait TransactionsCommitmentComputer {
     async fn compute_transactions_commitment(
         &self,
         serialized_transactions: &Bytes,
+        encoder: &mut ReedSolomonEncoder,
     ) -> ConsensusResult<TransactionsCommitment>;
 }
 
@@ -61,6 +62,7 @@ impl<C: CoreThreadDispatcher> TransactionsCommitmentComputer for AuthorityServic
     async fn compute_transactions_commitment(
         &self,
         serialized_transactions: &Bytes,
+        encoder: &mut ReedSolomonEncoder,
     ) -> ConsensusResult<TransactionsCommitment> {
         let info_length = self.context.committee.info_length();
         let parity_length = self.context.committee.size() - info_length;
@@ -74,7 +76,6 @@ impl<C: CoreThreadDispatcher> TransactionsCommitmentComputer for AuthorityServic
             .map(|chunk| chunk.to_vec())
             .collect();
 
-        let mut encoder = self.encoder.lock().await;
         let encoded_shards = encoder
             .encode_shards(sharded_transactions, info_length, parity_length)
             .expect("We should expect correct encoding of the shards");
@@ -148,7 +149,6 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     /// multiple times. The size is limited by MAX_FILTER_SIZE, elements are
     /// evicted when the threshold is exceeded
     received_block_headers: FilterForHeaders,
-    encoder: Mutex<ReedSolomonEncoder>,
 }
 
 impl<C: CoreThreadDispatcher> AuthorityService<C> {
@@ -167,12 +167,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             context.clone(),
             core_dispatcher.clone(),
         ));
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let encoder = Mutex::new(
-            ReedSolomonEncoder::new(info_length, parity_length, 2)
-                .expect("We should expect correct creation of the ReedSolomonEncoder"),
-        );
+
         Self {
             context,
             block_verifier,
@@ -185,7 +180,6 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             dag_state,
             store,
             received_block_headers: FilterForHeaders::new(),
-            encoder,
         }
     }
 }
@@ -196,6 +190,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         &self,
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
+        encoder: &mut ReedSolomonEncoder,
     ) -> ConsensusResult<()> {
         fail_point_async!("consensus-rpc-response");
 
@@ -247,7 +242,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         if signed_block_header.transactions_commitment()
             != self
-                .compute_transactions_commitment(&serialized_transactions)
+                .compute_transactions_commitment(&serialized_transactions, encoder)
                 .await
                 .expect("we should expect correct computation of the transactions commitment")
         {

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -27,7 +27,7 @@ use tracing::{debug, info, warn};
 use crate::{
     CommitIndex, Round, Transaction, VerifiedBlockHeader,
     block_header::{
-        BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, Shard, SignedBlockHeader,
+        BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, SignedBlockHeader,
         TransactionsCommitment, VerifiedBlock, VerifiedTransactions,
     },
     block_verifier::BlockVerifier,
@@ -36,7 +36,6 @@ use crate::{
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::{DagState, MAX_HEADERS_PER_BUNDLE},
-    encoder::ShardEncoder,
     error::{ConsensusError, ConsensusResult},
     network::{
         BlockBundle, BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockAndHeaders,
@@ -1228,7 +1227,7 @@ mod tests {
         let now = context.clock.timestamp_utc_ms();
         let max_drift = context.parameters.max_forward_time_drift;
         let input_block = VerifiedBlock::new_for_test(
-            TestBlockHeader::new(1, 0)
+            TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder)
                 .set_timestamp_ms(now + max_drift.as_millis() as u64 + 1)
                 .build(),
         );
@@ -1318,7 +1317,7 @@ mod tests {
         let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
             .expect("We should expect correct creation of the ReedSolomonEncoder");
 
-        let input_block = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 0).build());
+        let input_block = VerifiedBlock::new_for_test(TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build());
 
         let service = authority_service.clone();
         let serialized_block_bundle = SerializedBlockBundle::try_from(input_block.clone()).unwrap();
@@ -1403,11 +1402,11 @@ mod tests {
             .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         let input_block = VerifiedBlock::new_for_test(
-            TestBlockHeader::new(1, 0)
+            TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder)
                 .set_commitment(
                     TransactionsCommitment::compute_transactions_commitment(&Bytes::from_static(
-                        b"dummy data",
-                    ))
+                        b"dummy data"
+                    ), &context, &mut encoder)
                     .unwrap(),
                 )
                 .build(),
@@ -1478,14 +1477,16 @@ mod tests {
         let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
             .expect("We should expect correct creation of the ReedSolomonEncoder");
 
-        let input_block = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 0).build());
+        let input_block = VerifiedBlock::new_for_test(TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build());
         let num_of_block_headers = MAX_HEADERS_PER_BUNDLE + 1;
         let mut headers = (0..num_of_block_headers)
             .map(|i| {
                 VerifiedBlockHeader::new_for_test(
-                    TestBlockHeader::new(
+                    TestBlockHeader::new_with_commitment(
                         (i / committee_size + 1) as u32,
                         (i % committee_size) as u8,
+                        &context,
+                        &mut encoder,
                     )
                     .build(),
                 )
@@ -1544,7 +1545,7 @@ mod tests {
 
         // Create a block with a big round
         let input_block = VerifiedBlock::new_for_test(
-            TestBlockHeader::new(MAX_HEADERS_PER_BUNDLE as u32 + 1, 0).build(),
+            TestBlockHeader::new_with_commitment(MAX_HEADERS_PER_BUNDLE as u32 + 1, 0, &context, &mut encoder).build(),
         );
 
         let block_bundle = BlockBundle {
@@ -2309,6 +2310,10 @@ mod tests {
             dag_state.clone(),
             store,
         ));
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         // Set up DAG with blocks
         let protocol_keypairs = key_pairs.iter().map(|kp| kp.1.clone()).collect();
@@ -2379,7 +2384,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 signed_block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions, &context, &mut encoder)
                     .unwrap()
             );
 
@@ -2440,7 +2445,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 signed_block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions, &context, &mut encoder)
                     .unwrap()
             );
 
@@ -3036,6 +3041,10 @@ mod tests {
             dag_state.clone(),
             store,
         ));
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         // Set up DAG with blocks
         let mut dag_builder = DagBuilder::new(context.clone());
@@ -3102,7 +3111,7 @@ mod tests {
                 .expect("We expect to find the header with such block_ref");
             assert_eq!(
                 block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions, &context, &mut encoder)
                     .unwrap()
             );
         }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -15,7 +15,6 @@ use dashmap::DashSet;
 use futures::{Stream, StreamExt, ready, stream, task};
 use iota_macros::fail_point_async;
 use parking_lot::RwLock;
-use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::AuthorityIndex;
 use tokio::{
     sync::{Mutex, broadcast},
@@ -1089,7 +1088,6 @@ mod tests {
     use futures::StreamExt;
     use iota_metrics::monitored_mpsc::unbounded_channel;
     use parking_lot::{Mutex, RwLock};
-    use reed_solomon_simd::ReedSolomonEncoder;
     use starfish_config::{AuthorityIndex, Parameters};
     use tokio::{sync::broadcast, time::sleep};
 
@@ -1111,6 +1109,7 @@ mod tests {
         core::{Core, CoreSignals},
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
         dag_state::{DagState, MAX_HEADERS_PER_BUNDLE},
+        encoder::create_encoder,
         error::{ConsensusError, ConsensusResult},
         leader_schedule::LeaderSchedule,
         network::{
@@ -1219,10 +1218,7 @@ mod tests {
             dag_state,
             store,
         ));
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         // Test rejecting block with time drift.
         let now = context.clock.timestamp_utc_ms();
@@ -1313,10 +1309,7 @@ mod tests {
             dag_state,
             store,
         ));
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         let input_block = VerifiedBlock::new_for_test(
             TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build(),
@@ -1399,10 +1392,7 @@ mod tests {
             dag_state,
             store,
         ));
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         let input_block = VerifiedBlock::new_for_test(
             TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder)
@@ -1477,10 +1467,7 @@ mod tests {
             dag_state,
             store,
         ));
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         let input_block = VerifiedBlock::new_for_test(
             TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build(),
@@ -2011,10 +1998,7 @@ mod tests {
             dag_state.clone(),
             store,
         ));
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         let protocol_keypairs = key_pairs.iter().map(|kp| kp.1.clone()).collect();
         let mut dag_builder =
@@ -2158,10 +2142,7 @@ mod tests {
             dag_state.clone(),
             store,
         ));
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         let protocol_keypairs = key_pairs.iter().map(|kp| kp.1.clone()).collect();
         let mut dag_builder =
@@ -2323,10 +2304,7 @@ mod tests {
             dag_state.clone(),
             store,
         ));
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         // Set up DAG with blocks
         let protocol_keypairs = key_pairs.iter().map(|kp| kp.1.clone()).collect();
@@ -3062,10 +3040,7 @@ mod tests {
             dag_state.clone(),
             store,
         ));
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         // Set up DAG with blocks
         let mut dag_builder = DagBuilder::new(context.clone());

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -151,7 +151,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         &self,
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
-        encoder: &mut Box<dyn ShardEncoder + Send>,
+        encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
     ) -> ConsensusResult<()> {
         fail_point_async!("consensus-rpc-response");
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -36,6 +36,7 @@ use crate::{
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::{DagState, MAX_HEADERS_PER_BUNDLE},
+    encoder::ShardEncoder,
     error::{ConsensusError, ConsensusResult},
     network::{
         BlockBundle, BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockAndHeaders,
@@ -151,7 +152,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         &self,
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
-        encoder: &mut ReedSolomonEncoder,
+        encoder: &mut Box<dyn ShardEncoder + Send>,
     ) -> ConsensusResult<()> {
         fail_point_async!("consensus-rpc-response");
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -15,6 +15,7 @@ use dashmap::DashSet;
 use futures::{Stream, StreamExt, ready, stream, task};
 use iota_macros::fail_point_async;
 use parking_lot::RwLock;
+use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::AuthorityIndex;
 use tokio::{
     sync::{Mutex, broadcast},
@@ -45,8 +46,43 @@ use crate::{
     synchronizer::SynchronizerHandle,
     transactions_synchronizer::TransactionsSynchronizerHandle,
 };
+use crate::block_header::Shard;
+use crate::encoder::ShardEncoder;
 
 pub(crate) const COMMIT_LAG_MULTIPLIER: u32 = 5;
+
+pub trait TransactionsCommitmentComputer {
+    async fn compute_transactions_commitment(&self, serialized_transactions: &Bytes) -> ConsensusResult<TransactionsCommitment>;
+}
+
+impl<C: CoreThreadDispatcher> TransactionsCommitmentComputer for AuthorityService<C> {
+    async fn compute_transactions_commitment(&self, serialized_transactions: &Bytes) -> ConsensusResult<TransactionsCommitment> {
+        let info_length = self.context.committee.info_length();
+        let parity_length = self.context.committee.size() - info_length;
+        assert!(
+                    serialized_transactions.len() % info_length == 0,
+                    "Serialized transactions length must be divisible by info length"
+                );
+        // Compute transaction commitment that will be included in the block header// Compute transaction commitment that will be included in the block header
+        let sharded_transactions: Vec<Shard> = serialized_transactions
+            .chunks(serialized_transactions.len() / info_length)
+            .map(|chunk| chunk.to_vec())
+            .collect();
+
+        let mut encoder = self.encoder.lock().await;
+        let encoded_shards = encoder
+            .encode_shards(sharded_transactions, info_length, parity_length)
+            .expect("We should expect correct encoding of the shards");
+
+        let transactions_commitment = TransactionsCommitment::compute_merkle_root(&encoded_shards)
+            .expect(
+                "We should expect correct computation of the Merkle root for encoded transactions",
+            );
+        Ok(transactions_commitment)
+    }
+}
+
+
 const MAX_FILTER_SIZE: u32 = 10000;
 
 struct FilterForHeaders {
@@ -108,6 +144,7 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     /// multiple times. The size is limited by MAX_FILTER_SIZE, elements are
     /// evicted when the threshold is exceeded
     received_block_headers: FilterForHeaders,
+    encoder: Mutex<ReedSolomonEncoder>,
 }
 
 impl<C: CoreThreadDispatcher> AuthorityService<C> {
@@ -121,11 +158,18 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         rx_block_broadcaster: broadcast::Receiver<VerifiedBlock>,
         dag_state: Arc<RwLock<DagState>>,
         store: Arc<dyn Store>,
+
     ) -> Self {
         let subscription_counter = Arc::new(SubscriptionCounter::new(
             context.clone(),
             core_dispatcher.clone(),
         ));
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let encoder = Mutex::new(
+            ReedSolomonEncoder::new(info_length, parity_length, 2)
+                .expect("We should expect correct creation of the ReedSolomonEncoder"),
+        );
         Self {
             context,
             block_verifier,
@@ -138,6 +182,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             dag_state,
             store,
             received_block_headers: FilterForHeaders::new(),
+            encoder,
         }
     }
 }
@@ -198,8 +243,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         if signed_block_header.transactions_commitment()
-            != TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
-                .expect("we should expect correct computation of the transactions commitment")
+            != self.compute_transactions_commitment(&serialized_transactions)
+                .await.expect("we should expect correct computation of the transactions commitment")
         {
             return Err(ConsensusError::TransactionCommitmentFailure {
                 round: signed_block_header.round(),
@@ -1392,7 +1437,7 @@ mod tests {
         let input_block = VerifiedBlock::new_for_test(
             TestBlockHeader::new(1, 0)
                 .set_commitment(
-                    TransactionsCommitment::compute_transactions_commitment(&Bytes::from_static(
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&Bytes::from_static(
                         b"dummy data",
                     ))
                     .unwrap(),
@@ -2368,7 +2413,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 signed_block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized_transactions)
                     .unwrap()
             );
 
@@ -2429,7 +2474,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 signed_block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized_transactions)
                     .unwrap()
             );
 
@@ -3091,7 +3136,7 @@ mod tests {
                 .expect("We expect to find the header with such block_ref");
             assert_eq!(
                 block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized_transactions)
                     .unwrap()
             );
         }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -27,7 +27,7 @@ use tracing::{debug, info, warn};
 use crate::{
     CommitIndex, Round, Transaction, VerifiedBlockHeader,
     block_header::{
-        BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, SignedBlockHeader,
+        BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, Shard, SignedBlockHeader,
         TransactionsCommitment, VerifiedBlock, VerifiedTransactions,
     },
     block_verifier::BlockVerifier,
@@ -36,6 +36,7 @@ use crate::{
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::{DagState, MAX_HEADERS_PER_BUNDLE},
+    encoder::ShardEncoder,
     error::{ConsensusError, ConsensusResult},
     network::{
         BlockBundle, BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockAndHeaders,
@@ -46,24 +47,28 @@ use crate::{
     synchronizer::SynchronizerHandle,
     transactions_synchronizer::TransactionsSynchronizerHandle,
 };
-use crate::block_header::Shard;
-use crate::encoder::ShardEncoder;
 
 pub(crate) const COMMIT_LAG_MULTIPLIER: u32 = 5;
 
 pub trait TransactionsCommitmentComputer {
-    async fn compute_transactions_commitment(&self, serialized_transactions: &Bytes) -> ConsensusResult<TransactionsCommitment>;
+    async fn compute_transactions_commitment(
+        &self,
+        serialized_transactions: &Bytes,
+    ) -> ConsensusResult<TransactionsCommitment>;
 }
 
 impl<C: CoreThreadDispatcher> TransactionsCommitmentComputer for AuthorityService<C> {
-    async fn compute_transactions_commitment(&self, serialized_transactions: &Bytes) -> ConsensusResult<TransactionsCommitment> {
+    async fn compute_transactions_commitment(
+        &self,
+        serialized_transactions: &Bytes,
+    ) -> ConsensusResult<TransactionsCommitment> {
         let info_length = self.context.committee.info_length();
         let parity_length = self.context.committee.size() - info_length;
         assert!(
-                    serialized_transactions.len() % info_length == 0,
-                    "Serialized transactions length must be divisible by info length"
-                );
-        // Compute transaction commitment that will be included in the block header// Compute transaction commitment that will be included in the block header
+            serialized_transactions.len() % info_length == 0,
+            "Serialized transactions length must be divisible by info length"
+        );
+        // Compute transaction commitment that will be included in the block header
         let sharded_transactions: Vec<Shard> = serialized_transactions
             .chunks(serialized_transactions.len() / info_length)
             .map(|chunk| chunk.to_vec())
@@ -81,7 +86,6 @@ impl<C: CoreThreadDispatcher> TransactionsCommitmentComputer for AuthorityServic
         Ok(transactions_commitment)
     }
 }
-
 
 const MAX_FILTER_SIZE: u32 = 10000;
 
@@ -158,7 +162,6 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         rx_block_broadcaster: broadcast::Receiver<VerifiedBlock>,
         dag_state: Arc<RwLock<DagState>>,
         store: Arc<dyn Store>,
-
     ) -> Self {
         let subscription_counter = Arc::new(SubscriptionCounter::new(
             context.clone(),
@@ -243,8 +246,10 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         if signed_block_header.transactions_commitment()
-            != self.compute_transactions_commitment(&serialized_transactions)
-                .await.expect("we should expect correct computation of the transactions commitment")
+            != self
+                .compute_transactions_commitment(&serialized_transactions)
+                .await
+                .expect("we should expect correct computation of the transactions commitment")
         {
             return Err(ConsensusError::TransactionCommitmentFailure {
                 round: signed_block_header.round(),
@@ -1437,9 +1442,9 @@ mod tests {
         let input_block = VerifiedBlock::new_for_test(
             TestBlockHeader::new(1, 0)
                 .set_commitment(
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&Bytes::from_static(
-                        b"dummy data",
-                    ))
+                    TransactionsCommitment::compute_transactions_commitment_for_test(
+                        &Bytes::from_static(b"dummy data"),
+                    )
                     .unwrap(),
                 )
                 .build(),
@@ -2413,8 +2418,10 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 signed_block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized_transactions)
-                    .unwrap()
+                TransactionsCommitment::compute_transactions_commitment_for_test(
+                    &serialized_transactions
+                )
+                .unwrap()
             );
 
             let verified_block_header =
@@ -2474,8 +2481,10 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 signed_block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized_transactions)
-                    .unwrap()
+                TransactionsCommitment::compute_transactions_commitment_for_test(
+                    &serialized_transactions
+                )
+                .unwrap()
             );
 
             let verified_block_header =
@@ -3136,8 +3145,10 @@ mod tests {
                 .expect("We expect to find the header with such block_ref");
             assert_eq!(
                 block_header.transactions_commitment(),
-                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized_transactions)
-                    .unwrap()
+                TransactionsCommitment::compute_transactions_commitment_for_test(
+                    &serialized_transactions
+                )
+                .unwrap()
             );
         }
 

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -64,35 +64,6 @@ impl Transaction {
         let bytes = bcs::to_bytes(transactions).map_err(ConsensusError::SerializationFailure)?;
         Ok(bytes.into())
     }
-
-    pub(crate) fn pad_transactions_for_sharding(
-        mut serialized: Vec<u8>,
-        info_length: usize,
-    ) -> Result<Bytes, ConsensusError> {
-        let bytes_length = serialized.len();
-        let mut statements_with_len: Vec<u8> = (bytes_length as u32).to_le_bytes().to_vec();
-        statements_with_len.append(&mut serialized);
-        // increase the length by 4 for u32
-        let mut shard_bytes = (bytes_length + 4).div_ceil(info_length);
-
-        // Ensure shard_bytes meets alignment requirements.
-        if shard_bytes % 2 != 0 {
-            shard_bytes += 1;
-        }
-        let length_with_padding = shard_bytes * info_length;
-        statements_with_len.resize(length_with_padding, 0);
-        Ok(statements_with_len.into())
-    }
-
-    #[expect(dead_code)]
-    pub(crate) fn serialize_and_pad_for_sharding(
-        transactions: &[Transaction],
-        info_length: usize,
-    ) -> Result<Bytes, ConsensusError> {
-        let serialized =
-            bcs::to_bytes(transactions).map_err(ConsensusError::SerializationFailure)?;
-        Self::pad_transactions_for_sharding(serialized, info_length)
-    }
 }
 
 /// A block header includes references to previous round blocks and a commitment
@@ -452,13 +423,6 @@ impl TransactionsCommitment {
     pub const MIN: Self = Self([u8::MIN; starfish_config::DIGEST_LENGTH]);
     pub const MAX: Self = Self([u8::MAX; starfish_config::DIGEST_LENGTH]);
     pub const DEFAULT_FOR_TEST: Self = Self([u8::MIN; starfish_config::DIGEST_LENGTH]);
-
-    #[expect(dead_code)]
-    pub(crate) fn compute_transactions_commitment_for_test(
-        _serialized_transactions: &Bytes,
-    ) -> ConsensusResult<TransactionsCommitment> {
-        Ok(Self::DEFAULT_FOR_TEST)
-    }
 
     pub(crate) fn compute_transactions_commitment(
         serialized_transactions: &Bytes,

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -11,6 +11,7 @@ use std::{
 
 use bytes::Bytes;
 use fastcrypto::hash::{Digest, HashFunction};
+use reed_solomon_simd::ReedSolomonEncoder;
 use rs_merkle::MerkleTree;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
@@ -22,6 +23,7 @@ use starfish_config::{
 use crate::{
     commit::CommitVote,
     context::Context,
+    encoder::ShardEncoder,
     ensure,
     error::{ConsensusError, ConsensusResult},
 };
@@ -59,6 +61,7 @@ impl Transaction {
     }
 
     /// Serialises a vector of transactions using the bcs serializer
+    #[expect(dead_code)]
     pub(crate) fn serialize(transactions: &[Transaction]) -> Result<Bytes, ConsensusError> {
         let bytes = bcs::to_bytes(transactions).map_err(ConsensusError::SerializationFailure)?;
         Ok(bytes.into())
@@ -102,6 +105,8 @@ impl Transaction {
         }
         Ok(padded[4..4 + original_len].to_vec())
     }
+
+    #[expect(dead_code)]
     pub(crate) fn serialize_and_pad_for_sharding(
         transactions: &[Transaction],
         info_length: usize,
@@ -468,13 +473,41 @@ impl TransactionsCommitment {
     /// Lexicographic min & max digest.
     pub const MIN: Self = Self([u8::MIN; starfish_config::DIGEST_LENGTH]);
     pub const MAX: Self = Self([u8::MAX; starfish_config::DIGEST_LENGTH]);
+    pub const DEFAULT_FOR_TEST: Self = Self([u8::MIN; starfish_config::DIGEST_LENGTH]);
 
+    #[expect(dead_code)]
     pub(crate) fn compute_transactions_commitment_for_test(
-        serialized_transactions: &Bytes,
+        _serialized_transactions: &Bytes,
     ) -> ConsensusResult<TransactionsCommitment> {
-        let mut hasher = DefaultHashFunction::new();
-        hasher.update(serialized_transactions);
-        Ok(TransactionsCommitment(hasher.finalize().into()))
+        Ok(Self::DEFAULT_FOR_TEST)
+    }
+
+    pub(crate) fn compute_transactions_commitment(
+        serialized_transactions: &Bytes,
+        context: &Arc<Context>,
+        encoder: &mut ReedSolomonEncoder,
+    ) -> ConsensusResult<TransactionsCommitment> {
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        assert!(
+            serialized_transactions.len() % info_length == 0,
+            "Serialized transactions length must be divisible by info length"
+        );
+        // Compute transaction commitment that will be included in the block header
+        let sharded_transactions: Vec<Shard> = serialized_transactions
+            .chunks(serialized_transactions.len() / info_length)
+            .map(|chunk| chunk.to_vec())
+            .collect();
+
+        let encoded_shards = encoder
+            .encode_shards(sharded_transactions, info_length, parity_length)
+            .expect("We should expect correct encoding of the shards");
+
+        let transactions_commitment = TransactionsCommitment::compute_merkle_root(&encoded_shards)
+            .expect(
+                "We should expect correct computation of the Merkle root for encoded transactions",
+            );
+        Ok(transactions_commitment)
     }
 
     pub(crate) fn compute_merkle_root(
@@ -853,7 +886,7 @@ pub struct VerifiedTransactions {
     /// Commitment of transactions in the block
     transactions_commitment: TransactionsCommitment,
 
-    /// The serialized bytes of the transactions.
+    /// The serialized bytes of the transactions with padding for sharding.
     serialized: Bytes,
 }
 
@@ -1038,16 +1071,26 @@ pub struct TestBlockHeader {
 }
 
 impl TestBlockHeader {
-    pub fn new(round: Round, author: u8) -> Self {
+    pub fn new(
+        round: Round,
+        author: u8,
+        context: &Arc<Context>,
+        encoder: &mut ReedSolomonEncoder,
+    ) -> Self {
+        let txs = vec![];
+        let serialized_transactions =
+            Transaction::serialize_and_pad_for_sharding(&txs, context.committee.info_length())
+                .expect("We should expect correct serialization of the transactions for sharding");
         Self {
             block_header: BlockHeaderV1 {
                 round,
                 author: author.into(),
-                transactions_commitment:
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&Bytes::from(
-                        bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap(),
-                    ))
-                    .unwrap(),
+                transactions_commitment: TransactionsCommitment::compute_transactions_commitment(
+                    &serialized_transactions,
+                    context,
+                    encoder,
+                )
+                .unwrap(),
                 ..Default::default()
             },
             ancestors: vec![],
@@ -1055,22 +1098,30 @@ impl TestBlockHeader {
         }
     }
 
-    pub fn new_with_transaction(round: Round, author: u8, tx: u8) -> Self {
+    pub fn new_with_transaction(
+        round: Round,
+        author: u8,
+        tx: u8,
+        context: &Arc<Context>,
+        encoder: &mut ReedSolomonEncoder,
+    ) -> Self {
+        let txs = vec![vec![tx; 16]]
+            .into_iter()
+            .map(Transaction::new)
+            .collect::<Vec<Transaction>>();
+        let serialized_transactions =
+            Transaction::serialize_and_pad_for_sharding(&txs, context.committee.info_length())
+                .expect("We should expect correct serialization of the transactions for sharding");
         Self {
             block_header: BlockHeaderV1 {
                 round,
                 author: author.into(),
-                transactions_commitment:
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&Bytes::from(
-                        bcs::to_bytes::<Vec<Transaction>>(
-                            &vec![vec![tx; 16]]
-                                .into_iter()
-                                .map(Transaction::new)
-                                .collect(),
-                        )
-                        .unwrap(),
-                    ))
-                    .unwrap(),
+                transactions_commitment: TransactionsCommitment::compute_transactions_commitment(
+                    &serialized_transactions,
+                    context,
+                    encoder,
+                )
+                .unwrap(),
                 ..Default::default()
             },
             ancestors: vec![],

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1042,13 +1042,10 @@ pub struct TestBlockHeader {
 
 #[cfg(test)]
 impl TestBlockHeader {
-    /// Creates a simple block with no transactions and without real computation of transactions commitment.
-    /// Use it when you don't need to check the commitment and don't want to create and pass the encoder.
-    pub(crate) fn new(
-        round: Round,
-        author: u8,
-    ) -> Self {
-
+    /// Creates a simple block with no transactions and without real computation
+    /// of transactions commitment. Use it when you don't need to check the
+    /// commitment and don't want to create and pass the encoder.
+    pub(crate) fn new(round: Round, author: u8) -> Self {
         Self {
             block_header: BlockHeaderV1 {
                 round,
@@ -1067,9 +1064,8 @@ impl TestBlockHeader {
         encoder: &mut ReedSolomonEncoder,
     ) -> Self {
         let txs = vec![];
-        let serialized_transactions =
-            Transaction::serialize(&txs)
-                .expect("We should expect correct serialization of the transactions");
+        let serialized_transactions = Transaction::serialize(&txs)
+            .expect("We should expect correct serialization of the transactions");
         Self {
             block_header: BlockHeaderV1 {
                 round,
@@ -1087,7 +1083,6 @@ impl TestBlockHeader {
         }
     }
 
-
     pub(crate) fn new_with_transaction(
         round: Round,
         author: u8,
@@ -1099,9 +1094,8 @@ impl TestBlockHeader {
             .into_iter()
             .map(Transaction::new)
             .collect::<Vec<Transaction>>();
-        let serialized_transactions =
-            Transaction::serialize(&txs)
-                .expect("We should expect correct serialization of the transactions for sharding");
+        let serialized_transactions = Transaction::serialize(&txs)
+            .expect("We should expect correct serialization of the transactions for sharding");
         Self {
             block_header: BlockHeaderV1 {
                 round,

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -11,7 +11,6 @@ use std::{
 
 use bytes::Bytes;
 use fastcrypto::hash::{Digest, HashFunction};
-use reed_solomon_simd::ReedSolomonEncoder;
 use rs_merkle::MerkleTree;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
@@ -1061,7 +1060,7 @@ impl TestBlockHeader {
         round: Round,
         author: u8,
         context: &Arc<Context>,
-        encoder: &mut ReedSolomonEncoder,
+        encoder: &mut Box<dyn ShardEncoder + Send>,
     ) -> Self {
         let txs = vec![];
         let serialized_transactions = Transaction::serialize(&txs)
@@ -1088,7 +1087,7 @@ impl TestBlockHeader {
         author: u8,
         tx: u8,
         context: &Arc<Context>,
-        encoder: &mut ReedSolomonEncoder,
+        encoder: &mut Box<dyn ShardEncoder + Send>,
     ) -> Self {
         let txs = vec![vec![tx; 16]]
             .into_iter()

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -61,7 +61,6 @@ impl Transaction {
     }
 
     /// Serialises a vector of transactions using the bcs serializer
-    #[expect(dead_code)]
     pub(crate) fn serialize(transactions: &[Transaction]) -> Result<Bytes, ConsensusError> {
         let bytes = bcs::to_bytes(transactions).map_err(ConsensusError::SerializationFailure)?;
         Ok(bytes.into())

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -11,6 +11,7 @@ use std::{
 
 use bytes::Bytes;
 use fastcrypto::hash::{Digest, HashFunction};
+use reed_solomon_simd::ReedSolomonEncoder;
 use rs_merkle::MerkleTree;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
@@ -64,12 +65,7 @@ impl Transaction {
         Ok(bytes.into())
     }
 
-    pub(crate) fn serialize_and_pad_shards(
-        transactions: &[Transaction],
-        info_length: usize,
-    ) -> Result<Bytes, ConsensusError> {
-        let mut serialized =
-            bcs::to_bytes(transactions).map_err(ConsensusError::SerializationFailure)?;
+    pub(crate) fn pad_transactions_for_sharding(mut serialized: Vec<u8>, info_length: usize) -> Result<Bytes, ConsensusError> {
         let bytes_length = serialized.len();
         let mut statements_with_len: Vec<u8> = (bytes_length as u32).to_le_bytes().to_vec();
         statements_with_len.append(&mut serialized);
@@ -80,10 +76,17 @@ impl Transaction {
         if shard_bytes % 2 != 0 {
             shard_bytes += 1;
         }
-
         let length_with_padding = shard_bytes * info_length;
         statements_with_len.resize(length_with_padding, 0);
         Ok(statements_with_len.into())
+    }
+    pub(crate) fn serialize_and_pad_for_sharding(
+        transactions: &[Transaction],
+        info_length: usize,
+    ) -> Result<Bytes, ConsensusError> {
+        let serialized =
+            bcs::to_bytes(transactions).map_err(ConsensusError::SerializationFailure)?;
+        Self::pad_transactions_for_sharding(serialized, info_length)
     }
 }
 
@@ -443,7 +446,9 @@ impl TransactionsCommitment {
     /// Lexicographic min & max digest.
     pub const MIN: Self = Self([u8::MIN; starfish_config::DIGEST_LENGTH]);
     pub const MAX: Self = Self([u8::MAX; starfish_config::DIGEST_LENGTH]);
-    pub(crate) fn compute_transactions_commitment(
+
+
+    pub(crate) fn compute_transactions_commitment_for_test(
         serialized_transactions: &Bytes,
     ) -> ConsensusResult<TransactionsCommitment> {
         let mut hasher = DefaultHashFunction::new();
@@ -451,7 +456,7 @@ impl TransactionsCommitment {
         Ok(TransactionsCommitment(hasher.finalize().into()))
     }
 
-    pub fn compute_merkle_root(
+    pub(crate) fn compute_merkle_root(
         encoded_statements: &Vec<Shard>,
     ) -> ConsensusResult<TransactionsCommitment> {
         let mut leaves: Vec<[u8; DefaultHashFunction::OUTPUT_SIZE]> = Vec::new();
@@ -1017,7 +1022,7 @@ impl TestBlockHeader {
             block_header: BlockHeaderV1 {
                 round,
                 author: author.into(),
-                transactions_commitment: TransactionsCommitment::compute_transactions_commitment(
+                transactions_commitment: TransactionsCommitment::compute_transactions_commitment_for_test(
                     &Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
                 )
                 .unwrap(),
@@ -1033,7 +1038,7 @@ impl TestBlockHeader {
             block_header: BlockHeaderV1 {
                 round,
                 author: author.into(),
-                transactions_commitment: TransactionsCommitment::compute_transactions_commitment(
+                transactions_commitment: TransactionsCommitment::compute_transactions_commitment_for_test(
                     &Bytes::from(
                         bcs::to_bytes::<Vec<Transaction>>(
                             &vec![vec![tx; 16]]

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -85,26 +85,6 @@ impl Transaction {
         Ok(statements_with_len.into())
     }
 
-    pub(crate) fn extract_serialized_transactions_from_padded_data(
-        padded: &[u8],
-    ) -> Result<Vec<u8>, ConsensusError> {
-        if padded.len() < 4 {
-            return Err(ConsensusError::ShardsVecIsTooSmall(padded.len(), 4));
-        }
-        let original_len = u32::from_le_bytes(
-            padded[0..4]
-                .try_into()
-                .map_err(|_| ConsensusError::ShardsVecIsTooSmall(padded.len(), 4))?,
-        ) as usize;
-        if padded.len() < 4 + original_len {
-            return Err(ConsensusError::ShardsVecIsTooSmall(
-                padded.len(),
-                4 + original_len,
-            ));
-        }
-        Ok(padded[4..4 + original_len].to_vec())
-    }
-
     #[expect(dead_code)]
     pub(crate) fn serialize_and_pad_for_sharding(
         transactions: &[Transaction],
@@ -488,18 +468,8 @@ impl TransactionsCommitment {
     ) -> ConsensusResult<TransactionsCommitment> {
         let info_length = context.committee.info_length();
         let parity_length = context.committee.size() - info_length;
-        assert!(
-            serialized_transactions.len() % info_length == 0,
-            "Serialized transactions length must be divisible by info length"
-        );
-        // Compute transaction commitment that will be included in the block header
-        let sharded_transactions: Vec<Shard> = serialized_transactions
-            .chunks(serialized_transactions.len() / info_length)
-            .map(|chunk| chunk.to_vec())
-            .collect();
-
         let encoded_shards = encoder
-            .encode_shards(sharded_transactions, info_length, parity_length)
+            .encode_transactions(serialized_transactions, info_length, parity_length)
             .expect("We should expect correct encoding of the shards");
 
         let transactions_commitment = TransactionsCommitment::compute_merkle_root(&encoded_shards)
@@ -1062,6 +1032,7 @@ pub(crate) fn genesis_block_headers(context: Arc<Context>) -> Vec<VerifiedBlockH
 }
 
 /// This struct is public for testing in other crates.
+#[cfg(test)]
 #[derive(Clone)]
 pub struct TestBlockHeader {
     ancestors: Vec<BlockRef>,
@@ -1069,8 +1040,27 @@ pub struct TestBlockHeader {
     block_header: BlockHeaderV1,
 }
 
+#[cfg(test)]
 impl TestBlockHeader {
-    pub fn new(
+    /// Creates a simple block with no transactions and without real computation of transactions commitment.
+    /// Use it when you don't need to check the commitment and don't want to create and pass the encoder.
+    pub(crate) fn new(
+        round: Round,
+        author: u8,
+    ) -> Self {
+
+        Self {
+            block_header: BlockHeaderV1 {
+                round,
+                author: author.into(),
+                transactions_commitment: TransactionsCommitment::DEFAULT_FOR_TEST,
+                ..Default::default()
+            },
+            ancestors: vec![],
+            acknowledgments: vec![],
+        }
+    }
+    pub(crate) fn new_with_commitment(
         round: Round,
         author: u8,
         context: &Arc<Context>,
@@ -1078,8 +1068,8 @@ impl TestBlockHeader {
     ) -> Self {
         let txs = vec![];
         let serialized_transactions =
-            Transaction::serialize_and_pad_for_sharding(&txs, context.committee.info_length())
-                .expect("We should expect correct serialization of the transactions for sharding");
+            Transaction::serialize(&txs)
+                .expect("We should expect correct serialization of the transactions");
         Self {
             block_header: BlockHeaderV1 {
                 round,
@@ -1097,7 +1087,8 @@ impl TestBlockHeader {
         }
     }
 
-    pub fn new_with_transaction(
+
+    pub(crate) fn new_with_transaction(
         round: Round,
         author: u8,
         tx: u8,
@@ -1109,7 +1100,7 @@ impl TestBlockHeader {
             .map(Transaction::new)
             .collect::<Vec<Transaction>>();
         let serialized_transactions =
-            Transaction::serialize_and_pad_for_sharding(&txs, context.committee.info_length())
+            Transaction::serialize(&txs)
                 .expect("We should expect correct serialization of the transactions for sharding");
         Self {
             block_header: BlockHeaderV1 {

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -427,7 +427,7 @@ impl TransactionsCommitment {
     pub(crate) fn compute_transactions_commitment(
         serialized_transactions: &Bytes,
         context: &Arc<Context>,
-        encoder: &mut Box<dyn ShardEncoder + Send>,
+        encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
     ) -> ConsensusResult<TransactionsCommitment> {
         let info_length = context.committee.info_length();
         let parity_length = context.committee.size() - info_length;
@@ -1024,7 +1024,7 @@ impl TestBlockHeader {
         round: Round,
         author: u8,
         context: &Arc<Context>,
-        encoder: &mut Box<dyn ShardEncoder + Send>,
+        encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
     ) -> Self {
         let txs = vec![];
         let serialized_transactions = Transaction::serialize(&txs)
@@ -1051,7 +1051,7 @@ impl TestBlockHeader {
         author: u8,
         tx: u8,
         context: &Arc<Context>,
-        encoder: &mut Box<dyn ShardEncoder + Send>,
+        encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
     ) -> Self {
         let txs = vec![vec![tx; 16]]
             .into_iter()

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -58,9 +58,31 @@ impl Transaction {
     }
 
     /// Serialises a vector of transactions using the bcs serializer
-    pub(crate) fn serialize(transactions: &[Transaction]) -> Result<Bytes, bcs::Error> {
-        let bytes = bcs::to_bytes(transactions)?;
+    pub(crate) fn serialize(transactions: &[Transaction]) -> Result<Bytes, ConsensusError> {
+        let bytes = bcs::to_bytes(transactions).map_err(ConsensusError::SerializationFailure)?;
         Ok(bytes.into())
+    }
+
+    pub(crate) fn serialize_and_pad_shards(
+        transactions: &[Transaction],
+        info_length: usize,
+    ) -> Result<Bytes, ConsensusError> {
+        let mut serialized =
+            bcs::to_bytes(transactions).map_err(ConsensusError::SerializationFailure)?;
+        let bytes_length = serialized.len();
+        let mut statements_with_len: Vec<u8> = (bytes_length as u32).to_le_bytes().to_vec();
+        statements_with_len.append(&mut serialized);
+        // increase the length by 4 for u32
+        let mut shard_bytes = (bytes_length + 4).div_ceil(info_length);
+
+        // Ensure shard_bytes meets alignment requirements.
+        if shard_bytes % 2 != 0 {
+            shard_bytes += 1;
+        }
+
+        let length_with_padding = shard_bytes * info_length;
+        statements_with_len.resize(length_with_padding, 0);
+        Ok(statements_with_len.into())
     }
 }
 

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -64,7 +64,10 @@ impl Transaction {
         Ok(bytes.into())
     }
 
-    pub(crate) fn pad_transactions_for_sharding(mut serialized: Vec<u8>, info_length: usize) -> Result<Bytes, ConsensusError> {
+    pub(crate) fn pad_transactions_for_sharding(
+        mut serialized: Vec<u8>,
+        info_length: usize,
+    ) -> Result<Bytes, ConsensusError> {
         let bytes_length = serialized.len();
         let mut statements_with_len: Vec<u8> = (bytes_length as u32).to_le_bytes().to_vec();
         statements_with_len.append(&mut serialized);
@@ -80,12 +83,11 @@ impl Transaction {
         Ok(statements_with_len.into())
     }
 
-    pub(crate) fn extract_serialized_transactions_from_padded_data(padded: &[u8]) -> Result<Vec<u8>, ConsensusError> {
+    pub(crate) fn extract_serialized_transactions_from_padded_data(
+        padded: &[u8],
+    ) -> Result<Vec<u8>, ConsensusError> {
         if padded.len() < 4 {
-            return Err(ConsensusError::ShardsVecIsTooSmall(
-                padded.len(),
-                4,
-            ));
+            return Err(ConsensusError::ShardsVecIsTooSmall(padded.len(), 4));
         }
         let original_len = u32::from_le_bytes(
             padded[0..4]
@@ -466,7 +468,6 @@ impl TransactionsCommitment {
     /// Lexicographic min & max digest.
     pub const MIN: Self = Self([u8::MIN; starfish_config::DIGEST_LENGTH]);
     pub const MAX: Self = Self([u8::MAX; starfish_config::DIGEST_LENGTH]);
-
 
     pub(crate) fn compute_transactions_commitment_for_test(
         serialized_transactions: &Bytes,
@@ -1042,10 +1043,11 @@ impl TestBlockHeader {
             block_header: BlockHeaderV1 {
                 round,
                 author: author.into(),
-                transactions_commitment: TransactionsCommitment::compute_transactions_commitment_for_test(
-                    &Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
-                )
-                .unwrap(),
+                transactions_commitment:
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&Bytes::from(
+                        bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap(),
+                    ))
+                    .unwrap(),
                 ..Default::default()
             },
             ancestors: vec![],
@@ -1058,8 +1060,8 @@ impl TestBlockHeader {
             block_header: BlockHeaderV1 {
                 round,
                 author: author.into(),
-                transactions_commitment: TransactionsCommitment::compute_transactions_commitment_for_test(
-                    &Bytes::from(
+                transactions_commitment:
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&Bytes::from(
                         bcs::to_bytes::<Vec<Transaction>>(
                             &vec![vec![tx; 16]]
                                 .into_iter()
@@ -1067,9 +1069,8 @@ impl TestBlockHeader {
                                 .collect(),
                         )
                         .unwrap(),
-                    ),
-                )
-                .unwrap(),
+                    ))
+                    .unwrap(),
                 ..Default::default()
             },
             ancestors: vec![],

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -11,7 +11,6 @@ use std::{
 
 use bytes::Bytes;
 use fastcrypto::hash::{Digest, HashFunction};
-use reed_solomon_simd::ReedSolomonEncoder;
 use rs_merkle::MerkleTree;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
@@ -79,6 +78,27 @@ impl Transaction {
         let length_with_padding = shard_bytes * info_length;
         statements_with_len.resize(length_with_padding, 0);
         Ok(statements_with_len.into())
+    }
+
+    pub(crate) fn extract_serialized_transactions_from_padded_data(padded: &[u8]) -> Result<Vec<u8>, ConsensusError> {
+        if padded.len() < 4 {
+            return Err(ConsensusError::ShardsVecIsTooSmall(
+                padded.len(),
+                4,
+            ));
+        }
+        let original_len = u32::from_le_bytes(
+            padded[0..4]
+                .try_into()
+                .map_err(|_| ConsensusError::ShardsVecIsTooSmall(padded.len(), 4))?,
+        ) as usize;
+        if padded.len() < 4 + original_len {
+            return Err(ConsensusError::ShardsVecIsTooSmall(
+                padded.len(),
+                4 + original_len,
+            ));
+        }
+        Ok(padded[4..4 + original_len].to_vec())
     }
     pub(crate) fn serialize_and_pad_for_sharding(
         transactions: &[Transaction],

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -432,7 +432,7 @@ impl TransactionsCommitment {
         let info_length = context.committee.info_length();
         let parity_length = context.committee.size() - info_length;
         let encoded_shards = encoder
-            .encode_transactions(serialized_transactions, info_length, parity_length)
+            .encode_serialized_data(serialized_transactions, info_length, parity_length)
             .expect("We should expect correct encoding of the shards");
 
         let transactions_commitment = TransactionsCommitment::compute_merkle_root(&encoded_shards)
@@ -818,7 +818,7 @@ pub struct VerifiedTransactions {
     /// Commitment of transactions in the block
     transactions_commitment: TransactionsCommitment,
 
-    /// The serialized bytes of the transactions with padding for sharding.
+    /// The serialized bytes of the transactions.
     serialized: Bytes,
 }
 

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -464,7 +464,7 @@ impl TransactionsCommitment {
     pub(crate) fn compute_transactions_commitment(
         serialized_transactions: &Bytes,
         context: &Arc<Context>,
-        encoder: &mut ReedSolomonEncoder,
+        encoder: &mut Box<dyn ShardEncoder + Send>,
     ) -> ConsensusResult<TransactionsCommitment> {
         let info_length = context.committee.info_length();
         let parity_length = context.committee.size() - info_length;

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -11,11 +11,12 @@ use std::{
 
 use bytes::Bytes;
 use fastcrypto::hash::{Digest, HashFunction};
+use rs_merkle::MerkleTree;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
 use starfish_config::{
-    AuthorityIndex, DIGEST_LENGTH, DefaultHashFunction, Epoch, ProtocolKeyPair,
-    ProtocolKeySignature, ProtocolPublicKey,
+    AuthorityIndex, DIGEST_LENGTH, DefaultHashFunction, DefaultHashFunctionWrapper, Epoch,
+    ProtocolKeyPair, ProtocolKeySignature, ProtocolPublicKey,
 };
 
 use crate::{
@@ -448,6 +449,24 @@ impl TransactionsCommitment {
         let mut hasher = DefaultHashFunction::new();
         hasher.update(serialized_transactions);
         Ok(TransactionsCommitment(hasher.finalize().into()))
+    }
+
+    pub fn compute_merkle_root(
+        encoded_statements: &Vec<Shard>,
+    ) -> ConsensusResult<TransactionsCommitment> {
+        let mut leaves: Vec<[u8; DefaultHashFunction::OUTPUT_SIZE]> = Vec::new();
+        for shard in encoded_statements {
+            let mut hasher = DefaultHashFunction::new();
+            hasher.update(shard);
+            let leaf = hasher.finalize().into();
+            leaves.push(leaf);
+        }
+        let merkle_tree = MerkleTree::<DefaultHashFunctionWrapper>::from_leaves(&leaves);
+        let merkle_root = merkle_tree
+            .root()
+            .ok_or("couldn't get the merkle root")
+            .unwrap();
+        Ok(TransactionsCommitment(merkle_root))
     }
 }
 

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -853,7 +853,9 @@ impl Debug for CommitRange {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+
     use reed_solomon_simd::ReedSolomonEncoder;
+
     use super::*;
     use crate::{
         block_header::{TestBlockHeader, VerifiedBlock},
@@ -881,7 +883,14 @@ mod tests {
             .map(|index| {
                 let author_idx = index.0.value() as u8;
                 let tx = index.0.value() as u8;
-                let block = TestBlockHeader::new_with_transaction(0, author_idx, tx, &context, &mut encoder).build();
+                let block = TestBlockHeader::new_with_transaction(
+                    0,
+                    author_idx,
+                    tx,
+                    &context,
+                    &mut encoder,
+                )
+                .build();
                 VerifiedBlock::new_with_transaction_for_test(block, tx)
             })
             .map(|block| {

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -853,7 +853,7 @@ impl Debug for CommitRange {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-
+    use reed_solomon_simd::ReedSolomonEncoder;
     use super::*;
     use crate::{
         block_header::{TestBlockHeader, VerifiedBlock},
@@ -865,6 +865,10 @@ mod tests {
     async fn test_new_committed_subdag_from_commit() {
         let store = Arc::new(MemStore::new());
         let context = Arc::new(Context::new_for_test(4).0);
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         // Populate fully connected test blocks for round 0 ~ 3, authorities 0 ~ 3.
         let first_wave_rounds: u32 = WAVE_LENGTH;
@@ -877,7 +881,7 @@ mod tests {
             .map(|index| {
                 let author_idx = index.0.value() as u8;
                 let tx = index.0.value() as u8;
-                let block = TestBlockHeader::new_with_transaction(0, author_idx, tx).build();
+                let block = TestBlockHeader::new_with_transaction(0, author_idx, tx, &context, &mut encoder).build();
                 VerifiedBlock::new_with_transaction_for_test(block, tx)
             })
             .map(|block| {
@@ -906,7 +910,7 @@ mod tests {
             for author in 0..num_authorities {
                 let base_ts = round as BlockTimestampMs * 1000;
                 let block = VerifiedBlock::new_for_test(
-                    TestBlockHeader::new(round, author)
+                    TestBlockHeader::new_with_commitment(round, author, &context, &mut encoder)
                         .set_timestamp_ms(base_ts + (author as u32 + round) as u64)
                         .set_ancestors(ancestors.clone())
                         .set_acknowledgments(ancestors.clone())

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -854,12 +854,11 @@ impl Debug for CommitRange {
 mod tests {
     use std::sync::Arc;
 
-    use reed_solomon_simd::ReedSolomonEncoder;
-
     use super::*;
     use crate::{
         block_header::{TestBlockHeader, VerifiedBlock},
         context::Context,
+        encoder::create_encoder,
         storage::{WriteBatch, mem_store::MemStore},
     };
 
@@ -867,10 +866,7 @@ mod tests {
     async fn test_new_committed_subdag_from_commit() {
         let store = Arc::new(MemStore::new());
         let context = Arc::new(Context::new_for_test(4).0);
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         // Populate fully connected test blocks for round 0 ~ 3, authorities 0 ~ 3.
         let first_wave_rounds: u32 = WAVE_LENGTH;

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -638,18 +638,13 @@ impl Core {
         // Serialize the transaction
         let info_length = self.context.committee.info_length();
         let parity_length = self.context.committee.size() - info_length;
-        let serialized_transactions =
-            Transaction::serialize_and_pad_for_sharding(&transactions, info_length)
-                .expect("We should expect correct serialization and padding for transactions");
+        let serialized_transactions = Transaction::serialize(&transactions)
+            .expect("We should expect correct serialization for transactions");
         // Compute transaction commitment that will be included in the block header
-        let sharded_transactions: Vec<Shard> = serialized_transactions
-            .chunks(serialized_transactions.len() / info_length)
-            .map(|chunk| chunk.to_vec())
-            .collect();
 
         let encoded_shards = self
             .encoder
-            .encode_shards(sharded_transactions, info_length, parity_length)
+            .encode_transactions(&serialized_transactions, info_length, parity_length)
             .expect("We should expect correct encoding of the shards");
 
         let transactions_commitment = TransactionsCommitment::compute_merkle_root(&encoded_shards)

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -16,6 +16,7 @@ use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
 use iota_metrics::monitored_scope;
 use itertools::Itertools as _;
 use parking_lot::RwLock;
+pub(crate) use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::{AuthorityIndex, ProtocolKeyPair};
 #[cfg(test)]
 use starfish_config::{Stake, local_committee_and_keys};
@@ -31,14 +32,15 @@ use crate::{
     Transaction,
     block_header::{
         BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockRef, BlockTimestampMs, GENESIS_ROUND,
-        Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
-        VerifiedTransactions,
+        Round, Shard, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock,
+        VerifiedBlockHeader, VerifiedTransactions,
     },
     block_manager::BlockManager,
     commit::{CertifiedCommits, PendingSubDag},
     commit_observer::CommitObserver,
     context::Context,
     dag_state::DagState,
+    encoder::ShardEncoder,
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -120,6 +122,8 @@ pub(crate) struct Core {
     /// None it means that the last block sync mechanism is enabled, but it
     /// hasn't been initialised yet.
     last_known_proposed_round: Option<Round>,
+    /// Encoder is used to encode transactions into a longer vector of shards
+    encoder: ReedSolomonEncoder,
 }
 
 impl Core {
@@ -170,6 +174,10 @@ impl Core {
             // restriction.
             Some(0)
         };
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         Self {
             context,
@@ -187,6 +195,7 @@ impl Core {
             block_signer,
             dag_state,
             last_known_proposed_round: min_propose_round,
+            encoder,
         }
         .recover()
     }
@@ -627,8 +636,19 @@ impl Core {
         // be done in the end of the method.
         let (transactions, ack_transactions, _limit_reached) = self.transaction_consumer.next();
         // Serialize the transaction
-        let serialized_transactions = Transaction::serialize(&transactions)
-            .expect("We should expect correct serialization for transactions");
+        let info_length = self.context.committee.info_length();
+        let parity_length = self.context.committee.size() - info_length;
+        let serialized_transactions =
+            Transaction::serialize_and_pad_shards(&transactions, info_length)
+                .expect("We should expect correct serialization and padding for transactions");
+        let sharded_transactions: Vec<Shard> = serialized_transactions
+            .chunks(serialized_transactions.len() / info_length)
+            .map(|chunk| chunk.to_vec())
+            .collect();
+
+        let encoded_shards =
+            self.encoder
+                .encode_shards(sharded_transactions, info_length, parity_length);
         // Compute transaction commitment that will be included in the block header
         let transactions_commitment =
             TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -32,7 +32,7 @@ use crate::{
     Transaction,
     block_header::{
         BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockRef, BlockTimestampMs, GENESIS_ROUND,
-        Round, Shard, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock,
+        Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock,
         VerifiedBlockHeader, VerifiedTransactions,
     },
     block_manager::BlockManager,
@@ -1586,6 +1586,10 @@ mod test {
             store.clone(),
             leader_schedule.clone(),
         );
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         // First send some transactions, since the block will be created once we recover
         // core
@@ -1664,7 +1668,7 @@ mod test {
             .expect("we should expect correct serialization for transactions");
         // Compute transaction commitment that will be included in the block header
         let transactions_commitment =
-            TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+            TransactionsCommitment::compute_transactions_commitment(&serialized_transactions, &context, &mut encoder)
                 .expect("we should expect correct computation of the transactions commitment");
 
         // a new block should have been created during recovery.

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1669,10 +1669,8 @@ mod test {
             .expect("we should expect correct serialization for transactions");
         // Compute transaction commitment that will be included in the block header
         let transactions_commitment =
-            TransactionsCommitment::compute_transactions_commitment_for_test(
-                &serialized_transactions,
-            )
-            .expect("we should expect correct computation of the transactions commitment");
+            TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                .expect("we should expect correct computation of the transactions commitment");
 
         // a new block should have been created during recovery.
         let verified_block = block_receiver

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -641,7 +641,7 @@ impl Core {
 
         let encoded_shards = self
             .encoder
-            .encode_transactions(&serialized_transactions, info_length, parity_length)
+            .encode_serialized_data(&serialized_transactions, info_length, parity_length)
             .expect("We should expect correct encoding of the shards");
 
         let transactions_commitment = TransactionsCommitment::compute_merkle_root(&encoded_shards)

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -646,13 +646,15 @@ impl Core {
             .map(|chunk| chunk.to_vec())
             .collect();
 
-        let encoded_shards =
-            self.encoder
-                .encode_shards(sharded_transactions, info_length, parity_length);
+        let encoded_shards = self
+            .encoder
+            .encode_shards(sharded_transactions, info_length, parity_length)
+            .expect("We should expect correct encoding of the shards");
         // Compute transaction commitment that will be included in the block header
-        let transactions_commitment =
-            TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
-                .expect("We should expect correct computation of the transactions commitment");
+        let transactions_commitment = TransactionsCommitment::compute_merkle_root(&encoded_shards)
+            .expect(
+                "We should expect correct computation of the Merkle root for encoded transactions",
+            );
 
         self.context
             .metrics

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -16,7 +16,6 @@ use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
 use iota_metrics::monitored_scope;
 use itertools::Itertools as _;
 use parking_lot::RwLock;
-pub(crate) use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::{AuthorityIndex, ProtocolKeyPair};
 #[cfg(test)]
 use starfish_config::{Stake, local_committee_and_keys};
@@ -40,7 +39,7 @@ use crate::{
     commit_observer::CommitObserver,
     context::Context,
     dag_state::DagState,
-    encoder::{ShardEncoder, TrivialEncoder, create_encoder},
+    encoder::{ShardEncoder, create_encoder},
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -175,7 +174,7 @@ impl Core {
             Some(0)
         };
 
-        let encoder = create_encoder(context.clone());
+        let encoder = create_encoder(&context);
 
         Self {
             context,
@@ -1584,10 +1583,7 @@ mod test {
             store.clone(),
             leader_schedule.clone(),
         );
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         // First send some transactions, since the block will be created once we recover
         // core

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -639,8 +639,9 @@ impl Core {
         let info_length = self.context.committee.info_length();
         let parity_length = self.context.committee.size() - info_length;
         let serialized_transactions =
-            Transaction::serialize_and_pad_shards(&transactions, info_length)
+            Transaction::serialize_and_pad_for_sharding(&transactions, info_length)
                 .expect("We should expect correct serialization and padding for transactions");
+        // Compute transaction commitment that will be included in the block header
         let sharded_transactions: Vec<Shard> = serialized_transactions
             .chunks(serialized_transactions.len() / info_length)
             .map(|chunk| chunk.to_vec())
@@ -650,7 +651,7 @@ impl Core {
             .encoder
             .encode_shards(sharded_transactions, info_length, parity_length)
             .expect("We should expect correct encoding of the shards");
-        // Compute transaction commitment that will be included in the block header
+
         let transactions_commitment = TransactionsCommitment::compute_merkle_root(&encoded_shards)
             .expect(
                 "We should expect correct computation of the Merkle root for encoded transactions",
@@ -1668,7 +1669,7 @@ mod test {
             .expect("we should expect correct serialization for transactions");
         // Compute transaction commitment that will be included in the block header
         let transactions_commitment =
-            TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+            TransactionsCommitment::compute_transactions_commitment_for_test(&serialized_transactions)
                 .expect("we should expect correct computation of the transactions commitment");
 
         // a new block should have been created during recovery.

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1669,8 +1669,10 @@ mod test {
             .expect("we should expect correct serialization for transactions");
         // Compute transaction commitment that will be included in the block header
         let transactions_commitment =
-            TransactionsCommitment::compute_transactions_commitment_for_test(&serialized_transactions)
-                .expect("we should expect correct computation of the transactions commitment");
+            TransactionsCommitment::compute_transactions_commitment_for_test(
+                &serialized_transactions,
+            )
+            .expect("we should expect correct computation of the transactions commitment");
 
         // a new block should have been created during recovery.
         let verified_block = block_receiver

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -40,7 +40,7 @@ use crate::{
     commit_observer::CommitObserver,
     context::Context,
     dag_state::DagState,
-    encoder::{ShardEncoder, TrivialEncoder},
+    encoder::{ShardEncoder, TrivialEncoder, create_encoder},
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -174,17 +174,8 @@ impl Core {
             // restriction.
             Some(0)
         };
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let encoder: Box<dyn ShardEncoder + Send>;
-        if info_length > 0 && parity_length > 0 {
-            encoder = Box::new(
-                ReedSolomonEncoder::new(info_length, parity_length, 2)
-                    .expect("We should expect correct creation of the ReedSolomonEncoder"),
-            );
-        } else {
-            encoder = Box::new(TrivialEncoder {});
-        }
+
+        let encoder = create_encoder(context.clone());
 
         Self {
             context,

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -32,15 +32,15 @@ use crate::{
     Transaction,
     block_header::{
         BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockRef, BlockTimestampMs, GENESIS_ROUND,
-        Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock,
-        VerifiedBlockHeader, VerifiedTransactions,
+        Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
+        VerifiedTransactions,
     },
     block_manager::BlockManager,
     commit::{CertifiedCommits, PendingSubDag},
     commit_observer::CommitObserver,
     context::Context,
     dag_state::DagState,
-    encoder::ShardEncoder,
+    encoder::{ShardEncoder, TrivialEncoder},
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -123,7 +123,7 @@ pub(crate) struct Core {
     /// hasn't been initialised yet.
     last_known_proposed_round: Option<Round>,
     /// Encoder is used to encode transactions into a longer vector of shards
-    encoder: ReedSolomonEncoder,
+    encoder: Box<dyn ShardEncoder + Send>,
 }
 
 impl Core {
@@ -176,8 +176,15 @@ impl Core {
         };
         let info_length = context.committee.info_length();
         let parity_length = context.committee.size() - info_length;
-        let encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let encoder: Box<dyn ShardEncoder + Send>;
+        if info_length > 0 && parity_length > 0 {
+            encoder = Box::new(
+                ReedSolomonEncoder::new(info_length, parity_length, 2)
+                    .expect("We should expect correct creation of the ReedSolomonEncoder"),
+            );
+        } else {
+            encoder = Box::new(TrivialEncoder {});
+        }
 
         Self {
             context,
@@ -1667,9 +1674,12 @@ mod test {
         let serialized_transactions = Transaction::serialize(&transactions)
             .expect("we should expect correct serialization for transactions");
         // Compute transaction commitment that will be included in the block header
-        let transactions_commitment =
-            TransactionsCommitment::compute_transactions_commitment(&serialized_transactions, &context, &mut encoder)
-                .expect("we should expect correct computation of the transactions commitment");
+        let transactions_commitment = TransactionsCommitment::compute_transactions_commitment(
+            &serialized_transactions,
+            &context,
+            &mut encoder,
+        )
+        .expect("we should expect correct computation of the transactions commitment");
 
         // a new block should have been created during recovery.
         let verified_block = block_receiver

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -242,7 +242,7 @@ mod tests {
         /// Creates a new test setup with a full DAG containing the specified
         /// number of rounds
         fn new(num_rounds: u32) -> Self {
-            let context = Arc::new(Context::new_for_test(2).0);
+            let context = Arc::new(Context::new_for_test(4).0);
             let dag_state = Arc::new(RwLock::new(DagState::new(
                 context.clone(),
                 Arc::new(crate::storage::mem_store::MemStore::new()),

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -242,7 +242,7 @@ mod tests {
         /// Creates a new test setup with a full DAG containing the specified
         /// number of rounds
         fn new(num_rounds: u32) -> Self {
-            let context = Arc::new(Context::new_for_test(4).0);
+            let context = Arc::new(Context::new_for_test(2).0);
             let dag_state = Arc::new(RwLock::new(DagState::new(
                 context.clone(),
                 Arc::new(crate::storage::mem_store::MemStore::new()),

--- a/crates/starfish/core/src/encoder.rs
+++ b/crates/starfish/core/src/encoder.rs
@@ -18,14 +18,6 @@ pub trait ShardEncoder {
         parity_length: usize,
     ) -> Result<Vec<Shard>, ConsensusError>;
 
-    /// Creates shards from serialized transactions, padding as necessary to
-    /// ensure each shard is of equal length. The number of shards created is
-    /// equal to `info_length`.
-    fn create_shards_from_serialized_transactions(
-        serialized: &Bytes,
-        info_length: usize,
-    ) -> Vec<Shard>;
-
     /// Serializes and encodes transactions into a vector of shards using an
     /// error-correcting code with a dimension of `info_length` and
     /// redundancy of `parity_length`.
@@ -65,37 +57,69 @@ impl ShardEncoder for ReedSolomonEncoder {
         Ok(data)
     }
 
-    fn create_shards_from_serialized_transactions(
-        serialized: &Bytes,
-        info_length: usize,
-    ) -> Vec<Shard> {
-        let bytes_length = serialized.len();
-        let mut statements_with_len: Vec<u8> = (bytes_length as u32).to_le_bytes().to_vec();
-        statements_with_len.extend_from_slice(serialized);
-        // increase the length by 4 for u32
-        let mut shard_bytes = (bytes_length + 4).div_ceil(info_length);
-
-        // Ensure shard_bytes meets alignment requirements.
-        if shard_bytes % 2 != 0 {
-            shard_bytes += 1;
-        }
-
-        let length_with_padding = shard_bytes * info_length;
-        statements_with_len.resize(length_with_padding, 0);
-
-        let data: Vec<Shard> = statements_with_len
-            .chunks(shard_bytes)
-            .map(|chunk| chunk.to_vec())
-            .collect();
-        data
-    }
     fn encode_transactions(
         &mut self,
         serialized: &Bytes,
         info_length: usize,
         parity_length: usize,
     ) -> Result<Vec<Shard>, ConsensusError> {
-        let data = Self::create_shards_from_serialized_transactions(serialized, info_length);
+        let data = create_shards_from_serialized_transactions(serialized, info_length);
         self.encode_shards(data, info_length, parity_length)
     }
+}
+
+pub(crate) struct TrivialEncoder {}
+impl ShardEncoder for TrivialEncoder {
+    fn encode_shards(
+        &mut self,
+        data: Vec<Shard>,
+        info_length: usize,
+        _parity_length: usize,
+    ) -> Result<Vec<Shard>, ConsensusError> {
+        assert_eq!(
+            data.len(),
+            info_length,
+            "Data length must match info length"
+        );
+        assert!(info_length > 0, "Info length must be greater than 0");
+        Ok(data)
+    }
+
+    fn encode_transactions(
+        &mut self,
+        serialized: &Bytes,
+        info_length: usize,
+        parity_length: usize,
+    ) -> Result<Vec<Shard>, ConsensusError> {
+        let data = create_shards_from_serialized_transactions(serialized, info_length);
+        self.encode_shards(data, info_length, parity_length)
+    }
+}
+
+/// Creates shards from serialized transactions, padding as necessary to
+/// ensure each shard is of equal length. The number of shards created is
+/// equal to `info_length`.
+fn create_shards_from_serialized_transactions(
+    serialized: &Bytes,
+    info_length: usize,
+) -> Vec<Shard> {
+    let bytes_length = serialized.len();
+    let mut statements_with_len: Vec<u8> = (bytes_length as u32).to_le_bytes().to_vec();
+    statements_with_len.extend_from_slice(serialized);
+    // increase the length by 4 for u32
+    let mut shard_bytes = (bytes_length + 4).div_ceil(info_length);
+
+    // Ensure shard_bytes meets alignment requirements.
+    if shard_bytes % 2 != 0 {
+        shard_bytes += 1;
+    }
+
+    let length_with_padding = shard_bytes * info_length;
+    statements_with_len.resize(length_with_padding, 0);
+
+    let data: Vec<Shard> = statements_with_len
+        .chunks(shard_bytes)
+        .map(|chunk| chunk.to_vec())
+        .collect();
+    data
 }

--- a/crates/starfish/core/src/encoder.rs
+++ b/crates/starfish/core/src/encoder.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use bytes::Bytes;
 pub(crate) use reed_solomon_simd::ReedSolomonEncoder;
 
 use crate::{Transaction, block_header::Shard, error::ConsensusError};
@@ -23,7 +24,7 @@ pub trait ShardEncoder {
     #[expect(dead_code)]
     fn encode_transactions(
         &mut self,
-        block: Vec<Transaction>,
+        serialized_transactions: &Bytes,
         info_length: usize,
         parity_length: usize,
     ) -> Result<Vec<Shard>, ConsensusError>;
@@ -59,14 +60,13 @@ impl ShardEncoder for ReedSolomonEncoder {
 
     fn encode_transactions(
         &mut self,
-        block: Vec<Transaction>,
+        serialized: &Bytes,
         info_length: usize,
         parity_length: usize,
     ) -> Result<Vec<Shard>, ConsensusError> {
-        let mut serialized = bcs::to_bytes(&block).map_err(ConsensusError::SerializationFailure)?;
         let bytes_length = serialized.len();
         let mut statements_with_len: Vec<u8> = (bytes_length as u32).to_le_bytes().to_vec();
-        statements_with_len.append(&mut serialized);
+        statements_with_len.extend_from_slice(serialized);
         // increase the length by 4 for u32
         let mut shard_bytes = (bytes_length + 4).div_ceil(info_length);
 

--- a/crates/starfish/core/src/encoder.rs
+++ b/crates/starfish/core/src/encoder.rs
@@ -23,7 +23,7 @@ pub trait ShardEncoder {
     /// Serializes and encodes transactions into a vector of shards using an
     /// error-correcting code with a dimension of `info_length` and
     /// redundancy of `parity_length`.
-    fn encode_transactions(
+    fn encode_serialized_data(
         &mut self,
         serialized_transactions: &Bytes,
         info_length: usize,
@@ -59,7 +59,7 @@ impl ShardEncoder for ReedSolomonEncoder {
         Ok(data)
     }
 
-    fn encode_transactions(
+    fn encode_serialized_data(
         &mut self,
         serialized: &Bytes,
         info_length: usize,
@@ -87,7 +87,7 @@ impl ShardEncoder for TrivialEncoder {
         Ok(data)
     }
 
-    fn encode_transactions(
+    fn encode_serialized_data(
         &mut self,
         serialized: &Bytes,
         info_length: usize,

--- a/crates/starfish/core/src/encoder.rs
+++ b/crates/starfish/core/src/encoder.rs
@@ -128,14 +128,14 @@ fn create_shards_from_serialized_transactions(
 pub(crate) fn create_encoder(context: &Arc<Context>) -> Box<dyn ShardEncoder + Send> {
     let info_length = context.committee.info_length();
     let parity_length = context.committee.size() - info_length;
-    let encoder: Box<dyn ShardEncoder + Send>;
+    let encoder: Box<dyn ShardEncoder + Send> =
     if info_length > 0 && parity_length > 0 {
-        encoder = Box::new(
+        Box::new(
             ReedSolomonEncoder::new(info_length, parity_length, 2)
                 .expect("We should expect correct creation of the ReedSolomonEncoder"),
-        );
+        )
     } else {
-        encoder = Box::new(TrivialEncoder {});
-    }
+        Box::new(TrivialEncoder {})
+    };
     encoder
 }

--- a/crates/starfish/core/src/encoder.rs
+++ b/crates/starfish/core/src/encoder.rs
@@ -4,7 +4,7 @@
 use bytes::Bytes;
 pub(crate) use reed_solomon_simd::ReedSolomonEncoder;
 
-use crate::{Transaction, block_header::Shard, error::ConsensusError};
+use crate::{block_header::Shard, error::ConsensusError};
 
 /// Trait for encoding data into shards using systematic coding with
 /// configurable redundancy.
@@ -18,10 +18,17 @@ pub trait ShardEncoder {
         parity_length: usize,
     ) -> Result<Vec<Shard>, ConsensusError>;
 
+    /// Creates shards from serialized transactions, padding as necessary to
+    /// ensure each shard is of equal length. The number of shards created is
+    /// equal to `info_length`.
+    fn create_shards_from_serialized_transactions(
+        serialized: &Bytes,
+        info_length: usize,
+    ) -> Vec<Shard>;
+
     /// Serializes and encodes transactions into a vector of shards using an
     /// error-correcting code with a dimension of `info_length` and
     /// redundancy of `parity_length`.
-    #[expect(dead_code)]
     fn encode_transactions(
         &mut self,
         serialized_transactions: &Bytes,
@@ -58,12 +65,10 @@ impl ShardEncoder for ReedSolomonEncoder {
         Ok(data)
     }
 
-    fn encode_transactions(
-        &mut self,
+    fn create_shards_from_serialized_transactions(
         serialized: &Bytes,
         info_length: usize,
-        parity_length: usize,
-    ) -> Result<Vec<Shard>, ConsensusError> {
+    ) -> Vec<Shard> {
         let bytes_length = serialized.len();
         let mut statements_with_len: Vec<u8> = (bytes_length as u32).to_le_bytes().to_vec();
         statements_with_len.extend_from_slice(serialized);
@@ -82,7 +87,15 @@ impl ShardEncoder for ReedSolomonEncoder {
             .chunks(shard_bytes)
             .map(|chunk| chunk.to_vec())
             .collect();
-
+        data
+    }
+    fn encode_transactions(
+        &mut self,
+        serialized: &Bytes,
+        info_length: usize,
+        parity_length: usize,
+    ) -> Result<Vec<Shard>, ConsensusError> {
+        let data = Self::create_shards_from_serialized_transactions(serialized, info_length);
         self.encode_shards(data, info_length, parity_length)
     }
 }

--- a/crates/starfish/core/src/encoder.rs
+++ b/crates/starfish/core/src/encoder.rs
@@ -1,10 +1,12 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use bytes::Bytes;
 pub(crate) use reed_solomon_simd::ReedSolomonEncoder;
 
-use crate::{block_header::Shard, error::ConsensusError};
+use crate::{block_header::Shard, context::Context, error::ConsensusError};
 
 /// Trait for encoding data into shards using systematic coding with
 /// configurable redundancy.
@@ -122,4 +124,18 @@ fn create_shards_from_serialized_transactions(
         .map(|chunk| chunk.to_vec())
         .collect();
     data
+}
+pub(crate) fn create_encoder(context: Arc<Context>) -> Box<dyn ShardEncoder + Send> {
+    let info_length = context.committee.info_length();
+    let parity_length = context.committee.size() - info_length;
+    let encoder: Box<dyn ShardEncoder + Send>;
+    if info_length > 0 && parity_length > 0 {
+        encoder = Box::new(
+            ReedSolomonEncoder::new(info_length, parity_length, 2)
+                .expect("We should expect correct creation of the ReedSolomonEncoder"),
+        );
+    } else {
+        encoder = Box::new(TrivialEncoder {});
+    }
+    encoder
 }

--- a/crates/starfish/core/src/encoder.rs
+++ b/crates/starfish/core/src/encoder.rs
@@ -125,7 +125,7 @@ fn create_shards_from_serialized_transactions(
         .collect();
     data
 }
-pub(crate) fn create_encoder(context: Arc<Context>) -> Box<dyn ShardEncoder + Send> {
+pub(crate) fn create_encoder(context: &Arc<Context>) -> Box<dyn ShardEncoder + Send> {
     let info_length = context.committee.info_length();
     let parity_length = context.committee.size() - info_length;
     let encoder: Box<dyn ShardEncoder + Send>;

--- a/crates/starfish/core/src/encoder.rs
+++ b/crates/starfish/core/src/encoder.rs
@@ -128,8 +128,7 @@ fn create_shards_from_serialized_transactions(
 pub(crate) fn create_encoder(context: &Arc<Context>) -> Box<dyn ShardEncoder + Send> {
     let info_length = context.committee.info_length();
     let parity_length = context.committee.size() - info_length;
-    let encoder: Box<dyn ShardEncoder + Send> =
-    if info_length > 0 && parity_length > 0 {
+    let encoder: Box<dyn ShardEncoder + Send> = if info_length > 0 && parity_length > 0 {
         Box::new(
             ReedSolomonEncoder::new(info_length, parity_length, 2)
                 .expect("We should expect correct creation of the ReedSolomonEncoder"),

--- a/crates/starfish/core/src/encoder.rs
+++ b/crates/starfish/core/src/encoder.rs
@@ -125,10 +125,10 @@ fn create_shards_from_serialized_transactions(
         .collect();
     data
 }
-pub(crate) fn create_encoder(context: &Arc<Context>) -> Box<dyn ShardEncoder + Send> {
+pub(crate) fn create_encoder(context: &Arc<Context>) -> Box<dyn ShardEncoder + Send + Sync> {
     let info_length = context.committee.info_length();
     let parity_length = context.committee.size() - info_length;
-    let encoder: Box<dyn ShardEncoder + Send> = if info_length > 0 && parity_length > 0 {
+    let encoder: Box<dyn ShardEncoder + Send + Sync> = if info_length > 0 && parity_length > 0 {
         Box::new(
             ReedSolomonEncoder::new(info_length, parity_length, 2)
                 .expect("We should expect correct creation of the ReedSolomonEncoder"),

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -59,7 +59,9 @@ mod test_dag_parser;
 pub use authority_node::ConsensusAuthority;
 pub use block_header::{BlockHeaderAPI, BlockRef, Round};
 /// Exported API for testing.
-pub use block_header::{TestBlockHeader, Transaction, VerifiedBlockHeader};
+pub use block_header::{Transaction, VerifiedBlockHeader};
+#[cfg(test)]
+pub use block_header::TestBlockHeader;
 pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
 pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
 pub use network::tonic_network::to_socket_addr;

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -57,11 +57,11 @@ mod test_dag_parser;
 
 /// Exported consensus API.
 pub use authority_node::ConsensusAuthority;
+#[cfg(test)]
+pub use block_header::TestBlockHeader;
 pub use block_header::{BlockHeaderAPI, BlockRef, Round};
 /// Exported API for testing.
 pub use block_header::{Transaction, VerifiedBlockHeader};
-#[cfg(test)]
-pub use block_header::TestBlockHeader;
 pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
 pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
 pub use network::tonic_network::to_socket_addr;

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -132,7 +132,7 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         &self,
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
-        encoder: &mut Box<dyn ShardEncoder + Send>,
+        encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
     ) -> ConsensusResult<()>;
 
     /// Handles the subscription request from the peer.

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -53,7 +53,7 @@ pub(crate) mod tonic_network;
 #[cfg(msim)]
 pub mod tonic_network;
 mod tonic_tls;
-
+use reed_solomon_simd::ReedSolomonEncoder;
 /// A stream of serialized blocks with additional information such as headers or
 /// shards.
 pub(crate) type BlockBundleStream = Pin<Box<dyn Stream<Item = SerializedBlockBundle> + Send>>;
@@ -130,6 +130,7 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         &self,
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
+        encoder: &mut ReedSolomonEncoder,
     ) -> ConsensusResult<()>;
 
     /// Handles the subscription request from the peer.

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -54,6 +54,9 @@ pub(crate) mod tonic_network;
 pub mod tonic_network;
 mod tonic_tls;
 use reed_solomon_simd::ReedSolomonEncoder;
+
+use crate::encoder::ShardEncoder;
+
 /// A stream of serialized blocks with additional information such as headers or
 /// shards.
 pub(crate) type BlockBundleStream = Pin<Box<dyn Stream<Item = SerializedBlockBundle> + Send>>;
@@ -130,7 +133,7 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         &self,
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
-        encoder: &mut ReedSolomonEncoder,
+        encoder: &mut Box<dyn ShardEncoder + Send>,
     ) -> ConsensusResult<()>;
 
     /// Handles the subscription request from the peer.

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -53,7 +53,6 @@ pub(crate) mod tonic_network;
 #[cfg(msim)]
 pub mod tonic_network;
 mod tonic_tls;
-use reed_solomon_simd::ReedSolomonEncoder;
 
 use crate::encoder::ShardEncoder;
 

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -48,7 +48,7 @@ impl NetworkService for Mutex<TestService> {
         &self,
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
-        _encoder: &mut Box<dyn ShardEncoder + Send>,
+        _encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
     ) -> ConsensusResult<()> {
         let mut state = self.lock();
         state

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -47,6 +47,7 @@ impl NetworkService for Mutex<TestService> {
         &self,
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
+        _encoder: &mut ReedSolomonEncoder,
     ) -> ConsensusResult<()> {
         let mut state = self.lock();
         state

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -6,7 +6,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream;
 use parking_lot::Mutex;
-use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::AuthorityIndex;
 
 use crate::{

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream;
 use parking_lot::Mutex;
+use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::AuthorityIndex;
 
 use crate::{
@@ -15,7 +16,6 @@ use crate::{
     error::ConsensusResult,
     network::{BlockBundleStream, NetworkService, SerializedBlockBundle},
 };
-
 pub(crate) struct TestService {
     pub(crate) handle_subscribed_block_bundle: Vec<(AuthorityIndex, SerializedBlockBundle)>,
     pub(crate) handle_subscribed_block_bundle_requests: Vec<(AuthorityIndex, Round)>,

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -13,9 +13,11 @@ use crate::{
     Round,
     block_header::{BlockRef, VerifiedBlockHeader},
     commit::{CommitRange, TrustedCommit},
+    encoder::ShardEncoder,
     error::ConsensusResult,
     network::{BlockBundleStream, NetworkService, SerializedBlockBundle},
 };
+
 pub(crate) struct TestService {
     pub(crate) handle_subscribed_block_bundle: Vec<(AuthorityIndex, SerializedBlockBundle)>,
     pub(crate) handle_subscribed_block_bundle_requests: Vec<(AuthorityIndex, Round)>,
@@ -47,7 +49,7 @@ impl NetworkService for Mutex<TestService> {
         &self,
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
-        _encoder: &mut ReedSolomonEncoder,
+        _encoder: &mut Box<dyn ShardEncoder + Send>,
     ) -> ConsensusResult<()> {
         let mut state = self.lock();
         state

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -30,7 +30,7 @@ use crate::{
 pub(crate) struct RocksDBStore {
     /// Stores SignedBlockHeader by refs.
     block_headers: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
-    /// Stores Transactions by refs.
+    /// Stores Transactions with commitmetns
     transactions: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
     /// A secondary index that orders refs first by authors.
     digests_by_authorities: DBMap<(AuthorityIndex, Round, BlockHeaderDigest), ()>,
@@ -272,17 +272,35 @@ impl Store for RocksDBStore {
             .iter()
             .map(|r| (r.round, r.author, r.digest))
             .collect::<Vec<_>>();
-        let serialized_transactions = self.transactions.multi_get(keys)?;
+        let serialized_vec_transactions = self.transactions.multi_get(keys.clone())?;
+        // read headers to collect commitment
+        // TODO::optimize it later by storing commitment separately or together with
+        // transactions
+        let serialized_block_headers = self.block_headers.multi_get(keys)?;
         let mut result = Vec::with_capacity(refs.len());
-        for (i, serialized) in serialized_transactions.into_iter().enumerate() {
-            if let Some(bytes) = serialized {
-                let transactions: Vec<Transaction> =
-                    bcs::from_bytes(&bytes).map_err(ConsensusError::MalformedTransactions)?;
-                let commitment =
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&bytes)
-                        .expect("computation of the transactions commitment should not fail");
-                let verified = VerifiedTransactions::new(transactions, refs[i], commitment, bytes);
-                result.push(Some(verified));
+        for ((block_ref, serialized_block_header), serialized_transactions) in refs
+            .iter()
+            .zip(serialized_block_headers)
+            .zip(serialized_vec_transactions)
+        {
+            if let (Some(serialized_block_header), Some(serialized_transactions)) =
+                (serialized_block_header, serialized_transactions)
+            {
+                let signed_block_header: SignedBlockHeader =
+                    bcs::from_bytes(&serialized_block_header)
+                        .map_err(ConsensusError::MalformedHeader)?;
+                let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
+                    .map_err(ConsensusError::MalformedTransactions)?;
+
+                // We don't check the transactions commitment as it's loaded from storage.
+                let verified_transactions = VerifiedTransactions::new(
+                    transactions,
+                    block_ref.clone(),
+                    signed_block_header.transactions_commitment(),
+                    serialized_transactions,
+                );
+
+                result.push(Some(verified_transactions));
             } else {
                 result.push(None);
             }

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -19,8 +19,8 @@ use super::{CommitInfo, Store, WriteBatch};
 use crate::{
     Transaction,
     block_header::{
-        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, SignedBlockHeader,
-        VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
+        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, SignedBlockHeader, VerifiedBlock,
+        VerifiedBlockHeader, VerifiedTransactions,
     },
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
     error::{ConsensusError, ConsensusResult},

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -30,7 +30,7 @@ use crate::{
 pub(crate) struct RocksDBStore {
     /// Stores SignedBlockHeader by refs.
     block_headers: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
-    /// Stores Transactions with commitmetns
+    /// Stores Transactions by refs
     transactions: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
     /// A secondary index that orders refs first by authors.
     digests_by_authorities: DBMap<(AuthorityIndex, Round, BlockHeaderDigest), ()>,

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -278,8 +278,9 @@ impl Store for RocksDBStore {
             if let Some(bytes) = serialized {
                 let transactions: Vec<Transaction> =
                     bcs::from_bytes(&bytes).map_err(ConsensusError::MalformedTransactions)?;
-                let commitment = TransactionsCommitment::compute_transactions_commitment_for_test(&bytes)
-                    .expect("computation of the transactions commitment should not fail");
+                let commitment =
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&bytes)
+                        .expect("computation of the transactions commitment should not fail");
                 let verified = VerifiedTransactions::new(transactions, refs[i], commitment, bytes);
                 result.push(Some(verified));
             } else {

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -20,7 +20,7 @@ use crate::{
     Transaction,
     block_header::{
         BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, SignedBlockHeader,
-        TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
+        VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
     },
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
     error::{ConsensusError, ConsensusResult},

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -278,7 +278,7 @@ impl Store for RocksDBStore {
             if let Some(bytes) = serialized {
                 let transactions: Vec<Transaction> =
                     bcs::from_bytes(&bytes).map_err(ConsensusError::MalformedTransactions)?;
-                let commitment = TransactionsCommitment::compute_transactions_commitment(&bytes)
+                let commitment = TransactionsCommitment::compute_transactions_commitment_for_test(&bytes)
                     .expect("computation of the transactions commitment should not fail");
                 let verified = VerifiedTransactions::new(transactions, refs[i], commitment, bytes);
                 result.push(Some(verified));

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -295,7 +295,7 @@ impl Store for RocksDBStore {
                 // We don't check the transactions commitment as it's loaded from storage.
                 let verified_transactions = VerifiedTransactions::new(
                     transactions,
-                    block_ref.clone(),
+                    *block_ref,
                     signed_block_header.transactions_commitment(),
                     serialized_transactions,
                 );

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -279,13 +279,21 @@ async fn read_and_contain_transactions(
         VerifiedBlock::new_for_test(TestBlockHeader::new(11, 3).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(12, 1).build()),
     ];
-
+    // Write transactions to store
     let written_transactions: Vec<_> = written_blocks
         .iter()
         .map(|b| b.verified_transactions.clone())
         .collect();
     store
         .write(WriteBatch::default().transactions(written_transactions))
+        .unwrap();
+    // Also write headers since we read transaction commitment from headers now
+    let written_headers =  written_blocks
+        .iter()
+        .map(|b| b.verified_block_header.clone())
+        .collect();
+    store
+        .write(WriteBatch::default().block_headers(written_headers))
         .unwrap();
 
     // Test reading all transactions

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -288,7 +288,7 @@ async fn read_and_contain_transactions(
         .write(WriteBatch::default().transactions(written_transactions))
         .unwrap();
     // Also write headers since we read transaction commitment from headers now
-    let written_headers =  written_blocks
+    let written_headers = written_blocks
         .iter()
         .map(|b| b.verified_block_header.clone())
         .collect();

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -17,6 +17,7 @@ use crate::{
     block_header::BlockHeaderAPI as _,
     context::Context,
     dag_state::DagState,
+    encoder::{ShardEncoder, TrivialEncoder, create_encoder},
     error::ConsensusError,
     network::{NetworkClient, NetworkService},
 };
@@ -118,8 +119,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
 
         let info_length = context.committee.info_length();
         let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(context.clone());
 
         'subscription: loop {
             context

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -7,6 +7,7 @@ use std::{sync::Arc, time::Duration};
 use futures::StreamExt;
 use iota_metrics::spawn_monitored_task;
 use parking_lot::{Mutex, RwLock};
+use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::AuthorityIndex;
 use tokio::{task::JoinHandle, time::sleep};
 use tracing::{debug, error, info};
@@ -114,6 +115,12 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         let peer_hostname = &context.committee.authority(peer).hostname;
         let mut retries: i64 = 0;
         let mut delay = INITIAL_RETRY_INTERVAL;
+
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
+
         'subscription: loop {
             context
                 .metrics
@@ -195,7 +202,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                             .with_label_values(&[peer_hostname])
                             .inc();
                         let result = authority_service
-                            .handle_subscribed_block_bundle(peer, block.clone())
+                            .handle_subscribed_block_bundle(peer, block.clone(), &mut encoder)
                             .await;
                         if let Err(e) = result {
                             match e {

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -7,7 +7,6 @@ use std::{sync::Arc, time::Duration};
 use futures::StreamExt;
 use iota_metrics::spawn_monitored_task;
 use parking_lot::{Mutex, RwLock};
-use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::AuthorityIndex;
 use tokio::{task::JoinHandle, time::sleep};
 use tracing::{debug, error, info};
@@ -17,7 +16,7 @@ use crate::{
     block_header::BlockHeaderAPI as _,
     context::Context,
     dag_state::DagState,
-    encoder::{ShardEncoder, TrivialEncoder, create_encoder},
+    encoder::create_encoder,
     error::ConsensusError,
     network::{NetworkClient, NetworkService},
 };
@@ -117,9 +116,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         let mut retries: i64 = 0;
         let mut delay = INITIAL_RETRY_INTERVAL;
 
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = create_encoder(context.clone());
+        let mut encoder = create_encoder(&context);
 
         'subscription: loop {
             context

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -600,9 +600,12 @@ impl DagBuilder {
             rng.fill(&mut tx_bytes[..]);
             let transactions = vec![Transaction::new(tx_bytes.to_vec())];
             let serialized_transactions = Transaction::serialize(&transactions).unwrap();
-            let commitment =
-                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions, &self.context, &mut self.encoder)
-                    .unwrap();
+            let commitment = TransactionsCommitment::compute_transactions_commitment(
+                &serialized_transactions,
+                &self.context,
+                &mut self.encoder,
+            )
+            .unwrap();
 
             let verified_transactions = VerifiedTransactions::new(
                 transactions,
@@ -1066,7 +1069,8 @@ impl<'a> LayerBuilder<'a> {
                 let serialized_transactions = Transaction::serialize(&transactions).unwrap();
                 let commitment = TransactionsCommitment::compute_transactions_commitment(
                     &serialized_transactions,
-                    &self.dag_builder.context, &mut self.dag_builder.encoder
+                    &self.dag_builder.context,
+                    &mut self.dag_builder.encoder,
                 )
                 .unwrap();
 

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -591,10 +591,9 @@ impl DagBuilder {
             rng.fill(&mut tx_bytes[..]);
             let transactions = vec![Transaction::new(tx_bytes.to_vec())];
             let serialized_transactions = Transaction::serialize(&transactions).unwrap();
-            let commitment = TransactionsCommitment::compute_transactions_commitment_for_test(
-                &serialized_transactions,
-            )
-            .unwrap();
+            let commitment =
+                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                    .unwrap();
 
             let verified_transactions = VerifiedTransactions::new(
                 transactions,
@@ -1056,7 +1055,7 @@ impl<'a> LayerBuilder<'a> {
                 rng.fill(&mut tx_bytes[..]);
                 let transactions = vec![Transaction::new(tx_bytes.to_vec())];
                 let serialized_transactions = Transaction::serialize(&transactions).unwrap();
-                let commitment = TransactionsCommitment::compute_transactions_commitment_for_test(
+                let commitment = TransactionsCommitment::compute_transactions_commitment(
                     &serialized_transactions,
                 )
                 .unwrap();

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -10,6 +10,7 @@ use std::{
 
 use parking_lot::RwLock;
 use rand::{Rng, SeedableRng, rngs::StdRng, seq::SliceRandom};
+use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::{AuthorityIndex, ProtocolKeyPair};
 
 use crate::{
@@ -117,6 +118,8 @@ pub(crate) struct DagBuilder {
     // Protocol keypairs are used to compute signature for headers. If it is None, then the Default
     // signature is used
     protocol_keypair: Option<Vec<ProtocolKeyPair>>,
+
+    encoder: ReedSolomonEncoder,
 }
 /// The `AncestorSelection` enum is an interim data structure used to specify
 /// how ancestors should be selected for a block in the `DagBuilder`. `UseLast`
@@ -150,6 +153,11 @@ impl DagBuilder {
             .map(|block| (block.reference(), block))
             .collect();
         let last_ancestors = genesis.keys().cloned().collect();
+
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
         Self {
             last_committed_rounds: vec![0; context.committee.size()],
             context,
@@ -163,6 +171,7 @@ impl DagBuilder {
             transactions: BTreeMap::new(),
             committed_sub_dags: vec![],
             protocol_keypair: None,
+            encoder,
         }
     }
 
@@ -592,7 +601,7 @@ impl DagBuilder {
             let transactions = vec![Transaction::new(tx_bytes.to_vec())];
             let serialized_transactions = Transaction::serialize(&transactions).unwrap();
             let commitment =
-                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions, &self.context, &mut self.encoder)
                     .unwrap();
 
             let verified_transactions = VerifiedTransactions::new(
@@ -1057,6 +1066,7 @@ impl<'a> LayerBuilder<'a> {
                 let serialized_transactions = Transaction::serialize(&transactions).unwrap();
                 let commitment = TransactionsCommitment::compute_transactions_commitment(
                     &serialized_transactions,
+                    &self.dag_builder.context, &mut self.dag_builder.encoder
                 )
                 .unwrap();
 

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -119,7 +119,7 @@ pub(crate) struct DagBuilder {
     // signature is used
     protocol_keypair: Option<Vec<ProtocolKeyPair>>,
 
-    encoder: Box<dyn ShardEncoder + Send>,
+    encoder: Box<dyn ShardEncoder + Send + Sync>,
 }
 /// The `AncestorSelection` enum is an interim data structure used to specify
 /// how ancestors should be selected for a block in the `DagBuilder`. `UseLast`

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -10,7 +10,6 @@ use std::{
 
 use parking_lot::RwLock;
 use rand::{Rng, SeedableRng, rngs::StdRng, seq::SliceRandom};
-use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::{AuthorityIndex, ProtocolKeyPair};
 
 use crate::{
@@ -23,6 +22,7 @@ use crate::{
     commit::{CertifiedCommit, CommitDigest, TrustedCommit, WAVE_LENGTH},
     context::Context,
     dag_state::DagState,
+    encoder::{ShardEncoder, create_encoder},
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
     linearizer::{BlockStoreAPI, Linearizer},
 };
@@ -119,7 +119,7 @@ pub(crate) struct DagBuilder {
     // signature is used
     protocol_keypair: Option<Vec<ProtocolKeyPair>>,
 
-    encoder: ReedSolomonEncoder,
+    encoder: Box<dyn ShardEncoder + Send>,
 }
 /// The `AncestorSelection` enum is an interim data structure used to specify
 /// how ancestors should be selected for a block in the `DagBuilder`. `UseLast`
@@ -154,10 +154,7 @@ impl DagBuilder {
             .collect();
         let last_ancestors = genesis.keys().cloned().collect();
 
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let encoder = create_encoder(&context);
         Self {
             last_committed_rounds: vec![0; context.committee.size()],
             context,

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -592,7 +592,7 @@ impl DagBuilder {
             let transactions = vec![Transaction::new(tx_bytes.to_vec())];
             let serialized_transactions = Transaction::serialize(&transactions).unwrap();
             let commitment =
-                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized_transactions)
                     .unwrap();
 
             let verified_transactions = VerifiedTransactions::new(
@@ -1055,7 +1055,7 @@ impl<'a> LayerBuilder<'a> {
                 rng.fill(&mut tx_bytes[..]);
                 let transactions = vec![Transaction::new(tx_bytes.to_vec())];
                 let serialized_transactions = Transaction::serialize(&transactions).unwrap();
-                let commitment = TransactionsCommitment::compute_transactions_commitment(
+                let commitment = TransactionsCommitment::compute_transactions_commitment_for_test(
                     &serialized_transactions,
                 )
                 .unwrap();

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -591,9 +591,10 @@ impl DagBuilder {
             rng.fill(&mut tx_bytes[..]);
             let transactions = vec![Transaction::new(tx_bytes.to_vec())];
             let serialized_transactions = Transaction::serialize(&transactions).unwrap();
-            let commitment =
-                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized_transactions)
-                    .unwrap();
+            let commitment = TransactionsCommitment::compute_transactions_commitment_for_test(
+                &serialized_transactions,
+            )
+            .unwrap();
 
             let verified_transactions = VerifiedTransactions::new(
                 transactions,

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1001,7 +1001,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 .get(&serialized_transactions.block_ref)
                 .expect("header for fetched transactions must exist");
             if block_header.transactions_commitment()
-                != TransactionsCommitment::compute_transactions_commitment(
+                != TransactionsCommitment::compute_transactions_commitment_for_test(
                     &serialized_transactions.serialized_transactions,
                 )
                 .expect("correct computation of the transactions commitment should be successful")
@@ -1106,7 +1106,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1205,7 +1205,7 @@ mod tests {
             let serialized_vec = bcs::to_bytes(&transactions).unwrap();
             let serialized = Bytes::from(serialized_vec);
             let commitment =
-                TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
 
             // Create a test block header with the correct commitment
             let header = VerifiedBlockHeader::new_for_test(
@@ -1313,7 +1313,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1429,7 +1429,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1534,7 +1534,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1641,7 +1641,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1746,7 +1746,7 @@ mod tests {
             let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
             let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
             let commitment =
-                TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
 
             // Create a test block header with the correct commitment
             let header = VerifiedBlockHeader::new_for_test(

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -22,6 +22,7 @@ use rand::{
     rngs::{OsRng, StdRng},
     seq::SliceRandom,
 };
+use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::AuthorityIndex;
 use tokio::{
     runtime::Handle,
@@ -767,7 +768,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             peer,
             transactions_guard,
             core_dispatcher.clone(),
-            context.clone(),
+            context,
             block_verifier.clone(),
             dag_state.clone(),
             sync_method,
@@ -912,12 +913,14 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 }
 
                 let block_verifier = block_verifier.clone();
+                let context_cloned = context.clone();
                 move || {
                     Self::verify_transactions(
                         serialized_transactions,
                         block_verifier,
                         peer_index,
                         block_headers_map,
+                        context_cloned,
                     )
                 }
             })
@@ -982,6 +985,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         block_verifier: Arc<V>,
         peer_index: AuthorityIndex,
         block_headers_map: BTreeMap<BlockRef, VerifiedBlockHeader>,
+        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedTransactions>> {
         let mut collected_verified_transactions = Vec::new();
 
@@ -1000,9 +1004,16 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             let block_header = block_headers_map
                 .get(&serialized_transactions.block_ref)
                 .expect("header for fetched transactions must exist");
+
+            let info_length = context.committee.info_length();
+            let parity_length = context.committee.size() - info_length;
+            let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+                .expect("We should expect correct creation of the ReedSolomonEncoder");
             if block_header.transactions_commitment()
-                != TransactionsCommitment::compute_transactions_commitment_for_test(
+                != TransactionsCommitment::compute_transactions_commitment(
                     &serialized_transactions.serialized_transactions,
+                    &context,
+                    &mut encoder,
                 )
                 .expect("correct computation of the transactions commitment should be successful")
             {
@@ -1106,8 +1117,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
-                        .unwrap();
+                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1206,8 +1216,7 @@ mod tests {
             let serialized_vec = bcs::to_bytes(&transactions).unwrap();
             let serialized = Bytes::from(serialized_vec);
             let commitment =
-                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
-                    .unwrap();
+                TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
 
             // Create a test block header with the correct commitment
             let header = VerifiedBlockHeader::new_for_test(
@@ -1315,8 +1324,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
-                        .unwrap();
+                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1432,8 +1440,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
-                        .unwrap();
+                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1538,8 +1545,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
-                        .unwrap();
+                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1646,8 +1652,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
-                        .unwrap();
+                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1752,8 +1757,7 @@ mod tests {
             let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
             let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
             let commitment =
-                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
-                    .unwrap();
+                TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
 
             // Create a test block header with the correct commitment
             let header = VerifiedBlockHeader::new_for_test(

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -22,7 +22,6 @@ use rand::{
     rngs::{OsRng, StdRng},
     seq::SliceRandom,
 };
-use reed_solomon_simd::ReedSolomonEncoder;
 use starfish_config::AuthorityIndex;
 use tokio::{
     runtime::Handle,
@@ -1006,7 +1005,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 .get(&serialized_transactions.block_ref)
                 .expect("header for fetched transactions must exist");
 
-            let mut encoder = create_encoder(context.clone());
+            let mut encoder = create_encoder(&context);
             if block_header.transactions_commitment()
                 != TransactionsCommitment::compute_transactions_commitment(
                     &serialized_transactions.serialized_transactions,
@@ -1100,10 +1099,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         // Create some test transactions
         let block_round_author: Vec<(Round, u8)> = vec![(1, 1), (2, 1), (3, 2)];
@@ -1205,10 +1201,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         // Create block round author pairs
         let block_round_authors = (1..LIVE_FETCH_TRANSACTIONS_CONCURRENCY * 2 + 1)
@@ -1322,10 +1315,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         // Create some test transactions
         let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
@@ -1446,10 +1436,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         // Create some test transactions
         let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
@@ -1559,10 +1546,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         // Create some test transactions
         let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
@@ -1674,10 +1658,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         // Create some test transactions
         let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
@@ -1789,10 +1770,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
-        let info_length = context.committee.info_length();
-        let parity_length = context.committee.size() - info_length;
-        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-            .expect("We should expect correct creation of the ReedSolomonEncoder");
+        let mut encoder = create_encoder(&context);
 
         // Create some test transactions
         let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1106,7 +1106,8 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
+                        .unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1205,7 +1206,8 @@ mod tests {
             let serialized_vec = bcs::to_bytes(&transactions).unwrap();
             let serialized = Bytes::from(serialized_vec);
             let commitment =
-                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
+                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
+                    .unwrap();
 
             // Create a test block header with the correct commitment
             let header = VerifiedBlockHeader::new_for_test(
@@ -1313,7 +1315,8 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
+                        .unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1429,7 +1432,8 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
+                        .unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1534,7 +1538,8 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
+                        .unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1641,7 +1646,8 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
+                        .unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1746,7 +1752,8 @@ mod tests {
             let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
             let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
             let commitment =
-                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized).unwrap();
+                TransactionsCommitment::compute_transactions_commitment_for_test(&serialized)
+                    .unwrap();
 
             // Create a test block header with the correct commitment
             let header = VerifiedBlockHeader::new_for_test(

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1120,8 +1120,12 @@ mod tests {
                 // Create a dummy transaction
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
-                let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
+                let commitment = TransactionsCommitment::compute_transactions_commitment(
+                    &serialized,
+                    &context,
+                    &mut encoder,
+                )
+                .unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1223,8 +1227,12 @@ mod tests {
             let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
             let serialized_vec = bcs::to_bytes(&transactions).unwrap();
             let serialized = Bytes::from(serialized_vec);
-            let commitment =
-                TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
+            let commitment = TransactionsCommitment::compute_transactions_commitment(
+                &serialized,
+                &context,
+                &mut encoder,
+            )
+            .unwrap();
 
             // Create a test block header with the correct commitment
             let header = VerifiedBlockHeader::new_for_test(
@@ -1335,8 +1343,12 @@ mod tests {
                 // Create a dummy transaction
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
-                let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
+                let commitment = TransactionsCommitment::compute_transactions_commitment(
+                    &serialized,
+                    &context,
+                    &mut encoder,
+                )
+                .unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1455,8 +1467,12 @@ mod tests {
                 // Create a dummy transaction
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
-                let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
+                let commitment = TransactionsCommitment::compute_transactions_commitment(
+                    &serialized,
+                    &context,
+                    &mut encoder,
+                )
+                .unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1564,8 +1580,12 @@ mod tests {
                 // Create a dummy transaction
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
-                let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
+                let commitment = TransactionsCommitment::compute_transactions_commitment(
+                    &serialized,
+                    &context,
+                    &mut encoder,
+                )
+                .unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1675,8 +1695,12 @@ mod tests {
                 // Create a dummy transaction
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
-                let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
+                let commitment = TransactionsCommitment::compute_transactions_commitment(
+                    &serialized,
+                    &context,
+                    &mut encoder,
+                )
+                .unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1784,8 +1808,12 @@ mod tests {
             // Create a dummy transaction
             let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
             let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
-            let commitment =
-                TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
+            let commitment = TransactionsCommitment::compute_transactions_commitment(
+                &serialized,
+                &context,
+                &mut encoder,
+            )
+            .unwrap();
 
             // Create a test block header with the correct commitment
             let header = VerifiedBlockHeader::new_for_test(

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -39,6 +39,7 @@ use crate::{
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
+    encoder::create_encoder,
     error::{ConsensusError, ConsensusResult},
     network::{NetworkClient, SerializedTransactions},
 };
@@ -1005,10 +1006,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 .get(&serialized_transactions.block_ref)
                 .expect("header for fetched transactions must exist");
 
-            let info_length = context.committee.info_length();
-            let parity_length = context.committee.size() - info_length;
-            let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
-                .expect("We should expect correct creation of the ReedSolomonEncoder");
+            let mut encoder = create_encoder(context.clone());
             if block_header.transactions_commitment()
                 != TransactionsCommitment::compute_transactions_commitment(
                     &serialized_transactions.serialized_transactions,

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1102,6 +1102,10 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         // Create some test transactions
         let block_round_author: Vec<(Round, u8)> = vec![(1, 1), (2, 1), (3, 2)];
@@ -1117,7 +1121,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1199,6 +1203,10 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         // Create block round author pairs
         let block_round_authors = (1..LIVE_FETCH_TRANSACTIONS_CONCURRENCY * 2 + 1)
@@ -1216,7 +1224,7 @@ mod tests {
             let serialized_vec = bcs::to_bytes(&transactions).unwrap();
             let serialized = Bytes::from(serialized_vec);
             let commitment =
-                TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
 
             // Create a test block header with the correct commitment
             let header = VerifiedBlockHeader::new_for_test(
@@ -1308,6 +1316,10 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         // Create some test transactions
         let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
@@ -1324,7 +1336,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1424,6 +1436,10 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         // Create some test transactions
         let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
@@ -1440,7 +1456,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1529,6 +1545,10 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         // Create some test transactions
         let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
@@ -1545,7 +1565,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1636,6 +1656,10 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         // Create some test transactions
         let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
@@ -1652,7 +1676,7 @@ mod tests {
                 let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
                 let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
                 let commitment =
-                    TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                    TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
 
                 // Create a test block header with the correct commitment
                 let header = VerifiedBlockHeader::new_for_test(
@@ -1743,6 +1767,10 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let mut encoder = ReedSolomonEncoder::new(info_length, parity_length, 2)
+            .expect("We should expect correct creation of the ReedSolomonEncoder");
 
         // Create some test transactions
         let block_round_author: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
@@ -1757,7 +1785,7 @@ mod tests {
             let transactions = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
             let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
             let commitment =
-                TransactionsCommitment::compute_transactions_commitment(&serialized).unwrap();
+                TransactionsCommitment::compute_transactions_commitment(&serialized, &context, &mut encoder).unwrap();
 
             // Create a test block header with the correct commitment
             let header = VerifiedBlockHeader::new_for_test(


### PR DESCRIPTION
# Description of change

This PR changes transaction commitment to Merkle root of encoded transactions.

More precisely, the transaction data of the proposed block is serialised and broken into info_length shards (info_length = f + 1 for n = 3f + 1). Then these shards are encoded into n shards (n - number of validators). After that, a Merkle tree with n leaves is built, and each leaf is a hash of a shard. The root of this tree is transaction commitment.

To achieve that, the following changes have been introduced:
1. One encoder is added to the core. It is used to compute transaction commitment to include in the block header of the created block.
2. n encoders are created during the subscription process, one encoder for each connection. These encoders are used to verify the transaction commitment of the blocks received through streaming.
3. Encoders are also created in the transaction synchronizer to verify the transaction data received through this path as well.
4. Computation of transaction commitment was removed from the function that reads transactions from the database. Instead, we read transaction commitments from the corresponding headers. It may be later optimised by, for example, storing commitments separately or together with transactions.
5. Any struct that implements the trait ShardEncoder can be used. At the moment, the trait is implemented for ReedSolomonEncoder and TrivialEncoder. TrivialEncoder doesn't actually do anything; it returns the same vector of shards as it is given. It is used for small committees of size < 4, since ReedSolomonEncoder doesn't work for info_length=n. 

## Links to any relevant issues

`fixes #8649 `.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: start of sharded Starfish implementation
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
