### PR TITLE
feat(starfish): add metrics for shards

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -372,10 +372,10 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 bcs::from_bytes(serialized_shard).map_err(ConsensusError::MalformedShard)?;
 
             if shard.block_ref.round >= verified_block.round() {
-                let e = Err(ConsensusError::TooBigShardRoundInABundle {
+                let e = ConsensusError::TooBigShardRoundInABundle {
                     shard_round: shard.block_ref.round,
                     block_round: verified_block.round(),
-                });
+                };
                 self.context
                     .metrics
                     .node_metrics
@@ -383,11 +383,11 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                     .with_label_values(&[
                         peer_hostname.as_str(),
                         "handle_subscribed_block_bundle",
-                        "invalid round in header",
+                        e.clone().name(),
                     ])
                     .inc();
-                info!("Invalid shard from {}: {}", peer, e.as_ref().unwrap_err());
-                return e;
+                info!("Invalid shard from {}: {}", peer, e);
+                return Err(e);
             }
 
             let proof_check = TransactionsCommitment::check_merkle_proof(

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -350,13 +350,13 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             );
 
             additional_block_headers.push(verified_block_header);
-            self.context
-                .metrics
-                .node_metrics
-                .valid_headers_in_bundles
-                .with_label_values(&[peer_hostname.as_str(), "handle_subscribed_block_bundle"])
-                .inc();
         }
