### PR TITLE
feat(starfish): send only useful shards

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -118,18 +118,19 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     /// For each peer, the set of authorities whose block headers the local node
     /// considered useful when receiving a block bundle from that peer.
     /// Keyed by the peer’s AuthorityIndex.
-    useful_authorities_from_peer: Arc<RwLock<BTreeMap<AuthorityIndex, BTreeSet<AuthorityIndex>>>>,
+    useful_headers_authors_from_peer:
+        Arc<RwLock<BTreeMap<AuthorityIndex, BTreeSet<AuthorityIndex>>>>,
     /// For each peer, the set of local authorities that the peer reported as
     /// useful to them (communicated inside their block bundles).
     /// Keyed by the peer’s AuthorityIndex.
-    useful_authorities_to_peer: Arc<RwLock<BTreeMap<AuthorityIndex, BTreeSet<AuthorityIndex>>>>,
+    useful_headers_authors_to_peer: Arc<RwLock<BTreeMap<AuthorityIndex, BTreeSet<AuthorityIndex>>>>,
     /// For each peer, stores the latest round in which a received block bundle
     /// from any peer included a useful shard originating from a block
     /// created by authority `i`.
-    last_round_with_useful_shards_from_peer: Arc<RwLock<Vec<Round>>>,
+    last_round_with_useful_shards_by_block_author: Arc<RwLock<Vec<Round>>>,
     /// For each peer `i`, stores a set of authority indices representing the
     /// authors of blocks whose shards were reported as useful by peer `i`.
