### PR TITLE
feat(consensus): add `consensus_max_acknowledgments_per_block` to `iota-protocol-config`

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1458,6 +1458,7 @@
                   "u64": "20"
                 },
                 "consensus_gc_depth": null,
+                "consensus_max_acknowledgments_per_block": null,
                 "consensus_max_num_transactions_in_block": {
                   "u64": "512"
                 },

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1135,6 +1135,13 @@ pub struct ProtocolConfig {
     /// Configures the garbage collection depth for consensus. When is unset or
     /// `0` then the garbage collection is disabled.
     consensus_gc_depth: Option<u32>,
+
+    /// Configures the maximum number of acknowledgments to be included in a
+    /// block. It must be reasonably larger than the number of validators
+    /// because not all validators create their blocks at the same pace.
+    /// Default value set to 400. (5 x expected committee size (80)).
+    /// Applicable only to `starfish` consensus.
+    consensus_max_acknowledgments_per_block: Option<u32>,
 }
 
 // feature flags
@@ -1295,6 +1302,10 @@ impl ProtocolConfig {
             "The consensus linearize sub dag V2 requires GC to be enabled"
         );
         res
+    }
+
+    pub fn consensus_max_acknowledgments_per_block_or_default(&self) -> u32 {
+        self.consensus_max_acknowledgments_per_block.unwrap_or(400)
     }
 
     pub fn variant_nodes(&self) -> bool {
@@ -1941,6 +1952,8 @@ impl ProtocolConfig {
             max_committee_members_count: None,
 
             consensus_gc_depth: None,
+
+            consensus_max_acknowledgments_per_block: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -53,15 +53,6 @@ use crate::{
 // TODO: Move to protocol config, and verify in BlockVerifier.
 const MAX_COMMIT_VOTES_PER_BLOCK: usize = 100;
 
-// Maximum number of acknowledgments to be included in a block. It must be
-// reasonably larger than the number of validators because not all validators
-// create their blocks at the same pace. For now we set it as a
-// constant to not make the block header size too large.
-// TODO: https://github.com/iotaledger/iota/issues/8378
-// After testing decide how to compress acknowledgments and move to a
-// protocol config
-const MAX_ACKNOWLEDGMENTS_PER_BLOCK: usize = 400;
-
 pub(crate) struct Core {
     context: Arc<Context>,
     /// The consumer to use in order to pull transactions to be included for the
@@ -677,10 +668,11 @@ impl Core {
 
         // Consume the acknowledgments about transaction data availability for past
         // blocks to be included.
-        let acknowledgments = self
-            .dag_state
-            .write()
-            .take_acknowledgments(MAX_ACKNOWLEDGMENTS_PER_BLOCK);
+        let acknowledgments = self.dag_state.write().take_acknowledgments(
+            self.context
+                .protocol_config
+                .consensus_max_acknowledgments_per_block_or_default() as usize,
+        );
 
         self.context
             .metrics


### PR DESCRIPTION
# Description of change

Moved `MAX_ACKNOWLEDGMENTS_PER_BLOCK` parameter used in starfish consensus to the `iota-protocol-config`.
- added `consensus_max_acknowledgments_per_block` parameter to `iota-protocol-config`
- added `consensus_max_acknowledgments_per_block_or_default` getter method to default to the currently used value.
- replaced usage of `MAX_ACKNOWLEDGMENTS_PER_BLOCK` in starfish to `protocol_config.consensus_max_acknowledgments_per_block_or_default`

## Links to any relevant issues

fixes #8378.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol:
  - added `consensus_max_acknowledgments_per_block` parameter used in starfish consensus
  - added `consensus_max_acknowledgments_per_block_or_default` getter method to default to the currently used value.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
