### PR TITLE
upstream(graphql): cache chain identifier & use ticks

### DIFF
--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -66,9 +66,10 @@ use crate::{
         exchange_rates_task::TriggerExchangeRatesTask,
         system_package_task::SystemPackageTask,
         version::{check_version_middleware, set_version_middleware},
-        watermark_task::{Watermark, WatermarkLock, WatermarkTask},
+        watermark_task::{ChainIdentifierOnceCellLock, Watermark, WatermarkLock, WatermarkTask},
     },
     types::{
+        chain_identifier::ChainIdentifier,
         datatype::IMoveDatatype,
         move_object::IMoveObject,
         object::IObject,
@@ -374,6 +375,7 @@ impl ServerBuilder {
             ))
             .layer(axum::extract::Extension(schema))
             .layer(axum::extract::Extension(watermark_task.lock()))
+            .layer(axum::extract::Extension(watermark_task.chain_id_lock()))
             .layer(Self::cors()?);
 
         Ok(Server {
@@ -560,6 +562,7 @@ async fn graphql_handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     schema: Extension<IotaGraphQLSchema>,
     Extension(watermark_lock): Extension<WatermarkLock>,
+    Extension(chain_identifier_lock): Extension<ChainIdentifierOnceCellLock>,
     headers: HeaderMap,
     req: GraphQLRequest,
 ) -> (axum::http::Extensions, GraphQLResponse) {
@@ -574,6 +577,7 @@ async fn graphql_handler(
     req.data.insert(addr);
 
     req.data.insert(Watermark::new(watermark_lock).await);
+    req.data.insert(chain_identifier_lock.read());
 
     let result = schema.execute(req).await;
 
@@ -716,7 +720,7 @@ pub mod tests {
     };
     use iota_indexer::optimistic_indexing::OptimisticTransactionExecutor;
     use iota_sdk::wallet_context::WalletContext;
-    use iota_types::transaction::TransactionData;
+    use iota_types::{digests::get_mainnet_chain_identifier, transaction::TransactionData};
     use uuid::Uuid;
 
     use super::*;
@@ -750,6 +754,7 @@ pub mod tests {
             service_config.limits.clone(),
             metrics.clone(),
         );
+        let loader = DataLoader::new(db.clone());
         let pg_conn_pool = PgManager::new(reader);
         let cancellation_token = CancellationToken::new();
         let watermark = Watermark {
@@ -766,11 +771,13 @@ pub mod tests {
         );
         ServerBuilder::new(state)
             .context_data(db)
+            .context_data(loader)
             .context_data(pg_conn_pool)
             .context_data(service_config)
             .context_data(query_id())
             .context_data(ip_address())
             .context_data(watermark)
+            .context_data(ChainIdentifier::from(get_mainnet_chain_identifier()))
             .context_data(metrics)
     }
 
@@ -839,7 +846,7 @@ pub mod tests {
             schema.execute(query).await
         }
 
-        let query = "{ chainIdentifier }";
+        let query = r#"{ checkpoint(id: {sequenceNumber: 0 }) { digest }}"#;
         let timeout = Duration::from_millis(1000);
         let delay = Duration::from_millis(100);
 

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -562,7 +562,7 @@ async fn graphql_handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     schema: Extension<IotaGraphQLSchema>,
     Extension(watermark_lock): Extension<WatermarkLock>,
-    Extension(chain_identifier_lock): Extension<ChainIdentifierCache>,
+    Extension(chain_identifier_cache): Extension<ChainIdentifierCache>,
     headers: HeaderMap,
     req: GraphQLRequest,
 ) -> (axum::http::Extensions, GraphQLResponse) {
@@ -577,7 +577,7 @@ async fn graphql_handler(
     req.data.insert(addr);
 
     req.data.insert(Watermark::new(watermark_lock).await);
-    req.data.insert(chain_identifier_lock.read());
+    req.data.insert(chain_identifier_cache.read());
 
     let result = schema.execute(req).await;
 

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -66,7 +66,7 @@ use crate::{
         exchange_rates_task::TriggerExchangeRatesTask,
         system_package_task::SystemPackageTask,
         version::{check_version_middleware, set_version_middleware},
-        watermark_task::{ChainIdentifierOnceCellLock, Watermark, WatermarkLock, WatermarkTask},
+        watermark_task::{ChainIdentifierCache, Watermark, WatermarkLock, WatermarkTask},
     },
     types::{
         chain_identifier::ChainIdentifier,
@@ -375,7 +375,7 @@ impl ServerBuilder {
             ))
             .layer(axum::extract::Extension(schema))
             .layer(axum::extract::Extension(watermark_task.lock()))
-            .layer(axum::extract::Extension(watermark_task.chain_id_lock()))
+            .layer(axum::extract::Extension(watermark_task.chain_id_cache()))
             .layer(Self::cors()?);
 
         Ok(Server {
@@ -562,7 +562,7 @@ async fn graphql_handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     schema: Extension<IotaGraphQLSchema>,
     Extension(watermark_lock): Extension<WatermarkLock>,
-    Extension(chain_identifier_lock): Extension<ChainIdentifierOnceCellLock>,
+    Extension(chain_identifier_lock): Extension<ChainIdentifierCache>,
     headers: HeaderMap,
     req: GraphQLRequest,
 ) -> (axum::http::Extensions, GraphQLResponse) {

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -66,10 +66,10 @@ use crate::{
         exchange_rates_task::TriggerExchangeRatesTask,
         system_package_task::SystemPackageTask,
         version::{check_version_middleware, set_version_middleware},
-        watermark_task::{ChainIdentifierCache, Watermark, WatermarkLock, WatermarkTask},
+        watermark_task::{Watermark, WatermarkLock, WatermarkTask},
     },
     types::{
-        chain_identifier::ChainIdentifier,
+        chain_identifier::{ChainIdentifier, ChainIdentifierCache},
         datatype::IMoveDatatype,
         move_object::IMoveObject,
         object::IObject,
@@ -375,7 +375,6 @@ impl ServerBuilder {
             ))
             .layer(axum::extract::Extension(schema))
             .layer(axum::extract::Extension(watermark_task.lock()))
-            .layer(axum::extract::Extension(watermark_task.chain_id_cache()))
             .layer(Self::cors()?);
 
         Ok(Server {
@@ -505,7 +504,8 @@ impl ServerBuilder {
             .context_data(iota_names_config)
             .context_data(zklogin_config)
             .context_data(metrics.clone())
-            .context_data(config.clone());
+            .context_data(config.clone())
+            .context_data(ChainIdentifierCache::default());
 
         if config.internal_features.feature_gate {
             builder = builder.extension(FeatureGate);
@@ -562,7 +562,6 @@ async fn graphql_handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     schema: Extension<IotaGraphQLSchema>,
     Extension(watermark_lock): Extension<WatermarkLock>,
-    Extension(chain_identifier_cache): Extension<ChainIdentifierCache>,
     headers: HeaderMap,
     req: GraphQLRequest,
 ) -> (axum::http::Extensions, GraphQLResponse) {
@@ -577,7 +576,6 @@ async fn graphql_handler(
     req.data.insert(addr);
 
     req.data.insert(Watermark::new(watermark_lock).await);
-    req.data.insert(chain_identifier_cache.read());
 
     let result = schema.execute(req).await;
 

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -69,7 +69,7 @@ use crate::{
         watermark_task::{Watermark, WatermarkLock, WatermarkTask},
     },
     types::{
-        chain_identifier::{ChainIdentifier, ChainIdentifierCache},
+        chain_identifier::ChainIdentifierCache,
         datatype::IMoveDatatype,
         move_object::IMoveObject,
         object::IObject,
@@ -718,7 +718,7 @@ pub mod tests {
     };
     use iota_indexer::optimistic_indexing::OptimisticTransactionExecutor;
     use iota_sdk::wallet_context::WalletContext;
-    use iota_types::{digests::get_mainnet_chain_identifier, transaction::TransactionData};
+    use iota_types::transaction::TransactionData;
     use uuid::Uuid;
 
     use super::*;
@@ -775,7 +775,7 @@ pub mod tests {
             .context_data(query_id())
             .context_data(ip_address())
             .context_data(watermark)
-            .context_data(ChainIdentifier::from(get_mainnet_chain_identifier()))
+            .context_data(ChainIdentifierCache::default())
             .context_data(metrics)
     }
 

--- a/crates/iota-graphql-rpc/src/server/watermark_task.rs
+++ b/crates/iota-graphql-rpc/src/server/watermark_task.rs
@@ -7,10 +7,7 @@ use std::{mem, sync::Arc, time::Duration};
 use async_graphql::ServerError;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use iota_indexer::schema::checkpoints;
-use tokio::{
-    sync::{OnceCell, RwLock, watch},
-    time::Interval,
-};
+use tokio::sync::{OnceCell, RwLock, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
@@ -46,10 +43,7 @@ pub(crate) struct ChainIdentifierCache(pub(crate) Arc<OnceCell<ChainIdentifier>>
 impl ChainIdentifierCache {
     /// Read the stored chain identifier.
     pub(crate) fn read(&self) -> ChainIdentifier {
-        self.0
-            .get()
-            .map(|chain_identifier| chain_identifier.into_inner().into())
-            .unwrap_or_default()
+        self.0.get().copied().unwrap_or_default()
     }
 }
 
@@ -89,11 +83,11 @@ impl WatermarkTask {
     }
 
     pub(crate) async fn run(&self) {
-        let mut interval = tokio::time::interval(self.sleep);
         // start the process of finding & setting the chain identifier
         // so that it can be used in all requests.
-        self.initialize_chain_identifier(&mut interval).await;
+        self.initialize_chain_identifier().await;
 
+        let mut interval = tokio::time::interval(self.sleep);
         loop {
             tokio::select! {
                 _ = self.cancel.cancelled() => {
@@ -154,7 +148,8 @@ impl WatermarkTask {
     ///
     /// This ensures is initialized only once, regardless of how many times this
     /// method is called concurrently.
-    async fn initialize_chain_identifier(&self, interval: &mut Interval) {
+    async fn initialize_chain_identifier(&self) {
+        let mut interval = tokio::time::interval(self.sleep);
         self.chain_identifier.0.get_or_init(|| async {
             loop {
                 tokio::select! {

--- a/crates/iota-graphql-rpc/src/server/watermark_task.rs
+++ b/crates/iota-graphql-rpc/src/server/watermark_task.rs
@@ -146,8 +146,8 @@ impl WatermarkTask {
 
     /// Initialize the chain identifier if not already initialized.
     ///
-    /// This ensures is initialized only once, regardless of how many times this
-    /// method is called concurrently.
+    /// This ensures it is initialized only once, regardless of how many times
+    /// this method is called concurrently.
     async fn initialize_chain_identifier(&self) {
         let mut interval = tokio::time::interval(self.sleep);
         self.chain_identifier.0.get_or_init(|| async {

--- a/crates/iota-graphql-rpc/src/server/watermark_task.rs
+++ b/crates/iota-graphql-rpc/src/server/watermark_task.rs
@@ -26,9 +26,8 @@ use crate::{
 pub(crate) struct WatermarkTask {
     /// Thread-safe watermark that avoids writer starvation
     watermark: WatermarkLock,
-    /// Thread-safe container for chain identifier with guaranteed one-time
-    /// initialization.
-    chain_identifier: ChainIdentifierOnceCellLock,
+    /// Cached chain identifier.
+    chain_identifier: ChainIdentifierCache,
     db: Db,
     metrics: Metrics,
     sleep: Duration,
@@ -39,13 +38,12 @@ pub(crate) struct WatermarkTask {
 
 pub(crate) type WatermarkLock = Arc<RwLock<Watermark>>;
 
-/// Thread-safe container for chain identifier with guaranteed one-time
-/// initialization. Once set, typically from database, the value cannot be
-/// changed.
+/// Cache the chain identifier with guaranteed one-time initialization. Once
+/// set, typically from database, the value cannot be changed.
 #[derive(Clone, Default)]
-pub(crate) struct ChainIdentifierOnceCellLock(pub(crate) Arc<OnceCell<ChainIdentifier>>);
+pub(crate) struct ChainIdentifierCache(pub(crate) Arc<OnceCell<ChainIdentifier>>);
 
-impl ChainIdentifierOnceCellLock {
+impl ChainIdentifierCache {
     /// Read the stored chain identifier.
     pub(crate) fn read(&self) -> ChainIdentifier {
         self.0
@@ -138,12 +136,12 @@ impl WatermarkTask {
         self.watermark.clone()
     }
 
-    /// Returns a clone of the chain identifier lock.
+    /// Returns a clone of the chain identifier cache.
     ///
     /// It clones the underlying `Arc<OnceCell<ChainIdentifier>>` wrapper, which
-    /// means the returned `ChainIdentifierOnceCellLock` shares the same inner
-    /// data with the original.
-    pub(crate) fn chain_id_lock(&self) -> ChainIdentifierOnceCellLock {
+    /// means the returned `ChainIdentifierCache` shares the same inner data
+    /// with the original.
+    pub(crate) fn chain_id_cache(&self) -> ChainIdentifierCache {
         self.chain_identifier.clone()
     }
 

--- a/crates/iota-graphql-rpc/src/server/watermark_task.rs
+++ b/crates/iota-graphql-rpc/src/server/watermark_task.rs
@@ -46,7 +46,7 @@ pub(crate) type WatermarkLock = Arc<RwLock<Watermark>>;
 pub(crate) struct ChainIdentifierOnceCellLock(pub(crate) Arc<OnceCell<ChainIdentifier>>);
 
 impl ChainIdentifierOnceCellLock {
-    /// Read the stord chain identifier.
+    /// Read the stored chain identifier.
     pub(crate) fn read(&self) -> ChainIdentifier {
         self.0
             .get()

--- a/crates/iota-graphql-rpc/src/server/watermark_task.rs
+++ b/crates/iota-graphql-rpc/src/server/watermark_task.rs
@@ -7,7 +7,10 @@ use std::{mem, sync::Arc, time::Duration};
 use async_graphql::ServerError;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use iota_indexer::schema::checkpoints;
-use tokio::sync::{RwLock, watch};
+use tokio::{
+    sync::{OnceCell, RwLock, watch},
+    time::Interval,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
@@ -15,6 +18,7 @@ use crate::{
     data::{Db, DbConnection, QueryExecutor},
     error::Error,
     metrics::Metrics,
+    types::chain_identifier::ChainIdentifier,
 };
 
 /// Watermark task that periodically updates the current checkpoint, checkpoint
@@ -22,6 +26,9 @@ use crate::{
 pub(crate) struct WatermarkTask {
     /// Thread-safe watermark that avoids writer starvation
     watermark: WatermarkLock,
+    /// Thread-safe container for chain identifier with guaranteed one-time
+    /// initialization.
+    chain_identifier: ChainIdentifierOnceCellLock,
     db: Db,
     metrics: Metrics,
     sleep: Duration,
@@ -31,6 +38,22 @@ pub(crate) struct WatermarkTask {
 }
 
 pub(crate) type WatermarkLock = Arc<RwLock<Watermark>>;
+
+/// Thread-safe container for chain identifier with guaranteed one-time
+/// initialization. Once set, typically from database, the value cannot be
+/// changed.
+#[derive(Clone, Default)]
+pub(crate) struct ChainIdentifierOnceCellLock(pub(crate) Arc<OnceCell<ChainIdentifier>>);
+
+impl ChainIdentifierOnceCellLock {
+    /// Read the stord chain identifier.
+    pub(crate) fn read(&self) -> ChainIdentifier {
+        self.0
+            .get()
+            .map(|chain_identifier| chain_identifier.into_inner().into())
+            .unwrap_or_default()
+    }
+}
 
 /// Watermark used by GraphQL queries to ensure cross-query consistency and flag
 /// epoch-boundary changes.
@@ -57,6 +80,7 @@ impl WatermarkTask {
 
         Self {
             watermark: Default::default(),
+            chain_identifier: Default::default(),
             db,
             metrics,
             sleep,
@@ -67,18 +91,23 @@ impl WatermarkTask {
     }
 
     pub(crate) async fn run(&self) {
+        let mut interval = tokio::time::interval(self.sleep);
+        // start the process of finding & setting the chain identifier
+        // so that it can be used in all requests.
+        self.initialize_chain_identifier(&mut interval).await;
+
         loop {
             tokio::select! {
                 _ = self.cancel.cancelled() => {
-                    info!("Shutdown signal received, terminating watermark update task");
+                    info!("shutdown signal received, terminating watermark update task");
                     return;
                 },
-                _ = tokio::time::sleep(self.sleep) => {
+                _ = interval.tick() => {
                     let Watermark {checkpoint, epoch, checkpoint_timestamp_ms } = match Watermark::query(&self.db).await {
                         Ok(Some(watermark)) => watermark,
                         Ok(None) => continue,
                         Err(e) => {
-                            error!("{}", e);
+                            error!("error fetching the watermark: {e}");
                             self.metrics.inc_errors(&[ServerError::new(e.to_string(), None)]);
                             continue;
                         }
@@ -100,13 +129,56 @@ impl WatermarkTask {
         }
     }
 
+    /// Returns a clone of the watermark lock.
+    ///
+    /// It clones the underlying `Arc<RwLock<Watermark>>` wrapper, which means
+    /// the returned `WatermarkLock` shares the same inner data with the
+    /// original.
     pub(crate) fn lock(&self) -> WatermarkLock {
         self.watermark.clone()
+    }
+
+    /// Returns a clone of the chain identifier lock.
+    ///
+    /// It clones the underlying `Arc<OnceCell<ChainIdentifier>>` wrapper, which
+    /// means the returned `ChainIdentifierOnceCellLock` shares the same inner
+    /// data with the original.
+    pub(crate) fn chain_id_lock(&self) -> ChainIdentifierOnceCellLock {
+        self.chain_identifier.clone()
     }
 
     /// Receiver for subscribing to epoch changes.
     pub(crate) fn epoch_receiver(&self) -> watch::Receiver<u64> {
         self.receiver.clone()
+    }
+
+    /// Initialize the chain identifier if not already initialized.
+    ///
+    /// This ensures is initialized only once, regardless of how many times this
+    /// method is called concurrently.
+    async fn initialize_chain_identifier(&self, interval: &mut Interval) {
+        self.chain_identifier.0.get_or_init(|| async {
+            loop {
+                tokio::select! {
+                    _ = self.cancel.cancelled() => {
+                        info!("shutdown signal received, terminating attempt to get chain identifier");
+                        // return a default in case of cancellation
+                        return ChainIdentifier::default();
+                    },
+                    _ = interval.tick() => {
+                        match ChainIdentifier::query(&self.db).await {
+                            Ok(Some(chain)) => return chain.into(),
+                            Ok(None) => continue,
+                            Err(e) => {
+                                error!("failed to fetch chain identifier: {e}");
+                                self.metrics.inc_errors(&[ServerError::new(e.to_string(), None)]);
+                                continue;
+                            }
+                        }
+                    }
+                }
+            }
+        }).await;
     }
 }
 

--- a/crates/iota-graphql-rpc/src/server/watermark_task.rs
+++ b/crates/iota-graphql-rpc/src/server/watermark_task.rs
@@ -7,7 +7,7 @@ use std::{mem, sync::Arc, time::Duration};
 use async_graphql::ServerError;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use iota_indexer::schema::checkpoints;
-use tokio::sync::{OnceCell, RwLock, watch};
+use tokio::sync::{RwLock, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
@@ -15,7 +15,6 @@ use crate::{
     data::{Db, DbConnection, QueryExecutor},
     error::Error,
     metrics::Metrics,
-    types::chain_identifier::ChainIdentifier,
 };
 
 /// Watermark task that periodically updates the current checkpoint, checkpoint
@@ -23,8 +22,6 @@ use crate::{
 pub(crate) struct WatermarkTask {
     /// Thread-safe watermark that avoids writer starvation
     watermark: WatermarkLock,
-    /// Cached chain identifier.
-    chain_identifier: ChainIdentifierCache,
     db: Db,
     metrics: Metrics,
     sleep: Duration,
@@ -34,18 +31,6 @@ pub(crate) struct WatermarkTask {
 }
 
 pub(crate) type WatermarkLock = Arc<RwLock<Watermark>>;
-
-/// Cache the chain identifier with guaranteed one-time initialization. Once
-/// set, typically from database, the value cannot be changed.
-#[derive(Clone, Default)]
-pub(crate) struct ChainIdentifierCache(pub(crate) Arc<OnceCell<ChainIdentifier>>);
-
-impl ChainIdentifierCache {
-    /// Read the stored chain identifier.
-    pub(crate) fn read(&self) -> ChainIdentifier {
-        self.0.get().copied().unwrap_or_default()
-    }
-}
 
 /// Watermark used by GraphQL queries to ensure cross-query consistency and flag
 /// epoch-boundary changes.
@@ -72,7 +57,6 @@ impl WatermarkTask {
 
         Self {
             watermark: Default::default(),
-            chain_identifier: Default::default(),
             db,
             metrics,
             sleep,
@@ -83,10 +67,6 @@ impl WatermarkTask {
     }
 
     pub(crate) async fn run(&self) {
-        // start the process of finding & setting the chain identifier
-        // so that it can be used in all requests.
-        self.initialize_chain_identifier().await;
-
         let mut interval = tokio::time::interval(self.sleep);
         loop {
             tokio::select! {
@@ -130,48 +110,9 @@ impl WatermarkTask {
         self.watermark.clone()
     }
 
-    /// Returns a clone of the chain identifier cache.
-    ///
-    /// It clones the underlying `Arc<OnceCell<ChainIdentifier>>` wrapper, which
-    /// means the returned `ChainIdentifierCache` shares the same inner data
-    /// with the original.
-    pub(crate) fn chain_id_cache(&self) -> ChainIdentifierCache {
-        self.chain_identifier.clone()
-    }
-
     /// Receiver for subscribing to epoch changes.
     pub(crate) fn epoch_receiver(&self) -> watch::Receiver<u64> {
         self.receiver.clone()
-    }
-
-    /// Initialize the chain identifier if not already initialized.
-    ///
-    /// This ensures it is initialized only once, regardless of how many times
-    /// this method is called concurrently.
-    async fn initialize_chain_identifier(&self) {
-        let mut interval = tokio::time::interval(self.sleep);
-        self.chain_identifier.0.get_or_init(|| async {
-            loop {
-                tokio::select! {
-                    _ = self.cancel.cancelled() => {
-                        info!("shutdown signal received, terminating attempt to get chain identifier");
-                        // return a default in case of cancellation
-                        return ChainIdentifier::default();
-                    },
-                    _ = interval.tick() => {
-                        match ChainIdentifier::query(&self.db).await {
-                            Ok(Some(chain)) => return chain.into(),
-                            Ok(None) => continue,
-                            Err(e) => {
-                                error!("failed to fetch chain identifier: {e}");
-                                self.metrics.inc_errors(&[ServerError::new(e.to_string(), None)]);
-                                continue;
-                            }
-                        }
-                    }
-                }
-            }
-        }).await;
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/chain_identifier.rs
+++ b/crates/iota-graphql-rpc/src/types/chain_identifier.rs
@@ -2,39 +2,78 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use async_graphql::*;
-use diesel::{OptionalExtension, QueryDsl};
+use diesel::QueryDsl;
 use iota_indexer::schema::chain_identifier;
 use iota_types::{
     digests::ChainIdentifier as NativeChainIdentifier, messages_checkpoint::CheckpointDigest,
 };
+use tokio::sync::OnceCell;
+use tracing::error;
 
 use crate::{
     data::{Db, DbConnection, QueryExecutor},
     error::Error,
+    metrics::Metrics,
 };
 
+/// Cache the chain identifier with guaranteed one-time initialization. Once
+/// set, typically from database, the value cannot be changed.
+#[derive(Clone, Default)]
+pub(crate) struct ChainIdentifierCache(Arc<OnceCell<ChainIdentifier>>);
+
+impl ChainIdentifierCache {
+    /// Read or initialize the stored chain identifier by querying the database
+    /// once and cache the result to avoid subsequent queries.
+    ///
+    /// If the database query fails, this function will return an error, but the
+    /// cached value remains unset. Subsequent calls will continue to attempt
+    /// database queries until one succeeds, at which point the value will be
+    /// cached for all future calls.
+    ///
+    /// This ensures the chain identifier is only queried once successfully,
+    /// improving performance while maintaining proper error handling.
+    pub(crate) async fn read(&self, db: &Db, metrics: &Metrics) -> Result<ChainIdentifier, Error> {
+        self.0
+            .get_or_try_init(|| async {
+                match ChainIdentifier::query(db).await {
+                    Ok(chain) => Ok(chain.into()),
+                    Err(e) => {
+                        error!("failed to fetch chain identifier: {e}");
+                        metrics.inc_errors(&[ServerError::new(e.to_string(), None)]);
+                        Err(e)
+                    }
+                }
+            })
+            .await
+            .copied()
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default)]
-pub(crate) struct ChainIdentifier(Option<NativeChainIdentifier>);
+pub(crate) struct ChainIdentifier(NativeChainIdentifier);
 
 impl ChainIdentifier {
-    /// Unwraps the inner `Option<NativeChainIdentifier>`.
-    pub(crate) fn into_inner(self) -> Option<NativeChainIdentifier> {
+    /// Unwraps the inner
+    /// [`NativeChainIdentifier`](iota_types::digests::ChainIdentifier).
+    pub(crate) fn into_inner(self) -> NativeChainIdentifier {
         self.0
     }
 
     /// Query the Chain Identifier from the DB.
-    pub(crate) async fn query(db: &Db) -> Result<Option<NativeChainIdentifier>, Error> {
+    pub(crate) async fn query(db: &Db) -> Result<NativeChainIdentifier, Error> {
         use chain_identifier::dsl;
 
-        db.execute(move |conn| {
-            conn.first(move || dsl::chain_identifier.select(dsl::checkpoint_digest))
-                .optional()
-        })
-        .await
-        .map_err(|e| Error::Internal(format!("Failed to fetch genesis digest: {e}")))?
-        .map(Self::from_bytes)
-        .transpose()
+        let digest_bytes = db
+            .execute(move |conn| {
+                conn.first(move || dsl::chain_identifier.select(dsl::checkpoint_digest))
+            })
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to fetch genesis digest: {e}")))?;
+
+        Self::from_bytes(digest_bytes)
     }
 
     /// Treat `bytes` as a checkpoint digest and extract a chain identifier from
@@ -46,14 +85,8 @@ impl ChainIdentifier {
     }
 }
 
-impl From<Option<NativeChainIdentifier>> for ChainIdentifier {
-    fn from(chain_identifier: Option<NativeChainIdentifier>) -> Self {
-        Self(chain_identifier)
-    }
-}
-
 impl From<NativeChainIdentifier> for ChainIdentifier {
     fn from(chain_identifier: NativeChainIdentifier) -> Self {
-        Self(Some(chain_identifier))
+        Self(chain_identifier)
     }
 }

--- a/crates/iota-graphql-rpc/src/types/chain_identifier.rs
+++ b/crates/iota-graphql-rpc/src/types/chain_identifier.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::*;
-use diesel::QueryDsl;
+use diesel::{OptionalExtension, QueryDsl};
 use iota_indexer::schema::chain_identifier;
 use iota_types::{
     digests::ChainIdentifier as NativeChainIdentifier, messages_checkpoint::CheckpointDigest,
@@ -14,21 +14,31 @@ use crate::{
     error::Error,
 };
 
-pub(crate) struct ChainIdentifier;
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct ChainIdentifier(Option<NativeChainIdentifier>);
 
 impl ChainIdentifier {
+    /// Unwraps the inner `Option<NativeChainIdentifier>`.
+    pub(crate) fn into_inner(self) -> Option<NativeChainIdentifier> {
+        self.0
+    }
+
     /// Query the Chain Identifier from the DB.
-    pub(crate) async fn query(db: &Db) -> Result<NativeChainIdentifier, Error> {
+    pub(crate) async fn query(db: &Db) -> Result<Option<NativeChainIdentifier>, Error> {
         use chain_identifier::dsl;
 
-        let digest_bytes = db
+        let Some(digest_bytes) = db
             .execute(move |conn| {
                 conn.first(move || dsl::chain_identifier.select(dsl::checkpoint_digest))
+                    .optional()
             })
             .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch genesis digest: {e}")))?;
+            .map_err(|e| Error::Internal(format!("Failed to fetch genesis digest: {e}")))?
+        else {
+            return Ok(None);
+        };
 
-        Self::from_bytes(digest_bytes)
+        Self::from_bytes(digest_bytes).map(Some)
     }
 
     /// Treat `bytes` as a checkpoint digest and extract a chain identifier from
@@ -37,5 +47,17 @@ impl ChainIdentifier {
         let genesis_digest = CheckpointDigest::try_from(bytes)
             .map_err(|e| Error::Internal(format!("Failed to deserialize genesis digest: {e}")))?;
         Ok(NativeChainIdentifier::from(genesis_digest))
+    }
+}
+
+impl From<Option<NativeChainIdentifier>> for ChainIdentifier {
+    fn from(chain_identifier: Option<NativeChainIdentifier>) -> Self {
+        Self(chain_identifier)
+    }
+}
+
+impl From<NativeChainIdentifier> for ChainIdentifier {
+    fn from(chain_identifier: NativeChainIdentifier) -> Self {
+        Self(Some(chain_identifier))
     }
 }

--- a/crates/iota-graphql-rpc/src/types/chain_identifier.rs
+++ b/crates/iota-graphql-rpc/src/types/chain_identifier.rs
@@ -27,18 +27,14 @@ impl ChainIdentifier {
     pub(crate) async fn query(db: &Db) -> Result<Option<NativeChainIdentifier>, Error> {
         use chain_identifier::dsl;
 
-        let Some(digest_bytes) = db
-            .execute(move |conn| {
-                conn.first(move || dsl::chain_identifier.select(dsl::checkpoint_digest))
-                    .optional()
-            })
-            .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch genesis digest: {e}")))?
-        else {
-            return Ok(None);
-        };
-
-        Self::from_bytes(digest_bytes).map(Some)
+        db.execute(move |conn| {
+            conn.first(move || dsl::chain_identifier.select(dsl::checkpoint_digest))
+                .optional()
+        })
+        .await
+        .map_err(|e| Error::Internal(format!("Failed to fetch genesis digest: {e}")))?
+        .map(Self::from_bytes)
+        .transpose()
     }
 
     /// Treat `bytes` as a checkpoint digest and extract a chain identifier from

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -60,10 +60,15 @@ impl Query {
     /// First four bytes of the network's genesis checkpoint digest (uniquely
     /// identifies the network).
     async fn chain_identifier(&self, ctx: &Context<'_>) -> Result<String> {
-        Ok(ChainIdentifier::query(ctx.data_unchecked())
-            .await
-            .extend()?
-            .to_string())
+        // we want to panic if the chain identifier is missing, as there's something
+        // wrong with the service.
+        let chain_id: ChainIdentifier = *ctx.data_unchecked();
+
+        if let Some(id) = chain_id.into_inner() {
+            Ok(id.to_string())
+        } else {
+            Err(Error::Internal("chain identifier not initialized.".into())).extend()
+        }
     }
 
     /// Range of checkpoints that the RPC has data available for (for data

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -26,7 +26,7 @@ use crate::{
         address::Address,
         available_range::AvailableRange,
         base64::Base64 as GraphQLBase64,
-        chain_identifier::ChainIdentifier,
+        chain_identifier::ChainIdentifierCache,
         checkpoint::{self, Checkpoint, CheckpointId},
         coin::Coin,
         coin_metadata::CoinMetadata,
@@ -60,16 +60,15 @@ impl Query {
     /// First four bytes of the network's genesis checkpoint digest (uniquely
     /// identifies the network).
     async fn chain_identifier(&self, ctx: &Context<'_>) -> Result<String> {
-        // On every GraphQLRequest the chain identifier is injected into the Request
-        // Data in the `graphql_handler` function, if it panic it's a bug, it should be
-        // always present.
-        let chain_id: ChainIdentifier = *ctx.data_unchecked();
+        // the chain identifier cache is added to the context during server
+        // initialization, if it panics it's a bug, it should be always present.
+        let chain_id_cache: &ChainIdentifierCache = ctx.data_unchecked();
 
-        if let Some(id) = chain_id.into_inner() {
-            Ok(id.to_string())
-        } else {
-            Err(Error::Internal("chain identifier not initialized.".into())).extend()
-        }
+        chain_id_cache
+            .read(ctx.data_unchecked(), ctx.data_unchecked())
+            .await
+            .map(|id| id.into_inner().to_string())
+            .extend()
     }
 
     /// Range of checkpoints that the RPC has data available for (for data

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -60,8 +60,9 @@ impl Query {
     /// First four bytes of the network's genesis checkpoint digest (uniquely
     /// identifies the network).
     async fn chain_identifier(&self, ctx: &Context<'_>) -> Result<String> {
-        // we want to panic if the chain identifier is missing, as there's something
-        // wrong with the service.
+        // On every GraphQLRequest the chain identifier is injected into the Request
+        // Data in the `graphql_handler` function, if it panic it's a bug, it should be
+        // always present.
         let chain_id: ChainIdentifier = *ctx.data_unchecked();
 
         if let Some(id) = chain_id.into_inner() {


### PR DESCRIPTION
# Description of change

This PR includes an upstream patch regarding caching the `chain identifier` and storing it in memory instead of fetching it from database for every issued request since the chain identifier does not change. 

Also it includes the usage of interval `tick()` instead of the `tokio::time::sleep` in the WatermarkTask for more accurate updates of the checkpoint sequence number in the background to keep our queries consistently on `self.sleep` duration, instead of `self.sleep + query time`.

## Links to any relevant issues

fixes #8677 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Ran crate tests
```shell
cargo nextest run -p iota-graphql-rpc --features pg_integration --no-fail-fast --test-threads 1
```
- used the iota binary to spin up an indexer and graphql instance and test the  the chain identifier query 
```shell
cargo r --features indexer -- start --force-regenesis   --with-indexer --with-graphql
```
when requesting the chain identifier the response is near instant.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
 > The following patch does not change any logic in the `iota-indexer` crate thus it's core functionality remains intact.
