### PR TITLE
feat(consensus): replace gc depth constants with `consensus_gc_depth` protocol config param

### DIFF
--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -19,11 +19,11 @@ use crate::{
     block_header::{BlockHeaderAPI, VerifiedBlockHeader},
     commit::{CommitAPI, CommitIndex, PendingSubDag, load_pending_subdag_from_store},
     context::Context,
-    dag_state::{DagState, MAX_TRANSACTIONS_ACK_DEPTH},
+    dag_state::DagState,
     data_manager::DataManager,
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
-    linearizer::{Linearizer, MAX_LINEARIZER_DEPTH},
+    linearizer::Linearizer,
     storage::Store,
 };
 
@@ -174,11 +174,11 @@ impl CommitObserver {
 
             // The earliest commit that still might acknowledge not-yet-committed
             // transactions that still have a chance of being committed is no higher than
-            // `last_pending_commit_index - MAX_TRANSACTIONS_ACK_CHECK -
-            // MAX_LINEARIZER_DEPTH`.
+            // `last_pending_commit_index - protocol_config.gc_depth() * 2, once for
+            // max linearizer depth and once for max transaction ack depth.
 
             let commit_index_to_recover_acks =
-                last_commit_index.saturating_sub(MAX_TRANSACTIONS_ACK_DEPTH + MAX_LINEARIZER_DEPTH);
+                last_commit_index.saturating_sub(self.context.protocol_config.gc_depth() * 2);
 
             recovery_lower_bound = recovery_lower_bound
                 .min(commit_index_to_recover_acks)

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -29,16 +29,10 @@ use crate::{
     },
     context::Context,
     leader_scoring::{ReputationScores, ScoringSubdag},
-    linearizer::MAX_LINEARIZER_DEPTH,
     storage::{Store, WriteBatch},
     threshold_clock::ThresholdClock,
 };
 
-/// Acknowledgment depth is the maximum number of rounds from current round
-/// for which acknowledgments are kept in memory and can be injected in a new
-/// block.
-// TODO: make it derivable from the protocol parameters
-pub(crate) const MAX_TRANSACTIONS_ACK_DEPTH: Round = 50;
 pub(crate) const MAX_HEADERS_PER_BUNDLE: usize = 150;
 pub(crate) const MAX_SHARDS_PER_BUNDLE: usize = 150;
 
