### PR TITLE
refactor(iota-data-ingestion-core): use gRPC instead of REST API to sync checkpoints from fullnode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5997,6 +5997,8 @@ dependencies = [
  "fastcrypto",
  "futures",
  "iota-config",
+ "iota-grpc-api",
+ "iota-grpc-types",
  "iota-metrics",
  "iota-protocol-config",
  "iota-rest-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6016,6 +6016,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.12",
+ "tonic 0.13.1",
  "tracing",
  "url",
 ]

--- a/crates/iota-data-ingestion-core/Cargo.toml
+++ b/crates/iota-data-ingestion-core/Cargo.toml
@@ -32,6 +32,8 @@ url.workspace = true
 
 # internal dependencies
 iota-config.workspace = true
+iota-grpc-api.workspace = true
+iota-grpc-types.workspace = true
 iota-metrics.workspace = true
 iota-protocol-config.workspace = true
 iota-rest-api.workspace = true

--- a/crates/iota-data-ingestion-core/Cargo.toml
+++ b/crates/iota-data-ingestion-core/Cargo.toml
@@ -27,6 +27,7 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-stream.workspace = true
 tokio-util.workspace = true
+tonic.workspace = true
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/iota-data-ingestion-core/src/errors.rs
+++ b/crates/iota-data-ingestion-core/src/errors.rs
@@ -25,6 +25,9 @@ pub enum IngestionError {
     #[error(transparent)]
     RestApi(#[from] iota_rest_api::client::sdk::Error),
 
+    #[error("Grpc error: `{0}`")]
+    Grpc(String),
+
     #[error("Register at least one worker pool")]
     EmptyWorkerPool,
 

--- a/crates/iota-data-ingestion-core/src/errors.rs
+++ b/crates/iota-data-ingestion-core/src/errors.rs
@@ -25,7 +25,7 @@ pub enum IngestionError {
     #[error(transparent)]
     RestApi(#[from] iota_rest_api::client::sdk::Error),
 
-    #[error("Grpc error: `{0}`")]
+    #[error("grpc error: `{0}`")]
     Grpc(String),
 
     #[error("Register at least one worker pool")]
@@ -63,4 +63,10 @@ pub enum IngestionError {
 
     #[error("Checkpoint not available yet")]
     CheckpointNotAvailableYet,
+}
+
+impl From<tonic::Status> for IngestionError {
+    fn from(value: tonic::Status) -> Self {
+        Self::Grpc(value.to_string())
+    }
 }

--- a/crates/iota-data-ingestion-core/src/reader/fetch.rs
+++ b/crates/iota-data-ingestion-core/src/reader/fetch.rs
@@ -80,7 +80,7 @@ pub(crate) trait LocalRead {
     fn read_local_files(&self) -> IngestionResult<Vec<Arc<CheckpointData>>> {
         // files are already sorted by sequence number in ascending order
         let files = self.list_unprocessed_checkpoint_files()?;
-        debug!("unprocessed local files {:?}", files);
+        debug!("unprocessed local files {files:?}");
         let mut checkpoints = vec![];
         for (_, filename) in files.iter().take(MAX_CHECKPOINTS_IN_PROGRESS) {
             let checkpoint = self.read_checkpoint_file(filename)?;

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -290,6 +290,25 @@ impl CheckpointReaderActor {
         Ok(())
     }
 
+    /// Fetch checkpoints from the live object store and stream them to a
+    /// channel.
+    async fn fetch_live(
+        &mut self,
+        batch_size: usize,
+        live: &dyn ObjectStore,
+    ) -> IngestionResult<()> {
+        let mut checkpoint_stream = (self.current_checkpoint_number..u64::MAX)
+            .map(|checkpoint_number| fetch_from_object_store(live, checkpoint_number))
+            .pipe(futures::stream::iter)
+            .buffered(batch_size);
+        while let Some(checkpoint_result) = checkpoint_stream.next().await {
+            let (checkpoint, size) = checkpoint_result?;
+            self.send_remote_checkpoint_with_capacity_check(checkpoint, size)
+                .await?;
+        }
+        Ok(())
+    }
+
     /// Fetches checkpoints from the fullnode trough a gRPC streaming connection
     /// and stream them to a channel.
     async fn fetch_from_fullnode(&mut self, client: &mut CheckpointClient) -> IngestionResult<()> {
@@ -329,10 +348,7 @@ impl CheckpointReaderActor {
             return Err(IngestionError::Grpc("checkpoint stream was closed".into()));
         };
 
-        let checkpoint: CheckpointData = genesis_checkpoint
-            .map(GrpcCheckpoint)
-            .map_err(|e| IngestionError::Grpc(e.to_string()))?
-            .try_into()?;
+        let checkpoint: CheckpointData = genesis_checkpoint.map(GrpcCheckpoint)?.try_into()?;
 
         let size = bcs::serialized_size(&checkpoint)?;
         self.send_remote_checkpoint_with_capacity_check(Arc::new(checkpoint), size)
@@ -370,10 +386,7 @@ impl CheckpointReaderActor {
             })?;
 
         while let Some(checkpoint) = checkpoints_stream.next().await {
-            let checkpoint: CheckpointData = checkpoint
-                .map(GrpcCheckpoint)
-                .map_err(|e| IngestionError::Grpc(e.to_string()))?
-                .try_into()?;
+            let checkpoint: CheckpointData = checkpoint.map(GrpcCheckpoint)?.try_into()?;
 
             let size = bcs::serialized_size(&checkpoint)?;
             self.send_remote_checkpoint_with_capacity_check(Arc::new(checkpoint), size)
@@ -400,21 +413,11 @@ impl CheckpointReaderActor {
             }
             RemoteStore::HybridHistoricalStore { historical, live } => {
                 if let Err(err) = self.fetch_historical(historical).await {
+                    // attempt to fetch from live object store if historical store does not contain
+                    // the requested checkpoint.
                     if matches!(err, IngestionError::CheckpointNotAvailableYet) {
                         let live = live.as_ref().ok_or(err)?;
-                        let mut checkpoint_stream = (self.current_checkpoint_number..u64::MAX)
-                            .map(|checkpoint_number| {
-                                fetch_from_object_store(live, checkpoint_number)
-                            })
-                            .pipe(futures::stream::iter)
-                            .buffered(batch_size);
-
-                        while let Some(checkpoint_result) = checkpoint_stream.next().await {
-                            let (checkpoint, size) = checkpoint_result?;
-                            self.send_remote_checkpoint_with_capacity_check(checkpoint, size)
-                                .await?;
-                        }
-                        return Ok(());
+                        return self.fetch_live(batch_size, live).await;
                     }
                     return Err(err);
                 }

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -14,6 +14,7 @@ use iota_config::{
     node::ArchiveReaderConfig,
     object_storage_config::{ObjectStoreConfig, ObjectStoreType},
 };
+use iota_grpc_api::{CheckpointClient, CheckpointContent, NodeClient};
 use iota_metrics::spawn_monitored_task;
 use iota_rest_api::CheckpointData;
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
@@ -36,7 +37,7 @@ use crate::{
     IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS, create_remote_store_client,
     history::reader::HistoricalReader,
     reader::{
-        fetch::{LocalRead, ReadSource, fetch_from_full_node, fetch_from_object_store},
+        fetch::{LocalRead, ReadSource, fetch_from_object_store},
         v1::{DataLimiter, ReaderOptions},
     },
 };
@@ -50,11 +51,11 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum RemoteUrl {
     /// The URL to the Fullnode server that exposes
-    /// checkpoint data.
+    /// checkpoint data streaming through gRPC.
     ///
     /// # Example
     /// ```text
-    /// "http://127.0.0.1:9000/api/v1"
+    /// "http://127.0.0.1:50051"
     /// ```
     Fullnode(String),
     /// A hybrid source combining historical object store and optional live
@@ -85,7 +86,7 @@ pub enum RemoteUrl {
 /// used by the ingestion framework to fetch checkpoint data. Each variant
 /// corresponds to a different type of remote source.
 enum RemoteStore {
-    Fullnode(iota_rest_api::Client),
+    Fullnode(CheckpointClient),
     HybridHistoricalStore {
         historical: HistoricalReader,
         live: Option<Box<dyn ObjectStore>>,
@@ -99,7 +100,11 @@ impl RemoteStore {
         timeout_secs: u64,
     ) -> IngestionResult<Self> {
         let store = match remote_url {
-            RemoteUrl::Fullnode(url) => RemoteStore::Fullnode(iota_rest_api::Client::new(url)),
+            RemoteUrl::Fullnode(ref url) => NodeClient::connect(url)
+                .await
+                .map(|node_client| node_client.checkpoint_client())?
+                .ok_or_else(|| IngestionError::Grpc("failed to get the checkpoint client".into()))
+                .map(RemoteStore::Fullnode)?,
             RemoteUrl::HybridHistoricalStore {
                 historical_url,
                 live_url,
@@ -284,6 +289,98 @@ impl CheckpointReaderActor {
         Ok(())
     }
 
+    /// Fetches checkpoints form the fullnode trough a gRPC streaming connection
+    /// and stream them to a channel.
+    async fn fetch_from_fullnode(&mut self, client: &mut CheckpointClient) -> IngestionResult<()> {
+        // the genesis checkpoint needs to be handled differently since it may be
+        // processed in chunks due to its size.
+        if self.current_checkpoint_number == 0 {
+            self.fetch_genesis_checkpoint_from_fullnode(client).await?;
+        }
+        self.fetch_checkpoints_from_fullnode(client).await
+    }
+
+    /// Fetches the genesis checkpoint from the fullnode through a gRPC
+    /// streaming connection.
+    async fn fetch_genesis_checkpoint_from_fullnode(
+        &mut self,
+        client: &mut CheckpointClient,
+    ) -> IngestionResult<()> {
+        let show_full_checkpoint = true;
+        let mut genesis_checkpoint_stream = client
+            .stream_checkpoints(Some(0), Some(0), show_full_checkpoint)
+            .await
+            .map_err(|e| {
+                IngestionError::Grpc(format!("failed to initialize the checkpoint stream: {e}"))
+            })?;
+
+        // TODO: When genesis checkpoint chunked streaming will be implemented, collect
+        // all chunks, assemble them into a full CheckpointData, then send it
+        // downstream.
+        //
+        // Currently we receive the entire genesis checkpoint in a
+        // single message, which works for small checkpoints. Large genesis
+        // checkpoints (e.g. with migration data) may exceed gRPC's ~2GB message
+        // limit, and it will not work, so this logic must be revised to handle chunk
+        // assembly.
+        let Some(genesis_checkpoint) = genesis_checkpoint_stream.next().await else {
+            return Err(IngestionError::Grpc("checkpoint stream was closed".into()));
+        };
+
+        let checkpoint: CheckpointData = genesis_checkpoint
+            .map(GrpcCheckpoint)
+            .map_err(|e| IngestionError::Grpc(e.to_string()))?
+            .try_into()?;
+
+        let size = bcs::serialized_size(&checkpoint)?;
+        self.send_remote_checkpoint_with_capacity_check(Arc::new(checkpoint), size)
+            .await
+    }
+
+    /// Fetches checkpoints from the fullnode through a gRPC streaming
+    /// connection.
+    ///
+    /// # Note
+    /// It should be used to download checkpoints except genesis one.
+    ///
+    /// For downloading the genesis checkpoint the
+    /// [`fetch_genesis_checkpoint_from_fullnode`](Self::fetch_genesis_checkpoint_from_fullnode)
+    /// method should be used.
+    async fn fetch_checkpoints_from_fullnode(
+        &mut self,
+        client: &mut CheckpointClient,
+    ) -> IngestionResult<()> {
+        if self.current_checkpoint_number == 0 {
+            return Err(IngestionError::Grpc(
+                "use a dedicated method to handle the download of the genesis checkpoint".into(),
+            ));
+        }
+        let show_full_checkpoint = true;
+        let mut checkpoints_stream = client
+            .stream_checkpoints(
+                Some(self.current_checkpoint_number),
+                None, // internally it resolves to u64::MAX
+                show_full_checkpoint,
+            )
+            .await
+            .map_err(|e| {
+                IngestionError::Grpc(format!("failed to initialize the checkpoint stream: {e}"))
+            })?;
+
+        while let Some(genesis_checkpoint) = checkpoints_stream.next().await {
+            let checkpoint: CheckpointData = genesis_checkpoint
+                .map(GrpcCheckpoint)
+                .map_err(|e| IngestionError::Grpc(e.to_string()))?
+                .try_into()?;
+
+            let size = bcs::serialized_size(&checkpoint)?;
+            self.send_remote_checkpoint_with_capacity_check(Arc::new(checkpoint), size)
+                .await?;
+        }
+
+        Ok(())
+    }
+
     /// Fetches remote checkpoints from the remote store and streams them to the
     /// channel.
     ///
@@ -297,16 +394,7 @@ impl CheckpointReaderActor {
         let batch_size = self.reader_options.batch_size;
         match remote_store.as_ref() {
             RemoteStore::Fullnode(client) => {
-                let mut checkpoint_stream = (self.current_checkpoint_number..u64::MAX)
-                    .map(|checkpoint_number| fetch_from_full_node(client, checkpoint_number))
-                    .pipe(futures::stream::iter)
-                    .buffered(batch_size);
-
-                while let Some(checkpoint_result) = checkpoint_stream.next().await {
-                    let (checkpoint, size) = checkpoint_result?;
-                    self.send_remote_checkpoint_with_capacity_check(checkpoint, size)
-                        .await?;
-                }
+                self.fetch_from_fullnode(&mut client.clone()).await?;
             }
             RemoteStore::HybridHistoricalStore { historical, live } => {
                 if let Err(err) = self.fetch_historical(historical).await {
@@ -573,5 +661,33 @@ impl CheckpointReader {
             component: "CheckpointReader".into(),
             msg: err.to_string(),
         })
+    }
+}
+
+/// Holds the checkpoint content received from a gRPC checkpoint stream.
+///
+/// Allows to easily convert the checkpoint content into a [`CheckpointData`]
+/// struct.
+struct GrpcCheckpoint(CheckpointContent);
+
+impl GrpcCheckpoint {
+    /// Unwraps the inner [`CheckpointContent`].
+    fn into_inner(self) -> CheckpointContent {
+        self.0
+    }
+}
+
+impl TryFrom<GrpcCheckpoint> for iota_types::full_checkpoint_content::CheckpointData {
+    type Error = IngestionError;
+
+    fn try_from(grpc_data: GrpcCheckpoint) -> Result<Self, Self::Error> {
+        match grpc_data.into_inner() {
+            CheckpointContent::Data(grpc_data) => grpc_data.into_v1().ok_or(IngestionError::Grpc(
+                "expected checkpoint data but received summary".into(),
+            )),
+            CheckpointContent::Summary(_) => Err(IngestionError::Grpc(
+                "expected checkpoint data but received summary".into(),
+            )),
+        }
     }
 }

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -222,8 +222,8 @@ impl CheckpointReaderActor {
                 || self.is_checkpoint_ahead(&checkpoints[0], self.current_checkpoint_number))
     }
 
-    /// Fetch checkpoints from the historical object store and stream them to a
-    /// channel.
+    /// Fetches checkpoints from the historical object store and streams them to
+    /// a channel.
     async fn fetch_historical(
         &mut self,
         historical_reader: &HistoricalReader,
@@ -290,7 +290,7 @@ impl CheckpointReaderActor {
         Ok(())
     }
 
-    /// Fetch checkpoints from the live object store and stream them to a
+    /// Fetches checkpoints from the live object store and streams them to a
     /// channel.
     async fn fetch_live(
         &mut self,
@@ -310,7 +310,7 @@ impl CheckpointReaderActor {
     }
 
     /// Fetches checkpoints from the fullnode trough a gRPC streaming connection
-    /// and stream them to a channel.
+    /// and streams them to a channel.
     async fn fetch_from_fullnode(&mut self, client: &mut CheckpointClient) -> IngestionResult<()> {
         // the genesis checkpoint needs to be handled differently since it may be
         // processed in chunks due to its size.
@@ -322,7 +322,7 @@ impl CheckpointReaderActor {
     }
 
     /// Fetches the genesis checkpoint from the fullnode through a gRPC
-    /// streaming connection.
+    /// streaming connection and streams them to a channel.
     async fn fetch_genesis_checkpoint_from_fullnode(
         &mut self,
         client: &mut CheckpointClient,

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -15,6 +15,7 @@ use iota_config::{
     object_storage_config::{ObjectStoreConfig, ObjectStoreType},
 };
 use iota_grpc_api::{CheckpointClient, CheckpointContent, NodeClient};
+use iota_grpc_types::CheckpointData as GrpcCheckpointData;
 use iota_metrics::spawn_monitored_task;
 use iota_rest_api::CheckpointData;
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
@@ -289,7 +290,7 @@ impl CheckpointReaderActor {
         Ok(())
     }
 
-    /// Fetches checkpoints form the fullnode trough a gRPC streaming connection
+    /// Fetches checkpoints from the fullnode trough a gRPC streaming connection
     /// and stream them to a channel.
     async fn fetch_from_fullnode(&mut self, client: &mut CheckpointClient) -> IngestionResult<()> {
         // the genesis checkpoint needs to be handled differently since it may be
@@ -297,7 +298,8 @@ impl CheckpointReaderActor {
         if self.current_checkpoint_number == 0 {
             self.fetch_genesis_checkpoint_from_fullnode(client).await?;
         }
-        self.fetch_checkpoints_from_fullnode(client).await
+        self.fetch_post_genesis_checkpoints_from_fullnode(client)
+            .await
     }
 
     /// Fetches the genesis checkpoint from the fullnode through a gRPC
@@ -346,7 +348,7 @@ impl CheckpointReaderActor {
     /// For downloading the genesis checkpoint the
     /// [`fetch_genesis_checkpoint_from_fullnode`](Self::fetch_genesis_checkpoint_from_fullnode)
     /// method should be used.
-    async fn fetch_checkpoints_from_fullnode(
+    async fn fetch_post_genesis_checkpoints_from_fullnode(
         &mut self,
         client: &mut CheckpointClient,
     ) -> IngestionResult<()> {
@@ -367,8 +369,8 @@ impl CheckpointReaderActor {
                 IngestionError::Grpc(format!("failed to initialize the checkpoint stream: {e}"))
             })?;
 
-        while let Some(genesis_checkpoint) = checkpoints_stream.next().await {
-            let checkpoint: CheckpointData = genesis_checkpoint
+        while let Some(checkpoint) = checkpoints_stream.next().await {
+            let checkpoint: CheckpointData = checkpoint
                 .map(GrpcCheckpoint)
                 .map_err(|e| IngestionError::Grpc(e.to_string()))?
                 .try_into()?;
@@ -682,9 +684,9 @@ impl TryFrom<GrpcCheckpoint> for iota_types::full_checkpoint_content::Checkpoint
 
     fn try_from(grpc_data: GrpcCheckpoint) -> Result<Self, Self::Error> {
         match grpc_data.into_inner() {
-            CheckpointContent::Data(grpc_data) => grpc_data.into_v1().ok_or(IngestionError::Grpc(
-                "expected checkpoint data but received summary".into(),
-            )),
+            CheckpointContent::Data(grpc_checkpoint_data) => match grpc_checkpoint_data {
+                GrpcCheckpointData::V1(checkpoint_data) => Ok(checkpoint_data),
+            },
             CheckpointContent::Summary(_) => Err(IngestionError::Grpc(
                 "expected checkpoint data but received summary".into(),
             )),

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use backoff::backoff::Backoff;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use iota_config::{
     node::ArchiveReaderConfig,
     object_storage_config::{ObjectStoreConfig, ObjectStoreType},
@@ -224,7 +224,7 @@ impl CheckpointReaderActor {
 
     /// Fetches checkpoints from the historical object store and streams them to
     /// a channel.
-    async fn fetch_historical(
+    async fn relay_from_historical(
         &mut self,
         historical_reader: &HistoricalReader,
     ) -> IngestionResult<()> {
@@ -292,7 +292,7 @@ impl CheckpointReaderActor {
 
     /// Fetches checkpoints from the live object store and streams them to a
     /// channel.
-    async fn fetch_live(
+    async fn relay_from_live(
         &mut self,
         batch_size: usize,
         live: &dyn ObjectStore,
@@ -311,19 +311,19 @@ impl CheckpointReaderActor {
 
     /// Fetches checkpoints from the fullnode trough a gRPC streaming connection
     /// and streams them to a channel.
-    async fn fetch_from_fullnode(&mut self, client: &mut CheckpointClient) -> IngestionResult<()> {
+    async fn relay_from_fullnode(&mut self, client: &mut CheckpointClient) -> IngestionResult<()> {
         // the genesis checkpoint needs to be handled differently since it may be
         // processed in chunks due to its size.
         if self.current_checkpoint_number == 0 {
-            self.fetch_genesis_checkpoint_from_fullnode(client).await?;
+            self.relay_genesis_checkpoint_from_fullnode(client).await?;
         }
-        self.fetch_post_genesis_checkpoints_from_fullnode(client)
+        self.relay_post_genesis_checkpoints_from_fullnode(client)
             .await
     }
 
     /// Fetches the genesis checkpoint from the fullnode through a gRPC
     /// streaming connection and streams them to a channel.
-    async fn fetch_genesis_checkpoint_from_fullnode(
+    async fn relay_genesis_checkpoint_from_fullnode(
         &mut self,
         client: &mut CheckpointClient,
     ) -> IngestionResult<()> {
@@ -333,7 +333,8 @@ impl CheckpointReaderActor {
             .await
             .map_err(|e| {
                 IngestionError::Grpc(format!("failed to initialize the checkpoint stream: {e}"))
-            })?;
+            })?
+            .map_ok(GrpcCheckpoint);
 
         // TODO: When genesis checkpoint chunked streaming will be implemented, collect
         // all chunks, assemble them into a full CheckpointData, then send it
@@ -348,7 +349,7 @@ impl CheckpointReaderActor {
             return Err(IngestionError::Grpc("checkpoint stream was closed".into()));
         };
 
-        let checkpoint: CheckpointData = genesis_checkpoint.map(GrpcCheckpoint)?.try_into()?;
+        let checkpoint: CheckpointData = genesis_checkpoint?.try_into()?;
 
         let size = bcs::serialized_size(&checkpoint)?;
         self.send_remote_checkpoint_with_capacity_check(Arc::new(checkpoint), size)
@@ -356,7 +357,7 @@ impl CheckpointReaderActor {
     }
 
     /// Fetches checkpoints from the fullnode through a gRPC streaming
-    /// connection.
+    /// connection and streams them to a channel.
     ///
     /// # Note
     /// It should be used to download checkpoints except genesis one.
@@ -364,7 +365,7 @@ impl CheckpointReaderActor {
     /// For downloading the genesis checkpoint the
     /// [`fetch_genesis_checkpoint_from_fullnode`](Self::fetch_genesis_checkpoint_from_fullnode)
     /// method should be used.
-    async fn fetch_post_genesis_checkpoints_from_fullnode(
+    async fn relay_post_genesis_checkpoints_from_fullnode(
         &mut self,
         client: &mut CheckpointClient,
     ) -> IngestionResult<()> {
@@ -383,10 +384,11 @@ impl CheckpointReaderActor {
             .await
             .map_err(|e| {
                 IngestionError::Grpc(format!("failed to initialize the checkpoint stream: {e}"))
-            })?;
+            })?
+            .map_ok(GrpcCheckpoint);
 
-        while let Some(checkpoint) = checkpoints_stream.next().await {
-            let checkpoint: CheckpointData = checkpoint.map(GrpcCheckpoint)?.try_into()?;
+        while let Some(grpc_checkpoint) = checkpoints_stream.next().await {
+            let checkpoint: CheckpointData = grpc_checkpoint?.try_into()?;
 
             let size = bcs::serialized_size(&checkpoint)?;
             self.send_remote_checkpoint_with_capacity_check(Arc::new(checkpoint), size)
@@ -409,15 +411,15 @@ impl CheckpointReaderActor {
         let batch_size = self.reader_options.batch_size;
         match remote_store.as_ref() {
             RemoteStore::Fullnode(client) => {
-                self.fetch_from_fullnode(&mut client.clone()).await?;
+                self.relay_from_fullnode(&mut client.clone()).await?;
             }
             RemoteStore::HybridHistoricalStore { historical, live } => {
-                if let Err(err) = self.fetch_historical(historical).await {
+                if let Err(err) = self.relay_from_historical(historical).await {
                     // attempt to fetch from live object store if historical store does not contain
                     // the requested checkpoint.
                     if matches!(err, IngestionError::CheckpointNotAvailableYet) {
                         let live = live.as_ref().ok_or(err)?;
-                        return self.fetch_live(batch_size, live).await;
+                        return self.relay_from_live(batch_size, live).await;
                     }
                     return Err(err);
                 }
@@ -682,7 +684,7 @@ impl GrpcCheckpoint {
     }
 }
 
-impl TryFrom<GrpcCheckpoint> for iota_types::full_checkpoint_content::CheckpointData {
+impl TryFrom<GrpcCheckpoint> for CheckpointData {
     type Error = IngestionError;
 
     fn try_from(grpc_data: GrpcCheckpoint) -> Result<Self, Self::Error> {

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -271,7 +271,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
             self.task_name, self.concurrency
         );
         // This channel will be used to send progress data from Workers to WorkerPool
-        // mian loop.
+        // main loop.
         let (progress_sender, mut progress_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         // This channel will be used to send Workers progress data from WorkerPool to
         // watermark tracking task.

--- a/examples/custom-indexer/rust/remote_reader.rs
+++ b/examples/custom-indexer/rust/remote_reader.rs
@@ -56,10 +56,10 @@ async fn main() -> Result<()> {
     executor.register(worker_pool).await?;
 
     let config = CheckpointReaderConfig {
-        // It's also possible to start a fullnode locally and use the REST API to sync checkpoints
-        // data.
+        // It's also possible to start a fullnode locally and use the gRPC connection to sync
+        // checkpoints data.
         //
-        // remote_store_url: Some(RemoteUrl::Fullnode("http://127.0.0.1:9000/api/v1".to_string())),
+        // remote_store_url: Some(RemoteUrl::Fullnode("http://127.0.0.1:50051".to_string())),
         remote_store_url: Some(RemoteUrl::HybridHistoricalStore {
             historical_url: "https://checkpoints.mainnet.iota.cafe/ingestion/historical".into(),
             live_url: Some("https://checkpoints.mainnet.iota.cafe/ingestion/live".into()),


### PR DESCRIPTION
# Description of change

This PR adds the ability for the ingestion core to receive a stream of checkpoints trough a gRPC connection from fullnode instead of polling from the REST API.

## Links to any relevant issues

fixes #7923 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- used the`testnet` network  and also started a local network to test the changes, both tests were conducted for several hours.
- the checkpoints are being downloaded (received form the stream) reliably, no gaps are present, in case of connection loss, the stream is terminated, once the connection is available it resumes downloading the checkpoints (start/stop VPN) all done automatically as prior to REST API implementation

> [!NOTE]
> A known issue is regarding downloading checkpoints which exceeds the gRPC limit of 4MB, which is not possible at the moment. The Node team is working on providing a chunking ability to stream large size checkpoints, like the genesis one.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> The following patch does not affect the indexer, it uses the old checkpoint reader impl which uses the REST API to download checkpoints. The patch introduced the changes on the new checkpoint reader (v2).

### Release Notes
- [x] Indexer: `iota-data-ingestion-core` CheckpointReader V2 use gRPC instead of REST API to sync checkpoints from fullnode
