### PR TITLE
refactor(graphql-rpc): Reclassify transaction-block related variants

### DIFF
--- a/crates/iota-graphql-rpc/src/mutation.rs
+++ b/crates/iota-graphql-rpc/src/mutation.rs
@@ -2,15 +2,17 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 use async_graphql::*;
+use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
 use fastcrypto::encoding::Base64;
-use iota_indexer::optimistic_indexing::OptimisticTransactionExecutor;
-use iota_json_rpc_types::IotaTransactionBlockResponseOptions;
-use iota_types::{
-    effects::TransactionEffects as NativeTransactionEffects, event::Event as NativeEvent,
-    transaction::SenderSignedData,
+use iota_indexer::{
+    models::transactions::OptimisticTransaction,
+    optimistic_indexing::OptimisticTransactionExecutor,
+    schema::{optimistic_transactions, tx_global_order},
 };
+use iota_json_rpc_types::IotaTransactionBlockResponseOptions;
 
 use crate::{
+    data::{Db, DbConnection, QueryExecutor},
     error::Error,
     types::{
         execution_result::ExecutionResult,
@@ -18,6 +20,30 @@ use crate::{
     },
 };
 pub struct Mutation;
+
+/// Query optimistic transaction by digest from the database
+async fn query_optimistic_transaction_by_digest(
+    db: &Db,
+    digest_bytes: Vec<u8>,
+) -> Result<OptimisticTransaction, Error> {
+    db.execute_repeatable(move |conn| {
+        conn.first(move || {
+            optimistic_transactions::table
+                .inner_join(
+                    tx_global_order::table.on(optimistic_transactions::global_sequence_number
+                        .eq(tx_global_order::global_sequence_number)
+                        .and(
+                            optimistic_transactions::optimistic_sequence_number
+                                .eq(tx_global_order::optimistic_sequence_number),
+                        )),
+                )
+                .filter(tx_global_order::tx_digest.eq(digest_bytes.clone()))
+                .select(OptimisticTransaction::as_select())
+        })
+    })
+    .await
+    .map_err(|e| Error::Internal(format!("Unable to query optimistic transaction: {e}")))
+}
 
 /// Mutations are used to write to the IOTA network.
 #[Object]
@@ -90,28 +116,11 @@ impl Mutation {
             .map_err(|e| Error::Internal(format!("Unable to execute transaction: {e}")))
             .extend()?;
 
-        let native: NativeTransactionEffects = bcs::from_bytes(&result.raw_effects)
-            .map_err(|e| Error::Internal(format!("Unable to deserialize transaction effects: {e}")))
-            .extend()?;
-        let tx_data: SenderSignedData = bcs::from_bytes(&result.raw_transaction)
-            .map_err(|e| Error::Internal(format!("Unable to deserialize transaction data: {e}")))
-            .extend()?;
+        let tx_digest = result.digest;
+        let digest_bytes = tx_digest.inner().to_vec();
 
-        let events = result
-            .events
-            .ok_or_else(|| {
-                Error::Internal("No events are returned from transaction execution".to_string())
-            })?
-            .data
-            .into_iter()
-            .map(|e| NativeEvent {
-                package_id: e.package_id,
-                transaction_module: e.transaction_module,
-                sender: e.sender,
-                type_: e.type_,
-                contents: e.bcs.into_bytes(),
-            })
-            .collect();
+        let db: &Db = ctx.data_unchecked();
+        let optimistic_tx = query_optimistic_transaction_by_digest(db, digest_bytes).await?;
 
         Ok(ExecutionResult {
             errors: if result.errors.is_empty() {
@@ -120,11 +129,13 @@ impl Mutation {
                 Some(result.errors)
             },
             effects: TransactionBlockEffects {
-                kind: TransactionBlockEffectsKind::Executed {
-                    tx_data,
-                    native,
-                    events,
-                },
+                kind: TransactionBlockEffectsKind::try_from(optimistic_tx)
+                    .map_err(|e| {
+                        Error::Internal(format!(
+                            "Unable to create TransactionBlockEffectsKind: {e}"
+                        ))
+                    })
+                    .extend()?,
                 // set to u64::MAX, as the executed transaction has not been indexed yet
                 checkpoint_viewed_at: u64::MAX,
             },

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -11,7 +11,10 @@ use async_graphql::{
 use cursor::EvLookup;
 use diesel::{ExpressionMethods, QueryDsl};
 use iota_indexer::{
-    models::{events::StoredEvent, transactions::StoredTransaction},
+    models::{
+        events::StoredEvent,
+        transactions::{OptimisticTransaction, StoredTransaction},
+    },
     schema::{checkpoints, events},
 };
 use iota_types::{
@@ -255,6 +258,46 @@ impl Event {
                 .to_canonical_string(/* with_prefix */ true),
             bcs: native_event.contents.clone(),
             timestamp_ms: stored_tx.timestamp_ms,
+        };
+
+        Ok(Self {
+            stored: Some(stored_event),
+            native: native_event,
+            checkpoint_viewed_at,
+        })
+    }
+
+    pub(crate) fn try_from_optimistic_transaction(
+        optimistic_tx: &OptimisticTransaction,
+        idx: usize,
+        checkpoint_viewed_at: u64,
+    ) -> Result<Self, Error> {
+        let Some(serialized_event) = &optimistic_tx.get_event_at_idx(idx) else {
+            return Err(Error::Internal(format!(
+                "Could not find event with event_sequence_number {} at optimistic transaction {}",
+                idx, optimistic_tx.optimistic_sequence_number
+            )));
+        };
+
+        let native_event: NativeEvent = bcs::from_bytes(serialized_event).map_err(|_| {
+            Error::Internal(format!(
+                "Failed to deserialize event with {} at optimistic transaction {}",
+                idx, optimistic_tx.optimistic_sequence_number
+            ))
+        })?;
+
+        let stored_event = StoredEvent {
+            tx_sequence_number: optimistic_tx.optimistic_sequence_number,
+            event_sequence_number: idx as i64,
+            transaction_digest: optimistic_tx.transaction_digest.clone(),
+            senders: vec![Some(native_event.sender.to_vec())],
+            package: native_event.package_id.to_vec(),
+            module: native_event.transaction_module.to_string(),
+            event_type: native_event
+                .type_
+                .to_canonical_string(/* with_prefix */ true),
+            bcs: native_event.contents.clone(),
+            timestamp_ms: -1, // Optimistic transactions don't have timestamps yet
         };
 
         Ok(Self {

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -246,6 +246,7 @@ impl Event {
             ))
         })?;
 
+        let with_prefix = true;
         let stored_event = StoredEvent {
             tx_sequence_number: stored_tx.tx_sequence_number,
             event_sequence_number: idx as i64,
@@ -253,9 +254,7 @@ impl Event {
             senders: vec![Some(native_event.sender.to_vec())],
             package: native_event.package_id.to_vec(),
             module: native_event.transaction_module.to_string(),
-            event_type: native_event
-                .type_
-                .to_canonical_string(/* with_prefix */ true),
+            event_type: native_event.type_.to_canonical_string(with_prefix),
             bcs: native_event.contents.clone(),
             timestamp_ms: stored_tx.timestamp_ms,
         };
@@ -274,18 +273,19 @@ impl Event {
     ) -> Result<Self, Error> {
         let Some(serialized_event) = &optimistic_tx.get_event_at_idx(idx) else {
             return Err(Error::Internal(format!(
-                "Could not find event with event_sequence_number {} at optimistic transaction {}",
-                idx, optimistic_tx.optimistic_sequence_number
+                "Could not find event with event_sequence_number {idx} at optimistic transaction {}",
+                optimistic_tx.optimistic_sequence_number
             )));
         };
 
         let native_event: NativeEvent = bcs::from_bytes(serialized_event).map_err(|_| {
             Error::Internal(format!(
-                "Failed to deserialize event with {} at optimistic transaction {}",
-                idx, optimistic_tx.optimistic_sequence_number
+                "Failed to deserialize event with {idx} at optimistic transaction {}",
+                optimistic_tx.optimistic_sequence_number
             ))
         })?;
 
+        let with_prefix = true;
         let stored_event = StoredEvent {
             tx_sequence_number: optimistic_tx.optimistic_sequence_number,
             event_sequence_number: idx as i64,
@@ -293,9 +293,7 @@ impl Event {
             senders: vec![Some(native_event.sender.to_vec())],
             package: native_event.package_id.to_vec(),
             module: native_event.transaction_module.to_string(),
-            event_type: native_event
-                .type_
-                .to_canonical_string(/* with_prefix */ true),
+            event_type: native_event.type_.to_canonical_string(with_prefix),
             bcs: native_event.contents.clone(),
             timestamp_ms: -1, // Optimistic transactions don't have timestamps yet
         };

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -14,8 +14,8 @@ use async_graphql::{
 };
 use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
 use iota_indexer::{
-    models::objects::StoredHistoryObject,
-    schema::{objects_history, objects_version},
+    models::objects::{StoredHistoryObject, StoredObject},
+    schema::{objects, objects_history, objects_version},
     types::{ObjectStatus as NativeObjectStatus, OwnerType},
 };
 use iota_types::{
@@ -226,6 +226,14 @@ pub(crate) enum ObjectLookup {
         /// The checkpoint sequence number at which this was viewed at.
         checkpoint_viewed_at: u64,
     },
+
+    /// Variant analogous to VersionAt but for optimistic transactions,
+    /// using the most recent not checkpointed data,
+    /// not bound by any checkpoint sequence number.
+    OptimisticVersion {
+        /// The exact version of the object to be fetched.
+        version: u64,
+    },
 }
 
 pub(crate) type Cursor = cursor::BcsCursor<HistoricalObjectCursor>;
@@ -313,6 +321,15 @@ struct HistoricalKey {
     id: IotaAddress,
     version: u64,
     checkpoint_viewed_at: u64,
+}
+
+/// `DataLoader` key for fetching objects that haven't been checkpointed yet.
+/// This is used specifically for loading objects
+/// that are part of optimistic transaction effects.
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+struct OptimisticKey {
+    id: IotaAddress,
+    version: u64,
 }
 
 /// `DataLoader` key for fetching the latest version of an object whose parent
@@ -908,6 +925,11 @@ impl Object {
         }
     }
 
+    /// Look-up a specific version of the object from optimistic transactions.
+    pub(crate) fn at_optimistic_version(version: u64) -> ObjectLookup {
+        ObjectLookup::OptimisticVersion { version }
+    }
+
     pub(crate) async fn query(
         ctx: &Context<'_>,
         id: IotaAddress,
@@ -927,6 +949,10 @@ impl Object {
                         checkpoint_viewed_at,
                     })
                     .await
+            }
+
+            ObjectLookup::OptimisticVersion { version } => {
+                loader.load_one(OptimisticKey { id, version }).await
             }
 
             ObjectLookup::UnderParent {
@@ -1331,6 +1357,85 @@ impl Loader<HistoricalKey> for Db {
                 None,
             )?;
             result.insert(*key, object);
+        }
+
+        Ok(result)
+    }
+}
+
+impl Loader<OptimisticKey> for Db {
+    type Value = Object;
+    type Error = Error;
+
+    async fn load(&self, keys: &[OptimisticKey]) -> Result<HashMap<OptimisticKey, Object>, Error> {
+        use objects::dsl as o;
+
+        let id_versions: BTreeSet<_> = keys
+            .iter()
+            .map(|key| (key.id.into_vec(), key.version as i64))
+            .collect();
+
+        let objects: Vec<StoredObject> = self
+            .execute(move |conn| {
+                conn.results(move || {
+                    let mut query = o::objects.select(StoredObject::as_select()).into_boxed();
+                    for (id, version) in id_versions.iter().cloned() {
+                        query =
+                            query.or_filter(o::object_id.eq(id).and(o::object_version.eq(version)));
+                    }
+                    query
+                })
+            })
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to fetch optimistic objects: {e}")))?;
+
+        let mut result = HashMap::new();
+        let id_version_to_stored = objects
+            .into_iter()
+            .map(|stored| {
+                addr(&stored.object_id).map(|id| ((id, stored.object_version as u64), stored))
+            })
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
+
+        // Collect keys that were not found in objects table
+        let mut missing_keys = Vec::new();
+        for key in keys {
+            if let Some(stored) = id_version_to_stored.get(&(key.id, key.version)) {
+                let object = Object::from_native(
+                    key.id,
+                    bcs::from_bytes(&stored.serialized_object).map_err(|_| {
+                        Error::Internal(format!("Failed to deserialize object {}", key.id))
+                    })?,
+                    u64::MAX,
+                    None,
+                );
+                result.insert(*key, object);
+            } else {
+                missing_keys.push(*key);
+            }
+        }
+
+        // For missing keys, fallback to using the objects_history table
+        if !missing_keys.is_empty() {
+            let historical_keys: Vec<HistoricalKey> = missing_keys
+                .iter()
+                .map(|key| HistoricalKey {
+                    id: key.id,
+                    version: key.version,
+                    checkpoint_viewed_at: u64::MAX,
+                })
+                .collect();
+
+            let historical_result: HashMap<HistoricalKey, Object> =
+                self.load(&historical_keys).await?;
+
+            for (historical_key, object) in historical_result {
+                let optimistic_key = OptimisticKey {
+                    id: historical_key.id,
+                    version: historical_key.version,
+                };
+                result.insert(optimistic_key, object);
+            }
         }
 
         Ok(result)

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -227,8 +227,8 @@ pub(crate) enum ObjectLookup {
         checkpoint_viewed_at: u64,
     },
 
-    /// Variant analogous to VersionAt but for optimistic transactions,
-    /// using the most recent not checkpointed data,
+    /// Variant analogous to [`VersionAt`](Self::VersionAt) but for optimistic
+    /// transactions, using the most recent not checkpointed data,
     /// not bound by any checkpoint sequence number.
     OptimisticVersion {
         /// The exact version of the object to be fetched.

--- a/crates/iota-graphql-rpc/src/types/object_change.rs
+++ b/crates/iota-graphql-rpc/src/types/object_change.rs
@@ -10,10 +10,10 @@ use crate::types::{iota_address::IotaAddress, object::Object};
 /// Represents the source of an object change (derived from transaction kind)
 #[derive(Clone, Debug)]
 pub(crate) enum ObjectChangeSource {
-    /// Object change from a stored (checkpointed) transaction
-    Stored,
-    /// Object change from an optimistic (not yet checkpointed) transaction
-    ExecutedOptimistically,
+    /// Object change from a checkpointed transaction
+    Checkpointed,
+    /// Object change from an executed (not yet checkpointed) transaction
+    Executed,
     /// Object change from a dry run transaction (dryRunTransactionBlock)
     DryRun,
 }
@@ -41,10 +41,8 @@ impl ObjectChange {
         };
 
         let object_lookup = match self.source {
-            ObjectChangeSource::ExecutedOptimistically => {
-                Object::at_optimistic_version(version.value())
-            }
-            ObjectChangeSource::Stored | ObjectChangeSource::DryRun => {
+            ObjectChangeSource::Executed => Object::at_optimistic_version(version.value()),
+            ObjectChangeSource::Checkpointed | ObjectChangeSource::DryRun => {
                 Object::at_version(version.value(), self.checkpoint_viewed_at)
             }
         };
@@ -60,10 +58,8 @@ impl ObjectChange {
         };
 
         let object_lookup = match self.source {
-            ObjectChangeSource::ExecutedOptimistically => {
-                Object::at_optimistic_version(version.value())
-            }
-            ObjectChangeSource::Stored | ObjectChangeSource::DryRun => {
+            ObjectChangeSource::Executed => Object::at_optimistic_version(version.value()),
+            ObjectChangeSource::Checkpointed | ObjectChangeSource::DryRun => {
                 Object::at_version(version.value(), self.checkpoint_viewed_at)
             }
         };

--- a/crates/iota-graphql-rpc/src/types/object_change.rs
+++ b/crates/iota-graphql-rpc/src/types/object_change.rs
@@ -7,10 +7,23 @@ use iota_types::effects::{IDOperation, ObjectChange as NativeObjectChange};
 
 use crate::types::{iota_address::IotaAddress, object::Object};
 
+/// Represents the source of an object change (derived from transaction kind)
+#[derive(Clone, Debug)]
+pub(crate) enum ObjectChangeSource {
+    /// Object change from a stored (checkpointed) transaction
+    Stored,
+    /// Object change from an optimistic (not yet checkpointed) transaction
+    ExecutedOptimistically,
+    /// Object change from a dry run transaction (dryRunTransactionBlock)
+    DryRun,
+}
+
 pub(crate) struct ObjectChange {
     pub native: NativeObjectChange,
     /// The checkpoint sequence number this was viewed at.
     pub checkpoint_viewed_at: u64,
+    /// The source of this object change (derived from transaction kind)
+    pub source: ObjectChangeSource,
 }
 
 /// Effect on an individual Object (keyed by its ID).
@@ -27,13 +40,17 @@ impl ObjectChange {
             return Ok(None);
         };
 
-        Object::query(
-            ctx,
-            self.native.id.into(),
-            Object::at_version(version.value(), self.checkpoint_viewed_at),
-        )
-        .await
-        .extend()
+        let object_lookup = match self.source {
+            ObjectChangeSource::ExecutedOptimistically => {
+                Object::at_optimistic_version(version.value())
+            }
+            ObjectChangeSource::Stored | ObjectChangeSource::DryRun => {
+                Object::at_version(version.value(), self.checkpoint_viewed_at)
+            }
+        };
+        Object::query(ctx, self.native.id.into(), object_lookup)
+            .await
+            .extend()
     }
 
     /// The contents of the object immediately after the transaction.
@@ -42,13 +59,17 @@ impl ObjectChange {
             return Ok(None);
         };
 
-        Object::query(
-            ctx,
-            self.native.id.into(),
-            Object::at_version(version.value(), self.checkpoint_viewed_at),
-        )
-        .await
-        .extend()
+        let object_lookup = match self.source {
+            ObjectChangeSource::ExecutedOptimistically => {
+                Object::at_optimistic_version(version.value())
+            }
+            ObjectChangeSource::Stored | ObjectChangeSource::DryRun => {
+                Object::at_version(version.value(), self.checkpoint_viewed_at)
+            }
+        };
+        Object::query(ctx, self.native.id.into(), object_lookup)
+            .await
+            .extend()
     }
 
     /// Whether the ID was created in this transaction.

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -10,7 +10,7 @@ use cursor::TxLookup;
 use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
 use fastcrypto::encoding::{Base58, Encoding};
 use iota_indexer::{
-    models::transactions::StoredTransaction,
+    models::transactions::{OptimisticTransaction, StoredTransaction},
     schema::{transactions, tx_digests},
 };
 use iota_types::{
@@ -70,13 +70,13 @@ pub(crate) enum TransactionBlockInner {
         stored_tx: StoredTransaction,
         native: NativeSenderSignedData,
     },
-    /// A transaction block that has been executed via executeTransactionBlock
-    /// but not yet indexed.
-    Executed {
-        tx_data: NativeSenderSignedData,
-        effects: NativeTransactionEffects,
-        events: Vec<NativeEvent>,
+    /// A transaction block that has been executed but not yet indexed,
+    /// stored in the optimistic transactions table.
+    ExecutedOptimistically {
+        optimistic_tx: OptimisticTransaction,
+        native: NativeSenderSignedData,
     },
+
     /// A transaction block that has been executed via dryRunTransactionBlock.
     /// This variant also does not return signatures or digest since only
     /// `NativeTransactionData` is present.
@@ -224,9 +224,10 @@ impl TransactionBlock {
             TransactionBlockInner::Stored { stored_tx, .. } => {
                 Some(Base64::from(&stored_tx.raw_transaction))
             }
-            TransactionBlockInner::Executed { tx_data, .. } => {
-                bcs::to_bytes(&tx_data).ok().map(Base64::from)
+            TransactionBlockInner::ExecutedOptimistically { optimistic_tx, .. } => {
+                Some(Base64::from(&optimistic_tx.raw_transaction))
             }
+
             // Dry run transaction does not have signatures so no sender signed data.
             TransactionBlockInner::DryRun { .. } => None,
         }
@@ -237,7 +238,10 @@ impl TransactionBlock {
     fn native(&self) -> &NativeTransactionData {
         match &self.inner {
             TransactionBlockInner::Stored { native, .. } => native.transaction_data(),
-            TransactionBlockInner::Executed { tx_data, .. } => tx_data.transaction_data(),
+            TransactionBlockInner::ExecutedOptimistically { native, .. } => {
+                native.transaction_data()
+            }
+
             TransactionBlockInner::DryRun { tx_data, .. } => tx_data,
         }
     }
@@ -245,7 +249,8 @@ impl TransactionBlock {
     fn native_signed_data(&self) -> Option<&NativeSenderSignedData> {
         match &self.inner {
             TransactionBlockInner::Stored { native, .. } => Some(native),
-            TransactionBlockInner::Executed { tx_data, .. } => Some(tx_data),
+            TransactionBlockInner::ExecutedOptimistically { native, .. } => Some(native),
+
             TransactionBlockInner::DryRun { .. } => None,
         }
     }
@@ -515,6 +520,23 @@ impl TryFrom<StoredTransaction> for TransactionBlockInner {
     }
 }
 
+impl TryFrom<OptimisticTransaction> for TransactionBlockInner {
+    type Error = Error;
+
+    fn try_from(optimistic_tx: OptimisticTransaction) -> Result<Self, Error> {
+        let native = bcs::from_bytes(&optimistic_tx.raw_transaction).map_err(|e| {
+            Error::Internal(format!(
+                "Failed to deserialize NativeSenderSignedData from optimistic transaction: {e}"
+            ))
+        })?;
+
+        Ok(TransactionBlockInner::ExecutedOptimistically {
+            optimistic_tx,
+            native,
+        })
+    }
+}
+
 impl TryFrom<TransactionBlockEffects> for TransactionBlock {
     type Error = Error;
 
@@ -524,15 +546,10 @@ impl TryFrom<TransactionBlockEffects> for TransactionBlock {
             TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
                 TransactionBlockInner::try_from(stored_tx.clone())
             }
-            TransactionBlockEffectsKind::Executed {
-                tx_data,
-                native,
-                events,
-            } => Ok(TransactionBlockInner::Executed {
-                tx_data: tx_data.clone(),
-                effects: native.clone(),
-                events: events.clone(),
-            }),
+            TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+                TransactionBlockInner::try_from(optimistic_tx.clone())
+            }
+
             TransactionBlockEffectsKind::DryRun {
                 tx_data,
                 native,

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -64,15 +64,16 @@ pub(crate) struct TransactionBlock {
 
 #[derive(Clone, Debug)]
 pub(crate) enum TransactionBlockInner {
-    /// A transaction block that has been indexed and stored in the database,
-    /// containing all information that the other two variants have, and more.
-    Stored {
+    /// A transaction block that has been checkpointed and stored in the
+    /// database, containing all information that the other two variants
+    /// have, and more.
+    Checkpointed {
         stored_tx: StoredTransaction,
         native: NativeSenderSignedData,
     },
-    /// A transaction block that has been executed but not yet indexed,
-    /// stored in the optimistic transactions table.
-    ExecutedOptimistically {
+    /// A transaction block that has been executed and indexed without
+    /// checkpoint information.
+    Executed {
         optimistic_tx: OptimisticTransaction,
         native: NativeSenderSignedData,
     },
@@ -160,16 +161,17 @@ impl TransactionBlock {
     /// If the owner of the gas object(s) is not the same as the sender, the
     /// transaction block is a sponsored transaction block.
     async fn gas_input(&self, ctx: &Context<'_>) -> Option<GasInput> {
-        let checkpoint_viewed_at = if matches!(self.inner, TransactionBlockInner::Stored { .. }) {
-            self.checkpoint_viewed_at
-        } else {
-            // Non-stored transactions have a sentinel checkpoint_viewed_at value that
-            // generally prevents access to further queries, but inputs should
-            // generally be available so try to access them at the high
-            // watermark.
-            let Watermark { checkpoint, .. } = *ctx.data_unchecked();
-            checkpoint
-        };
+        let checkpoint_viewed_at =
+            if matches!(self.inner, TransactionBlockInner::Checkpointed { .. }) {
+                self.checkpoint_viewed_at
+            } else {
+                // Non-checkpointed transactions have a sentinel checkpoint_viewed_at value that
+                // generally prevents access to further queries, but inputs should
+                // generally be available so try to access them at the high
+                // watermark.
+                let Watermark { checkpoint, .. } = *ctx.data_unchecked();
+                checkpoint
+            };
 
         Some(GasInput::from(
             self.native().gas_data(),
@@ -221,10 +223,10 @@ impl TransactionBlock {
     /// and Base64 encoded.
     async fn bcs(&self) -> Option<Base64> {
         match &self.inner {
-            TransactionBlockInner::Stored { stored_tx, .. } => {
+            TransactionBlockInner::Checkpointed { stored_tx, .. } => {
                 Some(Base64::from(&stored_tx.raw_transaction))
             }
-            TransactionBlockInner::ExecutedOptimistically { optimistic_tx, .. } => {
+            TransactionBlockInner::Executed { optimistic_tx, .. } => {
                 Some(Base64::from(&optimistic_tx.raw_transaction))
             }
 
@@ -237,10 +239,8 @@ impl TransactionBlock {
 impl TransactionBlock {
     fn native(&self) -> &NativeTransactionData {
         match &self.inner {
-            TransactionBlockInner::Stored { native, .. } => native.transaction_data(),
-            TransactionBlockInner::ExecutedOptimistically { native, .. } => {
-                native.transaction_data()
-            }
+            TransactionBlockInner::Checkpointed { native, .. } => native.transaction_data(),
+            TransactionBlockInner::Executed { native, .. } => native.transaction_data(),
 
             TransactionBlockInner::DryRun { tx_data, .. } => tx_data,
         }
@@ -248,8 +248,8 @@ impl TransactionBlock {
 
     fn native_signed_data(&self) -> Option<&NativeSenderSignedData> {
         match &self.inner {
-            TransactionBlockInner::Stored { native, .. } => Some(native),
-            TransactionBlockInner::ExecutedOptimistically { native, .. } => Some(native),
+            TransactionBlockInner::Checkpointed { native, .. } => Some(native),
+            TransactionBlockInner::Executed { native, .. } => Some(native),
 
             TransactionBlockInner::DryRun { .. } => None,
         }
@@ -516,7 +516,7 @@ impl TryFrom<StoredTransaction> for TransactionBlockInner {
         let native = bcs::from_bytes(&stored_tx.raw_transaction)
             .map_err(|e| Error::Internal(format!("Error deserializing transaction block: {e}")))?;
 
-        Ok(TransactionBlockInner::Stored { stored_tx, native })
+        Ok(TransactionBlockInner::Checkpointed { stored_tx, native })
     }
 }
 
@@ -530,7 +530,7 @@ impl TryFrom<OptimisticTransaction> for TransactionBlockInner {
             ))
         })?;
 
-        Ok(TransactionBlockInner::ExecutedOptimistically {
+        Ok(TransactionBlockInner::Executed {
             optimistic_tx,
             native,
         })
@@ -543,10 +543,10 @@ impl TryFrom<TransactionBlockEffects> for TransactionBlock {
     fn try_from(effects: TransactionBlockEffects) -> Result<Self, Error> {
         let checkpoint_viewed_at = effects.checkpoint_viewed_at;
         let inner = match effects.kind {
-            TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
+            TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
                 TransactionBlockInner::try_from(stored_tx.clone())
             }
-            TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+            TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
                 TransactionBlockInner::try_from(optimistic_tx.clone())
             }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -56,15 +56,15 @@ pub(crate) struct TransactionBlockEffects {
 
 #[derive(Clone, Debug)]
 pub(crate) enum TransactionBlockEffectsKind {
-    /// A transaction that has been indexed and stored in the database,
+    /// A transaction that has been checkpointed and stored in the database,
     /// containing all information that the other two variants have, and more.
-    Stored {
+    Checkpointed {
         stored_tx: StoredTransaction,
         native: NativeTransactionEffects,
     },
-    /// A transaction block that has been executed but not yet indexed,
-    /// stored in the optimistic transactions table.
-    ExecutedOptimistically {
+    /// A transaction block that has been executed and indexed without
+    /// checkpoint information.
+    Executed {
         optimistic_tx: OptimisticTransaction,
         native: NativeTransactionEffects,
     },
@@ -339,10 +339,8 @@ impl TransactionBlockEffects {
 
         // Determine the source based on the transaction block effects kind
         let source = match &self.kind {
-            TransactionBlockEffectsKind::Stored { .. } => ObjectChangeSource::Stored,
-            TransactionBlockEffectsKind::ExecutedOptimistically { .. } => {
-                ObjectChangeSource::ExecutedOptimistically
-            }
+            TransactionBlockEffectsKind::Checkpointed { .. } => ObjectChangeSource::Checkpointed,
+            TransactionBlockEffectsKind::Executed { .. } => ObjectChangeSource::Executed,
             TransactionBlockEffectsKind::DryRun { .. } => ObjectChangeSource::DryRun,
         };
 
@@ -375,8 +373,10 @@ impl TransactionBlockEffects {
         let mut connection = Connection::new(false, false);
 
         let balance_len = match &self.kind {
-            TransactionBlockEffectsKind::Stored { stored_tx, .. } => stored_tx.get_balance_len(),
-            TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+            TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
+                stored_tx.get_balance_len()
+            }
+            TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
                 optimistic_tx.get_balance_len()
             }
             // DryRun variant doesn't have balance changes available
@@ -394,10 +394,10 @@ impl TransactionBlockEffects {
 
         for c in cs {
             let serialized = match &self.kind {
-                TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
+                TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
                     stored_tx.get_balance_at_idx(c.ix)
                 }
-                TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+                TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
                     optimistic_tx.get_balance_at_idx(c.ix)
                 }
                 _ => None,
@@ -428,8 +428,10 @@ impl TransactionBlockEffects {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let mut connection = Connection::new(false, false);
         let len = match &self.kind {
-            TransactionBlockEffectsKind::Stored { stored_tx, .. } => stored_tx.get_event_len(),
-            TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+            TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
+                stored_tx.get_event_len()
+            }
+            TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
                 optimistic_tx.get_event_len()
             }
             TransactionBlockEffectsKind::DryRun { events, .. } => events.len(),
@@ -445,10 +447,10 @@ impl TransactionBlockEffects {
 
         for c in cs {
             let event = match &self.kind {
-                TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
+                TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
                     Event::try_from_stored_transaction(stored_tx, c.ix, c.c).extend()?
                 }
-                TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+                TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
                     Event::try_from_optimistic_transaction(optimistic_tx, c.ix, c.c).extend()?
                 }
                 TransactionBlockEffectsKind::DryRun { events, .. } => Event {
@@ -466,7 +468,7 @@ impl TransactionBlockEffects {
     /// Timestamp corresponding to the checkpoint this transaction was finalized
     /// in.
     async fn timestamp(&self) -> Result<Option<DateTime>, Error> {
-        let TransactionBlockEffectsKind::Stored { stored_tx, .. } = &self.kind else {
+        let TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } = &self.kind else {
             return Ok(None);
         };
         Ok(Some(DateTime::from_ms(stored_tx.timestamp_ms)?))
@@ -485,9 +487,9 @@ impl TransactionBlockEffects {
 
     /// The checkpoint this transaction was finalized in.
     async fn checkpoint(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        // If the transaction data is not a stored transaction, it's not in the
+        // If the transaction data is not a checkpointed transaction, it's not in the
         // checkpoint yet so we return None.
-        let TransactionBlockEffectsKind::Stored { stored_tx, .. } = &self.kind else {
+        let TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } = &self.kind else {
             return Ok(None);
         };
 
@@ -503,8 +505,10 @@ impl TransactionBlockEffects {
     /// Base64 encoded bcs serialization of the on-chain transaction effects.
     async fn bcs(&self) -> Result<Base64> {
         let bytes = match &self.kind {
-            TransactionBlockEffectsKind::Stored { stored_tx, .. } => stored_tx.raw_effects.clone(),
-            TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+            TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
+                stored_tx.raw_effects.clone()
+            }
+            TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
                 optimistic_tx.raw_effects.clone()
             }
             _ => bcs::to_bytes(&self.native())
@@ -519,9 +523,9 @@ impl TransactionBlockEffects {
 impl TransactionBlockEffects {
     fn native(&self) -> &NativeTransactionEffects {
         match &self.kind {
-            TransactionBlockEffectsKind::Stored { native, .. } => native,
+            TransactionBlockEffectsKind::Checkpointed { native, .. } => native,
             TransactionBlockEffectsKind::DryRun { native, .. } => native,
-            TransactionBlockEffectsKind::ExecutedOptimistically { native, .. } => native,
+            TransactionBlockEffectsKind::Executed { native, .. } => native,
         }
     }
 
@@ -530,7 +534,7 @@ impl TransactionBlockEffects {
     /// should not occur.
     fn transaction_data(&self) -> Result<NativeTransactionData> {
         Ok(match &self.kind {
-            TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
+            TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
                 let s: NativeSenderSignedData = bcs::from_bytes(&stored_tx.raw_transaction)
                     .map_err(|e| {
                         Error::Internal(format!("Error deserializing transaction data: {e}"))
@@ -538,7 +542,7 @@ impl TransactionBlockEffects {
                 s.transaction_data().clone()
             }
             TransactionBlockEffectsKind::DryRun { tx_data, .. } => tx_data.clone(),
-            TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+            TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
                 let data: NativeSenderSignedData = bcs::from_bytes(&optimistic_tx.raw_transaction)
                     .map_err(|e| {
                         Error::Internal(format!("Error deserializing transaction data: {e}"))
@@ -626,7 +630,7 @@ impl TryFrom<OptimisticTransaction> for TransactionBlockEffectsKind {
             ))
         })?;
 
-        Ok(TransactionBlockEffectsKind::ExecutedOptimistically {
+        Ok(TransactionBlockEffectsKind::Executed {
             optimistic_tx,
             native,
         })
@@ -639,9 +643,9 @@ impl TryFrom<TransactionBlock> for TransactionBlockEffects {
     fn try_from(block: TransactionBlock) -> Result<Self, Error> {
         let checkpoint_viewed_at = block.checkpoint_viewed_at;
         let kind = match block.inner {
-            TransactionBlockInner::Stored { stored_tx, .. } => {
+            TransactionBlockInner::Checkpointed { stored_tx, .. } => {
                 bcs::from_bytes(&stored_tx.raw_effects)
-                    .map(|native| TransactionBlockEffectsKind::Stored {
+                    .map(|native| TransactionBlockEffectsKind::Checkpointed {
                         stored_tx: stored_tx.clone(),
                         native,
                     })
@@ -649,7 +653,7 @@ impl TryFrom<TransactionBlock> for TransactionBlockEffects {
                         Error::Internal(format!("Error deserializing transaction effects: {e}"))
                     })
             }
-            TransactionBlockInner::ExecutedOptimistically { optimistic_tx, .. } => {
+            TransactionBlockInner::Executed { optimistic_tx, .. } => {
                 TransactionBlockEffectsKind::try_from(optimistic_tx.clone())
             }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -7,7 +7,7 @@ use async_graphql::{
     *,
 };
 use fastcrypto::encoding::{Base64 as FBase64, Encoding};
-use iota_indexer::models::transactions::StoredTransaction;
+use iota_indexer::models::transactions::{OptimisticTransaction, StoredTransaction};
 use iota_package_resolver::{CleverError, ErrorConstants};
 use iota_types::{
     effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
@@ -37,7 +37,7 @@ use crate::{
         epoch::Epoch,
         event::Event,
         gas::GasEffects,
-        object_change::ObjectChange,
+        object_change::{ObjectChange, ObjectChangeSource},
         transaction_block::{TransactionBlock, TransactionBlockInner},
         uint53::UInt53,
         unchanged_shared_object::UnchangedSharedObject,
@@ -62,14 +62,13 @@ pub(crate) enum TransactionBlockEffectsKind {
         stored_tx: StoredTransaction,
         native: NativeTransactionEffects,
     },
-    /// A transaction block that has been executed via executeTransactionBlock
-    /// but not yet indexed. So it does not contain checkpoint, timestamp or
-    /// balanceChanges.
-    Executed {
-        tx_data: NativeSenderSignedData,
+    /// A transaction block that has been executed but not yet indexed,
+    /// stored in the optimistic transactions table.
+    ExecutedOptimistically {
+        optimistic_tx: OptimisticTransaction,
         native: NativeTransactionEffects,
-        events: Vec<NativeEvent>,
     },
+
     /// A transaction block that has been executed via dryRunTransactionBlock.
     /// Similar to Executed, it does not contain checkpoint, timestamp or
     /// balanceChanges.
@@ -338,10 +337,20 @@ impl TransactionBlockEffects {
         connection.has_previous_page = prev;
         connection.has_next_page = next;
 
+        // Determine the source based on the transaction block effects kind
+        let source = match &self.kind {
+            TransactionBlockEffectsKind::Stored { .. } => ObjectChangeSource::Stored,
+            TransactionBlockEffectsKind::ExecutedOptimistically { .. } => {
+                ObjectChangeSource::ExecutedOptimistically
+            }
+            TransactionBlockEffectsKind::DryRun { .. } => ObjectChangeSource::DryRun,
+        };
+
         for c in cs {
             let object_change = ObjectChange {
                 native: object_changes[c.ix].clone(),
                 checkpoint_viewed_at: c.c,
+                source: source.clone(),
             };
 
             connection
@@ -365,12 +374,17 @@ impl TransactionBlockEffects {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let mut connection = Connection::new(false, false);
 
-        let TransactionBlockEffectsKind::Stored { stored_tx, .. } = &self.kind else {
-            return Ok(connection);
+        let balance_len = match &self.kind {
+            TransactionBlockEffectsKind::Stored { stored_tx, .. } => stored_tx.get_balance_len(),
+            TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+                optimistic_tx.get_balance_len()
+            }
+            // DryRun variant doesn't have balance changes available
+            _ => return Ok(connection),
         };
 
-        let Some((prev, next, _, cs)) = page
-            .paginate_consistent_indices(stored_tx.get_balance_len(), self.checkpoint_viewed_at)?
+        let Some((prev, next, _, cs)) =
+            page.paginate_consistent_indices(balance_len, self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
@@ -379,11 +393,21 @@ impl TransactionBlockEffects {
         connection.has_next_page = next;
 
         for c in cs {
-            let Some(serialized) = &stored_tx.get_balance_at_idx(c.ix) else {
+            let serialized = match &self.kind {
+                TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
+                    stored_tx.get_balance_at_idx(c.ix)
+                }
+                TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+                    optimistic_tx.get_balance_at_idx(c.ix)
+                }
+                _ => None,
+            };
+
+            let Some(serialized) = serialized else {
                 continue;
             };
 
-            let balance_change = BalanceChange::read(serialized, c.c).extend()?;
+            let balance_change = BalanceChange::read(&serialized, c.c).extend()?;
             connection
                 .edges
                 .push(Edge::new(c.encode_cursor(), balance_change));
@@ -405,8 +429,10 @@ impl TransactionBlockEffects {
         let mut connection = Connection::new(false, false);
         let len = match &self.kind {
             TransactionBlockEffectsKind::Stored { stored_tx, .. } => stored_tx.get_event_len(),
-            TransactionBlockEffectsKind::Executed { events, .. }
-            | TransactionBlockEffectsKind::DryRun { events, .. } => events.len(),
+            TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+                optimistic_tx.get_event_len()
+            }
+            TransactionBlockEffectsKind::DryRun { events, .. } => events.len(),
         };
         let Some((prev, next, _, cs)) =
             page.paginate_consistent_indices(len, self.checkpoint_viewed_at)?
@@ -422,8 +448,10 @@ impl TransactionBlockEffects {
                 TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
                     Event::try_from_stored_transaction(stored_tx, c.ix, c.c).extend()?
                 }
-                TransactionBlockEffectsKind::Executed { events, .. }
-                | TransactionBlockEffectsKind::DryRun { events, .. } => Event {
+                TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+                    Event::try_from_optimistic_transaction(optimistic_tx, c.ix, c.c).extend()?
+                }
+                TransactionBlockEffectsKind::DryRun { events, .. } => Event {
                     stored: None,
                     native: events[c.ix].clone(),
                     checkpoint_viewed_at: c.c,
@@ -474,12 +502,14 @@ impl TransactionBlockEffects {
 
     /// Base64 encoded bcs serialization of the on-chain transaction effects.
     async fn bcs(&self) -> Result<Base64> {
-        let bytes = if let TransactionBlockEffectsKind::Stored { stored_tx, .. } = &self.kind {
-            stored_tx.raw_effects.clone()
-        } else {
-            bcs::to_bytes(&self.native())
+        let bytes = match &self.kind {
+            TransactionBlockEffectsKind::Stored { stored_tx, .. } => stored_tx.raw_effects.clone(),
+            TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+                optimistic_tx.raw_effects.clone()
+            }
+            _ => bcs::to_bytes(&self.native())
                 .map_err(|e| Error::Internal(format!("Error serializing transaction effects: {e}")))
-                .extend()?
+                .extend()?,
         };
 
         Ok(Base64::from(bytes))
@@ -490,8 +520,8 @@ impl TransactionBlockEffects {
     fn native(&self) -> &NativeTransactionEffects {
         match &self.kind {
             TransactionBlockEffectsKind::Stored { native, .. } => native,
-            TransactionBlockEffectsKind::Executed { native, .. } => native,
             TransactionBlockEffectsKind::DryRun { native, .. } => native,
+            TransactionBlockEffectsKind::ExecutedOptimistically { native, .. } => native,
         }
     }
 
@@ -507,10 +537,14 @@ impl TransactionBlockEffects {
                     })?;
                 s.transaction_data().clone()
             }
-            TransactionBlockEffectsKind::Executed { tx_data, .. } => {
-                tx_data.transaction_data().clone()
-            }
             TransactionBlockEffectsKind::DryRun { tx_data, .. } => tx_data.clone(),
+            TransactionBlockEffectsKind::ExecutedOptimistically { optimistic_tx, .. } => {
+                let data: NativeSenderSignedData = bcs::from_bytes(&optimistic_tx.raw_transaction)
+                    .map_err(|e| {
+                        Error::Internal(format!("Error deserializing transaction data: {e}"))
+                    })?;
+                data.transaction_data().clone()
+            }
         })
     }
 
@@ -582,6 +616,23 @@ impl EdgeNameType for DependencyConnectionNames {
     }
 }
 
+impl TryFrom<OptimisticTransaction> for TransactionBlockEffectsKind {
+    type Error = Error;
+
+    fn try_from(optimistic_tx: OptimisticTransaction) -> Result<Self, Error> {
+        let native = bcs::from_bytes(&optimistic_tx.raw_effects).map_err(|e| {
+            Error::Internal(format!(
+                "Failed to deserialize NativeTransactionEffects from optimistic transaction: {e}"
+            ))
+        })?;
+
+        Ok(TransactionBlockEffectsKind::ExecutedOptimistically {
+            optimistic_tx,
+            native,
+        })
+    }
+}
+
 impl TryFrom<TransactionBlock> for TransactionBlockEffects {
     type Error = Error;
 
@@ -598,15 +649,10 @@ impl TryFrom<TransactionBlock> for TransactionBlockEffects {
                         Error::Internal(format!("Error deserializing transaction effects: {e}"))
                     })
             }
-            TransactionBlockInner::Executed {
-                tx_data,
-                effects,
-                events,
-            } => Ok(TransactionBlockEffectsKind::Executed {
-                tx_data,
-                native: effects,
-                events,
-            }),
+            TransactionBlockInner::ExecutedOptimistically { optimistic_tx, .. } => {
+                TransactionBlockEffectsKind::try_from(optimistic_tx.clone())
+            }
+
             TransactionBlockInner::DryRun {
                 tx_data,
                 effects,

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -33,7 +33,7 @@ pub struct ObjectRefColumn {
 // NOTE: please add updating statement like below in pg_indexer_store.rs,
 // if new columns are added here:
 // objects::epoch.eq(excluded(objects::epoch))
-#[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
+#[derive(Queryable, Selectable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
 #[diesel(table_name = objects, primary_key(object_id))]
 pub struct StoredObject {
     pub object_id: Vec<u8>,

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -200,6 +200,30 @@ impl OptimisticTransaction {
             success_command_count: stored.success_command_count,
         }
     }
+
+    pub fn get_balance_len(&self) -> usize {
+        self.balance_changes.len()
+    }
+
+    pub fn get_balance_at_idx(&self, idx: usize) -> Option<Vec<u8>> {
+        self.balance_changes.get(idx).cloned().flatten()
+    }
+
+    pub fn get_object_len(&self) -> usize {
+        self.object_changes.len()
+    }
+
+    pub fn get_object_at_idx(&self, idx: usize) -> Option<Vec<u8>> {
+        self.object_changes.get(idx).cloned().flatten()
+    }
+
+    pub fn get_event_len(&self) -> usize {
+        self.events.len()
+    }
+
+    pub fn get_event_at_idx(&self, idx: usize) -> Option<Vec<u8>> {
+        self.events.get(idx).cloned().flatten()
+    }
 }
 
 pub type StoredTransactionEvents = Vec<Option<Vec<u8>>>;


### PR DESCRIPTION
# Description of change

Introduces the `ExecutedOptimistically` transaction kind variant to represent transactions that are optimistically indexed, but not yet checkpointed. This replaces the previous `Executed` variant, as it's no longer needed. (we don't have transactions now that are executed, but not optimistically indexed)

This change should allow us later to return optimistic transactions from Graphql getTransactionBlock query.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/8648

## How the change has been tested

`cargo nextest run -p iota-graphql-rpc --release --features pg_integration --no-fail-fast --test-threads 1`

`cargo run --features indexer --release --bin iota start --with-faucet --force-regenesis --with-indexer --with-graphql` followed by `cd sdk/graphql-transport && npm run test:e2e`

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
