### PR TITLE
fix(consensus): reading own blocks returns only fully available blocks from DAG state

### DIFF
--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -149,7 +149,7 @@ impl BlockManager {
                 // for this accepted header we already have a block, so we add it to dag_state
                 self.dag_state
                     .write()
-                    .add_transactions(block.verified_transactions, "block streaming");
+                    .add_transactions(block.verified_transactions, "Block streaming");
             }
         }
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -221,7 +221,7 @@ impl Core {
         let last_proposed_block = match self.try_propose(true).unwrap() {
             (Some(block), _) => Some(block),
             (None, _) => {
-                let last_proposed_block = self.dag_state.read().get_last_proposed_block();
+                let last_proposed_block = self.dag_state.read().recover_own_block();
                 if self.should_propose() {
                     assert!(
                         last_proposed_block.round() != GENESIS_ROUND,
@@ -1132,10 +1132,6 @@ impl Core {
         self.last_proposed_block_header().round()
     }
 
-    #[expect(dead_code)]
-    fn last_proposed_block(&self) -> VerifiedBlock {
-        self.dag_state.read().get_last_proposed_block()
-    }
 
     fn last_proposed_block_header(&self) -> VerifiedBlockHeader {
         self.dag_state.read().get_last_proposed_block_header()

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -221,7 +221,7 @@ impl Core {
         let last_proposed_block = match self.try_propose(true).unwrap() {
             (Some(block), _) => Some(block),
             (None, _) => {
-                let last_proposed_block = self.dag_state.read().recover_own_block();
+                let last_proposed_block = self.dag_state.read().recover_last_own_block();
                 if self.should_propose() {
                     assert!(
                         last_proposed_block.round() != GENESIS_ROUND,

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1132,7 +1132,6 @@ impl Core {
         self.last_proposed_block_header().round()
     }
 
-
     fn last_proposed_block_header(&self) -> VerifiedBlockHeader {
         self.dag_state.read().get_last_proposed_block_header()
     }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -817,7 +817,6 @@ impl DagState {
             let transactions_opt = self.recent_transactions.get(block_ref);
             if let (Some(header), Some(transactions)) = (header_opt, transactions_opt) {
                 blocks.push(VerifiedBlock::new(header.clone(), transactions.clone()));
-                continue;
             } else {
                 warn!("Block header or transactions missing for block ref: {block_ref}");
             }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -747,7 +747,9 @@ impl DagState {
 
     /// Gets the last proposed block from this authority.
     /// If no block is proposed yet, returns Genesis block.
-    pub(crate) fn get_last_proposed_block(&self) -> VerifiedBlock {
+    /// NOTE: the method panics if transactions or headers are not found in DAG State for the
+    /// most recent header, as that should not happen for correct initialization
+    pub(crate) fn recover_last_own_block(&self) -> VerifiedBlock {
         if let Some(last) = self.recent_headers_refs_by_authority[self.context.own_index].last() {
             let header = self
                 .recent_block_headers
@@ -800,7 +802,8 @@ impl DagState {
 
     /// Returns own cached recent blocks.
     /// Blocks returned are limited to round >= `start`, and cached.
-    /// NOTE: caller should not assume returned blocks are always chained.
+    /// NOTE: the method is soft in the sense that the if transactions are not
+    /// found for a block header, that block is not included in the return result
     pub(crate) fn get_own_cached_blocks(&self, start: Round) -> Vec<VerifiedBlock> {
         let authority = self.context.own_index;
         let mut blocks = vec![];
@@ -808,16 +811,18 @@ impl DagState {
             Included(BlockRef::new(start, authority, BlockHeaderDigest::MIN)),
             Unbounded,
         )) {
-            // Panic if header or transactions are missing for the block_ref.
-            let header = self
+            let header_opt = self
                 .recent_block_headers
-                .get(block_ref)
-                .unwrap_or_else(|| panic!("Missing block header for {block_ref:?}"));
-            let transactions = self
+                .get(block_ref);
+            let transactions_opt = self
                 .recent_transactions
-                .get(block_ref)
-                .unwrap_or_else(|| panic!("Missing transactions for {block_ref:?}"));
-            blocks.push(VerifiedBlock::new(header.clone(), transactions.clone()));
+                .get(block_ref);
+            if let (Some(header), Some(transactions)) = (header_opt, transactions_opt) {
+                blocks.push(VerifiedBlock::new(header.clone(), transactions.clone()));
+                continue;
+            } else {
+                warn!("Block header or transactions missing for block ref: {block_ref}");
+            }
         }
         blocks
     }
@@ -2472,7 +2477,7 @@ mod test {
 
         // Check the last proposed block
         assert_eq!(
-            dag_state.get_last_proposed_block(),
+            dag_state.recover_own_block(),
             dag_builder.blocks(num_rounds..=num_rounds)[0].clone()
         );
 
@@ -2505,7 +2510,7 @@ mod test {
 
         // The last proposed block should be from the round 5
         assert_eq!(
-            dag_state.get_last_proposed_block(),
+            dag_state.recover_own_block(),
             dag_builder.blocks(5..=5)[0].clone()
         );
 
@@ -2953,7 +2958,7 @@ mod test {
                 .into_iter()
                 .find(|block| block.author() == context.own_index)
                 .unwrap();
-            assert_eq!(dag_state.read().get_last_proposed_block(), my_genesis_block);
+            assert_eq!(dag_state.read().recover_own_block(), my_genesis_block);
         }
 
         // WHEN adding some block headers for authorities, only the last ones should be

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2475,7 +2475,7 @@ mod test {
 
         // Check the last proposed block
         assert_eq!(
-            dag_state.recover_own_block(),
+            dag_state.recover_last_own_block(),
             dag_builder.blocks(num_rounds..=num_rounds)[0].clone()
         );
 
@@ -2508,7 +2508,7 @@ mod test {
 
         // The last proposed block should be from the round 5
         assert_eq!(
-            dag_state.recover_own_block(),
+            dag_state.recover_last_own_block(),
             dag_builder.blocks(5..=5)[0].clone()
         );
 
@@ -2956,7 +2956,7 @@ mod test {
                 .into_iter()
                 .find(|block| block.author() == context.own_index)
                 .unwrap();
-            assert_eq!(dag_state.read().recover_own_block(), my_genesis_block);
+            assert_eq!(dag_state.read().recover_last_own_block(), my_genesis_block);
         }
 
         // WHEN adding some block headers for authorities, only the last ones should be

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -375,7 +375,7 @@ impl DagState {
             .iter()
             .max()
             .expect("There should be at least one last committed round");
-        info!(
+        debug!(
             "Last solid commit has leader at round {}; last pending commit has leader at round {}",
             last_solid_commit_leader_round, max_commit_round
         );
@@ -747,8 +747,9 @@ impl DagState {
 
     /// Gets the last proposed block from this authority.
     /// If no block is proposed yet, returns Genesis block.
-    /// NOTE: the method panics if transactions or headers are not found in DAG State for the
-    /// most recent header, as that should not happen for correct initialization
+    /// NOTE: the method panics if transactions or headers are not found in DAG
+    /// State for the most recent header, as that should not happen for
+    /// correct initialization
     pub(crate) fn recover_last_own_block(&self) -> VerifiedBlock {
         if let Some(last) = self.recent_headers_refs_by_authority[self.context.own_index].last() {
             let header = self
@@ -803,7 +804,8 @@ impl DagState {
     /// Returns own cached recent blocks.
     /// Blocks returned are limited to round >= `start`, and cached.
     /// NOTE: the method is soft in the sense that the if transactions are not
-    /// found for a block header, that block is not included in the return result
+    /// found for a given block header, that block is not included in the return
+    /// result
     pub(crate) fn get_own_cached_blocks(&self, start: Round) -> Vec<VerifiedBlock> {
         let authority = self.context.own_index;
         let mut blocks = vec![];
@@ -811,12 +813,8 @@ impl DagState {
             Included(BlockRef::new(start, authority, BlockHeaderDigest::MIN)),
             Unbounded,
         )) {
-            let header_opt = self
-                .recent_block_headers
-                .get(block_ref);
-            let transactions_opt = self
-                .recent_transactions
-                .get(block_ref);
+            let header_opt = self.recent_block_headers.get(block_ref);
+            let transactions_opt = self.recent_transactions.get(block_ref);
             if let (Some(header), Some(transactions)) = (header_opt, transactions_opt) {
                 blocks.push(VerifiedBlock::new(header.clone(), transactions.clone()));
                 continue;


### PR DESCRIPTION
# Description of change

Due to the non-atomic nature of storing transactions and headers in the DAG state, we could have an own block header, but no transactions for that header leading to the panic when calling method `get_own_cached_blocks`. In particular, that is used after getting a subscription for streaming own blocks.

We change the method `get_own_cached_blocks` to return only blocks which have both headers and transactions and don't return those with missing parts (e.g. transactions).

## Links to any relevant issues

Fixes #8874

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes
