### PR TITLE
fix(graphql-rpc): Missing fields in graphql dryrun response

### DIFF
--- a/crates/iota-graphql-rpc/src/types/dry_run_result.rs
+++ b/crates/iota-graphql-rpc/src/types/dry_run_result.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::*;
-use iota_json_rpc_types::{DevInspectResults, IotaExecutionResult};
+use iota_json_rpc_types::{DevInspectResults, DryRunTransactionBlockResponse, IotaExecutionResult};
 use iota_types::{
     TypeTag, effects::TransactionEffects as NativeTransactionEffects,
     transaction::TransactionData as NativeTransactionData,
@@ -128,8 +128,15 @@ impl TryFrom<DevInspectResults> for DryRunResult {
         let transaction = Some(TransactionBlock {
             inner: TransactionBlockInner::DryRun {
                 tx_data,
-                effects,
+                native_effects: Some(effects.clone()),
+                rpc: effects.try_into().map_err(|e| {
+                    Error::Internal(format!(
+                        "Failed to convert native effects to RPC effects: {e}"
+                    ))
+                })?,
+                rpc_object_changes: Vec::new(), // DevInspectResults doesn't have object changes
                 events,
+                balance_changes: Vec::new(), // DevInspectResults doesn't have balance changes
             },
             // set to u64::MAX, as dry running a transaction makes use of a fullnode's state, which
             // is typically ahead of the indexed state.
@@ -137,6 +144,54 @@ impl TryFrom<DevInspectResults> for DryRunResult {
         });
         Ok(Self {
             error: dev_inspect_results.error,
+            results,
+            transaction,
+        })
+    }
+}
+
+impl DryRunResult {
+    pub fn from_dry_run_response(
+        dry_run_response: DryRunTransactionBlockResponse,
+        tx_data: NativeTransactionData,
+    ) -> Result<Self, crate::error::Error> {
+        // DryRunTransactionBlockResponse doesn't have execution results like DevInspectResults
+        let results = None;
+
+        let events = dry_run_response
+            .events
+            .data
+            .into_iter()
+            .map(|e| e.into())
+            .collect();
+
+        // Serialize balance changes for storage
+        let serialized_balance_changes: Result<Vec<Vec<u8>>, Error> = dry_run_response
+            .balance_changes
+            .iter()
+            .map(|bc| {
+                bcs::to_bytes(bc).map_err(|e| {
+                    Error::Internal(format!("Failed to serialize balance change: {e}"))
+                })
+            })
+            .collect();
+
+        let transaction = Some(TransactionBlock {
+            inner: TransactionBlockInner::DryRun {
+                tx_data,
+                native_effects: None,
+                rpc: dry_run_response.effects,
+                rpc_object_changes: dry_run_response.object_changes,
+                events,
+                balance_changes: serialized_balance_changes?,
+            },
+            // set to u64::MAX, as dry running a transaction makes use of a fullnode's state, which
+            // is typically ahead of the indexed state.
+            checkpoint_viewed_at: u64::MAX,
+        });
+
+        Ok(Self {
+            error: None, // DryRunTransactionBlockResponse doesn't have error field
             results,
             transaction,
         })

--- a/crates/iota-graphql-rpc/src/types/gas.rs
+++ b/crates/iota-graphql-rpc/src/types/gas.rs
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::{connection::Connection, *};
-use iota_types::{
-    effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
-    gas::GasCostSummary as NativeGasCostSummary,
-    transaction::GasData,
-};
+use iota_json_rpc_types::IotaTransactionBlockEffects;
+use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
+use iota_types::{gas::GasCostSummary as NativeGasCostSummary, transaction::GasData};
 
 use crate::types::{
     address::Address,
@@ -160,12 +158,15 @@ impl GasEffects {
     /// which this `GasEffects` was queried for. This is stored on
     /// `GasEffects` so that when viewing that entity's state, it will be as
     /// if it was read at the same checkpoint.
-    pub(crate) fn from(effects: &NativeTransactionEffects, checkpoint_viewed_at: u64) -> Self {
-        let ((id, version, _digest), _owner) = effects.gas_object();
+    pub(crate) fn from_rpc_effects(
+        effects: &IotaTransactionBlockEffects,
+        checkpoint_viewed_at: u64,
+    ) -> Self {
+        let gas_obj = effects.gas_object();
         Self {
             summary: GasCostSummary::from(effects.gas_cost_summary()),
-            object_id: IotaAddress::from(id),
-            object_version: version.value(),
+            object_id: IotaAddress::from(gas_obj.reference.object_id),
+            object_version: gas_obj.reference.version.value(),
             checkpoint_viewed_at,
         }
     }

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -13,7 +13,7 @@ use iota_types::{
     TypeTag,
     gas_coin::GAS,
     supported_protocol_versions::Chain,
-    transaction::{TransactionData, TransactionDataAPI, TransactionKind},
+    transaction::{TransactionData, TransactionKind},
 };
 use move_core_types::account_address::AccountAddress;
 use serde::de::DeserializeOwned;
@@ -190,17 +190,20 @@ impl Query {
                     gas_objects,
                 )
             } else {
-                // This implies `TransactionData`
+                // This implies `TransactionData` - use dry_run to get balance changes
                 let tx_data = deserialize_tx_data::<TransactionData>(&tx_bytes)?;
 
-                (
-                    tx_data.sender(),
-                    tx_data.clone().into_kind(),
-                    Some(tx_data.gas_price().into()),
-                    Some(tx_data.gas_owner()),
-                    Some(tx_data.gas_budget().into()),
-                    Some(tx_data.gas().to_vec()),
-                )
+                let tx_bytes_base64 =
+                    Base64::from_bytes(&bcs::to_bytes(&tx_data).map_err(|e| {
+                        Error::Client(format!("Failed to serialize transaction data: {e}"))
+                    })?);
+
+                let dry_run_response = write_api
+                    .dry_run_transaction_block(tx_bytes_base64)
+                    .await
+                    .map_err(|e| Error::Client(e.to_string()))?;
+
+                return DryRunResult::from_dry_run_response(dry_run_response, tx_data).extend();
             };
 
         let dev_inspect_args = DevInspectArgs {

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -2,8 +2,6 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashMap};
-
 use async_graphql::{connection::CursorType, dataloader::Loader, *};
 use connection::Edge;
 use cursor::TxLookup;
@@ -14,6 +12,7 @@ use iota_indexer::{
     schema::{optimistic_transactions, transactions, tx_digests, tx_global_order},
 };
 use iota_json_rpc_api::ReadApiClient;
+use iota_json_rpc_types::{IotaTransactionBlockEffects, ObjectChange as RpcObjectChange};
 use iota_types::{
     base_types::IotaAddress as NativeIotaAddress,
     effects::TransactionEffects as NativeTransactionEffects,
@@ -25,6 +24,7 @@ use iota_types::{
     },
 };
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
 
 use crate::{
     config::ServiceConfig,
@@ -84,8 +84,11 @@ pub(crate) enum TransactionBlockInner {
     /// `NativeTransactionData` is present.
     DryRun {
         tx_data: NativeTransactionData,
-        effects: NativeTransactionEffects,
+        native_effects: Option<NativeTransactionEffects>,
+        rpc: IotaTransactionBlockEffects,
+        rpc_object_changes: Vec<RpcObjectChange>,
         events: Vec<NativeEvent>,
+        balance_changes: Vec<Vec<u8>>,
     },
 }
 
@@ -651,12 +654,18 @@ impl TryFrom<TransactionBlockEffects> for TransactionBlock {
 
             TransactionBlockEffectsKind::DryRun {
                 tx_data,
-                native,
+                native_effects,
+                rpc,
+                rpc_object_changes,
                 events,
+                balance_changes,
             } => Ok(TransactionBlockInner::DryRun {
                 tx_data: tx_data.clone(),
-                effects: native.clone(),
+                native_effects: native_effects.clone(),
+                rpc: rpc.clone(),
+                rpc_object_changes: rpc_object_changes.clone(),
                 events: events.clone(),
+                balance_changes: balance_changes.clone(),
             }),
         }?;
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -8,9 +8,16 @@ use async_graphql::{
 };
 use fastcrypto::encoding::{Base64 as FBase64, Encoding};
 use iota_indexer::models::transactions::{OptimisticTransaction, StoredTransaction};
+use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
+use iota_json_rpc_types::{
+    IotaExecutionStatus, IotaTransactionBlockEffects, ObjectChange as RpcObjectChange,
+};
 use iota_package_resolver::{CleverError, ErrorConstants};
 use iota_types::{
-    effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
+    effects::{
+        ObjectChange as NativeObjectChange, TransactionEffects as NativeTransactionEffects,
+        TransactionEffectsAPI,
+    },
     event::Event as NativeEvent,
     execution_status::{
         ExecutionFailureStatus, ExecutionStatus as NativeExecutionStatus, MoveLocation,
@@ -61,12 +68,14 @@ pub(crate) enum TransactionBlockEffectsKind {
     Checkpointed {
         stored_tx: StoredTransaction,
         native: NativeTransactionEffects,
+        rpc: IotaTransactionBlockEffects,
     },
     /// A transaction block that has been executed and indexed without
     /// checkpoint information.
     Executed {
         optimistic_tx: OptimisticTransaction,
         native: NativeTransactionEffects,
+        rpc: IotaTransactionBlockEffects,
     },
 
     /// A transaction block that has been executed via dryRunTransactionBlock.
@@ -74,8 +83,11 @@ pub(crate) enum TransactionBlockEffectsKind {
     /// balanceChanges.
     DryRun {
         tx_data: NativeTransactionData,
-        native: NativeTransactionEffects,
+        native_effects: Option<NativeTransactionEffects>,
+        rpc: IotaTransactionBlockEffects,
+        rpc_object_changes: Vec<RpcObjectChange>,
         events: Vec<NativeEvent>,
+        balance_changes: Vec<Vec<u8>>,
     },
 }
 
@@ -109,9 +121,10 @@ impl TransactionBlockEffects {
 
     /// Whether the transaction executed successfully or not.
     async fn status(&self) -> Option<ExecutionStatus> {
-        Some(match self.native().status() {
-            NativeExecutionStatus::Success => ExecutionStatus::Success,
-            NativeExecutionStatus::Failure { .. } => ExecutionStatus::Failure,
+        let rpc = self.rpc();
+        Some(match rpc.status() {
+            IotaExecutionStatus::Success => ExecutionStatus::Success,
+            IotaExecutionStatus::Failure { .. } => ExecutionStatus::Failure,
         })
     }
 
@@ -119,7 +132,15 @@ impl TransactionBlockEffects {
     /// created or modified by this transaction, immediately following this
     /// transaction.
     async fn lamport_version(&self) -> UInt53 {
-        self.native().lamport_version().value().into()
+        let rpc = self.rpc();
+        let lamport_version = rpc
+            .created()
+            .iter()
+            .chain(rpc.mutated().iter())
+            .map(|obj| obj.reference.version)
+            .max()
+            .unwrap_or_else(|| 1.into());
+        lamport_version.value().into()
     }
 
     /// The reason for a transaction failure, if it did fail.
@@ -128,7 +149,22 @@ impl TransactionBlockEffects {
     /// displaying the abort code and location.
     async fn errors(&self, ctx: &Context<'_>) -> Result<Option<String>> {
         let resolver: &PackageResolver = ctx.data_unchecked();
-        let status = self.resolve_native_status_impl(resolver).await?;
+
+        // Check if native() is available for detailed error resolution
+        let status = if self.native().is_some() {
+            // Use the full resolve_native_status_impl for detailed error information
+            self.resolve_native_status_impl(resolver).await?
+        } else {
+            // Fall back to simple error string from rpc() when native() is None
+            match self.rpc().status() {
+                IotaExecutionStatus::Success => {
+                    return Ok(None);
+                }
+                IotaExecutionStatus::Failure { error } => {
+                    return Ok(Some(error.clone()));
+                }
+            }
+        };
 
         match status {
             NativeExecutionStatus::Success => Ok(None),
@@ -226,7 +262,8 @@ impl TransactionBlockEffects {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let mut connection = Connection::new(false, false);
 
-        let dependencies = self.native().dependencies();
+        let rpc = self.rpc();
+        let dependencies: Vec<_> = rpc.dependencies().to_vec();
 
         let Some(consistent_page) =
             page.paginate_consistent_indices(dependencies.len(), self.checkpoint_viewed_at)?
@@ -271,7 +308,10 @@ impl TransactionBlockEffects {
 
     /// Effects to the gas object.
     async fn gas_effects(&self) -> Option<GasEffects> {
-        Some(GasEffects::from(self.native(), self.checkpoint_viewed_at))
+        Some(GasEffects::from_rpc_effects(
+            self.rpc(),
+            self.checkpoint_viewed_at,
+        ))
     }
 
     /// Shared objects that are referenced by but not changed by this
@@ -287,7 +327,10 @@ impl TransactionBlockEffects {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let mut connection = Connection::new(false, false);
 
-        let input_shared_objects = self.native().input_shared_objects();
+        let input_shared_objects: Vec<_> = match self.native() {
+            Some(native) => native.input_shared_objects(),
+            None => return Ok(connection),
+        };
 
         let Some(consistent_page) = page
             .paginate_consistent_indices(input_shared_objects.len(), self.checkpoint_viewed_at)?
@@ -326,7 +369,27 @@ impl TransactionBlockEffects {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let mut connection = Connection::new(false, false);
 
-        let object_changes = self.native().object_changes();
+        let object_changes: Vec<_> = match &self.kind {
+            TransactionBlockEffectsKind::Checkpointed { native, .. }
+            | TransactionBlockEffectsKind::Executed { native, .. } => native.object_changes(),
+            TransactionBlockEffectsKind::DryRun {
+                native_effects,
+                rpc_object_changes,
+                ..
+            } => {
+                // Use native effects if available, otherwise convert RPC object changes
+                if let Some(native) = native_effects {
+                    native.object_changes()
+                } else if !rpc_object_changes.is_empty() {
+                    rpc_object_changes
+                        .iter()
+                        .map(Self::rpc_to_native_object_change)
+                        .collect()
+                } else {
+                    return Ok(connection);
+                }
+            }
+        };
 
         let Some(consistent_page) =
             page.paginate_consistent_indices(object_changes.len(), self.checkpoint_viewed_at)?
@@ -379,8 +442,9 @@ impl TransactionBlockEffects {
             TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
                 optimistic_tx.get_balance_len()
             }
-            // DryRun variant doesn't have balance changes available
-            _ => return Ok(connection),
+            TransactionBlockEffectsKind::DryRun {
+                balance_changes, ..
+            } => balance_changes.len(),
         };
 
         let Some(consistent_page) =
@@ -400,14 +464,16 @@ impl TransactionBlockEffects {
                 TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
                     optimistic_tx.get_balance_at_idx(c.ix)
                 }
-                _ => None,
+                TransactionBlockEffectsKind::DryRun {
+                    balance_changes, ..
+                } => balance_changes.get(c.ix).cloned(),
             };
 
             let Some(serialized) = serialized else {
                 continue;
             };
 
-            let balance_change = BalanceChange::read(&serialized, c.c).extend()?;
+            let balance_change = BalanceChange::read(serialized.as_slice(), c.c).extend()?;
             connection
                 .edges
                 .push(Edge::new(c.encode_cursor(), balance_change));
@@ -476,13 +542,10 @@ impl TransactionBlockEffects {
 
     /// The epoch this transaction was finalized in.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(
-            ctx,
-            Some(self.native().executed_epoch()),
-            self.checkpoint_viewed_at,
-        )
-        .await
-        .extend()
+        let rpc = self.rpc();
+        Epoch::query(ctx, Some(rpc.executed_epoch()), self.checkpoint_viewed_at)
+            .await
+            .extend()
     }
 
     /// The checkpoint this transaction was finalized in.
@@ -503,29 +566,49 @@ impl TransactionBlockEffects {
     }
 
     /// Base64 encoded bcs serialization of the on-chain transaction effects.
-    async fn bcs(&self) -> Result<Base64> {
+    async fn bcs(&self) -> Result<Option<Base64>> {
         let bytes = match &self.kind {
             TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
-                stored_tx.raw_effects.clone()
+                Some(stored_tx.raw_effects.clone())
             }
             TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
-                optimistic_tx.raw_effects.clone()
+                Some(optimistic_tx.raw_effects.clone())
             }
-            _ => bcs::to_bytes(&self.native())
-                .map_err(|e| Error::Internal(format!("Error serializing transaction effects: {e}")))
-                .extend()?,
+            TransactionBlockEffectsKind::DryRun { native_effects, .. } => {
+                // Only return BCS data if native effects are available
+                match native_effects {
+                    Some(native) => Some(
+                        bcs::to_bytes(native)
+                            .map_err(|e| {
+                                Error::Internal(format!(
+                                    "Error serializing transaction effects: {e}"
+                                ))
+                            })
+                            .extend()?,
+                    ),
+                    None => None,
+                }
+            }
         };
 
-        Ok(Base64::from(bytes))
+        Ok(bytes.map(Base64::from))
     }
 }
 
 impl TransactionBlockEffects {
-    fn native(&self) -> &NativeTransactionEffects {
+    fn rpc(&self) -> &IotaTransactionBlockEffects {
         match &self.kind {
-            TransactionBlockEffectsKind::Checkpointed { native, .. } => native,
-            TransactionBlockEffectsKind::DryRun { native, .. } => native,
-            TransactionBlockEffectsKind::Executed { native, .. } => native,
+            TransactionBlockEffectsKind::Checkpointed { rpc, .. } => rpc,
+            TransactionBlockEffectsKind::DryRun { rpc, .. } => rpc,
+            TransactionBlockEffectsKind::Executed { rpc, .. } => rpc,
+        }
+    }
+
+    fn native(&self) -> Option<&NativeTransactionEffects> {
+        match &self.kind {
+            TransactionBlockEffectsKind::Checkpointed { native, .. } => Some(native),
+            TransactionBlockEffectsKind::DryRun { native_effects, .. } => native_effects.as_ref(),
+            TransactionBlockEffectsKind::Executed { native, .. } => Some(native),
         }
     }
 
@@ -559,6 +642,75 @@ impl TransactionBlockEffects {
     ///   transaction, this will return Ok(None).
     /// * If the transaction was a programmable transaction, this will return
     ///   Ok(Some(tx)).
+    /// Convert RPC ObjectChange to native ObjectChange format
+    fn rpc_to_native_object_change(rpc_change: &RpcObjectChange) -> NativeObjectChange {
+        use iota_types::effects::IDOperation;
+
+        match rpc_change {
+            RpcObjectChange::Published { package_id, .. } => NativeObjectChange {
+                id: *package_id,
+                input_version: None,
+                input_digest: None,
+                output_version: Some(1u64.into()),
+                output_digest: None,
+                id_operation: IDOperation::Created,
+            },
+            RpcObjectChange::Transferred {
+                object_id, version, ..
+            } => NativeObjectChange {
+                id: *object_id,
+                input_version: None,
+                input_digest: None,
+                output_version: Some(*version),
+                output_digest: None,
+                id_operation: IDOperation::None,
+            },
+            RpcObjectChange::Mutated {
+                object_id,
+                version,
+                previous_version,
+                ..
+            } => NativeObjectChange {
+                id: *object_id,
+                input_version: Some(*previous_version),
+                input_digest: None,
+                output_version: Some(*version),
+                output_digest: None,
+                id_operation: IDOperation::None,
+            },
+            RpcObjectChange::Deleted {
+                object_id, version, ..
+            } => NativeObjectChange {
+                id: *object_id,
+                input_version: Some(*version),
+                input_digest: None,
+                output_version: None,
+                output_digest: None,
+                id_operation: IDOperation::Deleted,
+            },
+            RpcObjectChange::Wrapped {
+                object_id, version, ..
+            } => NativeObjectChange {
+                id: *object_id,
+                input_version: Some(*version),
+                input_digest: None,
+                output_version: None,
+                output_digest: None,
+                id_operation: IDOperation::Deleted,
+            },
+            RpcObjectChange::Created {
+                object_id, version, ..
+            } => NativeObjectChange {
+                id: *object_id,
+                input_version: None,
+                input_digest: None,
+                output_version: Some(*version),
+                output_digest: None,
+                id_operation: IDOperation::Created,
+            },
+        }
+    }
+
     fn programmable_transaction(&self) -> Result<Option<ProgrammableTransaction>> {
         let tx_data = self.transaction_data()?;
         match tx_data.into_kind() {
@@ -577,7 +729,7 @@ impl TransactionBlockEffects {
         &self,
         resolver: &PackageResolver,
     ) -> Result<NativeExecutionStatus> {
-        let mut status = self.native().status().clone();
+        let mut status = self.native().as_ref().unwrap().status().clone();
         if let NativeExecutionStatus::Failure {
             error:
                 ExecutionFailureStatus::MoveAbort(MoveLocation { module, .. }, _)
@@ -624,15 +776,22 @@ impl TryFrom<OptimisticTransaction> for TransactionBlockEffectsKind {
     type Error = Error;
 
     fn try_from(optimistic_tx: OptimisticTransaction) -> Result<Self, Error> {
-        let native = bcs::from_bytes(&optimistic_tx.raw_effects).map_err(|e| {
+        let native: NativeTransactionEffects = bcs::from_bytes(&optimistic_tx.raw_effects).map_err(|e| {
             Error::Internal(format!(
                 "Failed to deserialize NativeTransactionEffects from optimistic transaction: {e}"
+            ))
+        })?;
+
+        let rpc: IotaTransactionBlockEffects = native.clone().try_into().map_err(|e| {
+            Error::Internal(format!(
+                "Failed to convert native effects to RPC effects: {e}"
             ))
         })?;
 
         Ok(TransactionBlockEffectsKind::Executed {
             optimistic_tx,
             native,
+            rpc,
         })
     }
 }
@@ -656,14 +815,22 @@ impl TryFrom<TransactionBlock> for TransactionBlockEffectsKind {
     fn try_from(block: TransactionBlock) -> Result<Self, Error> {
         match block.inner {
             TransactionBlockInner::Checkpointed { stored_tx, .. } => {
-                bcs::from_bytes(&stored_tx.raw_effects)
-                    .map(|native| TransactionBlockEffectsKind::Checkpointed {
-                        stored_tx: stored_tx.clone(),
-                        native,
-                    })
+                let native: NativeTransactionEffects = bcs::from_bytes(&stored_tx.raw_effects)
                     .map_err(|e| {
                         Error::Internal(format!("Error deserializing transaction effects: {e}"))
-                    })
+                    })?;
+
+                let rpc: IotaTransactionBlockEffects = native.clone().try_into().map_err(|e| {
+                    Error::Internal(format!(
+                        "Failed to convert native effects to RPC effects: {e}"
+                    ))
+                })?;
+
+                Ok(TransactionBlockEffectsKind::Checkpointed {
+                    stored_tx: stored_tx.clone(),
+                    native,
+                    rpc,
+                })
             }
             TransactionBlockInner::Executed { optimistic_tx, .. } => {
                 TransactionBlockEffectsKind::try_from(optimistic_tx.clone())
@@ -671,12 +838,18 @@ impl TryFrom<TransactionBlock> for TransactionBlockEffectsKind {
 
             TransactionBlockInner::DryRun {
                 tx_data,
-                effects,
+                native_effects,
+                rpc,
+                rpc_object_changes,
                 events,
+                balance_changes,
             } => Ok(TransactionBlockEffectsKind::DryRun {
                 tx_data,
-                native: effects,
+                native_effects,
+                rpc,
+                rpc_object_changes,
                 events,
+                balance_changes,
             }),
         }
     }

--- a/crates/iota-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/iota-graphql-rpc/tests/e2e_tests.rs
@@ -724,6 +724,131 @@ mod tests {
                 }
             }
         }"#;
+
+        let query_new = r#"{
+          dryRunTransactionBlock(txBytes: $tx) {
+            transaction {
+                digest
+                indexedOnNode
+                sender {
+                    address
+                }
+                gasInput {
+                    gasSponsor {
+                        address
+                    }
+                    gasPrice
+                }
+                effects {
+                  transactionBlock {
+                    digest
+                  }
+                  status
+                  lamportVersion
+                  errors
+                  dependencies {
+                    edges {
+                      node {
+                        digest
+                      }
+                    }
+                  }
+                  gasEffects {
+                    gasObject {
+                      iotaNamesDefaultName
+                      digest
+                      storageRebate
+                      bcs
+                    }
+                    gasSummary {
+                      computationCost
+                      computationCostBurned
+                      storageCost
+                      storageRebate
+                      nonRefundableStorageFee
+                    }
+                  }
+
+                  unchangedSharedObjects {
+                    edges {
+                      node {
+                        __typename
+                      }
+                    }
+                  }
+                  objectChanges {
+                    edges {
+                      node {
+                        idCreated
+                        idDeleted
+                      }
+                    }
+                  }
+                  balanceChanges {
+                    edges {
+                      node {
+                        amount
+                      }
+                    }
+                  }
+                  events {
+                    edges {
+                      node {
+                        timestamp
+                      }
+                    }
+                  }
+                  timestamp
+                  epoch {
+                    referenceGasPrice
+                    endTimestamp
+                    totalCheckpoints
+                    totalTransactions
+                    totalGasFees
+                    totalStakeRewards
+                    fundSize
+                    netInflow
+                    fundInflow
+                    fundOutflow
+                    systemStateVersion
+                    iotaTotalSupply
+                    iotaTreasuryCapId
+                    liveObjectSetDigest
+                  }
+                  checkpoint {
+                    previousCheckpointDigest
+                    networkTotalTransactions
+                  }
+                }
+            }
+            error
+            results {
+              mutatedReferences {
+                input {
+                  __typename
+                  ... on Input {
+                    ix
+                  }
+                  ... on Result {
+                    cmd
+                    ix
+                  }
+                }
+                type {
+                  repr
+                }
+              }
+              returnValues {
+                type {
+                  repr
+                }
+                bcs
+              }
+            }
+
+          }
+        }"#;
+
         let variables = vec![GraphqlQueryVariable {
             name: "tx".to_string(),
             ty: "String!".to_string(),
@@ -731,7 +856,7 @@ mod tests {
         }];
         let res = cluster
             .graphql_client
-            .execute_to_graphql(query.to_string(), true, variables, vec![])
+            .execute_to_graphql(query_new.to_string(), true, variables, vec![])
             .await
             .unwrap();
         let binding = res.response_body().data.clone().into_json().unwrap();
@@ -752,7 +877,7 @@ mod tests {
         assert_eq!(sender_read, sender.to_string());
         let indexed_on_node = tx.get("indexedOnNode").unwrap().as_bool().unwrap();
         assert!(!indexed_on_node);
-        assert!(res.get("results").unwrap().is_array());
+        assert!(res.get("results").unwrap().is_null(), "{}", res);
         cluster.cleanup_resources().await
     }
 

--- a/sdk/graphql-transport/test/compatibility.test.ts
+++ b/sdk/graphql-transport/test/compatibility.test.ts
@@ -654,7 +654,7 @@ describe('GraphQL IotaClient compatibility', () => {
     });
 
     // TODO: Skipped because of GraphQL inconsistencies in the implementation, see https://github.com/iotaledger/iota/issues/7323
-    test.skip('dryRunTransactionBlock', async () => {
+    test('dryRunTransactionBlock', async () => {
         const tx = new Transaction();
         tx.setSender(toolbox.address());
         const [coin] = tx.splitCoins(tx.gas, [1]);


### PR DESCRIPTION
# Description of change

Missing fields in graphql dryrun response

## Links to any relevant issues

related to https://github.com/iotaledger/iota/issues/7323

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
