### PR TITLE
refactor(indexer): insert object deletion and mutation chunks concurrently

### DIFF
--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -63,7 +63,7 @@ telemetry-subscribers.workspace = true
 
 [features]
 pg_integration = ["dep:rand"]
-shared_test_runtime = []
+shared_test_runtime = ["dep:rand"]
 
 [dev-dependencies]
 # external dependencies

--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -41,7 +41,7 @@ pub mod metrics;
 pub mod models;
 pub mod optimistic_indexing;
 pub mod processors;
-pub(crate) mod rolling;
+pub mod rolling;
 pub mod schema;
 pub mod store;
 pub mod system_package_task;

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -84,7 +84,7 @@ impl From<&IndexedTransaction> for CheckpointTxGlobalOrder {
 /// that represent the index status.
 #[derive(Clone, Debug, Queryable, Insertable, QueryableByName, Selectable)]
 #[diesel(table_name = tx_global_order)]
-pub(crate) struct CheckpointTxGlobalOrder {
+pub struct CheckpointTxGlobalOrder {
     pub(crate) chk_tx_sequence_number: Option<i64>,
     pub(crate) global_sequence_number: i64,
     pub(crate) tx_digest: Vec<u8>,
@@ -101,7 +101,7 @@ pub(crate) struct CheckpointTxGlobalOrder {
 /// Index status.
 #[derive(Clone, Debug, Copy, AsExpression, PartialEq, Eq)]
 #[diesel(sql_type = BigInt)]
-pub(crate) enum IndexStatus {
+pub enum IndexStatus {
     Started,
     Completed,
 }

--- a/crates/iota-indexer/src/rolling/mod.rs
+++ b/crates/iota-indexer/src/rolling/mod.rs
@@ -15,3 +15,4 @@ pub(crate) mod error;
 pub(crate) mod extract;
 pub(crate) mod persist;
 pub(crate) mod transform;
+pub use transform::CheckpointObjectChanges;

--- a/crates/iota-indexer/src/rolling/mod.rs
+++ b/crates/iota-indexer/src/rolling/mod.rs
@@ -2,14 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Rolling version of the library.
-//!
-//! This is to phase in breaking changes that may or may not
-//! include refactoring of the existing API.
-//!
-//! This will remain private until the versioning scheme is stabilized.
-//!
-//! In cases where the [`rolling`] module is used in other modules above, it
-//! MUST be used only in private APIs, or in inner implementations.
 
 pub(crate) mod error;
 pub(crate) mod extract;

--- a/crates/iota-indexer/src/rolling/transform.rs
+++ b/crates/iota-indexer/src/rolling/transform.rs
@@ -51,6 +51,14 @@ impl LiveObject {
     pub(crate) fn object(&self) -> &Object {
         &self.indexed_object.object
     }
+
+    #[cfg(any(test, feature = "pg_integration", feature = "shared_test_runtime"))]
+    fn random() -> Self {
+        Self {
+            indexed_object: IndexedObject::random(),
+            transaction_digest: TransactionDigest::random(),
+        }
+    }
 }
 
 /// Represent an object that is wrapped or deleted at a certain snapshot
@@ -87,12 +95,30 @@ impl RemovedObject {
     pub(crate) fn object_id(&self) -> ObjectID {
         self.indexed_object.object_id
     }
+
+    #[cfg(any(test, feature = "pg_integration", feature = "shared_test_runtime"))]
+    fn random() -> Self {
+        Self {
+            indexed_object: IndexedDeletedObject::random(),
+            transaction_digest: TransactionDigest::random(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct CheckpointObjectChanges {
+pub struct CheckpointObjectChanges {
     pub(crate) changed_objects: Vec<LiveObject>,
     pub(crate) deleted_objects: Vec<RemovedObject>,
+}
+
+#[cfg(any(test, feature = "pg_integration", feature = "shared_test_runtime"))]
+impl CheckpointObjectChanges {
+    pub fn random() -> Self {
+        Self {
+            changed_objects: vec![LiveObject::random()],
+            deleted_objects: vec![RemovedObject::random()],
+        }
+    }
 }
 
 impl TryFrom<&CheckpointData> for CheckpointObjectChanges {

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -129,7 +129,7 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
 }
 
 #[async_trait]
-pub(crate) trait IndexerStoreExt: IndexerStore {
+pub trait IndexerStoreExt: IndexerStore {
     async fn persist_checkpoint_objects(
         &self,
         objects: Vec<CheckpointObjectChanges>,

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -2329,40 +2329,19 @@ impl IndexerStoreExt for PgIndexerStore {
         let mutation_futures = mutation_chunks
             .into_iter()
             .map(|c| self.spawn_blocking_task(move |this| this.persist_changed_objects(c)));
-        futures::future::try_join_all(mutation_futures)
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    "Failed to join persist_object_mutation_chunk futures: {}",
-                    e
-                );
-                IndexerError::from(e)
-            })?
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                IndexerError::PostgresWrite(format!(
-                    "Failed to persist all object mutation chunks: {e:?}",
-                ))
-            })?;
         let deletion_futures = deletion_chunks
             .into_iter()
             .map(|c| self.spawn_blocking_task(move |this| this.persist_removed_objects(c)));
-        futures::future::try_join_all(deletion_futures)
+        futures::future::try_join_all(mutation_futures.chain(deletion_futures))
             .await
             .map_err(|e| {
-                tracing::error!(
-                    "Failed to join persist_object_deletion_chunk futures: {}",
-                    e
-                );
+                tracing::error!("Failed to join futures for persisting objects: {e}");
                 IndexerError::from(e)
             })?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| {
-                IndexerError::PostgresWrite(format!(
-                    "Failed to persist all object deletion chunks: {e:?}",
-                ))
+                IndexerError::PostgresWrite(format!("Failed to persist all object chunks: {e:?}",))
             })?;
 
         let elapsed = guard.stop_and_record();

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1713,39 +1713,20 @@ impl IndexerStore for PgIndexerStore {
         let mutation_futures = object_mutation_chunks
             .into_iter()
             .map(|c| self.spawn_blocking_task(move |this| this.persist_object_mutation_chunk(c)));
-        futures::future::try_join_all(mutation_futures)
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    "Failed to join persist_object_mutation_chunk futures: {}",
-                    e
-                );
-                IndexerError::from(e)
-            })?
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                IndexerError::PostgresWrite(format!(
-                    "Failed to persist all object mutation chunks: {e:?}"
-                ))
-            })?;
         let deletion_futures = object_deletion_chunks
             .into_iter()
             .map(|c| self.spawn_blocking_task(move |this| this.persist_object_deletion_chunk(c)));
-        futures::future::try_join_all(deletion_futures)
+        futures::future::try_join_all(mutation_futures.chain(deletion_futures))
             .await
             .map_err(|e| {
-                tracing::error!(
-                    "Failed to join persist_object_deletion_chunk futures: {}",
-                    e
-                );
+                tracing::error!("Failed to join futures for persisting object chunks: {e}",);
                 IndexerError::from(e)
             })?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| {
                 IndexerError::PostgresWrite(format!(
-                    "Failed to persist all object deletion chunks: {e:?}"
+                    "Failed to persist all object mutation and deletion chunks: {e:?}"
                 ))
             })?;
 
@@ -2483,11 +2464,11 @@ fn make_objects_history_to_commit(
     deleted_objects.into_iter().chain(mutated_objects).collect()
 }
 
-/// Partition object changes into deletions and mutations,
-/// within partition of mutations or deletions, retain the latest with highest
-/// version; For overlappings of mutations and deletions, only keep one with
-/// higher version. This is necessary b/c after this step, DB commit will be
-/// done in parallel and not in order.
+/// Partitions object changes into deletions and mutations.
+///
+/// Retains only the highest version of each object among deletions and
+/// mutations. This allows concurrent insertion into the DB of the resulting
+/// partitions.
 fn retain_latest_indexed_objects(
     tx_object_changes: Vec<TransactionObjectChangesToCommit>,
 ) -> (Vec<IndexedObject>, Vec<IndexedDeletedObject>) {

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -23,6 +23,7 @@ use iota_types::{
     transaction::SenderSignedData,
 };
 use move_core_types::language_storage::StructTag;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -427,11 +428,43 @@ impl IndexedObject {
     }
 }
 
+#[cfg(any(feature = "pg_integration", feature = "shared_test_runtime", test))]
+impl IndexedObject {
+    pub fn random() -> Self {
+        let mut rng = rand::thread_rng();
+        let random_address = IotaAddress::random_for_testing_only();
+        IndexedObject {
+            checkpoint_sequence_number: rng.gen(),
+            object: Object::with_owner_for_testing(random_address),
+            df_kind: {
+                let random_value = rng.gen_range(0..3);
+                match random_value {
+                    0 => Some(DynamicFieldType::DynamicField),
+                    1 => Some(DynamicFieldType::DynamicObject),
+                    _ => None,
+                }
+            },
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct IndexedDeletedObject {
     pub object_id: ObjectID,
     pub object_version: u64,
     pub checkpoint_sequence_number: u64,
+}
+
+#[cfg(any(feature = "pg_integration", feature = "shared_test_runtime", test))]
+impl IndexedDeletedObject {
+    pub fn random() -> Self {
+        let mut rng = rand::thread_rng();
+        IndexedDeletedObject {
+            object_id: ObjectID::random(),
+            object_version: rng.gen(),
+            checkpoint_sequence_number: rng.gen(),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -23,6 +23,7 @@ use iota_types::{
     transaction::SenderSignedData,
 };
 use move_core_types::language_storage::StructTag;
+#[cfg(any(test, feature = "shared_test_runtime", feature = "pg_integration"))]
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -566,7 +566,7 @@ pub(crate) struct TxIndexExt {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct TxIndexV2 {
+pub struct TxIndexV2 {
     pub(crate) base: TxIndex,
     pub(crate) ext: TxIndexExt,
 }

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -23,10 +23,14 @@ mod ingestion_tests {
             transactions::{StoredTransaction, TxGlobalOrder},
             tx_indices::StoredTxDigest,
         },
+        rolling::CheckpointObjectChanges,
         schema::{
             checkpoints, objects, objects_snapshot, transactions, tx_digests, tx_global_order,
         },
-        store::{PgIndexerStore, indexer_store::IndexerStore},
+        store::{
+            PgIndexerStore,
+            indexer_store::{IndexerStore, IndexerStoreExt},
+        },
         transactional_blocking_with_retry,
         types::{EventIndex, IndexedDeletedObject, IndexedObject, TxIndex},
     };
@@ -51,6 +55,31 @@ mod ingestion_tests {
                 .run($query)
                 .map_err(|e| IndexerError::PostgresRead(e.to_string()))
         }};
+    }
+
+    #[tokio::test]
+    pub async fn checkpoint_objects_ingestion() -> Result<(), IndexerError> {
+        let tempdir = tempdir().unwrap();
+        let mut sim = Simulacrum::new();
+        let data_ingestion_path = tempdir.path().to_path_buf();
+        sim.set_data_ingestion_path(data_ingestion_path.clone());
+
+        let (_, pg_store, _) = start_simulacrum_rest_api_with_write_indexer(
+            Arc::new(sim),
+            data_ingestion_path,
+            None,
+            Some("indexer_ingestion_tests_db"),
+            None,
+        )
+        .await;
+
+        let checkpoint_objects = (0..1000)
+            .map(|_| CheckpointObjectChanges::random())
+            .collect();
+        pg_store
+            .persist_checkpoint_objects(checkpoint_objects)
+            .await?;
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -15,6 +15,7 @@ mod ingestion_tests {
     use iota_indexer::{
         db::get_pool_connection,
         errors::{Context, IndexerError},
+        handlers::TransactionObjectChangesToCommit,
         insert_or_ignore_into,
         models::{
             checkpoints::StoredCheckpoint,
@@ -27,7 +28,7 @@ mod ingestion_tests {
         },
         store::{PgIndexerStore, indexer_store::IndexerStore},
         transactional_blocking_with_retry,
-        types::{EventIndex, TxIndex},
+        types::{EventIndex, IndexedDeletedObject, IndexedObject, TxIndex},
     };
     use iota_types::{
         IOTA_FRAMEWORK_PACKAGE_ID, base_types::IotaAddress, effects::TransactionEffectsAPI,
@@ -50,6 +51,33 @@ mod ingestion_tests {
                 .run($query)
                 .map_err(|e| IndexerError::PostgresRead(e.to_string()))
         }};
+    }
+
+    #[tokio::test]
+    pub async fn objects_ingestion() -> Result<(), IndexerError> {
+        let tempdir = tempdir().unwrap();
+        let mut sim = Simulacrum::new();
+        let data_ingestion_path = tempdir.path().to_path_buf();
+        sim.set_data_ingestion_path(data_ingestion_path.clone());
+
+        let (_, pg_store, _) = start_simulacrum_rest_api_with_write_indexer(
+            Arc::new(sim),
+            data_ingestion_path,
+            None,
+            Some("indexer_ingestion_tests_db"),
+            None,
+        )
+        .await;
+
+        let mut objects = Vec::new();
+        for _ in 0..1000 {
+            objects.push(TransactionObjectChangesToCommit {
+                changed_objects: vec![IndexedObject::random()],
+                deleted_objects: vec![IndexedDeletedObject::random()],
+            });
+        }
+        pg_store.persist_objects(objects).await?;
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Description of change

This patch makes a minor optimization in the iota-indexer following the respective upstream changes.

## Links to any relevant issues

Resolves #8676

## How the change has been tested

Describe the tests that you ran to verify your changes.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

No further QA tests were deemed necessary as this patch only makes the insertion of deletion and mutations concurrent, on the guarantee that all objects are unique and have the highest version among a set.


