### PR TITLE
fix(consensus): acknowledgments pruning and metrics

### DIFF
--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -682,6 +682,22 @@ impl Core {
             .write()
             .take_acknowledgments(MAX_ACKNOWLEDGMENTS_PER_BLOCK);
 
+
+        self.context
+            .metrics
+            .node_metrics
+            .proposed_block_acknowledgments
+            .observe(acknowledgments.len() as f64);
+        for acknowledgment in &acknowledgments {
+            let authority = &self.context.committee.authority(acknowledgment.author()).hostname;
+            self.context
+                .metrics
+                .node_metrics
+                .proposed_block_acknowledgments_depth
+                .with_label_values(&[authority])
+                .observe(clock_round.saturating_sub(acknowledgment.round()).into());
+        }
+
         // Consume the commit votes to be included.
         let commit_votes = self
             .dag_state
@@ -699,6 +715,7 @@ impl Core {
             commit_votes,
             transactions_commitment,
         ));
+
         let signed_block_header = SignedBlockHeader::new(block_header, &self.block_signer)
             .expect("Block signing failed.");
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -682,14 +682,17 @@ impl Core {
             .write()
             .take_acknowledgments(MAX_ACKNOWLEDGMENTS_PER_BLOCK);
 
-
         self.context
             .metrics
             .node_metrics
             .proposed_block_acknowledgments
             .observe(acknowledgments.len() as f64);
         for acknowledgment in &acknowledgments {
-            let authority = &self.context.committee.authority(acknowledgment.author).hostname;
+            let authority = &self
+                .context
+                .committee
+                .authority(acknowledgment.author)
+                .hostname;
             self.context
                 .metrics
                 .node_metrics

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -689,13 +689,13 @@ impl Core {
             .proposed_block_acknowledgments
             .observe(acknowledgments.len() as f64);
         for acknowledgment in &acknowledgments {
-            let authority = &self.context.committee.authority(acknowledgment.author()).hostname;
+            let authority = &self.context.committee.authority(acknowledgment.author).hostname;
             self.context
                 .metrics
                 .node_metrics
                 .proposed_block_acknowledgments_depth
                 .with_label_values(&[authority])
-                .observe(clock_round.saturating_sub(acknowledgment.round()).into());
+                .observe(clock_round.saturating_sub(acknowledgment.round).into());
         }
 
         // Consume the commit votes to be included.

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1414,7 +1414,7 @@ impl DagState {
             }
             taken.push(*ack);
         }
-        
+
         if let Some(last) = taken.last() {
             last_ack = Some(*last);
         }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1410,10 +1410,13 @@ impl DagState {
 
         for ack in self.pending_acknowledgments.iter() {
             if taken.len() >= limit || ack.round >= clock_round {
-                last_ack = Some(*ack);
                 break;
             }
             taken.push(*ack);
+        }
+        
+        if let Some(last) = taken.last() {
+            last_ack = Some(*last);
         }
 
         if let Some(last_ack) = last_ack {

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -104,6 +104,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) proposed_block_transactions: Histogram,
     pub(crate) proposed_block_ancestors: Histogram,
     pub(crate) proposed_block_ancestors_depth: HistogramVec,
+    pub(crate) proposed_block_acknowledgments: Histogram,
+    pub(crate) proposed_block_acknowledgments_depth: HistogramVec,
     pub(crate) gap_to_available_commit: IntGauge,
     pub(crate) gap_to_unavailable_transactions: IntGauge,
     pub(crate) highest_verified_authority_round: IntGaugeVec,
@@ -257,6 +259,19 @@ impl NodeMetrics {
             proposed_block_ancestors_depth: register_histogram_vec_with_registry!(
                 "proposed_block_ancestors_depth",
                 "The depth in rounds of ancestors included in newly proposed blocks",
+                &["authority"],
+                exponential_buckets(1.0, 2.0, 14).unwrap(),
+                registry,
+            ).unwrap(),
+            proposed_block_acknowledgments: register_histogram_with_registry!(
+                "proposed_block_acknowledgments",
+                "Number of acknowledgments in proposed blocks",
+                exponential_buckets(1.0, 1.4, 20).unwrap(),
+                registry,
+            ).unwrap(),
+            proposed_block_acknowledgments_depth: register_histogram_vec_with_registry!(
+                "proposed_block_acknowledgments_depth",
+                "The depth in rounds of acknowledgments included in newly proposed blocks",
                 &["authority"],
                 exponential_buckets(1.0, 2.0, 14).unwrap(),
                 registry,


### PR DESCRIPTION
# Description of change

We fix a bug of pruning already included acknowledgments. Because of that, block headers were much larger than expected
In addition, we have added a few metrics to represent acknowledgments

## Links to any relevant issues

Fixes #8790 

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

