### PR TITLE
fix(external-crates/move-package): Download dependency before reading manifest files

### DIFF
--- a/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
@@ -131,6 +131,14 @@ impl ResolvedGraph {
                         if let PM::DependencyKind::OnChain(_) = internal.kind {
                             continue;
                         }
+                        dependency_cache
+                            .download_and_update_if_remote(
+                                *dep_name,
+                                &internal.kind,
+                                progress_output,
+                            )
+                            .with_context(|| format!("Fetching '{dep_name}'"))?;
+
                         let dep_path = &resolved_pkg.package_path.join(local_path(&internal.kind));
                         let dep_manifest = parse_move_manifest_from_file(dep_path)?;
                         if dep_name != &dep_manifest.package.name {


### PR DESCRIPTION
# Description of change

This fixes a bug where transitive dependencies of externally resolved  dependencies are accessed before they are fetched.
The prior code could attempt to parse a dependency’s manifest before it had been fetched/updated, especially for externally resolved sources (git/remote registries). That broke when a dependency’s transitive deps weren’t present locally yet.

This change makes sure any remote dependency is present/and up to date in the cache before reading its manifest.

According to [changes](https://github.com/MystenLabs/sui/commit/e39ebeeee34337284f8b3d3fb366ed683017912e).

## Links to any relevant issues

Fixes #8324 .

## How the change has been tested

Run move-package tests.