### PR TITLE
feat(consensus): track useful authorities during block bundle exchange

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     pin::Pin,
     sync::Arc,
     time::Duration,
@@ -114,6 +114,14 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     received_block_headers: FilterForHeaders,
     /// Sender to send received transaction messages to the shard reconstructor
     transaction_message_sender: Sender<Vec<TransactionMessage>>,
+    /// For each peer, the set of authorities whose block headers the local node
+    /// considered useful when receiving a block bundle from that peer.
+    /// Keyed by the peer’s AuthorityIndex.
+    useful_authorities_from_peer: Arc<RwLock<BTreeMap<AuthorityIndex, BTreeSet<AuthorityIndex>>>>,
+    /// For each peer, the set of local authorities that the peer reported as
+    /// useful to them (communicated inside their block bundles).
+    /// Keyed by the peer’s AuthorityIndex.
+    useful_authorities_to_peer: Arc<RwLock<BTreeMap<AuthorityIndex, BTreeSet<AuthorityIndex>>>>,
 }
 
 impl<C: CoreThreadDispatcher> AuthorityService<C> {
@@ -146,6 +154,8 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             dag_state,
             store,
             received_block_headers: FilterForHeaders::new(),
+            useful_authorities_from_peer: Arc::new(RwLock::new(BTreeMap::new())),
+            useful_authorities_to_peer: Arc::new(RwLock::new(BTreeMap::new())),
             transaction_message_sender,
         }
     }
@@ -162,9 +172,17 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         fail_point_async!("consensus-rpc-response");
 
         let peer_hostname = &self.context.committee.authority(peer).hostname;
-        // 1. Create a verified block and make some preliminary checks
         let serialized_block_bundle_parts =
             SerializedBlockBundleParts::try_from(serialized_block_bundle)?;
+
+        // Cache authorities this peer finds useful for cordial
+        let useful_authorities_to_peer = serialized_block_bundle_parts.useful_authorities();
+        {
+            let mut guard = self.useful_authorities_to_peer.write();
+            guard.insert(peer, useful_authorities_to_peer);
+        }
+
+        // 1. Create a verified block and make some preliminary checks
         let SerializedHeaderAndTransactions {
             serialized_block_header,
             serialized_transactions,
@@ -528,13 +546,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             warn!("Failed to send transaction messages to shard reconstructor: {e}");
         }
 
-        // 10. Add additional headers from bundle to dag, receive missing ancestors for
-        //     them
-        // Normally, there should be no missing ancestors, as the headers are sent in
-        // order of increasing rounds.
+        // 10.Add additional headers from bundle to dag, receive missing ancestors for
+        // them. Normally, there should be no missing ancestors, as the headers are
+        // sent in order of increasing rounds.
         let (mut missing_ancestors, mut missing_committed_txns) = self
             .core_dispatcher
-            .add_block_headers(additional_block_headers)
+            .add_block_headers(additional_block_headers.clone())
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
 
@@ -567,7 +584,21 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
 
-        // 13. schedule the fetching of missing ancestors (if any) from this peer
+        // 13. update `useful_authorities_from_peer`
+        // create a set of authority indexes from the `additional_block_headers`
+        // and `missing_ancestors`
+        let useful_authorities = additional_block_headers
+            .iter()
+            .map(|block_header| block_header.author())
+            .chain(missing_ancestors.iter().map(|block_ref| block_ref.author))
+            .collect::<BTreeSet<_>>();
+        {
+            let mut useful_authorities_from_peer_write_guard =
+                self.useful_authorities_from_peer.write();
+            useful_authorities_from_peer_write_guard.insert(peer, useful_authorities);
+        }
+
+        // 14. schedule the fetching of missing ancestors (if any) from this peer
         if !missing_ancestors.is_empty() {
             if let Err(err) = self
                 .synchronizer
@@ -578,7 +609,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             }
         }
 
