### PR TITLE
fix(indexer): Handle errors for task common_handler.start_transform_and_load

### DIFF
--- a/crates/iota-indexer/src/handlers/mod.rs
+++ b/crates/iota-indexer/src/handlers/mod.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
 use tokio_util::sync::CancellationToken;
+use tracing::info;
 
 use crate::{
     errors::IndexerError,
@@ -105,6 +106,7 @@ impl<T> CommonHandler<T> {
 
         loop {
             if cancel.is_cancelled() {
+                info!("transform and load task terminating gracefully");
                 return Ok(());
             }
 
@@ -118,6 +120,7 @@ impl<T> CommonHandler<T> {
                 match stream.next().now_or_never() {
                     Some(Some(tuple_chunk)) => {
                         if cancel.is_cancelled() {
+                            info!("transform and load task terminating gracefully");
                             return Ok(());
                         }
                         for (cp_seq, data) in tuple_chunk {

--- a/crates/iota-indexer/src/handlers/objects_snapshot_handler.rs
+++ b/crates/iota-indexer/src/handlers/objects_snapshot_handler.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use iota_data_ingestion_core::Worker;
 use iota_metrics::{get_metrics, metered_channel::Sender, spawn_monitored_task};
 use iota_types::full_checkpoint_content::CheckpointData;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -104,7 +105,7 @@ pub async fn start_objects_snapshot_handler(
     metrics: IndexerMetrics,
     snapshot_config: SnapshotLagConfig,
     cancel: CancellationToken,
-) -> IndexerResult<(ObjectsSnapshotHandler, u64)> {
+) -> IndexerResult<(ObjectsSnapshotHandler, u64, JoinHandle<IndexerResult<()>>)> {
     info!("Starting object snapshot handler...");
 
     let global_metrics = get_metrics().unwrap();
@@ -120,8 +121,13 @@ pub async fn start_objects_snapshot_handler(
 
     let watermark_hi = objects_snapshot_handler.get_watermark_hi().await?;
     let common_handler = CommonHandler::new(Box::new(objects_snapshot_handler.clone()));
-    spawn_monitored_task!(common_handler.start_transform_and_load(receiver, cancel));
-    Ok((objects_snapshot_handler, watermark_hi.unwrap_or_default()))
+    let task_handle =
+        spawn_monitored_task!(common_handler.start_transform_and_load(receiver, cancel));
+    Ok((
+        objects_snapshot_handler,
+        watermark_hi.unwrap_or_default(),
+        task_handle,
+    ))
 }
 
 impl ObjectsSnapshotHandler {

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::HashMap, env};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use iota_data_ingestion_core::{
     DataIngestionMetrics, IndexerExecutor, ProgressStore, ReaderOptions, WorkerPool,
@@ -64,13 +64,14 @@ impl Indexer {
 
         // Start objects snapshot processor, which is a separate pipeline with its
         // ingestion pipeline.
-        let (object_snapshot_worker, object_snapshot_watermark) = start_objects_snapshot_handler(
-            store.clone(),
-            metrics.clone(),
-            snapshot_config,
-            cancel.clone(),
-        )
-        .await?;
+        let (object_snapshot_worker, object_snapshot_watermark, mut object_snapshot_task_handle) =
+            start_objects_snapshot_handler(
+                store.clone(),
+                metrics.clone(),
+                snapshot_config,
+                cancel.clone(),
+            )
+            .await?;
 
         if let Some(retention_config) = retention_config {
             let pruner = Pruner::new(store.clone(), retention_config, metrics.clone())?;
@@ -126,8 +127,8 @@ impl Indexer {
         );
         executor.register(worker_pool).await?;
         info!("Starting data ingestion executor...");
-        executor
-            .run(
+        let mut executor_handle = tokio::spawn(
+            executor.run(
                 config
                     .sources
                     .data_ingestion_path
@@ -140,8 +141,26 @@ impl Indexer {
                     .map(|url| url.as_str().to_owned()),
                 vec![],
                 extra_reader_options,
-            )
-            .await?;
+            ),
+        );
+
+        tokio::select! {
+            executor_result = &mut executor_handle => {
+                // Executor completed first - cancel snapshot task and check result
+                cancel.cancel();
+                let snapshot_result = object_snapshot_task_handle.await;
+                executor_result.context("failed to join data ingestion executor")?.context("data ingestion executor failed")?;
+                snapshot_result.context("failed to join snapshot task during shutdown")?.context("snapshot task failed during shutdown")?;
+            },
+            snapshot_result = &mut object_snapshot_task_handle => {
+                // Snapshot task completed first - cancel executor and check result
+                cancel.cancel();
+                let executor_result = executor_handle.await;
+                snapshot_result.context("failed to join snapshot task")?.context("snapshot task failed")?;
+                executor_result.context("failed to join data ingestion executor during shutdown")?.context("data ingestion executor failed during shutdown")?;
+            }
+        };
+
         Ok(())
     }
 

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, env};
+use std::{collections::HashMap, env, time::Duration};
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -14,6 +14,9 @@ use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use prometheus::Registry;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
+
+// Timeout for waiting for tasks to shutdown gracefully after cancellation
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
 use crate::{
     build_optimistic_json_rpc_server,
@@ -148,16 +151,24 @@ impl Indexer {
             executor_result = &mut executor_handle => {
                 // Executor completed first - cancel snapshot task and check result
                 cancel.cancel();
-                let snapshot_result = object_snapshot_task_handle.await;
+                let snapshot_result = tokio::time::timeout(
+                    SHUTDOWN_TIMEOUT,
+                    object_snapshot_task_handle
+                ).await
+                .context("timeout waiting for snapshot task to shutdown");
                 executor_result.context("failed to join data ingestion executor")?.context("data ingestion executor failed")?;
-                snapshot_result.context("failed to join snapshot task during shutdown")?.context("snapshot task failed during shutdown")?;
+                snapshot_result?.context("failed to join snapshot task during shutdown")?.context("snapshot task failed during shutdown")?;
             },
             snapshot_result = &mut object_snapshot_task_handle => {
                 // Snapshot task completed first - cancel executor and check result
                 cancel.cancel();
-                let executor_result = executor_handle.await;
+                let executor_result = tokio::time::timeout(
+                    SHUTDOWN_TIMEOUT,
+                    executor_handle
+                ).await
+                .context("timeout waiting for executor to shutdown");
                 snapshot_result.context("failed to join snapshot task")?.context("snapshot task failed")?;
-                executor_result.context("failed to join data ingestion executor during shutdown")?.context("data ingestion executor failed during shutdown")?;
+                executor_result?.context("failed to join data ingestion executor during shutdown")?.context("data ingestion executor failed during shutdown")?;
             }
         };
 

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -15,7 +15,7 @@ use prometheus::Registry;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-// Timeout for waiting for tasks to shutdown gracefully after cancellation
+/// Timeout for waiting for tasks to shutdown gracefully after cancellation
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
 use crate::{


### PR DESCRIPTION
# Description of change

Handle errors for task common_handler.start_transform_and_load

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/5780

## How the change has been tested

I've ran custom checks, to verify that on failure graceful shutdown of the other branch works.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
