### PR TITLE
feat(starfish): send shard and proof in a block bundle

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -26,8 +26,8 @@ use tracing::{debug, info, warn};
 use crate::{
     CommitIndex, Round, Transaction, VerifiedBlockHeader,
     block_header::{
-        BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, SignedBlockHeader,
-        TransactionsCommitment, VerifiedBlock, VerifiedTransactions,
+        BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, ShardWithProof,
+        SignedBlockHeader, TransactionsCommitment, VerifiedBlock, VerifiedTransactions,
     },
     block_verifier::BlockVerifier,
     commit::{CommitAPI as _, CommitRange, TrustedCommit},
@@ -38,8 +38,8 @@ use crate::{
     encoder::ShardEncoder,
     error::{ConsensusError, ConsensusResult},
     network::{
-        BlockBundle, BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockAndHeaders,
-        SerializedBlockBundle, SerializedHeaderAndTransactions, SerializedTransactions,
+        BlockBundle, BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockBundle,
+        SerializedBlockBundleParts, SerializedHeaderAndTransactions, SerializedTransactions,
     },
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::Store,
@@ -157,13 +157,13 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         let peer_hostname = &self.context.committee.authority(peer).hostname;
         // 1. Create a verified block and make some preliminary checks
-        let serialized_block_and_headers =
-            SerializedBlockAndHeaders::try_from(serialized_block_bundle)?;
+        let serialized_block_bundle_parts =
+            SerializedBlockBundleParts::try_from(serialized_block_bundle)?;
         let SerializedHeaderAndTransactions {
             serialized_block_header,
             serialized_transactions,
         } = SerializedHeaderAndTransactions::try_from(SerializedBlock {
-            serialized_block: serialized_block_and_headers.serialized_block,
+            serialized_block: serialized_block_bundle_parts.serialized_block,
         })?;
 
         let signed_block_header: SignedBlockHeader =
@@ -200,15 +200,13 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             info!("Invalid block header from {}: {}", peer, e);
             return Err(e);
         }
-
-        if signed_block_header.transactions_commitment()
-            != TransactionsCommitment::compute_transactions_commitment(
-                &serialized_transactions,
-                &self.context,
-                encoder,
-            )
-            .expect("we should expect correct computation of the transactions commitment")
-        {
+        let (transaction_commitment, our_shard, proof_for_shard) = TransactionsCommitment::compute_merkle_root_shard_and_proof(
+            &serialized_transactions,
+            &self.context,
+            encoder,
+        )
+            .expect("we should expect correct computation of the transactions commitment, our shard and its proof");
+        if signed_block_header.transactions_commitment() != transaction_commitment {
             return Err(ConsensusError::TransactionCommitmentFailure {
                 round: signed_block_header.round(),
                 author: signed_block_header.author(),
@@ -282,15 +280,15 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // 4. Create block headers from bytes from a bundle
 
-        if serialized_block_and_headers.serialized_headers.len() > MAX_HEADERS_PER_BUNDLE {
+        if serialized_block_bundle_parts.serialized_headers.len() > MAX_HEADERS_PER_BUNDLE {
             return Err(ConsensusError::TooManyHeadersInABundle {
-                count: serialized_block_and_headers.serialized_headers.len(),
+                count: serialized_block_bundle_parts.serialized_headers.len(),
                 limit: MAX_HEADERS_PER_BUNDLE,
             });
         }
 
         let mut additional_block_headers = vec![];
-        for serialized_header in serialized_block_and_headers.serialized_headers {
+        for serialized_header in serialized_block_bundle_parts.serialized_headers {
             let digest = VerifiedBlockHeader::compute_digest(&serialized_header);
             if self.received_block_headers.contains(&digest) {
                 self.context
@@ -445,7 +443,29 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .with_label_values(&[peer_hostname.as_str(), "handle_subscribed_block_bundle"])
             .inc_by(digests_to_exclude.len() as u64);
 
-        // 8. Add additional headers from bundle to dag, receive missing ancestors for
+        // 8. Collect shards from a bundle, check their proofs and send to decoders.
+        if serialized_block_bundle_parts.serialized_shards.len() > MAX_SHARDS_PER_BUNDLE {
+            return Err(ConsensusError::TooManyShardsInABundle {
+                count: serialized_block_bundle_parts.serialized_shards.len(),
+                limit: MAX_SHARDS_PER_BUNDLE,
+            });
+        }
+        // TODO: use correct type
+        let mut shards_for_decoder: Vec<ShardWithProof> = vec![];
+        for serialized_shard in serialized_block_bundle_parts.serialized_shards.iter() {
+            let shard: ShardWithProof =
+                bcs::from_bytes(serialized_shard).map_err(ConsensusError::MalformedShard)?;
+            if TransactionsCommitment::check_merkle_proof(
+                shard.clone(),
+                self.context.committee.size(),
+                self.context.own_index.value(),
+            ) {
+                shards_for_decoder.push(shard);
+            }
+        }
+        // TODO: send to decoders
+
+        // 9. Add additional headers from bundle to dag, receive missing ancestors for
         //    them
         // Normally, there should be no missing ancestors, as the headers are sent in
         // order of increasing rounds.
@@ -455,7 +475,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
 
-        // 9. Add block to dag, add its missing ancestors to the set
+        // 10. Add the block to dag, add its missing ancestors to the set
         let (missing_block_ancestors, missing_block_committed_transactions) = self
             .core_dispatcher
             .add_blocks(vec![verified_block])
@@ -464,9 +484,19 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         missing_ancestors.extend(missing_block_ancestors);
         missing_committed_txns.extend(missing_block_committed_transactions);
+        // 11. Add our shard from the received block and its proof to the dag_state
+        self.core_dispatcher
+            .add_shards(vec![ShardWithProof {
+                shard: our_shard,
+                transaction_commitment,
+                proof: proof_for_shard,
+                block_ref,
+            }])
+            .await
+            .map_err(|_| ConsensusError::Shutdown)?;
 
         if !missing_ancestors.is_empty() {
-            // 10. schedule the fetching of missing ancestors from this peer
+            // 12. schedule the fetching of missing ancestors from this peer
             if let Err(err) = self
                 .synchronizer
                 .fetch_headers(missing_ancestors, peer)
@@ -531,10 +561,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 let mut dag_state_guard = dag_state.write();
                 let block_headers =
                     dag_state_guard.take_unknown_headers_for_authority(peer, block.round());
+                let shards = dag_state_guard.take_unknown_shards_for_authority(peer, block.round());
                 drop(dag_state_guard);
                 let block_bundle = BlockBundle {
                     verified_block: block,
                     verified_headers: block_headers,
+                    shards,
                 };
                 async move {
                     match SerializedBlockBundle::try_from(block_bundle) {
@@ -1097,8 +1129,8 @@ mod tests {
             AuthorityService, BroadcastedBlockStream, MAX_FILTER_SIZE, SubscriptionCounter,
         },
         block_header::{
-            BlockHeaderAPI, BlockRef, SignedBlockHeader, TestBlockHeader, TransactionsCommitment,
-            VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
+            BlockHeaderAPI, BlockRef, ShardWithProof, SignedBlockHeader, TestBlockHeader,
+            TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
         },
         block_manager::BlockManager,
         block_verifier::SignedBlockVerifier,
@@ -1114,7 +1146,7 @@ mod tests {
         leader_schedule::LeaderSchedule,
         network::{
             BlockBundle, BlockBundleStream, NetworkClient, NetworkService, SerializedBlock,
-            SerializedBlockAndHeaders, SerializedBlockBundle, SerializedHeaderAndTransactions,
+            SerializedBlockBundle, SerializedBlockBundleParts, SerializedHeaderAndTransactions,
             SerializedTransactions,
         },
         storage::{Store, mem_store::MemStore},
@@ -1489,9 +1521,10 @@ mod tests {
         let big_block_bundle = BlockBundle {
             verified_block: input_block.clone(),
             verified_headers: headers.clone(),
+            shards: vec![],
         };
         let serialized_big_block_bundle = SerializedBlockBundle::try_from(
-            SerializedBlockAndHeaders::try_from(big_block_bundle).unwrap(),
+            SerializedBlockBundleParts::try_from(big_block_bundle).unwrap(),
         )
         .unwrap();
 
@@ -1516,9 +1549,10 @@ mod tests {
         let block_bundle_with_big_rounds = BlockBundle {
             verified_block: input_block.clone(),
             verified_headers: headers.clone(),
+            shards: vec![],
         };
         let serialized_block_bundle_with_big_round = SerializedBlockBundle::try_from(
-            SerializedBlockAndHeaders::try_from(block_bundle_with_big_rounds).unwrap(),
+            SerializedBlockBundleParts::try_from(block_bundle_with_big_rounds).unwrap(),
         )
         .unwrap();
 
@@ -1551,9 +1585,10 @@ mod tests {
         let block_bundle = BlockBundle {
             verified_block: input_block.clone(),
             verified_headers: headers.clone(),
+            shards: vec![],
         };
         let serialized_block_bundle = SerializedBlockBundle::try_from(
-            SerializedBlockAndHeaders::try_from(block_bundle).unwrap(),
+            SerializedBlockBundleParts::try_from(block_bundle).unwrap(),
         )
         .unwrap();
 
@@ -1867,6 +1902,10 @@ mod tests {
             unimplemented!("Unimplemented")
         }
 
+        async fn add_shards(&self, _shards: Vec<ShardWithProof>) -> Result<(), CoreError> {
+            Ok(())
+        }
+
         async fn get_missing_transaction_data(
             &self,
         ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
@@ -2031,9 +2070,10 @@ mod tests {
                 let block_bundle = BlockBundle {
                     verified_block: block,
                     verified_headers: headers,
+                    shards: vec![],
                 };
                 let serialized_block_bundle = SerializedBlockBundle::try_from(
-                    SerializedBlockAndHeaders::try_from(block_bundle).unwrap(),
+                    SerializedBlockBundleParts::try_from(block_bundle).unwrap(),
                 )
                 .unwrap();
                 authority_service
@@ -2167,9 +2207,10 @@ mod tests {
                 let block_bundle = BlockBundle {
                     verified_block: block,
                     verified_headers: vec![],
+                    shards: vec![],
                 };
                 let serialized_block_bundle = SerializedBlockBundle::try_from(
-                    SerializedBlockAndHeaders::try_from(block_bundle).unwrap(),
+                    SerializedBlockBundleParts::try_from(block_bundle).unwrap(),
                 )
                 .unwrap();
                 authority_service
@@ -2361,7 +2402,8 @@ mod tests {
 
         // Check the correctness of the received blocks
         for (i, bundle) in received_bundles.into_iter().enumerate() {
-            let serialized_block_and_headers = SerializedBlockAndHeaders::try_from(bundle).unwrap();
+            let serialized_block_and_headers =
+                SerializedBlockBundleParts::try_from(bundle).unwrap();
             let SerializedHeaderAndTransactions {
                 serialized_block_header,
                 serialized_transactions,
@@ -2426,7 +2468,8 @@ mod tests {
 
         // Check blocks from the second batch
         for (i, bundle) in received_bundles.into_iter().enumerate() {
-            let serialized_block_and_headers = SerializedBlockAndHeaders::try_from(bundle).unwrap();
+            let serialized_block_and_headers =
+                SerializedBlockBundleParts::try_from(bundle).unwrap();
             let SerializedHeaderAndTransactions {
                 serialized_block_header,
                 serialized_transactions,

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -27,7 +27,8 @@ use crate::{
     CommitIndex, Round, Transaction, VerifiedBlockHeader,
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, ShardWithProof,
-        SignedBlockHeader, TransactionsCommitment, VerifiedBlock, VerifiedTransactions,
+        SignedBlockHeader, TransactionsCommitment, VerifiedBlock, VerifiedOwnShard,
+        VerifiedTransactions,
     },
     block_verifier::BlockVerifier,
     commit::{CommitAPI as _, CommitRange, TrustedCommit},
@@ -357,14 +358,42 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .inc();
         }
 
-        // 5. Observe headers and the block for the commit votes. When local commit is
+        // 5. Collect shards from a bundle and check their proofs.
+        if serialized_block_bundle_parts.serialized_shards.len() > MAX_SHARDS_PER_BUNDLE {
+            return Err(ConsensusError::TooManyShardsInABundle {
+                count: serialized_block_bundle_parts.serialized_shards.len(),
+                limit: MAX_SHARDS_PER_BUNDLE,
+            });
+        }
+        // TODO: use correct type
+        let mut shards_for_decoder: Vec<ShardWithProof> = vec![];
+        for serialized_shard in serialized_block_bundle_parts.serialized_shards.iter() {
+            let shard: ShardWithProof =
+                bcs::from_bytes(serialized_shard).map_err(ConsensusError::MalformedShard)?;
+            let proof_check = TransactionsCommitment::check_merkle_proof(
+                shard.clone(),
+                self.context.committee.size(),
+                peer.value(),
+            );
+            if proof_check {
+                shards_for_decoder.push(shard);
+            } else {
+                return Err(ConsensusError::IncorrectShardProof {
+                    peer,
+                    round: shard.block_ref.round,
+                });
+            }
+        }
+        // TODO: send to decoders
+
+        // 6. Observe headers and the block for the commit votes. When local commit is
         // lagging too much, commit sync loop will trigger fetching.
         for block_header in additional_block_headers.iter() {
             self.commit_vote_monitor.observe_block(block_header);
         }
         self.commit_vote_monitor.observe_block(&verified_block);
 
-        // 6. Reject blocks when local commit index is lagging too far from quorum
+        // 7. Reject blocks when local commit index is lagging too far from quorum
         //    commit
         // index.
         //
@@ -405,7 +434,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .with_label_values(&[peer_hostname])
             .inc();
 
-        // 7. Add digests to filter. Exclude from the vector those that are already
+        // 8. Add digests to filter. Exclude from the vector those that are already
         //    inserted
         let mut digests_to_add_to_filter = vec![];
         for block_header in additional_block_headers.iter() {
@@ -443,28 +472,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .with_label_values(&[peer_hostname.as_str(), "handle_subscribed_block_bundle"])
             .inc_by(digests_to_exclude.len() as u64);
 
-        // 8. Collect shards from a bundle, check their proofs and send to decoders.
-        if serialized_block_bundle_parts.serialized_shards.len() > MAX_SHARDS_PER_BUNDLE {
-            return Err(ConsensusError::TooManyShardsInABundle {
-                count: serialized_block_bundle_parts.serialized_shards.len(),
-                limit: MAX_SHARDS_PER_BUNDLE,
-            });
-        }
-        // TODO: use correct type
-        let mut shards_for_decoder: Vec<ShardWithProof> = vec![];
-        for serialized_shard in serialized_block_bundle_parts.serialized_shards.iter() {
-            let shard: ShardWithProof =
-                bcs::from_bytes(serialized_shard).map_err(ConsensusError::MalformedShard)?;
-            if TransactionsCommitment::check_merkle_proof(
-                shard.clone(),
-                self.context.committee.size(),
-                self.context.own_index.value(),
-            ) {
-                shards_for_decoder.push(shard);
-            }
-        }
-        // TODO: send to decoders
-
         // 9. Add additional headers from bundle to dag, receive missing ancestors for
         //    them
         // Normally, there should be no missing ancestors, as the headers are sent in
@@ -494,8 +501,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let serialized_shard_for_core: Bytes = bcs::to_bytes(&shard_for_core)
             .map_err(ConsensusError::SerializationFailure)?
             .into();
+        let shard_for_core = VerifiedOwnShard {
+            serialized_shard: serialized_shard_for_core,
+            block_ref,
+        };
         self.core_dispatcher
-            .add_shards(vec![(block_ref, serialized_shard_for_core)])
+            .add_shards(vec![shard_for_core])
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
 
@@ -1135,7 +1146,7 @@ mod tests {
         },
         block_header::{
             BlockHeaderAPI, BlockRef, SignedBlockHeader, TestBlockHeader, TransactionsCommitment,
-            VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
+            VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
         },
         block_manager::BlockManager,
         block_verifier::SignedBlockVerifier,
@@ -1907,7 +1918,7 @@ mod tests {
             unimplemented!("Unimplemented")
         }
 
-        async fn add_shards(&self, _shards: Vec<(BlockRef, Bytes)>) -> Result<(), CoreError> {
+        async fn add_shards(&self, _shards: Vec<VerifiedOwnShard>) -> Result<(), CoreError> {
             Ok(())
         }
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -34,7 +34,7 @@ use crate::{
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
-    dag_state::{DagState, MAX_HEADERS_PER_BUNDLE},
+    dag_state::{DagState, MAX_HEADERS_PER_BUNDLE, MAX_SHARDS_PER_BUNDLE},
     encoder::ShardEncoder,
     error::{ConsensusError, ConsensusResult},
     network::{

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -485,13 +485,17 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         missing_ancestors.extend(missing_block_ancestors);
         missing_committed_txns.extend(missing_block_committed_transactions);
         // 11. Add our shard from the received block and its proof to the dag_state
+        let shard_for_core = ShardWithProof {
+            shard: our_shard,
+            transaction_commitment,
+            proof: proof_for_shard,
+            block_ref,
+        };
+        let serialized_shard_for_core: Bytes = bcs::to_bytes(&shard_for_core)
+            .map_err(ConsensusError::SerializationFailure)?
+            .into();
         self.core_dispatcher
-            .add_shards(vec![ShardWithProof {
-                shard: our_shard,
-                transaction_commitment,
-                proof: proof_for_shard,
-                block_ref,
-            }])
+            .add_shards(vec![(block_ref, serialized_shard_for_core)])
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
 
@@ -561,12 +565,13 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 let mut dag_state_guard = dag_state.write();
                 let block_headers =
                     dag_state_guard.take_unknown_headers_for_authority(peer, block.round());
-                let shards = dag_state_guard.take_unknown_shards_for_authority(peer, block.round());
+                let serialized_shards =
+                    dag_state_guard.take_unknown_shards_for_authority(peer, block.round());
                 drop(dag_state_guard);
                 let block_bundle = BlockBundle {
                     verified_block: block,
                     verified_headers: block_headers,
-                    shards,
+                    serialized_shards,
                 };
                 async move {
                     match SerializedBlockBundle::try_from(block_bundle) {
@@ -1129,8 +1134,8 @@ mod tests {
             AuthorityService, BroadcastedBlockStream, MAX_FILTER_SIZE, SubscriptionCounter,
         },
         block_header::{
-            BlockHeaderAPI, BlockRef, ShardWithProof, SignedBlockHeader, TestBlockHeader,
-            TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
+            BlockHeaderAPI, BlockRef, SignedBlockHeader, TestBlockHeader, TransactionsCommitment,
+            VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
         },
         block_manager::BlockManager,
         block_verifier::SignedBlockVerifier,
@@ -1521,7 +1526,7 @@ mod tests {
         let big_block_bundle = BlockBundle {
             verified_block: input_block.clone(),
             verified_headers: headers.clone(),
-            shards: vec![],
+            serialized_shards: vec![],
         };
         let serialized_big_block_bundle = SerializedBlockBundle::try_from(
             SerializedBlockBundleParts::try_from(big_block_bundle).unwrap(),
@@ -1549,7 +1554,7 @@ mod tests {
         let block_bundle_with_big_rounds = BlockBundle {
             verified_block: input_block.clone(),
             verified_headers: headers.clone(),
-            shards: vec![],
+            serialized_shards: vec![],
         };
         let serialized_block_bundle_with_big_round = SerializedBlockBundle::try_from(
             SerializedBlockBundleParts::try_from(block_bundle_with_big_rounds).unwrap(),
@@ -1585,7 +1590,7 @@ mod tests {
         let block_bundle = BlockBundle {
             verified_block: input_block.clone(),
             verified_headers: headers.clone(),
-            shards: vec![],
+            serialized_shards: vec![],
         };
         let serialized_block_bundle = SerializedBlockBundle::try_from(
             SerializedBlockBundleParts::try_from(block_bundle).unwrap(),
@@ -1902,7 +1907,7 @@ mod tests {
             unimplemented!("Unimplemented")
         }
 
-        async fn add_shards(&self, _shards: Vec<ShardWithProof>) -> Result<(), CoreError> {
+        async fn add_shards(&self, _shards: Vec<(BlockRef, Bytes)>) -> Result<(), CoreError> {
             Ok(())
         }
 
@@ -2070,7 +2075,7 @@ mod tests {
                 let block_bundle = BlockBundle {
                     verified_block: block,
                     verified_headers: headers,
-                    shards: vec![],
+                    serialized_shards: vec![],
                 };
                 let serialized_block_bundle = SerializedBlockBundle::try_from(
                     SerializedBlockBundleParts::try_from(block_bundle).unwrap(),
@@ -2207,7 +2212,7 @@ mod tests {
                 let block_bundle = BlockBundle {
                     verified_block: block,
                     verified_headers: vec![],
-                    shards: vec![],
+                    serialized_shards: vec![],
                 };
                 let serialized_block_bundle = SerializedBlockBundle::try_from(
                     SerializedBlockBundleParts::try_from(block_bundle).unwrap(),

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -427,10 +427,9 @@ pub(crate) struct ShardWithProof {
     pub(crate) block_ref: BlockRef,
 }
 
-impl PartialEq for ShardWithProof {
-    fn eq(&self, other: &Self) -> bool {
-        self.transaction_commitment == other.transaction_commitment
-    }
+pub(crate) struct VerifiedOwnShard {
+    pub(crate) serialized_shard: Bytes,
+    pub(crate) block_ref: BlockRef,
 }
 
 impl TransactionsCommitment {

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -11,7 +11,7 @@ use std::{
 
 use bytes::Bytes;
 use fastcrypto::hash::{Digest, HashFunction};
-use rs_merkle::MerkleTree;
+use rs_merkle::{MerkleProof, MerkleTree};
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
 use starfish_config::{
@@ -417,12 +417,46 @@ impl AsRef<[u8]> for BlockHeaderDigest {
 // explicitly the transaction data.
 #[derive(Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionsCommitment([u8; starfish_config::DIGEST_LENGTH]);
+pub type MerkleProofBytes = Vec<u8>;
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub(crate) struct ShardWithProof {
+    pub(crate) shard: Shard,
+    pub(crate) transaction_commitment: TransactionsCommitment,
+    pub(crate) proof: MerkleProofBytes,
+    pub(crate) block_ref: BlockRef,
+}
+
+impl PartialEq for ShardWithProof {
+    fn eq(&self, other: &Self) -> bool {
+        self.transaction_commitment == other.transaction_commitment
+    }
+}
 
 impl TransactionsCommitment {
     /// Lexicographic min & max digest.
     pub const MIN: Self = Self([u8::MIN; starfish_config::DIGEST_LENGTH]);
     pub const MAX: Self = Self([u8::MAX; starfish_config::DIGEST_LENGTH]);
     pub const DEFAULT_FOR_TEST: Self = Self([u8::MIN; starfish_config::DIGEST_LENGTH]);
+
+    pub(crate) fn compute_merkle_root_shard_and_proof(
+        serialized_transactions: &Bytes,
+        context: &Arc<Context>,
+        encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
+    ) -> ConsensusResult<(TransactionsCommitment, Shard, MerkleProofBytes)> {
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.size() - info_length;
+        let encoded_shards =
+            encoder.encode_serialized_data(serialized_transactions, info_length, parity_length)?;
+        let own_index = context.own_index;
+        let (transactions_commitment, merkle_proof) =
+            TransactionsCommitment::compute_merkle_root_and_proof(&encoded_shards, own_index)?;
+        Ok((
+            transactions_commitment,
+            encoded_shards[own_index].clone(),
+            merkle_proof,
+        ))
+    }
 
     pub(crate) fn compute_transactions_commitment(
         serialized_transactions: &Bytes,
@@ -435,16 +469,18 @@ impl TransactionsCommitment {
             .encode_serialized_data(serialized_transactions, info_length, parity_length)
             .expect("We should expect correct encoding of the shards");
 
-        let transactions_commitment = TransactionsCommitment::compute_merkle_root(&encoded_shards)
-            .expect(
-                "We should expect correct computation of the Merkle root for encoded transactions",
-            );
+        let (transactions_commitment, _) = TransactionsCommitment::compute_merkle_root_and_proof(
+            &encoded_shards,
+            context.own_index,
+        )
+        .expect("We should expect correct computation of the Merkle root for encoded transactions");
         Ok(transactions_commitment)
     }
 
-    pub(crate) fn compute_merkle_root(
+    pub(crate) fn compute_merkle_root_and_proof(
         encoded_statements: &Vec<Shard>,
-    ) -> ConsensusResult<TransactionsCommitment> {
+        own_index: AuthorityIndex,
+    ) -> ConsensusResult<(TransactionsCommitment, MerkleProofBytes)> {
         let mut leaves: Vec<[u8; DefaultHashFunction::OUTPUT_SIZE]> = Vec::new();
         for shard in encoded_statements {
             let mut hasher = DefaultHashFunction::new();
@@ -457,7 +493,28 @@ impl TransactionsCommitment {
             .root()
             .ok_or("couldn't get the merkle root")
             .unwrap();
-        Ok(TransactionsCommitment(merkle_root))
+
+        let indices_to_prove = vec![own_index.value()];
+        let merkle_proof = merkle_tree.proof(&indices_to_prove);
+        let merkle_proof_bytes = merkle_proof.to_bytes();
+        Ok((TransactionsCommitment(merkle_root), merkle_proof_bytes))
+    }
+
+    pub(crate) fn check_merkle_proof(
+        shard: ShardWithProof,
+        tree_size: usize,
+        leaf_index: usize,
+    ) -> bool {
+        let mut hasher = DefaultHashFunction::new();
+        hasher.update(shard.shard);
+        let leaf = hasher.finalize().into();
+        let proof = MerkleProof::<DefaultHashFunctionWrapper>::try_from(shard.proof).unwrap();
+        proof.verify(
+            shard.transaction_commitment.0,
+            &[leaf_index],
+            &[leaf],
+            tree_size,
+        )
     }
 }
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -10,6 +10,7 @@ use std::{
     vec,
 };
 
+use bytes::Bytes;
 use iota_macros::fail_point;
 #[cfg(test)]
 use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
@@ -31,8 +32,8 @@ use crate::{
     Transaction,
     block_header::{
         BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockRef, BlockTimestampMs, GENESIS_ROUND,
-        Round, ShardWithProof, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock,
-        VerifiedBlockHeader, VerifiedTransactions,
+        Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
+        VerifiedTransactions,
     },
     block_manager::BlockManager,
     commit::{CertifiedCommits, PendingSubDag},
@@ -420,7 +421,10 @@ impl Core {
     }
 
     /// Adds shards to the DAG state. The proof is assumed to be already checked
-    pub(crate) fn add_shards(&mut self, shards: Vec<ShardWithProof>) -> ConsensusResult<()> {
+    pub(crate) fn add_shards(
+        &mut self,
+        serialized_shards: Vec<(BlockRef, Bytes)>,
+    ) -> ConsensusResult<()> {
         let _scope = monitored_scope("Core::add_transactions");
         let _s = self
             .context
@@ -432,8 +436,8 @@ impl Core {
 
         // Add shards to the dag state.
         let mut dag_state_guard = self.dag_state.write();
-        for shard in shards {
-            dag_state_guard.add_shard(shard);
+        for serialized_shard in serialized_shards {
+            dag_state_guard.add_shard(serialized_shard);
         }
         // Safe to drop the guard here as the write/read locks will be asquired in
         // commit_observer

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -31,8 +31,8 @@ use crate::{
     Transaction,
     block_header::{
         BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockRef, BlockTimestampMs, GENESIS_ROUND,
-        Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
-        VerifiedTransactions,
+        Round, ShardWithProof, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock,
+        VerifiedBlockHeader, VerifiedTransactions,
     },
     block_manager::BlockManager,
     commit::{CertifiedCommits, PendingSubDag},
@@ -122,7 +122,7 @@ pub(crate) struct Core {
     /// hasn't been initialised yet.
     last_known_proposed_round: Option<Round>,
     /// Encoder is used to encode transactions into a longer vector of shards
-    encoder: Box<dyn ShardEncoder + Send>,
+    encoder: Box<dyn ShardEncoder + Send + Sync>,
 }
 
 impl Core {
@@ -419,6 +419,28 @@ impl Core {
         Ok(())
     }
 
+    /// Adds shards to the DAG state. The proof is assumed to be already checked
+    pub(crate) fn add_shards(&mut self, shards: Vec<ShardWithProof>) -> ConsensusResult<()> {
+        let _scope = monitored_scope("Core::add_transactions");
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["Core::add_shards"])
+            .start_timer();
+
+        // Add shards to the dag state.
+        let mut dag_state_guard = self.dag_state.write();
+        for shard in shards {
+            dag_state_guard.add_shard(shard);
+        }
+        // Safe to drop the guard here as the write/read locks will be asquired in
+        // commit_observer
+        drop(dag_state_guard);
+        Ok(())
+    }
+
     // Adds the certified commits that have been synced via the commit syncer. We
     // are using the commit info to skip running the decision
     // rule and immediately commit the corresponding leaders and sub dags.
@@ -638,16 +660,12 @@ impl Core {
         let serialized_transactions = Transaction::serialize(&transactions)
             .expect("We should expect correct serialization for transactions");
         // Compute transaction commitment that will be included in the block header
-
-        let encoded_shards = self
-            .encoder
-            .encode_serialized_data(&serialized_transactions, info_length, parity_length)
-            .expect("We should expect correct encoding of the shards");
-
-        let transactions_commitment = TransactionsCommitment::compute_merkle_root(&encoded_shards)
-            .expect(
-                "We should expect correct computation of the Merkle root for encoded transactions",
-            );
+        let transactions_commitment = TransactionsCommitment::compute_transactions_commitment(
+            &serialized_transactions,
+            &self.context,
+            &mut self.encoder,
+        )
+        .expect("We should expect correct computation of the Merkle root for encoded transactions");
 
         self.context
             .metrics

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -655,8 +655,6 @@ impl Core {
         // be done in the end of the method.
         let (transactions, ack_transactions, _limit_reached) = self.transaction_consumer.next();
         // Serialize the transaction
-        let info_length = self.context.committee.info_length();
-        let parity_length = self.context.committee.size() - info_length;
         let serialized_transactions = Transaction::serialize(&transactions)
             .expect("We should expect correct serialization for transactions");
         // Compute transaction commitment that will be included in the block header

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -10,7 +10,6 @@ use std::{
     vec,
 };
 
-use bytes::Bytes;
 use iota_macros::fail_point;
 #[cfg(test)]
 use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
@@ -33,7 +32,7 @@ use crate::{
     block_header::{
         BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockRef, BlockTimestampMs, GENESIS_ROUND,
         Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
-        VerifiedTransactions,
+        VerifiedOwnShard, VerifiedTransactions,
     },
     block_manager::BlockManager,
     commit::{CertifiedCommits, PendingSubDag},
@@ -423,7 +422,7 @@ impl Core {
     /// Adds shards to the DAG state. The proof is assumed to be already checked
     pub(crate) fn add_shards(
         &mut self,
-        serialized_shards: Vec<(BlockRef, Bytes)>,
+        serialized_shards: Vec<VerifiedOwnShard>,
     ) -> ConsensusResult<()> {
         let _scope = monitored_scope("Core::add_transactions");
         let _s = self

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -24,7 +24,7 @@ use tracing::warn;
 
 use crate::{
     BlockHeaderAPI as _, VerifiedBlockHeader,
-    block_header::{BlockRef, Round, VerifiedBlock, VerifiedTransactions},
+    block_header::{BlockRef, Round, ShardWithProof, VerifiedBlock, VerifiedTransactions},
     commit::CertifiedCommits,
     context::Context,
     core::Core,
@@ -75,6 +75,8 @@ enum CoreThreadCommand {
     GetMissingBlocks(oneshot::Sender<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>),
     /// Add transactions to be processed and accepted
     AddTransactions(Vec<VerifiedTransactions>, oneshot::Sender<()>),
+    /// Add shards to the dag_state
+    AddShards(Vec<ShardWithProof>, oneshot::Sender<()>),
     /// Get missing transaction data that need to be synced
     GetMissingTransactionData(oneshot::Sender<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>),
 }
@@ -115,6 +117,8 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
         &self,
         transactions: Vec<VerifiedTransactions>,
     ) -> Result<(), CoreError>;
+
+    async fn add_shards(&self, transactions: Vec<ShardWithProof>) -> Result<(), CoreError>;
 
     async fn get_missing_transaction_data(
         &self,
@@ -214,6 +218,11 @@ impl CoreThread {
                         CoreThreadCommand::AddTransactions(transactions, sender) => {
                             let _scope = monitored_scope("CoreThread::loop::add_transactions");
                             self.core.add_transactions(transactions)?;
+                            sender.send(()).ok();
+                        }
+                        CoreThreadCommand::AddShards(shards_with_proofs, sender) => {
+                            let _scope = monitored_scope("CoreThread::loop::add_shards");
+                            self.core.add_shards(shards_with_proofs)?;
                             sender.send(()).ok();
                         }
                         CoreThreadCommand::GetMissingTransactionData(sender) => {
@@ -375,6 +384,13 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
     ) -> Result<(), CoreError> {
         let (sender, receiver) = oneshot::channel();
         self.send(CoreThreadCommand::AddTransactions(transactions, sender))
+            .await;
+        receiver.await.map_err(|e| Shutdown(e.to_string()))
+    }
+
+    async fn add_shards(&self, shards_with_proof: Vec<ShardWithProof>) -> Result<(), CoreError> {
+        let (sender, receiver) = oneshot::channel();
+        self.send(CoreThreadCommand::AddShards(shards_with_proof, sender))
             .await;
         receiver.await.map_err(|e| Shutdown(e.to_string()))
     }
@@ -561,6 +577,10 @@ pub(crate) mod tests {
             _transactions: Vec<VerifiedTransactions>,
         ) -> Result<(), CoreError> {
             unimplemented!()
+        }
+
+        async fn add_shards(&self, _shards: Vec<ShardWithProof>) -> Result<(), CoreError> {
+            unimplemented!("Unimplemented")
         }
 
         async fn get_missing_transaction_data(

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -12,7 +12,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use iota_metrics::{
     monitored_mpsc::{Receiver, Sender, WeakSender, channel},
     monitored_scope, spawn_logged_monitored_task,
@@ -25,7 +24,7 @@ use tracing::warn;
 
 use crate::{
     BlockHeaderAPI as _, VerifiedBlockHeader,
-    block_header::{BlockRef, Round, VerifiedBlock, VerifiedTransactions},
+    block_header::{BlockRef, Round, VerifiedBlock, VerifiedOwnShard, VerifiedTransactions},
     commit::CertifiedCommits,
     context::Context,
     core::Core,
@@ -77,7 +76,7 @@ enum CoreThreadCommand {
     /// Add transactions to be processed and accepted
     AddTransactions(Vec<VerifiedTransactions>, oneshot::Sender<()>),
     /// Add shards to the dag_state
-    AddShards(Vec<(BlockRef, Bytes)>, oneshot::Sender<()>),
+    AddShards(Vec<VerifiedOwnShard>, oneshot::Sender<()>),
     /// Get missing transaction data that need to be synced
     GetMissingTransactionData(oneshot::Sender<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>),
 }
@@ -119,7 +118,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
         transactions: Vec<VerifiedTransactions>,
     ) -> Result<(), CoreError>;
 
-    async fn add_shards(&self, shards: Vec<(BlockRef, Bytes)>) -> Result<(), CoreError>;
+    async fn add_shards(&self, shards: Vec<VerifiedOwnShard>) -> Result<(), CoreError>;
 
     async fn get_missing_transaction_data(
         &self,
@@ -389,7 +388,7 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         receiver.await.map_err(|e| Shutdown(e.to_string()))
     }
 
-    async fn add_shards(&self, shards: Vec<(BlockRef, Bytes)>) -> Result<(), CoreError> {
+    async fn add_shards(&self, shards: Vec<VerifiedOwnShard>) -> Result<(), CoreError> {
         let (sender, receiver) = oneshot::channel();
         self.send(CoreThreadCommand::AddShards(shards, sender))
             .await;
@@ -580,7 +579,7 @@ pub(crate) mod tests {
             unimplemented!()
         }
 
-        async fn add_shards(&self, _shards: Vec<(BlockRef, Bytes)>) -> Result<(), CoreError> {
+        async fn add_shards(&self, _shards: Vec<VerifiedOwnShard>) -> Result<(), CoreError> {
             unimplemented!("Unimplemented")
         }
 

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use iota_metrics::{
     monitored_mpsc::{Receiver, Sender, WeakSender, channel},
     monitored_scope, spawn_logged_monitored_task,
@@ -24,7 +25,7 @@ use tracing::warn;
 
 use crate::{
     BlockHeaderAPI as _, VerifiedBlockHeader,
-    block_header::{BlockRef, Round, ShardWithProof, VerifiedBlock, VerifiedTransactions},
+    block_header::{BlockRef, Round, VerifiedBlock, VerifiedTransactions},
     commit::CertifiedCommits,
     context::Context,
     core::Core,
@@ -76,7 +77,7 @@ enum CoreThreadCommand {
     /// Add transactions to be processed and accepted
     AddTransactions(Vec<VerifiedTransactions>, oneshot::Sender<()>),
     /// Add shards to the dag_state
-    AddShards(Vec<ShardWithProof>, oneshot::Sender<()>),
+    AddShards(Vec<(BlockRef, Bytes)>, oneshot::Sender<()>),
     /// Get missing transaction data that need to be synced
     GetMissingTransactionData(oneshot::Sender<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>),
 }
@@ -118,7 +119,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
         transactions: Vec<VerifiedTransactions>,
     ) -> Result<(), CoreError>;
 
-    async fn add_shards(&self, transactions: Vec<ShardWithProof>) -> Result<(), CoreError>;
+    async fn add_shards(&self, shards: Vec<(BlockRef, Bytes)>) -> Result<(), CoreError>;
 
     async fn get_missing_transaction_data(
         &self,
@@ -220,9 +221,9 @@ impl CoreThread {
                             self.core.add_transactions(transactions)?;
                             sender.send(()).ok();
                         }
-                        CoreThreadCommand::AddShards(shards_with_proofs, sender) => {
+                        CoreThreadCommand::AddShards(serialized_shards, sender) => {
                             let _scope = monitored_scope("CoreThread::loop::add_shards");
-                            self.core.add_shards(shards_with_proofs)?;
+                            self.core.add_shards(serialized_shards)?;
                             sender.send(()).ok();
                         }
                         CoreThreadCommand::GetMissingTransactionData(sender) => {
@@ -388,9 +389,9 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         receiver.await.map_err(|e| Shutdown(e.to_string()))
     }
 
-    async fn add_shards(&self, shards_with_proof: Vec<ShardWithProof>) -> Result<(), CoreError> {
+    async fn add_shards(&self, shards: Vec<(BlockRef, Bytes)>) -> Result<(), CoreError> {
         let (sender, receiver) = oneshot::channel();
-        self.send(CoreThreadCommand::AddShards(shards_with_proof, sender))
+        self.send(CoreThreadCommand::AddShards(shards, sender))
             .await;
         receiver.await.map_err(|e| Shutdown(e.to_string()))
     }
@@ -579,7 +580,7 @@ pub(crate) mod tests {
             unimplemented!()
         }
 
-        async fn add_shards(&self, _shards: Vec<ShardWithProof>) -> Result<(), CoreError> {
+        async fn add_shards(&self, _shards: Vec<(BlockRef, Bytes)>) -> Result<(), CoreError> {
             unimplemented!("Unimplemented")
         }
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -19,8 +19,9 @@ use tracing::{debug, error, info};
 
 use crate::{
     block_header::{
-        BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
-        VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions, genesis_blocks,
+        BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round,
+        ShardWithProof, Slot, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
+        genesis_blocks,
     },
     commit::{
         CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRef, CommitVote,
@@ -39,6 +40,7 @@ use crate::{
 // TODO: make it derivable from the protocol parameters
 pub(crate) const MAX_TRANSACTIONS_ACK_DEPTH: Round = 50;
 pub(crate) const MAX_HEADERS_PER_BUNDLE: usize = 150;
+pub(crate) const MAX_SHARDS_PER_BUNDLE: usize = 150;
 
 /// DagState provides the API to write and read accepted blocks from the DAG.
 /// Only uncommitted and last committed blocks are cached in memory.
@@ -64,7 +66,8 @@ pub(crate) struct DagState {
     /// the last consumed commit. Note: all transactions in blocks below that
     /// round are evicted from memory.
     recent_transactions: BTreeMap<BlockRef, VerifiedTransactions>,
-
+    /// Contains recent shards with their Merkle proofs.
+    recent_shards_with_proofs: BTreeMap<BlockRef, ShardWithProof>,
     /// Indexes recent block headers refs by their authorities.
     /// Vec position corresponds to the authority index.
     recent_headers_refs_by_authority: Vec<BTreeSet<BlockRef>>,
@@ -127,6 +130,10 @@ pub(crate) struct DagState {
     /// Is used to ensure that we send block headers that are really needed
     /// to the authority, and not the ones that they already know.
     block_headers_not_known_by_authority: Vec<BTreeSet<BlockRef>>,
+
+    /// Keeps tracks of all shards we know and haven't sent yet to the
+    /// authority.
+    shards_not_known_by_authority: Vec<BTreeSet<BlockRef>>,
 
     /// Transactions to be flushed to storage.
     transactions_to_write: Vec<VerifiedTransactions>,
@@ -208,6 +215,7 @@ impl DagState {
             genesis,
             recent_block_headers: BTreeMap::new(),
             recent_transactions: BTreeMap::new(),
+            recent_shards_with_proofs: BTreeMap::new(),
             recent_headers_refs_by_authority: vec![BTreeSet::new(); num_authorities],
             threshold_clock,
             highest_accepted_round: 0,
@@ -224,6 +232,7 @@ impl DagState {
             pending_acknowledgments: BTreeSet::new(),
             recent_dag_cordial_knowledge: vec![BTreeMap::new(); num_authorities],
             block_headers_not_known_by_authority: vec![BTreeSet::new(); num_authorities],
+            shards_not_known_by_authority: vec![BTreeSet::new(); num_authorities],
             scoring_subdag,
             store: store.clone(),
             cached_rounds,
@@ -335,6 +344,27 @@ impl DagState {
 
             if block_ref.round >= min_round {
                 self.add_pending_acknowledgment(block_ref);
+            }
+        }
+    }
+
+    pub(crate) fn add_shard(&mut self, shard: ShardWithProof) {
+        let block_ref = shard.block_ref;
+        if self
+            .recent_shards_with_proofs
+            .insert(block_ref, shard)
+            .is_none()
+        {
+            tracing::debug!("Adding shard for block ref: {block_ref}");
+            for authority_index in 0..self.shards_not_known_by_authority.len() {
+                // we are going to send shard to every authority except our own and the author
+                // of the block
+                if (authority_index == block_ref.author.value())
+                    || (authority_index == self.context.own_index.value())
+                {
+                    continue;
+                }
+                self.shards_not_known_by_authority[authority_index].insert(block_ref);
             }
         }
     }
@@ -1253,6 +1283,35 @@ impl DagState {
             .collect()
     }
 
+    pub(crate) fn take_unknown_shards_for_authority(
+        &mut self,
+        authority_index: AuthorityIndex,
+        round_upper_bound_exclusive: Round,
+    ) -> Vec<ShardWithProof> {
+        let mut set = mem::take(&mut self.shards_not_known_by_authority[authority_index.value()]);
+
+        let split_point = {
+            let round_bound = BlockRef::new(
+                round_upper_bound_exclusive,
+                AuthorityIndex::MIN,
+                BlockHeaderDigest::MIN,
+            );
+            let nth_element = set
+                .iter()
+                .nth(MAX_SHARDS_PER_BUNDLE)
+                .map_or(round_bound, |x| *x);
+            min(nth_element, round_bound)
+        };
+
+        self.shards_not_known_by_authority[authority_index.value()] = set.split_off(&split_point);
+        let mut shards: Vec<ShardWithProof> = vec![];
+        for block_ref in set.into_iter() {
+            if let Some(shard) = self.recent_shards_with_proofs.get(&block_ref) {
+                shards.push(shard.clone());
+            }
+        }
+        shards
+    }
     pub(crate) fn take_commit_votes(&mut self, limit: usize) -> Vec<CommitVote> {
         let mut votes = Vec::new();
         while !self.pending_commit_votes.is_empty() && votes.len() < limit {
@@ -1310,6 +1369,11 @@ impl DagState {
         // === 2. Evict from block_headers_not_known_by_authority ===
         for authority_index in 0..self.context.committee.size() {
             let old_set = &mut self.block_headers_not_known_by_authority[authority_index];
+            old_set.retain(|block_ref| block_ref.round > self.evicted_rounds[block_ref.author]);
+        }
+        // === 3. Evict from shards_not_known_by_authority ===
+        for authority_index in 0..self.context.committee.size() {
+            let old_set = &mut self.shards_not_known_by_authority[authority_index];
             old_set.retain(|block_ref| block_ref.round > self.evicted_rounds[block_ref.author]);
         }
     }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -12,6 +12,7 @@ use std::{
     vec,
 };
 
+use bytes::Bytes;
 use itertools::Itertools as _;
 use starfish_config::AuthorityIndex;
 use tokio::time::Instant;
@@ -19,9 +20,8 @@ use tracing::{debug, error, info};
 
 use crate::{
     block_header::{
-        BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round,
-        ShardWithProof, Slot, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
-        genesis_blocks,
+        BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
+        VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions, genesis_blocks,
     },
     commit::{
         CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRef, CommitVote,
@@ -67,7 +67,7 @@ pub(crate) struct DagState {
     /// round are evicted from memory.
     recent_transactions: BTreeMap<BlockRef, VerifiedTransactions>,
     /// Contains recent shards with their Merkle proofs.
-    recent_shards_with_proofs: BTreeMap<BlockRef, ShardWithProof>,
+    recent_shards: BTreeMap<BlockRef, Bytes>,
     /// Indexes recent block headers refs by their authorities.
     /// Vec position corresponds to the authority index.
     recent_headers_refs_by_authority: Vec<BTreeSet<BlockRef>>,
@@ -215,7 +215,7 @@ impl DagState {
             genesis,
             recent_block_headers: BTreeMap::new(),
             recent_transactions: BTreeMap::new(),
-            recent_shards_with_proofs: BTreeMap::new(),
+            recent_shards: BTreeMap::new(),
             recent_headers_refs_by_authority: vec![BTreeSet::new(); num_authorities],
             threshold_clock,
             highest_accepted_round: 0,
@@ -348,13 +348,9 @@ impl DagState {
         }
     }
 
-    pub(crate) fn add_shard(&mut self, shard: ShardWithProof) {
-        let block_ref = shard.block_ref;
-        if self
-            .recent_shards_with_proofs
-            .insert(block_ref, shard)
-            .is_none()
-        {
+    pub(crate) fn add_shard(&mut self, shard: (BlockRef, Bytes)) {
+        let block_ref = shard.0;
+        if self.recent_shards.insert(block_ref, shard.1).is_none() {
             tracing::debug!("Adding shard for block ref: {block_ref}");
             for authority_index in 0..self.shards_not_known_by_authority.len() {
                 // we are going to send shard to every authority except our own and the author
@@ -1287,7 +1283,7 @@ impl DagState {
         &mut self,
         authority_index: AuthorityIndex,
         round_upper_bound_exclusive: Round,
-    ) -> Vec<ShardWithProof> {
+    ) -> Vec<Bytes> {
         let mut set = mem::take(&mut self.shards_not_known_by_authority[authority_index.value()]);
 
         let split_point = {
@@ -1304,9 +1300,9 @@ impl DagState {
         };
 
         self.shards_not_known_by_authority[authority_index.value()] = set.split_off(&split_point);
-        let mut shards: Vec<ShardWithProof> = vec![];
+        let mut shards: Vec<Bytes> = vec![];
         for block_ref in set.into_iter() {
-            if let Some(shard) = self.recent_shards_with_proofs.get(&block_ref) {
+            if let Some(shard) = self.recent_shards.get(&block_ref) {
                 shards.push(shard.clone());
             }
         }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -21,7 +21,7 @@ use tracing::{debug, error, info};
 use crate::{
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
-        VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions, genesis_blocks,
+        VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions, genesis_blocks,
     },
     commit::{
         CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRef, CommitVote,
@@ -348,9 +348,13 @@ impl DagState {
         }
     }
 
-    pub(crate) fn add_shard(&mut self, shard: (BlockRef, Bytes)) {
-        let block_ref = shard.0;
-        if self.recent_shards.insert(block_ref, shard.1).is_none() {
+    pub(crate) fn add_shard(&mut self, shard: VerifiedOwnShard) {
+        let block_ref = shard.block_ref;
+        if self
+            .recent_shards
+            .insert(block_ref, shard.serialized_shard)
+            .is_none()
+        {
             tracing::debug!("Adding shard for block ref: {block_ref}");
             for authority_index in 0..self.shards_not_known_by_authority.len() {
                 // we are going to send shard to every authority except our own and the author

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -20,6 +20,9 @@ pub(crate) enum ConsensusError {
     #[error("Error deserializing block header: {0}")]
     MalformedHeader(bcs::Error),
 
+    #[error("Error deserializing shard with proof: {0}")]
+    MalformedShard(bcs::Error),
+
     #[error("Error deserializing block transactions: {0}")]
     MalformedTransactions(bcs::Error),
 
@@ -225,6 +228,9 @@ pub(crate) enum ConsensusError {
 
     #[error("Block bundle contains too many additional headers: {count} > {limit}")]
     TooManyHeadersInABundle { count: usize, limit: usize },
+
+    #[error("Block bundle contains too many shards: {count} > {limit}")]
+    TooManyShardsInABundle { count: usize, limit: usize },
 
     #[error(
         "Round of the header in a bundle is greater or equal to the block round: {header_round} >= {block_round}"

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -229,9 +229,6 @@ pub(crate) enum ConsensusError {
     #[error("Block bundle contains too many additional headers: {count} > {limit}")]
     TooManyHeadersInABundle { count: usize, limit: usize },
 
-    #[error("Block bundle contains too many shards: {count} > {limit}")]
-    TooManyShardsInABundle { count: usize, limit: usize },
-
     #[error(
         "Round of the header in a bundle is greater or equal to the block round: {header_round} >= {block_round}"
     )]
@@ -239,6 +236,12 @@ pub(crate) enum ConsensusError {
         header_round: Round,
         block_round: Round,
     },
+
+    #[error("Block bundle contains too many shards: {count} > {limit}")]
+    TooManyShardsInABundle { count: usize, limit: usize },
+
+    #[error("Block bundle from {peer} contains shard from round {round} with incorrect proof")]
+    IncorrectShardProof { peer: AuthorityIndex, round: Round },
 }
 
 impl ConsensusError {

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -32,7 +32,7 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     Round, VerifiedBlockHeader,
-    block_header::{BlockRef, ShardWithProof, VerifiedBlock},
+    block_header::{BlockRef, VerifiedBlock},
     commit::{CommitRange, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
 };
@@ -246,7 +246,7 @@ impl TryFrom<SerializedBlock> for SerializedHeaderAndTransactions {
 pub(crate) struct BlockBundle {
     pub(crate) verified_block: VerifiedBlock,
     pub(crate) verified_headers: Vec<VerifiedBlockHeader>,
-    pub(crate) shards: Vec<ShardWithProof>,
+    pub(crate) serialized_shards: Vec<Bytes>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -294,19 +294,11 @@ impl TryFrom<BlockBundle> for SerializedBlockBundleParts {
         for block_header in block_bundle.verified_headers.iter() {
             serialized_block_headers.push(block_header.serialized().clone());
         }
-        let mut serialized_shards: Vec<Bytes> = vec![];
-        for shard in block_bundle.shards.iter() {
-            serialized_shards.push(
-                bcs::to_bytes(&shard)
-                    .map_err(ConsensusError::SerializationFailure)?
-                    .into(),
-            );
-        }
 
         Ok(Self {
             serialized_block: Bytes::from(bytes),
             serialized_headers: serialized_block_headers,
-            serialized_shards,
+            serialized_shards: block_bundle.serialized_shards,
         })
     }
 }

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -32,7 +32,7 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     Round, VerifiedBlockHeader,
-    block_header::{BlockRef, VerifiedBlock},
+    block_header::{BlockRef, ShardWithProof, VerifiedBlock},
     commit::{CommitRange, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
 };
@@ -246,12 +246,14 @@ impl TryFrom<SerializedBlock> for SerializedHeaderAndTransactions {
 pub(crate) struct BlockBundle {
     pub(crate) verified_block: VerifiedBlock,
     pub(crate) verified_headers: Vec<VerifiedBlockHeader>,
+    pub(crate) shards: Vec<ShardWithProof>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) struct SerializedBlockAndHeaders {
+pub(crate) struct SerializedBlockBundleParts {
     pub(crate) serialized_block: Bytes,
     pub(crate) serialized_headers: Vec<Bytes>,
+    pub(crate) serialized_shards: Vec<Bytes>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -259,7 +261,7 @@ pub(crate) struct SerializedBlockBundle {
     pub(crate) serialized_block_bundle: Bytes,
 }
 
-impl TryFrom<VerifiedBlock> for SerializedBlockAndHeaders {
+impl TryFrom<VerifiedBlock> for SerializedBlockBundleParts {
     type Error = ConsensusError;
     fn try_from(verified_block: VerifiedBlock) -> ConsensusResult<Self> {
         let (serialized_block_header, serialized_transactions) = verified_block.serialized();
@@ -272,11 +274,12 @@ impl TryFrom<VerifiedBlock> for SerializedBlockAndHeaders {
         Ok(Self {
             serialized_block: Bytes::from(bytes),
             serialized_headers: vec![],
+            serialized_shards: vec![],
         })
     }
 }
 
-impl TryFrom<BlockBundle> for SerializedBlockAndHeaders {
+impl TryFrom<BlockBundle> for SerializedBlockBundleParts {
     type Error = ConsensusError;
     fn try_from(block_bundle: BlockBundle) -> ConsensusResult<Self> {
         let (serialized_block_header, serialized_transactions) =
@@ -288,20 +291,29 @@ impl TryFrom<BlockBundle> for SerializedBlockAndHeaders {
         let bytes = bcs::to_bytes(&serialized_header_and_transactions)
             .map_err(ConsensusError::SerializationFailure)?;
         let mut serialized_block_headers = vec![];
-        for block_header in block_bundle.verified_headers.into_iter() {
+        for block_header in block_bundle.verified_headers.iter() {
             serialized_block_headers.push(block_header.serialized().clone());
+        }
+        let mut serialized_shards: Vec<Bytes> = vec![];
+        for shard in block_bundle.shards.iter() {
+            serialized_shards.push(
+                bcs::to_bytes(&shard)
+                    .map_err(ConsensusError::SerializationFailure)?
+                    .into(),
+            );
         }
 
         Ok(Self {
             serialized_block: Bytes::from(bytes),
             serialized_headers: serialized_block_headers,
+            serialized_shards,
         })
     }
 }
 
-impl TryFrom<SerializedBlockAndHeaders> for SerializedBlockBundle {
+impl TryFrom<SerializedBlockBundleParts> for SerializedBlockBundle {
     type Error = ConsensusError;
-    fn try_from(serialized_block_and_headers: SerializedBlockAndHeaders) -> ConsensusResult<Self> {
+    fn try_from(serialized_block_and_headers: SerializedBlockBundleParts) -> ConsensusResult<Self> {
         let bytes = bcs::to_bytes(&serialized_block_and_headers)
             .map_err(ConsensusError::SerializationFailure)?;
         Ok(Self {
@@ -310,7 +322,7 @@ impl TryFrom<SerializedBlockAndHeaders> for SerializedBlockBundle {
     }
 }
 
-impl TryFrom<SerializedBlockBundle> for SerializedBlockAndHeaders {
+impl TryFrom<SerializedBlockBundle> for SerializedBlockBundleParts {
     type Error = ConsensusError;
     fn try_from(bundle: SerializedBlockBundle) -> ConsensusResult<Self> {
         bcs::from_bytes(&bundle.serialized_block_bundle)
@@ -321,14 +333,14 @@ impl TryFrom<SerializedBlockBundle> for SerializedBlockAndHeaders {
 impl TryFrom<VerifiedBlock> for SerializedBlockBundle {
     type Error = ConsensusError;
     fn try_from(verified_block: VerifiedBlock) -> ConsensusResult<Self> {
-        SerializedBlockBundle::try_from(SerializedBlockAndHeaders::try_from(verified_block)?)
+        SerializedBlockBundle::try_from(SerializedBlockBundleParts::try_from(verified_block)?)
     }
 }
 
 impl TryFrom<BlockBundle> for SerializedBlockBundle {
     type Error = ConsensusError;
     fn try_from(block_bundle: BlockBundle) -> ConsensusResult<Self> {
-        SerializedBlockBundle::try_from(SerializedBlockAndHeaders::try_from(block_bundle)?)
+        SerializedBlockBundle::try_from(SerializedBlockBundleParts::try_from(block_bundle)?)
     }
 }
 

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -1411,7 +1411,7 @@ mod tests {
         CommitDigest, CommitIndex,
         authority_service::COMMIT_LAG_MULTIPLIER,
         block_header::{
-            BlockHeaderDigest, BlockRef, Round, ShardWithProof, TestBlockHeader, VerifiedBlock,
+            BlockHeaderDigest, BlockRef, Round, TestBlockHeader, VerifiedBlock,
             VerifiedBlockHeader, VerifiedTransactions,
         },
         block_verifier::NoopBlockVerifier,
@@ -2382,7 +2382,7 @@ mod tests {
             unimplemented!("Unimplemented")
         }
 
-        async fn add_shards(&self, _shards: Vec<ShardWithProof>) -> Result<(), CoreError> {
+        async fn add_shards(&self, _shards: Vec<(BlockRef, Bytes)>) -> Result<(), CoreError> {
             unimplemented!("Unimplemented")
         }
 

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -1411,7 +1411,7 @@ mod tests {
         CommitDigest, CommitIndex,
         authority_service::COMMIT_LAG_MULTIPLIER,
         block_header::{
-            BlockHeaderDigest, BlockRef, Round, TestBlockHeader, VerifiedBlock,
+            BlockHeaderDigest, BlockRef, Round, ShardWithProof, TestBlockHeader, VerifiedBlock,
             VerifiedBlockHeader, VerifiedTransactions,
         },
         block_verifier::NoopBlockVerifier,
@@ -2379,6 +2379,10 @@ mod tests {
             &self,
             _transactions: Vec<VerifiedTransactions>,
         ) -> Result<(), CoreError> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn add_shards(&self, _shards: Vec<ShardWithProof>) -> Result<(), CoreError> {
             unimplemented!("Unimplemented")
         }
 

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -1412,7 +1412,7 @@ mod tests {
         authority_service::COMMIT_LAG_MULTIPLIER,
         block_header::{
             BlockHeaderDigest, BlockRef, Round, TestBlockHeader, VerifiedBlock,
-            VerifiedBlockHeader, VerifiedTransactions,
+            VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
         },
         block_verifier::NoopBlockVerifier,
         commit::{CertifiedCommits, CommitRange, CommitVote, TrustedCommit},
@@ -2382,7 +2382,7 @@ mod tests {
             unimplemented!("Unimplemented")
         }
 
-        async fn add_shards(&self, _shards: Vec<(BlockRef, Bytes)>) -> Result<(), CoreError> {
+        async fn add_shards(&self, _shards: Vec<VerifiedOwnShard>) -> Result<(), CoreError> {
             unimplemented!("Unimplemented")
         }
 

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1067,7 +1067,7 @@ mod tests {
     use crate::{
         Round, TestBlockHeader,
         block_header::{
-            BlockHeaderDigest, BlockRef, TransactionsCommitment, VerifiedBlock,
+            BlockHeaderDigest, BlockRef, ShardWithProof, TransactionsCommitment, VerifiedBlock,
             VerifiedBlockHeader, VerifiedTransactions,
         },
         block_verifier::NoopBlockVerifier,
@@ -2065,6 +2065,9 @@ mod tests {
             Ok(())
         }
 
+        async fn add_shards(&self, _shards: Vec<ShardWithProof>) -> Result<(), CoreError> {
+            unimplemented!("Unimplemented")
+        }
         async fn get_missing_transaction_data(
             &self,
         ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1067,7 +1067,7 @@ mod tests {
     use crate::{
         Round, TestBlockHeader,
         block_header::{
-            BlockHeaderDigest, BlockRef, ShardWithProof, TransactionsCommitment, VerifiedBlock,
+            BlockHeaderDigest, BlockRef, TransactionsCommitment, VerifiedBlock,
             VerifiedBlockHeader, VerifiedTransactions,
         },
         block_verifier::NoopBlockVerifier,
@@ -2065,7 +2065,7 @@ mod tests {
             Ok(())
         }
 
-        async fn add_shards(&self, _shards: Vec<ShardWithProof>) -> Result<(), CoreError> {
+        async fn add_shards(&self, _shards: Vec<(BlockRef, Bytes)>) -> Result<(), CoreError> {
             unimplemented!("Unimplemented")
         }
         async fn get_missing_transaction_data(

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1068,7 +1068,7 @@ mod tests {
         Round, TestBlockHeader,
         block_header::{
             BlockHeaderDigest, BlockRef, TransactionsCommitment, VerifiedBlock,
-            VerifiedBlockHeader, VerifiedTransactions,
+            VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
         },
         block_verifier::NoopBlockVerifier,
         commit::{CertifiedCommits, CommitRange},
@@ -2065,7 +2065,7 @@ mod tests {
             Ok(())
         }
 
-        async fn add_shards(&self, _shards: Vec<(BlockRef, Bytes)>) -> Result<(), CoreError> {
+        async fn add_shards(&self, _shards: Vec<VerifiedOwnShard>) -> Result<(), CoreError> {
             unimplemented!("Unimplemented")
         }
         async fn get_missing_transaction_data(


### PR DESCRIPTION
# Description of change

In this PR, we start sending shards in block bundles.

In more detail, the following changes are introduced.
1. When we receive a block bundle, our shard with its proof is extracted from the transaction data of the received block. Shard and its proof are sent to the core to be stored in dag_state.
2. When we create a block bundle to send to validator **v**, we add to the bundle shards and their proofs that we know but haven't yet sent to validator **v**.
3. When we receive a block bundle, we extract those shards and proofs and verify proofs against the transaction commitment. Then the shards with correct proofs are collected to be sent to decoders. The decoding logic will be implemented in a subsequent PR.
4. Shard eviction from dag_state is implemented.

## Links to any relevant issues

Fixes #8672 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