-    peers_reporting_useful_shards: Arc<RwLock<Vec<BTreeSet<AuthorityIndex>>>>,
+    useful_shards_authors_to_peer: Arc<RwLock<Vec<BTreeSet<AuthorityIndex>>>>,
 }
 
 impl<C: CoreThreadDispatcher> AuthorityService<C> {
@@ -163,14 +164,14 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             dag_state,
             store,
             received_block_headers: FilterForHeaders::new(),
-            useful_authorities_from_peer: Arc::new(RwLock::new(BTreeMap::new())),
-            useful_authorities_to_peer: Arc::new(RwLock::new(BTreeMap::new())),
+            useful_headers_authors_from_peer: Arc::new(RwLock::new(BTreeMap::new())),
+            useful_headers_authors_to_peer: Arc::new(RwLock::new(BTreeMap::new())),
             transaction_message_sender,
-            last_round_with_useful_shards_from_peer: Arc::new(RwLock::new(vec![
+            last_round_with_useful_shards_by_block_author: Arc::new(RwLock::new(vec![
                 GENESIS_ROUND;
                 committee_size
             ])),
-            peers_reporting_useful_shards: Arc::new(RwLock::new(vec![
+            useful_shards_authors_to_peer: Arc::new(RwLock::new(vec![
                 BTreeSet::new();
                 committee_size
             ])),
@@ -193,14 +194,14 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             SerializedBlockBundleParts::try_from(serialized_block_bundle)?;
 
         // Cache authorities this peer finds useful for cordial
-        let useful_authorities_to_peer = serialized_block_bundle_parts.useful_authorities();
+        let useful_authorities_to_peer = serialized_block_bundle_parts.useful_headers_authors();
         {
-            let mut guard = self.useful_authorities_to_peer.write();
+            let mut guard = self.useful_headers_authors_to_peer.write();
             guard.insert(peer, useful_authorities_to_peer);
         }
         let useful_shards_authors_to_peer = serialized_block_bundle_parts.useful_shards_authors();
         {
-            let mut guard = self.peers_reporting_useful_shards.write();
+            let mut guard = self.useful_shards_authors_to_peer.write();
             guard[peer] = useful_shards_authors_to_peer;
         }
 
@@ -620,26 +621,31 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
 
-        // 13. update `useful_authorities_from_peer`
+        // 13. update `useful_headers_authors_from_peer`
         // create a set of authority indexes from the `additional_block_headers`
         // and `missing_ancestors`
-        let useful_authorities = additional_block_headers
-            .iter()
-            .map(|block_header| block_header.author())
-            .chain(missing_ancestors.iter().map(|block_ref| block_ref.author))
-            .collect::<BTreeSet<_>>();
         {
+            let useful_headers_authors = additional_block_headers
+                .iter()
+                .map(|block_header| block_header.author())
+                .chain(missing_ancestors.iter().map(|block_ref| block_ref.author))
+                .collect::<BTreeSet<_>>();
+
             let mut useful_authorities_from_peer_write_guard =
-                self.useful_authorities_from_peer.write();
-            useful_authorities_from_peer_write_guard.insert(peer, useful_authorities);
+                self.useful_headers_authors_from_peer.write();
+            useful_authorities_from_peer_write_guard.insert(peer, useful_headers_authors);
         }
+        // 14. Update `last_round_with_useful_shards_by_block_author`:
+        // For each validator whose block is in `additional_block_headers`,
+        // set their entry to the maximum of its current value and the round of the
+        // received block.
         {
             let useful_shard_authors = additional_block_headers
                 .iter()
                 .map(|block_header| block_header.author())
                 .collect::<Vec<_>>();
             let mut last_round_with_useful_shards_from_peer_write_guard =
-                self.last_round_with_useful_shards_from_peer.write();
+                self.last_round_with_useful_shards_by_block_author.write();
             for author in useful_shard_authors {
                 last_round_with_useful_shards_from_peer_write_guard[author] = max(
                     last_round_with_useful_shards_from_peer_write_guard[author],
@@ -648,7 +654,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             }
         }
 
-        // 14. schedule the fetching of missing ancestors (if any) from this peer
+        // 15. schedule the fetching of missing ancestors (if any) from this peer
         if !missing_ancestors.is_empty() {
             if let Err(err) = self
                 .synchronizer
@@ -659,7 +665,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             }
         }
 
-        // 15. schedule the fetching of missing committed transactions (if any)
+        // 16. schedule the fetching of missing committed transactions (if any)
         if !missing_committed_txns.is_empty() {
             if let Err(err) = self
                 .transactions_synchronizer
@@ -710,11 +716,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // new blocks.
         Ok(Box::pin(missed_blocks.chain({
             let dag_state = Arc::clone(&self.dag_state);
-            let useful_authorities_from_peer = Arc::clone(&self.useful_authorities_from_peer);
-            let useful_authorities_to_peer = Arc::clone(&self.useful_authorities_to_peer);
-            let last_round_with_useful_shards_from_peer =
-                Arc::clone(&self.last_round_with_useful_shards_from_peer);
-            let peers_reporting_useful_shards = Arc::clone(&self.peers_reporting_useful_shards);
+            let useful_headers_authors_from_peer =
+                Arc::clone(&self.useful_headers_authors_from_peer);
+            let useful_headers_authors_to_peer = Arc::clone(&self.useful_headers_authors_to_peer);
+            let last_round_with_useful_shards_by_block_author =
+                Arc::clone(&self.last_round_with_useful_shards_by_block_author);
+            let useful_shards_authors_to_peer = Arc::clone(&self.useful_shards_authors_to_peer);
             let committee = self
                 .context
                 .committee
@@ -723,33 +730,34 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .collect::<BTreeSet<_>>();
 
             broadcasted_blocks.filter_map(move |block| {
-                let useful_authorities_to_peer_guard = useful_authorities_to_peer.read();
-                let useful_authorities_to_peer_read = useful_authorities_to_peer_guard
+                let useful_headers_authors_to_peer_guard = useful_headers_authors_to_peer.read();
+                let useful_headers_authors_to_peer_read = useful_headers_authors_to_peer_guard
                     .get(&peer)
                     .map(|authorities| authorities.iter().cloned().collect::<BTreeSet<_>>());
-                drop(useful_authorities_to_peer_guard);
+                drop(useful_headers_authors_to_peer_guard);
 
-                let peers_reporting_useful_shards_guard = peers_reporting_useful_shards.read();
-                let peers_reporting_useful_shards_read =
-                    peers_reporting_useful_shards_guard[peer].clone();
-                drop(peers_reporting_useful_shards_guard);
+                let useful_shards_authors_to_peer_guard = useful_shards_authors_to_peer.read();
+                let useful_shards_authors_to_peer_read =
+                    useful_shards_authors_to_peer_guard[peer].clone();
+                drop(useful_shards_authors_to_peer_guard);
 
-                let useful_authorities_from_peer_guard = useful_authorities_from_peer.read();
-                let useful_authorities_from_peer_read =
-                    match useful_authorities_from_peer_guard.get(&peer) {
+                let useful_headers_authors_from_peer_guard =
+                    useful_headers_authors_from_peer.read();
+                let useful_headers_authors_from_peer_read =
+                    match useful_headers_authors_from_peer_guard.get(&peer) {
                         None => committee.clone(),
                         Some(useful_authorities) => useful_authorities.clone(),
                     };
-                drop(useful_authorities_from_peer_guard);
+                drop(useful_headers_authors_from_peer_guard);
 
-                let last_round_with_useful_shards_from_peer_guard =
-                    last_round_with_useful_shards_from_peer.read();
-                let last_round_with_useful_shards_from_peer_read =
-                    last_round_with_useful_shards_from_peer_guard.clone();
-                drop(last_round_with_useful_shards_from_peer_guard);
+                let last_round_with_useful_shards_by_block_author_guard =
+                    last_round_with_useful_shards_by_block_author.read();
+                let last_round_with_useful_shards_by_block_author_read =
+                    last_round_with_useful_shards_by_block_author_guard.clone();
+                drop(last_round_with_useful_shards_by_block_author_guard);
 
                 let mut dag_state_guard = dag_state.write();
-                let block_headers = match useful_authorities_to_peer_read {
+                let block_headers = match useful_headers_authors_to_peer_read {
                     None => dag_state_guard.take_unknown_headers_for_authority(peer, block.round()),
                     Some(authorities) => dag_state_guard.take_useful_headers_for_authority(
                         peer,
@@ -761,12 +769,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 let serialized_shards = dag_state_guard.take_useful_shards_for_authority(
                     peer,
                     block.round(),
-                    peers_reporting_useful_shards_read,
+                    useful_shards_authors_to_peer_read,
                 );
                 drop(dag_state_guard);
 
                 let useful_shards_authors = DagState::get_useful_shards_authors(
-                    last_round_with_useful_shards_from_peer_read,
+                    last_round_with_useful_shards_by_block_author_read,
                     block.round(),
                 );
 
@@ -774,7 +782,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                     verified_block: block,
                     verified_headers: block_headers,
                     serialized_shards,
-                    useful_authorities: useful_authorities_from_peer_read,
+                    useful_headers_authors: useful_headers_authors_from_peer_read,
                     useful_shards_authors,
                 };
                 async move {
@@ -1745,7 +1753,7 @@ mod tests {
             verified_block: input_block.clone(),
             verified_headers: headers.clone(),
             serialized_shards: vec![],
-            useful_authorities: (0u8..(committee_size as u8)).map(Into::into).collect(),
+            useful_headers_authors: (0u8..(committee_size as u8)).map(Into::into).collect(),
             useful_shards_authors: (0u8..(committee_size as u8)).map(Into::into).collect(),
         };
         let serialized_big_block_bundle = SerializedBlockBundle::try_from(
@@ -1759,7 +1767,7 @@ mod tests {
             verified_block: input_block.clone(),
             verified_headers: headers.clone(),
             serialized_shards: vec![],
-            useful_authorities: (0u8..(committee_size as u8)).map(Into::into).collect(),
+            useful_headers_authors: (0u8..(committee_size as u8)).map(Into::into).collect(),
             useful_shards_authors: (0u8..(committee_size as u8)).map(Into::into).collect(),
         };
         let serialized_block_bundle_with_big_round = SerializedBlockBundle::try_from(
@@ -1797,7 +1805,7 @@ mod tests {
             verified_block: input_block.clone(),
             verified_headers: headers.clone(),
             serialized_shards: vec![],
-            useful_authorities: (0u8..(committee_size as u8)).map(Into::into).collect(),
+            useful_headers_authors: (0u8..(committee_size as u8)).map(Into::into).collect(),
             useful_shards_authors: (0u8..(committee_size as u8)).map(Into::into).collect(),
         };
         let serialized_block_bundle = SerializedBlockBundle::try_from(
@@ -2293,7 +2301,7 @@ mod tests {
                     verified_block: block,
                     verified_headers: headers,
                     serialized_shards: vec![],
-                    useful_authorities: (0u8..(context.committee.size() as u8))
+                    useful_headers_authors: (0u8..(context.committee.size() as u8))
                         .map(Into::into)
                         .collect(),
                     useful_shards_authors: (0u8..(context.committee.size() as u8))
@@ -2439,7 +2447,7 @@ mod tests {
                     verified_block: block,
                     verified_headers: vec![],
                     serialized_shards: vec![],
-                    useful_authorities: (0u8..(context.committee.size() as u8))
+                    useful_headers_authors: (0u8..(context.committee.size() as u8))
                         .map(Into::into)
                         .collect(),
                     useful_shards_authors: (0u8..(context.committee.size() as u8))

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -123,10 +123,10 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     /// useful to them (communicated inside their block bundles).
     /// Keyed by the peer’s AuthorityIndex.
     useful_authorities_to_peer: Arc<RwLock<BTreeMap<AuthorityIndex, BTreeSet<AuthorityIndex>>>>,
-    /// For each peer `i`, stores a vector where each entry at index `j`
-    /// represents the last round in which a received bundle from peer `i`
-    /// contained a useful shard from a block created by authority `j`.
-    last_round_with_useful_shards_from_peer: Arc<RwLock<Vec<Vec<Round>>>>,
+    /// For each peer, stores the latest round in which a received block bundle
+    /// from any peer included a useful shard originating from a block
+    /// created by authority `i`.
+    last_round_with_useful_shards_from_peer: Arc<RwLock<Vec<Round>>>,
     /// For each peer `i`, stores a set of authority indices representing the
     /// authors of blocks whose shards were reported as useful by peer `i`.
     peers_reporting_useful_shards: Arc<RwLock<Vec<BTreeSet<AuthorityIndex>>>>,
@@ -167,10 +167,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             useful_authorities_to_peer: Arc::new(RwLock::new(BTreeMap::new())),
             transaction_message_sender,
             last_round_with_useful_shards_from_peer: Arc::new(RwLock::new(vec![
-                vec![
-                    GENESIS_ROUND;
-                    committee_size
-                ];
+                GENESIS_ROUND;
                 committee_size
             ])),
             peers_reporting_useful_shards: Arc::new(RwLock::new(vec![
@@ -644,8 +641,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             let mut last_round_with_useful_shards_from_peer_write_guard =
                 self.last_round_with_useful_shards_from_peer.write();
             for author in useful_shard_authors {
-                last_round_with_useful_shards_from_peer_write_guard[peer][author] = max(
-                    last_round_with_useful_shards_from_peer_write_guard[peer][author],
+                last_round_with_useful_shards_from_peer_write_guard[author] = max(
+                    last_round_with_useful_shards_from_peer_write_guard[author],
                     block_round,
                 );
             }
@@ -748,7 +745,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 let last_round_with_useful_shards_from_peer_guard =
                     last_round_with_useful_shards_from_peer.read();
                 let last_round_with_useful_shards_from_peer_read =
-                    last_round_with_useful_shards_from_peer_guard[peer].clone();
+                    last_round_with_useful_shards_from_peer_guard.clone();
                 drop(last_round_with_useful_shards_from_peer_guard);
 
                 let mut dag_state_guard = dag_state.write();

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1749,17 +1749,6 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        let big_block_bundle = BlockBundle {
-            verified_block: input_block.clone(),
-            verified_headers: headers.clone(),
-            serialized_shards: vec![],
-            useful_headers_authors: (0u8..(committee_size as u8)).map(Into::into).collect(),
-            useful_shards_authors: (0u8..(committee_size as u8)).map(Into::into).collect(),
-        };
-        let serialized_big_block_bundle = SerializedBlockBundle::try_from(
-            SerializedBlockBundleParts::try_from(big_block_bundle).unwrap(),
-        )
-        .unwrap();
 
         let service = authority_service.clone();
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    cmp::max,
     collections::{BTreeMap, BTreeSet, VecDeque},
     pin::Pin,
     sync::Arc,
@@ -122,6 +123,13 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     /// useful to them (communicated inside their block bundles).
     /// Keyed by the peer’s AuthorityIndex.
     useful_authorities_to_peer: Arc<RwLock<BTreeMap<AuthorityIndex, BTreeSet<AuthorityIndex>>>>,
+    /// For each peer `i`, stores a vector where each entry at index `j`
+    /// represents the last round in which a received bundle from peer `i`
+    /// contained a useful shard from a block created by authority `j`.
+    last_round_with_useful_shards_from_peer: Arc<RwLock<Vec<Vec<Round>>>>,
+    /// For each peer `i`, stores a set of authority indices representing the
+    /// authors of blocks whose shards were reported as useful by peer `i`.
+    peers_reporting_useful_shards: Arc<RwLock<Vec<BTreeSet<AuthorityIndex>>>>,
 }
 
 impl<C: CoreThreadDispatcher> AuthorityService<C> {
@@ -141,6 +149,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             context.clone(),
             core_dispatcher.clone(),
         ));
+        let committee_size = context.committee.size();
 
         Self {
             context,
@@ -157,6 +166,17 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             useful_authorities_from_peer: Arc::new(RwLock::new(BTreeMap::new())),
             useful_authorities_to_peer: Arc::new(RwLock::new(BTreeMap::new())),
             transaction_message_sender,
+            last_round_with_useful_shards_from_peer: Arc::new(RwLock::new(vec![
+                vec![
+                    GENESIS_ROUND;
+                    committee_size
+                ];
+                committee_size
+            ])),
+            peers_reporting_useful_shards: Arc::new(RwLock::new(vec![
+                BTreeSet::new();
+                committee_size
+            ])),
         }
     }
 }
@@ -180,6 +200,11 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         {
             let mut guard = self.useful_authorities_to_peer.write();
             guard.insert(peer, useful_authorities_to_peer);
+        }
+        let useful_shards_authors_to_peer = serialized_block_bundle_parts.useful_shards_authors();
+        {
+            let mut guard = self.peers_reporting_useful_shards.write();
+            guard[peer] = useful_shards_authors_to_peer;
         }
 
         // 1. Create a verified block and make some preliminary checks
@@ -569,6 +594,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .map_err(|_| ConsensusError::Shutdown)?;
 
         // 11. Add the block to dag, add its missing ancestors to the set
+        let block_round = verified_block.round();
         let (missing_block_ancestors, missing_block_committed_transactions) = self
             .core_dispatcher
             .add_blocks(vec![verified_block])
@@ -609,6 +635,20 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             let mut useful_authorities_from_peer_write_guard =
                 self.useful_authorities_from_peer.write();
             useful_authorities_from_peer_write_guard.insert(peer, useful_authorities);
+        }
+        {
+            let useful_shard_authors = additional_block_headers
+                .iter()
+                .map(|block_header| block_header.author())
+                .collect::<Vec<_>>();
+            let mut last_round_with_useful_shards_from_peer_write_guard =
+                self.last_round_with_useful_shards_from_peer.write();
+            for author in useful_shard_authors {
+                last_round_with_useful_shards_from_peer_write_guard[peer][author] = max(
+                    last_round_with_useful_shards_from_peer_write_guard[peer][author],
+                    block_round,
+                );
+            }
         }
 
         // 14. schedule the fetching of missing ancestors (if any) from this peer
@@ -675,6 +715,9 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             let dag_state = Arc::clone(&self.dag_state);
             let useful_authorities_from_peer = Arc::clone(&self.useful_authorities_from_peer);
             let useful_authorities_to_peer = Arc::clone(&self.useful_authorities_to_peer);
+            let last_round_with_useful_shards_from_peer =
+                Arc::clone(&self.last_round_with_useful_shards_from_peer);
+            let peers_reporting_useful_shards = Arc::clone(&self.peers_reporting_useful_shards);
             let committee = self
                 .context
                 .committee
@@ -688,6 +731,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                     .get(&peer)
                     .map(|authorities| authorities.iter().cloned().collect::<BTreeSet<_>>());
                 drop(useful_authorities_to_peer_guard);
+
+                let peers_reporting_useful_shards_guard = peers_reporting_useful_shards.read();
+                let peers_reporting_useful_shards_read =
+                    peers_reporting_useful_shards_guard[peer].clone();
+                drop(peers_reporting_useful_shards_guard);
+
                 let useful_authorities_from_peer_guard = useful_authorities_from_peer.read();
                 let useful_authorities_from_peer_read =
                     match useful_authorities_from_peer_guard.get(&peer) {
@@ -695,6 +744,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                         Some(useful_authorities) => useful_authorities.clone(),
                     };
                 drop(useful_authorities_from_peer_guard);
+
+                let last_round_with_useful_shards_from_peer_guard =
+                    last_round_with_useful_shards_from_peer.read();
+                let last_round_with_useful_shards_from_peer_read =
+                    last_round_with_useful_shards_from_peer_guard[peer].clone();
+                drop(last_round_with_useful_shards_from_peer_guard);
 
                 let mut dag_state_guard = dag_state.write();
                 let block_headers = match useful_authorities_to_peer_read {
@@ -705,15 +760,25 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                         authorities,
                     ),
                 };
-                let serialized_shards =
-                    dag_state_guard.take_unknown_shards_for_authority(peer, block.round());
+
+                let serialized_shards = dag_state_guard.take_useful_shards_for_authority(
+                    peer,
+                    block.round(),
+                    peers_reporting_useful_shards_read,
+                );
                 drop(dag_state_guard);
+
+                let useful_shards_authors = DagState::get_useful_shards_authors(
+                    last_round_with_useful_shards_from_peer_read,
+                    block.round(),
+                );
 
                 let block_bundle = BlockBundle {
                     verified_block: block,
                     verified_headers: block_headers,
                     serialized_shards,
                     useful_authorities: useful_authorities_from_peer_read,
+                    useful_shards_authors,
                 };
                 async move {
                     match SerializedBlockBundle::try_from(block_bundle) {
@@ -1679,6 +1744,17 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
+        let big_block_bundle = BlockBundle {
+            verified_block: input_block.clone(),
+            verified_headers: headers.clone(),
+            serialized_shards: vec![],
+            useful_authorities: (0u8..(committee_size as u8)).map(Into::into).collect(),
+            useful_shards_authors: (0u8..(committee_size as u8)).map(Into::into).collect(),
+        };
+        let serialized_big_block_bundle = SerializedBlockBundle::try_from(
+            SerializedBlockBundleParts::try_from(big_block_bundle).unwrap(),
+        )
+        .unwrap();
 
         let service = authority_service.clone();
 
@@ -1687,6 +1763,7 @@ mod tests {
             verified_headers: headers.clone(),
             serialized_shards: vec![],
             useful_authorities: (0u8..(committee_size as u8)).map(Into::into).collect(),
+            useful_shards_authors: (0u8..(committee_size as u8)).map(Into::into).collect(),
         };
         let serialized_block_bundle_with_big_round = SerializedBlockBundle::try_from(
             SerializedBlockBundleParts::try_from(block_bundle_with_big_rounds).unwrap(),
@@ -1724,6 +1801,7 @@ mod tests {
             verified_headers: headers.clone(),
             serialized_shards: vec![],
             useful_authorities: (0u8..(committee_size as u8)).map(Into::into).collect(),
+            useful_shards_authors: (0u8..(committee_size as u8)).map(Into::into).collect(),
         };
         let serialized_block_bundle = SerializedBlockBundle::try_from(
             SerializedBlockBundleParts::try_from(block_bundle).unwrap(),
@@ -2221,6 +2299,9 @@ mod tests {
                     useful_authorities: (0u8..(context.committee.size() as u8))
                         .map(Into::into)
                         .collect(),
+                    useful_shards_authors: (0u8..(context.committee.size() as u8))
+                        .map(Into::into)
+                        .collect(),
                 };
                 let serialized_block_bundle = SerializedBlockBundle::try_from(
                     SerializedBlockBundleParts::try_from(block_bundle).unwrap(),
@@ -2362,6 +2443,9 @@ mod tests {
                     verified_headers: vec![],
                     serialized_shards: vec![],
                     useful_authorities: (0u8..(context.committee.size() as u8))
+                        .map(Into::into)
+                        .collect(),
+                    useful_shards_authors: (0u8..(context.committee.size() as u8))
                         .map(Into::into)
                         .collect(),
                 };

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -33,6 +33,8 @@ use crate::{
     threshold_clock::ThresholdClock,
 };
 
+const MAX_ROUND_GAP_FOR_USEFUL_SHARDS: usize = 5;
+
 /// DagState provides the API to write and read accepted blocks from the DAG.
 /// Only uncommitted and last committed blocks are cached in memory.
 /// The rest of blocks are stored on disk.
@@ -1343,6 +1345,36 @@ impl DagState {
         to_take
     }
 
+    fn take_block_refs_of_useful_shards_for_authority(
+        &mut self,
+        authority_index: AuthorityIndex,
+        round_upper_bound_exclusive: Round,
+        useful_authorities: BTreeSet<AuthorityIndex>,
+    ) -> Vec<BlockRef> {
+        let set = &mut self.shards_not_known_by_authority[authority_index.value()];
+
+        // Collect candidate block_refs we want to take out
+        let mut to_take = Vec::new();
+
+        for block_ref in set.iter() {
+            if to_take.len() >= MAX_SHARDS_PER_BUNDLE
+                || block_ref.round >= round_upper_bound_exclusive
+            {
+                break;
+            }
+            if useful_authorities.contains(&block_ref.author) {
+                to_take.push(*block_ref);
+            }
+        }
+
+        // Remove the references from the set and update cordial knowledge
+        for block_ref in &to_take {
+            set.remove(block_ref);
+        }
+
+        to_take
+    }
+
     /// Retrieves up to `MAX_HEADERS_PER_BUNDLE` previously unknown block
     /// headers for the given authority, restricted to rounds strictly below
     /// `round_upper_bound_exclusive`.
@@ -1391,34 +1423,39 @@ impl DagState {
             .collect()
     }
 
-    pub(crate) fn take_unknown_shards_for_authority(
+    pub(crate) fn take_useful_shards_for_authority(
         &mut self,
         authority_index: AuthorityIndex,
         round_upper_bound_exclusive: Round,
+        useful_authorities: BTreeSet<AuthorityIndex>,
     ) -> Vec<Bytes> {
-        let mut set = mem::take(&mut self.shards_not_known_by_authority[authority_index.value()]);
+        let block_refs = self.take_block_refs_of_useful_shards_for_authority(
+            authority_index,
+            round_upper_bound_exclusive,
+            useful_authorities,
+        );
+        block_refs
+            .iter()
+            .map(|block_ref| {
+                self.recent_shards
+                    .get(block_ref)
+                    .expect("Shard should be in DagState")
+                    .clone()
+            })
+            .collect::<Vec<_>>()
+    }
 
-        let split_point = {
-            let round_bound = BlockRef::new(
-                round_upper_bound_exclusive,
-                AuthorityIndex::MIN,
-                BlockHeaderDigest::MIN,
-            );
-            let nth_element = set
-                .iter()
-                .nth(self.context.parameters.max_shards_per_bundle)
-                .map_or(round_bound, |x| *x);
-            min(nth_element, round_bound)
-        };
-
-        self.shards_not_known_by_authority[authority_index.value()] = set.split_off(&split_point);
-        let mut shards: Vec<Bytes> = vec![];
-        for block_ref in set.into_iter() {
-            if let Some(shard) = self.recent_shards.get(&block_ref) {
-                shards.push(shard.clone());
+    pub(crate) fn get_useful_shards_authors(
+        last_useful_round: Vec<Round>,
+        block_round: Round,
+    ) -> BTreeSet<AuthorityIndex> {
+        let mut useful_authorities = BTreeSet::new();
+        for (i, round) in last_useful_round.iter().enumerate() {
+            if block_round - round < MAX_ROUND_GAP_FOR_USEFUL_SHARDS as u32 {
+                useful_authorities.insert(AuthorityIndex::from(i as u8));
             }
         }
-        shards
+        useful_authorities
     }
     pub(crate) fn take_commit_votes(&mut self, limit: usize) -> Vec<CommitVote> {
         let mut votes = Vec::new();

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -33,6 +33,9 @@ use crate::{
     threshold_clock::ThresholdClock,
 };
 
+/// If a shard from a block created by authority v1 is useful to authority v2 at
+/// round r, then shards from v1 will be sent to v2 up to round r +
+/// MAX_ROUND_GAP_FOR_USEFUL_SHARDS.
 const MAX_ROUND_GAP_FOR_USEFUL_SHARDS: usize = 5;
 
 /// DagState provides the API to write and read accepted blocks from the DAG.
@@ -1449,13 +1452,13 @@ impl DagState {
         last_useful_round: Vec<Round>,
         block_round: Round,
     ) -> BTreeSet<AuthorityIndex> {
-        let mut useful_authorities = BTreeSet::new();
+        let mut useful_shard_authors = BTreeSet::new();
         for (i, round) in last_useful_round.iter().enumerate() {
-            if block_round - round < MAX_ROUND_GAP_FOR_USEFUL_SHARDS as u32 {
-                useful_authorities.insert(AuthorityIndex::from(i as u8));
+            if block_round - round <= MAX_ROUND_GAP_FOR_USEFUL_SHARDS as u32 {
+                useful_shard_authors.insert(AuthorityIndex::from(i as u8));
             }
         }
-        useful_authorities
+        useful_shard_authors
     }
     pub(crate) fn take_commit_votes(&mut self, limit: usize) -> Vec<CommitVote> {
         let mut votes = Vec::new();

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1360,7 +1360,7 @@ impl DagState {
         let mut to_take = Vec::new();
 
         for block_ref in set.iter() {
-            if to_take.len() >= MAX_SHARDS_PER_BUNDLE
+            if to_take.len() >= self.context.parameters.max_shards_per_bundle
                 || block_ref.round >= round_upper_bound_exclusive
             {
                 break;

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -247,6 +247,7 @@ pub(crate) struct BlockBundle {
     pub(crate) verified_headers: Vec<VerifiedBlockHeader>,
     pub(crate) serialized_shards: Vec<Bytes>,
     pub(crate) useful_authorities: BTreeSet<AuthorityIndex>,
+    pub(crate) useful_shards_authors: BTreeSet<AuthorityIndex>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -255,21 +256,39 @@ pub(crate) struct SerializedBlockBundleParts {
     pub(crate) serialized_headers: Vec<Bytes>,
     pub(crate) serialized_shards: Vec<Bytes>,
     pub(crate) useful_authorities_bitmask: [u64; 4],
+    pub(crate) useful_shards_authors_bitmask: [u64; 4],
 }
 
+fn authority_set_to_bitmask(authorities: &BTreeSet<AuthorityIndex>) -> [u64; 4] {
+    let mut bitmask = [0u64; 4];
+    for authority_index in authorities {
+        let index = authority_index.value();
+        let array_index = index / 64;
+        let bit_pos = index % 64;
+        bitmask[array_index] |= 1u64 << bit_pos;
+    }
+    bitmask
+}
+
+fn bitmask_to_authority_set(bitmask: [u64; 4]) -> BTreeSet<AuthorityIndex> {
+    let mut set = BTreeSet::new();
+    for array_index in 0..4 {
+        let mut bits = bitmask[array_index];
+        let base = array_index * 64;
+        while bits != 0 {
+            let bit = bits.trailing_zeros() as usize;
+            set.insert(AuthorityIndex::from((base + bit) as u8));
+            bits &= bits - 1;
+        }
+    }
+    set
+}
 impl SerializedBlockBundleParts {
     pub(crate) fn useful_authorities(&self) -> BTreeSet<AuthorityIndex> {
-        let mut useful_authorities = BTreeSet::new();
-        for array_index in 0..4 {
-            let mut bits = self.useful_authorities_bitmask[array_index];
-            let base = array_index * 64;
-            while bits != 0 {
-                let bit = bits.trailing_zeros() as usize;
-                useful_authorities.insert(AuthorityIndex::from((base + bit) as u8));
-                bits &= bits - 1;
-            }
-        }
-        useful_authorities
+        bitmask_to_authority_set(self.useful_authorities_bitmask)
+    }
+    pub(crate) fn useful_shards_authors(&self) -> BTreeSet<AuthorityIndex> {
+        bitmask_to_authority_set(self.useful_shards_authors_bitmask)
     }
 }
 
@@ -293,6 +312,7 @@ impl TryFrom<VerifiedBlock> for SerializedBlockBundleParts {
             serialized_headers: vec![],
             serialized_shards: vec![],
             useful_authorities_bitmask: [0u64; 4],
+            useful_shards_authors_bitmask: [0u64; 4],
         })
     }
 }
@@ -312,18 +332,14 @@ impl TryFrom<BlockBundle> for SerializedBlockBundleParts {
         for block_header in block_bundle.verified_headers.iter() {
             serialized_block_headers.push(block_header.serialized().clone());
         }
-        let mut useful_authorities_bitmask = [0u64; 4];
-        for authority_index in block_bundle.useful_authorities {
-            let index = authority_index.value();
-            let array_index = index / 64;
-            let bit_pos = index % 64;
-            useful_authorities_bitmask[array_index] |= 1u64 << bit_pos;
-        }
         Ok(Self {
             serialized_block: Bytes::from(bytes),
             serialized_headers: serialized_block_headers,
             serialized_shards: block_bundle.serialized_shards,
-            useful_authorities_bitmask,
+            useful_authorities_bitmask: authority_set_to_bitmask(&block_bundle.useful_authorities),
+            useful_shards_authors_bitmask: authority_set_to_bitmask(
+                &block_bundle.useful_shards_authors,
+            ),
         })
     }
 }
@@ -389,6 +405,7 @@ mod tests {
             verified_headers: vec![],
             serialized_shards: vec![],
             useful_authorities: useful_authorities.clone(),
+            useful_shards_authors: useful_authorities.clone(),
         };
         let serialized_bundle = SerializedBlockBundle::try_from(block_bundle).unwrap();
         let serialized_bundle_parts =

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -246,7 +246,7 @@ pub(crate) struct BlockBundle {
     pub(crate) verified_block: VerifiedBlock,
     pub(crate) verified_headers: Vec<VerifiedBlockHeader>,
     pub(crate) serialized_shards: Vec<Bytes>,
-    pub(crate) useful_authorities: BTreeSet<AuthorityIndex>,
+    pub(crate) useful_headers_authors: BTreeSet<AuthorityIndex>,
     pub(crate) useful_shards_authors: BTreeSet<AuthorityIndex>,
 }
 
@@ -255,7 +255,7 @@ pub(crate) struct SerializedBlockBundleParts {
     pub(crate) serialized_block: Bytes,
     pub(crate) serialized_headers: Vec<Bytes>,
     pub(crate) serialized_shards: Vec<Bytes>,
-    pub(crate) useful_authorities_bitmask: [u64; 4],
+    pub(crate) useful_headers_authors_bitmask: [u64; 4],
     pub(crate) useful_shards_authors_bitmask: [u64; 4],
 }
 
@@ -285,8 +285,8 @@ fn bitmask_to_authority_set(bitmask: [u64; 4]) -> BTreeSet<AuthorityIndex> {
 }
 
 impl SerializedBlockBundleParts {
-    pub(crate) fn useful_authorities(&self) -> BTreeSet<AuthorityIndex> {
-        bitmask_to_authority_set(self.useful_authorities_bitmask)
+    pub(crate) fn useful_headers_authors(&self) -> BTreeSet<AuthorityIndex> {
+        bitmask_to_authority_set(self.useful_headers_authors_bitmask)
     }
     pub(crate) fn useful_shards_authors(&self) -> BTreeSet<AuthorityIndex> {
         bitmask_to_authority_set(self.useful_shards_authors_bitmask)
@@ -312,7 +312,7 @@ impl TryFrom<VerifiedBlock> for SerializedBlockBundleParts {
             serialized_block: Bytes::from(bytes),
             serialized_headers: vec![],
             serialized_shards: vec![],
-            useful_authorities_bitmask: [0u64; 4],
+            useful_headers_authors_bitmask: [0u64; 4],
             useful_shards_authors_bitmask: [0u64; 4],
         })
     }
@@ -337,7 +337,9 @@ impl TryFrom<BlockBundle> for SerializedBlockBundleParts {
             serialized_block: Bytes::from(bytes),
             serialized_headers: serialized_block_headers,
             serialized_shards: block_bundle.serialized_shards,
-            useful_authorities_bitmask: authority_set_to_bitmask(&block_bundle.useful_authorities),
+            useful_headers_authors_bitmask: authority_set_to_bitmask(
+                &block_bundle.useful_headers_authors,
+            ),
             useful_shards_authors_bitmask: authority_set_to_bitmask(
                 &block_bundle.useful_shards_authors,
             ),
@@ -405,13 +407,13 @@ mod tests {
             verified_block: block,
             verified_headers: vec![],
             serialized_shards: vec![],
-            useful_authorities: useful_authorities.clone(),
+            useful_headers_authors: useful_authorities.clone(),
             useful_shards_authors: useful_authorities.clone(),
         };
         let serialized_bundle = SerializedBlockBundle::try_from(block_bundle).unwrap();
         let serialized_bundle_parts =
             SerializedBlockBundleParts::try_from(serialized_bundle).unwrap();
-        let converted_useful_authorities = serialized_bundle_parts.useful_authorities();
+        let converted_useful_authorities = serialized_bundle_parts.useful_headers_authors();
         assert_eq!(useful_authorities, converted_useful_authorities);
     }
 }

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -272,8 +272,8 @@ fn authority_set_to_bitmask(authorities: &BTreeSet<AuthorityIndex>) -> [u64; 4] 
 
 fn bitmask_to_authority_set(bitmask: [u64; 4]) -> BTreeSet<AuthorityIndex> {
     let mut set = BTreeSet::new();
-    for array_index in 0..4 {
-        let mut bits = bitmask[array_index];
+    for (array_index, &bits) in bitmask.iter().enumerate() {
+        let mut bits = bits;
         let base = array_index * 64;
         while bits != 0 {
             let bit = bits.trailing_zeros() as usize;
@@ -283,6 +283,7 @@ fn bitmask_to_authority_set(bitmask: [u64; 4]) -> BTreeSet<AuthorityIndex> {
     }
     set
 }
+
 impl SerializedBlockBundleParts {
     pub(crate) fn useful_authorities(&self) -> BTreeSet<AuthorityIndex> {
         bitmask_to_authority_set(self.useful_authorities_bitmask)


### PR DESCRIPTION
# Description of change

PR tracks shards of which authors could be sent to other validators.

Shards for encoded transaction data of validator $v$ are considered as useful for validator $u$ if validator $u$ is ready to include an additional block header of validator $v$ after filtering those blocks. In particular, this means that
the potential sequenced transaction data comes from validator $v$ indirectly.

If the shard of the block created by the validator $v$ was useful, then the shards from the blocks created by $v$ will be sent for some number of rounds. In other words, there is some inertia; we don't stop sending shards as soon as one of them is useless.

In practice, there are two prerequisites for the efficiency of this mechanism:
1) block bundle streaming is actively working (e.g. this mechanism wouldn't work if a validator is catching up and doesn't produce blocks)
2) cordial dissemination of block headers is enabled (without additional block headers, validators won't understand which shards are useful for them)

## Links to any relevant issues

fixes #8767 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

