### PR TITLE
feat(consensus): move `MAX_HEADERS_PER_BUNDLE` to config parameters

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -60,14 +60,6 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_sync_last_known_own_block_timeout")]
     pub sync_last_known_own_block_timeout: Duration,
 
-    /// Interval in milliseconds to probe highest received rounds of peers.
-    #[serde(default = "Parameters::default_round_prober_interval_ms")]
-    pub round_prober_interval_ms: u64,
-
-    /// Timeout in milliseconds for a round prober request.
-    #[serde(default = "Parameters::default_round_prober_request_timeout_ms")]
-    pub round_prober_request_timeout_ms: u64,
-
     /// Proposing new block is stopped when the propagation delay is greater
     /// than this threshold. Propagation delay is the difference between the
     /// round of the last proposed block and the highest round from this
@@ -98,6 +90,16 @@ pub struct Parameters {
     // processed as consensus output, before throttling of outgoing commit fetches starts.
     #[serde(default = "Parameters::default_commit_sync_batches_ahead")]
     pub commit_sync_batches_ahead: usize,
+
+    /// Maximum number of headers to be included in a bundle. Headers exceeding
+    /// the max allowed limit will be truncated.
+    #[serde(default = "Parameters::default_max_headers_per_bundle")]
+    pub max_headers_per_bundle: usize,
+
+    /// Maximum number of transaction shards to be included in a bundle. Shards
+    /// exceeding the max allowed limit will be truncated.
+    #[serde(default = "Parameters::default_max_shards_per_bundle")]
+    pub max_shards_per_bundle: usize,
 
     /// Tonic network settings.
     #[serde(default = "TonicParameters::default")]
@@ -164,15 +166,6 @@ impl Parameters {
             Duration::from_secs(5)
         }
     }
-
-    pub(crate) fn default_round_prober_interval_ms() -> u64 {
-        if cfg!(msim) { 1000 } else { 5000 }
-    }
-
-    pub(crate) fn default_round_prober_request_timeout_ms() -> u64 {
-        if cfg!(msim) { 800 } else { 4000 }
-    }
-
     pub(crate) fn default_propagation_delay_stop_proposal_threshold() -> u32 {
         // Propagation delay is usually 0 round in production.
         if cfg!(msim) { 2 } else { 5 }
@@ -206,6 +199,14 @@ impl Parameters {
         // and unprocessed fetched commits limited.
         32
     }
+
+    pub(crate) fn default_max_headers_per_bundle() -> usize {
+        150
+    }
+
+    pub(crate) fn default_max_shards_per_bundle() -> usize {
+        150
+    }
 }
 
 impl Default for Parameters {
@@ -222,14 +223,14 @@ impl Default for Parameters {
             max_transactions_per_fetch: Parameters::default_max_transactions_per_fetch(),
             sync_last_known_own_block_timeout:
                 Parameters::default_sync_last_known_own_block_timeout(),
-            round_prober_interval_ms: Parameters::default_round_prober_interval_ms(),
-            round_prober_request_timeout_ms: Parameters::default_round_prober_request_timeout_ms(),
             propagation_delay_stop_proposal_threshold:
                 Parameters::default_propagation_delay_stop_proposal_threshold(),
             dag_state_cached_rounds: Parameters::default_dag_state_cached_rounds(),
             commit_sync_parallel_fetches: Parameters::default_commit_sync_parallel_fetches(),
             commit_sync_batch_size: Parameters::default_commit_sync_batch_size(),
             commit_sync_batches_ahead: Parameters::default_commit_sync_batches_ahead(),
+            max_headers_per_bundle: Parameters::default_max_headers_per_bundle(),
+            max_shards_per_bundle: Parameters::default_max_shards_per_bundle(),
             tonic: TonicParameters::default(),
         }
     }

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -17,13 +17,13 @@ max_transactions_per_fetch: 100
 sync_last_known_own_block_timeout:
   secs: 5
   nanos: 0
