### PR TITLE
feat(move-package-alt): Add some initial infra for insta test for parsing valid move toml files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9256,7 +9256,7 @@ dependencies = [
  "serde_yaml",
  "similar",
  "tempfile",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.27",
  "walkdir",
 ]
 
@@ -9507,7 +9507,7 @@ dependencies = [
  "sha2 0.9.9",
  "tempfile",
  "toml 0.5.11",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.27",
  "treeline",
  "vfs",
  "walkdir",
@@ -9523,7 +9523,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml 0.5.11",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -12975,9 +12975,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -14553,18 +14553,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
-dependencies = [
- "combine",
- "indexmap 1.9.3",
- "itertools 0.10.5",
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
@@ -14596,6 +14584,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.11.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "toml_write",
  "winnow 0.7.11",

--- a/crates/iota-package-alt/src/iota_flavor.rs
+++ b/crates/iota-package-alt/src/iota_flavor.rs
@@ -12,12 +12,13 @@ use move_package_alt::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename = "kebab-case")]
 pub struct OnChainDependency {
     on_chain: bool,
 }
 
+#[derive(Debug)]
 pub struct IotaFlavor;
 
 impl MoveFlavor for IotaFlavor {

--- a/dprint.json
+++ b/dprint.json
@@ -18,7 +18,8 @@
     "crates/iota-graphql-rpc/docs/examples.md",
     "**/pnpm-lock.yaml",
     "external-crates/move/crates/move-stdlib/**/docs/**/*.md",
-    "crates/iota/src/unit_tests/fixtures/*"
+    "crates/iota/src/unit_tests/fixtures/*",
+    "external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment2/Move.toml"
   ],
   "toml": {
     "lineWidth": 80

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2235,8 +2235,11 @@ name = "move-package-alt"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "datatest-stable",
  "derive-where",
+ "insta",
  "lazy-regex",
+ "move-command-line-common",
  "serde",
  "serde_spanned",
  "toml",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -563,16 +563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,7 +1888,7 @@ dependencies = [
  "serde_yaml",
  "similar",
  "tempfile",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.27",
  "walkdir",
 ]
 
@@ -2223,7 +2213,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "toml",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.27",
  "treeline",
  "vfs",
  "walkdir",
@@ -2243,7 +2233,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3384,6 +3374,9 @@ name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde_with"
@@ -3871,16 +3864,7 @@ name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-
-[[package]]
-name = "toml_edit"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
 dependencies = [
- "combine",
- "indexmap 1.9.3",
- "itertools 0.10.5",
  "serde",
 ]
 
@@ -3892,8 +3876,28 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.11.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.11.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -4521,6 +4525,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -92,7 +92,7 @@ serde-name = "0.1.1"
 serde-reflection = "0.4"
 serde_bytes = "0.11.5"
 serde_json = "1.0.64"
-serde_spanned = "0.6.8"
+serde_spanned = { version = "0.6.8", features = ["serde"] }
 serde_with = "3.9.0"
 serde_yaml = "0.8.26"
 sha2 = "0.9.3"
@@ -112,7 +112,7 @@ thiserror = "1.0.24"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 tokio = { version = "1.46.1", features = ["full"] }
 toml = "0.5.8"
-toml_edit = { version = "0.14.3", features = ["easy"] }
+toml_edit =  { version = "0.22.24", features = ["serde", "default"] }
 tracing = "0.1.26"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 treeline = "0.1.0"

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -91,7 +91,7 @@ serde-name = "0.1.1"
 serde-reflection = "0.4"
 serde_bytes = "0.11.5"
 serde_json = "1.0.64"
-serde_spanned = { version = "0.6.8", features = ["serde"] }
+serde_spanned = { version = "0.6.9", features = ["serde"] }
 serde_with = "3.9.0"
 serde_yaml = "0.8.26"
 sha2 = "0.9.3"

--- a/external-crates/move/crates/move-package-alt/Cargo.toml
+++ b/external-crates/move/crates/move-package-alt/Cargo.toml
@@ -15,5 +15,14 @@ serde_spanned.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
 
+[dev-dependencies]
+datatest-stable.workspace = true
+insta.workspace = true
+move-command-line-common.workspace = true
+
+[[test]]
+name = "manifest_parsing_tests"
+harness = false
+
 [package.metadata.cargo-udeps.ignore]
 normal = ["serde", "serde_spanned", "toml", "toml_edit"]

--- a/external-crates/move/crates/move-package-alt/Cargo.toml
+++ b/external-crates/move/crates/move-package-alt/Cargo.toml
@@ -23,6 +23,3 @@ move-command-line-common.workspace = true
 [[test]]
 name = "manifest_parsing_tests"
 harness = false
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["serde", "serde_spanned", "toml", "toml_edit"]

--- a/external-crates/move/crates/move-package-alt/src/dependency/external.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/external.rs
@@ -5,7 +5,7 @@
 
 //! Types and methods for external dependencies (of the form `{ r.<res> = data }`)
 
-use std::{collections::BTreeMap, path::Path};
+use std::{collections::BTreeMap, fmt::Debug, path::Path};
 
 use serde::{Deserialize, Serialize};
 use serde_spanned::Spanned;
@@ -20,7 +20,7 @@ use super::PinnedDependencyInfo;
 /// An external dependency has the form `{ r.<res> = "<data>" }`; it is resolved by invoking the
 /// binary `<res>` (from the `PATH`), and passing `<data>` on the command line. The binary is
 /// expected to output a single resolved dependency on the command line.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ExternalDependency {
     /// Should be a table with a single entry; the name of the entry is the resolver binary to run
     /// and the value should be the argument passed to the resolver

--- a/external-crates/move/crates/move-package-alt/src/dependency/git.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/git.rs
@@ -7,7 +7,7 @@
 //!
 //! Git dependencies are cached in `~/.move`, which has the following structure:
 //!
-//! ```
+//! ```ignore
 //! .move/
 //!   git/
 //!     <remote 1>/ # a headless, sparse, and shallow git repository
@@ -18,7 +18,6 @@
 //!       ...
 //!     ...
 //! ```
-
 use std::{marker::PhantomData, path::PathBuf};
 
 use derive_where::derive_where;
@@ -28,18 +27,17 @@ use crate::errors::PackageResult;
 
 use super::{Pinned, Unpinned};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[derive_where(Clone)]
 pub struct GitDependency<P = Unpinned> {
-    /// The repository holding the dep
-    repo: String,
-
     /// The git commit-ish for the dep; guaranteed to be a commit if [P] is [Pinned].
+    #[serde(rename = "git")]
+    repo: String,
     rev: String,
 
     /// The path within the repository
-    path: PathBuf,
-
+    path: Option<PathBuf>,
+    #[serde(skip)]
     phantom: PhantomData<P>,
 }
 

--- a/external-crates/move/crates/move-package-alt/src/dependency/local.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/local.rs
@@ -12,7 +12,7 @@ use serde_spanned::Spanned;
 
 use crate::errors::Located;
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LocalDependency {
     /// The path on the filesystem, relative to the location of the containing file (which is
     /// stored in the `Located` wrapper)

--- a/external-crates/move/crates/move-package-alt/src/dependency/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/mod.rs
@@ -7,21 +7,23 @@ mod external;
 mod git;
 mod local;
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt::Debug};
 
+use derive_where::derive_where;
 use serde::{Deserialize, Serialize};
 
 use crate::{errors::PackageResult, flavor::MoveFlavor, package::PackageName};
 
-use derive_where::derive_where;
 use external::ExternalDependency;
 use git::GitDependency;
 use local::LocalDependency;
 
 /// Phantom type to represent pinned dependencies (see [PinnedDependency])
+#[derive(Debug)]
 pub struct Pinned;
 
 /// Phantom type to represent unpinned dependencies (see [ManifestDependencyInfo])
+#[derive(Debug)]
 pub struct Unpinned;
 
 /// [ManifestDependencyInfo]s contain the dependency-type-specific things that users write in their
@@ -31,8 +33,9 @@ pub struct Unpinned;
 /// that are not part of the ManifestDependencyInfo. We separate these partly because these things
 /// are not serialized to the Lock file. See [crate::package::manifest] for the full representation
 /// of an entry in the `dependencies` table.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[derive_where(Clone)]
+#[serde(untagged)]
 pub enum ManifestDependencyInfo<F: MoveFlavor> {
     Git(GitDependency<Unpinned>),
     External(ExternalDependency),
@@ -49,7 +52,7 @@ pub enum ManifestDependencyInfo<F: MoveFlavor> {
 /// development, because the developer would expect to use the latest code without having to
 /// explicitly repin, but we need to convert them to persistent dependencies when we publish since
 /// we want to retain that information for source verification.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[derive_where(Clone)]
 pub enum PinnedDependencyInfo<F: MoveFlavor + ?Sized> {
     Git(GitDependency<Pinned>),

--- a/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
@@ -9,6 +9,7 @@ pub use vanilla::Vanilla;
 
 use std::{
     collections::BTreeMap,
+    fmt::Debug,
     path::{Path, PathBuf},
 };
 
@@ -23,13 +24,13 @@ use crate::{
 /// A [MoveFlavor] is used to parameterize the package management system. It defines the types and
 /// methods for package management that are specific to a particular instantiation of the Move
 /// language.
-pub trait MoveFlavor {
+pub trait MoveFlavor: Debug {
     // TODO: this API is incomplete
 
     /// Additional flavor-specific dependency types. Currently we only support flavor-specific
     /// dependencies that are already pinned (although in principle you could use an
     /// external resolved to do resolution and pinning for flavor-specific deps)
-    type FlavorDependency<P: ?Sized>: Serialize + DeserializeOwned + Clone;
+    type FlavorDependency<P: ?Sized>: Debug + Serialize + DeserializeOwned + Clone;
 
     /// Pin a batch of [Self::FlavorDependency]s (see TODO). The keys of the returned map should be
     /// the same as the keys of [dep].
@@ -50,20 +51,20 @@ pub trait MoveFlavor {
     /// during publication.
     //
     // TODO: should this include object IDs, or is that generic for Move? What about build config?
-    type PublishedMetadata: Serialize + DeserializeOwned + Clone;
+    type PublishedMetadata: Debug + Serialize + DeserializeOwned + Clone;
 
     /// A [PackageMetadata] encapsulates the additional package information that can be stored in
     /// the `package` section of the manifest
-    type PackageMetadata: Serialize + DeserializeOwned + Clone;
+    type PackageMetadata: Debug + Serialize + DeserializeOwned + Clone;
 
     /// An [AddressInfo] should give a unique identifier for a compiled package
-    type AddressInfo: Serialize + DeserializeOwned + Clone;
+    type AddressInfo: Debug + Serialize + DeserializeOwned + Clone;
 
     /// An [EnvironmentID] uniquely identifies a place that a package can be published. For
     /// example, an environment ID might be a chain identifier
     //
     // TODO: Given an [EnvironmentID] and an [ObjectID], ... should be uniquely determined
-    type EnvironmentID: Serialize + DeserializeOwned + Clone + Eq;
+    type EnvironmentID: Debug + Serialize + DeserializeOwned + Clone + Eq;
 
     /// Return the implicit dependencies for a given environment
     fn implicit_deps(&self, environment: Self::EnvironmentID) -> Vec<PinnedDependencyInfo<Self>>;

--- a/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
@@ -25,6 +25,7 @@ use super::MoveFlavor;
 
 /// The [Vanilla] implementation of the [MoveFlavor] trait. This implementation supports no
 /// flavor-specific resolvers and stores no additional metadata in the lockfile.
+#[derive(Debug)]
 pub struct Vanilla;
 
 impl MoveFlavor for Vanilla {

--- a/external-crates/move/crates/move-package-alt/src/package/lockfile.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/lockfile.rs
@@ -5,6 +5,7 @@
 use std::{
     collections::BTreeMap,
     ffi::OsString,
+    fmt,
     fs::read_to_string,
     path::{Path, PathBuf},
 };
@@ -26,45 +27,45 @@ use crate::{
 
 use super::{EnvironmentName, PackageName};
 
-#[derive(Serialize, Deserialize)]
+#[derive(fmt::Debug, Serialize, Deserialize)]
 #[derive_where(Clone, Default)]
 #[serde(bound = "")]
-pub struct Lockfile<F: MoveFlavor> {
+pub struct Lockfile<F: MoveFlavor + fmt::Debug> {
     unpublished: UnpublishedTable<F>,
 
     #[serde(default)]
     published: BTreeMap<EnvironmentName, Publication<F>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(fmt::Debug, Serialize, Deserialize)]
 #[derive_where(Clone)]
 #[serde(bound = "")]
-pub struct Publication<F: MoveFlavor> {
+pub struct Publication<F: MoveFlavor + fmt::Debug> {
     #[serde(flatten)]
     metadata: F::PublishedMetadata,
     dependencies: BTreeMap<PackageName, PinnedDependencyInfo<F>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(fmt::Debug, Serialize, Deserialize)]
 #[derive_where(Default, Clone)]
 #[serde(rename_all = "kebab-case")]
 #[serde(bound = "")]
-struct UnpublishedTable<F: MoveFlavor> {
+struct UnpublishedTable<F: MoveFlavor + fmt::Debug> {
     dependencies: UnpublishedDependencies<F>,
 
     #[serde(default)]
     dep_overrides: BTreeMap<EnvironmentName, UnpublishedDependencies<F>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(fmt::Debug, Serialize, Deserialize)]
 #[derive_where(Default, Clone)]
 #[serde(bound = "")]
-struct UnpublishedDependencies<F: MoveFlavor> {
+struct UnpublishedDependencies<F: MoveFlavor + fmt::Debug> {
     pinned: BTreeMap<PackageName, PinnedDependencyInfo<F>>,
     unpinned: BTreeMap<PackageName, ManifestDependencyInfo<F>>,
 }
 
-impl<F: MoveFlavor> Lockfile<F> {
+impl<F: MoveFlavor + fmt::Debug> Lockfile<F> {
     /// Read `Move.lock` and all `Move.<env>.lock` files from the directory at `path`.
     /// Returns a new empty [Lockfile] if `path` doesn't contain a `Move.lock`.
     pub fn read_from(path: impl AsRef<Path>) -> anyhow::Result<Self> {
@@ -161,7 +162,7 @@ impl<F: MoveFlavor> Lockfile<F> {
     }
 }
 
-impl<F: MoveFlavor> Publication<F> {
+impl<F: MoveFlavor + fmt::Debug> Publication<F> {
     /// Pretty-print [self] as TOML
     fn render(&self) -> String {
         let mut toml = toml_edit::ser::to_document(self).expect("toml serialization succeeds");

--- a/external-crates/move/crates/move-package-alt/src/package/manifest.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/manifest.rs
@@ -3,8 +3,12 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    fmt::{Debug, Display, Formatter},
+};
 
+use derive_where::derive_where;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -17,8 +21,9 @@ use super::*;
 // Note: [Manifest] objects are immutable and should not implement [serde::Serialize]; any tool
 // writing these files should use [toml_edit] to set / preserve the formatting, since these are
 // user-editable files
-#[derive(Deserialize)]
-#[serde(rename = "kebab-case")]
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
 #[serde(bound = "")]
 pub struct Manifest<F: MoveFlavor> {
     package: PackageMetadata<F>,
@@ -29,7 +34,7 @@ pub struct Manifest<F: MoveFlavor> {
     dep_overrides: BTreeMap<EnvironmentName, BTreeMap<PackageName, ManifestDependencyOverride<F>>>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(bound = "")]
 struct PackageMetadata<F: MoveFlavor> {
     name: PackageName,
@@ -39,7 +44,7 @@ struct PackageMetadata<F: MoveFlavor> {
     metadata: F::PackageMetadata,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(bound = "")]
 #[serde(rename_all = "kebab-case")]
 struct ManifestDependency<F: MoveFlavor> {
@@ -53,7 +58,7 @@ struct ManifestDependency<F: MoveFlavor> {
     rename_from: Option<PackageName>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(bound = "")]
 #[serde(rename_all = "kebab-case")]
 struct ManifestDependencyOverride<F: MoveFlavor> {
@@ -68,7 +73,7 @@ struct ManifestDependencyOverride<F: MoveFlavor> {
 }
 
 impl<F: MoveFlavor> Manifest<F> {
-    fn read_from(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+    pub fn read_from(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let contents = std::fs::read_to_string(path)?;
         Ok(toml_edit::de::from_str(&contents)?)
     }

--- a/external-crates/move/crates/move-package-alt/src/package/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/mod.rs
@@ -7,6 +7,7 @@ pub mod lockfile;
 pub mod manifest;
 
 use std::{
+    fmt::Debug,
     marker::PhantomData,
     path::{Path, PathBuf},
 };

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 8, column 11
+  |
+8 | mainnet = 9123
+  |           ^^^^
+invalid type: integer `9123`, expected a string

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment/Move.toml
@@ -1,7 +1,6 @@
 [package]
 name = "example"
 edition = "2024.beta"
-version = "1.25.0"
 license = "Apache-2.0"
 authors = ["Move Team"]
 

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment1/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment1/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 8, column 11
+  |
+8 | mainnet = true
+  |           ^^^^
+invalid type: boolean `true`, expected a string

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment1/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment1/Move.toml
@@ -1,7 +1,6 @@
 [package]
 name = "example"
 edition = "2024.beta"
-version = "1.25.0"
 license = "Apache-2.0"
 authors = ["Move Team"]
 

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment2/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment2/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 8, column 1
+  |
+8 | ~124512 = "35834a8a"
+  | ^
+invalid key

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment2/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_invalid_environment2/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example"
+edition = "2024.beta"
+license = "Apache-2.0"
+authors = ["Move Team"]
+
+[environments]
+~124512 = "35834a8a"
+

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_missing_dep_override_git/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_missing_dep_override_git/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 12, column 41
+   |
+12 | foo = { rename-from = "Foo", override = "true", rev = "releases/v1", git = "https://example.com/foo.git" }
+   |                                         ^^^^^^
+invalid type: string "true", expected a boolean

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_missing_git_dep/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_missing_git_dep/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 11, column 7
+   |
+11 | foo = { rename-from = "Foo", override = true, rev = "releases/v1" }
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+data did not match any variant of untagged enum ManifestDependencyInfo

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_missing_git_dep/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/basic_missing_git_dep/Move.toml
@@ -6,7 +6,6 @@ authors = ["Move Team"]
 
 [environments]
 mainnet = "35834a8a"
-testnet = "4c78adac"
 
 [dependencies]
-foo = { rename-from = "Foo", override = "true", rev = "releases/v1" }
+foo = { rename-from = "Foo", override = true, rev = "releases/v1" }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/duplicate_top_level_field/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/duplicate_top_level_field/Move.snap
@@ -1,0 +1,9 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 5, column 1
+  |
+5 | [package]
+  | ^
+invalid table header
+duplicate key `package` in document root

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/duplicate_top_level_field/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/duplicate_top_level_field/Move.toml
@@ -1,4 +1,5 @@
 [package]
 name = "name"
+edition = "2024.beta"
 
 [package]

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/integer_subst_in_dependency/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/integer_subst_in_dependency/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 9, column 34
+  |
+9 | A = { local = "a", rename-from = { "A" = 1 } }
+  |                                  ^^^^^^^^^^^
+invalid type: map, expected a string

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/integer_subst_in_dependency/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/integer_subst_in_dependency/Move.toml
@@ -1,5 +1,9 @@
 [package]
 name = "name"
+edition = "2024.beta"
+
+[environments]
+mainnet = "35834a8a"
 
 [dependencies]
 A = { local = "a", rename-from = { "A" = 1 } }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_author/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_author/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "name", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_author/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_author/Move.toml
@@ -1,3 +1,7 @@
 [package]
 name = "name"
+edition = "2024.beta"
 authors = [1]
+
+[environments]
+mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_authors/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_authors/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "name", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_authors/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_authors/Move.toml
@@ -1,3 +1,7 @@
 [package]
 name = "name"
+edition = "2024.beta"
 authors = "nope"
+
+[environments]
+mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_hex_address_in_subst/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_hex_address_in_subst/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 6, column 34
+  |
+6 | A = { local = "a", rename-from = { "A" = "0xG" } }
+  |                                  ^^^^^^^^^^^^^^^
+invalid type: map, expected a string

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_hex_address_in_subst/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_hex_address_in_subst/Move.toml
@@ -1,5 +1,6 @@
 [package]
 name = "name"
+edition = "2024.beta"
 
 [dependencies]
 A = { local = "a", rename-from = { "A" = "0xG" } }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_identifier_package_name/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_identifier_package_name/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "®´∑œ", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_identifier_package_name/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/invalid_identifier_package_name/Move.toml
@@ -1,2 +1,6 @@
 [package]
 name = "®´∑œ"
+edition = "2024.beta"
+
+[environments]
+mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_minimal_required_field_name/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_minimal_required_field_name/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 1, column 1
+  |
+1 | [package]
+  | ^^^^^^^^^
+missing field `name`

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_minimal_required_field_name/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_minimal_required_field_name/Move.toml
@@ -1,2 +1,3 @@
 [package]
+edition = "2024.beta"
 version = "0.1.1"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_required_envs_segment/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_required_envs_segment/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 1, column 1
+  |
+1 | [package]
+  | ^
+missing field `environments`

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_required_envs_segment/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_required_envs_segment/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "test"
+edition = "2024"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_required_package_segment/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_required_package_segment/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 1, column 1
+  |
+1 | [dependencies]
+  | ^
+missing field `package`

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_required_package_segment/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/missing_required_package_segment/Move.toml
@@ -1,11 +1,2 @@
-name = "name"
-license = "license"
-authors = ["some author"]
-
 [dependencies]
 A = { local = "../a" }
-B = { local = "../b", rename-from = { "a" = "0xDEADBEEF" } }
-C = { local = "../some_path", rename-from = { "a" = "0xCAFE", d = "0x4" } }
-D = { local = "../some_path", rename-from = { "a" = "0xCAFE", C = "B" } }
-E = { local = "../some_path", rename-from = { "a" = "0xCAFE", C = "B", "OtherD" = "d" } }
-F = { local = "../some_path", rename-from = { "a" = "0xCAFE" } }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/no_path_set_for_dependency/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/no_path_set_for_dependency/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 6, column 5
+  |
+6 | A = { }
+  |     ^^^
+data did not match any variant of untagged enum ManifestDependencyInfo

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/no_path_set_for_dependency/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/no_path_set_for_dependency/Move.snap
@@ -3,6 +3,6 @@ source: crates/move-package-alt/tests/manifest_parsing_tests.rs
 ---
 TOML parse error at line 6, column 5
   |
-6 | A = { }
-  |     ^^^
+6 | A = {}
+  |     ^^
 data did not match any variant of untagged enum ManifestDependencyInfo

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/no_path_set_for_dependency/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/no_path_set_for_dependency/Move.toml
@@ -1,5 +1,6 @@
 [package]
 name = "name"
+edition = "2024.beta"
 
 [dependencies]
 A = {}

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_identifier_address_name_in_subst/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_identifier_address_name_in_subst/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 6, column 34
+  |
+6 | A = { local = "a", rename-from = { "©" = "A"  } }
+  |                                  ^^^^^^^^^^^^^^^
+invalid type: map, expected a string

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_identifier_address_name_in_subst/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_identifier_address_name_in_subst/Move.snap
@@ -3,6 +3,6 @@ source: crates/move-package-alt/tests/manifest_parsing_tests.rs
 ---
 TOML parse error at line 6, column 34
   |
-6 | A = { local = "a", rename-from = { "©" = "A"  } }
-  |                                  ^^^^^^^^^^^^^^^
+6 | A = { local = "a", rename-from = { "©" = "A" } }
+  |                                  ^^^^^^^^^^^^^^
 invalid type: map, expected a string

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_identifier_address_name_in_subst/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_identifier_address_name_in_subst/Move.toml
@@ -1,5 +1,6 @@
 [package]
 name = "name"
+edition = "2024.beta"
 
 [dependencies]
 A = { local = "a", rename-from = { "©" = "A" } }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_string_local_dep_path/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_string_local_dep_path/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 6, column 5
+  |
+6 | A = { local = 1 }
+  |     ^^^^^^^^^^^^^
+data did not match any variant of untagged enum ManifestDependencyInfo

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_string_local_dep_path/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_string_local_dep_path/Move.toml
@@ -1,5 +1,6 @@
 [package]
 name = "name"
+edition = "2024.beta"
 
 [dependencies]
 A = { local = 1 }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_string_package_name/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/non_string_package_name/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 2, column 8
+  |
+2 | name = 1
+  |        ^
+invalid type: integer `1`, expected a string

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/too_many_entries_renaming_instantiation/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/too_many_entries_renaming_instantiation/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 6, column 34
+  |
+6 | A = { local = "a", rename-from = { A = { B = "0x1", R = "0x2" } } }
+  |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+invalid type: map, expected a string

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/too_many_entries_renaming_instantiation/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/too_many_entries_renaming_instantiation/Move.toml
@@ -1,5 +1,6 @@
 [package]
 name = "name"
+edition = "2024.beta"
 
 [dependencies]
 A = { local = "a", rename-from = { A = { B = "0x1", R = "0x2" } } }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/unknown_toplevel_field/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/unknown_toplevel_field/Move.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+TOML parse error at line 10, column 2
+   |
+10 | [unknown_field]
+   |  ^^^^^^^^^^^^^
+unknown field `unknown_field`, expected one of `package`, `environments`, `dependencies`, `dep-overrides`

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/unknown_toplevel_field/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_invalid/unknown_toplevel_field/Move.toml
@@ -1,14 +1,13 @@
 [package]
 name = "name"
+edition = "2024.beta"
 license = "license"
 authors = ["some author"]
+
+[environments]
+mainnet = "35834a8a"
 
 [unknown_field]
 
 [dependencies]
 A = { local = "../a" }
-B = { local = "../b", rename-from = { "a" = "0xDEADBEEF" } }
-C = { local = "../some_path", rename-from = { "a" = "0xCAFE", "d" = "0x4" } }
-D = { local = "../some_path", rename-from = { "a" = "0xCAFE", "C" = "B" } }
-E = { local = "../some_path", rename-from = { "a" = "0xCAFE", "C" = "B", "OtherD" = "d" } }
-F = { local = "../some_path", rename-from = { "a" = "0xCAFE" } }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "example", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a", "testnet": "4c78adac"}, dependencies: {"foo": ManifestDependency { dependency_info: Git(GitDependency { repo: "https://example.com/foo.git", rev: "releases/v1", path: None, phantom: PhantomData<move_package_alt::dependency::Unpinned> }), is_override: true, rename_from: Some("Foo") }, "qwer": ManifestDependency { dependency_info: External(ExternalDependency { r: Table({"mvr": String("@pkg/qwer")}), fields: {} }), is_override: false, rename_from: None }}, dep_overrides: {"mainnet": {"bar": ManifestDependencyOverride { dependency: None, address_info: Some(()), use_environment: Some("mainnet_beta") }, "foo": ManifestDependencyOverride { dependency: None, address_info: Some(()), use_environment: Some("mainnet_alpha") }}} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic/Move.toml
@@ -5,23 +5,20 @@ license = "Apache-2.0"
 authors = ["Move Team"]
 flavor = "vanilla"
 
-[build]
-language-version = "1.0.0"
-
 [environments]
 mainnet = "35834a8a"
 testnet = "4c78adac"
 
 [dependencies]
-foo = { git = "https://example.com/foo.git", rev = "releases/v1", rename-from = "Foo", override = "true" }
+foo = { git = "https://example.com/foo.git", rev = "releases/v1", rename-from = "Foo", override = true }
 qwer = { r.mvr = "@pkg/qwer" }
 
 [dep-overrides]
 # used to override dependencies for specific environments
 mainnet.foo = { git = "https://example.com/foo.git", original-id = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb", published-at = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb", use-environment = "mainnet_alpha" }
 
-[dep-overrides.mainnet.foo]
-git = "https://example.com/foo.git"
-original-id = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb"
-published-at = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb"
-use-environment = "mainnet_alpha"
+[dep-overrides.mainnet.bar]
+git = "https://example.com/bar.git"
+original-id = "0x12g0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb"
+published-at = "0x12ga0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb"
+use-environment = "mainnet_beta"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_external_resolver/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_external_resolver/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "example", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {"qwer": ManifestDependency { dependency_info: External(ExternalDependency { r: Table({"mvr": String("@pkg/qwer")}), fields: {} }), is_override: false, rename_from: None }}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_external_resolver/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_external_resolver/Move.toml
@@ -8,4 +8,4 @@ authors = ["Move Team"]
 mainnet = "35834a8a"
 
 [dependencies]
-mvr = { r.mvr = "@pkg/qwer" }
+qwer = { r.mvr = "@pkg/qwer" }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_implicit_deps/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_implicit_deps/Move.snap
@@ -1,4 +1,4 @@
 ---
 source: crates/move-package-alt/tests/manifest_parsing_tests.rs
 ---
-Manifest { package: PackageMetadata { name: "example", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {"IOTA": ManifestDependency { dependency_info: Local(LocalDependency { local: "../../../../../../../../../crates/iota-framework/packages/iota-framework" }), is_override: false, rename_from: None }}, dep_overrides: {} }
+Manifest { package: PackageMetadata { name: "example", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {"Iota": ManifestDependency { dependency_info: Local(LocalDependency { local: "../../../../../../../../../crates/iota-framework/packages/iota-framework" }), is_override: false, rename_from: None }}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_implicit_deps/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_implicit_deps/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "example", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {"IOTA": ManifestDependency { dependency_info: Local(LocalDependency { local: "../../../../../../../../../crates/iota-framework/packages/iota-framework" }), is_override: false, rename_from: None }}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_no_dep_override_git/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_no_dep_override_git/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "example", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a", "testnet": "4c78adac"}, dependencies: {"foo": ManifestDependency { dependency_info: Git(GitDependency { repo: "https://example.com/foo.git", rev: "releases/v1", path: None, phantom: PhantomData<move_package_alt::dependency::Unpinned> }), is_override: true, rename_from: Some("Foo") }}, dep_overrides: {"mainnet": {"foo": ManifestDependencyOverride { dependency: None, address_info: Some(()), use_environment: Some("mainnet_alpha") }}} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_no_dep_override_git/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_no_dep_override_git/Move.toml
@@ -1,0 +1,15 @@
+[package]
+name = "example"
+edition = "2024.beta"
+license = "Apache-2.0"
+authors = ["Move Team"]
+
+[environments]
+mainnet = "35834a8a"
+testnet = "4c78adac"
+
+[dependencies]
+foo = { rename-from = "Foo", override = true, rev = "releases/v1", git = "https://example.com/foo.git" }
+
+[dep-overrides]
+mainnet.foo = { original-id = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb", published-at = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb", use-environment = "mainnet_alpha" }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_with_bar/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_with_bar/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "example", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a", "testnet": "4c78adac"}, dependencies: {"bar": ManifestDependency { dependency_info: Local(LocalDependency { local: "./bar" }), is_override: false, rename_from: None }, "foo": ManifestDependency { dependency_info: Git(GitDependency { repo: "https://example.com/foo.git", rev: "releases/v1", path: None, phantom: PhantomData<move_package_alt::dependency::Unpinned> }), is_override: true, rename_from: Some("Foo") }, "qwer": ManifestDependency { dependency_info: External(ExternalDependency { r: Table({"mvr": String("@pkg/qwer")}), fields: {} }), is_override: false, rename_from: None }}, dep_overrides: {"mainnet": {"foo": ManifestDependencyOverride { dependency: None, address_info: Some(()), use_environment: Some("mainnet_alpha") }}} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_with_bar/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_with_bar/Move.toml
@@ -9,16 +9,10 @@ mainnet = "35834a8a"
 testnet = "4c78adac"
 
 [dependencies]
-foo = { git = "https://example.com/foo.git", rev = "releases/v1", rename-from = "Foo", override = "true" }
+foo = { git = "https://example.com/foo.git", rev = "releases/v1", rename-from = "Foo", override = true }
 qwer = { r.mvr = "@pkg/qwer" }
 bar = { local = "./bar" }
 
 [dep-overrides]
 # used to override dependencies for specific environments
 mainnet.foo = { git = "https://example.com/foo.git", original-id = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb", published-at = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb", use-environment = "mainnet_alpha" }
-
-[dep-overrides.mainnet.foo]
-git = "https://example.com/foo.git"
-original-id = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb"
-published-at = "0x6ba0cc1a418ff3bebce0ff9ec3961e6cc794af9bc3a4114fb138d00a4c9274bb"
-use-environment = "mainnet_alpha"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_with_bar/bar/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_with_bar/bar/Move.snap
@@ -1,4 +1,4 @@
 ---
 source: crates/move-package-alt/tests/manifest_parsing_tests.rs
 ---
-Manifest { package: PackageMetadata { name: "bar", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {"IOTA": ManifestDependency { dependency_info: Local(LocalDependency { local: "../../../../../../../../../crates/iota-framework/packages/iota-framework" }), is_override: false, rename_from: None }}, dep_overrides: {} }
+Manifest { package: PackageMetadata { name: "bar", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {"Iota": ManifestDependency { dependency_info: Local(LocalDependency { local: "../../../../../../../../../crates/iota-framework/packages/iota-framework" }), is_override: false, rename_from: None }}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_with_bar/bar/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/basic_with_bar/bar/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "bar", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {"IOTA": ManifestDependency { dependency_info: Local(LocalDependency { local: "../../../../../../../../../crates/iota-framework/packages/iota-framework" }), is_override: false, rename_from: None }}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "name", edition: "2024", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024/Move.toml
@@ -1,8 +1,8 @@
 [package]
 name = "name"
+edition = "2024"
 license = "license"
 authors = ["some author"]
-edition = "2024"
 
 [environments]
 mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024_alpha/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024_alpha/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "name", edition: "2024.alpha", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024_alpha/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024_alpha/Move.toml
@@ -1,8 +1,8 @@
 [package]
 name = "name"
+edition = "2024.alpha"
 license = "license"
 authors = ["some author"]
-edition = "2024.alpha"
 
 [environments]
 mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024_beta/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024_beta/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "name", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024_beta/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_2024_beta/Move.toml
@@ -1,8 +1,8 @@
 [package]
 name = "name"
+edition = "2024.beta"
 license = "license"
 authors = ["some author"]
-edition = "2024.beta"
 
 [environments]
 mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_legacy/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_legacy/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "name", edition: "legacy", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_legacy/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_legacy/Move.toml
@@ -1,8 +1,8 @@
 [package]
 name = "name"
+edition = "legacy"
 license = "license"
 authors = ["some author"]
-edition = "legacy"
 
 [environments]
 mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_unknown/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_unknown/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "name", edition: "foobar", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_unknown/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_unknown/Move.toml
@@ -1,8 +1,8 @@
 [package]
 name = "name"
+edition = "foobar"
 license = "license"
 authors = ["some author"]
-edition = "foobar"
 
 [environments]
 mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_unknown_suffix/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_unknown_suffix/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "name", edition: "2024.final", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_unknown_suffix/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/edition_unknown_suffix/Move.toml
@@ -1,8 +1,8 @@
 [package]
 name = "name"
+edition = "2024.final"
 license = "license"
 authors = ["some author"]
-edition = "2024.final"
 
 [environments]
 mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_global_storage/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_global_storage/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "name", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_global_storage/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_global_storage/Move.toml
@@ -1,5 +1,6 @@
 [package]
 name = "name"
+edition = "2024.beta"
 license = "license"
 authors = ["some author"]
 flavor = "core"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_iota/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_iota/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "name", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_iota/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_iota/Move.toml
@@ -1,5 +1,6 @@
 [package]
 name = "name"
+edition = "2024.beta"
 license = "license"
 authors = ["some author"]
 flavor = "iota"

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_unknown/Move.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_unknown/Move.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-package-alt/tests/manifest_parsing_tests.rs
+---
+Manifest { package: PackageMetadata { name: "name", edition: "2024.beta", metadata: () }, environments: {"mainnet": "35834a8a"}, dependencies: {}, dep_overrides: {} }

--- a/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_unknown/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/manifest_parsing_valid/flavor_unknown/Move.toml
@@ -1,5 +1,6 @@
 [package]
 name = "name"
+edition = "2024.beta"
 license = "license"
 authors = ["some author"]
 flavor = "vanilla"

--- a/external-crates/move/crates/move-package-alt/tests/manifest_parsing_tests.rs
+++ b/external-crates/move/crates/move-package-alt/tests/manifest_parsing_tests.rs
@@ -1,0 +1,31 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use move_command_line_common::insta_assert;
+use move_package_alt::{flavor::Vanilla, package::manifest::Manifest};
+use std::path::Path;
+
+fn run_manifest_parsing_tests(input_path: &Path) -> datatest_stable::Result<()> {
+    let manifest = Manifest::<Vanilla>::read_from(input_path);
+
+    let contents = if let Ok(manifest) = manifest {
+        format!("{:?}", manifest)
+    } else {
+        format!("{}", manifest.unwrap_err())
+    };
+
+    insta_assert! {
+        input_path: input_path,
+        contents: contents,
+    }
+
+    Ok(())
+}
+
+datatest_stable::harness!(
+    run_manifest_parsing_tests,
+    "tests/data",
+    r"manifest_parsing.*\.toml$",
+);


### PR DESCRIPTION
# Description of change

Add some initial infra for insta test for parsing valid move toml files
In general it introduces insta snapshot tests for Move.toml parsing, unify dependency serde, add Debug across flavors/lockfiles.

According to [changes](https://github.com/MystenLabs/sui/commit/f3ea5cd0040a1c83f8875e5b064f531151a8b6d4).

Depends on the https://github.com/iotaledger/iota/issues/8331

## Links to any relevant issues

Fixes #8334 .

## How the change has been tested

Run manifest_parsing_tests.rs
