### PR TITLE
feat(move-package-alt): Add some manifest files for parsing

### DIFF
--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example"
+edition = "2024.beta"
+version = "1.25.0"
+license = "Apache-2.0"
+authors = ["Move Team"]
+
+[environments]
+mainnet = 9123

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment1/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment1/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example"
+edition = "2024.beta"
+version = "1.25.0"
+license = "Apache-2.0"
+authors = ["Move Team"]
+
+[environments]
+mainnet = true

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_missing_dep_override_git/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_missing_dep_override_git/Move.toml
@@ -1,0 +1,15 @@
+[package]
+name = "example"
+edition = "2024.beta"
+license = "Apache-2.0"
+authors = ["Move Team"]
+
+[environments]
+mainnet = "35834a8a"
+testnet = "4c78adac"
+
+[dependencies]
+foo = { rename-from = "Foo", override = "true", rev = "releases/v1", git = "https://example.com/foo.git" }
+
+[dep-overrides]
+mainnet.foo = { original-id = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb", published-at = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb", use-environment = "mainnet_alpha" }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_missing_git_dep/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_missing_git_dep/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example"
+edition = "2024.beta"
+license = "Apache-2.0"
+authors = ["Move Team"]
+
+[environments]
+mainnet = "35834a8a"
+testnet = "4c78adac"
+
+[dependencies]
+foo = { rename-from = "Foo", override = "true", rev = "releases/v1" }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/duplicate_top_level_field/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/duplicate_top_level_field/Move.toml
@@ -1,0 +1,4 @@
+[package]
+name = "name"
+
+[package]

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/integer_subst_in_dependency/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/integer_subst_in_dependency/Move.toml
@@ -1,0 +1,5 @@
+[package]
+name = "name"
+
+[dependencies]
+A = { local = "a", rename-from = { "A" = 1 } }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_author/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_author/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "name"
+authors = [1]

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_authors/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_authors/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "name"
+authors = "nope"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_hex_address_in_subst/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_hex_address_in_subst/Move.toml
@@ -1,0 +1,5 @@
+[package]
+name = "name"
+
+[dependencies]
+A = { local = "a", rename-from = { "A" = "0xG" } }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_identifier_package_name/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_identifier_package_name/Move.toml
@@ -1,0 +1,2 @@
+[package]
+name = "®´∑œ"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_minimal_required_field_name/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_minimal_required_field_name/Move.toml
@@ -1,0 +1,2 @@
+[package]
+version = "0.1.1"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_required_package_segment/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_required_package_segment/Move.toml
@@ -1,0 +1,11 @@
+name = "name"
+license = "license"
+authors = ["some author"]
+
+[dependencies]
+A = { local = "../a" }
+B = { local = "../b", rename-from = { "a" = "0xDEADBEEF" } }
+C = { local = "../some_path", rename-from = { "a" = "0xCAFE", d = "0x4" } }
+D = { local = "../some_path", rename-from = { "a" = "0xCAFE", C = "B" } }
+E = { local = "../some_path", rename-from = { "a" = "0xCAFE", C = "B", "OtherD" = "d" } }
+F = { local = "../some_path", rename-from = { "a" = "0xCAFE" } }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/no_path_set_for_dependency/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/no_path_set_for_dependency/Move.toml
@@ -1,0 +1,5 @@
+[package]
+name = "name"
+
+[dependencies]
+A = {}

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_identifier_address_name_in_subst/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_identifier_address_name_in_subst/Move.toml
@@ -1,0 +1,5 @@
+[package]
+name = "name"
+
+[dependencies]
+A = { local = "a", rename-from = { "©" = "A" } }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_string_local_dep_path/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_string_local_dep_path/Move.toml
@@ -1,0 +1,5 @@
+[package]
+name = "name"
+
+[dependencies]
+A = { local = 1 }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_string_package_name/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_string_package_name/Move.toml
@@ -1,0 +1,2 @@
+[package]
+name = 1

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/too_many_entries_renaming_instantiation/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/too_many_entries_renaming_instantiation/Move.toml
@@ -1,0 +1,5 @@
+[package]
+name = "name"
+
+[dependencies]
+A = { local = "a", rename-from = { A = { B = "0x1", R = "0x2" } } }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/unknown_toplevel_field/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/unknown_toplevel_field/Move.toml
@@ -1,0 +1,14 @@
+[package]
+name = "name"
+license = "license"
+authors = ["some author"]
+
+[unknown_field]
+
+[dependencies]
+A = { local = "../a" }
+B = { local = "../b", rename-from = { "a" = "0xDEADBEEF" } }
+C = { local = "../some_path", rename-from = { "a" = "0xCAFE", "d" = "0x4" } }
+D = { local = "../some_path", rename-from = { "a" = "0xCAFE", "C" = "B" } }
+E = { local = "../some_path", rename-from = { "a" = "0xCAFE", "C" = "B", "OtherD" = "d" } }
+F = { local = "../some_path", rename-from = { "a" = "0xCAFE" } }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic/Move.toml
@@ -1,0 +1,27 @@
+[package]
+name = "example"
+edition = "2024.beta"
+license = "Apache-2.0"
+authors = ["Move Team"]
+flavor = "vanilla"
+
+[build]
+language-version = "1.0.0"
+
+[environments]
+mainnet = "35834a8a"
+testnet = "4c78adac"
+
+[dependencies]
+foo = { git = "https://example.com/foo.git", rev = "releases/v1", rename-from = "Foo", override = "true" }
+qwer = { r.mvr = "@pkg/qwer" }
+
+[dep-overrides]
+# used to override dependencies for specific environments
+mainnet.foo = { git = "https://example.com/foo.git", original-id = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb", published-at = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb", use-environment = "mainnet_alpha" }
+
+[dep-overrides.mainnet.foo]
+git = "https://example.com/foo.git"
+original-id = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb"
+published-at = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb"
+use-environment = "mainnet_alpha"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_external_resolver/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_external_resolver/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "example"
+edition = "2024.beta"
+license = "Apache-2.0"
+authors = ["Move Team"]
+
+[environments]
+mainnet = "35834a8a"
+
+[dependencies]
+mvr = { r.mvr = "@pkg/qwer" }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_implicit_deps/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_implicit_deps/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example"
+edition = "2024.beta"
+license = "Apache-2.0"
+authors = ["Move Team"]
+implicit-deps = true
+
+[environments]
+mainnet = "35834a8a"
+
+[dependencies]
+Iota = { local = "../../../../../../../../../crates/iota-framework/packages/iota-framework" }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_with_bar/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_with_bar/Move.toml
@@ -1,0 +1,24 @@
+[package]
+name = "example"
+edition = "2024.beta"
+license = "Apache-2.0"
+authors = ["Move Team"]
+
+[environments]
+mainnet = "35834a8a"
+testnet = "4c78adac"
+
+[dependencies]
+foo = { git = "https://example.com/foo.git", rev = "releases/v1", rename-from = "Foo", override = "true" }
+qwer = { r.mvr = "@pkg/qwer" }
+bar = { local = "./bar" }
+
+[dep-overrides]
+# used to override dependencies for specific environments
+mainnet.foo = { git = "https://example.com/foo.git", original-id = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb", published-at = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb", use-environment = "mainnet_alpha" }
+
+[dep-overrides.mainnet.foo]
+git = "https://example.com/foo.git"
+original-id = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb"
+published-at = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb"
+use-environment = "mainnet_alpha"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_with_bar/bar/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_with_bar/bar/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bar"
+edition = "2024.beta"
+authors = ["Move Team"]
+license = "Apache-2.0"
+implicit-deps = true
+
+[environments]
+mainnet = "35834a8a"
+
+[dependencies]
+Iota = { local = "../../../../../../../../../crates/iota-framework/packages/iota-framework" }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "name"
+license = "license"
+authors = ["some author"]
+edition = "2024"
+
+[environments]
+mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024_alpha/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024_alpha/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "name"
+license = "license"
+authors = ["some author"]
+edition = "2024.alpha"
+
+[environments]
+mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024_beta/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024_beta/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "name"
+license = "license"
+authors = ["some author"]
+edition = "2024.beta"
+
+[environments]
+mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_legacy/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_legacy/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "name"
+license = "license"
+authors = ["some author"]
+edition = "legacy"
+
+[environments]
+mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_unknown/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_unknown/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "name"
+license = "license"
+authors = ["some author"]
+edition = "foobar"
+
+[environments]
+mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_unknown_suffix/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_unknown_suffix/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "name"
+license = "license"
+authors = ["some author"]
+edition = "2024.final"
+
+[environments]
+mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_global_storage/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_global_storage/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "name"
+license = "license"
+authors = ["some author"]
+flavor = "core"
+
+[environments]
+mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_iota/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_iota/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "name"
+license = "license"
+authors = ["some author"]
+flavor = "iota"
+
+[environments]
+mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_unknown/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_unknown/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "name"
+license = "license"
+authors = ["some author"]
+flavor = "vanilla"
+
+[environments]
+mainnet = "35834a8a"


### PR DESCRIPTION
# Description of change

This commit adds a set of Move.toml files under the new move-package-alt test tree to exercise the manifest parser for the alternative package manager. The fixtures cover both valid and invalid shapes (editions, flavors, deps, authors, env blocks, etc.), enabling deterministic parser/unit tests and future conformance checks.

According to [changes](https://github.com/MystenLabs/sui/commit/c25429e5f2fd81a56e3c42ded296dd32e2ded046).

## Links to any relevant issues

Fixes #8328 .

## How the change has been tested

Check the CI