@@ -346,7 +340,8 @@ impl DagState {
             self.transactions_to_write.push(transactions);
             // If a block is not very old, add it to pending acknowledgments
             let clock_round = self.threshold_clock_round();
-            let min_round: Round = clock_round.saturating_sub(MAX_TRANSACTIONS_ACK_DEPTH);
+            let min_round: Round =
+                clock_round.saturating_sub(self.context.protocol_config.gc_depth());
 
             if block_ref.round >= min_round {
                 self.add_pending_acknowledgment(block_ref);
@@ -1492,10 +1487,11 @@ impl DagState {
     }
 
     /// Function removes stalled pending acknowledgments that are older than
-    /// "current clock round minus MAX_TRANSACTIONS_ACK_DEPTH"
+    /// "current clock round minus protocol_config.gc_depth() aka
+    /// (MAX_TRANSACTIONS_ACK_DEPTH)"
     pub(crate) fn evict_pending_acknowledgments(&mut self) {
         let clock_round = self.threshold_clock_round();
-        let min_round: Round = clock_round.saturating_sub(MAX_TRANSACTIONS_ACK_DEPTH);
+        let min_round: Round = clock_round.saturating_sub(self.context.protocol_config.gc_depth());
 
         // Construct a dummy BlockRef with the minimum round to split on.
         // All entries < dummy will be removed.
@@ -1607,7 +1603,7 @@ impl DagState {
 
     /// Return the garbage collection round with respect a given round.
     pub(crate) fn gc_round(&self, round: Round) -> Round {
-        round.saturating_sub(MAX_LINEARIZER_DEPTH + MAX_TRANSACTIONS_ACK_DEPTH)
+        round.saturating_sub(self.context.protocol_config.gc_depth() * 2)
     }
 
     /// Last committed round per authority.
@@ -3214,7 +3210,7 @@ mod test {
         // Calculate the eviction round for acknowledgments
         let clock_round = dag_state.threshold_clock_round();
         let acknowledgements_eviction_round =
-            clock_round.saturating_sub(MAX_TRANSACTIONS_ACK_DEPTH + 1);
+            clock_round.saturating_sub(context.protocol_config.gc_depth() + 1);
 
         // Verify that for all blocks with round > eviction round, we have an
         // acknowledgement

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -15,16 +15,10 @@ use crate::{
     block_header::{BlockHeaderAPI, BlockHeaderDigest, BlockRef, VerifiedBlockHeader},
     commit::{Commit, CommitAPI, PendingSubDag, TrustedCommit, sort_sub_dag_blocks},
     context::Context,
-    dag_state::{DagState, MAX_TRANSACTIONS_ACK_DEPTH},
+    dag_state::DagState,
     leader_schedule::LeaderSchedule,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
 };
-
-/// The maximum depth of the linearizer, i.e. how many rounds back it will
-/// traverse the DAG from a committed leader block
-// TODO: https://github.com/iotaledger/iota/issues/8379
-// make it derivable from the protocol parameters
-pub(crate) const MAX_LINEARIZER_DEPTH: Round = 60;
 
 /// The `StorageAPI` trait provides an interface for the block store and has
 /// been mostly introduced for allowing to inject the test store in
@@ -92,6 +86,7 @@ impl Linearizer {
             leader_block.clone(),
             last_committed_rounds,
             &dag_state_guard,
+            self.context.protocol_config.gc_depth(),
         );
 
         drop(dag_state_guard);
@@ -152,6 +147,7 @@ impl Linearizer {
         leader_block: VerifiedBlockHeader,
         last_committed_rounds: Vec<u32>,
         dag_state: &impl BlockStoreAPI,
+        max_linearizer_depth: u32,
     ) -> Vec<VerifiedBlockHeader> {
         let leader_block_ref = leader_block.reference();
         let leader_round = leader_block.round();
@@ -177,7 +173,7 @@ impl Linearizer {
                             !committed.contains(ancestor)
                                 && last_committed_rounds[ancestor.author] < ancestor.round
                                 && ancestor.round
-                                    >= leader_round.saturating_sub(MAX_LINEARIZER_DEPTH)
+                                    >= leader_round.saturating_sub(max_linearizer_depth)
                         })
                         .collect::<Vec<_>>(),
                 )
@@ -260,8 +256,8 @@ impl Linearizer {
     /// called for solid committed leader round since we rely on the ack
     /// tracker in transaction synchronizer.
     pub(crate) fn evict_old_acknowledgments(&mut self, solid_commit_leader_round: Round) {
-        let lower_bound_round = solid_commit_leader_round
-            .saturating_sub(MAX_LINEARIZER_DEPTH + MAX_TRANSACTIONS_ACK_DEPTH);
+        let lower_bound_round =
+            solid_commit_leader_round.saturating_sub(self.context.protocol_config.gc_depth() * 2);
         let lower_bound = BlockRef::new(
             lower_bound_round + 1,
             AuthorityIndex::ZERO,
@@ -281,7 +277,7 @@ impl Linearizer {
     ) -> Vec<BlockRef> {
         let mut acknowledged_data = Vec::new();
         for block_ref in acknowledgments {
-            if block_ref.round < round.saturating_sub(MAX_TRANSACTIONS_ACK_DEPTH) {
+            if block_ref.round < round.saturating_sub(self.context.protocol_config.gc_depth()) {
                 continue; // Ignore acknowledgments for blocks that are too old
             }
             let votes_collector = self
@@ -735,10 +731,11 @@ mod tests {
         ));
         let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
         let num_rounds_to_evict = 20;
-        // Populate fully connected test blocks for round 0 ~ MAX_LINEARIZER_DEPTH +
-        // MAX_TRANSACTIONS_ACK_DEPTH + num_rounds_to_evict, authorities 0 ~ 3.
-        let num_rounds: u32 =
-            MAX_LINEARIZER_DEPTH + MAX_TRANSACTIONS_ACK_DEPTH + num_rounds_to_evict;
+        // Populate fully connected test blocks for round 0 ~ protocol_config.gc_depth()
+        // * 2
+        // + num_rounds_to_evict, authorities 0 ~
+        // 3.
+        let num_rounds: u32 = context.protocol_config.gc_depth() * 2 + num_rounds_to_evict;
         let mut dag_builder = DagBuilder::new(context.clone());
         dag_builder
             .layers(1..=num_rounds)

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -284,6 +284,7 @@ impl DagBuilder {
                 leader_block,
                 self.last_committed_rounds.clone(),
                 &storage,
+                self.context.protocol_config.gc_depth(),
             );
 
             // Update the last committed rounds


### PR DESCRIPTION
# Description of change

This PR replaces `MAX_LINEARIZER_DEPTH` and `MAX_TRANSACTIONS_ACK_DEPTH` with `protocol_config` field `consensus_gc_depth` accessed via the `gc_depth()` getter.

## Links to any relevant issues

Closes #8379

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
