### PR TITLE
feat(consensus): move `MAX_ACKNOWLEDGMENTS_PER_BLOCK` to `iota-protocol-config`

### DIFF
--- a/crates/iota-graphql-rpc/src/mutation.rs
+++ b/crates/iota-graphql-rpc/src/mutation.rs
@@ -2,15 +2,17 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 use async_graphql::*;
+use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
 use fastcrypto::encoding::Base64;
-use iota_indexer::optimistic_indexing::OptimisticTransactionExecutor;
-use iota_json_rpc_types::IotaTransactionBlockResponseOptions;
-use iota_types::{
-    effects::TransactionEffects as NativeTransactionEffects, event::Event as NativeEvent,
-    transaction::SenderSignedData,
+use iota_indexer::{
+    models::transactions::OptimisticTransaction,
+    optimistic_indexing::OptimisticTransactionExecutor,
+    schema::{optimistic_transactions, tx_global_order},
 };
+use iota_json_rpc_types::IotaTransactionBlockResponseOptions;
 
 use crate::{
+    data::{Db, DbConnection, QueryExecutor},
     error::Error,
     types::{
         execution_result::ExecutionResult,
@@ -18,6 +20,30 @@ use crate::{
     },
 };
 pub struct Mutation;
+
+/// Query optimistic transaction by digest from the database
+async fn query_optimistic_transaction_by_digest(
+    db: &Db,
+    digest_bytes: Vec<u8>,
+) -> Result<OptimisticTransaction, Error> {
+    db.execute_repeatable(move |conn| {
+        conn.first(move || {
+            optimistic_transactions::table
+                .inner_join(
+                    tx_global_order::table.on(optimistic_transactions::global_sequence_number
+                        .eq(tx_global_order::global_sequence_number)
+                        .and(
+                            optimistic_transactions::optimistic_sequence_number
+                                .eq(tx_global_order::optimistic_sequence_number),
+                        )),
+                )
+                .filter(tx_global_order::tx_digest.eq(digest_bytes.clone()))
+                .select(OptimisticTransaction::as_select())
+        })
+    })
+    .await
+    .map_err(|e| Error::Internal(format!("Unable to query optimistic transaction: {e}")))
+}
 
 /// Mutations are used to write to the IOTA network.
 #[Object]
@@ -90,28 +116,11 @@ impl Mutation {
             .map_err(|e| Error::Internal(format!("Unable to execute transaction: {e}")))
             .extend()?;
 
-        let native: NativeTransactionEffects = bcs::from_bytes(&result.raw_effects)
-            .map_err(|e| Error::Internal(format!("Unable to deserialize transaction effects: {e}")))
-            .extend()?;
-        let tx_data: SenderSignedData = bcs::from_bytes(&result.raw_transaction)
-            .map_err(|e| Error::Internal(format!("Unable to deserialize transaction data: {e}")))
-            .extend()?;
+        let tx_digest = result.digest;
+        let digest_bytes = tx_digest.inner().to_vec();
 
-        let events = result
-            .events
-            .ok_or_else(|| {
-                Error::Internal("No events are returned from transaction execution".to_string())
-            })?
-            .data
-            .into_iter()
-            .map(|e| NativeEvent {
-                package_id: e.package_id,
-                transaction_module: e.transaction_module,
-                sender: e.sender,
-                type_: e.type_,
-                contents: e.bcs.into_bytes(),
-            })
-            .collect();
+        let db: &Db = ctx.data_unchecked();
+        let optimistic_tx = query_optimistic_transaction_by_digest(db, digest_bytes).await?;
 
         Ok(ExecutionResult {
             errors: if result.errors.is_empty() {
@@ -120,11 +129,13 @@ impl Mutation {
                 Some(result.errors)
             },
             effects: TransactionBlockEffects {
-                kind: TransactionBlockEffectsKind::Executed {
-                    tx_data,
-                    native,
-                    events,
-                },
+                kind: TransactionBlockEffectsKind::try_from(optimistic_tx)
+                    .map_err(|e| {
+                        Error::Internal(format!(
+                            "Unable to create TransactionBlockEffectsKind: {e}"
+                        ))
+                    })
+                    .extend()?,
                 // set to u64::MAX, as the executed transaction has not been indexed yet
                 checkpoint_viewed_at: u64::MAX,
             },

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -11,7 +11,10 @@ use async_graphql::{
 use cursor::EvLookup;
 use diesel::{ExpressionMethods, QueryDsl};
 use iota_indexer::{
-    models::{events::StoredEvent, transactions::StoredTransaction},
+    models::{
+        events::StoredEvent,
+        transactions::{OptimisticTransaction, StoredTransaction},
+    },
     schema::{checkpoints, events},
 };
 use iota_types::{
@@ -243,6 +246,7 @@ impl Event {
             ))
         })?;
 
+        let with_prefix = true;
         let stored_event = StoredEvent {
             tx_sequence_number: stored_tx.tx_sequence_number,
             event_sequence_number: idx as i64,
@@ -250,11 +254,48 @@ impl Event {
             senders: vec![Some(native_event.sender.to_vec())],
             package: native_event.package_id.to_vec(),
             module: native_event.transaction_module.to_string(),
-            event_type: native_event
-                .type_
-                .to_canonical_string(/* with_prefix */ true),
+            event_type: native_event.type_.to_canonical_string(with_prefix),
             bcs: native_event.contents.clone(),
             timestamp_ms: stored_tx.timestamp_ms,
+        };
+
+        Ok(Self {
+            stored: Some(stored_event),
+            native: native_event,
+            checkpoint_viewed_at,
+        })
+    }
+
+    pub(crate) fn try_from_optimistic_transaction(
+        optimistic_tx: &OptimisticTransaction,
+        idx: usize,
+        checkpoint_viewed_at: u64,
+    ) -> Result<Self, Error> {
+        let Some(serialized_event) = &optimistic_tx.get_event_at_idx(idx) else {
+            return Err(Error::Internal(format!(
+                "Could not find event with event_sequence_number {idx} at optimistic transaction {}",
+                optimistic_tx.optimistic_sequence_number
+            )));
+        };
+
+        let native_event: NativeEvent = bcs::from_bytes(serialized_event).map_err(|_| {
+            Error::Internal(format!(
+                "Failed to deserialize event with {idx} at optimistic transaction {}",
+                optimistic_tx.optimistic_sequence_number
+            ))
+        })?;
+
+        let with_prefix = true;
+        let stored_event = StoredEvent {
+            tx_sequence_number: optimistic_tx.optimistic_sequence_number,
+            event_sequence_number: idx as i64,
+            transaction_digest: optimistic_tx.transaction_digest.clone(),
+            senders: vec![Some(native_event.sender.to_vec())],
+            package: native_event.package_id.to_vec(),
+            module: native_event.transaction_module.to_string(),
+            event_type: native_event.type_.to_canonical_string(with_prefix),
+            bcs: native_event.contents.clone(),
+            timestamp_ms: -1, // Optimistic transactions don't have timestamps yet
         };
 
         Ok(Self {

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -14,8 +14,8 @@ use async_graphql::{
 };
 use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
 use iota_indexer::{
-    models::objects::StoredHistoryObject,
-    schema::{objects_history, objects_version},
+    models::objects::{StoredHistoryObject, StoredObject},
+    schema::{objects, objects_history, objects_version},
     types::{ObjectStatus as NativeObjectStatus, OwnerType},
 };
 use iota_types::{
@@ -226,6 +226,14 @@ pub(crate) enum ObjectLookup {
         /// The checkpoint sequence number at which this was viewed at.
         checkpoint_viewed_at: u64,
     },
+
+    /// Variant analogous to [`VersionAt`](Self::VersionAt) but for optimistic
+    /// transactions, using the most recent not checkpointed data,
+    /// not bound by any checkpoint sequence number.
+    OptimisticVersion {
+        /// The exact version of the object to be fetched.
+        version: u64,
+    },
 }
 
 pub(crate) type Cursor = cursor::BcsCursor<HistoricalObjectCursor>;
@@ -313,6 +321,15 @@ struct HistoricalKey {
     id: IotaAddress,
     version: u64,
     checkpoint_viewed_at: u64,
+}
+
+/// `DataLoader` key for fetching objects that haven't been checkpointed yet.
+/// This is used specifically for loading objects
+/// that are part of optimistic transaction effects.
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+struct OptimisticKey {
+    id: IotaAddress,
+    version: u64,
 }
 
 /// `DataLoader` key for fetching the latest version of an object whose parent
@@ -908,6 +925,11 @@ impl Object {
         }
     }
 
+    /// Look-up a specific version of the object from optimistic transactions.
+    pub(crate) fn at_optimistic_version(version: u64) -> ObjectLookup {
+        ObjectLookup::OptimisticVersion { version }
+    }
+
     pub(crate) async fn query(
         ctx: &Context<'_>,
         id: IotaAddress,
@@ -927,6 +949,10 @@ impl Object {
                         checkpoint_viewed_at,
                     })
                     .await
+            }
+
+            ObjectLookup::OptimisticVersion { version } => {
+                loader.load_one(OptimisticKey { id, version }).await
             }
 
             ObjectLookup::UnderParent {
@@ -1331,6 +1357,85 @@ impl Loader<HistoricalKey> for Db {
                 None,
             )?;
             result.insert(*key, object);
+        }
+
+        Ok(result)
+    }
+}
+
+impl Loader<OptimisticKey> for Db {
+    type Value = Object;
+    type Error = Error;
+
+    async fn load(&self, keys: &[OptimisticKey]) -> Result<HashMap<OptimisticKey, Object>, Error> {
+        use objects::dsl as o;
+
+        let id_versions: BTreeSet<_> = keys
+            .iter()
+            .map(|key| (key.id.into_vec(), key.version as i64))
+            .collect();
+
+        let objects: Vec<StoredObject> = self
+            .execute(move |conn| {
+                conn.results(move || {
+                    let mut query = o::objects.select(StoredObject::as_select()).into_boxed();
+                    for (id, version) in id_versions.iter().cloned() {
+                        query =
+                            query.or_filter(o::object_id.eq(id).and(o::object_version.eq(version)));
+                    }
+                    query
+                })
+            })
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to fetch optimistic objects: {e}")))?;
+
+        let mut result = HashMap::new();
+        let id_version_to_stored = objects
+            .into_iter()
+            .map(|stored| {
+                addr(&stored.object_id).map(|id| ((id, stored.object_version as u64), stored))
+            })
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
+
+        // Collect keys that were not found in objects table
+        let mut missing_keys = Vec::new();
+        for key in keys {
+            if let Some(stored) = id_version_to_stored.get(&(key.id, key.version)) {
+                let object = Object::from_native(
+                    key.id,
+                    bcs::from_bytes(&stored.serialized_object).map_err(|_| {
+                        Error::Internal(format!("Failed to deserialize object {}", key.id))
+                    })?,
+                    u64::MAX,
+                    None,
+                );
+                result.insert(*key, object);
+            } else {
+                missing_keys.push(*key);
+            }
+        }
+
+        // For missing keys, fallback to using the objects_history table
+        if !missing_keys.is_empty() {
+            let historical_keys: Vec<HistoricalKey> = missing_keys
+                .iter()
+                .map(|key| HistoricalKey {
+                    id: key.id,
+                    version: key.version,
+                    checkpoint_viewed_at: u64::MAX,
+                })
+                .collect();
+
+            let historical_result: HashMap<HistoricalKey, Object> =
+                self.load(&historical_keys).await?;
+
+            for (historical_key, object) in historical_result {
+                let optimistic_key = OptimisticKey {
+                    id: historical_key.id,
+                    version: historical_key.version,
+                };
+                result.insert(optimistic_key, object);
+            }
         }
 
         Ok(result)

--- a/crates/iota-graphql-rpc/src/types/object_change.rs
+++ b/crates/iota-graphql-rpc/src/types/object_change.rs
@@ -7,10 +7,23 @@ use iota_types::effects::{IDOperation, ObjectChange as NativeObjectChange};
 
 use crate::types::{iota_address::IotaAddress, object::Object};
 
+/// Represents the source of an object change (derived from transaction kind)
+#[derive(Clone, Debug)]
+pub(crate) enum ObjectChangeSource {
+    /// Object change from a checkpointed transaction
+    Checkpointed,
+    /// Object change from an executed (not yet checkpointed) transaction
+    Executed,
+    /// Object change from a dry run transaction (dryRunTransactionBlock)
+    DryRun,
+}
+
 pub(crate) struct ObjectChange {
     pub native: NativeObjectChange,
     /// The checkpoint sequence number this was viewed at.
     pub checkpoint_viewed_at: u64,
+    /// The source of this object change (derived from transaction kind)
+    pub source: ObjectChangeSource,
 }
 
 /// Effect on an individual Object (keyed by its ID).
@@ -27,13 +40,15 @@ impl ObjectChange {
             return Ok(None);
         };
 
-        Object::query(
-            ctx,
-            self.native.id.into(),
-            Object::at_version(version.value(), self.checkpoint_viewed_at),
-        )
-        .await
-        .extend()
+        let object_lookup = match self.source {
+            ObjectChangeSource::Executed => Object::at_optimistic_version(version.value()),
+            ObjectChangeSource::Checkpointed | ObjectChangeSource::DryRun => {
+                Object::at_version(version.value(), self.checkpoint_viewed_at)
+            }
+        };
+        Object::query(ctx, self.native.id.into(), object_lookup)
+            .await
+            .extend()
     }
 
     /// The contents of the object immediately after the transaction.
@@ -42,13 +57,15 @@ impl ObjectChange {
             return Ok(None);
         };
 
-        Object::query(
-            ctx,
-            self.native.id.into(),
-            Object::at_version(version.value(), self.checkpoint_viewed_at),
-        )
-        .await
-        .extend()
+        let object_lookup = match self.source {
+            ObjectChangeSource::Executed => Object::at_optimistic_version(version.value()),
+            ObjectChangeSource::Checkpointed | ObjectChangeSource::DryRun => {
+                Object::at_version(version.value(), self.checkpoint_viewed_at)
+            }
+        };
+        Object::query(ctx, self.native.id.into(), object_lookup)
+            .await
+            .extend()
     }
 
     /// Whether the ID was created in this transaction.

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -10,7 +10,7 @@ use cursor::TxLookup;
 use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
 use fastcrypto::encoding::{Base58, Encoding};
 use iota_indexer::{
-    models::transactions::StoredTransaction,
+    models::transactions::{OptimisticTransaction, StoredTransaction},
     schema::{transactions, tx_digests},
 };
 use iota_types::{
@@ -64,19 +64,20 @@ pub(crate) struct TransactionBlock {
 
 #[derive(Clone, Debug)]
 pub(crate) enum TransactionBlockInner {
-    /// A transaction block that has been indexed and stored in the database,
-    /// containing all information that the other two variants have, and more.
-    Stored {
+    /// A transaction block that has been checkpointed and stored in the
+    /// database, containing all information that the other two variants
+    /// have, and more.
+    Checkpointed {
         stored_tx: StoredTransaction,
         native: NativeSenderSignedData,
     },
-    /// A transaction block that has been executed via executeTransactionBlock
-    /// but not yet indexed.
+    /// A transaction block that has been executed and indexed without
+    /// checkpoint information.
     Executed {
-        tx_data: NativeSenderSignedData,
-        effects: NativeTransactionEffects,
-        events: Vec<NativeEvent>,
+        optimistic_tx: OptimisticTransaction,
+        native: NativeSenderSignedData,
     },
+
     /// A transaction block that has been executed via dryRunTransactionBlock.
     /// This variant also does not return signatures or digest since only
     /// `NativeTransactionData` is present.
@@ -160,16 +161,17 @@ impl TransactionBlock {
     /// If the owner of the gas object(s) is not the same as the sender, the
     /// transaction block is a sponsored transaction block.
     async fn gas_input(&self, ctx: &Context<'_>) -> Option<GasInput> {
-        let checkpoint_viewed_at = if matches!(self.inner, TransactionBlockInner::Stored { .. }) {
-            self.checkpoint_viewed_at
-        } else {
-            // Non-stored transactions have a sentinel checkpoint_viewed_at value that
-            // generally prevents access to further queries, but inputs should
-            // generally be available so try to access them at the high
-            // watermark.
-            let Watermark { checkpoint, .. } = *ctx.data_unchecked();
-            checkpoint
-        };
+        let checkpoint_viewed_at =
+            if matches!(self.inner, TransactionBlockInner::Checkpointed { .. }) {
+                self.checkpoint_viewed_at
+            } else {
+                // Non-checkpointed transactions have a sentinel checkpoint_viewed_at value that
+                // generally prevents access to further queries, but inputs should
+                // generally be available so try to access them at the high
+                // watermark.
+                let Watermark { checkpoint, .. } = *ctx.data_unchecked();
+                checkpoint
+            };
 
         Some(GasInput::from(
             self.native().gas_data(),
@@ -221,12 +223,13 @@ impl TransactionBlock {
     /// and Base64 encoded.
     async fn bcs(&self) -> Option<Base64> {
         match &self.inner {
-            TransactionBlockInner::Stored { stored_tx, .. } => {
+            TransactionBlockInner::Checkpointed { stored_tx, .. } => {
                 Some(Base64::from(&stored_tx.raw_transaction))
             }
-            TransactionBlockInner::Executed { tx_data, .. } => {
-                bcs::to_bytes(&tx_data).ok().map(Base64::from)
+            TransactionBlockInner::Executed { optimistic_tx, .. } => {
+                Some(Base64::from(&optimistic_tx.raw_transaction))
             }
+
             // Dry run transaction does not have signatures so no sender signed data.
             TransactionBlockInner::DryRun { .. } => None,
         }
@@ -236,16 +239,18 @@ impl TransactionBlock {
 impl TransactionBlock {
     fn native(&self) -> &NativeTransactionData {
         match &self.inner {
-            TransactionBlockInner::Stored { native, .. } => native.transaction_data(),
-            TransactionBlockInner::Executed { tx_data, .. } => tx_data.transaction_data(),
+            TransactionBlockInner::Checkpointed { native, .. } => native.transaction_data(),
+            TransactionBlockInner::Executed { native, .. } => native.transaction_data(),
+
             TransactionBlockInner::DryRun { tx_data, .. } => tx_data,
         }
     }
 
     fn native_signed_data(&self) -> Option<&NativeSenderSignedData> {
         match &self.inner {
-            TransactionBlockInner::Stored { native, .. } => Some(native),
-            TransactionBlockInner::Executed { tx_data, .. } => Some(tx_data),
+            TransactionBlockInner::Checkpointed { native, .. } => Some(native),
+            TransactionBlockInner::Executed { native, .. } => Some(native),
+
             TransactionBlockInner::DryRun { .. } => None,
         }
     }
@@ -511,7 +516,24 @@ impl TryFrom<StoredTransaction> for TransactionBlockInner {
         let native = bcs::from_bytes(&stored_tx.raw_transaction)
             .map_err(|e| Error::Internal(format!("Error deserializing transaction block: {e}")))?;
 
-        Ok(TransactionBlockInner::Stored { stored_tx, native })
+        Ok(TransactionBlockInner::Checkpointed { stored_tx, native })
+    }
+}
+
+impl TryFrom<OptimisticTransaction> for TransactionBlockInner {
+    type Error = Error;
+
+    fn try_from(optimistic_tx: OptimisticTransaction) -> Result<Self, Error> {
+        let native = bcs::from_bytes(&optimistic_tx.raw_transaction).map_err(|e| {
+            Error::Internal(format!(
+                "Failed to deserialize NativeSenderSignedData from optimistic transaction: {e}"
+            ))
+        })?;
+
+        Ok(TransactionBlockInner::Executed {
+            optimistic_tx,
+            native,
+        })
     }
 }
 
@@ -521,18 +543,13 @@ impl TryFrom<TransactionBlockEffects> for TransactionBlock {
     fn try_from(effects: TransactionBlockEffects) -> Result<Self, Error> {
         let checkpoint_viewed_at = effects.checkpoint_viewed_at;
         let inner = match effects.kind {
-            TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
+            TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
                 TransactionBlockInner::try_from(stored_tx.clone())
             }
-            TransactionBlockEffectsKind::Executed {
-                tx_data,
-                native,
-                events,
-            } => Ok(TransactionBlockInner::Executed {
-                tx_data: tx_data.clone(),
-                effects: native.clone(),
-                events: events.clone(),
-            }),
+            TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
+                TransactionBlockInner::try_from(optimistic_tx.clone())
+            }
+
             TransactionBlockEffectsKind::DryRun {
                 tx_data,
                 native,

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -7,7 +7,7 @@ use async_graphql::{
     *,
 };
 use fastcrypto::encoding::{Base64 as FBase64, Encoding};
-use iota_indexer::models::transactions::StoredTransaction;
+use iota_indexer::models::transactions::{OptimisticTransaction, StoredTransaction};
 use iota_package_resolver::{CleverError, ErrorConstants};
 use iota_types::{
     effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
@@ -37,7 +37,7 @@ use crate::{
         epoch::Epoch,
         event::Event,
         gas::GasEffects,
-        object_change::ObjectChange,
+        object_change::{ObjectChange, ObjectChangeSource},
         transaction_block::{TransactionBlock, TransactionBlockInner},
         uint53::UInt53,
         unchanged_shared_object::UnchangedSharedObject,
@@ -56,20 +56,19 @@ pub(crate) struct TransactionBlockEffects {
 
 #[derive(Clone, Debug)]
 pub(crate) enum TransactionBlockEffectsKind {
-    /// A transaction that has been indexed and stored in the database,
+    /// A transaction that has been checkpointed and stored in the database,
     /// containing all information that the other two variants have, and more.
-    Stored {
+    Checkpointed {
         stored_tx: StoredTransaction,
         native: NativeTransactionEffects,
     },
-    /// A transaction block that has been executed via executeTransactionBlock
-    /// but not yet indexed. So it does not contain checkpoint, timestamp or
-    /// balanceChanges.
+    /// A transaction block that has been executed and indexed without
+    /// checkpoint information.
     Executed {
-        tx_data: NativeSenderSignedData,
+        optimistic_tx: OptimisticTransaction,
         native: NativeTransactionEffects,
-        events: Vec<NativeEvent>,
     },
+
     /// A transaction block that has been executed via dryRunTransactionBlock.
     /// Similar to Executed, it does not contain checkpoint, timestamp or
     /// balanceChanges.
@@ -338,10 +337,18 @@ impl TransactionBlockEffects {
         connection.has_previous_page = prev;
         connection.has_next_page = next;
 
+        // Determine the source based on the transaction block effects kind
+        let source = match &self.kind {
+            TransactionBlockEffectsKind::Checkpointed { .. } => ObjectChangeSource::Checkpointed,
+            TransactionBlockEffectsKind::Executed { .. } => ObjectChangeSource::Executed,
+            TransactionBlockEffectsKind::DryRun { .. } => ObjectChangeSource::DryRun,
+        };
+
         for c in cs {
             let object_change = ObjectChange {
                 native: object_changes[c.ix].clone(),
                 checkpoint_viewed_at: c.c,
+                source: source.clone(),
             };
 
             connection
@@ -365,12 +372,19 @@ impl TransactionBlockEffects {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let mut connection = Connection::new(false, false);
 
-        let TransactionBlockEffectsKind::Stored { stored_tx, .. } = &self.kind else {
-            return Ok(connection);
+        let balance_len = match &self.kind {
+            TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
+                stored_tx.get_balance_len()
+            }
+            TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
+                optimistic_tx.get_balance_len()
+            }
+            // DryRun variant doesn't have balance changes available
+            _ => return Ok(connection),
         };
 
-        let Some((prev, next, _, cs)) = page
-            .paginate_consistent_indices(stored_tx.get_balance_len(), self.checkpoint_viewed_at)?
+        let Some((prev, next, _, cs)) =
+            page.paginate_consistent_indices(balance_len, self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
         };
@@ -379,11 +393,21 @@ impl TransactionBlockEffects {
         connection.has_next_page = next;
 
         for c in cs {
-            let Some(serialized) = &stored_tx.get_balance_at_idx(c.ix) else {
+            let serialized = match &self.kind {
+                TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
+                    stored_tx.get_balance_at_idx(c.ix)
+                }
+                TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
+                    optimistic_tx.get_balance_at_idx(c.ix)
+                }
+                _ => None,
+            };
+
+            let Some(serialized) = serialized else {
                 continue;
             };
 
-            let balance_change = BalanceChange::read(serialized, c.c).extend()?;
+            let balance_change = BalanceChange::read(&serialized, c.c).extend()?;
             connection
                 .edges
                 .push(Edge::new(c.encode_cursor(), balance_change));
@@ -404,9 +428,13 @@ impl TransactionBlockEffects {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let mut connection = Connection::new(false, false);
         let len = match &self.kind {
-            TransactionBlockEffectsKind::Stored { stored_tx, .. } => stored_tx.get_event_len(),
-            TransactionBlockEffectsKind::Executed { events, .. }
-            | TransactionBlockEffectsKind::DryRun { events, .. } => events.len(),
+            TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
+                stored_tx.get_event_len()
+            }
+            TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
+                optimistic_tx.get_event_len()
+            }
+            TransactionBlockEffectsKind::DryRun { events, .. } => events.len(),
         };
         let Some((prev, next, _, cs)) =
             page.paginate_consistent_indices(len, self.checkpoint_viewed_at)?
@@ -419,11 +447,13 @@ impl TransactionBlockEffects {
 
         for c in cs {
             let event = match &self.kind {
-                TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
+                TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
                     Event::try_from_stored_transaction(stored_tx, c.ix, c.c).extend()?
                 }
-                TransactionBlockEffectsKind::Executed { events, .. }
-                | TransactionBlockEffectsKind::DryRun { events, .. } => Event {
+                TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
+                    Event::try_from_optimistic_transaction(optimistic_tx, c.ix, c.c).extend()?
+                }
+                TransactionBlockEffectsKind::DryRun { events, .. } => Event {
                     stored: None,
                     native: events[c.ix].clone(),
                     checkpoint_viewed_at: c.c,
@@ -438,7 +468,7 @@ impl TransactionBlockEffects {
     /// Timestamp corresponding to the checkpoint this transaction was finalized
     /// in.
     async fn timestamp(&self) -> Result<Option<DateTime>, Error> {
-        let TransactionBlockEffectsKind::Stored { stored_tx, .. } = &self.kind else {
+        let TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } = &self.kind else {
             return Ok(None);
         };
         Ok(Some(DateTime::from_ms(stored_tx.timestamp_ms)?))
@@ -457,9 +487,9 @@ impl TransactionBlockEffects {
 
     /// The checkpoint this transaction was finalized in.
     async fn checkpoint(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        // If the transaction data is not a stored transaction, it's not in the
+        // If the transaction data is not a checkpointed transaction, it's not in the
         // checkpoint yet so we return None.
-        let TransactionBlockEffectsKind::Stored { stored_tx, .. } = &self.kind else {
+        let TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } = &self.kind else {
             return Ok(None);
         };
 
@@ -474,12 +504,16 @@ impl TransactionBlockEffects {
 
     /// Base64 encoded bcs serialization of the on-chain transaction effects.
     async fn bcs(&self) -> Result<Base64> {
-        let bytes = if let TransactionBlockEffectsKind::Stored { stored_tx, .. } = &self.kind {
-            stored_tx.raw_effects.clone()
-        } else {
-            bcs::to_bytes(&self.native())
+        let bytes = match &self.kind {
+            TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
+                stored_tx.raw_effects.clone()
+            }
+            TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
+                optimistic_tx.raw_effects.clone()
+            }
+            _ => bcs::to_bytes(&self.native())
                 .map_err(|e| Error::Internal(format!("Error serializing transaction effects: {e}")))
-                .extend()?
+                .extend()?,
         };
 
         Ok(Base64::from(bytes))
@@ -489,9 +523,9 @@ impl TransactionBlockEffects {
 impl TransactionBlockEffects {
     fn native(&self) -> &NativeTransactionEffects {
         match &self.kind {
-            TransactionBlockEffectsKind::Stored { native, .. } => native,
-            TransactionBlockEffectsKind::Executed { native, .. } => native,
+            TransactionBlockEffectsKind::Checkpointed { native, .. } => native,
             TransactionBlockEffectsKind::DryRun { native, .. } => native,
+            TransactionBlockEffectsKind::Executed { native, .. } => native,
         }
     }
 
@@ -500,17 +534,21 @@ impl TransactionBlockEffects {
     /// should not occur.
     fn transaction_data(&self) -> Result<NativeTransactionData> {
         Ok(match &self.kind {
-            TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
+            TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
                 let s: NativeSenderSignedData = bcs::from_bytes(&stored_tx.raw_transaction)
                     .map_err(|e| {
                         Error::Internal(format!("Error deserializing transaction data: {e}"))
                     })?;
                 s.transaction_data().clone()
             }
-            TransactionBlockEffectsKind::Executed { tx_data, .. } => {
-                tx_data.transaction_data().clone()
-            }
             TransactionBlockEffectsKind::DryRun { tx_data, .. } => tx_data.clone(),
+            TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
+                let data: NativeSenderSignedData = bcs::from_bytes(&optimistic_tx.raw_transaction)
+                    .map_err(|e| {
+                        Error::Internal(format!("Error deserializing transaction data: {e}"))
+                    })?;
+                data.transaction_data().clone()
+            }
         })
     }
 
@@ -582,15 +620,32 @@ impl EdgeNameType for DependencyConnectionNames {
     }
 }
 
+impl TryFrom<OptimisticTransaction> for TransactionBlockEffectsKind {
+    type Error = Error;
+
+    fn try_from(optimistic_tx: OptimisticTransaction) -> Result<Self, Error> {
+        let native = bcs::from_bytes(&optimistic_tx.raw_effects).map_err(|e| {
+            Error::Internal(format!(
+                "Failed to deserialize NativeTransactionEffects from optimistic transaction: {e}"
+            ))
+        })?;
+
+        Ok(TransactionBlockEffectsKind::Executed {
+            optimistic_tx,
+            native,
+        })
+    }
+}
+
 impl TryFrom<TransactionBlock> for TransactionBlockEffects {
     type Error = Error;
 
     fn try_from(block: TransactionBlock) -> Result<Self, Error> {
         let checkpoint_viewed_at = block.checkpoint_viewed_at;
         let kind = match block.inner {
-            TransactionBlockInner::Stored { stored_tx, .. } => {
+            TransactionBlockInner::Checkpointed { stored_tx, .. } => {
                 bcs::from_bytes(&stored_tx.raw_effects)
-                    .map(|native| TransactionBlockEffectsKind::Stored {
+                    .map(|native| TransactionBlockEffectsKind::Checkpointed {
                         stored_tx: stored_tx.clone(),
                         native,
                     })
@@ -598,15 +653,10 @@ impl TryFrom<TransactionBlock> for TransactionBlockEffects {
                         Error::Internal(format!("Error deserializing transaction effects: {e}"))
                     })
             }
-            TransactionBlockInner::Executed {
-                tx_data,
-                effects,
-                events,
-            } => Ok(TransactionBlockEffectsKind::Executed {
-                tx_data,
-                native: effects,
-                events,
-            }),
+            TransactionBlockInner::Executed { optimistic_tx, .. } => {
+                TransactionBlockEffectsKind::try_from(optimistic_tx.clone())
+            }
+
             TransactionBlockInner::DryRun {
                 tx_data,
                 effects,

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -33,7 +33,7 @@ pub struct ObjectRefColumn {
 // NOTE: please add updating statement like below in pg_indexer_store.rs,
 // if new columns are added here:
 // objects::epoch.eq(excluded(objects::epoch))
-#[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
+#[derive(Queryable, Selectable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
 #[diesel(table_name = objects, primary_key(object_id))]
 pub struct StoredObject {
     pub object_id: Vec<u8>,

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -200,6 +200,30 @@ impl OptimisticTransaction {
             success_command_count: stored.success_command_count,
         }
     }
+
+    pub fn get_balance_len(&self) -> usize {
+        self.balance_changes.len()
+    }
+
+    pub fn get_balance_at_idx(&self, idx: usize) -> Option<Vec<u8>> {
+        self.balance_changes.get(idx).cloned().flatten()
+    }
+
+    pub fn get_object_len(&self) -> usize {
+        self.object_changes.len()
+    }
+
+    pub fn get_object_at_idx(&self, idx: usize) -> Option<Vec<u8>> {
+        self.object_changes.get(idx).cloned().flatten()
+    }
+
+    pub fn get_event_len(&self) -> usize {
+        self.events.len()
+    }
+
+    pub fn get_event_at_idx(&self, idx: usize) -> Option<Vec<u8>> {
+        self.events.get(idx).cloned().flatten()
+    }
 }
 
 pub type StoredTransactionEvents = Vec<Option<Vec<u8>>>;

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1108,6 +1108,12 @@ pub struct ProtocolConfig {
     /// Configures the garbage collection depth for consensus. When is unset or
     /// `0` then the garbage collection is disabled.
     consensus_gc_depth: Option<u32>,
+
+    /// Configures the maximum number of acknowledgments to be included in a
+    /// block. It must be reasonably larger than the number of validators
+    /// because not all validators create their blocks at the same pace.
+    /// Applicable only to `starfish` consensus.
+    consensus_max_acknowledgments_per_block: Option<u32>,
 }
 
 // feature flags
@@ -1268,6 +1274,10 @@ impl ProtocolConfig {
             "The consensus linearize sub dag V2 requires GC to be enabled"
         );
         res
+    }
+
+    pub fn consensus_max_acknowledgments_per_block_or_default(&self) -> u32 {
+        self.consensus_max_acknowledgments_per_block.unwrap_or(400)
     }
 
     pub fn variant_nodes(&self) -> bool {
@@ -1888,6 +1898,8 @@ impl ProtocolConfig {
             max_committee_members_count: None,
 
             consensus_gc_depth: None,
+
+            consensus_max_acknowledgments_per_block: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -53,15 +53,6 @@ use crate::{
 // TODO: Move to protocol config, and verify in BlockVerifier.
 const MAX_COMMIT_VOTES_PER_BLOCK: usize = 100;
 
-// Maximum number of acknowledgments to be included in a block. It must be
-// reasonably larger than the number of validators because not all validators
-// create their blocks at the same pace. For now we set it as a
-// constant to not make the block header size too large.
-// TODO: https://github.com/iotaledger/iota/issues/8378
-// After testing decide how to compress acknowledgments and move to a
-// protocol config
-const MAX_ACKNOWLEDGMENTS_PER_BLOCK: usize = 400;
-
 pub(crate) struct Core {
     context: Arc<Context>,
     /// The consumer to use in order to pull transactions to be included for the
@@ -677,10 +668,11 @@ impl Core {
 
         // Consume the acknowledgments about transaction data availability for past
         // blocks to be included.
-        let acknowledgments = self
-            .dag_state
-            .write()
-            .take_acknowledgments(MAX_ACKNOWLEDGMENTS_PER_BLOCK);
+        let acknowledgments = self.dag_state.write().take_acknowledgments(
+            self.context
+                .protocol_config
+                .consensus_max_acknowledgments_per_block_or_default() as usize,
+        );
 
         // Consume the commit votes to be included.
         let commit_votes = self


### PR DESCRIPTION
# Description of change

Moved `MAX_ACKNOWLEDGMENTS_PER_BLOCK` parameter used in starfish consensus to the `iota-protocol-config`.
- Increased max protocol version to 13.
- added `consensus_max_acknowledgments_per_block` parameter to `iota-protocol-config`
- added `consensus_max_acknowledgments_per_block_or_default` getter method to default to the currently used value.
- replaced usage of `MAX_ACKNOWLEDGMENTS_PER_BLOCK` in starfish to `protocol_config.consensus_max_acknowledgments_per_block_or_default`
- updated snapshots.

## Links to any relevant issues

fixes #8378.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol:
  - Increased max protocol version to 13.
  - added `consensus_max_acknowledgments_per_block` parameter used in starfish consensus
  - added `consensus_max_acknowledgments_per_block_or_default` getter method to default to the currently used value.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
