### PR TITLE
fix(cli): Remove telemetry subscriber for the analyzer command

### DIFF
--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -598,6 +598,10 @@ impl IotaCommand {
             }
             IotaCommand::FireDrill { fire_drill } => run_fire_drill(fire_drill).await,
             IotaCommand::Analyzer => {
+                std::panic::set_hook(Box::new(|panic_info| {
+                    eprintln!("Fatal panic: {panic_info}");
+                    std::process::exit(1);
+                }));
                 analyzer::run(implicit_deps(latest_system_packages()));
                 Ok(())
             }

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -598,10 +598,6 @@ impl IotaCommand {
             }
             IotaCommand::FireDrill { fire_drill } => run_fire_drill(fire_drill).await,
             IotaCommand::Analyzer => {
-                std::panic::set_hook(Box::new(|panic_info| {
-                    eprintln!("Fatal panic: {panic_info}");
-                    std::process::exit(1);
-                }));
                 analyzer::run(implicit_deps(latest_system_packages()));
                 Ok(())
             }

--- a/crates/iota/src/main.rs
+++ b/crates/iota/src/main.rs
@@ -34,19 +34,21 @@ async fn main() {
 
     let args = Args::parse();
     let _guard = match args.command {
-        IotaCommand::KeyTool { .. } | IotaCommand::Move { .. } => {
+        IotaCommand::KeyTool { .. } | IotaCommand::Move { .. } => Some(
             telemetry_subscribers::TelemetryConfig::new()
                 .with_log_level("error")
                 .with_env()
-                .init()
-        }
+                .init(),
+        ),
         IotaCommand::Client {
             cmd: Some(ReplayBatch { .. }),
             ..
-        } => telemetry_subscribers::TelemetryConfig::new()
-            .with_log_level("info")
-            .with_env()
-            .init(),
+        } => Some(
+            telemetry_subscribers::TelemetryConfig::new()
+                .with_log_level("info")
+                .with_env()
+                .init(),
+        ),
 
         IotaCommand::Client {
             cmd: Some(ReplayTransaction {
@@ -63,25 +65,32 @@ async fn main() {
             if ptb_info {
                 config = config.with_trace_target("replay_ptb_info");
             }
-            config.init()
+            Some(config.init())
         }
         IotaCommand::Client {
             cmd: Some(ProfileTransaction { .. }),
             ..
         } => {
             // enable full logging for ProfileTransaction and ReplayTransaction
-            telemetry_subscribers::TelemetryConfig::new()
-                .with_env()
-                .init()
+            Some(
+                telemetry_subscribers::TelemetryConfig::new()
+                    .with_env()
+                    .init(),
+            )
         }
-        IotaCommand::Start { .. } => telemetry_subscribers::TelemetryConfig::new()
-            .with_log_level("info")
-            .with_env()
-            .init(),
-        _ => telemetry_subscribers::TelemetryConfig::new()
-            .with_log_level("error")
-            .with_env()
-            .init(),
+        IotaCommand::Start { .. } => Some(
+            telemetry_subscribers::TelemetryConfig::new()
+                .with_log_level("info")
+                .with_env()
+                .init(),
+        ),
+        IotaCommand::Analyzer { .. } => None,
+        _ => Some(
+            telemetry_subscribers::TelemetryConfig::new()
+                .with_log_level("error")
+                .with_env()
+                .init(),
+        ),
     };
     debug!("IOTA CLI version: {VERSION}");
     exit_main!(args.command.execute().await);

--- a/crates/iota/src/main.rs
+++ b/crates/iota/src/main.rs
@@ -84,7 +84,7 @@ async fn main() {
                 .with_env()
                 .init(),
         ),
-        IotaCommand::Analyzer { .. } => None,
+        IotaCommand::Analyzer => None,
         _ => Some(
             telemetry_subscribers::TelemetryConfig::new()
                 .with_log_level("error")


### PR DESCRIPTION
# Description of change

Before analyzing the fix we need a bit of background:
- The [IOTA Move VS Code](https://marketplace.visualstudio.com/items?itemName=iotaledger.iota-move) extension (current ver. 1.2.0) always tries to install a binary when launched/started. 
-  During this installation, it can pick one of these 3 cases:
    1. if the `iota-move.force-bundled` flag is set in the VS code settings 
        - -> force install the `move-analyzer` bin bundled with the extension in the ` ~/.iota/bin/` folder 
        - -> USE `~/.iota/bin/move-analyzer` as the command to run the [LSP server](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification);
    2. else, if the version of `~/.iota/bin/move-analyzer` is `>` than the version of `iota` 
        - -> USE `~/.iota/bin/move-analyzer` as the command to run the LSP server
    3. else -> USE `iota analyzer` as the command to run the LSP server
- The issue described in #6263, i.e., dangling `iota` processes, happens only in the case iii., that is when the `iota analyzer` command is used to run a LSP server.
- Cases i. and ii. are not affected by this. In fact, during tests, `move-analyzer` processes were never left dangling.

Based on the background information, we know that a comparison between the command `move-analyzer` and `iota analyzer` should lead to the same result; however, an experiment shows different results:
<img width="381" height="288" alt="commands comparison" src="https://github.com/user-attachments/assets/0c36c1ea-50b7-429c-9d65-d180b5ab16c6" />
- After running both commands, a server is started.
- A way to interact with the server is to hit "Enter"; this will force the initialization of a connection, but it will make the server panic because there is no actual client trying to connect.
- In the case of the `move-analyzer` command, the main thread is panicking and the process terminates.
- In the case of the `iota analyzer` command, the main thread is panicking and but the process does NOT terminate (I needed to force quit with CTRL+C).

Now back to the main issue:
- When a LSP client sends a stop signal to the [analyzer server](https://github.com/iotaledger/iota/blob/9ff49c6d4e85030c06a8f0127d8fb51f374d0564/external-crates/move/crates/move-analyzer/src/analyzer.rs#L342), the `run` is terminated.
- With another experiment, I checked that this signal reaches the server with no issues and no error are returned back, meaning that the `run` method actually terminates.
- So, it seems that, when this `analyzer::run` is invoked as an iota command [here](https://github.com/iotaledger/iota/blob/9ff49c6d4e85030c06a8f0127d8fb51f374d0564/crates/iota/src/iota_commands.rs#L601), it gets stuck. Whilst, when it is invoked in the [`move-analyzer` bin](https://github.com/iotaledger/iota/blob/9ff49c6d4e85030c06a8f0127d8fb51f374d0564/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs#L19) it goes through. 

Solution:
- using `std::panic::set_hook` in the iota command matched arm fixes the issue
- @iotaledger/dev-tools might have a more efficient solution though, or a better explanation about the different behaviors


(additionally, this is broken also in Sui:)
<img width="430" height="100" alt="sui" src="https://github.com/user-attachments/assets/6a30187d-9cfa-479a-9240-62b370f72b42" />


## Links to any relevant issues

Fixes #6263 

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Resolved a dangling IOTA process issue in the IOTA Move VS Code extension by removing the telemetry subscriber from the analyzer CLT command. For affected users, please update the installed `iota` binary on your system to `v1.9.x` and above.
- [ ] Rust SDK:
- [ ] REST API: