### PR TITLE
feat(move-package-alt): Starting to sketch out the modules in the new package management system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
  "memchr",
  "num",
  "regex",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -2143,7 +2143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.11",
  "serde",
 ]
 
@@ -3392,6 +3392,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7090,6 +7101,7 @@ name = "iota-package-alt"
 version = "1.8.0-alpha"
 dependencies = [
  "move-package-alt",
+ "serde",
 ]
 
 [[package]]
@@ -8462,7 +8474,30 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata 0.4.7",
+ "regex-automata 0.4.11",
+]
+
+[[package]]
+name = "lazy-regex"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -8768,7 +8803,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.6",
  "syn 2.0.100",
 ]
 
@@ -9504,6 +9539,9 @@ dependencies = [
 name = "move-package-alt"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "derive-where",
+ "lazy-regex",
  "serde",
  "serde_spanned",
  "toml 0.5.11",
@@ -11395,7 +11433,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.6",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -11939,14 +11977,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.11",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -11960,13 +11998,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -11983,9 +12021,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"

--- a/crates/iota-package-alt/Cargo.toml
+++ b/crates/iota-package-alt/Cargo.toml
@@ -10,4 +10,8 @@ publish = false
 workspace = true
 
 [dependencies]
+# external dependencies
+serde.workspace = true
+
+# internal dependencies
 move-package-alt.workspace = true

--- a/crates/iota-package-alt/src/iota_flavor.rs
+++ b/crates/iota-package-alt/src/iota_flavor.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use move_package_alt::{
+    dependency::{self, Pinned, PinnedDependencyInfo, Unpinned},
+    errors::PackageResult,
+    flavor::MoveFlavor,
+    package::PackageName,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename = "kebab-case")]
+pub struct OnChainDependency {
+    on_chain: bool,
+}
+
+pub struct IotaFlavor;
+
+impl MoveFlavor for IotaFlavor {
+    type FlavorDependency<P: ?Sized> = OnChainDependency;
+
+    fn pin(
+        &self,
+        deps: BTreeMap<PackageName, Self::FlavorDependency<Unpinned>>,
+    ) -> PackageResult<BTreeMap<PackageName, Self::FlavorDependency<Pinned>>> {
+        todo!()
+    }
+
+    fn fetch(
+        &self,
+        deps: BTreeMap<PackageName, Self::FlavorDependency<Pinned>>,
+    ) -> PackageResult<BTreeMap<PackageName, std::path::PathBuf>> {
+        todo!()
+    }
+
+    type PublishedMetadata = (); // TODO
+
+    type EnvironmentID = (); // TODO
+
+    type AddressInfo = (); // TODO
+
+    type PackageMetadata = (); // TODO
+
+    fn implicit_deps(&self, id: Self::EnvironmentID) -> Vec<PinnedDependencyInfo<Self>> {
+        todo!()
+    }
+}

--- a/crates/iota-package-alt/src/lib.rs
+++ b/crates/iota-package-alt/src/lib.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-fn main() {
-    println!("Hello, world!");
-}
+#![allow(unused)]
+
+mod iota_flavor;
+
+pub use iota_flavor::IotaFlavor;

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -822,6 +822,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,6 +1510,29 @@ dependencies = [
  "move-vm-test-utils",
  "move-vm-types",
  "once_cell",
+]
+
+[[package]]
+name = "lazy-regex"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2198,6 +2232,9 @@ dependencies = [
 name = "move-package-alt"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "derive-where",
+ "lazy-regex",
  "serde",
  "serde_spanned",
  "toml",

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -33,7 +33,7 @@ crossbeam-channel = "0.5.0"
 crossterm = "0.25.0"
 curve25519-dalek = { version = "0.1.0", package = "curve25519-dalek-fiat", default-features = false, features = ["std", "u64_backend"] }
 datatest-stable = "0.1.1"
-derivative = "2.2.0"
+derive-where = "1.2.7"
 digest = "0.9.0"
 dir-diff = "0.3.2"
 dirs-next = "2.0.0"
@@ -55,6 +55,7 @@ insta = "1.42.0"
 internment = { version = "0.5.0", features = ["arc"] }
 itertools = "0.10.0"
 json_comments = "0.2.2"
+lazy-regex = "3.4"
 leb128 = "0.2.5"
 libfuzzer-sys = "0.4"
 log = { version = "0.4.14", features = ["serde"] }

--- a/external-crates/move/crates/move-package-alt/Cargo.toml
+++ b/external-crates/move/crates/move-package-alt/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+anyhow.workspace = true
+derive-where.workspace = true
+lazy-regex.workspace = true
 serde.workspace = true
 serde_spanned.workspace = true
 toml.workspace = true

--- a/external-crates/move/crates/move-package-alt/src/dependency/external.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/external.rs
@@ -1,0 +1,39 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types and methods for external dependencies (of the form `{ r.<res> = data }`)
+
+use std::{collections::BTreeMap, path::Path};
+
+use serde::{Deserialize, Serialize};
+use serde_spanned::Spanned;
+
+use crate::{
+    errors::{PackageError, PackageResult},
+    flavor::MoveFlavor,
+};
+
+use super::PinnedDependencyInfo;
+
+/// An external dependency has the form `{ r.<res> = "<data>" }`; it is resolved by invoking the
+/// binary `<res>` (from the `PATH`), and passing `<data>` on the command line. The binary is
+/// expected to output a single resolved dependency on the command line.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ExternalDependency {
+    /// Should be a table with a single entry; the name of the entry is the resolver binary to run
+    /// and the value should be the argument passed to the resolver
+    r: toml::Value,
+
+    #[serde(flatten)]
+    fields: BTreeMap<String, String>,
+}
+
+impl ExternalDependency {
+    /// Invoke the external binary and deserialize its output as a dependency, then pin the
+    /// dependency.
+    fn resolve<F: MoveFlavor>(&self) -> PackageResult<PinnedDependencyInfo<F>> {
+        todo!()
+    }
+}

--- a/external-crates/move/crates/move-package-alt/src/dependency/git.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/git.rs
@@ -1,0 +1,59 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types and methods for external dependencies (of the form `{ git = "<repo>" }`)
+//!
+//! Git dependencies are cached in `~/.move`, which has the following structure:
+//!
+//! ```
+//! .move/
+//!   git/
+//!     <remote 1>/ # a headless, sparse, and shallow git repository
+//!       <sha 1>/ # a worktree checked out to the given sha
+//!       <sha 2>/
+//!       ...
+//!     <remote 2>/
+//!       ...
+//!     ...
+//! ```
+
+use std::{marker::PhantomData, path::PathBuf};
+
+use derive_where::derive_where;
+use serde::{Deserialize, Serialize};
+
+use crate::errors::PackageResult;
+
+use super::{Pinned, Unpinned};
+
+#[derive(Serialize, Deserialize)]
+#[derive_where(Clone)]
+pub struct GitDependency<P = Unpinned> {
+    /// The repository holding the dep
+    repo: String,
+
+    /// The git commit-ish for the dep; guaranteed to be a commit if [P] is [Pinned].
+    rev: String,
+
+    /// The path within the repository
+    path: PathBuf,
+
+    phantom: PhantomData<P>,
+}
+
+impl GitDependency<Unpinned> {
+    /// Replace the commit-ish [self.rev] with a commit (i.e. a SHA). Requires fetching the git
+    /// repository
+    pub fn pin(&self) -> PackageResult<GitDependency<Pinned>> {
+        todo!()
+    }
+}
+
+impl GitDependency<Pinned> {
+    /// Ensures that the given sha is downloaded
+    pub fn fetch(&self) -> PackageResult<PathBuf> {
+        todo!()
+    }
+}

--- a/external-crates/move/crates/move-package-alt/src/dependency/local.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/local.rs
@@ -1,0 +1,29 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types and methods related to local dependencies (of the form `{ local = "<path>" }`)
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_spanned::Spanned;
+
+use crate::errors::Located;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct LocalDependency {
+    /// The path on the filesystem, relative to the location of the containing file (which is
+    /// stored in the `Located` wrapper)
+    local: PathBuf,
+}
+
+impl TryFrom<(&Path, toml_edit::Value)> for LocalDependency {
+    type Error = anyhow::Error; // TODO
+
+    fn try_from(value: (&Path, toml_edit::Value)) -> Result<Self, Self::Error> {
+        // TODO: just deserialize
+        todo!()
+    }
+}

--- a/external-crates/move/crates/move-package-alt/src/dependency/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/mod.rs
@@ -1,0 +1,76 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+mod external;
+mod git;
+mod local;
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{errors::PackageResult, flavor::MoveFlavor, package::PackageName};
+
+use derive_where::derive_where;
+use external::ExternalDependency;
+use git::GitDependency;
+use local::LocalDependency;
+
+/// Phantom type to represent pinned dependencies (see [PinnedDependency])
+pub struct Pinned;
+
+/// Phantom type to represent unpinned dependencies (see [ManifestDependencyInfo])
+pub struct Unpinned;
+
+/// [ManifestDependencyInfo]s contain the dependency-type-specific things that users write in their
+/// Move.toml files in the `dependencies` section.
+///
+/// There are additional general fields in the manifest format (like `override` or `rename-from`)
+/// that are not part of the ManifestDependencyInfo. We separate these partly because these things
+/// are not serialized to the Lock file. See [crate::package::manifest] for the full representation
+/// of an entry in the `dependencies` table.
+#[derive(Serialize, Deserialize)]
+#[derive_where(Clone)]
+pub enum ManifestDependencyInfo<F: MoveFlavor> {
+    Git(GitDependency<Unpinned>),
+    External(ExternalDependency),
+    Local(LocalDependency),
+    FlavorSpecific(F::FlavorDependency<Unpinned>),
+}
+
+/// Pinned dependencies are guaranteed to always resolve to the same package source. For example,
+/// a git dependendency with a branch or tag revision may change over time (and is thus not
+/// pinned), whereas a git dependency with a sha revision is always guaranteed to produce the same
+/// files.
+///
+/// Local dependencies are a somewhat special case here - we want to pin them as local deps during
+/// development, because the developer would expect to use the latest code without having to
+/// explicitly repin, but we need to convert them to persistent dependencies when we publish since
+/// we want to retain that information for source verification.
+#[derive(Serialize, Deserialize)]
+#[derive_where(Clone)]
+pub enum PinnedDependencyInfo<F: MoveFlavor + ?Sized> {
+    Git(GitDependency<Pinned>),
+    Local(LocalDependency),
+    FlavorSpecific(F::FlavorDependency<Pinned>),
+}
+
+/// Replace all dependencies with their pinned versions. The returned map is guaranteed to have the
+/// same keys as [deps].
+// TODO: this needs to change to support the fact that external resolvers return different results
+// depending on the environment
+fn pin<F: MoveFlavor>(
+    deps: BTreeMap<PackageName, ManifestDependencyInfo<F>>,
+) -> PackageResult<BTreeMap<PackageName, PinnedDependencyInfo<F>>> {
+    todo!()
+}
+
+/// Ensure that all dependencies are stored locally and return the paths to their contents. The
+/// returned map is guaranteed to have the same keys as [deps].
+fn fetch<F: MoveFlavor>(
+    deps: BTreeMap<PackageName, PinnedDependencyInfo<F>>,
+) -> PackageResult<BTreeMap<PackageName, PinnedDependencyInfo<F>>> {
+    todo!()
+}

