### PR TITLE
feat(iota-protocol-config,iota-core): Add feature flag for selecting committee supporting next epoch version

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4909,9 +4909,9 @@ impl AuthorityState {
             let mut eligible_active_validators = (0..active_validators.len() as u64).collect();
 
             // Use validators supporting the target protocol version as eligible validators
-            // in the next version if track_non_committee_eligible_validators feature flag
-            // is set to true.
-            if config.track_non_committee_eligible_validators() {
+            // in the next version if select_committee_supporting_next_epoch_version feature
+            // flag is set to true.
+            if config.select_committee_supporting_next_epoch_version() {
                 eligible_active_validators = Self::get_validators_supporting_protocol_version(
                     next_epoch_protocol_version,
                     next_epoch_protocol_digest,

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -72,6 +72,7 @@ async fn test_authority_reject_authority_capabilities() {
     let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
     protocol_config.set_select_committee_from_eligible_validators_for_testing(true);
     protocol_config.set_track_non_committee_eligible_validators_for_testing(true);
+    protocol_config.set_select_committee_supporting_next_epoch_version(true);
 
     let authority_state = TestAuthorityBuilder::new()
         .with_protocol_config(protocol_config)
@@ -179,6 +180,7 @@ async fn test_handle_capability_notification_v1_feature_disabled() {
     let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
     protocol_config.set_select_committee_from_eligible_validators_for_testing(false);
     protocol_config.set_track_non_committee_eligible_validators_for_testing(false);
+    protocol_config.set_select_committee_supporting_next_epoch_version(false);
 
     let authority_state = TestAuthorityBuilder::new()
         .with_protocol_config(protocol_config)

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1334,6 +1334,7 @@
                 "relocate_event_module": true,
                 "rethrow_serialization_type_layout_errors": true,
                 "select_committee_from_eligible_validators": false,
+                "select_committee_supporting_next_epoch_version": false,
                 "track_non_committee_eligible_validators": false,
                 "uncompressed_g1_group_elements": true,
                 "validate_identifier_inputs": false,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -335,11 +335,21 @@ struct FeatureFlags {
     select_committee_from_eligible_validators: bool,
 
     // If true, non-committee active validators will sign and send AuthorityCapabilitiesV1 to the
-    // committee. The committee will track them and include them in the epoch change. If this is
-    // disabled, then all active validators are used for selecting the committee (same as previous
-    // behavior).
+    // committee. Once the committee reaches consensus over the AuthorityCapabilitiesV1, it is
+    // recorded and possible to use in the committee selection if
+    // select_validators_supporting_next_epoch_version is enabled. This flag does not change the
+    // way that eligible_validators vector is created - still all active validators are used for
+    // selecting the committee.
     #[serde(skip_serializing_if = "is_false")]
     track_non_committee_eligible_validators: bool,
+
+    // The committee be selected from active_validators who support the next protocol version AND
+    // have issued a correct AuthorityCapabilities notification. This flag should only be enabled
+    // if both select_committee_from_eligible_validators and
+    // track_non_committee_eligible_validators are enabled. If this is disabled, then all
+    // active validators are used for selecting the committee (default behavior).
+    #[serde(skip_serializing_if = "is_false")]
+    select_committee_supporting_next_epoch_version: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1363,6 +1373,18 @@ impl ProtocolConfig {
     pub fn track_non_committee_eligible_validators(&self) -> bool {
         self.feature_flags.track_non_committee_eligible_validators
     }
+
+    pub fn select_committee_supporting_next_epoch_version(&self) -> bool {
+        let res = self
+            .feature_flags
+            .select_committee_supporting_next_epoch_version;
+        assert!(
+            !res || (self.track_non_committee_eligible_validators()
+                && self.select_committee_from_eligible_validators()),
+            "select_committee_from_eligible_validators_with_buffer requires track_non_committee_eligible_validators to be set"
+        );
+        res
+    }
 }
 
 #[cfg(not(msim))]
@@ -2178,12 +2200,18 @@ impl ProtocolConfig {
                     cfg.feature_flags.normalize_ptb_arguments = true;
                 }
                 13 => {
-                    // Enable selecting committee based on eligible active validators in all
+                    // Enable selecting committee based on eligible active validators on all
                     // networks.
                     cfg.feature_flags.select_committee_from_eligible_validators = true;
+                    // Enable tracking non-committee eligible active
+                    // validators on all networks.
+                    cfg.feature_flags.track_non_committee_eligible_validators = true;
+
                     if chain != Chain::Testnet && chain != Chain::Mainnet {
-                        // Enable tracking non-committee eligible active validators in devnet.
-                        cfg.feature_flags.track_non_committee_eligible_validators = true;
+                        // Enable selecting committee only from active validators that next epoch
+                        // version and issued valid AuthorityCapabilities notification in devnet.
+                        cfg.feature_flags
+                            .select_committee_supporting_next_epoch_version = true;
                     }
                 }
                 // Use this template when making changes:
@@ -2352,6 +2380,11 @@ impl ProtocolConfig {
 
     pub fn set_track_non_committee_eligible_validators_for_testing(&mut self, val: bool) {
         self.feature_flags.track_non_committee_eligible_validators = val;
+    }
+
+    pub fn set_select_committee_supporting_next_epoch_version(&mut self, val: bool) {
+        self.feature_flags
+            .select_committee_supporting_next_epoch_version = val;
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1381,7 +1381,7 @@ impl ProtocolConfig {
         assert!(
             !res || (self.track_non_committee_eligible_validators()
                 && self.select_committee_from_eligible_validators()),
-            "select_committee_from_eligible_validators_with_buffer requires track_non_committee_eligible_validators to be set"
+            "select_committee_supporting_next_epoch_version requires select_committee_from_eligible_validators to be set"
         );
         res
     }

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_13.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_13.snap
@@ -26,6 +26,7 @@ feature_flags:
   additional_multisig_checks: true
   normalize_ptb_arguments: true
   select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_13.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_13.snap
@@ -27,6 +27,7 @@ feature_flags:
   additional_multisig_checks: true
   normalize_ptb_arguments: true
   select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_13.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_13.snap
@@ -34,6 +34,7 @@ feature_flags:
   normalize_ptb_arguments: true
   select_committee_from_eligible_validators: true
   track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000


### PR DESCRIPTION
# Description of change

Add a separate feature flag for selecting committee supporting next epoch version instead of functionality being covered by `track_non_committee_eligible_validators` flag that controls sending/processing of AuthorityCapabilities notifications from non-committee active validators. 

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
