### PR TITLE
feat(iota-core): Include digest when creating `eligible_validators` vector

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -62,7 +62,7 @@ use iota_types::{
         default_hash,
     },
     deny_list_v1::check_coin_deny_list_v1_during_signing,
-    digests::{ChainIdentifier, TransactionEventsDigest},
+    digests::{ChainIdentifier, Digest, TransactionEventsDigest},
     dynamic_field::{DynamicFieldInfo, DynamicFieldName, visitor as DFV},
     effects::{
         InputSharedObject, SignedTransactionEffects, TransactionEffects, TransactionEffectsAPI,
@@ -4621,7 +4621,7 @@ impl AuthorityState {
         committee: &Committee,
         capabilities: Vec<AuthorityCapabilitiesV1>,
         mut buffer_stake_bps: u64,
-    ) -> Option<(ProtocolVersion, Vec<ObjectRef>)> {
+    ) -> Option<(ProtocolVersion, Vec<ObjectRef>, Digest)> {
         if buffer_stake_bps > 10000 {
             warn!("clamping buffer_stake_bps to 10000");
             buffer_stake_bps = 10000;
@@ -4693,7 +4693,7 @@ impl AuthorityState {
                 );
 
                 let has_support = total_votes >= effective_threshold;
-                has_support.then_some((proposed_protocol_version, packages))
+                has_support.then_some((proposed_protocol_version, packages, digest))
             })
     }
 
