### PR TITLE
refactor(graphql-rpc): Fix complex return type in paginate_consistent_indices

### DIFF
--- a/crates/iota-graphql-rpc/src/types/cursor.rs
+++ b/crates/iota-graphql-rpc/src/types/cursor.rs
@@ -244,7 +244,9 @@ where
     }
 }
 
-pub(crate) struct ConsistentPage {
+pub(crate) type ConsistentPageCursor = JsonCursor<ConsistentIndexCursor>;
+
+pub(crate) struct ConsistentPage<I: Iterator<Item = ConsistentPageCursor>> {
     /// Whether there is a previous page available
     pub has_previous_page: bool,
     /// Whether there is a next page available
@@ -252,7 +254,7 @@ pub(crate) struct ConsistentPage {
     /// The checkpoint viewed at for consistency
     pub checkpoint_viewed_at: u64,
     /// Iterator of cursors within the page
-    pub cursors: Box<dyn Iterator<Item = JsonCursor<ConsistentIndexCursor>> + Send>,
+    pub cursors: I,
 }
 
 impl Page<JsonCursor<ConsistentIndexCursor>> {
@@ -265,7 +267,7 @@ impl Page<JsonCursor<ConsistentIndexCursor>> {
         &self,
         total: usize,
         checkpoint_viewed_at: u64,
-    ) -> Result<Option<ConsistentPage>, Error> {
+    ) -> Result<Option<ConsistentPage<impl Iterator<Item = ConsistentPageCursor>>>, Error> {
         let cursor_viewed_at = self.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
@@ -286,12 +288,12 @@ impl Page<JsonCursor<ConsistentIndexCursor>> {
             has_previous_page: 0 < lo,
             has_next_page: hi < total,
             checkpoint_viewed_at,
-            cursors: Box::new((lo..hi).map(move |ix| {
+            cursors: (lo..hi).map(move |ix| {
                 JsonCursor::new(ConsistentIndexCursor {
                     ix,
                     c: checkpoint_viewed_at,
                 })
-            })),
+            }),
         }))
     }
 }

--- a/crates/iota-graphql-rpc/src/types/cursor.rs
+++ b/crates/iota-graphql-rpc/src/types/cursor.rs
@@ -244,26 +244,28 @@ where
     }
 }
 