-round_prober_interval_ms: 5000
-round_prober_request_timeout_ms: 4000
 propagation_delay_stop_proposal_threshold: 5
 dag_state_cached_rounds: 500
 commit_sync_parallel_fetches: 8
 commit_sync_batch_size: 100
 commit_sync_batches_ahead: 32
+max_headers_per_bundle: 150
+max_shards_per_bundle: 150
 tonic:
   keepalive_interval:
     secs: 5

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -35,7 +35,7 @@ use crate::{
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
-    dag_state::{DagState, MAX_HEADERS_PER_BUNDLE, MAX_SHARDS_PER_BUNDLE},
+    dag_state::DagState,
     encoder::ShardEncoder,
     error::{ConsensusError, ConsensusResult},
     network::{
@@ -303,16 +303,22 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         // 4. Create block headers from bytes from a bundle
-
-        if serialized_block_bundle_parts.serialized_headers.len() > MAX_HEADERS_PER_BUNDLE {
-            return Err(ConsensusError::TooManyHeadersInABundle {
-                count: serialized_block_bundle_parts.serialized_headers.len(),
-                limit: MAX_HEADERS_PER_BUNDLE,
-            });
-        }
+        // 4.a. Truncate headers in bundle to max_headers_per_bundle
+        let serialized_headers = if serialized_block_bundle_parts.serialized_headers.len()
+            > self.context.parameters.max_headers_per_bundle
+        {
+            warn!("BlockBundle: {block_ref} exceeds max_headers_per_bundle.");
+            serialized_block_bundle_parts
+                .serialized_headers
+                .into_iter()
+                .take(self.context.parameters.max_headers_per_bundle)
+                .collect::<Vec<_>>()
+        } else {
+            serialized_block_bundle_parts.serialized_headers
+        };
 
         let mut additional_block_headers = vec![];
-        for serialized_header in serialized_block_bundle_parts.serialized_headers {
+        for serialized_header in serialized_headers {
             let digest = VerifiedBlockHeader::compute_digest(&serialized_header);
             if self.received_block_headers.contains(&digest) {
                 self.context
@@ -382,15 +388,22 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .inc_by(additional_block_headers.len() as u64);
 
         // 5. Collect shards from a bundle and check their proofs.
-        if serialized_block_bundle_parts.serialized_shards.len() > MAX_SHARDS_PER_BUNDLE {
-            return Err(ConsensusError::TooManyShardsInABundle {
-                count: serialized_block_bundle_parts.serialized_shards.len(),
-                limit: MAX_SHARDS_PER_BUNDLE,
-            });
-        }
+        // 5.a. Truncate shards in bundle to max_shards_per_bundle.
+        let serialized_shards = if serialized_block_bundle_parts.serialized_shards.len()
+            > self.context.parameters.max_shards_per_bundle
+        {
+            warn!("BlockBundle: {block_ref} exceeds max_shards_per_bundle.");
+            serialized_block_bundle_parts
+                .serialized_shards
+                .into_iter()
+                .take(self.context.parameters.max_shards_per_bundle)
+                .collect::<Vec<_>>()
+        } else {
+            serialized_block_bundle_parts.serialized_shards
+        };
 
         let mut verified_shards: Vec<ShardWithProof> = vec![];
-        for serialized_shard in serialized_block_bundle_parts.serialized_shards.iter() {
+        for serialized_shard in &serialized_shards {
             let shard: ShardWithProof =
                 bcs::from_bytes(serialized_shard).map_err(ConsensusError::MalformedShard)?;
 
@@ -1277,7 +1290,7 @@ mod tests {
         context::Context,
         core::{Core, CoreSignals},
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
-        dag_state::{DagState, MAX_HEADERS_PER_BUNDLE},
+        dag_state::DagState,
         encoder::create_encoder,
         error::{ConsensusError, ConsensusResult},
         leader_schedule::LeaderSchedule,
@@ -1653,8 +1666,7 @@ mod tests {
         let input_block = VerifiedBlock::new_for_test(
             TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build(),
         );
-        let num_of_block_headers = MAX_HEADERS_PER_BUNDLE + 1;
-        let mut headers = (0..num_of_block_headers)
+        let headers = (0..context.parameters.max_headers_per_bundle)
             .map(|i| {
                 VerifiedBlockHeader::new_for_test(
                     TestBlockHeader::new_with_commitment(
@@ -1667,35 +1679,9 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        let big_block_bundle = BlockBundle {
-            verified_block: input_block.clone(),
-            verified_headers: headers.clone(),
-            serialized_shards: vec![],
-            useful_authorities: (0u8..(committee_size as u8)).map(Into::into).collect(),
-        };
-        let serialized_big_block_bundle = SerializedBlockBundle::try_from(
-            SerializedBlockBundleParts::try_from(big_block_bundle).unwrap(),
-        )
-        .unwrap();
 
         let service = authority_service.clone();
 
-        // Send a bundle with too many headers
-        let result = authority_service
-            .handle_subscribed_block_bundle(
-                context.committee.to_authority_index(0).unwrap(),
-                serialized_big_block_bundle,
-                &mut encoder,
-            )
-            .await;
-
-        if let Err(ConsensusError::TooManyHeadersInABundle { .. }) = result {
-            // everything is fine
-        } else {
-            panic!("Expected TooManyHeadersInABundle error, got {result:?}");
-        }
-
-        headers.pop();
         let block_bundle_with_big_rounds = BlockBundle {
             verified_block: input_block.clone(),
             verified_headers: headers.clone(),
@@ -1725,7 +1711,7 @@ mod tests {
         // Create a block with a big round
         let input_block = VerifiedBlock::new_for_test(
             TestBlockHeader::new_with_commitment(
-                MAX_HEADERS_PER_BUNDLE as u32 + 1,
+                context.parameters.max_headers_per_bundle as u32 + 1,
                 0,
                 &context,
                 &mut encoder,

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -33,9 +33,6 @@ use crate::{
     threshold_clock::ThresholdClock,
 };
 
-pub(crate) const MAX_HEADERS_PER_BUNDLE: usize = 150;
-pub(crate) const MAX_SHARDS_PER_BUNDLE: usize = 150;
-
 /// DagState provides the API to write and read accepted blocks from the DAG.
 /// Only uncommitted and last committed blocks are cached in memory.
 /// The rest of blocks are stored on disk.
@@ -56,9 +53,10 @@ pub(crate) struct DagState {
     recent_block_headers: BTreeMap<BlockRef, VerifiedBlockHeader>,
 
     /// Contains recent transactions. It contains
-    /// MAX_TRANSACTIONS_ACK_DEPTH+MAX_LINEARIZER_DEPTH from the round of
-    /// the last consumed commit. Note: all transactions in blocks below that
-    /// round are evicted from memory.
+    /// MAX_TRANSACTIONS_ACK_DEPTH + MAX_LINEARIZER_DEPTH =
+    /// (protocol_config.gc_depth * 2) from the round of the last consumed
+    /// commit. Note: all transactions in blocks below that round are
+    /// evicted from memory.
     recent_transactions: BTreeMap<BlockRef, VerifiedTransactions>,
     /// Contains recent shards with their Merkle proofs.
     recent_shards: BTreeMap<BlockRef, Bytes>,
@@ -89,7 +87,8 @@ pub(crate) struct DagState {
     /// Round of the last committed leader which created a commit with available
     /// transactions. Does not persist across restarts and after recovery.
     /// All transactions below this round minus MAX_TRANSACTIONS_ACK_DEPTH
-    /// minus MAX_LINEARIZER_DEPTH are evicted from memory.
+    /// (protocol_config.gc_depth) minus MAX_LINEARIZER_DEPTH
+    /// (protocol_config.gc_depth) are evicted from memory.
     last_solid_commit_leader_round: Option<Round>,
 
     /// Rounds for latest blocks traversed by linearizer per authority.
@@ -1270,7 +1269,7 @@ impl DagState {
             );
             let nth_element = set
                 .iter()
-                .nth(MAX_HEADERS_PER_BUNDLE)
+                .nth(self.context.parameters.max_headers_per_bundle)
                 .map_or(round_bound, |x| *x);
             min(nth_element, round_bound)
         };
@@ -1289,10 +1288,10 @@ impl DagState {
         block_refs
     }
 
-    /// Removes and returns up to `MAX_HEADERS_PER_BUNDLE` block references that
-    /// the given authority has not yet seen, limited to rounds strictly
-    /// below `round_upper_bound_exclusive` and filtered by the provided authors
-    /// `useful_authorities`.
+    /// Removes and returns up to `context.parameters.max_headers_per_bundle`
+    /// block references that the given authority has not yet seen, limited
+    /// to rounds strictly below `round_upper_bound_exclusive` and filtered
+    /// by the provided authors `useful_authorities`.
     ///
     /// Side effects:
     /// - Updates `block_headers_not_known_by_authority` so these refs are no
@@ -1315,7 +1314,7 @@ impl DagState {
         let mut to_take = Vec::new();
 
         for block_ref in set.iter() {
-            if to_take.len() >= MAX_HEADERS_PER_BUNDLE
+            if to_take.len() >= self.context.parameters.max_headers_per_bundle
                 || block_ref.round >= round_upper_bound_exclusive
             {
                 break;
@@ -1405,7 +1404,7 @@ impl DagState {
             );
             let nth_element = set
                 .iter()
-                .nth(MAX_SHARDS_PER_BUNDLE)
+                .nth(self.context.parameters.max_shards_per_bundle)
                 .map_or(round_bound, |x| *x);
             min(nth_element, round_bound)
         };
@@ -1455,9 +1454,10 @@ impl DagState {
             .retain(|block_ref, _| block_ref.round > self.evicted_rounds[block_ref.author]);
     }
 
-    /// Function removes stalled transactions that are older than
-    /// "last consume leader round minus MAX_TRANSACTIONS_ACK_DEPTH minus
-    /// MAX_LINEARIZER_DEPTH"
+    /// Function removes stalled transactions that are older than  "last consume
+    /// leader round minus MAX_TRANSACTIONS_ACK_DEPTH
+    /// (protocol_config.gc_depth) minus MAX_LINEARIZER_DEPTH
+    /// (protocol_config.gc_depth)"
     pub(crate) fn evict_transactions(&mut self) {
         let transaction_gc_round = self.gc_round_for_last_solid_commit();
         let header_eviction_round = self.calculate_authority_eviction_round(self.context.own_index);

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -234,9 +234,6 @@ pub(crate) enum ConsensusError {
     #[error("Vector of shards is too small: {0} bytes found, at least {1} bytes needed")]
     ShardsVecIsTooSmall(usize, usize),
 
-    #[error("Block bundle contains too many additional headers: {count} > {limit}")]
-    TooManyHeadersInABundle { count: usize, limit: usize },
-
     #[error(
         "Round of the header in a bundle is greater or equal to the block round: {header_round} >= {block_round}"
     )]
@@ -244,9 +241,6 @@ pub(crate) enum ConsensusError {
         header_round: Round,
         block_round: Round,
     },
-
-    #[error("Block bundle contains too many shards: {count} > {limit}")]
-    TooManyShardsInABundle { count: usize, limit: usize },
 
     #[error("Block bundle from {peer} contains shard from round {round} with incorrect proof")]
     IncorrectShardProof { peer: AuthorityIndex, round: Round },


### PR DESCRIPTION
# Description of change

Move `MAX_HEADERS_PER_BUNDLE` and `MAX_SHARDS_PER_BUNDLE` to `starfish-config` crate.
- added `max_headers_per_bundle` config parameter
- added `max_shards_per_bundle` config parameter
- added default methods for both
- removed `round_prober_interval_ms` and `round_prober_request_timeout_ms` unused config parameters and their associated `default` methods
- changed code in `handle_subscribed_block_bundle` to truncated headers and shards exceeding limits.

## Links to any relevant issues

fixes #8766.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