+        self.context
+            .metrics
+            .node_metrics
+            .valid_headers_in_bundles
+            .with_label_values(&[peer_hostname.as_str(), "handle_subscribed_block_bundle"])
+            .inc_by(additional_block_headers.len() as u64);
 
         // 5. Collect shards from a bundle and check their proofs.
         if serialized_block_bundle_parts.serialized_shards.len() > MAX_SHARDS_PER_BUNDLE {
@@ -370,6 +370,26 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         for serialized_shard in serialized_block_bundle_parts.serialized_shards.iter() {
             let shard: ShardWithProof =
                 bcs::from_bytes(serialized_shard).map_err(ConsensusError::MalformedShard)?;
+
+            if shard.block_ref.round >= verified_block.round() {
+                let e = Err(ConsensusError::TooBigShardRoundInABundle {
+                    shard_round: shard.block_ref.round,
+                    block_round: verified_block.round(),
+                });
+                self.context
+                    .metrics
+                    .node_metrics
+                    .invalid_shard_in_bundles
+                    .with_label_values(&[
+                        peer_hostname.as_str(),
+                        "handle_subscribed_block_bundle",
+                        "invalid round in header",
+                    ])
+                    .inc();
+                info!("Invalid shard from {}: {}", peer, e.as_ref().unwrap_err());
+                return e;
+            }
+
             let proof_check = TransactionsCommitment::check_merkle_proof(
                 shard.clone(),
                 self.context.committee.size(),
@@ -378,12 +398,30 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             if proof_check {
                 shards_for_decoder.push(shard);
             } else {
-                return Err(ConsensusError::IncorrectShardProof {
+                let e = ConsensusError::IncorrectShardProof {
                     peer,
                     round: shard.block_ref.round,
-                });
+                };
+                self.context
+                    .metrics
+                    .node_metrics
+                    .invalid_shard_in_bundles
+                    .with_label_values(&[
+                        peer_hostname.as_str(),
+                        "handle_subscribed_block_bundle",
+                        e.clone().name(),
+                    ])
+                    .inc();
+                info!("Invalid shard from {}: {}", peer, e);
+                return Err(e);
             }
         }
+        self.context
+            .metrics
+            .node_metrics
+            .valid_shards_in_bundles
+            .with_label_values(&[peer_hostname.as_str(), "handle_subscribed_block_bundle"])
+            .inc_by(shards_for_decoder.len() as u64);
         // TODO: send to decoders
 
         // 6. Observe headers and the block for the commit votes. When local commit is

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1555,6 +1555,9 @@ impl DagState {
             .dag_state_recent_headers
             .set(self.recent_block_headers.len() as i64);
         metrics
+            .dag_state_recent_shards
+            .set(self.recent_shards.len() as i64);
+        metrics
             .dag_state_recent_transactions
             .set(self.recent_transactions.len() as i64);
         metrics.dag_state_recent_refs.set(

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -242,6 +242,14 @@ pub(crate) enum ConsensusError {
 
     #[error("Block bundle from {peer} contains shard from round {round} with incorrect proof")]
     IncorrectShardProof { peer: AuthorityIndex, round: Round },
+
+    #[error(
+        "Round of the shard in a bundle is greater or equal to the block round: {shard_round} >= {block_round}"
+    )]
+    TooBigShardRoundInABundle {
+        shard_round: Round,
+        block_round: Round,
+    },
 }
 
 impl ConsensusError {

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -122,6 +122,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) accepted_block_headers: IntCounterVec,
     pub(crate) dag_state_recent_transactions: IntGauge,
     pub(crate) dag_state_recent_headers: IntGauge,
+    pub(crate) dag_state_recent_shards: IntGauge,
     pub(crate) dag_state_recent_refs: IntGauge,
     pub(crate) dag_state_store_read_count: IntCounterVec,
     pub(crate) dag_state_store_write_count: IntCounter,
@@ -142,6 +143,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) filtered_headers_in_bundles: IntCounterVec,
     pub(crate) received_unique_headers_from_bundles: IntCounterVec,
     pub(crate) processed_duplicated_headers_in_bundles: IntCounterVec,
+    pub(crate) invalid_shard_in_bundles: IntCounterVec,
+    pub(crate) valid_shards_in_bundles: IntCounterVec,
     pub(crate) rejected_blocks: IntCounterVec,
     pub(crate) rejected_future_blocks: IntCounterVec,
     pub(crate) subscribed_blocks: IntCounterVec,
@@ -352,6 +355,11 @@ impl NodeMetrics {
                 "Number of recent block headers cached in the DagState",
                 registry,
             ).unwrap(),
+            dag_state_recent_shards: register_int_gauge_with_registry!(
+                "dag_state_recent_shards",
+                "Number of recent shards cached in the DagState",
+                registry,
+            ).unwrap(),
             dag_state_recent_refs: register_int_gauge_with_registry!(
                 "dag_state_recent_refs",
                 "Number of recent refs cached in the DagState",
@@ -452,7 +460,7 @@ impl NodeMetrics {
             ).unwrap(),
             invalid_headers_in_bundles: register_int_counter_vec_with_registry!(
                 "invalid_headers_in_bundles",
-                "Number of invalid block headers received from block bundles per sender authority",
+                "Number of block bundles that contain invalid header per sender authority",
                 &["authority", "source", "error"],
                 registry,
             ).unwrap(),
@@ -477,6 +485,18 @@ impl NodeMetrics {
             processed_duplicated_headers_in_bundles: register_int_counter_vec_with_registry!(
                 "processed_duplicated_headers_in_bundles",
                 "Number of times block headers from bundles were not filtered and processed extra time (i.e. deserialized and verified) per sender authority",
+                &["authority", "source"],
+                registry,
+            ).unwrap(),
+            invalid_shard_in_bundles: register_int_counter_vec_with_registry!(
+                "invalid_shard_in_bundles",
+                "Number of block bundles that contain invalid shards per sender authority",
+                &["authority", "source", "error"],
+                registry,
+            ).unwrap(),
+            valid_shards_in_bundles: register_int_counter_vec_with_registry!(
+                "valid_shards_in_bundles",
+                "Number of valid shards received from block bundles per sender authority",
                 &["authority", "source"],
                 registry,
             ).unwrap(),


### PR DESCRIPTION
# Description of change

This PR adds some new metrics for shards we receive in block bundles and store in dag_state.

## Links to any relevant issues

`fixes #8714 `.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

