### PR TITLE
fix(iota-grpc-api): use --experimental_allow_proto3_optional

### DIFF
--- a/crates/iota-grpc-api/build.rs
+++ b/crates/iota-grpc-api/build.rs
@@ -3,6 +3,7 @@
 
 fn main() {
     tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(
             &[
                 "proto/common.proto",


### PR DESCRIPTION
# Description of change

Use `--experimental_allow_proto3_optional` flag, as it otherwise didn't compile for me when running `cargo install --locked --bin iota --features=iota-names,indexer,tracing --path crates/iota`
```
error: failed to run custom build command for `iota-grpc-api v1.9.0-alpha (/home/t/Desktop/iota/crates/iota-grpc-api)`

Caused by:
  process didn't exit successfully: `/home/t/Desktop/iota/target/release/build/iota-grpc-api-a0ed16882dcf7443/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=proto/common.proto
  cargo:rerun-if-changed=proto/checkpoint.proto
  cargo:rerun-if-changed=proto/event.proto
  cargo:rerun-if-changed=proto/

  --- stderr

  thread 'main' panicked at crates/iota-grpc-api/build.rs:14:10:
  called `Result::unwrap()` on an `Err` value: Custom { kind: Other, error: "protoc failed: checkpoint.proto: This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set.\n" }
```

## How the change has been tested

Compiles now
