### PR TITLE
feat(graphql-rpc): support move-view function calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6342,6 +6342,7 @@ dependencies = [
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-types",
+ "jsonrpsee",
  "move-binary-format",
  "move-core-types",
  "move-disassembler",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6330,6 +6330,7 @@ dependencies = [
  "iota-graphql-rpc-client",
  "iota-graphql-rpc-headers",
  "iota-indexer",
+ "iota-json",
  "iota-json-rpc",
  "iota-json-rpc-api",
  "iota-json-rpc-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6339,7 +6339,6 @@ dependencies = [
  "iota-network-stack",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.9.0-alpha",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-types",

--- a/crates/iota-graphql-rpc/Cargo.toml
+++ b/crates/iota-graphql-rpc/Cargo.toml
@@ -54,6 +54,7 @@ iota-graphql-config.workspace = true
 iota-graphql-rpc-client.workspace = true
 iota-graphql-rpc-headers.workspace = true
 iota-indexer.workspace = true
+iota-json.workspace = true
 iota-json-rpc.workspace = true
 iota-json-rpc-api.workspace = true
 iota-json-rpc-types.workspace = true

--- a/crates/iota-graphql-rpc/Cargo.toml
+++ b/crates/iota-graphql-rpc/Cargo.toml
@@ -63,7 +63,6 @@ iota-names.workspace = true
 iota-network-stack.workspace = true
 iota-package-resolver.workspace = true
 iota-rest-api.workspace = true
-iota-sdk.workspace = true
 iota-swarm-config.workspace = true
 iota-types.workspace = true
 move-binary-format.workspace = true

--- a/crates/iota-graphql-rpc/Cargo.toml
+++ b/crates/iota-graphql-rpc/Cargo.toml
@@ -31,6 +31,7 @@ http.workspace = true
 http-body-util = "0.1.2"
 hyper.workspace = true
 im.workspace = true
+jsonrpsee.workspace = true
 once_cell.workspace = true
 prometheus.workspace = true
 reqwest.workspace = true

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -2696,6 +2696,12 @@ type MoveValue {
 
 """
 The result of a move-view function call.
+
+Execution errors are captured in the `error` field, in which
+case the `results` field will be `None`.
+
+On success, the `results` field will contain the return values of the
+move view function, and the `error` field will be `None`.
 """
 type MoveViewResult {
 	"""

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -2695,6 +2695,20 @@ type MoveValue {
 }
 
 """
+The result of a move-view function call.
+"""
+type MoveViewResult {
+	"""
+	Execution error from executing the move view call.
+	"""
+	error: String
+	"""
+	The return values of the move view function.
+	"""
+	results: [JSON!]
+}
+
+"""
 The visibility modifier describes which modules can access this module
 member. By default, a module member can be called only within the same
 module.
@@ -3555,6 +3569,7 @@ type Query {
 	Configuration for this RPC service
 	"""
 	serviceConfig: ServiceConfig!
+	moveViewCall(functionName: String!, typeArgs: [String!], arguments: [JSON!]): MoveViewResult!
 	"""
 	Simulate running a transaction to inspect its effects without
 	committing to them on-chain.

--- a/crates/iota-graphql-rpc/src/error.rs
+++ b/crates/iota-graphql-rpc/src/error.rs
@@ -80,6 +80,8 @@ pub enum Error {
     Internal(String),
     #[error(transparent)]
     IotaNames(#[from] IotaNamesError),
+    #[error("{0}")]
+    ServerInit(String),
 }
 
 impl ErrorExtensions for Error {
@@ -96,6 +98,9 @@ impl ErrorExtensions for Error {
             }
             Error::IotaNames(_) => {
                 e.set("code", code::BAD_REQUEST);
+            }
+            Error::ServerInit(_) => {
+                e.set("code", code::UNKNOWN);
             }
         })
     }

--- a/crates/iota-graphql-rpc/src/mutation.rs
+++ b/crates/iota-graphql-rpc/src/mutation.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use async_graphql::*;
 use fastcrypto::encoding::Base64;
-use iota_indexer::apis::OptimisticWriteApi;
 use iota_json_rpc_api::WriteApiServer;
 use iota_json_rpc_types::IotaTransactionBlockResponseOptions;
 use iota_types::{
@@ -13,6 +12,7 @@ use iota_types::{
 
 use crate::{
     error::Error,
+    server::builder::get_write_api,
     types::{
         execution_result::ExecutionResult,
         transaction_block_effects::{TransactionBlockEffects, TransactionBlockEffectsKind},
@@ -48,14 +48,7 @@ impl Mutation {
         tx_bytes: String,
         signatures: Vec<String>,
     ) -> Result<ExecutionResult> {
-        let write_api: &Option<OptimisticWriteApi> = ctx
-            .data()
-            .map_err(|_| Error::Internal("Unable to fetch OptimisticWriteApi".to_string()))
-            .extend()?;
-        let optimistic_tx_executor = write_api
-            .as_ref()
-            .ok_or_else(|| Error::Internal("OptimisticWriteApi not initialized".to_string()))
-            .extend()?;
+        let write_api = get_write_api(ctx).extend()?;
         let tx_data = Base64::try_from(tx_bytes)
             .map_err(|e| {
                 Error::Client(format!(
@@ -81,7 +74,7 @@ impl Mutation {
             .with_raw_input()
             .with_raw_effects();
 
-        let result = optimistic_tx_executor
+        let result = write_api
             .execute_transaction_block(tx_data, sigs, Some(options), None)
             .await
             .map_err(|e| Error::Internal(format!("Unable to execute transaction: {e}")))

--- a/crates/iota-graphql-rpc/src/mutation.rs
+++ b/crates/iota-graphql-rpc/src/mutation.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 use async_graphql::*;
 use fastcrypto::encoding::Base64;
-use iota_indexer::optimistic_indexing::OptimisticTransactionExecutor;
+use iota_indexer::{apis::OptimisticWriteApi, optimistic_indexing::OptimisticTransactionExecutor};
+use iota_json_rpc_api::WriteApiServer;
 use iota_json_rpc_types::IotaTransactionBlockResponseOptions;
 use iota_types::{
     effects::TransactionEffects as NativeTransactionEffects, event::Event as NativeEvent,
@@ -47,17 +48,13 @@ impl Mutation {
         tx_bytes: String,
         signatures: Vec<String>,
     ) -> Result<ExecutionResult> {
-        let optimistic_tx_executor: &Option<OptimisticTransactionExecutor> = ctx
+        let write_api: &Option<OptimisticWriteApi> = ctx
             .data()
-            .map_err(|_| {
-                Error::Internal("Unable to fetch OptimisticTransactionExecutor".to_string())
-            })
+            .map_err(|_| Error::Internal("Unable to fetch OptimisticWriteApi".to_string()))
             .extend()?;
-        let optimistic_tx_executor = optimistic_tx_executor
+        let optimistic_tx_executor = write_api
             .as_ref()
-            .ok_or_else(|| {
-                Error::Internal("OptimisticTransactionExecutor not initialized".to_string())
-            })
+            .ok_or_else(|| Error::Internal("OptimisticWriteApi not initialized".to_string()))
             .extend()?;
         let tx_data = Base64::try_from(tx_bytes)
             .map_err(|e| {
@@ -85,7 +82,7 @@ impl Mutation {
             .with_raw_effects();
 
         let result = optimistic_tx_executor
-            .execute_and_index_transaction(tx_data, sigs, Some(options))
+            .execute_transaction_block(tx_data, sigs, Some(options), None)
             .await
             .map_err(|e| Error::Internal(format!("Unable to execute transaction: {e}")))
             .extend()?;

--- a/crates/iota-graphql-rpc/src/mutation.rs
+++ b/crates/iota-graphql-rpc/src/mutation.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use async_graphql::*;
 use fastcrypto::encoding::Base64;
-use iota_indexer::{apis::OptimisticWriteApi, optimistic_indexing::OptimisticTransactionExecutor};
+use iota_indexer::apis::OptimisticWriteApi;
 use iota_json_rpc_api::WriteApiServer;
 use iota_json_rpc_types::IotaTransactionBlockResponseOptions;
 use iota_types::{

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -37,7 +37,6 @@ use iota_json_rpc_api::CLIENT_SDK_TYPE_HEADER;
 use iota_metrics::spawn_monitored_task;
 use iota_network_stack::callback::{CallbackLayer, MakeCallbackHandler, ResponseHandler};
 use iota_package_resolver::{PackageStoreWithLruCache, Resolver};
-use iota_sdk::IotaClientBuilder;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use tokio::{join, net::TcpListener, sync::OnceCell};
 use tokio_util::sync::CancellationToken;
@@ -467,18 +466,7 @@ impl ServerBuilder {
 
         // SDK for talking to fullnode. Used for executing transactions only
         // TODO: fail fast if no url, once we enable mutations fully
-        let (iota_sdk_client, write_api) = if let Some(url) = &config.tx_exec_full_node.node_rpc_url
-        {
-            let iota_sdk_client = IotaClientBuilder::default()
-                .request_timeout(RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD)
-                .max_concurrent_requests(MAX_CONCURRENT_REQUESTS)
-                .build(url)
-                .await
-                .map_err(|e| {
-                    Error::Internal(format!(
-                        "Failed to connect to fullnode {e}. Is the node server running?"
-                    ))
-                })?;
+        let write_api = if let Some(url) = &config.tx_exec_full_node.node_rpc_url {
             let json_rpc_client = get_json_rpc_client(url)?;
             let indexer_store = PgIndexerStore::new(reader.get_pool(), indexer_metrics.clone());
             let optimistic_tx_executor = OptimisticTransactionExecutor::new(
@@ -491,12 +479,12 @@ impl ServerBuilder {
                 WriteApi::new(json_rpc_client, reader),
                 optimistic_tx_executor,
             );
-            (Some(iota_sdk_client), Some(write_api))
+            Some(write_api)
         } else {
             warn!(
                 "No fullnode url found in config. `dryRunTransactionBlock` and `executeTransactionBlock` will not work"
             );
-            (None, None)
+            None
         };
 
         builder = builder
@@ -505,7 +493,6 @@ impl ServerBuilder {
             .context_data(db)
             .context_data(pg_conn_pool)
             .context_data(resolver)
-            .context_data(iota_sdk_client)
             .context_data(write_api)
             .context_data(iota_names_config)
             .context_data(zklogin_config)

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -29,6 +29,7 @@ use iota_graphql_rpc_headers::LIMITS_HEADER;
 use iota_indexer::{
     apis::{OptimisticWriteApi, WriteApi},
     db::{get_pool_connection, setup_postgres::check_db_migration_consistency},
+    indexer_reader::IndexerReader,
     metrics::IndexerMetrics,
     optimistic_indexing::OptimisticTransactionExecutor,
     store::PgIndexerStore,
@@ -445,7 +446,7 @@ impl ServerBuilder {
             // time).
             config.service.limits.request_timeout_ms.into(),
         )
-        .map_err(|e| Error::Internal(format!("Failed to create pg connection pool: {e}")))?;
+        .map_err(|e| Error::ServerInit(format!("Failed to create pg connection pool: {e}")))?;
 
         // DB
         let db = Db::new(
@@ -464,28 +465,12 @@ impl ServerBuilder {
         builder.db_reader = Some(db.clone());
         builder.resolver = Some(resolver.clone());
 
-        // SDK for talking to fullnode. Used for executing transactions only
-        // TODO: fail fast if no url, once we enable mutations fully
-        let write_api = if let Some(url) = &config.tx_exec_full_node.node_rpc_url {
-            let json_rpc_client = get_json_rpc_client(url)?;
-            let indexer_store = PgIndexerStore::new(reader.get_pool(), indexer_metrics.clone());
-            let optimistic_tx_executor = OptimisticTransactionExecutor::new(
-                url,
-                reader.clone(),
-                indexer_store,
-                indexer_metrics.clone(),
-            );
-            let write_api = OptimisticWriteApi::new(
-                WriteApi::new(json_rpc_client, reader),
-                optimistic_tx_executor,
-            );
-            Some(write_api)
-        } else {
-            warn!(
-                "No fullnode url found in config. `dryRunTransactionBlock` and `executeTransactionBlock` will not work"
-            );
-            None
+        let Some(fullnode_url) = config.tx_exec_full_node.node_rpc_url.as_ref() else {
+            return Err(Error::ServerInit(
+                "No fullnode url found in config".to_string(),
+            ));
         };
+        let write_api = build_write_api(fullnode_url, reader, indexer_metrics)?;
 
         builder = builder
             .context_data(config.service.clone())
@@ -583,15 +568,26 @@ async fn graphql_handler(
 pub(crate) fn get_write_api<'ctx>(
     ctx: &'ctx Context<'_>,
 ) -> Result<&'ctx OptimisticWriteApi, Error> {
-    let write_api: &Option<OptimisticWriteApi> = ctx
-        .data()
-        .map_err(|_| Error::Internal("Unable to get node execution interface".to_string()))?;
-    write_api
-        .as_ref()
-        .ok_or_else(|| Error::Internal("Node execution interface not initialized".to_string()))
+    ctx.data_opt()
+        .ok_or_else(|| Error::Internal("Unable to get node execution interface".to_string()))
 }
 
-fn get_json_rpc_client(rpc_client_url: &str) -> Result<HttpClient, Error> {
+fn build_write_api(
+    fullnode_url: &str,
+    reader: IndexerReader,
+    metrics: IndexerMetrics,
+) -> Result<OptimisticWriteApi, Error> {
+    let json_rpc_client = build_json_rpc_client(fullnode_url)?;
+    let indexer_store = PgIndexerStore::new(reader.get_pool(), metrics.clone());
+    let optimistic_tx_executor =
+        OptimisticTransactionExecutor::new(fullnode_url, reader.clone(), indexer_store, metrics);
+    Ok(OptimisticWriteApi::new(
+        WriteApi::new(json_rpc_client, reader),
+        optimistic_tx_executor,
+    ))
+}
+
+fn build_json_rpc_client(rpc_client_url: &str) -> Result<HttpClient, Error> {
     let mut headers = HeaderMap::new();
     headers.insert(CLIENT_SDK_TYPE_HEADER, HeaderValue::from_static("graphql"));
 
@@ -863,7 +859,7 @@ pub mod tests {
         let fn_rpc_url = &cluster.validator_fullnode_handle.fullnode_handle.rpc_url;
         let indexer_metrics = store.get_metrics();
         let indexer_reader = iota_indexer::indexer_reader::IndexerReader::new(store.blocking_cp());
-        let json_rpc_client = get_json_rpc_client(fn_rpc_url).unwrap();
+        let json_rpc_client = build_json_rpc_client(fn_rpc_url).unwrap();
 
         let optimistic_tx_executor =
             iota_indexer::optimistic_indexing::OptimisticTransactionExecutor::new(

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -585,10 +585,10 @@ pub(crate) fn get_write_api<'ctx>(
 ) -> Result<&'ctx OptimisticWriteApi, Error> {
     let write_api: &Option<OptimisticWriteApi> = ctx
         .data()
-        .map_err(|_| Error::Internal("Unable to fetch IOTA SDK client".to_string()))?;
+        .map_err(|_| Error::Internal("Unable to get node execution interface".to_string()))?;
     write_api
         .as_ref()
-        .ok_or_else(|| Error::Internal("IOTA SDK client not initialized".to_string()))
+        .ok_or_else(|| Error::Internal("Node execution interface not initialized".to_string()))
 }
 
 fn get_json_rpc_client(rpc_client_url: &str) -> Result<HttpClient, Error> {

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -598,7 +598,7 @@ fn build_json_rpc_client(rpc_client_url: &str) -> Result<HttpClient, Error> {
         .max_concurrent_requests(MAX_CONCURRENT_REQUESTS);
 
     builder.build(rpc_client_url).map_err(|e| {
-        warn!("Failed to get new Http client with error: {:?}", e);
+        warn!("Failed to get new Http client with error: {e:?}");
         Error::Internal(format!(
             "Failed to initialize fullnode RPC client with error: {e:?}"
         ))

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use async_graphql::{
-    EmptySubscription, Schema, SchemaBuilder,
+    Context, EmptySubscription, Schema, SchemaBuilder,
     extensions::{ApolloTracing, ExtensionFactory, Tracing},
 };
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
@@ -27,14 +27,18 @@ use chrono::Utc;
 use http::{HeaderValue, Method, Request};
 use iota_graphql_rpc_headers::LIMITS_HEADER;
 use iota_indexer::{
+    apis::{OptimisticWriteApi, WriteApi},
     db::{get_pool_connection, setup_postgres::check_db_migration_consistency},
     metrics::IndexerMetrics,
+    optimistic_indexing::OptimisticTransactionExecutor,
     store::PgIndexerStore,
 };
+use iota_json_rpc_api::CLIENT_SDK_TYPE_HEADER;
 use iota_metrics::spawn_monitored_task;
 use iota_network_stack::callback::{CallbackLayer, MakeCallbackHandler, ResponseHandler};
 use iota_package_resolver::{PackageStoreWithLruCache, Resolver};
 use iota_sdk::IotaClientBuilder;
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use tokio::{join, net::TcpListener, sync::OnceCell};
 use tokio_util::sync::CancellationToken;
 use tower::{Layer, Service};
@@ -463,8 +467,7 @@ impl ServerBuilder {
 
         // SDK for talking to fullnode. Used for executing transactions only
         // TODO: fail fast if no url, once we enable mutations fully
-        let (iota_sdk_client, optimistic_tx_executor) = if let Some(url) =
-            &config.tx_exec_full_node.node_rpc_url
+        let (iota_sdk_client, write_api) = if let Some(url) = &config.tx_exec_full_node.node_rpc_url
         {
             let iota_sdk_client = IotaClientBuilder::default()
                 .request_timeout(RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD)
@@ -476,15 +479,19 @@ impl ServerBuilder {
                         "Failed to connect to fullnode {e}. Is the node server running?"
                     ))
                 })?;
+            let json_rpc_client = get_json_rpc_client(url)?;
             let indexer_store = PgIndexerStore::new(reader.get_pool(), indexer_metrics.clone());
-            let optimistic_tx_executor =
-                iota_indexer::optimistic_indexing::OptimisticTransactionExecutor::new(
-                    url,
-                    reader.clone(),
-                    indexer_store,
-                    indexer_metrics.clone(),
-                );
-            (Some(iota_sdk_client), Some(optimistic_tx_executor))
+            let optimistic_tx_executor = OptimisticTransactionExecutor::new(
+                url,
+                reader.clone(),
+                indexer_store,
+                indexer_metrics.clone(),
+            );
+            let write_api = OptimisticWriteApi::new(
+                WriteApi::new(json_rpc_client, reader),
+                optimistic_tx_executor,
+            );
+            (Some(iota_sdk_client), Some(write_api))
         } else {
             warn!(
                 "No fullnode url found in config. `dryRunTransactionBlock` and `executeTransactionBlock` will not work"
@@ -499,7 +506,7 @@ impl ServerBuilder {
             .context_data(pg_conn_pool)
             .context_data(resolver)
             .context_data(iota_sdk_client)
-            .context_data(optimistic_tx_executor)
+            .context_data(write_api)
             .context_data(iota_names_config)
             .context_data(zklogin_config)
             .context_data(metrics.clone())
@@ -584,6 +591,35 @@ async fn graphql_handler(
         extensions.insert(GraphqlErrors(std::sync::Arc::new(result.errors.clone())));
     };
     (extensions, result.into())
+}
+
+pub(crate) fn get_write_api<'ctx>(
+    ctx: &'ctx Context<'_>,
+) -> Result<&'ctx OptimisticWriteApi, Error> {
+    let write_api: &Option<OptimisticWriteApi> = ctx
+        .data()
+        .map_err(|_| Error::Internal("Unable to fetch IOTA SDK client".to_string()))?;
+    write_api
+        .as_ref()
+        .ok_or_else(|| Error::Internal("IOTA SDK client not initialized".to_string()))
+}
+
+fn get_json_rpc_client(rpc_client_url: &str) -> Result<HttpClient, Error> {
+    let mut headers = HeaderMap::new();
+    headers.insert(CLIENT_SDK_TYPE_HEADER, HeaderValue::from_static("graphql"));
+
+    let builder = HttpClientBuilder::default()
+        .max_request_size(2 << 30)
+        .set_headers(headers.clone())
+        .request_timeout(RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD)
+        .max_concurrent_requests(MAX_CONCURRENT_REQUESTS);
+
+    builder.build(rpc_client_url).map_err(|e| {
+        warn!("Failed to get new Http client with error: {:?}", e);
+        Error::Internal(format!(
+            "Failed to initialize fullnode RPC client with error: {e:?}"
+        ))
+    })
 }
 
 #[derive(Clone)]
@@ -724,6 +760,7 @@ pub mod tests {
         config::{ConnectionConfig, Limits, ServiceConfig, Version},
         context_data::db_data_provider::PgManager,
         extensions::{query_limits_checker::QueryLimitsChecker, timeout::Timeout},
+        test_infra::cluster::Cluster,
     };
 
     /// Prepares a schema for tests dealing with extensions. Returns a
@@ -789,10 +826,7 @@ pub mod tests {
         Uuid::new_v4()
     }
 
-    pub async fn test_timeout_impl(
-        wallet: &WalletContext,
-        optimistic_tx_executor: &OptimisticTransactionExecutor,
-    ) {
+    pub async fn test_timeout_impl(cluster: &Cluster) {
         struct TimedExecuteExt {
             pub min_req_delay: Duration,
         }
@@ -822,14 +856,14 @@ pub mod tests {
             delay: Duration,
             timeout: Duration,
             query: &str,
-            optimistic_tx_executor: &OptimisticTransactionExecutor,
+            write_api: &OptimisticWriteApi,
         ) -> Response {
             let mut cfg = ServiceConfig::default();
             cfg.limits.request_timeout_ms = timeout.as_millis() as u32;
             cfg.limits.mutation_timeout_ms = timeout.as_millis() as u32;
 
             let schema = prep_schema(None, Some(cfg))
-                .context_data(Some(optimistic_tx_executor.clone()))
+                .context_data(Some(write_api.clone()))
                 .extension(Timeout)
                 .extension(TimedExecuteExt {
                     min_req_delay: delay,
@@ -839,17 +873,36 @@ pub mod tests {
             schema.execute(query).await
         }
 
+        let wallet = &cluster.validator_fullnode_handle.wallet;
+        let store = &cluster.indexer_store;
+        let fn_rpc_url = &cluster.validator_fullnode_handle.fullnode_handle.rpc_url;
+        let indexer_metrics = store.get_metrics();
+        let indexer_reader = iota_indexer::indexer_reader::IndexerReader::new(store.blocking_cp());
+        let json_rpc_client = get_json_rpc_client(fn_rpc_url).unwrap();
+
+        let optimistic_tx_executor =
+            iota_indexer::optimistic_indexing::OptimisticTransactionExecutor::new(
+                fn_rpc_url,
+                indexer_reader.clone(),
+                store.clone(),
+                indexer_metrics,
+            );
+        let write_api = OptimisticWriteApi::new(
+            WriteApi::new(json_rpc_client, indexer_reader),
+            optimistic_tx_executor,
+        );
+
         let query = "{ chainIdentifier }";
         let timeout = Duration::from_millis(1000);
         let delay = Duration::from_millis(100);
 
-        test_timeout(delay, timeout, query, optimistic_tx_executor)
+        test_timeout(delay, timeout, query, &write_api)
             .await
             .into_result()
             .expect("Should complete successfully");
 
         // Should timeout
-        let errs: Vec<_> = test_timeout(delay, delay, query, optimistic_tx_executor)
+        let errs: Vec<_> = test_timeout(delay, delay, query, &write_api)
             .await
             .into_result()
             .unwrap_err()
@@ -892,7 +945,7 @@ pub mod tests {
             tx_bytes.encoded(),
             signature_base64.encoded()
         );
-        let errs: Vec<_> = test_timeout(delay, delay, &query, optimistic_tx_executor)
+        let errs: Vec<_> = test_timeout(delay, delay, &query, &write_api)
             .await
             .into_result()
             .unwrap_err()

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -750,8 +750,6 @@ pub mod tests {
         Response,
         extensions::{Extension, ExtensionContext, NextExecute},
     };
-    use iota_indexer::optimistic_indexing::OptimisticTransactionExecutor;
-    use iota_sdk::wallet_context::WalletContext;
     use iota_types::transaction::TransactionData;
     use uuid::Uuid;
 

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -837,14 +837,14 @@ pub mod tests {
             delay: Duration,
             timeout: Duration,
             query: &str,
-            write_api: &OptimisticWriteApi,
+            write_api: OptimisticWriteApi,
         ) -> Response {
             let mut cfg = ServiceConfig::default();
             cfg.limits.request_timeout_ms = timeout.as_millis() as u32;
             cfg.limits.mutation_timeout_ms = timeout.as_millis() as u32;
 
             let schema = prep_schema(None, Some(cfg))
-                .context_data(Some(write_api.clone()))
+                .context_data(write_api)
                 .extension(Timeout)
                 .extension(TimedExecuteExt {
                     min_req_delay: delay,
@@ -877,13 +877,13 @@ pub mod tests {
         let timeout = Duration::from_millis(1000);
         let delay = Duration::from_millis(100);
 
-        test_timeout(delay, timeout, query, &write_api)
+        test_timeout(delay, timeout, query, write_api.clone())
             .await
             .into_result()
             .expect("Should complete successfully");
 
         // Should timeout
-        let errs: Vec<_> = test_timeout(delay, delay, query, &write_api)
+        let errs: Vec<_> = test_timeout(delay, delay, query, write_api.clone())
             .await
             .into_result()
             .unwrap_err()
@@ -926,7 +926,7 @@ pub mod tests {
             tx_bytes.encoded(),
             signature_base64.encoded()
         );
-        let errs: Vec<_> = test_timeout(delay, delay, &query, &write_api)
+        let errs: Vec<_> = test_timeout(delay, delay, &query, write_api.clone())
             .await
             .into_result()
             .unwrap_err()

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -106,8 +106,11 @@ pub async fn start_cluster(
 }
 
 /// Takes in a simulated instantiation of an IOTA blockchain and builds a
-/// cluster around it. This cluster is typically used in e2e tests to emulate
-/// and test behaviors.
+/// cluster around it.
+///
+/// This cluster is typically used in e2e tests to emulate
+/// and test behaviors. It should be noted however that queries
+/// that rely on the fullnode Write API are not supported yet.
 pub async fn serve_executor(
     graphql_connection_config: ConnectionConfig,
     internal_data_source_rpc_port: u16,
@@ -147,9 +150,11 @@ pub async fn serve_executor(
     .await;
 
     // Starts graphql server
-    let graphql_server_handle = start_graphql_server(
+    let graphql_server_handle = start_graphql_server_with_fn_rpc(
         graphql_connection_config.clone(),
-        cancellation_token.clone(),
+        // this does not provide access to the node write api
+        Some(format!("http://{executor_server_url}")),
+        Some(cancellation_token.clone()),
     )
     .await;
 
@@ -215,14 +220,6 @@ pub async fn wait_for_graphql_checkpoint_pruned(
     })
     .await
     .expect("Timeout waiting for checkpoint to be pruned");
-}
-
-pub async fn start_graphql_server(
-    graphql_connection_config: ConnectionConfig,
-    cancellation_token: CancellationToken,
-) -> JoinHandle<()> {
-    start_graphql_server_with_fn_rpc(graphql_connection_config, None, Some(cancellation_token))
-        .await
 }
 
 pub async fn start_graphql_server_with_fn_rpc(

--- a/crates/iota-graphql-rpc/src/types/json.rs
+++ b/crates/iota-graphql-rpc/src/types/json.rs
@@ -5,10 +5,11 @@
 use std::fmt;
 
 use async_graphql::*;
+use serde::Serialize;
 
 /// Arbitrary JSON data.
-#[derive(Debug)]
-pub(crate) struct Json(Value);
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct Json(pub(crate) Value);
 
 #[Scalar(name = "JSON", use_type_description = true)]
 impl ScalarType for Json {

--- a/crates/iota-graphql-rpc/src/types/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod move_package;
 pub(crate) mod move_struct;
 pub(crate) mod move_type;
 pub(crate) mod move_value;
+pub(crate) mod move_view_result;
 pub(crate) mod object;
 pub(crate) mod object_change;
 pub(crate) mod object_read;

--- a/crates/iota-graphql-rpc/src/types/move_value.rs
+++ b/crates/iota-graphql-rpc/src/types/move_value.rs
@@ -68,7 +68,7 @@ type MoveData =
   }"
 );
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) enum MoveData {
     Address(IotaAddress),
     #[serde(rename = "UID")]
@@ -84,13 +84,13 @@ pub(crate) enum MoveData {
     Variant(MoveVariant),
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct MoveVariant {
     name: String,
     fields: Vec<MoveField>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct MoveField {
     name: String,
     value: MoveData,

--- a/crates/iota-graphql-rpc/src/types/move_view_result.rs
+++ b/crates/iota-graphql-rpc/src/types/move_view_result.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+use iota_json_rpc_types::{IotaMoveValue, IotaMoveViewCallResults};
+use serde::Serialize;
+
+use crate::{error::Error, types::json::Json};
+
+/// The result of a move-view function call.
+#[derive(Clone, Debug, Serialize, Default, SimpleObject)]
+pub(crate) struct MoveViewResult {
+    /// Execution error from executing the move view call.
+    error: Option<String>,
+    /// The return values of the move view function.
+    results: Option<Vec<Json>>,
+}
+
+impl TryFrom<IotaMoveViewCallResults> for MoveViewResult {
+    type Error = Error;
+
+    fn try_from(value: IotaMoveViewCallResults) -> Result<Self, Error> {
+        let mut result = Self::default();
+        match value {
+            IotaMoveViewCallResults::Error(e) => result.error = Some(e),
+            IotaMoveViewCallResults::Results(results) => {
+                result.results = Some(
+                    results
+                        .into_iter()
+                        .map(TryInto::try_into)
+                        .collect::<Result<_, _>>()?,
+                );
+            }
+        }
+        Ok(result)
+    }
+}
+
+impl TryFrom<IotaMoveValue> for Json {
+    type Error = Error;
+
+    fn try_from(value: IotaMoveValue) -> Result<Self, Error> {
+        let json = serde_json::to_value(value).map_err(|e| Error::Internal(e.to_string()))?;
+
+        Ok(Self(
+            Value::try_from(json).map_err(|e| Error::Internal(e.to_string()))?,
+        ))
+    }
+}

--- a/crates/iota-graphql-rpc/src/types/move_view_result.rs
+++ b/crates/iota-graphql-rpc/src/types/move_view_result.rs
@@ -48,8 +48,8 @@ impl TryFrom<IotaMoveValue> for Json {
     fn try_from(value: IotaMoveValue) -> Result<Self, Error> {
         let json = serde_json::to_value(value).map_err(|e| Error::Internal(e.to_string()))?;
 
-        Ok(Self(
-            Value::try_from(json).map_err(|e| Error::Internal(e.to_string()))?,
-        ))
+        Value::try_from(json)
+            .map_err(|e| Error::Internal(e.to_string()))
+            .map(Self)
     }
 }

--- a/crates/iota-graphql-rpc/src/types/move_view_result.rs
+++ b/crates/iota-graphql-rpc/src/types/move_view_result.rs
@@ -8,6 +8,12 @@ use serde::Serialize;
 use crate::{error::Error, types::json::Json};
 
 /// The result of a move-view function call.
+///
+/// Execution errors are captured in the `error` field, in which
+/// case the `results` field will be `None`.
+///
+/// On success, the `results` field will contain the return values of the
+/// move view function, and the `error` field will be `None`.
 #[derive(Clone, Debug, Serialize, Default, SimpleObject)]
 pub(crate) struct MoveViewResult {
     /// Execution error from executing the move view call.

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -6,8 +6,8 @@ use std::str::FromStr;
 
 use async_graphql::{connection::Connection, *};
 use fastcrypto::encoding::{Base64, Encoding};
+use iota_json_rpc_api::WriteApiServer;
 use iota_json_rpc_types::DevInspectArgs;
-use iota_sdk::IotaClient;
 use iota_types::{
     TypeTag,
     gas_coin::GAS,
@@ -21,7 +21,7 @@ use crate::{
     connection::ScanConnection,
     error::Error,
     mutation::Mutation,
-    server::watermark_task::Watermark,
+    server::{builder::get_write_api, watermark_task::Watermark},
     types::{
         address::Address,
         available_range::AvailableRange,
@@ -83,6 +83,16 @@ impl Query {
             .extend()
     }
 
+    async fn move_view_call(
+        &self,
+        ctx: &Context<'_>,
+        function_name: String,
+        type_args: Option<Vec<String>>,
+        arguments: Option<Vec<String>>,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+
     /// Simulate running a transaction to inspect its effects without
     /// committing to them on-chain.
     ///
@@ -109,15 +119,7 @@ impl Query {
     ) -> Result<DryRunResult> {
         let skip_checks = skip_checks.unwrap_or(false);
 
-        let iota_sdk_client: &Option<IotaClient> = ctx
-            .data()
-            .map_err(|_| Error::Internal("Unable to fetch IOTA SDK client".to_string()))
-            .extend()?;
-        let iota_sdk_client = iota_sdk_client
-            .as_ref()
-            .ok_or_else(|| Error::Internal("IOTA SDK client not initialized".to_string()))
-            .extend()?;
-
+        let write_api = get_write_api(ctx).extend()?;
         let (sender_address, tx_kind, gas_price, gas_sponsor, gas_budget, gas_objects) =
             if let Some(TransactionMetadata {
                 sender,
@@ -171,11 +173,15 @@ impl Query {
             skip_checks: Some(skip_checks),
         };
 
-        let res = iota_sdk_client
-            .read_api()
+        let tx_bytes = Base64::from_bytes(
+            &bcs::to_bytes(&tx_kind)
+                .map_err(|e| Error::Internal(e.to_string()))
+                .extend()?,
+        );
+        let res = write_api
             .dev_inspect_transaction_block(
                 sender_address,
-                tx_kind,
+                tx_bytes,
                 gas_price,
                 None,
                 Some(dev_inspect_args),

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -6,8 +6,9 @@ use std::str::FromStr;
 
 use async_graphql::{connection::Connection, *};
 use fastcrypto::encoding::{Base64, Encoding};
+use iota_json::IotaJsonValue;
 use iota_json_rpc_api::WriteApiServer;
-use iota_json_rpc_types::DevInspectArgs;
+use iota_json_rpc_types::{DevInspectArgs, IotaTypeTag};
 use iota_types::{
     TypeTag,
     gas_coin::GAS,
@@ -39,6 +40,7 @@ use crate::{
         iota_names_registration::{IotaNames, Name},
         move_package::{self, MovePackage, MovePackageCheckpointFilter, MovePackageVersionFilter},
         move_type::MoveType,
+        move_view_result::MoveViewResult,
         object::{self, Object, ObjectFilter},
         owner::Owner,
         protocol_config::ProtocolConfigs,
@@ -88,9 +90,22 @@ impl Query {
         ctx: &Context<'_>,
         function_name: String,
         type_args: Option<Vec<String>>,
-        arguments: Option<Vec<String>>,
-    ) -> Result<bool> {
-        Ok(true)
+        arguments: Option<Vec<serde_json::Value>>,
+    ) -> Result<MoveViewResult> {
+        let type_args = type_args.map(|args| args.into_iter().map(IotaTypeTag::new).collect());
+        let call_args = arguments
+            .unwrap_or_default()
+            .into_iter()
+            .map(IotaJsonValue::new)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Error::Client(e.to_string()))
+            .extend()?;
+        let write_api = get_write_api(ctx).extend()?;
+        let results = write_api
+            .view_function_call(function_name, type_args, call_args)
+            .await?;
+
+        results.try_into().extend()
     }
 
     /// Simulate running a transaction to inspect its effects without

--- a/crates/iota-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/iota-graphql-rpc/tests/e2e_tests.rs
@@ -862,34 +862,13 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_timeout() {
-        let _guard = telemetry_subscribers::TelemetryConfig::new()
-            .with_env()
-            .init();
         let cluster =
             iota_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
                 .await;
         cluster
             .wait_for_checkpoint_catchup(0, Duration::from_secs(10))
             .await;
-        // timeout test includes mutation timeout, which requires an
-        // [OptimisticTransactionExecutor] to be able to run the test, and a
-        // transaction. [WalletContext] gives access to all other components that are
-        // needed.
-        let wallet = &cluster.validator_fullnode_handle.wallet;
-        let store = &cluster.indexer_store;
-        let fn_rpc_url = &cluster.validator_fullnode_handle.fullnode_handle.rpc_url;
-        let indexer_metrics = store.get_metrics();
-        let indexer_reader = iota_indexer::indexer_reader::IndexerReader::new(store.blocking_cp());
-
-        let optimistic_tx_executor =
-            iota_indexer::optimistic_indexing::OptimisticTransactionExecutor::new(
-                fn_rpc_url,
-                indexer_reader,
-                store.clone(),
-                indexer_metrics,
-            );
-
-        test_timeout_impl(wallet, &optimistic_tx_executor).await;
+        test_timeout_impl(&cluster).await;
         cluster.cleanup_resources().await
     }
 

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2699,6 +2699,20 @@ type MoveValue {
 }
 
 """
+The result of a move-view function call.
+"""
+type MoveViewResult {
+	"""
+	Execution error from executing the move view call.
+	"""
+	error: String
+	"""
+	The return values of the move view function.
+	"""
+	results: [JSON!]
+}
+
+"""
 The visibility modifier describes which modules can access this module
 member. By default, a module member can be called only within the same
 module.
@@ -3559,6 +3573,7 @@ type Query {
 	Configuration for this RPC service
 	"""
 	serviceConfig: ServiceConfig!
+	moveViewCall(functionName: String!, typeArgs: [String!], arguments: [JSON!]): MoveViewResult!
 	"""
 	Simulate running a transaction to inspect its effects without
 	committing to them on-chain.

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2700,6 +2700,12 @@ type MoveValue {
 
 """
 The result of a move-view function call.
+
+Execution errors are captured in the `error` field, in which
+case the `results` field will be `None`.
+
+On success, the `results` field will contain the return values of the
+move view function, and the `error` field will be `None`.
 """
 type MoveViewResult {
 	"""

--- a/crates/iota-indexer/src/apis/mod.rs
+++ b/crates/iota-indexer/src/apis/mod.rs
@@ -9,7 +9,7 @@ pub(crate) use indexer_api::IndexerApi;
 pub(crate) use move_utils::MoveUtilsApi;
 pub(crate) use read_api::ReadApi;
 pub(crate) use transaction_builder_api::TransactionBuilderApi;
-pub(crate) use write_api::{OptimisticWriteApi, WriteApi};
+pub use write_api::{OptimisticWriteApi, WriteApi};
 
 mod coin_api;
 mod extended_api;

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -28,13 +28,15 @@ use crate::{
     types::IotaTransactionBlockResponseWithOptions,
 };
 
-pub(crate) struct WriteApi {
+#[derive(Clone)]
+pub struct WriteApi {
     fullnode: HttpClient,
     transaction_builder: TransactionBuilder,
     package_resolver: IndexerStorePackageResolver,
 }
 
-pub(crate) struct OptimisticWriteApi {
+#[derive(Clone)]
+pub struct OptimisticWriteApi {
     write_api: WriteApi,
     optimistic_tx_executor: OptimisticTransactionExecutor,
 }


### PR DESCRIPTION
# Description of change

This patch adds support for move-view function calls in the GraphQL API.

The output is fully compatible with the JSON-RPC:

This query
```graphql
{
  moveViewCall(
    functionName: "0x2d7a8e89feadf4d346643cb69cac861d177891ab4c82b2ff7666324b772a53ac::wat_counter::get_counter"
    arguments: ["0x6a574d438156bd05ec9cd4b569fe50313b16d43eaab4833cc358bf4f26e9fe7a"]
  ) {
    error
    results
  }
}
```
returns this
```json
{
  "data": {
    "moveViewCall": {
      "error": null,
      "results": [
        "10"
      ]
    }
  }
}
```

While this query

```graphql
{
  moveViewCall(
    functionName: "0x2d7a8e89feadf4d346643cb69cac861d177891ab4c82b2ff7666324b772a53ac::wat_counter::get_wat_object"
    arguments: ["0x6a574d438156bd05ec9cd4b569fe50313b16d43eaab4833cc358bf4f26e9fe7a"]
  ) {
    error
    results
  }
}
```

Returns this
```json
{
  "data": {
    "moveViewCall": {
      "error": null,
      "results": [
        {
          "type": "0x2d7a8e89feadf4d346643cb69cac861d177891ab4c82b2ff7666324b772a53ac::wat_counter::Wat",
          "fields": {
            "counter": "10",
            "id": {
              "id": "0x6a574d438156bd05ec9cd4b569fe50313b16d43eaab4833cc358bf4f26e9fe7a"
            }
          }
        }
      ]
    }
  }
}
```
## Links to any relevant issues

Fixes #8346 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

Manual tests have been performed additionally.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Verification of API backward compatibility.

### Release Notes

- [x] GraphQL: Introducing a new `moveViewCall` query path to call move-view functions. :rotating_light:  The server now requires that the fullnode JSON-RPC url is specified in the configuration, to be able to run `mutation.executeTransactionBlock`, `query.{moveViewCall,dryRunTransactionBlock}`. :rotating_light: 