-        // 14. schedule the fetching of missing committed transactions (if any)
+        // 15. schedule the fetching of missing committed transactions (if any)
         if !missing_committed_txns.is_empty() {
             if let Err(err) = self
                 .transactions_synchronizer
@@ -629,18 +660,47 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // new blocks.
         Ok(Box::pin(missed_blocks.chain({
             let dag_state = Arc::clone(&self.dag_state);
+            let useful_authorities_from_peer = Arc::clone(&self.useful_authorities_from_peer);
+            let useful_authorities_to_peer = Arc::clone(&self.useful_authorities_to_peer);
+            let committee = self
+                .context
+                .committee
+                .authorities()
+                .map(|(index, _)| index)
+                .collect::<BTreeSet<_>>();
 
             broadcasted_blocks.filter_map(move |block| {
+                let useful_authorities_to_peer_guard = useful_authorities_to_peer.read();
+                let useful_authorities_to_peer_read = useful_authorities_to_peer_guard
+                    .get(&peer)
+                    .map(|authorities| authorities.iter().cloned().collect::<BTreeSet<_>>());
+                drop(useful_authorities_to_peer_guard);
+                let useful_authorities_from_peer_guard = useful_authorities_from_peer.read();
+                let useful_authorities_from_peer_read =
+                    match useful_authorities_from_peer_guard.get(&peer) {
+                        None => committee.clone(),
+                        Some(useful_authorities) => useful_authorities.clone(),
+                    };
+                drop(useful_authorities_from_peer_guard);
+
                 let mut dag_state_guard = dag_state.write();
-                let block_headers =
-                    dag_state_guard.take_unknown_headers_for_authority(peer, block.round());
+                let block_headers = match useful_authorities_to_peer_read {
+                    None => dag_state_guard.take_unknown_headers_for_authority(peer, block.round()),
+                    Some(authorities) => dag_state_guard.take_useful_headers_for_authority(
+                        peer,
+                        block.round(),
+                        authorities,
+                    ),
+                };
                 let serialized_shards =
                     dag_state_guard.take_unknown_shards_for_authority(peer, block.round());
                 drop(dag_state_guard);
+
                 let block_bundle = BlockBundle {
                     verified_block: block,
                     verified_headers: block_headers,
                     serialized_shards,
+                    useful_authorities: useful_authorities_from_peer_read,
                 };
                 async move {
                     match SerializedBlockBundle::try_from(block_bundle) {
@@ -698,8 +758,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let commit_sync_handle = highest_accepted_rounds.is_empty();
 
         // For commit sync, the fetch size is larger. For periodic/live synchronizer,
-        // the fetch size is smaller.else { Instead of rejecting the request, we
-        // truncate the size to allow an easy update of this parameter in the future.
+        // the fetch size is smaller. Instead of rejecting the request, we truncate
+        // the size to allow an easy update of this parameter in the future.
         let max_fetch_size = if commit_sync_handle {
             self.context.parameters.max_headers_per_commit_sync_fetch
         } else {
@@ -1611,6 +1671,7 @@ mod tests {
             verified_block: input_block.clone(),
             verified_headers: headers.clone(),
             serialized_shards: vec![],
+            useful_authorities: (0u8..(committee_size as u8)).map(Into::into).collect(),
         };
         let serialized_big_block_bundle = SerializedBlockBundle::try_from(
             SerializedBlockBundleParts::try_from(big_block_bundle).unwrap(),
@@ -1639,6 +1700,7 @@ mod tests {
             verified_block: input_block.clone(),
             verified_headers: headers.clone(),
             serialized_shards: vec![],
+            useful_authorities: (0u8..(committee_size as u8)).map(Into::into).collect(),
         };
         let serialized_block_bundle_with_big_round = SerializedBlockBundle::try_from(
             SerializedBlockBundleParts::try_from(block_bundle_with_big_rounds).unwrap(),
@@ -1675,6 +1737,7 @@ mod tests {
             verified_block: input_block.clone(),
             verified_headers: headers.clone(),
             serialized_shards: vec![],
+            useful_authorities: (0u8..(committee_size as u8)).map(Into::into).collect(),
         };
         let serialized_block_bundle = SerializedBlockBundle::try_from(
             SerializedBlockBundleParts::try_from(block_bundle).unwrap(),
@@ -2169,6 +2232,9 @@ mod tests {
                     verified_block: block,
                     verified_headers: headers,
                     serialized_shards: vec![],
+                    useful_authorities: (0u8..(context.committee.size() as u8))
+                        .map(Into::into)
+                        .collect(),
                 };
                 let serialized_block_bundle = SerializedBlockBundle::try_from(
                     SerializedBlockBundleParts::try_from(block_bundle).unwrap(),
@@ -2309,6 +2375,9 @@ mod tests {
                     verified_block: block,
                     verified_headers: vec![],
                     serialized_shards: vec![],
+                    useful_authorities: (0u8..(context.committee.size() as u8))
+                        .map(Into::into)
+                        .collect(),
                 };
                 let serialized_block_bundle = SerializedBlockBundle::try_from(
                     SerializedBlockBundleParts::try_from(block_bundle).unwrap(),

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -16,7 +16,7 @@ use bytes::Bytes;
 use itertools::Itertools as _;
 use starfish_config::AuthorityIndex;
 use tokio::time::Instant;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     block_header::{
@@ -1246,16 +1246,24 @@ impl DagState {
         self.commit_info_to_write
             .push((last_commit.reference(), commit_info));
     }
-
-    /// Takes a batch of at most MAX_HEADERS_PER_BUNDLE unknown headers for the
-    /// given authority, but only from round smaller than
-    /// round_upper_bound_exclusive. Marks these headers as known to the
-    /// authority.
-    pub(crate) fn take_unknown_headers_for_authority(
+    /// Removes and returns up to `MAX_HEADERS_PER_BUNDLE` block references that
+    /// the given authority has not yet seen, limited to rounds strictly
+    /// below `round_upper_bound_exclusive`.
+    ///
+    /// Side effects:
+    /// - Updates `block_headers_not_known_by_authority` so these refs are no
+    ///   longer considered "unknown" for the authority.
+    /// - Marks the given authority as knowing these blocks inside
+    ///   `recent_dag_cordial_knowledge`.
+    ///
+    /// Returns:
+    /// - A vector of `BlockRef`s corresponding to the unknown blocks that were
+    ///   revealed to the authority.
+    fn take_unknown_block_refs_for_authority(
         &mut self,
         authority_index: AuthorityIndex,
         round_upper_bound_exclusive: Round,
-    ) -> Vec<VerifiedBlockHeader> {
+    ) -> Vec<BlockRef> {
         let mut set =
             mem::take(&mut self.block_headers_not_known_by_authority[authority_index.value()]);
 
@@ -1283,6 +1291,104 @@ impl DagState {
                 .expect("We expect block ref to be in recent dag cordial knowledge");
             who_knows_given_block.insert(authority_index);
         }
+        block_refs
+    }
+
+    /// Removes and returns up to `MAX_HEADERS_PER_BUNDLE` block references that
+    /// the given authority has not yet seen, limited to rounds strictly
+    /// below `round_upper_bound_exclusive` and filtered by the provided authors
+    /// `useful_authorities`.
+    ///
+    /// Side effects:
+    /// - Updates `block_headers_not_known_by_authority` so these refs are no
+    ///   longer considered "unknown" for the authority.
+    /// - Marks the given authority as knowing these blocks inside
+    ///   `recent_dag_cordial_knowledge`.
+    ///
+    /// Returns:
+    /// - A vector of `BlockRef`s corresponding to the unknown blocks that were
+    ///   revealed to the authority.
+    fn take_useful_block_refs_for_authority(
+        &mut self,
+        authority_index: AuthorityIndex,
+        round_upper_bound_exclusive: Round,
+        useful_authorities: BTreeSet<AuthorityIndex>,
+    ) -> Vec<BlockRef> {
+        let set = &mut self.block_headers_not_known_by_authority[authority_index.value()];
+
+        // Collect candidate block_refs we want to take out
+        let mut to_take = Vec::new();
+
+        for block_ref in set.iter() {
+            if to_take.len() >= MAX_HEADERS_PER_BUNDLE
+                || block_ref.round >= round_upper_bound_exclusive
+            {
+                break;
+            }
+            if useful_authorities.contains(&block_ref.author) {
+                to_take.push(block_ref.clone());
+            }
+        }
+
+        // Remove the references from the set and update cordial knowledge
+        for block_ref in &to_take {
+            set.remove(block_ref);
+
+            if let Some((_, who_knows_given_block)) = self.recent_dag_cordial_knowledge
+                [block_ref.author.value()]
+            .get_mut(&(block_ref.round, block_ref.digest))
+            {
+                who_knows_given_block.insert(authority_index);
+            } else {
+                warn!("Block_ref {block_ref} missing in recent_dag_cordial_knowledge");
+            }
+        }
+
+        to_take
+    }
+
+    /// Retrieves up to `MAX_HEADERS_PER_BUNDLE` previously unknown block
+    /// headers for the given authority, restricted to rounds strictly below
+    /// `round_upper_bound_exclusive`.
+    ///
+    /// This builds on [`take_unknown_block_refs_for_authority`], resolving the
+    /// returned block references into full `VerifiedBlockHeader`s.
+    ///
+    /// Panics if any of the block headers are missing from `DagState` or disk.
+    pub(crate) fn take_unknown_headers_for_authority(
+        &mut self,
+        authority_index: AuthorityIndex,
+        round_upper_bound_exclusive: Round,
+    ) -> Vec<VerifiedBlockHeader> {
+        let block_refs = self
+            .take_unknown_block_refs_for_authority(authority_index, round_upper_bound_exclusive);
+
+        self.get_block_headers(&block_refs)
+            .into_iter()
+            .map(|opt| opt.expect("All headers should be in DagState or on disk"))
+            .collect()
+    }
+    /// Retrieves up to `MAX_HEADERS_PER_BUNDLE` unknown block headers for the
+    /// given authority, but only those authored by peers listed in
+    /// `useful_authorities`. Excludes blocks from other authorities.
+    ///
+    /// This builds on [`take_unknown_block_refs_for_authority`], filtering the
+    /// result with `useful_authorities` and resolving the returned block
+    /// references into full `VerifiedBlockHeader`s.
+    ///
+    /// Panics if any of the block headers are missing from `DagState` or disk.
+    pub(crate) fn take_useful_headers_for_authority(
+        &mut self,
+        authority_index: AuthorityIndex,
+        round_upper_bound_exclusive: Round,
+        useful_authorities: BTreeSet<AuthorityIndex>,
+    ) -> Vec<VerifiedBlockHeader> {
+        let block_refs = self.take_useful_block_refs_for_authority(
+            authority_index,
+            round_upper_bound_exclusive,
+            useful_authorities,
+        );
+
         self.get_block_headers(&block_refs)
             .into_iter()
             .map(|opt| opt.expect("All headers should be in DagState or on disk"))

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1326,7 +1326,7 @@ impl DagState {
                 break;
             }
             if useful_authorities.contains(&block_ref.author) {
-                to_take.push(block_ref.clone());
+                to_take.push(*block_ref);
             }
         }
 

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -22,7 +22,7 @@
 //! network outside of this module, so they can be reused easily across network
 //! implementations.
 
-use std::{pin::Pin, time::Duration};
+use std::{collections::BTreeSet, pin::Pin, time::Duration};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -36,7 +36,6 @@ use crate::{
     commit::{CommitRange, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
 };
-
 // Tonic generated RPC stubs.
 mod tonic_gen {
     include!(concat!(env!("OUT_DIR"), "/consensus.ConsensusService.rs"));
@@ -247,6 +246,7 @@ pub(crate) struct BlockBundle {
     pub(crate) verified_block: VerifiedBlock,
     pub(crate) verified_headers: Vec<VerifiedBlockHeader>,
     pub(crate) serialized_shards: Vec<Bytes>,
+    pub(crate) useful_authorities: BTreeSet<AuthorityIndex>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -254,6 +254,23 @@ pub(crate) struct SerializedBlockBundleParts {
     pub(crate) serialized_block: Bytes,
     pub(crate) serialized_headers: Vec<Bytes>,
     pub(crate) serialized_shards: Vec<Bytes>,
+    pub(crate) useful_authorities_bitmask: [u64; 4],
+}
+
+impl SerializedBlockBundleParts {
+    pub(crate) fn useful_authorities(&self) -> BTreeSet<AuthorityIndex> {
+        let mut useful_authorities = BTreeSet::new();
+        for array_index in 0..4 {
+            let mut bits = self.useful_authorities_bitmask[array_index];
+            let base = array_index * 64;
+            while bits != 0 {
+                let bit = bits.trailing_zeros() as usize;
+                useful_authorities.insert(AuthorityIndex::from((base + bit) as u8));
+                bits &= bits - 1;
+            }
+        }
+        useful_authorities
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -275,6 +292,7 @@ impl TryFrom<VerifiedBlock> for SerializedBlockBundleParts {
             serialized_block: Bytes::from(bytes),
             serialized_headers: vec![],
             serialized_shards: vec![],
+            useful_authorities_bitmask: [0u64; 4],
         })
     }
 }
@@ -294,11 +312,18 @@ impl TryFrom<BlockBundle> for SerializedBlockBundleParts {
         for block_header in block_bundle.verified_headers.iter() {
             serialized_block_headers.push(block_header.serialized().clone());
         }
-
+        let mut useful_authorities_bitmask = [0u64; 4];
+        for authority_index in block_bundle.useful_authorities {
+            let index = authority_index.value();
+            let array_index = index / 64;
+            let bit_pos = index % 64;
+            useful_authorities_bitmask[array_index] |= 1u64 << bit_pos;
+        }
         Ok(Self {
             serialized_block: Bytes::from(bytes),
             serialized_headers: serialized_block_headers,
             serialized_shards: block_bundle.serialized_shards,
+            useful_authorities_bitmask,
         })
     }
 }
@@ -340,4 +365,35 @@ impl TryFrom<BlockBundle> for SerializedBlockBundle {
 pub(crate) struct SerializedTransactions {
     pub(crate) block_ref: BlockRef,
     pub(crate) serialized_transactions: Bytes,
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{seq::IteratorRandom, thread_rng};
+
+    use super::*;
+    use crate::TestBlockHeader;
+    #[test]
+    fn test_block_bundle_useful_authorities_set_bitmask_conversion() {
+        let block = VerifiedBlock::new_for_test(TestBlockHeader::new(0u32, 0u8).build());
+        // Generate a random sample of AuthorityIndex values (from 0..=255).
+        let mut rng = thread_rng();
+        let useful_authorities: BTreeSet<AuthorityIndex> = (0u8..=255)
+            .choose_multiple(&mut rng, 50) // pick 50 random distinct authorities
+            .into_iter()
+            .map(AuthorityIndex::from)
+            .collect();
+
+        let block_bundle = BlockBundle {
+            verified_block: block,
+            verified_headers: vec![],
+            serialized_shards: vec![],
+            useful_authorities: useful_authorities.clone(),
+        };
+        let serialized_bundle = SerializedBlockBundle::try_from(block_bundle).unwrap();
+        let serialized_bundle_parts =
+            SerializedBlockBundleParts::try_from(serialized_bundle).unwrap();
+        let converted_useful_authorities = serialized_bundle_parts.useful_authorities();
+        assert_eq!(useful_authorities, converted_useful_authorities);
+    }
 }


### PR DESCRIPTION
# Description of change

This change introduces tracking of useful authorities during block bundle exchange

- Added `useful_authorities_from_peer` and `useful_authorities_to_peer` to `AuthorityService` for tracking which authorities are considered useful when exchanging bundles with peers.
- Extended `BlockBundle` with a new `useful_authorities` field and updated serialization (`SerializedBlockBundleParts`) to encode/decode this via a [u64; 4] bitmask.
- Refactored DagState to expose:
  - take_unknown_block_refs_for_authority
  - take_unknown_headers_for_authority
  - take_useful_headers_for_authority
- Updated network handling to:
  - Cache peer-reported useful authorities.
  - Record locally observed useful authorities when receiving bundles.
  - Prefer sending only useful headers when peers specify them.
- Added a test to validate bitmask to/from `BTreeSet` conversion.

## Links to any relevant issues

fixes #8411

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