--- a/external-crates/move/crates/move-package-alt/src/errors.rs
+++ b/external-crates/move/crates/move-package-alt/src/errors.rs
@@ -1,0 +1,29 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{ops::Range, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_spanned::Spanned;
+
+// TODO: sensible error type
+pub type PackageError = anyhow::Error;
+
+// TODO: sensible error type
+pub type PackageResult<T> = anyhow::Result<T>;
+
+// TODO: implement Deref, get deserialization right, etc
+// Maybe the right thing is to make the path optional and mutable, then go back and patch it up
+// after deserialization? Then the type system doesn't help anymore, but at least we can just
+// deserialize immediately without
+#[derive(Serialize, Deserialize)]
+pub struct Located<T> {
+    // TODO: Spanned<T>
+    #[serde(flatten)]
+    inner: T,
+
+    #[serde(skip)]
+    path: Option<PathBuf>,
+}

--- a/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
@@ -1,0 +1,70 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod vanilla;
+
+pub use vanilla::Vanilla;
+
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{
+    dependency::{Pinned, PinnedDependencyInfo, Unpinned},
+    errors::PackageResult,
+    package::PackageName,
+};
+
+/// A [MoveFlavor] is used to parameterize the package management system. It defines the types and
+/// methods for package management that are specific to a particular instantiation of the Move
+/// language.
+pub trait MoveFlavor {
+    // TODO: this API is incomplete
+
+    /// Additional flavor-specific dependency types. Currently we only support flavor-specific
+    /// dependencies that are already pinned (although in principle you could use an
+    /// external resolved to do resolution and pinning for flavor-specific deps)
+    type FlavorDependency<P: ?Sized>: Serialize + DeserializeOwned + Clone;
+
+    /// Pin a batch of [Self::FlavorDependency]s (see TODO). The keys of the returned map should be
+    /// the same as the keys of [dep].
+    //
+    // TODO: this interface means we can't batch dep-overrides together
+    fn pin(
+        &self,
+        deps: BTreeMap<PackageName, Self::FlavorDependency<Unpinned>>,
+    ) -> PackageResult<BTreeMap<PackageName, Self::FlavorDependency<Pinned>>>;
+
+    /// Fetch a batch [Self::FlavorDependency] (see TODO)
+    fn fetch(
+        &self,
+        deps: BTreeMap<PackageName, Self::FlavorDependency<Pinned>>,
+    ) -> PackageResult<BTreeMap<PackageName, PathBuf>>;
+
+    /// A [PublishedMetadata] should contain all of the information that is generated
+    /// during publication.
+    //
+    // TODO: should this include object IDs, or is that generic for Move? What about build config?
+    type PublishedMetadata: Serialize + DeserializeOwned + Clone;
+
+    /// A [PackageMetadata] encapsulates the additional package information that can be stored in
+    /// the `package` section of the manifest
+    type PackageMetadata: Serialize + DeserializeOwned + Clone;
+
+    /// An [AddressInfo] should give a unique identifier for a compiled package
+    type AddressInfo: Serialize + DeserializeOwned + Clone;
+
+    /// An [EnvironmentID] uniquely identifies a place that a package can be published. For
+    /// example, an environment ID might be a chain identifier
+    //
+    // TODO: Given an [EnvironmentID] and an [ObjectID], ... should be uniquely determined
+    type EnvironmentID: Serialize + DeserializeOwned + Clone + Eq;
+
+    /// Return the implicit dependencies for a given environment
+    fn implicit_deps(&self, environment: Self::EnvironmentID) -> Vec<PinnedDependencyInfo<Self>>;
+}

--- a/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
@@ -1,0 +1,60 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Defines the [Vanilla] implementation of the [MoveFlavor] trait. This implementation supports no
+//! flavor-specific resolvers and stores no additional metadata in the lockfile.
+
+use std::{
+    collections::{self, BTreeMap},
+    marker::PhantomData,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::dependency::PinnedDependencyInfo;
+use crate::{
+    dependency::{Pinned, Unpinned},
+    errors::PackageResult,
+    package::PackageName,
+};
+
+use super::MoveFlavor;
+
+/// The [Vanilla] implementation of the [MoveFlavor] trait. This implementation supports no
+/// flavor-specific resolvers and stores no additional metadata in the lockfile.
+pub struct Vanilla;
+
+impl MoveFlavor for Vanilla {
+    type PublishedMetadata = ();
+    type PackageMetadata = ();
+    type EnvironmentID = String;
+    type AddressInfo = ();
+
+    fn implicit_deps(&self, environment: Self::EnvironmentID) -> Vec<PinnedDependencyInfo<Self>> {
+        vec![]
+    }
+
+    // TODO: should be !, but that's not supported; instead
+    // should be some type that always gives an error during
+    // deserialization
+    type FlavorDependency<P: ?Sized> = ();
+
+    fn pin(
+        &self,
+        deps: BTreeMap<PackageName, Self::FlavorDependency<Unpinned>>,
+    ) -> PackageResult<BTreeMap<PackageName, Self::FlavorDependency<Pinned>>> {
+        // always an error
+        todo!()
+    }
+
+    fn fetch(
+        &self,
+        deps: BTreeMap<PackageName, Self::FlavorDependency<Pinned>>,
+    ) -> PackageResult<BTreeMap<PackageName, PathBuf>> {
+        // always an error
+        todo!()
+    }
+}

--- a/external-crates/move/crates/move-package-alt/src/lib.rs
+++ b/external-crates/move/crates/move-package-alt/src/lib.rs
@@ -1,3 +1,14 @@
+// Copyright (c) The Diem Core Contributors
 // Copyright (c) The Move Contributors
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+
+//! This library defines the package management system for Move.
+//!
+//! TODO: major modules, etc
+
+#![allow(unused)]
+pub mod dependency;
+pub mod errors;
+pub mod flavor;
+pub mod package;

--- a/external-crates/move/crates/move-package-alt/src/main.rs
+++ b/external-crates/move/crates/move-package-alt/src/main.rs
@@ -1,7 +1,0 @@
-// Copyright (c) The Move Contributors
-// Modifications Copyright (c) 2025 IOTA Stiftung
-// SPDX-License-Identifier: Apache-2.0
-
-fn main() {
-    println!("Hello, world!");
-}

--- a/external-crates/move/crates/move-package-alt/src/package/lockfile.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/lockfile.rs
@@ -1,0 +1,236 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+use std::{
+    collections::BTreeMap,
+    ffi::OsString,
+    fs::read_to_string,
+    path::{Path, PathBuf},
+};
+
+use anyhow::bail;
+use derive_where::derive_where;
+use lazy_regex::regex_captures;
+use serde::{Deserialize, Serialize};
+use serde_spanned::Spanned;
+use toml_edit::{
+    visit_mut::{visit_table_like_kv_mut, visit_table_mut, VisitMut},
+    Document, InlineTable, Item, KeyMut, Table, Value,
+};
+
+use crate::{
+    dependency::{ManifestDependencyInfo, PinnedDependencyInfo},
+    flavor::MoveFlavor,
+};
+
+use super::{EnvironmentName, PackageName};
+
+#[derive(Serialize, Deserialize)]
+#[derive_where(Clone, Default)]
+#[serde(bound = "")]
+pub struct Lockfile<F: MoveFlavor> {
+    unpublished: UnpublishedTable<F>,
+
+    #[serde(default)]
+    published: BTreeMap<EnvironmentName, Publication<F>>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[derive_where(Clone)]
+#[serde(bound = "")]
+pub struct Publication<F: MoveFlavor> {
+    #[serde(flatten)]
+    metadata: F::PublishedMetadata,
+    dependencies: BTreeMap<PackageName, PinnedDependencyInfo<F>>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[derive_where(Default, Clone)]
+#[serde(rename_all = "kebab-case")]
+#[serde(bound = "")]
+struct UnpublishedTable<F: MoveFlavor> {
+    dependencies: UnpublishedDependencies<F>,
+
+    #[serde(default)]
+    dep_overrides: BTreeMap<EnvironmentName, UnpublishedDependencies<F>>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[derive_where(Default, Clone)]
+#[serde(bound = "")]
+struct UnpublishedDependencies<F: MoveFlavor> {
+    pinned: BTreeMap<PackageName, PinnedDependencyInfo<F>>,
+    unpinned: BTreeMap<PackageName, ManifestDependencyInfo<F>>,
+}
+
+impl<F: MoveFlavor> Lockfile<F> {
+    /// Read `Move.lock` and all `Move.<env>.lock` files from the directory at `path`.
+    /// Returns a new empty [Lockfile] if `path` doesn't contain a `Move.lock`.
+    pub fn read_from(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        // Parse `Move.lock`
+        let lockfile_name = path.as_ref().join("Move.lock");
+        let Ok(lockfile_str) = read_to_string(&lockfile_name) else {
+            return Ok(Self::default());
+        };
+        let mut lockfiles = toml_edit::de::from_str::<Self>(&lockfile_str)?;
+
+        // Add in `Move.<env>.lock` files
+        let dir = std::fs::read_dir(path)?;
+        for entry in dir {
+            let Ok(file) = entry else { continue };
+
+            let Some(env_name) = lockname_to_env_name(file.file_name()) else {
+                continue;
+            };
+
+            let metadata_contents = std::fs::read_to_string(file.path())?;
+            let metadata: Publication<F> = toml_edit::de::from_str(&metadata_contents)
+                .or_else(|_| bail!(format!("Couldn't parse {file:?}")))?;
+
+            let old_entry = lockfiles.published.insert(env_name.clone(), metadata);
+            if old_entry.is_some() {
+                bail!("Move.lock and Move.{env_name}.lock both contain publication information for {env_name}; TODO.");
+            }
+        }
+
+        Ok(lockfiles)
+    }
+
+    /// Serialize [self] into `Move.lock` and `Move.<env>.lock`.
+    ///
+    /// The [PublishedMetadata] in `self.published.<env>` are partitioned: if `env` is in [envs]
+    /// then it is saved to `Move.lock` (and `Move.<env>.lock` is deleted), otherwise the metadata
+    /// is stored in `Move.<env>.lock`.
+    pub fn write_to(
+        &self,
+        path: impl AsRef<Path>,
+        envs: BTreeMap<EnvironmentName, F::EnvironmentID>,
+    ) -> anyhow::Result<()> {
+        let mut output: Lockfile<F> = self.clone();
+        let (pubs, locals): (BTreeMap<_, _>, BTreeMap<_, _>) = output
+            .published
+            .into_iter()
+            .partition(|(env_name, metadata)| envs.contains_key(env_name));
+        output.published = pubs;
+
+        std::fs::write(path.as_ref().join("Move.lock"), output.render())?;
+
+        for (chain, metadata) in locals {
+            std::fs::write(
+                path.as_ref().join(format!("Move.{}.lock", chain)),
+                metadata.render(),
+            )?;
+        }
+
+        for chain in output.published.keys() {
+            let _ = std::fs::remove_file(path.as_ref().join(format!("Move.{}.lock", chain)));
+        }
+
+        Ok(())
+    }
+
+    /// Pretty-print [self] as a TOML document
+    fn render(&self) -> String {
+        let mut toml = toml_edit::ser::to_document(self).expect("toml serialization succeeds");
+
+        expand_toml(&mut toml);
+        // TODO: maybe this could be more concise and not duplicated in [PublishedMetadata.render]
+        // by making the flattener smarter (e.g. it knows to fold anything called pinned, unpinned,
+        // or dependencies, or something like that)
+        flatten_toml(&mut toml["unpublished"]["dependencies"]["pinned"]);
+        flatten_toml(&mut toml["unpublished"]["dependencies"]["unpinned"]);
+        flatten_toml(&mut toml["unpublished"]["dependencies"]["unpinned"]);
+        for (_, chain) in toml["unpublished"]["dep-overrides"]
+            .as_table_like_mut()
+            .unwrap()
+            .iter_mut()
+        {
+            flatten_toml(chain.get_mut("pinned").unwrap());
+            flatten_toml(chain.get_mut("unpinned").unwrap());
+        }
+
+        for (_, chain) in toml["published"].as_table_like_mut().unwrap().iter_mut() {
+            flatten_toml(chain.get_mut("dependencies").unwrap());
+        }
+
+        toml.decor_mut()
+            .set_prefix("# Generated by move; do not edit\n# This file should be checked in.\n\n");
+
+        toml.to_string()
+    }
+}
+
+impl<F: MoveFlavor> Publication<F> {
+    /// Pretty-print [self] as TOML
+    fn render(&self) -> String {
+        let mut toml = toml_edit::ser::to_document(self).expect("toml serialization succeeds");
+        expand_toml(&mut toml);
+        flatten_toml(&mut toml["dependencies"]);
+
+        toml.decor_mut().set_prefix(
+            "# Generated by move; do not edit\n# This file should not be checked in\n\n",
+        );
+        toml.to_string()
+    }
+}
+
+/// Replace every inline table in [toml] with an implicit standard table (implicit tables are not
+/// included if they have no keys directly inside them)
+fn expand_toml(toml: &mut Document) {
+    struct Expander;
+
+    impl VisitMut for Expander {
+        fn visit_table_mut(&mut self, table: &mut Table) {
+            table.set_implicit(true);
+            visit_table_mut(self, table);
+        }
+
+        fn visit_table_like_kv_mut(&mut self, mut key: KeyMut<'_>, node: &mut Item) {
+            if let Item::Value(Value::InlineTable(inline_table)) = node {
+                let inline_table = std::mem::replace(inline_table, InlineTable::new());
+                let table = inline_table.into_table();
+                key.fmt();
+                *node = Item::Table(table);
+            }
+            visit_table_like_kv_mut(self, key, node);
+        }
+    }
+
+    let mut visitor = Expander;
+    visitor.visit_document_mut(toml);
+}
+
+/// Replace every table in [toml] with a non-implicit inline table.
+fn flatten_toml(toml: &mut Item) {
+    struct Inliner;
+
+    impl VisitMut for Inliner {
+        fn visit_table_mut(&mut self, table: &mut Table) {
+            table.set_implicit(false);
+            visit_table_mut(self, table);
+        }
+
+        fn visit_table_like_kv_mut(&mut self, mut key: KeyMut<'_>, node: &mut Item) {
+            if let Item::Table(table) = node {
+                let table = std::mem::replace(table, Table::new());
+                let inline_table = table.into_inline_table();
+                key.fmt();
+                *node = Item::Value(Value::InlineTable(inline_table));
+            }
+        }
+    }
+
+    let mut visitor = Inliner;
+    visitor.visit_item_mut(toml);
+}
+
+/// Given a filename of the form `Move.<env>.lock`, returns `<env>`.
+fn lockname_to_env_name(filename: OsString) -> Option<String> {
+    let Ok(filename) = filename.into_string() else {
+        return None;
+    };
+
+    let (_, env_name) = regex_captures!(r"Move\.(.*)\.lock", &filename)?;
+    Some(env_name.to_string())
+}

--- a/external-crates/move/crates/move-package-alt/src/package/manifest.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/manifest.rs
@@ -1,0 +1,85 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    dependency::ManifestDependencyInfo,
+    flavor::{MoveFlavor, Vanilla},
+};
+
+use super::*;
+
+// Note: [Manifest] objects are immutable and should not implement [serde::Serialize]; any tool
+// writing these files should use [toml_edit] to set / preserve the formatting, since these are
+// user-editable files
+#[derive(Deserialize)]
+#[serde(rename = "kebab-case")]
+#[serde(bound = "")]
+pub struct Manifest<F: MoveFlavor> {
+    package: PackageMetadata<F>,
+    environments: BTreeMap<EnvironmentName, F::EnvironmentID>,
+    #[serde(default)]
+    dependencies: BTreeMap<PackageName, ManifestDependency<F>>,
+    #[serde(default)]
+    dep_overrides: BTreeMap<EnvironmentName, BTreeMap<PackageName, ManifestDependencyOverride<F>>>,
+}
+
+#[derive(Deserialize)]
+#[serde(bound = "")]
+struct PackageMetadata<F: MoveFlavor> {
+    name: PackageName,
+    edition: String,
+
+    #[serde(flatten)]
+    metadata: F::PackageMetadata,
+}
+
+#[derive(Deserialize)]
+#[serde(bound = "")]
+#[serde(rename_all = "kebab-case")]
+struct ManifestDependency<F: MoveFlavor> {
+    #[serde(flatten)]
+    dependency_info: ManifestDependencyInfo<F>,
+
+    #[serde(rename = "override", default)]
+    is_override: bool,
+
+    #[serde(default)]
+    rename_from: Option<PackageName>,
+}
+
+#[derive(Deserialize)]
+#[serde(bound = "")]
+#[serde(rename_all = "kebab-case")]
+struct ManifestDependencyOverride<F: MoveFlavor> {
+    #[serde(flatten, default)]
+    dependency: Option<ManifestDependency<F>>,
+
+    #[serde(flatten, default)]
+    address_info: Option<F::AddressInfo>,
+
+    #[serde(default)]
+    use_environment: Option<EnvironmentName>,
+}
+
+impl<F: MoveFlavor> Manifest<F> {
+    fn read_from(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let contents = std::fs::read_to_string(path)?;
+        Ok(toml_edit::de::from_str(&contents)?)
+    }
+
+    fn write_template(path: impl AsRef<Path>, name: &PackageName) -> anyhow::Result<()> {
+        std::fs::write(
+            path,
+            r###"
+            "###,
+        )?;
+
+        Ok(())
+    }
+}

--- a/external-crates/move/crates/move-package-alt/src/package/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/mod.rs
@@ -1,0 +1,64 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod lockfile;
+pub mod manifest;
+
+use std::{
+    marker::PhantomData,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::flavor::MoveFlavor;
+use lockfile::{Lockfile, Publication};
+
+pub type EnvironmentName = String;
+pub type PackageName = String;
+
+pub struct Package<F: MoveFlavor> {
+    // TODO: maybe hold a lock on the lock file? Maybe not if move-analyzer wants to hold on to a
+    // Package long term?
+    // TODO: manifest: manifest::Manifest,
+    lockfiles: Lockfile<F>,
+    path: PathBuf,
+}
+
+impl<F: MoveFlavor> Package<F> {
+    /// Load a package from the manifest and lock files in directory [path].
+    /// Makes a best effort to translate old-style packages into the current format,
+    ///
+    /// Fails if [path] does not exist, or if it doesn't contain a manifest
+    pub fn load(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        todo!()
+    }
+
+    /// The path to the root directory of this package. This path is guaranteed to exist
+    /// and contain a manifest file.
+    pub fn path(&self) -> &Path {
+        todo!()
+    }
+
+    /// Return the metadata for the most recent published version in the given environemtn
+    pub fn publication_for(&self, env: EnvironmentName) -> Option<Publication<F>> {
+        todo!()
+    }
+
+    /// Register a published package on the given chain in the saved lockfiles
+    pub fn add_publication_for(
+        &mut self,
+        env: EnvironmentName,
+        metadata: Publication<F>,
+    ) -> anyhow::Result<()> {
+        // TODO: we'll have to update the local dependencies here
+        todo!()
+    }
+
+    /// Load and return all the transitive dependencies of this package
+    pub fn transitive_dependencies(&self) -> Vec<Package<F>> {
+        todo!()
+    }
+}


### PR DESCRIPTION
# Description of change

It seems these changes is the first major step toward a modernized, flavor-based Move package manager.
This is the first foundation for a new package management system that:
Cleanly separates generic Move package logic from chain-specific behavior via a MoveFlavor trait.

**Starting to sketch out the modules in the new package management system**

According to [changes](https://github.com/MystenLabs/sui/commit/3e03ed34394b1010dec75d5d46e4b97537a80ea1).

## Links to any relevant issues

Fixes #8327 .

## How the change has been tested

Check the CI