### PR TITLE
feat(iota-json-rpc-types): support results in batchTransaction

### DIFF
--- a/.changeset/shy-carpets-work.md
+++ b/.changeset/shy-carpets-work.md
@@ -1,0 +1,6 @@
+---
+'@iota/graphql-transport': minor
+'@iota/iota-sdk': minor
+---
+
+Update move types

--- a/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
+++ b/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
@@ -10,7 +10,7 @@ use iota_json_rpc_api::{
     TransactionBuilderClient,
 };
 use iota_json_rpc_types::{
-    IotaObjectDataOptions, IotaObjectResponseQuery, MoveCallParams, ObjectsPage,
+    IotaObjectDataOptions, IotaObjectResponseQuery, MoveCallParams, ObjectsPage, PtbInput,
     RPCTransactionRequestParams, StakeStatus, TransactionBlockBytes, TransferObjectParams,
 };
 use iota_protocol_config::ProtocolConfig;
@@ -415,7 +415,10 @@ fn batch_transaction() {
                             module: "pay".to_string(),
                             function: "split".to_string(),
                             type_arguments: type_args![GAS::type_tag()]?,
-                            arguments: call_args!(coin_to_split, amount_to_split)?,
+                            arguments: call_args!(coin_to_split, amount_to_split)?
+                                .into_iter()
+                                .map(PtbInput::CallArg)
+                                .collect(),
                         }),
                         RPCTransactionRequestParams::TransferObjectRequestParams(
                             TransferObjectParams {

--- a/crates/iota-json-rpc-tests/tests/transaction_builder_api.rs
+++ b/crates/iota-json-rpc-tests/tests/transaction_builder_api.rs
@@ -5,20 +5,22 @@
 use std::str::FromStr;
 use std::{collections::BTreeMap, path::Path};
 
-use iota_json::{call_args, type_args};
+use iota_json::{call_arg, call_args, type_args};
 use iota_json_rpc_api::{
     CoinReadApiClient, IndexerApiClient, ReadApiClient, TransactionBuilderClient, WriteApiClient,
 };
 use iota_json_rpc_types::{
-    IotaObjectDataOptions, IotaObjectResponseQuery, IotaTransactionBlockEffectsAPI,
+    IotaArgument, IotaObjectDataOptions, IotaObjectResponseQuery, IotaTransactionBlockEffectsAPI,
     IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, MoveCallParams,
-    ObjectChange, RPCTransactionRequestParams, TransactionBlockBytes, TransferObjectParams,
+    ObjectChange, PtbInput, RPCTransactionRequestParams, TransactionBlockBytes,
+    TransferObjectParams,
 };
 use iota_macros::sim_test;
 use iota_move_build::BuildConfig;
 use iota_types::{
     IOTA_FRAMEWORK_ADDRESS,
     base_types::{ObjectID, SequenceNumber},
+    coin::Coin,
     digests::ObjectDigest,
     gas_coin::GAS,
     object::Owner,
@@ -567,7 +569,10 @@ async fn test_batch_transaction() -> Result<(), anyhow::Error> {
                     module: "pay".to_string(),
                     function: "split".to_string(),
                     type_arguments: type_args![GAS::type_tag()]?,
-                    arguments: call_args!(coin_to_split.coin_object_id, amount_to_split)?,
+                    arguments: call_args!(coin_to_split.coin_object_id, amount_to_split)?
+                        .into_iter()
+                        .map(PtbInput::CallArg)
+                        .collect(),
                 }),
                 RPCTransactionRequestParams::TransferObjectRequestParams(TransferObjectParams {
                     recipient: other_address,
@@ -627,6 +632,95 @@ async fn test_batch_transaction() -> Result<(), anyhow::Error> {
             transferred_object.owner(),
             Some(Owner::AddressOwner(other_address))
         );
+    }
+
+    Ok(())
+}
+
+#[sim_test]
+async fn test_batch_transaction_with_result() -> Result<(), anyhow::Error> {
+    let cluster = TestClusterBuilder::new().build().await;
+    let http_client = cluster.rpc_client();
+    let address = cluster.get_address_0();
+    let other_address = cluster.get_address_1();
+
+    let coins = http_client
+        .get_coins(address, None, None, Some(2))
+        .await
+        .unwrap()
+        .data;
+    let coin_to_split = &coins[0];
+    let gas = &coins[1];
+    let amount_to_split = 10;
+
+    let transaction_bytes: TransactionBlockBytes = http_client
+        .batch_transaction(
+            address,
+            vec![
+                RPCTransactionRequestParams::MoveCallRequestParams(MoveCallParams {
+                    package_object_id: ObjectID::new(IOTA_FRAMEWORK_ADDRESS.into_bytes()),
+                    module: "coin".to_string(),
+                    function: "split".to_string(),
+                    type_arguments: type_args![GAS::type_tag()]?,
+                    arguments: call_args!(coin_to_split.coin_object_id, amount_to_split)?
+                        .into_iter()
+                        .map(PtbInput::CallArg)
+                        .collect(),
+                }),
+                RPCTransactionRequestParams::MoveCallRequestParams(MoveCallParams {
+                    package_object_id: ObjectID::new(IOTA_FRAMEWORK_ADDRESS.into_bytes()),
+                    module: "transfer".to_string(),
+                    function: "public_transfer".to_string(),
+                    type_arguments: type_args![Coin::type_(GAS::type_tag())]?,
+                    arguments: vec![
+                        PtbInput::PtbRef(IotaArgument::Result(0)),
+                        PtbInput::CallArg(call_arg!(other_address)?),
+                    ],
+                }),
+            ],
+            Some(gas.coin_object_id),
+            10_000_000.into(),
+            None,
+        )
+        .await?;
+
+    let tx_response = execute_tx(&cluster, http_client, transaction_bytes)
+        .await
+        .unwrap();
+
+    // Assert results of the move call
+    {
+        let created_coin_ids: Vec<ObjectID> = tx_response
+            .effects
+            .unwrap()
+            .created()
+            .iter()
+            .map(|coin| coin.object_id())
+            .collect();
+        let coins = http_client
+            .get_coins(address, None, None, Some(100))
+            .await
+            .unwrap()
+            .data;
+        let split_coin_balance = coins
+            .iter()
+            .find(|coin| coin.coin_object_id == coin_to_split.coin_object_id)
+            .unwrap()
+            .balance;
+        let other_coins = http_client
+            .get_coins(other_address, None, None, Some(100))
+            .await
+            .unwrap()
+            .data;
+        let new_coin_balances: Vec<u64> = other_coins
+            .iter()
+            .filter(|coin| created_coin_ids.contains(&coin.coin_object_id))
+            .map(|coin| coin.balance)
+            .collect();
+        let expected_split_coin_balance = coin_to_split.balance - amount_to_split;
+
+        assert_eq!(split_coin_balance, expected_split_coin_balance);
+        assert_eq!(new_coin_balances, vec![amount_to_split]);
     }
 
     Ok(())

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2049,6 +2049,13 @@ impl From<Argument> for IotaArgument {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum PtbInput {
+    PtbRef(IotaArgument),
+    CallArg(IotaJsonValue),
+}
+
 /// The transaction for calling a Move function, either an entry function or a
 /// public function (which cannot return references).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -2195,7 +2202,7 @@ pub struct MoveCallParams {
     pub function: String,
     #[serde(default)]
     pub type_arguments: Vec<IotaTypeTag>,
-    pub arguments: Vec<IotaJsonValue>,
+    pub arguments: Vec<PtbInput>,
 }
 
 #[serde_as]

--- a/crates/iota-json/src/lib.rs
+++ b/crates/iota-json/src/lib.rs
@@ -766,7 +766,7 @@ pub fn is_receiving_argument(view: &CompiledModule, arg_type: &SignatureToken) -
     )
 }
 
-fn resolve_call_args(
+pub fn resolve_call_args(
     view: &CompiledModule,
     type_args: &[TypeTag],
     json_args: &[IotaJsonValue],
@@ -823,6 +823,7 @@ pub fn resolve_move_function_args(
             combined_args_json.len()
         );
     }
+
     // Check that the args are valid and convert to the correct format
     let call_args = resolve_call_args(&module, type_args, &combined_args_json, parameters)?;
     let tupled_call_args = call_args

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -9993,7 +9993,7 @@
           "arguments": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IotaJsonValue"
+              "$ref": "#/components/schemas/PtbInput"
             }
           },
           "function": {
@@ -11432,6 +11432,16 @@
       },
       "ProtocolVersion": {
         "$ref": "#/components/schemas/BigInt_for_uint64"
+      },
+      "PtbInput": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/IotaArgument"
+          },
+          {
+            "$ref": "#/components/schemas/IotaJsonValue"
+          }
+        ]
       },
       "PublicKey": {
         "oneOf": [

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -20,8 +20,8 @@ use iota_json_rpc_types::{
     IotaTransactionBlockResponseQuery, IotaTypeTag, MoveCallParams, MoveFunctionArgType,
     ObjectChange,
     ObjectValueKind::{ByImmutableReference, ByMutableReference, ByValue},
-    ObjectsPage, OwnedObjectRef, ProtocolConfigResponse, RPCTransactionRequestParams, Stake,
-    StakeStatus, TransactionBlockBytes, TransactionBlocksPage, TransactionFilter,
+    ObjectsPage, OwnedObjectRef, ProtocolConfigResponse, PtbInput, RPCTransactionRequestParams,
+    Stake, StakeStatus, TransactionBlockBytes, TransactionBlocksPage, TransactionFilter,
     TransferObjectParams, ValidatorApy, ValidatorApys,
 };
 use iota_open_rpc::ExamplePairing;
@@ -151,7 +151,10 @@ impl RpcExampleProvider {
                 arguments: vec![
                     IotaJsonValue::new(json!(coin_ref.0)).unwrap(),
                     IotaJsonValue::new(json!(random_amount)).unwrap(),
-                ],
+                ]
+                .into_iter()
+                .map(PtbInput::CallArg)
+                .collect(),
             }),
             RPCTransactionRequestParams::TransferObjectRequestParams(TransferObjectParams {
                 recipient,

--- a/crates/iota-transaction-builder/src/lib.rs
+++ b/crates/iota-transaction-builder/src/lib.rs
@@ -8,11 +8,11 @@ pub mod utils;
 
 use std::{result::Result, str::FromStr, sync::Arc};
 
-use anyhow::{Ok, bail};
+use anyhow::bail;
 use async_trait::async_trait;
 use iota_json::IotaJsonValue;
 use iota_json_rpc_types::{
-    IotaObjectDataOptions, IotaObjectResponse, IotaTypeTag, RPCTransactionRequestParams,
+    IotaObjectDataOptions, IotaObjectResponse, IotaTypeTag, PtbInput, RPCTransactionRequestParams,
 };
 use iota_types::{
     IOTA_FRAMEWORK_PACKAGE_ID,
@@ -466,6 +466,40 @@ impl TransactionBuilder {
         Ok(())
     }
 
+    /// Adds a single move call to the provided
+    /// [`ProgrammableTransactionBuilder`].
+    ///
+    /// Accepting [`PtbInput`] so one can also provide results from previous
+    /// move calls.
+    pub async fn single_move_call_with_ptb_inputs(
+        &self,
+        builder: &mut ProgrammableTransactionBuilder,
+        package: ObjectID,
+        module: &str,
+        function: &str,
+        type_args: Vec<IotaTypeTag>,
+        call_args: Vec<PtbInput>,
+    ) -> anyhow::Result<()> {
+        let module = Identifier::from_str(module)?;
+        let function = Identifier::from_str(function)?;
+
+        let type_args = type_args
+            .into_iter()
+            .map(|ty| ty.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let call_args = self
+            .resolve_and_check_call_args(
+                builder, package, &module, &function, &type_args, call_args,
+            )
+            .await?;
+
+        builder.command(Command::move_call(
+            package, module, function, type_args, call_args,
+        ));
+        Ok(())
+    }
+
     /// Construct a transaction kind for the SplitCoin transaction type
     /// It expects that only one of the two: split_amounts or split_count is
     /// provided If both are provided, it will use split_amounts.
@@ -694,7 +728,7 @@ impl TransactionBuilder {
                         .await?
                 }
                 RPCTransactionRequestParams::MoveCallRequestParams(param) => {
-                    self.single_move_call(
+                    self.single_move_call_with_ptb_inputs(
                         &mut builder,
                         param.package_object_id,
                         &param.module,

--- a/crates/iota-transaction-builder/src/utils.rs
+++ b/crates/iota-transaction-builder/src/utils.rs
@@ -4,15 +4,16 @@
 
 use std::{collections::BTreeMap, result::Result};
 
-use anyhow::{Ok, anyhow, bail};
+use anyhow::{anyhow, bail};
 use futures::future::join_all;
 use iota_json::{
-    IotaJsonValue, ResolvedCallArg, is_receiving_argument, resolve_move_function_args,
+    IotaJsonValue, ResolvedCallArg, is_receiving_argument, resolve_call_args,
+    resolve_move_function_args,
 };
-use iota_json_rpc_types::{IotaData, IotaObjectDataOptions, IotaRawData};
+use iota_json_rpc_types::{IotaArgument, IotaData, IotaObjectDataOptions, IotaRawData, PtbInput};
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
-    base_types::{IotaAddress, ObjectID, ObjectRef, ObjectType},
+    base_types::{IotaAddress, ObjectID, ObjectRef, ObjectType, TxContext, TxContextKind},
     gas_coin::GasCoin,
     move_package::MovePackage,
     object::{Object, Owner},
@@ -127,25 +128,7 @@ impl TransactionBuilder {
         type_args: &[TypeTag],
         json_args: Vec<IotaJsonValue>,
     ) -> Result<Vec<Argument>, anyhow::Error> {
-        let object = self
-            .0
-            .get_object_with_options(package_id, IotaObjectDataOptions::bcs_lossless())
-            .await?
-            .into_object()?;
-        let Some(IotaRawData::Package(package)) = object.bcs else {
-            bail!(
-                "Bcs field in object [{}] is missing or not a package.",
-                package_id
-            );
-        };
-        let package: MovePackage = MovePackage::new(
-            package.id,
-            object.version,
-            package.module_map,
-            ProtocolConfig::get_for_min_version().max_move_package_size(),
-            package.type_origin_table,
-            package.linkage_table,
-        )?;
+        let package = self.load_move_package(package_id).await?;
 
         let json_args_and_tokens = resolve_move_function_args(
             &package,
@@ -198,6 +181,119 @@ impl TransactionBuilder {
         Ok(args)
     }
 
+    /// Convert provided PtbInput's for a move function to their
+    /// [`Argument`] representation and check their validity.
+    pub async fn resolve_and_check_call_args(
+        &self,
+        builder: &mut ProgrammableTransactionBuilder,
+        package_id: ObjectID,
+        module: &Identifier,
+        function: &Identifier,
+        type_args: &[TypeTag],
+        call_args: Vec<PtbInput>,
+    ) -> Result<Vec<Argument>, anyhow::Error> {
+        let package = self.load_move_package(package_id).await?;
+
+        let module_compiled = package.deserialize_module(module, &BinaryConfig::standard())?;
+        let function_str = function.as_ident_str();
+        let function_def = module_compiled
+            .function_defs
+            .iter()
+            .find(|function_def| {
+                module_compiled.identifier_at(
+                    module_compiled
+                        .function_handle_at(function_def.function)
+                        .name,
+                ) == function_str
+            })
+            .ok_or_else(|| anyhow!("Could not resolve function {function} in module {module}"))?;
+        let function_signature = module_compiled.function_handle_at(function_def.function);
+        let parameters = &module_compiled
+            .signature_at(function_signature.parameters)
+            .0;
+
+        let expected_len = match parameters.last() {
+            Some(param) if TxContext::kind(&module_compiled, param) != TxContextKind::None => {
+                parameters.len() - 1
+            }
+            _ => parameters.len(),
+        };
+
+        if call_args.len() != expected_len {
+            bail!("Expected {expected_len} args, found {}", call_args.len());
+        }
+
+        let mut arguments = Vec::with_capacity(expected_len);
+        let mut objects = BTreeMap::new();
+
+        for (idx, (arg, param)) in call_args
+            .into_iter()
+            .zip(parameters.iter().take(expected_len))
+            .enumerate()
+        {
+            let argument = match arg {
+                PtbInput::CallArg(value) => {
+                    let json_slice = [value];
+                    let param_slice = [param.clone()];
+                    let resolved =
+                        resolve_call_args(&module_compiled, type_args, &json_slice, &param_slice)?;
+                    let resolved_arg = resolved
+                        .into_iter()
+                        .next()
+                        .ok_or_else(|| anyhow!("Unable to resolve pure argument at index {idx}"))?;
+
+                    match resolved_arg {
+                        ResolvedCallArg::Pure(bytes) => builder.input(CallArg::Pure(bytes))?,
+                        ResolvedCallArg::Object(id) => {
+                            let is_mutable = match param {
+                                SignatureToken::MutableReference(_) => true,
+                                _ => !param.is_reference(),
+                            };
+                            let object_arg = self
+                                .get_object_arg(
+                                    id,
+                                    &mut objects,
+                                    is_mutable,
+                                    &module_compiled,
+                                    param,
+                                )
+                                .await?;
+                            builder.input(CallArg::Object(object_arg))?
+                        }
+                        ResolvedCallArg::ObjVec(vec_ids) => {
+                            let mut object_args = Vec::with_capacity(vec_ids.len());
+                            for id in vec_ids {
+                                object_args.push(
+                                    self.get_object_arg(
+                                        id,
+                                        &mut objects,
+                                        false,
+                                        &module_compiled,
+                                        param,
+                                    )
+                                    .await?,
+                                );
+                            }
+                            builder.make_obj_vec(object_args)?
+                        }
+                    }
+                }
+                PtbInput::PtbRef(iota_arg) => match iota_arg {
+                    IotaArgument::GasCoin => Argument::GasCoin,
+                    IotaArgument::Input(idx) => Argument::Input(idx),
+                    IotaArgument::Result(idx) => Argument::Result(idx),
+                    IotaArgument::NestedResult(idx, nested_idx) => {
+                        Argument::NestedResult(idx, nested_idx)
+                    }
+                },
+            };
+
+            arguments.push(argument);
+        }
+
+        Ok(arguments)
+    }
+
     /// Get the latest object ref for an object.
     pub async fn get_object_ref(&self, object_id: ObjectID) -> anyhow::Result<ObjectRef> {
         // TODO: we should add retrial to reduce the transaction building error rate
@@ -219,5 +315,25 @@ impl TransactionBuilder {
             .into_object()?;
 
         Ok((object.object_ref(), object.object_type()?))
+    }
+
+    // Helper function to load a Move package from an object ID.
+    async fn load_move_package(&self, package_id: ObjectID) -> Result<MovePackage, anyhow::Error> {
+        let object = self
+            .0
+            .get_object_with_options(package_id, IotaObjectDataOptions::bcs_lossless())
+            .await?
+            .into_object()?;
+        let Some(IotaRawData::Package(package)) = object.bcs else {
+            bail!("Bcs field in object [{package_id}] is missing or not a package.");
+        };
+        Ok(MovePackage::new(
+            package.id,
+            object.version,
+            package.module_map,
+            ProtocolConfig::get_for_min_version().max_move_package_size(),
+            package.type_origin_table,
+            package.linkage_table,
+        )?)
     }
 }

--- a/sdk/graphql-transport/src/generated/queries.ts
+++ b/sdk/graphql-transport/src/generated/queries.ts
@@ -1498,7 +1498,12 @@ export type Epoch = {
    * epoch.
    */
   transactionBlocks: TransactionBlockConnection;
-  /** Validator related properties, including the active validators. */
+  /**
+   * Validator related properties, including the active validators.
+   *
+   * For epochs other than the current the data provided refer to the start
+   * of the epoch.
+   */
   validatorSet?: Maybe<ValidatorSet>;
 };
 
@@ -5562,14 +5567,17 @@ export type Validator = {
   operationCap?: Maybe<MoveObject>;
   /**
    * Pending pool token withdrawn during the current epoch, emptied at epoch
-   * boundaries.
+   * boundaries. Zero for past epochs.
    */
   pendingPoolTokenWithdraw?: Maybe<Scalars['BigInt']['output']>;
-  /** Pending stake amount for this epoch. */
+  /**
+   * Pending stake amount for the current epoch, emptied at epoch boundaries.
+   * Zero for past epochs.
+   */
   pendingStake?: Maybe<Scalars['BigInt']['output']>;
   /**
    * Pending stake withdrawn during the current epoch, emptied at epoch
-   * boundaries.
+   * boundaries. Zero for past epochs.
    */
   pendingTotalIotaWithdraw?: Maybe<Scalars['BigInt']['output']>;
   /** Total number of pool tokens issued by the pool. */

--- a/sdk/typescript/src/client/types/generated.ts
+++ b/sdk/typescript/src/client/types/generated.ts
@@ -1081,7 +1081,7 @@ export interface MoveCallMetrics {
     rank7Days: [MoveFunctionName, string][];
 }
 export interface MoveCallParams {
-    arguments: unknown[];
+    arguments: PtbInput[];
     function: string;
     module: string;
     packageObjectId: string;
@@ -1497,6 +1497,7 @@ export type ProtocolConfigValue =
     | {
           bool: string;
       };
+export type PtbInput = IotaArgument | unknown;
 export type PublicKey =
     | {
           Ed25519: string;

--- a/sdk/typescript/src/client/types/params.ts
+++ b/sdk/typescript/src/client/types/params.ts
@@ -460,7 +460,7 @@ export interface UnsafeMoveCallParams {
     typeArguments: string[];
     /**
      * the arguments to be passed into the Move function, in
-     * [IotaJson](/developer/references/iota-api) format
+     * [IotaJson](https://docs.iota.org/developer/references/iota-api) format
      */
     arguments: unknown[];
     /**

--- a/sdk/typescript/src/graphql/generated/2025.2/schema.graphql
+++ b/sdk/typescript/src/graphql/generated/2025.2/schema.graphql
@@ -1155,6 +1155,9 @@ type Epoch {
 	referenceGasPrice: BigInt
 	"""
 	Validator related properties, including the active validators.
+	
+	For epochs other than the current the data provided refer to the start
+	of the epoch.
 	"""
 	validatorSet: ValidatorSet
 	"""
@@ -4754,17 +4757,18 @@ type Validator {
 	"""
 	poolTokenBalance: BigInt
 	"""
-	Pending stake amount for this epoch.
+	Pending stake amount for the current epoch, emptied at epoch boundaries.
+	Zero for past epochs.
 	"""
 	pendingStake: BigInt
 	"""
 	Pending stake withdrawn during the current epoch, emptied at epoch
-	boundaries.
+	boundaries. Zero for past epochs.
 	"""
 	pendingTotalIotaWithdraw: BigInt
 	"""
 	Pending pool token withdrawn during the current epoch, emptied at epoch
-	boundaries.
+	boundaries. Zero for past epochs.
 	"""
 	pendingPoolTokenWithdraw: BigInt
 	"""


### PR DESCRIPTION
# Description of change

Feature-Branch PR

Add support to reference results of previous commands in the transaction
like this `"arguments": [{"Result": 0}]`

Fixes epic https://github.com/iotaledger/iota/issues/8749

## How the change has been tested

```bash
iota start --force-regenesis --with-faucet

iota client switch --env localnet
iota client faucet
ACTIVE_ADDRESS=$(iota client active-address)
read GAS_COIN COIN_TO_SPLIT < <(iota client gas --json | jq -r '[.[0].gasCoinId, .[1].gasCoinId] | @sh' | tr -d \')
AMOUNT_TO_SPLIT=1000
# just sending to own address
RECIPIENT_ADDRESS=$(iota client active-address)
GAS_BUDGET=100000000

# without gas coin
JSON_DATA='{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "unsafe_batchTransaction",
  "params": {
    "signer": "'$SENDER_ADDRESS'",
    "single_transaction_params": [
      {
        "moveCallRequestParams": {
          "packageObjectId": "0x2",
          "module": "coin",
          "function": "split",
          "typeArguments": ["0x2::iota::IOTA"],
          "arguments": ["'$COIN_TO_SPLIT'", "'$AMOUNT_TO_SPLIT'"]
        }
      },
      {
        "moveCallRequestParamsV2": {
          "packageObjectId": "0x2",
          "module": "transfer",
          "function": "public_transfer",
          "typeArguments": ["0x2::coin::Coin<0x2::iota::IOTA>"],
          "arguments": [{"Result": 0}, {"Pure": "'$RECIPIENT_ADDRESS'"}]
        }
      }
    ],
    "gas": "'$GAS_COIN'",
    "gas_budget": "'$GAS_BUDGET'"
  }
}'

echo "$JSON_DATA"

curl http://localhost:9000 \
--header 'content-type: application/json' \
--data "$JSON_DATA" | jq .
```

```JSON
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "txBytes": "AAADAQA3td2Z0qo0perjxpLvkeal2gagyNzh4eRAIjOcdpmXmwIAAAAAAAAAIOoHM85GUzDO3pf8HMApM8E1KnnOlVWrhhgYquKUOzsjAAjoAwAAAAAAAAAgERERERUE6TUOY11lzTjM0sApQ0xqOkgNiUepumoVshUCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACBGNvaW4Fc3BsaXQBBwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACBGlvdGEESU9UQQACAQAAAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACCHRyYW5zZmVyD3B1YmxpY190cmFuc2ZlcgEHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIEY29pbgRDb2luAQcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgRpb3RhBElPVEEAAgIAAAECABEREREVBOk1DmNdZc04zNLAKUNMajpIDYlHqbpqFbIVARfhNmCqOECu1WCaq7Kt8z25MkA/BI2KrRRMrcIqrY2+AgAAAAAAAAAgtGDVq6PjTxcJ9KQdJp0LhXtlUyX23syRmSgTNHADnTgRERERFQTpNQ5jXWXNOMzSwClDTGo6SA2JR6m6ahWyFegDAAAAAAAAAOH1BQAAAAAA",
    "gas": [
      {
        "objectId": "0x17e13660aa3840aed5609aabb2adf33db932403f048d8aad144cadc22aad8dbe",
        "version": 2,
        "digest": "D982YfFE89pNogyCPUZDgGSBAGz29KSdRoymEYoqXzsq"
      }
    ],
    "inputObjects": [
      {
        "ImmOrOwnedMoveObject": {
          "objectId": "0x37b5dd99d2aa34a5eae3c692ef91e6a5da06a0c8dce1e1e44022339c7699979b",
          "version": 2,
          "digest": "GkYmiw1Mqbk9iNaY5Z241BRttw7RM71CXitotVTuMBxe"
        }
      },
      {
        "MovePackage": "0x0000000000000000000000000000000000000000000000000000000000000002"
      },
      {
        "ImmOrOwnedMoveObject": {
          "objectId": "0x17e13660aa3840aed5609aabb2adf33db932403f048d8aad144cadc22aad8dbe",
          "version": 2,
          "digest": "D982YfFE89pNogyCPUZDgGSBAGz29KSdRoymEYoqXzsq"
        }
      }
    ]
  }
}
```

- [ ] Basic tests (linting, compilation, formatting, unit/integration
tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my
feature works
- [ ] I have checked that new and existing unit tests pass locally with
my changes

Some tests fail because the graphql snapshots and TS SDK isn't updated
in this PR, they should be updated in another one

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [x] JSON-RPC: Added PtbInput to support referencing results in
unsafe_batchTransaction
- [ ] GraphQL:
- [ ] CLI:
- [x] Rust SDK: Added `single_move_call_with_ptb_inputs()` to support
referencing results of previous commands
- [ ] REST API:
