### PR TITLE
feat(graphql): add subscriptions support for events and transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6362,6 +6362,7 @@ dependencies = [
  "test-cluster",
  "thiserror 1.0.64",
  "tokio",
+ "tokio-stream",
  "tokio-util 0.7.12",
  "toml 0.7.8",
  "tower 0.4.13",

--- a/crates/iota-graphql-rpc/Cargo.toml
+++ b/crates/iota-graphql-rpc/Cargo.toml
@@ -40,6 +40,7 @@ tap.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
 toml.workspace = true
 tower.workspace = true

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -4279,6 +4279,49 @@ type StorageFund {
 	nonRefundableBalance: BigInt
 }
 
+type Subscription {
+	"""
+	Subscribe to incoming transactions from the IOTA network.
+	
+	If no filter is provided, all transactions will be returned.
+	"""
+	transactions(filter: SubscriptionTransactionFilter): TransactionBlock!
+	"""
+	Subscribe to incoming events from the IOTA network.
+	
+	If no filter is provided, all events will be returned.
+	"""
+	events(filter: SubscriptionEventFilter): Event!
+}
+
+"""
+Filter incoming events in a subscription.
+"""
+input SubscriptionEventFilter @oneOf {
+	"""
+	Filter incoming events by emitting module.
+	"""
+	emittingModule: String
+}
+
+"""
+Filter incoming transactions in a subscription.
+"""
+input SubscriptionTransactionFilter @oneOf {
+	"""
+	Filter incoming transactions by kind.
+	"""
+	kind: TransactionBlockKindInput
+	"""
+	Filter incoming transactions by signing address.
+	"""
+	signingAddress: IotaAddress
+	"""
+	Filter incoming transactions by package, module, or function name.
+	"""
+	function: String
+}
+
 """
 Details of the system that are decided during genesis.
 """
@@ -4953,10 +4996,15 @@ Directs the executor to include this field or fragment only when the `if` argume
 """
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 """
+Indicates that an Input Object is a OneOf Input Object (and thus requires exactly one of its field be provided)
+"""
+directive @oneOf on INPUT_OBJECT
+"""
 Directs the executor to skip this field or fragment when the `if` argument is true.
 """
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 schema {
 	query: Query
 	mutation: Mutation
+	subscription: Subscription
 }

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -1380,6 +1380,16 @@ input EventFilter {
 }
 
 """
+Possible responses from a subscription.
+
+It could be one of the following:
+- A successful payload from the subscription stream.
+- A notice that the subscription has been lagged behind the network with the
+number of lost payloads.
+"""
+union EventSubscriptionPayload = Event | Lagged
+
+"""
 The result of an execution, including errors that occurred during said
 execution.
 """
@@ -1694,6 +1704,17 @@ scalar IotaAddress
 Arbitrary JSON data.
 """
 scalar JSON
+
+"""
+Notifies that the subscription consumer has fallen behind the live
+subscription stream and missed one or more payloads.
+"""
+type Lagged {
+	"""
+	Number of missed payloads since the previous emitted one.
+	"""
+	count: Int!
+}
 
 """
 Information used by a package to link to a specific version of its
@@ -4285,13 +4306,13 @@ type Subscription {
 	
 	If no filter is provided, all transactions will be returned.
 	"""
-	transactions(filter: SubscriptionTransactionFilter): TransactionBlock!
+	transactions(filter: SubscriptionTransactionFilter): TransactionBlockSubscriptionPayload!
 	"""
 	Subscribe to incoming events from the IOTA network.
 	
 	If no filter is provided, all events will be returned.
 	"""
-	events(filter: SubscriptionEventFilter): Event!
+	events(filter: SubscriptionEventFilter): EventSubscriptionPayload!
 }
 
 """
@@ -4300,6 +4321,9 @@ Filter incoming events in a subscription.
 input SubscriptionEventFilter @oneOf {
 	"""
 	Filter incoming events by emitting module.
+	
+	- Filter by package: "0x02"
+	- Filter by module: "0x02::coin"
 	"""
 	emittingModule: String
 }
@@ -4318,6 +4342,10 @@ input SubscriptionTransactionFilter @oneOf {
 	signingAddress: IotaAddress
 	"""
 	Filter incoming transactions by package, module, or function name.
+	
+	- Filter by package: "0x03"
+	- Filter by module: "0x03::iota_system"
+	- Filter by function: "0x03::iota_system::request_add_stake"
 	"""
 	function: String
 }
@@ -4573,6 +4601,16 @@ enum TransactionBlockKindInput {
 	"""
 	END_OF_EPOCH_TX
 }
+
+"""
+Possible responses from a subscription.
+
+It could be one of the following:
+- A successful payload from the subscription stream.
+- A notice that the subscription has been lagged behind the network with the
+number of lost payloads.
+"""
+union TransactionBlockSubscriptionPayload = TransactionBlock | Lagged
 
 union TransactionInput = OwnedOrImmutable | SharedInput | Receiving | Pure
 

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -553,9 +553,10 @@ pub fn export_schema() -> String {
     schema_builder().finish().sdl()
 }
 
-/// Entry point for graphql requests. Each request is stamped with a unique ID,
-/// a `ShowUsage` flag if set in the request headers, and the watermark as set
-/// by the background task.
+/// Entry point for graphql requests.
+///
+/// Each request is stamped with a unique ID, a `ShowUsage` flag if set in the
+/// request headers, and the watermark as set by the background task.
 async fn graphql_handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     schema: Extension<IotaGraphQLSchema>,
@@ -586,9 +587,11 @@ async fn graphql_handler(
     (extensions, result.into())
 }
 
-/// Entry point for graphql streaming requests. Each request is stamped with a
-/// unique ID, a `ShowUsage` flag if set in the request headers and tracks the
-/// connection information produced by the client.
+/// Entry point for graphql streaming requests.
+///
+/// Each request is stamped with a unique ID, a `ShowUsage` flag if set in the
+/// request headers and tracks the connection information produced by the
+/// client.
 async fn subscription_handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Extension(schema): Extension<IotaGraphQLSchema>,

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -11,17 +11,20 @@ use std::{
 };
 
 use async_graphql::{
-    EmptySubscription, Schema, SchemaBuilder,
+    Data, Schema, SchemaBuilder,
     extensions::{ApolloTracing, ExtensionFactory, Tracing},
+    http::ALL_WEBSOCKET_PROTOCOLS,
 };
-use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
+use async_graphql_axum::{GraphQLProtocol, GraphQLRequest, GraphQLResponse, GraphQLWebSocket};
 use axum::{
     Extension, Router,
     body::Body,
-    extract::{ConnectInfo, FromRef, Query as AxumQuery, State},
+    extract::{
+        ConnectInfo, FromRef, FromRequestParts, Query as AxumQuery, State, ws::WebSocketUpgrade,
+    },
     http::{HeaderMap, StatusCode},
     middleware::{self},
-    response::IntoResponse,
+    response::{IntoResponse, Response as AxumResponse},
     routing::{MethodRouter, Route, get, post},
 };
 use chrono::Utc;
@@ -71,6 +74,7 @@ use crate::{
         object::IObject,
         owner::IOwner,
         query::{IotaGraphQLSchema, Query},
+        subscription::{GraphQLStream, Subscription},
     },
 };
 
@@ -166,7 +170,7 @@ impl Server {
 
 pub(crate) struct ServerBuilder {
     state: AppState,
-    schema: SchemaBuilder<Query, Mutation, EmptySubscription>,
+    schema: SchemaBuilder<Query, Mutation, Subscription>,
     router: Option<Router>,
     db_reader: Option<Db>,
     resolver: Option<PackageResolver>,
@@ -239,7 +243,7 @@ impl ServerBuilder {
         self
     }
 
-    fn build_schema(self) -> Schema<Query, Mutation, EmptySubscription> {
+    fn build_schema(self) -> Schema<Query, Mutation, Subscription> {
         self.schema.finish()
     }
 
@@ -249,7 +253,7 @@ impl ServerBuilder {
         self,
     ) -> (
         String,
-        Schema<Query, Mutation, EmptySubscription>,
+        Schema<Query, Mutation, Subscription>,
         Db,
         PackageResolver,
         Router,
@@ -275,9 +279,16 @@ impl ServerBuilder {
         if self.router.is_none() {
             let router: Router = Router::new()
                 .route("/", post(graphql_handler))
+                .route("/subscriptions", get(subscription_handler))
                 .route("/{version}", post(graphql_handler))
+                .route("/{version}/subscriptions", get(subscription_handler))
                 .route("/graphql", post(graphql_handler))
+                .route("/graphql/subscriptions", get(subscription_handler))
                 .route("/graphql/{version}", post(graphql_handler))
+                .route(
+                    "/graphql/{version}/subscriptions",
+                    get(subscription_handler),
+                )
                 .route("/health", get(health_check))
                 .route("/graphql/health", get(health_check))
                 .route("/graphql/{version}/health", get(health_check))
@@ -327,8 +338,8 @@ impl ServerBuilder {
         info!("Access control allow origin set to: {acl:?}");
 
         let cors = CorsLayer::new()
-            // Allow `POST` when accessing the resource
-            .allow_methods([Method::POST])
+            // Allow `POST` & `GET` when accessing the resource
+            .allow_methods([Method::POST, Method::GET])
             // Allow requests from any origin
             .allow_origin(acl)
             .allow_headers([hyper::header::CONTENT_TYPE, LIMITS_HEADER.clone()]);
@@ -479,6 +490,8 @@ impl ServerBuilder {
             None
         };
 
+        let graphql_streams = GraphQLStream::new(&config.connection.db_url, reader).await?;
+
         builder = builder
             .context_data(config.service.clone())
             .context_data(loader)
@@ -489,7 +502,8 @@ impl ServerBuilder {
             .context_data(iota_names_config)
             .context_data(zklogin_config)
             .context_data(metrics.clone())
-            .context_data(config.clone());
+            .context_data(config.clone())
+            .context_data(graphql_streams);
 
         if config.internal_features.feature_gate {
             builder = builder.extension(FeatureGate);
@@ -526,8 +540,8 @@ impl ServerBuilder {
     }
 }
 
-fn schema_builder() -> SchemaBuilder<Query, Mutation, EmptySubscription> {
-    async_graphql::Schema::build(Query, Mutation, EmptySubscription)
+fn schema_builder() -> SchemaBuilder<Query, Mutation, Subscription> {
+    async_graphql::Schema::build(Query, Mutation, Subscription)
         .register_output_type::<IMoveObject>()
         .register_output_type::<IObject>()
         .register_output_type::<IOwner>()
@@ -570,6 +584,47 @@ async fn graphql_handler(
         extensions.insert(GraphqlErrors(std::sync::Arc::new(result.errors.clone())));
     };
     (extensions, result.into())
+}
+
+/// Entry point for graphql streaming requests. Each request is stamped with a
+/// unique ID, a `ShowUsage` flag if set in the request headers and tracks the
+/// connection information produced by the client.
+async fn subscription_handler(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    Extension(schema): Extension<IotaGraphQLSchema>,
+    req: http::Request<Body>,
+) -> AxumResponse {
+    let headers_contains_show_usage = req.headers().contains_key(ShowUsage::name());
+    let (mut parts, _body) = req.into_parts();
+
+    // extract GraphQL protocol
+    let protocol = match GraphQLProtocol::from_request_parts(&mut parts, &()).await {
+        Ok(protocol) => protocol,
+        Err(err) => return err.into_response(),
+    };
+
+    // extract WebSocket upgrade from request
+    let upgrade = match WebSocketUpgrade::from_request_parts(&mut parts, &()).await {
+        Ok(upgrade) => upgrade,
+        Err(err) => return err.into_response(),
+    };
+
+    let resp = upgrade
+        .protocols(ALL_WEBSOCKET_PROTOCOLS)
+        .on_upgrade(move |stream| async move {
+            // create connection data with per-connection values
+            let mut connection_data = Data::default();
+            connection_data.insert(Uuid::new_v4());
+            if headers_contains_show_usage {
+                connection_data.insert(ShowUsage)
+            }
+            connection_data.insert(addr);
+
+            let connection =
+                GraphQLWebSocket::new(stream, schema, protocol).with_data(connection_data);
+            connection.serve().await;
+        });
+    resp
 }
 
 #[derive(Clone)]

--- a/crates/iota-graphql-rpc/src/server/graphiql_server.rs
+++ b/crates/iota-graphql-rpc/src/server/graphiql_server.rs
@@ -21,7 +21,9 @@ async fn graphiql(
     } else {
         "/graphql".to_string()
     };
-    let gq = async_graphql::http::GraphiQLSource::build().endpoint(&endpoint);
+    let gq = async_graphql::http::GraphiQLSource::build()
+        .endpoint(&endpoint)
+        .subscription_endpoint("/subscriptions");
     if let axum::Extension(Some(title)) = ide_title {
         axum::response::Html(gq.title(&title).finish())
     } else {

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -264,7 +264,7 @@ impl Event {
         })
     }
 
-    fn try_from_stored_event(
+    pub(crate) fn try_from_stored_event(
         stored: StoredEvent,
         checkpoint_viewed_at: u64,
     ) -> Result<Self, Error> {

--- a/crates/iota-graphql-rpc/src/types/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/mod.rs
@@ -46,6 +46,7 @@ pub(crate) mod safe_mode;
 pub(crate) mod stake;
 pub(crate) mod storage_fund;
 pub(crate) mod string_input;
+pub(crate) mod subscription;
 pub(crate) mod system_parameters;
 pub(crate) mod system_state_summary;
 pub(crate) mod transaction_block;

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -42,6 +42,7 @@ use crate::{
         object::{self, Object, ObjectFilter},
         owner::Owner,
         protocol_config::ProtocolConfigs,
+        subscription::Subscription,
         transaction_block::{self, TransactionBlock, TransactionBlockFilter},
         transaction_metadata::TransactionMetadata,
         type_filter::ExactTypeFilter,
@@ -53,7 +54,7 @@ use crate::{
 };
 
 pub(crate) struct Query;
-pub(crate) type IotaGraphQLSchema = async_graphql::Schema<Query, Mutation, EmptySubscription>;
+pub(crate) type IotaGraphQLSchema = async_graphql::Schema<Query, Mutation, Subscription>;
 
 #[Object]
 impl Query {

--- a/crates/iota-graphql-rpc/src/types/subscription/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/filter.rs
@@ -16,6 +16,9 @@ use crate::types::{
 #[derive(OneofObject, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum SubscriptionEventFilter {
     /// Filter incoming events by emitting module.
+    ///
+    /// - Filter by package: "0x02"
+    /// - Filter by module: "0x02::coin"
     EmittingModule(ModuleFilter),
 }
 
@@ -44,6 +47,10 @@ pub(crate) enum SubscriptionTransactionFilter {
     /// Filter incoming transactions by signing address.
     SigningAddress(IotaAddress),
     /// Filter incoming transactions by package, module, or function name.
+    ///
+    /// - Filter by package: "0x03"
+    /// - Filter by module: "0x03::iota_system"
+    /// - Filter by function: "0x03::iota_system::request_add_stake"
     Function(FqNameFilter),
 }
 

--- a/crates/iota-graphql-rpc/src/types/subscription/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/filter.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::OneofObject;
+use iota_indexer::stream::{ModuleFunction, StreamEventFilter, StreamTransactionFilter};
+use iota_json_rpc_types::IotaTransactionKind;
+use iota_types::base_types::ObjectID;
+
+use crate::types::{
+    iota_address::IotaAddress,
+    transaction_block::TransactionBlockKindInput,
+    type_filter::{FqNameFilter, ModuleFilter},
+};
+
+/// Filter incoming events in a subscription.
+#[derive(OneofObject, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SubscriptionEventFilter {
+    /// Filter incoming events by emitting module.
+    EmittingModule(ModuleFilter),
+}
+
+impl From<SubscriptionEventFilter> for StreamEventFilter {
+    fn from(value: SubscriptionEventFilter) -> Self {
+        use SubscriptionEventFilter::*;
+        match value {
+            EmittingModule(ModuleFilter::ByPackage(package)) => {
+                StreamEventFilter::EmittingPackage(package.into())
+            }
+            EmittingModule(ModuleFilter::ByModule(package, module)) => {
+                StreamEventFilter::EmittingModule {
+                    package: package.into(),
+                    module,
+                }
+            }
+        }
+    }
+}
+
+/// Filter incoming transactions in a subscription.
+#[derive(OneofObject, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SubscriptionTransactionFilter {
+    /// Filter incoming transactions by kind.
+    Kind(TransactionBlockKindInput),
+    /// Filter incoming transactions by signing address.
+    SigningAddress(IotaAddress),
+    /// Filter incoming transactions by package, module, or function name.
+    Function(FqNameFilter),
+}
+
+impl From<SubscriptionTransactionFilter> for StreamTransactionFilter {
+    fn from(value: SubscriptionTransactionFilter) -> Self {
+        use SubscriptionTransactionFilter::*;
+        match value {
+            Kind(kind) => StreamTransactionFilter::Kind(kind.into()),
+            SigningAddress(address) => StreamTransactionFilter::SigningAddress(address.into()),
+            Function(name) => {
+                let (package, module) = name.into();
+                StreamTransactionFilter::Function { package, module }
+            }
+        }
+    }
+}
+
+impl From<TransactionBlockKindInput> for IotaTransactionKind {
+    fn from(value: TransactionBlockKindInput) -> Self {
+        match value {
+            TransactionBlockKindInput::SystemTx => IotaTransactionKind::SystemTransaction,
+            TransactionBlockKindInput::ProgrammableTx => {
+                IotaTransactionKind::ProgrammableTransaction
+            }
+            TransactionBlockKindInput::Genesis => IotaTransactionKind::Genesis,
+            TransactionBlockKindInput::ConsensusCommitPrologueV1 => {
+                IotaTransactionKind::ConsensusCommitPrologueV1
+            }
+            TransactionBlockKindInput::AuthenticatorStateUpdateV1 => {
+                IotaTransactionKind::AuthenticatorStateUpdateV1
+            }
+            TransactionBlockKindInput::RandomnessStateUpdate => {
+                IotaTransactionKind::RandomnessStateUpdate
+            }
+            TransactionBlockKindInput::EndOfEpochTx => IotaTransactionKind::EndOfEpochTransaction,
+        }
+    }
+}
+
+impl From<FqNameFilter> for (ObjectID, Option<ModuleFunction>) {
+    fn from(value: FqNameFilter) -> Self {
+        use FqNameFilter::*;
+        match value {
+            ByModule(ModuleFilter::ByPackage(package)) => (package.into(), None),
+            ByModule(ModuleFilter::ByModule(package, module_name)) => (
+                package.into(),
+                Some(ModuleFunction {
+                    module_name,
+                    function_name: None,
+                }),
+            ),
+            ByFqName(package, module_name, function_name) => (
+                package.into(),
+                Some(ModuleFunction {
+                    module_name,
+                    function_name: Some(function_name),
+                }),
+            ),
+        }
+    }
+}

--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use async_graphql::{Context, Subscription};
+use async_graphql::{Context, OutputType, SimpleObject, Subscription, Union};
 use futures::{Stream, StreamExt, future};
 use iota_indexer::{
     indexer_reader::IndexerReader,
@@ -24,6 +24,30 @@ use crate::{
 
 mod filter;
 
+/// Notifies that the subscription consumer has fallen behind the live
+/// subscription stream and missed one or more payloads.
+#[derive(SimpleObject, Clone)]
+pub(crate) struct Lagged {
+    /// Number of missed payloads since the previous emitted one.
+    count: u64,
+}
+
+/// Possible responses from a subscription.
+///
+/// It could be one of the following:
+/// - A successful payload from the subscription stream.
+/// - A notice that the subscription has been lagged behind the network with the
+///   number of lost payloads.
+#[derive(Union, Clone)]
+#[graphql(concrete(name = "EventSubscriptionPayload", params(Event)))]
+#[graphql(concrete(name = "TransactionBlockSubscriptionPayload", params(TransactionBlock)))]
+pub(crate) enum SubscriptionItem<T: OutputType> {
+    /// Successfully received payload from the subscription stream.
+    Payload(T),
+    /// A notice that the subscription has been lagged behind the network.
+    Lagged(Lagged),
+}
+
 /// Subscribe to events and transactions from the IOTA network.
 pub struct Subscription;
 
@@ -36,7 +60,7 @@ impl Subscription {
         &self,
         ctx: &Context<'_>,
         filter: Option<SubscriptionTransactionFilter>,
-    ) -> impl Stream<Item = Result<TransactionBlock, Error>> {
+    ) -> impl Stream<Item = Result<SubscriptionItem<TransactionBlock>, Error>> {
         let streams = ctx.data_unchecked::<GraphQLStream>().clone();
         streams.subscribe_transactions(filter.map(Into::<StreamTransactionFilter>::into))
     }
@@ -48,7 +72,7 @@ impl Subscription {
         &self,
         ctx: &Context<'_>,
         filter: Option<SubscriptionEventFilter>,
-    ) -> impl Stream<Item = Result<Event, Error>> {
+    ) -> impl Stream<Item = Result<SubscriptionItem<Event>, Error>> {
         let streams = ctx.data_unchecked::<GraphQLStream>().clone();
         streams.subscribe_events(filter.map(Into::<StreamEventFilter>::into))
     }
@@ -92,7 +116,7 @@ impl GraphQLStream {
     pub(crate) fn subscribe_transactions(
         &self,
         filter: Option<StreamTransactionFilter>,
-    ) -> impl Stream<Item = Result<TransactionBlock, Error>> {
+    ) -> impl Stream<Item = Result<SubscriptionItem<TransactionBlock>, Error>> {
         self.streamer
             .subscribe_transactions()
             // - Some(Some(item)): Yield the item and continue the stream.
@@ -104,10 +128,14 @@ impl GraphQLStream {
                     return future::ready(None);
                 }
 
-                let Ok(stored) = stored.inspect_err(|BroadcastStreamRecvError::Lagged(count)| {
-                    warn!("subscriber lagging by {count} messages")
-                }) else {
-                    return future::ready(Some(None));
+                let stored = match stored {
+                    Ok(stored) => stored,
+                    Err(BroadcastStreamRecvError::Lagged(count)) => {
+                        warn!("subscriber lagging by {count} messages");
+                        return future::ready(Some(Some(Ok(SubscriptionItem::Lagged(Lagged {
+                            count,
+                        })))));
+                    }
                 };
 
                 if !Self::matches_filter(filter.as_ref(), &stored) {
@@ -121,7 +149,7 @@ impl GraphQLStream {
                             inner,
                             checkpoint_viewed_at,
                         };
-                        future::ready(Some(Some(Ok(tx))))
+                        future::ready(Some(Some(Ok(SubscriptionItem::Payload(tx)))))
                     }
                     Err(e) => {
                         *should_terminate_stream = true;
@@ -136,7 +164,7 @@ impl GraphQLStream {
     pub(crate) fn subscribe_events(
         &self,
         filter: Option<StreamEventFilter>,
-    ) -> impl Stream<Item = Result<Event, Error>> {
+    ) -> impl Stream<Item = Result<SubscriptionItem<Event>, Error>> {
         self.streamer
             .subscribe_events()
             // - Some(Some(item)): Yield the item and continue the stream.
@@ -148,10 +176,14 @@ impl GraphQLStream {
                     return future::ready(None);
                 }
 
-                let Ok(stored) = stored.inspect_err(|BroadcastStreamRecvError::Lagged(count)| {
-                    warn!("subscriber lagging by {count} messages")
-                }) else {
-                    return future::ready(Some(None));
+                let stored = match stored {
+                    Ok(stored) => stored,
+                    Err(BroadcastStreamRecvError::Lagged(count)) => {
+                        warn!("subscriber lagging by {count} messages");
+                        return future::ready(Some(Some(Ok(SubscriptionItem::Lagged(Lagged {
+                            count,
+                        })))));
+                    }
                 };
 
                 if !Self::matches_filter(filter.as_ref(), &stored) {
@@ -159,7 +191,7 @@ impl GraphQLStream {
                 }
 
                 match Event::try_from_stored_event(stored, 0) {
-                    Ok(ev) => future::ready(Some(Some(Ok(ev)))),
+                    Ok(ev) => future::ready(Some(Some(Ok(SubscriptionItem::Payload(ev))))),
                     Err(e) => {
                         *should_terminate_stream = true;
                         future::ready(Some(Some(Err(e))))

--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use async_graphql::{Context, OutputType, SimpleObject, Subscription, Union};
-use futures::{Stream, StreamExt, future};
+use futures::{Stream, StreamExt, TryStreamExt, future};
 use iota_indexer::{
     indexer_reader::IndexerReader,
     stream::{IndexerStreamer, StreamEventFilter, StreamTransactionFilter},
@@ -119,45 +119,34 @@ impl GraphQLStream {
     ) -> impl Stream<Item = Result<SubscriptionItem<TransactionBlock>, Error>> {
         self.streamer
             .subscribe_transactions()
-            // - Some(Some(item)): Yield the item and continue the stream.
-            // - Some(None): Do not yield an item, but continue the stream (used for filtering).
-            // - None: Crucially, this signal stops the entire stream immediately, which is what we
-            // need for server-side dropping of the stream.
-            .scan(false, move |should_terminate_stream, stored| {
+            .try_filter(move |stored| future::ready(Self::matches_filter(filter.as_ref(), stored)))
+            .then(|stored| {
+                let subscription_item = match stored {
+                    Ok(stored) => {
+                        let checkpoint_viewed_at = stored.checkpoint_sequence_number as u64;
+                        TransactionBlockInner::try_from(stored).map(|inner| {
+                            SubscriptionItem::Payload(TransactionBlock {
+                                inner,
+                                checkpoint_viewed_at,
+                            })
+                        })
+                    }
+                    Err(BroadcastStreamRecvError::Lagged(count)) => {
+                        warn!("subscriber lagging by {count} messages");
+                        Ok(SubscriptionItem::Lagged(Lagged { count }))
+                    }
+                };
+                future::ready(subscription_item)
+            })
+            // intercept the error, send it to the client and terminate the stream.
+            .scan(false, |should_terminate_stream, subscription_item| {
                 if *should_terminate_stream {
                     return future::ready(None);
                 }
-
-                let stored = match stored {
-                    Ok(stored) => stored,
-                    Err(BroadcastStreamRecvError::Lagged(count)) => {
-                        warn!("subscriber lagging by {count} messages");
-                        return future::ready(Some(Some(Ok(SubscriptionItem::Lagged(Lagged {
-                            count,
-                        })))));
-                    }
-                };
-
-                if !Self::matches_filter(filter.as_ref(), &stored) {
-                    return future::ready(Some(None));
-                }
-
-                let checkpoint_viewed_at = stored.checkpoint_sequence_number as u64;
-                match TransactionBlockInner::try_from(stored) {
-                    Ok(inner) => {
-                        let tx = TransactionBlock {
-                            inner,
-                            checkpoint_viewed_at,
-                        };
-                        future::ready(Some(Some(Ok(SubscriptionItem::Payload(tx)))))
-                    }
-                    Err(e) => {
-                        *should_terminate_stream = true;
-                        future::ready(Some(Some(Err(e))))
-                    }
-                }
+                future::ready(Some(
+                    subscription_item.inspect_err(|_| *should_terminate_stream = true),
+                ))
             })
-            .filter_map(future::ready)
     }
 
     /// Subscribe to events from IOTA Network.
@@ -167,37 +156,27 @@ impl GraphQLStream {
     ) -> impl Stream<Item = Result<SubscriptionItem<Event>, Error>> {
         self.streamer
             .subscribe_events()
-            // - Some(Some(item)): Yield the item and continue the stream.
-            // - Some(None): Do not yield an item, but continue the stream (used for filtering).
-            // - None: Crucially, this signal stops the entire stream immediately, which is what we
-            // need for server-side dropping of the stream.
-            .scan(false, move |should_terminate_stream, stored| {
+            .try_filter(move |stored| future::ready(Self::matches_filter(filter.as_ref(), stored)))
+            .then(|stored| {
+                let subscription_item = match stored {
+                    Ok(stored) => {
+                        Event::try_from_stored_event(stored, 0).map(SubscriptionItem::Payload)
+                    }
+                    Err(BroadcastStreamRecvError::Lagged(count)) => {
+                        warn!("subscriber lagging by {count} messages");
+                        Ok(SubscriptionItem::Lagged(Lagged { count }))
+                    }
+                };
+                future::ready(subscription_item)
+            })
+            // intercept the error, send it to the client and terminate the stream.
+            .scan(false, |should_terminate_stream, subscription_item| {
                 if *should_terminate_stream {
                     return future::ready(None);
                 }
-
-                let stored = match stored {
-                    Ok(stored) => stored,
-                    Err(BroadcastStreamRecvError::Lagged(count)) => {
-                        warn!("subscriber lagging by {count} messages");
-                        return future::ready(Some(Some(Ok(SubscriptionItem::Lagged(Lagged {
-                            count,
-                        })))));
-                    }
-                };
-
-                if !Self::matches_filter(filter.as_ref(), &stored) {
-                    return future::ready(Some(None));
-                }
-
-                match Event::try_from_stored_event(stored, 0) {
-                    Ok(ev) => future::ready(Some(Some(Ok(SubscriptionItem::Payload(ev))))),
-                    Err(e) => {
-                        *should_terminate_stream = true;
-                        future::ready(Some(Some(Err(e))))
-                    }
-                }
+                future::ready(Some(
+                    subscription_item.inspect_err(|_| *should_terminate_stream = true),
+                ))
             })
-            .filter_map(future::ready)
     }
 }

--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -1,0 +1,171 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use async_graphql::{Context, Subscription};
+use futures::{Stream, StreamExt, future};
+use iota_indexer::{
+    indexer_reader::IndexerReader,
+    stream::{IndexerStreamer, StreamEventFilter, StreamTransactionFilter},
+};
+use iota_json_rpc_types::Filter;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+use tracing::warn;
+
+use crate::{
+    error::Error,
+    types::{
+        event::Event,
+        subscription::filter::{SubscriptionEventFilter, SubscriptionTransactionFilter},
+        transaction_block::{TransactionBlock, TransactionBlockInner},
+    },
+};
+
+mod filter;
+
+/// Subscribe to events and transactions from the IOTA network.
+pub struct Subscription;
+
+#[Subscription]
+impl Subscription {
+    /// Subscribe to incoming transactions from the IOTA network.
+    ///
+    /// If no filter is provided, all transactions will be returned.
+    async fn transactions(
+        &self,
+        ctx: &Context<'_>,
+        filter: Option<SubscriptionTransactionFilter>,
+    ) -> impl Stream<Item = Result<TransactionBlock, Error>> {
+        let streams = ctx.data_unchecked::<GraphQLStream>().clone();
+        streams.subscribe_transactions(filter.map(Into::<StreamTransactionFilter>::into))
+    }
+
+    /// Subscribe to incoming events from the IOTA network.
+    ///
+    /// If no filter is provided, all events will be returned.
+    async fn events(
+        &self,
+        ctx: &Context<'_>,
+        filter: Option<SubscriptionEventFilter>,
+    ) -> impl Stream<Item = Result<Event, Error>> {
+        let streams = ctx.data_unchecked::<GraphQLStream>().clone();
+        streams.subscribe_events(filter.map(Into::<StreamEventFilter>::into))
+    }
+}
+
+/// Provides real-time data streams for the GraphQL subscription feature.
+///
+/// It wraps the low-level [`IndexerStreamer`] and handles necessary
+/// data processing, filtering, and subscription-specific error handling before
+/// yielding items to GraphQL.
+///
+/// It ensures that when a critical data error occurs during item conversion,
+/// the resulting stream is gracefully terminated by the server.
+#[derive(Clone)]
+pub(crate) struct GraphQLStream {
+    streamer: Arc<IndexerStreamer>,
+}
+
+impl GraphQLStream {
+    pub(crate) async fn new(db_url: &str, indexer_reader: IndexerReader) -> Result<Self, Error> {
+        let streamer = IndexerStreamer::new(db_url, indexer_reader)
+            .await
+            .map_err(|e| Error::Internal(format!("failed to connect to postgres: {e}")))?;
+        Ok(Self {
+            streamer: Arc::new(streamer),
+        })
+    }
+
+    /// Checks if the provided filter matches the item.
+    ///
+    /// If no filter is provided, the item is **always** considered a match, and
+    /// the function returns `true`.
+    fn matches_filter<T, F>(filter: Option<&F>, item: &T) -> bool
+    where
+        F: Filter<T>,
+    {
+        filter.as_ref().map(|f| f.matches(item)).unwrap_or(true)
+    }
+
+    /// Subscribe to transactions from IOTA Network.
+    pub(crate) fn subscribe_transactions(
+        &self,
+        filter: Option<StreamTransactionFilter>,
+    ) -> impl Stream<Item = Result<TransactionBlock, Error>> {
+        self.streamer
+            .subscribe_transactions()
+            // - Some(Some(item)): Yield the item and continue the stream.
+            // - Some(None): Do not yield an item, but continue the stream (used for filtering).
+            // - None: Crucially, this signal stops the entire stream immediately, which is what we
+            // need for server-side dropping of the stream.
+            .scan(false, move |should_terminate_stream, stored| {
+                if *should_terminate_stream {
+                    return future::ready(None);
+                }
+
+                let Ok(stored) = stored.inspect_err(|BroadcastStreamRecvError::Lagged(count)| {
+                    warn!("subscriber lagging by {count} messages")
+                }) else {
+                    return future::ready(Some(None));
+                };
+
+                if !Self::matches_filter(filter.as_ref(), &stored) {
+                    return future::ready(Some(None));
+                }
+
+                let checkpoint_viewed_at = stored.checkpoint_sequence_number as u64;
+                match TransactionBlockInner::try_from(stored) {
+                    Ok(inner) => {
+                        let tx = TransactionBlock {
+                            inner,
+                            checkpoint_viewed_at,
+                        };
+                        future::ready(Some(Some(Ok(tx))))
+                    }
+                    Err(e) => {
+                        *should_terminate_stream = true;
+                        future::ready(Some(Some(Err(e))))
+                    }
+                }
+            })
+            .filter_map(future::ready)
+    }
+
+    /// Subscribe to events from IOTA Network.
+    pub(crate) fn subscribe_events(
+        &self,
+        filter: Option<StreamEventFilter>,
+    ) -> impl Stream<Item = Result<Event, Error>> {
+        self.streamer
+            .subscribe_events()
+            // - Some(Some(item)): Yield the item and continue the stream.
+            // - Some(None): Do not yield an item, but continue the stream (used for filtering).
+            // - None: Crucially, this signal stops the entire stream immediately, which is what we
+            // need for server-side dropping of the stream.
+            .scan(false, move |should_terminate_stream, stored| {
+                if *should_terminate_stream {
+                    return future::ready(None);
+                }
+
+                let Ok(stored) = stored.inspect_err(|BroadcastStreamRecvError::Lagged(count)| {
+                    warn!("subscriber lagging by {count} messages")
+                }) else {
+                    return future::ready(Some(None));
+                };
+
+                if !Self::matches_filter(filter.as_ref(), &stored) {
+                    return future::ready(Some(None));
+                }
+
+                match Event::try_from_stored_event(stored, 0) {
+                    Ok(ev) => future::ready(Some(Some(Ok(ev)))),
+                    Err(e) => {
+                        *should_terminate_stream = true;
+                        future::ready(Some(Some(Err(e))))
+                    }
+                }
+            })
+            .filter_map(future::ready)
+    }
+}

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -4283,6 +4283,49 @@ type StorageFund {
 	nonRefundableBalance: BigInt
 }
 
+type Subscription {
+	"""
+	Subscribe to incoming transactions from the IOTA network.
+	
+	If no filter is provided, all transactions will be returned.
+	"""
+	transactions(filter: SubscriptionTransactionFilter): TransactionBlock!
+	"""
+	Subscribe to incoming events from the IOTA network.
+	
+	If no filter is provided, all events will be returned.
+	"""
+	events(filter: SubscriptionEventFilter): Event!
+}
+
+"""
+Filter incoming events in a subscription.
+"""
+input SubscriptionEventFilter @oneOf {
+	"""
+	Filter incoming events by emitting module.
+	"""
+	emittingModule: String
+}
+
+"""
+Filter incoming transactions in a subscription.
+"""
+input SubscriptionTransactionFilter @oneOf {
+	"""
+	Filter incoming transactions by kind.
+	"""
+	kind: TransactionBlockKindInput
+	"""
+	Filter incoming transactions by signing address.
+	"""
+	signingAddress: IotaAddress
+	"""
+	Filter incoming transactions by package, module, or function name.
+	"""
+	function: String
+}
+
 """
 Details of the system that are decided during genesis.
 """
@@ -4957,10 +5000,15 @@ Directs the executor to include this field or fragment only when the `if` argume
 """
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 """
+Indicates that an Input Object is a OneOf Input Object (and thus requires exactly one of its field be provided)
+"""
+directive @oneOf on INPUT_OBJECT
+"""
 Directs the executor to skip this field or fragment when the `if` argument is true.
 """
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 schema {
 	query: Query
 	mutation: Mutation
+	subscription: Subscription
 }

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1384,6 +1384,16 @@ input EventFilter {
 }
 
 """
+Possible responses from a subscription.
+
+It could be one of the following:
+- A successful payload from the subscription stream.
+- A notice that the subscription has been lagged behind the network with the
+number of lost payloads.
+"""
+union EventSubscriptionPayload = Event | Lagged
+
+"""
 The result of an execution, including errors that occurred during said
 execution.
 """
@@ -1698,6 +1708,17 @@ scalar IotaAddress
 Arbitrary JSON data.
 """
 scalar JSON
+
+"""
+Notifies that the subscription consumer has fallen behind the live
+subscription stream and missed one or more payloads.
+"""
+type Lagged {
+	"""
+	Number of missed payloads since the previous emitted one.
+	"""
+	count: Int!
+}
 
 """
 Information used by a package to link to a specific version of its
@@ -4289,13 +4310,13 @@ type Subscription {
 	
 	If no filter is provided, all transactions will be returned.
 	"""
-	transactions(filter: SubscriptionTransactionFilter): TransactionBlock!
+	transactions(filter: SubscriptionTransactionFilter): TransactionBlockSubscriptionPayload!
 	"""
 	Subscribe to incoming events from the IOTA network.
 	
 	If no filter is provided, all events will be returned.
 	"""
-	events(filter: SubscriptionEventFilter): Event!
+	events(filter: SubscriptionEventFilter): EventSubscriptionPayload!
 }
 
 """
@@ -4304,6 +4325,9 @@ Filter incoming events in a subscription.
 input SubscriptionEventFilter @oneOf {
 	"""
 	Filter incoming events by emitting module.
+	
+	- Filter by package: "0x02"
+	- Filter by module: "0x02::coin"
 	"""
 	emittingModule: String
 }
@@ -4322,6 +4346,10 @@ input SubscriptionTransactionFilter @oneOf {
 	signingAddress: IotaAddress
 	"""
 	Filter incoming transactions by package, module, or function name.
+	
+	- Filter by package: "0x03"
+	- Filter by module: "0x03::iota_system"
+	- Filter by function: "0x03::iota_system::request_add_stake"
 	"""
 	function: String
 }
@@ -4577,6 +4605,16 @@ enum TransactionBlockKindInput {
 	"""
 	END_OF_EPOCH_TX
 }
+
+"""
+Possible responses from a subscription.
+
+It could be one of the following:
+- A successful payload from the subscription stream.
+- A notice that the subscription has been lagged behind the network with the
+number of lost payloads.
+"""
+union TransactionBlockSubscriptionPayload = TransactionBlock | Lagged
 
 union TransactionInput = OwnedOrImmutable | SharedInput | Receiving | Pure
 


### PR DESCRIPTION
# Description of change

This PR adds the feature to add subscription support for `events` and `transactions` for GraphQL.

For filtering capabilities it leverages the [`@oneOf`](https://graphql.org/blog/2025-09-04-multioption-inputs-with-oneof/) directive which does not allow more than one filter at a time for the input filter object.

## Links to any relevant issues

fixes #8561 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- ran graphql tests
```shell
cargo nextest run -p iota-graphql-rpc --features pg_integration --no-fail-fast --test-threads 1
```
- used the iota binary to spin up an indexer and graphql instance and test the subscription queries
```
cargo r --features indexer -- start --force-regenesis   --with-indexer --with-graphql
```
- used the integrated graphiQL ui to issue subscription queries
- used a third party graphql client (Postman) to issue the same queries

> [!NOTE]
> At approximately 1k subscribers, the local machine reached its operational limit. The sheer intensity and concurrent demand of managing the network, indexer, GraphQL server, and a high volume of WebSocket connections prevented reliable testing.

In future iteration we could add **Prometheus** metrics to track the total amount of active subscribers, how many subscribers experience lags, ect...

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> The following patch does not affect the normal operation of the indexer, thus tests were skipped.

### Release Notes
- [x] GraphQL: Add `Subscription` support for `Event` and `TransactionBlock`.
