### PR TITLE
refactor(move-package-alt): Use substring operation instead of lazy regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8478,29 +8478,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy-regex"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
-dependencies = [
- "lazy-regex-proc_macros",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "lazy-regex-proc_macros"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9541,7 +9518,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "derive-where",
- "lazy-regex",
  "serde",
  "serde_spanned",
  "toml 0.5.11",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1513,29 +1513,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy-regex"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
-dependencies = [
- "lazy-regex-proc_macros",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "lazy-regex-proc_macros"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,7 +2211,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "derive-where",
- "lazy-regex",
  "serde",
  "serde_spanned",
  "toml",

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -55,7 +55,6 @@ insta = "1.42.0"
 internment = { version = "0.5.0", features = ["arc"] }
 itertools = "0.10.0"
 json_comments = "0.2.2"
-lazy-regex = "3.4"
 leb128 = "0.2.5"
 libfuzzer-sys = "0.4"
 log = { version = "0.4.14", features = ["serde"] }

--- a/external-crates/move/crates/move-package-alt/Cargo.toml
+++ b/external-crates/move/crates/move-package-alt/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 [dependencies]
 anyhow.workspace = true
 derive-where.workspace = true
-lazy-regex.workspace = true
 serde.workspace = true
 serde_spanned.workspace = true
 toml.workspace = true

--- a/external-crates/move/crates/move-package-alt/src/package/lockfile.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/lockfile.rs
@@ -11,7 +11,6 @@ use std::{
 
 use anyhow::bail;
 use derive_where::derive_where;
-use lazy_regex::regex_captures;
 use serde::{Deserialize, Serialize};
 use serde_spanned::Spanned;
 use toml_edit::{
@@ -231,6 +230,43 @@ fn lockname_to_env_name(filename: OsString) -> Option<String> {
         return None;
     };
 
-    let (_, env_name) = regex_captures!(r"Move\.(.*)\.lock", &filename)?;
-    Some(env_name.to_string())
+    let prefix = "Move.";
+    let suffix = ".lock";
+
+    if filename.starts_with(prefix) && filename.ends_with(suffix) {
+        let start_index = prefix.len();
+        let end_index = filename.len() - suffix.len();
+
+        if start_index < end_index {
+            return Some(filename[start_index..end_index].to_string());
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lockname_to_env_name() {
+        assert_eq!(
+            lockname_to_env_name(OsString::from("Move.test.lock")),
+            Some("test".to_string())
+        );
+        assert_eq!(
+            lockname_to_env_name(OsString::from("Move.3vcga23.lock")),
+            Some("3vcga23".to_string())
+        );
+        assert_eq!(
+            lockname_to_env_name(OsString::from("Mve.test.lock.lock")),
+            None
+        );
+
+        assert_eq!(lockname_to_env_name(OsString::from("Move.lock")), None);
+        assert_eq!(lockname_to_env_name(OsString::from("Move.test.loc")), None);
+        assert_eq!(lockname_to_env_name(OsString::from("Move.testloc")), None);
+        assert_eq!(lockname_to_env_name(OsString::from("Move.test")), None);
+    }
 }


### PR DESCRIPTION
# Description of change

Minor refactor for `move-package-alt`, where lazy regex operations were removed in favor of string based ones.

Good to know:
The new package cannot be tested using
```
external-crates/move $ cargo test -p move-package-alt 
```
because it will fail on incorrectly identified doctests.

```
---- crates/move-package-alt/src/dependency/git.rs - dependency::git (line 10) stdout ----
error: expected item, found `.`
 --> crates/move-package-alt/src/dependency/git.rs:11:1
  |
1 | .move/
  | ^ expected item
  |
  = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>

error: aborting due to 1 previous error
```

This, we do not attempt to fix.
The functional way of running the test is:
```
external-crates/move $ cargo nextest run -p move-package-alt
```

If you wonder why the main Cargo.lock file was modified it is because of nextest. Not sure why does it change that, why it doesn't fail the same way as the normal `cargo test` though. 

## Links to any relevant issues

fixes #8329 