### PR TITLE
feat: bump iota to v1.10.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,7 +1835,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "const-str",
  "git-version",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "iota"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5440,7 +5440,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-simulator",
  "iota-source-validation",
  "iota-swarm",
@@ -5513,7 +5513,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "arrow-array 53.1.0",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5665,7 +5665,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5726,7 +5726,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-move-build",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -5748,7 +5748,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5898,7 +5898,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5953,7 +5953,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5986,7 +5986,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6020,7 +6020,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6049,7 +6049,7 @@ dependencies = [
  "iota-protocol-config",
  "iota-rest-api",
  "iota-rust-sdk",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-simulator",
  "iota-storage",
  "iota-swarm",
@@ -6080,7 +6080,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "serde_yaml",
 ]
@@ -6119,7 +6119,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6135,7 +6135,7 @@ dependencies = [
  "iota-keys",
  "iota-metrics",
  "iota-network-stack",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-types",
  "parking_lot 0.12.3",
  "prometheus",
@@ -6159,7 +6159,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6179,7 +6179,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6197,7 +6197,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6218,7 +6218,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6268,7 +6268,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6278,7 +6278,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6286,7 +6286,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6299,7 +6299,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6338,7 +6338,7 @@ dependencies = [
  "iota-network-stack",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-types",
@@ -6371,7 +6371,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6384,14 +6384,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "axum 0.8.4",
 ]
 
 [[package]]
 name = "iota-grpc-api"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6416,7 +6416,7 @@ dependencies = [
 
 [[package]]
 name = "iota-grpc-types"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "iota-types",
  "serde",
@@ -6424,7 +6424,7 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "axum 0.8.4",
  "bytes",
@@ -6445,7 +6445,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6510,7 +6510,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6526,7 +6526,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6600,7 +6600,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6619,7 +6619,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6638,7 +6638,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6690,7 +6690,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "bip32",
@@ -6711,7 +6711,7 @@ dependencies = [
 
 [[package]]
 name = "iota-kvstore"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6729,7 +6729,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6750,7 +6750,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger-signer"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6758,7 +6758,7 @@ dependencies = [
  "bip32",
  "clap",
  "iota-ledger",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "shared-crypto",
  "thiserror 1.0.64",
  "tokio",
@@ -6767,7 +6767,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6781,7 +6781,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-types",
  "move-core-types",
  "object_store 0.10.2",
@@ -6800,7 +6800,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -6810,7 +6810,7 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6822,7 +6822,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "backoff",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6868,7 +6868,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -6907,7 +6907,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6928,7 +6928,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "bin-version",
  "clap",
@@ -6961,7 +6961,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6973,7 +6973,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -7012,7 +7012,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anemo",
  "bcs",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7093,7 +7093,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7117,7 +7117,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7129,7 +7129,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7145,13 +7145,13 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -7161,7 +7161,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7182,7 +7182,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "clap",
  "insta",
@@ -7207,7 +7207,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7216,7 +7216,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7231,7 +7231,7 @@ dependencies = [
  "hex",
  "hyper 1.4.1",
  "iota-metrics",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-tls",
  "iota-types",
  "itertools 0.13.0",
@@ -7259,7 +7259,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7275,7 +7275,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-transaction-checks",
  "iota-types",
  "jsonrpsee",
@@ -7304,7 +7304,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7333,7 +7333,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-kv"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7360,7 +7360,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7377,7 +7377,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-swarm-config",
  "iota-types",
  "move-core-types",
@@ -7401,7 +7401,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7411,7 +7411,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-types",
  "itertools 0.13.0",
  "serde",
@@ -7486,7 +7486,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7525,7 +7525,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7547,7 +7547,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7581,7 +7581,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "colored",
@@ -7618,7 +7618,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -7640,7 +7640,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7655,7 +7655,7 @@ dependencies = [
  "iota-move",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-source-validation",
  "move-core-types",
  "move-package",
@@ -7676,7 +7676,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7727,7 +7727,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "bcs",
  "clap",
@@ -7755,7 +7755,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "futures",
@@ -7783,7 +7783,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -7812,7 +7812,7 @@ dependencies = [
 
 [[package]]
 name = "iota-synthetic-ingestion"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7829,12 +7829,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -7842,7 +7842,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7864,7 +7864,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -7886,7 +7886,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -7909,7 +7909,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7925,7 +7925,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -7938,7 +7938,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7983,7 +7983,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8058,7 +8058,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8086,7 +8086,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11376,7 +11376,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13170,7 +13170,7 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "bcs",
  "eyre",
@@ -13295,7 +13295,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14039,7 +14039,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -14126,7 +14126,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -14145,7 +14145,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.9.0-alpha",
+ "iota-sdk 1.10.0-alpha",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -14962,7 +14962,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -15034,7 +15034,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "bcs",
  "bincode",
@@ -15063,7 +15063,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -15073,7 +15073,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "serde",
  "thiserror 1.0.64",
@@ -15081,7 +15081,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "1.9.0-alpha"
+version = "1.10.0-alpha"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -114,12 +114,12 @@ task 15, lines 64-69:
 //# run-graphql --show-usage --show-headers --show-service-version
 Headers: {
     "content-type": "application/graphql-response+json",
-    "x-iota-rpc-version": "1.9.0-testing-no-sha",
+    "x-iota-rpc-version": "1.10.0-testing-no-sha",
     "vary": "origin, access-control-request-method, access-control-request-headers",
     "access-control-allow-origin": "*",
     "content-length": "157",
 }
-Service version: 1.9.0-testing-no-sha
+Service version: 1.10.0-testing-no-sha
 Response: {
   "data": {
     "checkpoint": {
@@ -376,7 +376,7 @@ Response: {
   "data": {
     "serviceConfig": {
       "availableVersions": [
-        "1.9"
+        "1.10"
       ]
     }
   }

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "1.9.0-alpha"
+    "version": "1.10.0-alpha"
   },
   "methods": [
     {


### PR DESCRIPTION
# Description of change

Bump main version to `v1.10.0-alpha` following https://github.com/iotaledger/iota/releases/tag/v1.9.0-alpha
