### PR TITLE
upstream(indexer): committer writes upper bounds to watermarks table

### DIFF
--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -387,9 +387,10 @@ impl ExecutorCluster {
                 tokio::time::sleep(Duration::from_secs(1)).await;
                 latest_snapshot_cp = self
                     .indexer_store
-                    .get_latest_object_snapshot_checkpoint_sequence_number()
+                    .get_latest_object_snapshot_watermark()
                     .await
                     .unwrap()
+                    .map(|watermark| watermark.cp)
                     .unwrap_or_default();
             }
         })

--- a/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS watermarks;

--- a/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/up.sql
@@ -1,0 +1,29 @@
+CREATE TABLE watermarks
+(
+    -- The table governed by this watermark, i.e `epochs`, `checkpoints`, `transactions`.
+    entity                      TEXT          NOT NULL,
+    -- Inclusive upper epoch bound for this entity's data. Committer updates this field. Pruner uses
+    -- this to determine if pruning is necessary based on the retention policy.
+    epoch_hi_inclusive          BIGINT        NOT NULL,
+    -- Inclusive lower epoch bound for this entity's data. Pruner updates this field when the epoch range exceeds the retention policy.
+    epoch_lo                    BIGINT        NOT NULL,
+    -- Inclusive upper checkpoint bound for this entity's data. Committer updates this field. All
+    -- data of this entity in the checkpoint must be persisted before advancing this watermark. The
+    -- committer refers to this on disaster recovery to resume writing.
+    checkpoint_hi_inclusive     BIGINT        NOT NULL,
+    -- Inclusive upper transaction sequence number bound for this entity's data. Committer updates
+    -- this field.
+    tx_hi_inclusive             BIGINT        NOT NULL,
+    -- Inclusive low watermark that the pruner advances. Corresponds to the epoch id, checkpoint
+    -- sequence number, or tx sequence number depending on the entity. Data before this watermark is
+    -- considered pruned by a reader. The underlying data may still exist in the db instance.
+    reader_lo                   BIGINT        NOT NULL,
+    -- Updated using the database's current timestamp when the pruner sees that some data needs to
+    -- be dropped. The pruner uses this column to determine whether to prune or wait long enough
+    -- that all in-flight reads complete or timeout before it acts on an updated watermark.
+    timestamp_ms                BIGINT        NOT NULL,
+    -- Column used by the pruner to track its true progress. Data at and below this watermark can
+    -- be immediately pruned.
+    pruner_lo                   BIGINT,
+    PRIMARY KEY (entity)
+);

--- a/crates/iota-indexer/src/handlers/mod.rs
+++ b/crates/iota-indexer/src/handlers/mod.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+
+use iota_rest_api::CheckpointData;
 
 use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
