### PR TITLE
feat(indexer): Metrics for optimistic indexing

### DIFF
--- a/crates/iota-indexer/src/metrics.rs
+++ b/crates/iota-indexer/src/metrics.rs
@@ -180,6 +180,19 @@ pub struct IndexerMetrics {
     pub epoch_pruning_latency: Histogram, // not used
     pub optimistic_pruner_total_rows_pruned: IntCounter,
     pub optimistic_pruner_batch_duration: Histogram,
+    // Optimistic indexing metrics
+    pub optimistic_tx_total_execution_and_indexing_time: Histogram,
+    pub optimistic_tx_node_response_wait_time: Histogram,
+    pub optimistic_tx_dependencies_wait_time: Histogram,
+    pub optimistic_tx_db_write_time: Histogram,
+    pub optimistic_tx_db_wait_and_read_time: Histogram,
+    pub optimistic_tx_count: IntCounter,
+    pub optimistic_tx_successful_db_writes_count: IntCounter,
+    pub optimistic_tx_failed_node_requests_count: IntCounter,
+    pub optimistic_tx_unique_global_order_violations_count: IntCounter,
+    pub optimistic_tx_with_missing_dependencies_count: IntCounter,
+    pub optimistic_tx_with_missing_objects_counts: IntCounter,
+    pub optimistic_tx_failed_db_writes_count: IntCounter,
 }
 
 impl IndexerMetrics {
@@ -823,7 +836,85 @@ impl IndexerMetrics {
                 "Time spent in pruning one epoch",
                 DB_UPDATE_QUERY_LATENCY_SEC_BUCKETS.to_vec(),
                 registry
-            ).unwrap(),
+            )
+            .unwrap(),
+            optimistic_tx_total_execution_and_indexing_time: register_histogram_with_registry!(
+                "optimistic_tx_total_execution_and_indexing_time",
+                "Total execution and indexing time for optimistic transaction",
+                DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            optimistic_tx_node_response_wait_time: register_histogram_with_registry!(
+                "optimistic_tx_node_response_wait_time",
+                "Time waiting for node response during optimistic indexing",
+                DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            optimistic_tx_dependencies_wait_time: register_histogram_with_registry!(
+                "optimistic_tx_dependencies_wait_time",
+                "Time spent waiting for transaction dependencies",
+                DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            optimistic_tx_db_write_time: register_histogram_with_registry!(
+                "optimistic_tx_db_write_time",
+                "Time spent writing optimistic transaction to database",
+                DB_UPDATE_QUERY_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            optimistic_tx_db_wait_and_read_time: register_histogram_with_registry!(
+                "optimistic_tx_db_wait_and_read_time",
+                "Time spent waiting and reading optimistic transaction from database before returning response",
+                DB_UPDATE_QUERY_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            optimistic_tx_count: register_int_counter_with_registry!(
+                "optimistic_tx_count",
+                "Total number of optimistic transactions executed through indexer",
+                registry,
+            )
+            .unwrap(),
+            optimistic_tx_successful_db_writes_count: register_int_counter_with_registry!(
+                "optimistic_tx_successful_db_writes_count",
+                "Number optimistic transactions successfully written to the database",
+                registry,
+            )
+            .unwrap(),
+            optimistic_tx_failed_node_requests_count: register_int_counter_with_registry!(
+                "optimistic_tx_failed_node_requests_count",
+                "Number of failed fullnode requests during optimistic indexing",
+                registry,
+            )
+            .unwrap(),
+            optimistic_tx_unique_global_order_violations_count: register_int_counter_with_registry!(
+                "optimistic_tx_unique_global_order_violations_count",
+                "Number of unique global order violations encountered during optimistic indexing",
+                registry,
+            )
+            .unwrap(),
+            optimistic_tx_with_missing_dependencies_count: register_int_counter_with_registry!(
+                "optimistic_tx_with_missing_dependencies_count",
+                "Number of transactions with missing dependencies that skipped optimistic indexing",
+                registry,
+            )
+            .unwrap(),
+            optimistic_tx_with_missing_objects_counts: register_int_counter_with_registry!(
+                "optimistic_tx_with_missing_objects_counts",
+                "Number of transactions with missing input/output objects that skipped optimistic indexing",
+                registry,
+            )
+            .unwrap(),
+            optimistic_tx_failed_db_writes_count: register_int_counter_with_registry!(
+                "optimistic_tx_failed_db_writes_count",
+                "Number of failed database writes during optimistic indexing",
+                registry,
+            )
+            .unwrap(),
         }
     }
 }

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -130,6 +130,7 @@ impl OptimisticTransactionExecutor {
             tracing::warn!(
                 "Cannot optimistically index because of missing in/out objs for tx: {tx_digest}"
             );
+            self.metrics.optimistic_tx_with_missing_objects_counts.inc();
             return Ok(());
         };
 
@@ -137,15 +138,26 @@ impl OptimisticTransactionExecutor {
             tracing::warn!(
                 "Cannot optimistically index because of missing in/out objs for tx: {tx_digest}"
             );
+            self.metrics.optimistic_tx_with_missing_objects_counts.inc();
             return Ok(());
         }
+        let deps_timer = self
+            .metrics
+            .optimistic_tx_dependencies_wait_time
+            .start_timer();
         tokio::select! {
-            Ok(_) = self.wait_for_tx_dependencies(&effects) => (),
-            Ok(true) = self.deep_check_all_dependencies_are_indexed(&effects) => (),
+            Ok(_) = self.wait_for_tx_dependencies(&effects) => {
+                deps_timer.stop_and_record();
+            },
+            Ok(true) = self.deep_check_all_dependencies_are_indexed(&effects) => {
+                deps_timer.stop_and_record();
+            },
             else => {
+                deps_timer.stop_and_discard();
                 tracing::warn!(
                     "Transaction {tx_digest} dependencies are not indexed, skipping optimistic indexing",
                 );
+                self.metrics.optimistic_tx_with_missing_dependencies_count.inc();
                 return Ok(());
             }
         };
@@ -156,6 +168,7 @@ impl OptimisticTransactionExecutor {
             input_objects,
             output_objects,
         };
+
         self.index_transaction_in_blocking_task(&full_tx_data).await
     }
 
@@ -183,6 +196,11 @@ impl OptimisticTransactionExecutor {
         signatures: Vec<Base64>,
         options: Option<IotaTransactionBlockResponseOptions>,
     ) -> Result<IotaTransactionBlockResponse, IndexerError> {
+        let _total_execution_time = self
+            .metrics
+            .optimistic_tx_total_execution_and_indexing_time
+            .start_timer();
+        self.metrics.optimistic_tx_count.inc();
         let tx_data: TransactionData = bcs::from_bytes(&tx_bytes.to_vec()?)?;
         let sigs = signatures
             .into_iter()
@@ -190,6 +208,11 @@ impl OptimisticTransactionExecutor {
             .collect::<Result<Vec<_>, FastCryptoError>>()?;
 
         let transaction = Transaction::from_generic_sig_data(tx_data, sigs);
+
+        let node_timer = self
+            .metrics
+            .optimistic_tx_node_response_wait_time
+            .start_timer();
         let response = self
             .rpc_client
             .execute_transaction(
@@ -201,15 +224,32 @@ impl OptimisticTransactionExecutor {
                 },
                 &transaction,
             )
-            .await
-            .map_err(|e| IndexerError::Generic(e.to_string()))?;
+            .await;
+
+        let response = match response {
+            Ok(response) => {
+                node_timer.stop_and_record();
+                response
+            }
+            Err(e) => {
+                node_timer.stop_and_discard();
+                self.metrics.optimistic_tx_failed_node_requests_count.inc();
+                return Err(IndexerError::Generic(e.to_string()));
+            }
+        };
 
         let tx_digest = *response.effects.transaction_digest();
         self.maybe_index_executed_transaction(transaction, response)
             .await?;
+
+        let db_read_timer = self
+            .metrics
+            .optimistic_tx_db_wait_and_read_time
+            .start_timer();
         let tx_block_response = self
             .wait_for_local_indexing(tx_digest, options.clone())
             .await?;
+        db_read_timer.stop_and_record();
 
         Ok(IotaTransactionBlockResponseWithOptions {
             response: tx_block_response,
@@ -257,6 +297,7 @@ impl OptimisticTransactionExecutor {
         &self,
         full_tx_data: &CheckpointTransaction,
     ) -> Result<(), IndexerError> {
+        let db_write_timer = self.metrics.optimistic_tx_db_write_time.start_timer();
         match tokio::task::spawn_blocking({
             let this: OptimisticTransactionExecutor = self.clone();
             let full_tx_data = full_tx_data.clone();
@@ -267,13 +308,28 @@ impl OptimisticTransactionExecutor {
             tracing::error!("Failed to join optimistic index_transaction: {e}");
             IndexerError::from(e)
         })? {
+            Ok(_) => {
+                db_write_timer.stop_and_record();
+                self.metrics.optimistic_tx_successful_db_writes_count.inc();
+                Ok(())
+            }
             // The unique violation error means that checkpoint indexing was faster than the
             // optimistic indexing. Let's just return and let checkpoint indexing handle
             // the transaction.
-            Ok(_) | Err(IndexerError::PostgresUniqueTxGlobalOrderViolation(_)) => Ok(()),
-            Err(e) => Err(IndexerError::PostgresWrite(format!(
-                "Failed to persist optimistic tx: {e:?}",
-            ))),
+            Err(IndexerError::PostgresUniqueTxGlobalOrderViolation(_)) => {
+                db_write_timer.stop_and_discard();
+                self.metrics
+                    .optimistic_tx_unique_global_order_violations_count
+                    .inc();
+                Ok(())
+            }
+            Err(e) => {
+                db_write_timer.stop_and_discard();
+                self.metrics.optimistic_tx_failed_db_writes_count.inc();
+                Err(IndexerError::PostgresWrite(format!(
+                    "Failed to persist optimistic tx: {e:?}",
+                )))
+            }
         }
     }
 


### PR DESCRIPTION
# Description of change

Add metrics for optimistic indexing, to have better overview on the performance and usage

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/8469

## How the change has been tested

Ran the indexer on staging and observed how the optimistic indexing metrics behave during stress test

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [x] Restart of indexer synchronization on a production-like database.
- [x] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