+pub(crate) struct ConsistentPage {
+    /// Whether there is a previous page available
+    pub has_previous_page: bool,
+    /// Whether there is a next page available
+    pub has_next_page: bool,
+    /// The checkpoint viewed at for consistency
+    pub checkpoint_viewed_at: u64,
+    /// Iterator of cursors within the page
+    pub cursors: Box<dyn Iterator<Item = JsonCursor<ConsistentIndexCursor>> + Send>,
+}
+
 impl Page<JsonCursor<ConsistentIndexCursor>> {
     /// Treat the cursors of this Page as indices into a range [0, total).
     /// Validates that the cursors of the page are consistent, and returns
     /// two booleans indicating whether there is a previous or next page in
     /// the range, the `checkpoint_viewed_at` to set for consistency, and an
     /// iterator of cursors within that Page.
-    #[allow(clippy::type_complexity)]
     pub(crate) fn paginate_consistent_indices(
         &self,
         total: usize,
         checkpoint_viewed_at: u64,
-    ) -> Result<
-        Option<(
-            bool,
-            bool,
-            u64,
-            impl Iterator<Item = JsonCursor<ConsistentIndexCursor>>,
-        )>,
-        Error,
-    > {
+    ) -> Result<Option<ConsistentPage>, Error> {
         let cursor_viewed_at = self.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
@@ -280,17 +282,17 @@ impl Page<JsonCursor<ConsistentIndexCursor>> {
             }
         }
 
-        Ok(Some((
-            0 < lo,
-            hi < total,
+        Ok(Some(ConsistentPage {
+            has_previous_page: 0 < lo,
+            has_next_page: hi < total,
             checkpoint_viewed_at,
-            (lo..hi).map(move |ix| {
+            cursors: Box::new((lo..hi).map(move |ix| {
                 JsonCursor::new(ConsistentIndexCursor {
                     ix,
                     c: checkpoint_viewed_at,
                 })
-            }),
-        )))
+            })),
+        }))
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/move_module.rs
+++ b/crates/iota-graphql-rpc/src/types/move_module.rs
@@ -85,20 +85,20 @@ impl MoveModule {
         let bytecode = self.parsed.bytecode();
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, checkpoint_viewed_at, cs)) = page
+        let Some(consistent_page) = page
             .paginate_consistent_indices(bytecode.friend_decls.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
         let runtime_id = *bytecode.self_id().address();
         let Some(package) = MovePackage::query(
             ctx,
             self.storage_id,
-            MovePackage::by_id_at(checkpoint_viewed_at),
+            MovePackage::by_id_at(consistent_page.checkpoint_viewed_at),
         )
         .await
         .extend()?
@@ -112,7 +112,7 @@ impl MoveModule {
 
         // Select `friend_decls[lo..hi]` using iterators to enumerate before taking a
         // sub-sequence from it, to get pairs `(i, friend_decls[i])`.
-        for c in cs {
+        for c in consistent_page.cursors {
             let decl = &bytecode.friend_decls[c.ix];
             let friend_pkg = bytecode.address_identifier_at(decl.address);
             let friend_mod = bytecode.identifier_at(decl.name);

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -228,13 +228,13 @@ impl TransactionBlockEffects {
 
         let dependencies = self.native().dependencies();
 
-        let Some((prev, next, _, cs)) =
+        let Some(consistent_page) =
             page.paginate_consistent_indices(dependencies.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        let indices: Vec<CDependencies> = cs.collect();
+        let indices: Vec<CDependencies> = consistent_page.cursors.collect();
 
         let (Some(fst), Some(lst)) = (indices.first(), indices.last()) else {
             return Ok(connection);
@@ -255,8 +255,8 @@ impl TransactionBlockEffects {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
         for c in indices {
             let digest: Digest = dependencies[c.ix].into();
@@ -289,16 +289,16 @@ impl TransactionBlockEffects {
 
         let input_shared_objects = self.native().input_shared_objects();
 
-        let Some((prev, next, _, cs)) = page
+        let Some(consistent_page) = page
             .paginate_consistent_indices(input_shared_objects.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for c in cs {
+        for c in consistent_page.cursors {
             let result = UnchangedSharedObject::try_from(input_shared_objects[c.ix].clone(), c.c);
             match result {
                 Ok(unchanged_shared_object) => {
@@ -328,14 +328,14 @@ impl TransactionBlockEffects {
 
         let object_changes = self.native().object_changes();
 
-        let Some((prev, next, _, cs)) =
+        let Some(consistent_page) =
             page.paginate_consistent_indices(object_changes.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
         // Determine the source based on the transaction block effects kind
         let source = match &self.kind {
@@ -344,7 +344,7 @@ impl TransactionBlockEffects {
             TransactionBlockEffectsKind::DryRun { .. } => ObjectChangeSource::DryRun,
         };
 
-        for c in cs {
+        for c in consistent_page.cursors {
             let object_change = ObjectChange {
                 native: object_changes[c.ix].clone(),
                 checkpoint_viewed_at: c.c,
@@ -383,16 +383,16 @@ impl TransactionBlockEffects {
             _ => return Ok(connection),
         };
 
-        let Some((prev, next, _, cs)) =
+        let Some(consistent_page) =
             page.paginate_consistent_indices(balance_len, self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for c in cs {
+        for c in consistent_page.cursors {
             let serialized = match &self.kind {
                 TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
                     stored_tx.get_balance_at_idx(c.ix)
@@ -436,16 +436,16 @@ impl TransactionBlockEffects {
             }
             TransactionBlockEffectsKind::DryRun { events, .. } => events.len(),
         };
-        let Some((prev, next, _, cs)) =
+        let Some(consistent_page) =
             page.paginate_consistent_indices(len, self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for c in cs {
+        for c in consistent_page.cursors {
             let event = match &self.kind {
                 TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
                     Event::try_from_stored_transaction(stored_tx, c.ix, c.c).extend()?

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -64,7 +64,7 @@ impl AuthenticatorStateUpdateTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, _, cs)) = page.paginate_consistent_indices(
+        let Some(consistent_page) = page.paginate_consistent_indices(
             self.native.new_active_jwks.len(),
             self.checkpoint_viewed_at,
         )?
@@ -72,10 +72,10 @@ impl AuthenticatorStateUpdateTransaction {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for c in cs {
+        for c in consistent_page.cursors {
             let active_jwk = ActiveJwk {
                 native: self.native.new_active_jwks[c.ix].clone(),
                 checkpoint_viewed_at: c.c,

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -172,16 +172,16 @@ impl EndOfEpochTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, _, cs)) =
+        let Some(consistent_page) =
             page.paginate_consistent_indices(self.native.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for c in cs {
+        for c in consistent_page.cursors {
             let tx = EndOfEpochTransactionKind::from(self.native[c.ix].clone(), c.c);
             connection.edges.push(Edge::new(c.encode_cursor(), tx));
         }
@@ -251,7 +251,7 @@ impl ChangeEpochTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, _, cs)) = page.paginate_consistent_indices(
+        let Some(consistent_page) = page.paginate_consistent_indices(
             self.native.system_packages.len(),
             self.checkpoint_viewed_at,
         )?
@@ -259,10 +259,10 @@ impl ChangeEpochTransaction {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for c in cs {
+        for c in consistent_page.cursors {
             let (version, modules, deps) = &self.native.system_packages[c.ix];
             let compiled_modules = modules
                 .iter()
@@ -358,16 +358,16 @@ impl ChangeEpochTransactionV2 {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, _, cs)) = page
+        let Some(consistent_page) = page
             .paginate_consistent_indices(self.system_packages.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for c in cs {
+        for c in consistent_page.cursors {
             let (version, modules, deps) = &self.system_packages[c.ix];
             let compiled_modules = modules
                 .iter()

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/genesis.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/genesis.rs
@@ -48,16 +48,16 @@ impl GenesisTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, _, cursors)) =
+        let Some(consistent_page) =
             page.paginate_consistent_indices(self.native.objects.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for cursor in cursors {
+        for cursor in consistent_page.cursors {
             let GenesisObject::RawObject { data, owner } = self.native.objects[cursor.ix].clone();
             let native =
                 NativeObject::new_from_genesis(data, owner, TransactionDigest::genesis_marker());
@@ -84,16 +84,16 @@ impl GenesisTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, _, cursors)) =
+        let Some(consistent_page) =
             page.paginate_consistent_indices(self.native.events.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for cursor in cursors {
+        for cursor in consistent_page.cursors {
             let native_event = self.native.events[cursor.ix].clone();
 
             let event = Event {

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -226,16 +226,16 @@ impl ProgrammableTransactionBlock {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, _, cs)) =
+        let Some(consistent_page) =
             page.paginate_consistent_indices(self.native.inputs.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for c in cs {
+        for c in consistent_page.cursors {
             let input = TransactionInput::from(self.native.inputs[c.ix].clone(), c.c);
             connection.edges.push(Edge::new(c.encode_cursor(), input));
         }
@@ -255,16 +255,16 @@ impl ProgrammableTransactionBlock {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, _, cs)) = page
+        let Some(consistent_page) = page
             .paginate_consistent_indices(self.native.commands.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for c in cs {
+        for c in consistent_page.cursors {
             let txn = ProgrammableTransaction::from(self.native.commands[c.ix].clone(), c.c);
             connection.edges.push(Edge::new(c.encode_cursor(), txn));
         }

--- a/crates/iota-graphql-rpc/src/types/validator.rs
+++ b/crates/iota-graphql-rpc/src/types/validator.rs
@@ -376,16 +376,16 @@ impl Validator {
             return Ok(connection);
         };
 
-        let Some((prev, next, _, cs)) =
+        let Some(consistent_page) =
             page.paginate_consistent_indices(addresses.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for c in cs {
+        for c in consistent_page.cursors {
             connection.edges.push(Edge::new(
                 c.encode_cursor(),
                 Address {

--- a/crates/iota-graphql-rpc/src/types/validator_set.rs
+++ b/crates/iota-graphql-rpc/src/types/validator_set.rs
@@ -91,16 +91,16 @@ impl ValidatorSet {
             return Ok(connection);
         };
 
-        let Some((prev, next, _, cs)) =
+        let Some(consistent_page) =
             page.paginate_consistent_indices(validators.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for c in cs {
+        for c in consistent_page.cursors {
             let mut validator = validators[c.ix].clone();
             validator.checkpoint_viewed_at = c.c;
             connection
@@ -127,16 +127,16 @@ impl ValidatorSet {
             return Ok(connection);
         };
 
-        let Some((prev, next, _, cs)) =
+        let Some(consistent_page) =
             page.paginate_consistent_indices(validators.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
 
-        connection.has_previous_page = prev;
-        connection.has_next_page = next;
+        connection.has_previous_page = consistent_page.has_previous_page;
+        connection.has_next_page = consistent_page.has_next_page;
 
-        for c in cs {
+        for c in consistent_page.cursors {
             let mut validator = validators[c.ix].clone();
             validator.checkpoint_viewed_at = c.c;
             connection


### PR DESCRIPTION
# Description of change

Fix complex return type in paginate_consistent_indices

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/4755

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