@@ -83,7 +86,7 @@ impl<T> CommonHandler<T> {
 
     async fn start_transform_and_load(
         &self,
-        cp_receiver: iota_metrics::metered_channel::Receiver<(u64, T)>,
+        cp_receiver: iota_metrics::metered_channel::Receiver<(CommitterWatermark, T)>,
         cancel: CancellationToken,
     ) -> IndexerResult<()> {
         let checkpoint_commit_batch_size = std::env::var("CHECKPOINT_COMMIT_BATCH_SIZE")
@@ -93,7 +96,9 @@ impl<T> CommonHandler<T> {
         let mut stream = iota_metrics::metered_channel::ReceiverStream::new(cp_receiver)
             .ready_chunks(checkpoint_commit_batch_size);
 
-        let mut unprocessed = BTreeMap::new();
+        // Mapping of ordered checkpoint data to ensure that we process them in order. The key is
+        // just the checkpoint sequence number, and the tuple is (CommitterWatermark, T).
+        let mut unprocessed: BTreeMap<u64, (CommitterWatermark, _)> = BTreeMap::new();
         let mut tuple_batch = vec![];
         let mut next_cp_to_process = self
             .handler
@@ -119,8 +124,8 @@ impl<T> CommonHandler<T> {
                         if cancel.is_cancelled() {
                             return Ok(());
                         }
-                        for (cp_seq, data) in tuple_chunk {
-                            unprocessed.insert(cp_seq, (cp_seq, data));
+                        for (watermark, data) in tuple_chunk {
+                            unprocessed.insert(watermark.cp, (watermark, data));
                         }
                     }
                     Some(None) => break, // Stream has ended
@@ -141,8 +146,8 @@ impl<T> CommonHandler<T> {
 
             if !tuple_batch.is_empty() && checkpoint_lag_limiter != 0 {
                 let tuple_batch = std::mem::take(&mut tuple_batch);
-                let (last_checkpoint_seq, _data) = tuple_batch.last().unwrap();
-                let last_checkpoint_seq = last_checkpoint_seq.to_owned();
+                let (committer_watermark, _data) = tuple_batch.last().unwrap();
+                let committer_watermark = committer_watermark.to_owned();
                 let batch = tuple_batch
                     .into_iter()
                     .map(|(_cp_seq, data)| data)
@@ -153,7 +158,7 @@ impl<T> CommonHandler<T> {
                         self.handler.name()
                     ))
                 })?;
-                self.handler.set_watermark_hi(last_checkpoint_seq).await?;
+                self.handler.set_watermark_hi(committer_watermark).await?;
             }
         }
         Err(IndexerError::ChannelClosed(format!(
@@ -174,8 +179,9 @@ pub trait Handler<T>: Send + Sync {
     /// read high watermark of the table DB
     async fn get_watermark_hi(&self) -> IndexerResult<Option<u64>>;
 
-    /// set high watermark of the table DB, also update metrics.
-    async fn set_watermark_hi(&self, watermark_hi: u64) -> IndexerResult<()>;
+    /// Updates the relevant entries on the `watermarks` table with the full `CommitterWatermark`,
+    /// which tracks the latest epoch, cp, and tx sequence number of the committed batch.
+    async fn set_watermark_hi(&self, watermark: CommitterWatermark) -> IndexerResult<()>;
 
     /// By default, return u64::MAX, which means no extra waiting is needed
     /// before committing; get max committable checkpoint, for handlers that
@@ -185,4 +191,103 @@ pub trait Handler<T>: Send + Sync {
     async fn get_max_committable_checkpoint(&self) -> IndexerResult<u64> {
         Ok(u64::MAX)
     }
+}
+
+/// The indexer writer operates on checkpoint data, which contains information on the current epoch,
+/// checkpoint, and transaction. These three numbers form the watermark upper bound for each
+/// committed table.
+#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
+pub struct CommitterWatermark {
+    pub epoch: u64,
+    pub cp: u64,
+    pub tx: u64,
+}
+impl From<&IndexedCheckpoint> for CommitterWatermark {
+    fn from(checkpoint: &IndexedCheckpoint) -> Self {
+        Self {
+            epoch: checkpoint.epoch,
+            cp: checkpoint.sequence_number,
+            tx: checkpoint.network_total_transactions.saturating_sub(1),
+        }
+    }
+}
+impl From<&CheckpointData> for CommitterWatermark {
+    fn from(checkpoint: &CheckpointData) -> Self {
+        Self {
+            epoch: checkpoint.checkpoint_summary.epoch,
+            cp: checkpoint.checkpoint_summary.sequence_number,
+            tx: checkpoint
+                .checkpoint_summary
+                .network_total_transactions
+                .saturating_sub(1),
+        }
+    }
+}
+/// Enum representing tables that a committer updates.
+#[derive(
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::EnumIter,
+    strum_macros::AsRefStr,
+    Hash,
+    Serialize,
+    Deserialize,
+    Clone,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum CommitterTables {
+    // Unpruned tables
+    ChainIdentifier,
+    Display,
+    Epochs,
+    FeatureFlags,
+    Objects,
+    ObjectsVersion,
+    Packages,
+    ProtocolConfigs,
+    // Prunable tables
+    ObjectsHistory,
+    Transactions,
+    Events,
+    EventEmitPackage,
+    EventEmitModule,
+    EventSenders,
+    EventStructInstantiation,
+    EventStructModule,
+    EventStructName,
+    EventStructPackage,
+    TxCallsPkg,
+    TxCallsMod,
+    TxCallsFun,
+    TxChangedObjects,
+    TxDigests,
+    TxInputObjects,
+    TxKinds,
+    TxRecipients,
+    TxSenders,
+    Checkpoints,
+    PrunerCpWatermark,
+}
+/// Enum representing tables that the objects snapshot processor updates.
+#[derive(
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::EnumIter,
+    strum_macros::AsRefStr,
+    Hash,
+    Serialize,
+    Deserialize,
+    Clone,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectsSnapshotHandlerTables {
+    ObjectsSnapshot,
 }

--- a/crates/iota-indexer/src/handlers/mod.rs
+++ b/crates/iota-indexer/src/handlers/mod.rs
@@ -104,7 +104,7 @@ impl<T> CommonHandler<T> {
             .handler
             .get_watermark_hi()
             .await?
-            .map(|n| n.saturating_add(1))
+            .map(|watermark| watermark.cp.saturating_add(1))
             .unwrap_or_default();
 
         loop {
@@ -177,7 +177,7 @@ pub trait Handler<T>: Send + Sync {
     async fn load(&self, batch: Vec<T>) -> IndexerResult<()>;
 
     /// read high watermark of the table DB
-    async fn get_watermark_hi(&self) -> IndexerResult<Option<u64>>;
+    async fn get_watermark_hi(&self) -> IndexerResult<Option<CommitterWatermark>>;
 
     /// Updates the relevant entries on the `watermarks` table with the full
     /// `CommitterWatermark`, which tracks the latest epoch, cp, and tx

--- a/crates/iota-indexer/src/handlers/mod.rs
+++ b/crates/iota-indexer/src/handlers/mod.rs
@@ -2,13 +2,12 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-
-use iota_rest_api::CheckpointData;
 
 use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
+use iota_rest_api::CheckpointData;
+use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -96,8 +95,9 @@ impl<T> CommonHandler<T> {
         let mut stream = iota_metrics::metered_channel::ReceiverStream::new(cp_receiver)
             .ready_chunks(checkpoint_commit_batch_size);
 
-        // Mapping of ordered checkpoint data to ensure that we process them in order. The key is
-        // just the checkpoint sequence number, and the tuple is (CommitterWatermark, T).
+        // Mapping of ordered checkpoint data to ensure that we process them in order.
+        // The key is just the checkpoint sequence number, and the tuple is
+        // (CommitterWatermark, T).
         let mut unprocessed: BTreeMap<u64, (CommitterWatermark, _)> = BTreeMap::new();
         let mut tuple_batch = vec![];
         let mut next_cp_to_process = self
@@ -179,8 +179,9 @@ pub trait Handler<T>: Send + Sync {
     /// read high watermark of the table DB
     async fn get_watermark_hi(&self) -> IndexerResult<Option<u64>>;
 
-    /// Updates the relevant entries on the `watermarks` table with the full `CommitterWatermark`,
-    /// which tracks the latest epoch, cp, and tx sequence number of the committed batch.
+    /// Updates the relevant entries on the `watermarks` table with the full
+    /// `CommitterWatermark`, which tracks the latest epoch, cp, and tx
+    /// sequence number of the committed batch.
     async fn set_watermark_hi(&self, watermark: CommitterWatermark) -> IndexerResult<()>;
 
     /// By default, return u64::MAX, which means no extra waiting is needed
@@ -193,9 +194,9 @@ pub trait Handler<T>: Send + Sync {
     }
 }
 
-/// The indexer writer operates on checkpoint data, which contains information on the current epoch,
-/// checkpoint, and transaction. These three numbers form the watermark upper bound for each
-/// committed table.
+/// The indexer writer operates on checkpoint data, which contains information
+/// on the current epoch, checkpoint, and transaction. These three numbers form
+/// the watermark upper bound for each committed table.
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub struct CommitterWatermark {
     pub epoch: u64,

--- a/crates/iota-indexer/src/handlers/objects_snapshot_handler.rs
+++ b/crates/iota-indexer/src/handlers/objects_snapshot_handler.rs
@@ -77,10 +77,8 @@ impl Handler<TransactionObjectChangesToCommit> for ObjectsSnapshotHandler {
         Ok(())
     }
 
-    async fn get_watermark_hi(&self) -> IndexerResult<Option<u64>> {
-        self.store
-            .get_latest_object_snapshot_checkpoint_sequence_number()
-            .await
+    async fn get_watermark_hi(&self) -> IndexerResult<Option<CommitterWatermark>> {
+        self.store.get_latest_object_snapshot_watermark().await
     }
 
     async fn set_watermark_hi(&self, watermark: CommitterWatermark) -> IndexerResult<()> {
@@ -123,7 +121,10 @@ pub async fn start_objects_snapshot_handler(
     let watermark_hi = objects_snapshot_handler.get_watermark_hi().await?;
     let common_handler = CommonHandler::new(Box::new(objects_snapshot_handler.clone()));
     spawn_monitored_task!(common_handler.start_transform_and_load(receiver, cancel));
-    Ok((objects_snapshot_handler, watermark_hi.unwrap_or_default()))
+    Ok((
+        objects_snapshot_handler,
+        watermark_hi.map(|w| w.cp).unwrap_or_default(),
+    ))
 }
 
 impl ObjectsSnapshotHandler {

--- a/crates/iota-indexer/src/handlers/objects_snapshot_handler.rs
+++ b/crates/iota-indexer/src/handlers/objects_snapshot_handler.rs
@@ -11,10 +11,9 @@ use iota_types::full_checkpoint_content::CheckpointData;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use super::{CommitterWatermark, ObjectsSnapshotHandlerTables};
-
 use super::{
-    CommonHandler, Handler, TransactionObjectChangesToCommit, checkpoint_handler::CheckpointHandler,
+    CommitterWatermark, CommonHandler, Handler, ObjectsSnapshotHandlerTables,
+    TransactionObjectChangesToCommit, checkpoint_handler::CheckpointHandler,
 };
 use crate::{
     config::SnapshotLagConfig,

--- a/crates/iota-indexer/src/handlers/objects_snapshot_handler.rs
+++ b/crates/iota-indexer/src/handlers/objects_snapshot_handler.rs
@@ -11,6 +11,8 @@ use iota_types::full_checkpoint_content::CheckpointData;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
+use super::{CommitterWatermark, ObjectsSnapshotHandlerTables};
+
 use super::{
     CommonHandler, Handler, TransactionObjectChangesToCommit, checkpoint_handler::CheckpointHandler,
 };
@@ -25,7 +27,7 @@ use crate::{
 #[derive(Clone)]
 pub struct ObjectsSnapshotHandler {
     pub store: PgIndexerStore,
-    pub sender: Sender<(u64, TransactionObjectChangesToCommit)>,
+    pub sender: Sender<(CommitterWatermark, TransactionObjectChangesToCommit)>,
     snapshot_config: SnapshotLagConfig,
     metrics: IndexerMetrics,
 }
@@ -47,7 +49,7 @@ impl Worker for ObjectsSnapshotHandler {
         let transformed_data = CheckpointHandler::index_objects(&checkpoint, &self.metrics).await?;
         self.sender
             .send((
-                checkpoint.checkpoint_summary.sequence_number,
+                CommitterWatermark::from(checkpoint.as_ref()),
                 transformed_data,
             ))
             .await
@@ -76,18 +78,19 @@ impl Handler<TransactionObjectChangesToCommit> for ObjectsSnapshotHandler {
         Ok(())
     }
 
-    // TODO: read watermark table when it's ready.
     async fn get_watermark_hi(&self) -> IndexerResult<Option<u64>> {
         self.store
             .get_latest_object_snapshot_checkpoint_sequence_number()
             .await
     }
 
-    // TODO: update watermark table when it's ready.
-    async fn set_watermark_hi(&self, watermark_hi: u64) -> IndexerResult<()> {
+    async fn set_watermark_hi(&self, watermark: CommitterWatermark) -> IndexerResult<()> {
+        self.store
+            .update_watermarks_upper_bound::<ObjectsSnapshotHandlerTables>(watermark)
+            .await?;
         self.metrics
             .latest_object_snapshot_sequence_number
-            .set(watermark_hi as i64);
+            .set(watermark.cp as i64);
         Ok(())
     }
 
@@ -127,7 +130,7 @@ pub async fn start_objects_snapshot_handler(
 impl ObjectsSnapshotHandler {
     pub fn new(
         store: PgIndexerStore,
-        sender: Sender<(u64, TransactionObjectChangesToCommit)>,
+        sender: Sender<(CommitterWatermark, TransactionObjectChangesToCommit)>,
         metrics: IndexerMetrics,
         snapshot_config: SnapshotLagConfig,
     ) -> ObjectsSnapshotHandler {

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -85,8 +85,9 @@ impl Indexer {
             store.persist_protocol_configs_and_feature_flags(chain_id)?;
         }
 
-        // Ingestion task watermarks are snapshotted once on indexer startup based on the
-        // corresponding watermark table before being handed off to the ingestion task.
+        // Ingestion task watermarks are snapshotted once on indexer startup based on
+        // the corresponding watermark table before being handed off to the
+        // ingestion task.
         let mut executor = IndexerExecutor::new(
             ShimIndexerProgressStore::new(vec![
                 ("primary".to_string(), primary_watermark),

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -85,6 +85,8 @@ impl Indexer {
             store.persist_protocol_configs_and_feature_flags(chain_id)?;
         }
 
+        // Ingestion task watermarks are snapshotted once on indexer startup based on the
+        // corresponding watermark table before being handed off to the ingestion task.
         let mut executor = IndexerExecutor::new(
             ShimIndexerProgressStore::new(vec![
                 ("primary".to_string(), primary_watermark),

--- a/crates/iota-indexer/src/metrics.rs
+++ b/crates/iota-indexer/src/metrics.rs
@@ -138,6 +138,7 @@ pub struct IndexerMetrics {
     pub checkpoint_db_commit_latency_tx_indices_chunks: Histogram,
     pub checkpoint_db_commit_latency_checkpoints: Histogram,
     pub checkpoint_db_commit_latency_epoch: Histogram,
+    pub checkpoint_db_commit_latency_watermarks: Histogram,
     pub thousand_transaction_avg_db_commit_latency: Histogram,
     pub object_db_commit_latency: Histogram, // not used
     pub object_mutation_db_commit_latency: Histogram, // not used
@@ -573,6 +574,13 @@ impl IndexerMetrics {
             checkpoint_db_commit_latency_epoch: register_histogram_with_registry!(
                 "checkpoint_db_commit_latency_epochs",
                 "Time spent committing epochs",
+                DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            checkpoint_db_commit_latency_watermarks: register_histogram_with_registry!(
+                "checkpoint_db_commit_latency_watermarks",
+                "Time spent committing watermarks",
                 DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )

--- a/crates/iota-indexer/src/models/mod.rs
+++ b/crates/iota-indexer/src/models/mod.rs
@@ -17,3 +17,4 @@ pub mod participation_metrics;
 pub mod transactions;
 pub mod tx_count_metrics;
 pub mod tx_indices;
+pub mod watermarks;

--- a/crates/iota-indexer/src/models/watermarks.rs
+++ b/crates/iota-indexer/src/models/watermarks.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+//
+use crate::{
+    handlers::CommitterWatermark,
+    schema::watermarks::{self},
+};
+use diesel::prelude::*;
+
+/// Represents a row in the `watermarks` table.
+#[derive(Queryable, Insertable, Default, QueryableByName)]
+#[diesel(table_name = watermarks, primary_key(entity))]
+pub struct StoredWatermark {
+    /// The table governed by this watermark, i.e `epochs`, `checkpoints`, `transactions`.
+    pub entity: String,
+    /// Inclusive upper epoch bound for this entity's data. Committer updates this field. Pruner uses
+    /// this to determine if pruning is necessary based on the retention policy.
+    pub epoch_hi_inclusive: i64,
+    /// Inclusive lower epoch bound for this entity's data. Pruner updates this field when the epoch range exceeds the retention policy.
+    pub epoch_lo: i64,
+    /// Inclusive upper checkpoint bound for this entity's data. Committer updates this field. All
+    /// data of this entity in the checkpoint must be persisted before advancing this watermark. The
+    /// committer refers to this on disaster recovery to resume writing.
+    pub checkpoint_hi_inclusive: i64,
+    /// Inclusive upper transaction sequence number bound for this entity's data. Committer updates
+    /// this field.
+    pub tx_hi_inclusive: i64,
+    /// Inclusive low watermark that the pruner advances. Corresponds to the epoch id, checkpoint
+    /// sequence number, or tx sequence number depending on the entity. Data before this watermark is
+    /// considered pruned by a reader. The underlying data may still exist in the db instance.
+    pub reader_lo: i64,
+    /// Updated using the database's current timestamp when the pruner sees that some data needs to
+    /// be dropped. The pruner uses this column to determine whether to prune or wait long enough
+    /// that all in-flight reads complete or timeout before it acts on an updated watermark.
+    pub timestamp_ms: i64,
+    /// Column used by the pruner to track its true progress. Data at and below this watermark can
+    /// be immediately pruned.
+    pub pruner_lo: Option<i64>,
+}
+
+impl StoredWatermark {
+    pub fn from_upper_bound_update(entity: &str, watermark: CommitterWatermark) -> Self {
+        StoredWatermark {
+            entity: entity.to_string(),
+            epoch_hi_inclusive: watermark.epoch as i64,
+            checkpoint_hi_inclusive: watermark.cp as i64,
+            tx_hi_inclusive: watermark.tx as i64,
+            ..StoredWatermark::default()
+        }
+    }
+}

--- a/crates/iota-indexer/src/models/watermarks.rs
+++ b/crates/iota-indexer/src/models/watermarks.rs
@@ -2,40 +2,48 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 //
+use diesel::prelude::*;
+
 use crate::{
     handlers::CommitterWatermark,
     schema::watermarks::{self},
 };
-use diesel::prelude::*;
 
 /// Represents a row in the `watermarks` table.
 #[derive(Queryable, Insertable, Default, QueryableByName)]
 #[diesel(table_name = watermarks, primary_key(entity))]
 pub struct StoredWatermark {
-    /// The table governed by this watermark, i.e `epochs`, `checkpoints`, `transactions`.
+    /// The table governed by this watermark, i.e `epochs`, `checkpoints`,
+    /// `transactions`.
     pub entity: String,
-    /// Inclusive upper epoch bound for this entity's data. Committer updates this field. Pruner uses
-    /// this to determine if pruning is necessary based on the retention policy.
+    /// Inclusive upper epoch bound for this entity's data. Committer updates
+    /// this field. Pruner uses this to determine if pruning is necessary
+    /// based on the retention policy.
     pub epoch_hi_inclusive: i64,
-    /// Inclusive lower epoch bound for this entity's data. Pruner updates this field when the epoch range exceeds the retention policy.
+    /// Inclusive lower epoch bound for this entity's data. Pruner updates this
+    /// field when the epoch range exceeds the retention policy.
     pub epoch_lo: i64,
-    /// Inclusive upper checkpoint bound for this entity's data. Committer updates this field. All
-    /// data of this entity in the checkpoint must be persisted before advancing this watermark. The
-    /// committer refers to this on disaster recovery to resume writing.
+    /// Inclusive upper checkpoint bound for this entity's data. Committer
+    /// updates this field. All data of this entity in the checkpoint must
+    /// be persisted before advancing this watermark. The committer refers
+    /// to this on disaster recovery to resume writing.
     pub checkpoint_hi_inclusive: i64,
-    /// Inclusive upper transaction sequence number bound for this entity's data. Committer updates
-    /// this field.
+    /// Inclusive upper transaction sequence number bound for this entity's
+    /// data. Committer updates this field.
     pub tx_hi_inclusive: i64,
-    /// Inclusive low watermark that the pruner advances. Corresponds to the epoch id, checkpoint
-    /// sequence number, or tx sequence number depending on the entity. Data before this watermark is
-    /// considered pruned by a reader. The underlying data may still exist in the db instance.
+    /// Inclusive low watermark that the pruner advances. Corresponds to the
+    /// epoch id, checkpoint sequence number, or tx sequence number
+    /// depending on the entity. Data before this watermark is considered
+    /// pruned by a reader. The underlying data may still exist in the db
+    /// instance.
     pub reader_lo: i64,
-    /// Updated using the database's current timestamp when the pruner sees that some data needs to
-    /// be dropped. The pruner uses this column to determine whether to prune or wait long enough
-    /// that all in-flight reads complete or timeout before it acts on an updated watermark.
+    /// Updated using the database's current timestamp when the pruner sees that
+    /// some data needs to be dropped. The pruner uses this column to
+    /// determine whether to prune or wait long enough that all in-flight
+    /// reads complete or timeout before it acts on an updated watermark.
     pub timestamp_ms: i64,
-    /// Column used by the pruner to track its true progress. Data at and below this watermark can
-    /// be immediately pruned.
+    /// Column used by the pruner to track its true progress. Data at and below
+    /// this watermark can be immediately pruned.
     pub pruner_lo: Option<i64>,
 }
 

--- a/crates/iota-indexer/src/rolling/persist.rs
+++ b/crates/iota-indexer/src/rolling/persist.rs
@@ -4,15 +4,16 @@
 //! Types and associated logic to use while persisting
 //! data to the database.
 
-use std::collections::{BTreeMap, HashMap};
-
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
+use std::collections::{BTreeMap, HashMap};
 use tap::tap::TapFallible;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
 
 use crate::{
-    handlers::{EpochToCommit, TransactionObjectChangesToCommit},
+    handlers::{
+        CommitterTables, CommitterWatermark, EpochToCommit, TransactionObjectChangesToCommit,
+    },
     metrics::IndexerMetrics,
     models::{display::StoredDisplay, obj_indices::StoredObjectVersion},
     rolling::transform::CheckpointObjectChanges,
@@ -75,6 +76,8 @@ pub(crate) async fn start_tx_checkpoint_commit_task(
             let epoch = checkpoint.epoch.clone();
             batch.push(checkpoint);
             next_checkpoint_sequence_number += 1;
+            // The batch will consist of contiguous checkpoints and at most one epoch boundary at
+            // the end.
             if batch.len() == checkpoint_commit_batch_size || epoch.is_some() {
                 commit_checkpoints(&state, batch, epoch, &metrics).await;
                 batch = vec![];
@@ -88,6 +91,10 @@ pub(crate) async fn start_tx_checkpoint_commit_task(
     Ok(())
 }
 
+/// Writes indexed checkpoint data to the database, and then update watermark upper bounds and
+/// metrics. Expects `indexed_checkpoint_batch` to be non-empty, and contain contiguous checkpoints.
+/// There can be at most one epoch boundary at the end. If an epoch boundary is detected,
+/// epoch-partitioned tables must be advanced.
 // Unwrap: Caller needs to make sure indexed_checkpoint_batch is not empty
 #[instrument(skip_all, fields(
     first = indexed_checkpoint_batch.first().as_ref().unwrap().checkpoint.sequence_number,
@@ -138,7 +145,7 @@ async fn commit_checkpoints(
     }
 
     let first_checkpoint_seq = checkpoint_batch.first().as_ref().unwrap().sequence_number;
-    let last_checkpoint_seq = checkpoint_batch.last().as_ref().unwrap().sequence_number;
+    let committer_watermark = CommitterWatermark::from(checkpoint_batch.last().unwrap());
 
     let guard = metrics.checkpoint_db_commit_latency.start_timer();
     let tx_batch = tx_batch.into_iter().flatten().collect::<Vec<_>>();
@@ -198,7 +205,8 @@ async fn commit_checkpoints(
 
     let is_epoch_end = epoch.is_some();
 
-    // handle partitioning on epoch boundary
+    // On epoch boundary, we need to modify the existing partitions' upper bound, and introduce a
+    // new partition for incoming data for the upcoming epoch.
     if let Some(epoch_data) = epoch {
         state
             .advance_epoch(epoch_data)
@@ -240,25 +248,36 @@ async fn commit_checkpoints(
         let _ = state.persist_protocol_configs_and_feature_flags(chain_id);
     }
 
+    state
+        .update_watermarks_upper_bound::<CommitterTables>(committer_watermark)
+        .await
+        .tap_err(|e| {
+            error!(
+                "Failed to update watermark upper bound with error: {}",
+                e.to_string()
+            );
+        })
+        .expect("Updating watermark upper bound in DB should not fail.");
+
     let elapsed = guard.stop_and_record();
 
     info!(
         elapsed,
         "Checkpoint {}-{} committed with {} transactions.",
         first_checkpoint_seq,
-        last_checkpoint_seq,
+        committer_watermark.cp,
         tx_count,
     );
     metrics
         .latest_tx_checkpoint_sequence_number
-        .set(last_checkpoint_seq as i64);
+        .set(committer_watermark.cp as i64);
     metrics
         .total_tx_checkpoint_committed
         .inc_by(checkpoint_num as u64);
     metrics.total_transaction_committed.inc_by(tx_count as u64);
     metrics
         .transaction_per_checkpoint
-        .observe(tx_count as f64 / (last_checkpoint_seq - first_checkpoint_seq + 1) as f64);
+        .observe(tx_count as f64 / (committer_watermark.cp - first_checkpoint_seq + 1) as f64);
     // 1000.0 is not necessarily the batch size, it's to roughly map average tx
     // commit latency to [0.1, 1] seconds, which is well covered by
     // DB_COMMIT_LATENCY_SEC_BUCKETS.

--- a/crates/iota-indexer/src/rolling/persist.rs
+++ b/crates/iota-indexer/src/rolling/persist.rs
@@ -4,8 +4,9 @@
 //! Types and associated logic to use while persisting
 //! data to the database.
 
-use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use std::collections::{BTreeMap, HashMap};
+
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use tap::tap::TapFallible;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
@@ -76,8 +77,8 @@ pub(crate) async fn start_tx_checkpoint_commit_task(
             let epoch = checkpoint.epoch.clone();
             batch.push(checkpoint);
             next_checkpoint_sequence_number += 1;
-            // The batch will consist of contiguous checkpoints and at most one epoch boundary at
-            // the end.
+            // The batch will consist of contiguous checkpoints and at most one epoch
+            // boundary at the end.
             if batch.len() == checkpoint_commit_batch_size || epoch.is_some() {
                 commit_checkpoints(&state, batch, epoch, &metrics).await;
                 batch = vec![];
@@ -91,9 +92,10 @@ pub(crate) async fn start_tx_checkpoint_commit_task(
     Ok(())
 }
 
-/// Writes indexed checkpoint data to the database, and then update watermark upper bounds and
-/// metrics. Expects `indexed_checkpoint_batch` to be non-empty, and contain contiguous checkpoints.
-/// There can be at most one epoch boundary at the end. If an epoch boundary is detected,
+/// Writes indexed checkpoint data to the database, and then update watermark
+/// upper bounds and metrics. Expects `indexed_checkpoint_batch` to be
+/// non-empty, and contain contiguous checkpoints. There can be at most one
+/// epoch boundary at the end. If an epoch boundary is detected,
 /// epoch-partitioned tables must be advanced.
 // Unwrap: Caller needs to make sure indexed_checkpoint_batch is not empty
 #[instrument(skip_all, fields(
@@ -205,8 +207,8 @@ async fn commit_checkpoints(
 
     let is_epoch_end = epoch.is_some();
 
-    // On epoch boundary, we need to modify the existing partitions' upper bound, and introduce a
-    // new partition for incoming data for the upcoming epoch.
+    // On epoch boundary, we need to modify the existing partitions' upper bound,
+    // and introduce a new partition for incoming data for the upcoming epoch.
     if let Some(epoch_data) = epoch {
         state
             .advance_epoch(epoch_data)

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -441,6 +441,19 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    watermarks (entity) {
+        entity -> Text,
+        epoch_hi_inclusive -> Int8,
+        epoch_lo -> Int8,
+        checkpoint_hi_inclusive -> Int8,
+        tx_hi_inclusive -> Int8,
+        reader_lo -> Int8,
+        timestamp_ms -> Int8,
+        pruner_lo -> Nullable<Int8>,
+    }
+}
+
 #[macro_export]
 macro_rules! for_all_tables {
     ($action:path) => {
@@ -484,7 +497,8 @@ macro_rules! for_all_tables {
             tx_kinds,
             tx_recipients,
             tx_senders,
-            tx_wrapped_or_deleted_objects
+            tx_wrapped_or_deleted_objects,
+            watermarks
         );
     };
 }

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -2,9 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{any::Any, collections::BTreeMap};
+
 use async_trait::async_trait;
 use diesel::PgConnection;
-use std::{any::Any, collections::BTreeMap};
 use strum::IntoEnumIterator;
 
 use crate::{

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -2,14 +2,14 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{any::Any, collections::BTreeMap};
-
 use async_trait::async_trait;
 use diesel::PgConnection;
+use std::{any::Any, collections::BTreeMap};
+use strum::IntoEnumIterator;
 
 use crate::{
     errors::IndexerError,
-    handlers::{EpochToCommit, TransactionObjectChangesToCommit},
+    handlers::{CommitterWatermark, EpochToCommit, TransactionObjectChangesToCommit},
     models::{
         display::StoredDisplay,
         obj_indices::StoredObjectVersion,
@@ -126,6 +126,14 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         conn: &mut PgConnection,
         object_changes: Vec<TransactionObjectChangesToCommit>,
     ) -> Result<(), IndexerError>;
+
+    /// Update the upper bound of the watermarks for the given tables.
+    async fn update_watermarks_upper_bound<E: IntoEnumIterator>(
+        &self,
+        watermark: CommitterWatermark,
+    ) -> Result<(), IndexerError>
+    where
+        E::Iterator: Iterator<Item: AsRef<str>>;
 }
 
 #[async_trait]

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -38,9 +38,9 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
 
     async fn get_available_checkpoint_range(&self) -> Result<(u64, u64), IndexerError>;
 
-    async fn get_latest_object_snapshot_checkpoint_sequence_number(
+    async fn get_latest_object_snapshot_watermark(
         &self,
-    ) -> Result<Option<u64>, IndexerError>;
+    ) -> Result<Option<CommitterWatermark>, IndexerError>;
 
     async fn get_chain_identifier(&self) -> Result<Option<Vec<u8>>, IndexerError>;
 

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -19,6 +19,7 @@ use iota_types::{
     digests::{ChainIdentifier, CheckpointDigest},
 };
 use itertools::Itertools;
+use strum::IntoEnumIterator;
 use tap::TapFallible;
 use tracing::info;
 
@@ -26,7 +27,7 @@ use super::pg_partition_manager::{EpochPartitionData, PgPartitionManager};
 use crate::{
     db::ConnectionPool,
     errors::{Context, IndexerError},
-    handlers::{EpochToCommit, TransactionObjectChangesToCommit},
+    handlers::{CommitterWatermark, EpochToCommit, TransactionObjectChangesToCommit},
     insert_or_ignore_into,
     metrics::IndexerMetrics,
     models::{
@@ -44,6 +45,7 @@ use crate::{
             CheckpointTxGlobalOrder, IndexStatus, OptimisticTransaction, StoredTransaction,
         },
         tx_indices::TxIndexV2Split,
+        watermarks::StoredWatermark,
     },
     on_conflict_do_update, on_conflict_do_update_with_condition, persist_chunk_into_table,
     persist_chunk_into_table_in_existing_connection, read_only_blocking,
@@ -58,7 +60,7 @@ use crate::{
         objects_version, optimistic_transactions, packages, protocol_configs, pruner_cp_watermark,
         transactions, tx_calls_fun, tx_calls_mod, tx_calls_pkg, tx_changed_objects, tx_digests,
         tx_global_order, tx_input_objects, tx_kinds, tx_recipients, tx_senders,
-        tx_wrapped_or_deleted_objects,
+        tx_wrapped_or_deleted_objects, watermarks,
     },
     store::{IndexerStore, IndexerStoreExt},
     transactional_blocking_with_retry,
@@ -290,9 +292,12 @@ impl PgIndexerStore {
         &self,
     ) -> Result<Option<u64>, IndexerError> {
         read_only_blocking!(&self.blocking_cp, |conn| {
-            objects_snapshot::dsl::objects_snapshot
-                .select(max(objects_snapshot::checkpoint_sequence_number))
-                .first::<Option<i64>>(conn)
+            watermarks::table
+                .select(watermarks::checkpoint_hi_inclusive)
+                .filter(watermarks::entity.eq("objects_snapshot"))
+                .first::<i64>(conn)
+                // Handle case where the watermark is not set yet
+                .optional()
                 .map(|v| v.map(|v| v as u64))
         })
         .context("Failed reading latest object snapshot checkpoint sequence number from PostgresDB")
@@ -1607,6 +1612,51 @@ impl PgIndexerStore {
         })
     }
 
+    fn update_watermarks_upper_bound<E: IntoEnumIterator>(
+        &self,
+        watermark: CommitterWatermark,
+    ) -> Result<(), IndexerError>
+    where
+        E::Iterator: Iterator<Item: AsRef<str>>,
+    {
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_watermarks
+            .start_timer();
+
+        let upper_bound_updates = E::iter()
+            .map(|table| StoredWatermark::from_upper_bound_update(table.as_ref(), watermark))
+            .collect::<Vec<_>>();
+
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                diesel::insert_into(watermarks::table)
+                    .values(&upper_bound_updates)
+                    .on_conflict(watermarks::entity)
+                    .do_update()
+                    .set((
+                        watermarks::epoch_hi_inclusive.eq(excluded(watermarks::epoch_hi_inclusive)),
+                        watermarks::checkpoint_hi_inclusive
+                            .eq(excluded(watermarks::checkpoint_hi_inclusive)),
+                        watermarks::tx_hi_inclusive.eq(excluded(watermarks::tx_hi_inclusive)),
+                    ))
+                    .execute(conn)
+                    .map_err(IndexerError::from)
+                    .context("Failed to update watermarks upper bound")?;
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+        .tap_ok(|_| {
+            let elapsed = guard.stop_and_record();
+            info!(elapsed, "Persisted watermarks");
+        })
+        .tap_err(|e| {
+            tracing::error!("Failed to persist watermarks with error: {}", e);
+        })
+    }
+
     async fn execute_in_blocking_worker<F, R>(&self, f: F) -> Result<R, IndexerError>
     where
         F: FnOnce(Self) -> Result<R, IndexerError> + Send + 'static,
@@ -2215,6 +2265,19 @@ impl IndexerStore for PgIndexerStore {
     async fn refresh_participation_metrics(&self) -> Result<(), IndexerError> {
         self.execute_in_blocking_worker(move |this| this.refresh_participation_metrics())
             .await
+    }
+
+    async fn update_watermarks_upper_bound<E: IntoEnumIterator>(
+        &self,
+        watermark: CommitterWatermark,
+    ) -> Result<(), IndexerError>
+    where
+        E::Iterator: Iterator<Item: AsRef<str>>,
+    {
+        self.execute_in_blocking_worker(move |this| {
+            this.update_watermarks_upper_bound::<E>(watermark)
+        })
+        .await
     }
 
     fn as_any(&self) -> &dyn StdAny {

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-
 use core::result::Result::Ok;
 use std::{any::Any as StdAny, collections::BTreeMap, time::Duration};
 
@@ -27,7 +26,10 @@ use super::pg_partition_manager::{EpochPartitionData, PgPartitionManager};
 use crate::{
     db::ConnectionPool,
     errors::{Context, IndexerError},
-    handlers::{CommitterWatermark, EpochToCommit, TransactionObjectChangesToCommit},
+    handlers::{
+        CommitterWatermark, EpochToCommit, ObjectsSnapshotHandlerTables,
+        TransactionObjectChangesToCommit,
+    },
     insert_or_ignore_into,
     metrics::IndexerMetrics,
     models::{
@@ -288,19 +290,32 @@ impl PgIndexerStore {
         .context("Failed reading transaction range from PostgresDB")
     }
 
-    fn get_latest_object_snapshot_checkpoint_sequence_number(
+    fn get_latest_object_snapshot_watermark(
         &self,
-    ) -> Result<Option<u64>, IndexerError> {
+    ) -> Result<Option<CommitterWatermark>, IndexerError> {
         read_only_blocking!(&self.blocking_cp, |conn| {
             watermarks::table
-                .select(watermarks::checkpoint_hi_inclusive)
-                .filter(watermarks::entity.eq("objects_snapshot"))
-                .first::<i64>(conn)
+                .select((
+                    watermarks::epoch_hi_inclusive,
+                    watermarks::checkpoint_hi_inclusive,
+                    watermarks::tx_hi_inclusive,
+                ))
+                .filter(
+                    watermarks::entity
+                        .eq(ObjectsSnapshotHandlerTables::ObjectsSnapshot.to_string()),
+                )
+                .first::<(i64, i64, i64)>(conn)
                 // Handle case where the watermark is not set yet
                 .optional()
-                .map(|v| v.map(|v| v as u64))
+                .map(|v| {
+                    v.map(|(epoch, cp, tx)| CommitterWatermark {
+                        epoch: epoch as u64,
+                        cp: cp as u64,
+                        tx: tx as u64,
+                    })
+                })
         })
-        .context("Failed reading latest object snapshot checkpoint sequence number from PostgresDB")
+        .context("Failed reading latest object snapshot watermark from PostgresDB")
     }
 
     fn persist_display_updates(
@@ -1724,13 +1739,11 @@ impl IndexerStore for PgIndexerStore {
             .await
     }
 
-    async fn get_latest_object_snapshot_checkpoint_sequence_number(
+    async fn get_latest_object_snapshot_watermark(
         &self,
-    ) -> Result<Option<u64>, IndexerError> {
-        self.execute_in_blocking_worker(|this| {
-            this.get_latest_object_snapshot_checkpoint_sequence_number()
-        })
-        .await
+    ) -> Result<Option<CommitterWatermark>, IndexerError> {
+        self.execute_in_blocking_worker(|this| this.get_latest_object_snapshot_watermark())
+            .await
     }
 
     async fn persist_objects(

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -422,9 +422,10 @@ pub async fn wait_for_objects_snapshot(
     tokio::time::timeout(Duration::from_secs(30), async {
         while {
             let cp_opt = pg_store
-                .get_latest_object_snapshot_checkpoint_sequence_number()
+                .get_latest_object_snapshot_watermark()
                 .await
-                .unwrap();
+                .unwrap()
+                .map(|watermark| watermark.cp);
             cp_opt.is_none() || (cp_opt.unwrap() < checkpoint_sequence_number)
         } {
             tokio::time::sleep(Duration::from_millis(100)).await;


### PR DESCRIPTION
# Description of change

Pull https://github.com/MystenLabs/sui/pull/19649 and https://github.com/MystenLabs/sui/pull/19793

Original description:
```
Adds watermarks table, and has committer writing upper bounds to it.

The committer works on the checkpoints level, so to simplify what it needs to do, we can have the committer call store.update_watermarks_upper_bound() once when it completes its batch of work. The upper bound update function relies on PrunableTable to tell it which of epoch, cp, or tx should be used to update the upper bound.
```

Skipped writing watermarks for the following tables from the patch, since we don't have them:
```
TxAffectedAddresses,
TxAffectedObjects,
FullObjectsHistory,
RawCheckpoints,
```

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/8462
fixes https://github.com/iotaledger/iota/issues/8730

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests) - RPC and Ingestion tests of iota-indexer
- [x] Patch-specific tests (correctness, functionality coverage) - inspected local DB after the test run to see that watermarks table is filled

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