@@ -4705,14 +4705,15 @@ impl AuthorityState {
         committee: &Committee,
         capabilities: Vec<AuthorityCapabilitiesV1>,
         buffer_stake_bps: u64,
-    ) -> (ProtocolVersion, Vec<ObjectRef>) {
+    ) -> (ProtocolVersion, Vec<ObjectRef>, Digest) {
         let mut next_protocol_version = current_protocol_version;
         let mut system_packages = vec![];
+        let mut protocol_version_digest = Digest::ZERO;
 
         // Finds the highest supported protocol version and system packages by
         // incrementing the proposed protocol version by one until no further
         // upgrades are supported.
-        while let Some((version, packages)) = Self::is_protocol_version_supported_v1(
+        while let Some((version, packages, digest)) = Self::is_protocol_version_supported_v1(
             next_protocol_version + 1,
             committee,
             capabilities.clone(),
@@ -4720,17 +4721,23 @@ impl AuthorityState {
         ) {
             next_protocol_version = version;
             system_packages = packages;
+            protocol_version_digest = digest;
         }
 
-        (next_protocol_version, system_packages)
+        (
+            next_protocol_version,
+            system_packages,
+            protocol_version_digest,
+        )
     }
 
     /// Returns the indices of validators that support the given protocol
-    /// version. This includes both committee and non-committee validators
-    /// based on their capabilities. Uses active validators instead of committee
-    /// indices.
+    /// version and digest. This includes both committee and non-committee
+    /// validators based on their capabilities. Uses active validators
+    /// instead of committee indices.
     fn get_validators_supporting_protocol_version(
         target_protocol_version: ProtocolVersion,
+        target_digest: Digest,
         active_validators: &[AuthorityPublicKey],
         capabilities: &[AuthorityCapabilitiesV1],
     ) -> Vec<u64> {
@@ -4738,17 +4745,18 @@ impl AuthorityState {
 
         for capability in capabilities {
             // Check if this validator supports the target protocol version and digest
-            if capability
+            if let Some(digest) = capability
                 .supported_protocol_versions
                 .get_version_digest(target_protocol_version)
-                .is_some()
             {
-                // Find the validator's index in the active validators list
-                if let Some(index) = active_validators
-                    .iter()
-                    .position(|name| AuthorityName::from(name) == capability.authority)
-                {
-                    eligible_validators.push(index as u64);
+                if digest == target_digest {
+                    // Find the validator's index in the active validators list
+                    if let Some(index) = active_validators
+                        .iter()
+                        .position(|name| AuthorityName::from(name) == capability.authority)
+                    {
+                        eligible_validators.push(index as u64);
+                    }
                 }
             }
         }
@@ -4855,7 +4863,7 @@ impl AuthorityState {
         let authority_capabilities = epoch_store
             .get_capabilities_v1()
             .expect("read capabilities from db cannot fail");
-        let (next_epoch_protocol_version, next_epoch_system_packages) =
+        let (next_epoch_protocol_version, next_epoch_system_packages, next_epoch_protocol_digest) =
             Self::choose_protocol_version_and_system_packages_v1(
                 epoch_store.protocol_version(),
                 epoch_store.committee(),
@@ -4904,6 +4912,7 @@ impl AuthorityState {
             if config.track_non_committee_eligible_validators() {
                 eligible_active_validators = Self::get_validators_supporting_protocol_version(
                     next_epoch_protocol_version,
+                    next_epoch_protocol_digest,
                     &active_validators,
                     &authority_capabilities,
                 );

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -107,7 +107,9 @@ use iota_types::{
     storage::{
         BackingPackageStore, BackingStore, ObjectKey, ObjectOrTombstone, ObjectStore, WriteKind,
     },
-    supported_protocol_versions::{ProtocolConfig, SupportedProtocolVersions},
+    supported_protocol_versions::{
+        ProtocolConfig, SupportedProtocolVersions, SupportedProtocolVersionsWithHashes,
+    },
     transaction::*,
     transaction_executor::SimulateTransactionResult,
 };
@@ -4702,13 +4704,14 @@ impl AuthorityState {
     /// returns the current protocol version and system packages.
     fn choose_protocol_version_and_system_packages_v1(
         current_protocol_version: ProtocolVersion,
+        current_protocol_digest: Digest,
         committee: &Committee,
         capabilities: Vec<AuthorityCapabilitiesV1>,
         buffer_stake_bps: u64,
     ) -> (ProtocolVersion, Vec<ObjectRef>, Digest) {
         let mut next_protocol_version = current_protocol_version;
         let mut system_packages = vec![];
-        let mut protocol_version_digest = Digest::ZERO;
+        let mut protocol_version_digest = current_protocol_digest;
 
         // Finds the highest supported protocol version and system packages by
         // incrementing the proposed protocol version by one until no further
@@ -4866,6 +4869,9 @@ impl AuthorityState {
         let (next_epoch_protocol_version, next_epoch_system_packages, next_epoch_protocol_digest) =
             Self::choose_protocol_version_and_system_packages_v1(
                 epoch_store.protocol_version(),
+                SupportedProtocolVersionsWithHashes::protocol_config_digest(
+                    epoch_store.protocol_config(),
+                ),
                 epoch_store.committee(),
                 authority_capabilities.clone(),
                 buffer_stake_bps,

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4623,7 +4623,7 @@ impl AuthorityState {
         committee: &Committee,
         capabilities: Vec<AuthorityCapabilitiesV1>,
         mut buffer_stake_bps: u64,
-    ) -> Option<(ProtocolVersion, Vec<ObjectRef>, Digest)> {
+    ) -> Option<(ProtocolVersion, Digest, Vec<ObjectRef>)> {
         if buffer_stake_bps > 10000 {
             warn!("clamping buffer_stake_bps to 10000");
             buffer_stake_bps = 10000;
@@ -4691,7 +4691,7 @@ impl AuthorityState {
                 );
 
                 let has_support = total_votes >= effective_threshold;
-                has_support.then_some((proposed_protocol_version, packages, digest))
+                has_support.then_some((proposed_protocol_version, digest, packages))
             })
     }
 
@@ -4712,15 +4712,15 @@ impl AuthorityState {
         // Finds the highest supported protocol version and system packages by
         // incrementing the proposed protocol version by one until no further
         // upgrades are supported.
-        while let Some((version, packages, digest)) = Self::is_protocol_version_supported_v1(
+        while let Some((version, digest, packages)) = Self::is_protocol_version_supported_v1(
             next_protocol_version + 1,
             committee,
             capabilities.clone(),
             buffer_stake_bps,
         ) {
             next_protocol_version = version;
-            system_packages = packages;
             protocol_version_digest = digest;
+            system_packages = packages;
         }
 
         (

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4934,7 +4934,7 @@ impl AuthorityState {
 
                 if eligible_validators_weight < effective_threshold {
                     error!(
-                        "Eligible validators weight {eligible_validators_weight} is less than effective threshold {effective_threshold} (quorum: {quorum_threshold}, buffer: {buffer_stake}). \
+                        "Eligible validators weight {eligible_validators_weight} is less than effective threshold {effective_threshold}. \
                         This could indicate a bug in validator selection logic or inconsistency with protocol version decision.",
                     );
                     // Pass all active validator indices as eligible validators

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4677,11 +4677,7 @@ impl AuthorityState {
 
                 let total_votes = stake_aggregator.total_votes();
                 let quorum_threshold = committee.quorum_threshold();
-                let f = committee.total_votes() - committee.quorum_threshold();
-
-                // multiple by buffer_stake_bps / 10000, rounded up.
-                let buffer_stake = (f * buffer_stake_bps).div_ceil(10000);
-                let effective_threshold = quorum_threshold + buffer_stake;
+                let effective_threshold = committee.effective_threshold(buffer_stake_bps);
 
                 info!(
                     protocol_config_digest = ?digest,
@@ -4934,10 +4930,7 @@ impl AuthorityState {
                 // Use the same effective threshold calculation that was used to decide the
                 // protocol version
                 let committee = epoch_store.committee();
-                let quorum_threshold = committee.quorum_threshold();
-                let f = committee.total_votes() - quorum_threshold;
-                let buffer_stake = (f * buffer_stake_bps).div_ceil(10000);
-                let effective_threshold = quorum_threshold + buffer_stake;
+                let effective_threshold = committee.effective_threshold(buffer_stake_bps);
 
                 if eligible_validators_weight < effective_threshold {
                     error!(
@@ -4945,8 +4938,7 @@ impl AuthorityState {
                         This could indicate a bug in validator selection logic or inconsistency with protocol version decision.",
                     );
                     // Pass all active validator indices as eligible validators
-                    // to perform selection among all of
-                    // them.
+                    // to perform selection among all of them.
                     eligible_active_validators = (0..active_validators.len() as u64).collect();
                 }
             }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4708,7 +4708,7 @@ impl AuthorityState {
         committee: &Committee,
         capabilities: Vec<AuthorityCapabilitiesV1>,
         buffer_stake_bps: u64,
-    ) -> (ProtocolVersion, Vec<ObjectRef>, Digest) {
+    ) -> (ProtocolVersion, Digest, Vec<ObjectRef>) {
         let mut next_protocol_version = current_protocol_version;
         let mut system_packages = vec![];
         let mut protocol_version_digest = current_protocol_digest;
@@ -4729,8 +4729,8 @@ impl AuthorityState {
 
         (
             next_protocol_version,
-            system_packages,
             protocol_version_digest,
+            system_packages,
         )
     }
 
@@ -4866,7 +4866,7 @@ impl AuthorityState {
         let authority_capabilities = epoch_store
             .get_capabilities_v1()
             .expect("read capabilities from db cannot fail");
-        let (next_epoch_protocol_version, next_epoch_system_packages, next_epoch_protocol_digest) =
+        let (next_epoch_protocol_version, next_epoch_protocol_digest, next_epoch_system_packages) =
             Self::choose_protocol_version_and_system_packages_v1(
                 epoch_store.protocol_version(),
                 SupportedProtocolVersionsWithHashes::protocol_config_digest(

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -5127,12 +5127,14 @@ async fn test_choose_next_system_packages() {
         capabilities.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(1), vec![]), result);
+    assert_eq!(result.0, ver(1));
+    assert_eq!(result.1, vec![]);
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     // for decided version
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0, // decided protocol version
+        result.2, // protocol digest
         &active_validators,
         &capabilities,
     );
@@ -5152,12 +5154,14 @@ async fn test_choose_next_system_packages() {
         capabilities.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(1), vec![]), result);
+    assert_eq!(result.0, ver(1));
+    assert_eq!(result.1, vec![]);
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     // for decided version
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0, // decided protocol version
+        result.2, // protocol digest
         &active_validators,
         &capabilities,
     );
@@ -5172,12 +5176,14 @@ async fn test_choose_next_system_packages() {
         capabilities.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(2), sort(vec![o1, o2])), result);
+    assert_eq!(result.0, ver(2));
+    assert_eq!(result.1, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     // for decided version
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0, // decided protocol version (ver(2))
+        result.2, // protocol digest
         &active_validators,
         &capabilities,
     );
@@ -5197,11 +5203,13 @@ async fn test_choose_next_system_packages() {
         capabilities.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(1), vec![]), result);
+    assert_eq!(result.0, ver(1));
+    assert_eq!(result.1, vec![]);
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &active_validators,
         &capabilities,
     );
@@ -5221,11 +5229,13 @@ async fn test_choose_next_system_packages() {
         capabilities.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(2), sort(vec![o1, o2])), result);
+    assert_eq!(result.0, ver(2));
+    assert_eq!(result.1, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &active_validators,
         &capabilities,
     );
@@ -5245,11 +5255,13 @@ async fn test_choose_next_system_packages() {
         capabilities.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(1), vec![]), result);
+    assert_eq!(result.0, ver(1));
+    assert_eq!(result.1, vec![]);
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &active_validators,
         &capabilities,
     );
@@ -5269,11 +5281,13 @@ async fn test_choose_next_system_packages() {
         capabilities.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(3), sort(vec![o1, o2])), result);
+    assert_eq!(result.0, ver(3));
+    assert_eq!(result.1, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &active_validators,
         &capabilities,
     );
@@ -5293,11 +5307,13 @@ async fn test_choose_next_system_packages() {
         capabilities.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(1), vec![]), result);
+    assert_eq!(result.0, ver(1));
+    assert_eq!(result.1, vec![]);
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &active_validators,
         &capabilities,
     );
@@ -5318,11 +5334,13 @@ async fn test_choose_next_system_packages() {
         capabilities.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(3), sort(vec![o1, o2])), result);
+    assert_eq!(result.0, ver(3));
+    assert_eq!(result.1, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &active_validators,
         &capabilities,
     );
@@ -5345,11 +5363,13 @@ async fn test_choose_next_system_packages() {
         capabilities.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(1), sort(vec![])), result);
+    assert_eq!(result.0, ver(1));
+    assert_eq!(result.1, sort(vec![]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &active_validators,
         &capabilities,
     );
@@ -5372,11 +5392,13 @@ async fn test_choose_next_system_packages() {
         capabilities.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(1), sort(vec![])), result);
+    assert_eq!(result.0, ver(1));
+    assert_eq!(result.1, sort(vec![]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &active_validators,
         &capabilities,
     );
@@ -5420,12 +5442,14 @@ async fn test_choose_next_system_packages() {
         capabilities_with_zero_weight.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(2), sort(vec![o1, o2])), result);
+    assert_eq!(result.0, ver(2));
+    assert_eq!(result.1, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     // including zero-weight authorities
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &all_active_validators,
         &capabilities_with_zero_weight,
     );
@@ -5449,11 +5473,13 @@ async fn test_choose_next_system_packages() {
         capabilities_higher_version.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(2), sort(vec![o1, o2])), result);
+    assert_eq!(result.0, ver(2));
+    assert_eq!(result.1, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &all_active_validators,
         &capabilities_higher_version,
     );
@@ -5477,11 +5503,13 @@ async fn test_choose_next_system_packages() {
         capabilities_lower_version.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(3), sort(vec![o1, o2])), result);
+    assert_eq!(result.0, ver(3));
+    assert_eq!(result.1, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &all_active_validators,
         &capabilities_lower_version,
     );
@@ -5505,11 +5533,13 @@ async fn test_choose_next_system_packages() {
         capabilities_different_objects.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(2), sort(vec![o1, o2])), result);
+    assert_eq!(result.0, ver(2));
+    assert_eq!(result.1, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &all_active_validators,
         &capabilities_different_objects,
     );
@@ -5535,11 +5565,13 @@ async fn test_choose_next_system_packages() {
         capabilities_only_zero_weight.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(1), vec![]), result);
+    assert_eq!(result.0, ver(1));
+    assert_eq!(result.1, vec![]);
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &all_active_validators,
         &capabilities_only_zero_weight,
     );
@@ -5565,11 +5597,13 @@ async fn test_choose_next_system_packages() {
         capabilities_conflicting_zero_weight.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(2), sort(vec![o1, o2])), result);
+    assert_eq!(result.0, ver(2));
+    assert_eq!(result.1, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &all_active_validators,
         &capabilities_conflicting_zero_weight,
     );
@@ -5596,11 +5630,13 @@ async fn test_choose_next_system_packages() {
         capabilities_mixed_agreement.clone(),
         protocol_config.buffer_stake_for_protocol_upgrade_bps(),
     );
-    assert_eq!((ver(2), sort(vec![o1, o2])), result);
+    assert_eq!(result.0, ver(2));
+    assert_eq!(result.1, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
+        result.2,
         &all_active_validators,
         &capabilities_mixed_agreement,
     );

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -5102,8 +5102,10 @@ async fn test_choose_next_system_packages() {
 
     let committee = Committee::new_simple_test_committee().0;
     let v = &committee.voting_rights;
-    let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-    protocol_config.set_buffer_stake_for_protocol_upgrade_bps_for_testing(7500);
+    let protocol_config_digest = SupportedProtocolVersionsWithHashes::protocol_config_digest(
+        &ProtocolConfig::get_for_version(ProtocolVersion::new(1), Chain::Unknown),
+    );
+    let buffer_stake_for_protocol_upgrade_bps_for_testing = 7500;
 
     // Create an active validators list for testing
     // get_validators_supporting_protocol_version
@@ -5123,9 +5125,10 @@ async fn test_choose_next_system_packages() {
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
     assert_eq!(result.1, vec![]);
@@ -5150,9 +5153,10 @@ async fn test_choose_next_system_packages() {
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
     assert_eq!(result.1, vec![]);
@@ -5168,13 +5172,14 @@ async fn test_choose_next_system_packages() {
     assert_eq!(supporting_validators, vec![0, 1, 2, 3]); // All validators still support version 1
 
     // Now 2f+1 is enough to upgrade
-    protocol_config.set_buffer_stake_for_protocol_upgrade_bps_for_testing(0);
+    let buffer_stake_for_protocol_upgrade_bps_for_testing = 0;
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
     assert_eq!(result.1, sort(vec![o1, o2]));
@@ -5199,9 +5204,10 @@ async fn test_choose_next_system_packages() {
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
     assert_eq!(result.1, vec![]);
@@ -5225,9 +5231,10 @@ async fn test_choose_next_system_packages() {
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
     assert_eq!(result.1, sort(vec![o1, o2]));
@@ -5251,9 +5258,10 @@ async fn test_choose_next_system_packages() {
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
     assert_eq!(result.1, vec![]);
@@ -5277,9 +5285,10 @@ async fn test_choose_next_system_packages() {
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(3));
     assert_eq!(result.1, sort(vec![o1, o2]));
@@ -5303,9 +5312,10 @@ async fn test_choose_next_system_packages() {
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
     assert_eq!(result.1, vec![]);
@@ -5330,9 +5340,10 @@ async fn test_choose_next_system_packages() {
     // upgrade to 3 which is the highest supported version
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(3));
     assert_eq!(result.1, sort(vec![o1, o2]));
@@ -5359,9 +5370,10 @@ async fn test_choose_next_system_packages() {
     // won't happen until everyone moves to 3.
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
     assert_eq!(result.1, sort(vec![]));
@@ -5388,9 +5400,10 @@ async fn test_choose_next_system_packages() {
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
     assert_eq!(result.1, sort(vec![]));
@@ -5438,9 +5451,10 @@ async fn test_choose_next_system_packages() {
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities_with_zero_weight.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
     assert_eq!(result.1, sort(vec![o1, o2]));
@@ -5469,9 +5483,10 @@ async fn test_choose_next_system_packages() {
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities_higher_version.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
     assert_eq!(result.1, sort(vec![o1, o2]));
@@ -5499,9 +5514,10 @@ async fn test_choose_next_system_packages() {
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities_lower_version.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(3));
     assert_eq!(result.1, sort(vec![o1, o2]));
@@ -5529,9 +5545,10 @@ async fn test_choose_next_system_packages() {
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities_different_objects.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
     assert_eq!(result.1, sort(vec![o1, o2]));
@@ -5561,9 +5578,10 @@ async fn test_choose_next_system_packages() {
     // Should not upgrade since zero-weight authorities cannot form a quorum
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities_only_zero_weight.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
     assert_eq!(result.1, vec![]);
@@ -5593,9 +5611,10 @@ async fn test_choose_next_system_packages() {
     // Should upgrade to v2 with o1,o2 despite zero-weight conflicting opinions
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities_conflicting_zero_weight.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
     assert_eq!(result.1, sort(vec![o1, o2]));
@@ -5626,9 +5645,10 @@ async fn test_choose_next_system_packages() {
 
     let result = AuthorityState::choose_protocol_version_and_system_packages_v1(
         ProtocolVersion::MIN,
+        protocol_config_digest,
         &committee,
         capabilities_mixed_agreement.clone(),
-        protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
     assert_eq!(result.1, sort(vec![o1, o2]));

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -5131,13 +5131,13 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
-    assert_eq!(result.1, vec![]);
+    assert_eq!(result.2, vec![]);
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     // for decided version
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0, // decided protocol version
-        result.2, // protocol digest
+        result.1, // protocol digest
         &active_validators,
         &capabilities,
     );
@@ -5159,13 +5159,13 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
-    assert_eq!(result.1, vec![]);
+    assert_eq!(result.2, vec![]);
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     // for decided version
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0, // decided protocol version
-        result.2, // protocol digest
+        result.1, // protocol digest
         &active_validators,
         &capabilities,
     );
@@ -5182,13 +5182,13 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
-    assert_eq!(result.1, sort(vec![o1, o2]));
+    assert_eq!(result.2, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     // for decided version
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0, // decided protocol version (ver(2))
-        result.2, // protocol digest
+        result.1, // protocol digest
         &active_validators,
         &capabilities,
     );
@@ -5210,12 +5210,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
-    assert_eq!(result.1, vec![]);
+    assert_eq!(result.2, vec![]);
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &active_validators,
         &capabilities,
     );
@@ -5237,12 +5237,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
-    assert_eq!(result.1, sort(vec![o1, o2]));
+    assert_eq!(result.2, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &active_validators,
         &capabilities,
     );
@@ -5264,12 +5264,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
-    assert_eq!(result.1, vec![]);
+    assert_eq!(result.2, vec![]);
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &active_validators,
         &capabilities,
     );
@@ -5291,12 +5291,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(3));
-    assert_eq!(result.1, sort(vec![o1, o2]));
+    assert_eq!(result.2, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &active_validators,
         &capabilities,
     );
@@ -5318,12 +5318,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
-    assert_eq!(result.1, vec![]);
+    assert_eq!(result.2, vec![]);
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &active_validators,
         &capabilities,
     );
@@ -5346,12 +5346,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(3));
-    assert_eq!(result.1, sort(vec![o1, o2]));
+    assert_eq!(result.2, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &active_validators,
         &capabilities,
     );
@@ -5376,12 +5376,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
-    assert_eq!(result.1, sort(vec![]));
+    assert_eq!(result.2, sort(vec![]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &active_validators,
         &capabilities,
     );
@@ -5406,12 +5406,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
-    assert_eq!(result.1, sort(vec![]));
+    assert_eq!(result.2, sort(vec![]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &active_validators,
         &capabilities,
     );
@@ -5457,13 +5457,13 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
-    assert_eq!(result.1, sort(vec![o1, o2]));
+    assert_eq!(result.2, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     // including zero-weight authorities
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &all_active_validators,
         &capabilities_with_zero_weight,
     );
@@ -5489,12 +5489,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
-    assert_eq!(result.1, sort(vec![o1, o2]));
+    assert_eq!(result.2, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &all_active_validators,
         &capabilities_higher_version,
     );
@@ -5520,12 +5520,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(3));
-    assert_eq!(result.1, sort(vec![o1, o2]));
+    assert_eq!(result.2, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &all_active_validators,
         &capabilities_lower_version,
     );
@@ -5551,12 +5551,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
-    assert_eq!(result.1, sort(vec![o1, o2]));
+    assert_eq!(result.2, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &all_active_validators,
         &capabilities_different_objects,
     );
@@ -5584,12 +5584,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(1));
-    assert_eq!(result.1, vec![]);
+    assert_eq!(result.2, vec![]);
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &all_active_validators,
         &capabilities_only_zero_weight,
     );
@@ -5617,12 +5617,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
-    assert_eq!(result.1, sort(vec![o1, o2]));
+    assert_eq!(result.2, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &all_active_validators,
         &capabilities_conflicting_zero_weight,
     );
@@ -5651,12 +5651,12 @@ async fn test_choose_next_system_packages() {
         buffer_stake_for_protocol_upgrade_bps_for_testing,
     );
     assert_eq!(result.0, ver(2));
-    assert_eq!(result.1, sort(vec![o1, o2]));
+    assert_eq!(result.2, sort(vec![o1, o2]));
 
     // Verify get_validators_supporting_protocol_version returns correct validators
     let supporting_validators = AuthorityState::get_validators_supporting_protocol_version(
         result.0,
-        result.2,
+        result.1,
         &all_active_validators,
         &capabilities_mixed_agreement,
     );

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1351,7 +1351,13 @@ impl ProtocolConfig {
     }
 
     pub fn select_committee_from_eligible_validators(&self) -> bool {
-        self.feature_flags.select_committee_from_eligible_validators
+        let res = self.feature_flags.select_committee_from_eligible_validators;
+        assert!(
+            !res || (self.protocol_defined_base_fee()
+                && self.max_committee_members_count_as_option().is_some()),
+            "select_committee_from_eligible_validators requires protocol_defined_base_fee and max_committee_members_count to be set"
+        );
+        res
     }
 
     pub fn track_non_committee_eligible_validators(&self) -> bool {

--- a/crates/iota-types/src/committee.rs
+++ b/crates/iota-types/src/committee.rs
@@ -215,6 +215,24 @@ impl Committee {
         }
     }
 
+    /// Calculates the effective threshold for protocol version selection.
+    /// This is the quorum threshold plus a buffer stake based on the given
+    /// basis points.
+    ///
+    /// The buffer is calculated as: f * buffer_stake_bps / 10000, rounded up
+    /// where f = total_votes - quorum_threshold
+    ///
+    /// buffer_stake_bps is clamped to a maximum of 10000.
+    pub fn effective_threshold(&self, mut buffer_stake_bps: u64) -> StakeUnit {
+        if buffer_stake_bps > 10000 {
+            buffer_stake_bps = 10000;
+        }
+        let quorum_threshold = self.quorum_threshold();
+        let f = self.total_votes() - quorum_threshold;
+        let buffer_stake = (f * buffer_stake_bps).div_ceil(10000);
+        quorum_threshold + buffer_stake
+    }
+
     pub fn num_members(&self) -> usize {
         self.voting_rights.len()
     }

--- a/crates/iota-types/src/supported_protocol_versions.rs
+++ b/crates/iota-types/src/supported_protocol_versions.rs
@@ -63,7 +63,7 @@ impl SupportedProtocolVersionsWithHashes {
 
     // Ideally this would be in iota-protocol-config, but iota-types depends on
     // iota-protocol-config, so it would introduce a circular dependency.
-    fn protocol_config_digest(config: &ProtocolConfig) -> Digest {
+    pub fn protocol_config_digest(config: &ProtocolConfig) -> Digest {
         let mut digest = DefaultHash::default();
         bcs::serialize_into(&mut digest, &config).expect("serialization cannot fail");
         Digest::new(digest.finalize().into())


### PR DESCRIPTION
# Description of change

Include digest when creating `eligible_validators` vector. 
Check that required protocol parameters are set when retrieving `select_committee_from_eligible_validators` param. 

## Links to any relevant issues

Partly covers #7814  

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
