### PR TITLE
chore(move-tooling): use mysten dependency and update locks

### DIFF
--- a/external-crates/move/tooling/prettier-extension/package-lock.json
+++ b/external-crates/move/tooling/prettier-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "prettier-move",
-	"version": "0.1.0",
+	"version": "0.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prettier-move",
-			"version": "0.1.0",
+			"version": "0.3.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@iota/prettier-plugin-move": "^0.2.2",
+				"@mysten/prettier-plugin-move": "^0.3.0",
 				"cosmiconfig": "^9.0.0",
 				"prettier": "^3.3.2"
 			},
@@ -232,10 +232,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/@iota/prettier-plugin-move": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@iota/prettier-plugin-move/-/prettier-plugin-move-0.2.2.tgz",
-			"integrity": "sha512-nWw55WTOUnQmfRdAIL49CUJ6W1Zq0N9Q7zVw1Cw6xj9ciBFL0y3pW9Aw7iIiTKi1ZKwgQjLUiwsq8TxkQvjMUg==",
+		"node_modules/@mysten/prettier-plugin-move": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@mysten/prettier-plugin-move/-/prettier-plugin-move-0.3.3.tgz",
+			"integrity": "sha512-UCq9W95fyYI6EUG3Lm1mtEyxBqVHzg7PdofMX7nSxn6841GwC7Tv6VhdRcDIANMbq+m6e2whxgEi+xXtDSnXrg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"prettier": "^3.3.2",

--- a/external-crates/move/tooling/prettier-extension/package.json
+++ b/external-crates/move/tooling/prettier-extension/package.json
@@ -76,7 +76,7 @@
 		"lint:fix": "pnpm run eslint:fix && pnpm run prettier:fix"
 	},
 	"dependencies": {
-		"@iota/prettier-plugin-move": "^0.3.0",
+		"@mysten/prettier-plugin-move": "^0.3.0",
 		"cosmiconfig": "^9.0.0",
 		"prettier": "^3.3.2"
 	},


### PR DESCRIPTION
# Description of change

Use `@mysten/prettier-plugin-move` dependency in prettier-extension and update package-lock