### PR TITLE
fix(graphql-rpc): Fix leftover Stored variant not renamed to Checkpointed

### DIFF
--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -92,7 +92,7 @@ pub(crate) enum TransactionBlockInner {
 impl TransactionBlockInner {
     /// Returns if the transaction is included in a checkpoint.
     fn is_checkpointed(&self) -> bool {
-        let TransactionBlockInner::Stored { stored_tx, .. } = &self else {
+        let TransactionBlockInner::Checkpointed { stored_tx, .. } = &self else {
             return false;
         };
         stored_tx.checkpoint_sequence_number >= 0


### PR DESCRIPTION
# Description of change

Fix leftover Stored variant not renamed to Checkpointed

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
