### PR TITLE
feat(consensus): skip acknowledgments for empty `VerifiedTransaction`

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -252,6 +252,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             verified_block_header.transactions_commitment(),
             serialized_transactions,
         );
+        let has_transactions = verified_transactions.has_transactions();
         let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);
 
         let block_ref = verified_block.reference();
@@ -579,23 +580,26 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         missing_committed_txns.extend(missing_block_committed_transactions);
 
         // 12. Add our shard from the received block and its proof to the dag_state
-        let shard_for_core = ShardWithProof {
-            shard: our_shard,
-            transaction_commitment,
-            proof: proof_for_shard,
-            block_ref,
-        };
-        let serialized_shard_for_core: Bytes = bcs::to_bytes(&shard_for_core)
-            .map_err(ConsensusError::SerializationFailure)?
-            .into();
-        let shard_for_core = VerifiedOwnShard {
-            serialized_shard: serialized_shard_for_core,
-            block_ref,
-        };
-        self.core_dispatcher
-            .add_shards(vec![shard_for_core])
-            .await
-            .map_err(|_| ConsensusError::Shutdown)?;
+        // only if it contains transactions
+        if has_transactions {
+            let shard_for_core = ShardWithProof {
+                shard: our_shard,
+                transaction_commitment,
+                proof: proof_for_shard,
+                block_ref,
+            };
+            let serialized_shard_for_core: Bytes = bcs::to_bytes(&shard_for_core)
+                .map_err(ConsensusError::SerializationFailure)?
+                .into();
+            let shard_for_core = VerifiedOwnShard {
+                serialized_shard: serialized_shard_for_core,
+                block_ref,
+            };
+            self.core_dispatcher
+                .add_shards(vec![shard_for_core])
+                .await
+                .map_err(|_| ConsensusError::Shutdown)?;
+        }
 
         // 13. update `useful_authorities_from_peer`
         // create a set of authority indexes from the `additional_block_headers`

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -68,19 +68,23 @@ impl Transaction {
     /// Create a vector of random transactions for testing.
     #[cfg(test)]
     pub fn random_transactions(count: usize, max_len: usize) -> Vec<Self> {
+        (0..count)
+            .map(|_| Self::random_transaction(max_len))
+            .collect()
+    }
+
+    // Create one random transaction for testing
+    #[cfg(test)]
+    pub fn random_transaction(max_len: usize) -> Self {
         use rand::{Rng, RngCore};
 
         let mut rng = rand::thread_rng();
-        (0..count)
-            .map(|_| {
-                let len = rng.gen_range(0..=max_len);
-                let mut buf = vec![0u8; len];
-                rng.fill_bytes(&mut buf);
-                Transaction {
-                    data: Bytes::from(buf),
-                }
-            })
-            .collect()
+        let len = rng.gen_range(0..=max_len);
+        let mut buf = vec![0u8; len];
+        rng.fill_bytes(&mut buf);
+        Transaction {
+            data: Bytes::from(buf),
+        }
     }
 }
 
@@ -932,6 +936,10 @@ impl VerifiedTransactions {
 
     pub fn serialized(&self) -> &Bytes {
         &self.serialized
+    }
+
+    pub fn has_transactions(&self) -> bool {
+        !self.transactions.is_empty()
     }
 }
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -336,6 +336,7 @@ impl DagState {
                 .with_label_values(&[source])
                 .inc();
             tracing::debug!("Adding transactions for block ref: {block_ref}");
+            let has_transactions = transactions.has_transactions();
             self.transactions_to_write.push(transactions);
             // If a block is not very old, add it to pending acknowledgments
             let clock_round = self.threshold_clock_round();
@@ -343,7 +344,23 @@ impl DagState {
                 clock_round.saturating_sub(self.context.protocol_config.gc_depth());
 
             if block_ref.round >= min_round {
-                self.add_pending_acknowledgment(block_ref);
+                if has_transactions {
+                    self.add_pending_acknowledgment(block_ref);
+                } else {
+                    // report skipped acknowledgment
+                    let hostname = self
+                        .context
+                        .committee
+                        .authority(block_ref.author)
+                        .hostname
+                        .as_str();
+                    self.context
+                        .metrics
+                        .node_metrics
+                        .skipped_empty_transaction_acknowledgments
+                        .with_label_values(&[hostname])
+                        .inc()
+                }
             }
         }
     }
@@ -1819,10 +1836,12 @@ mod test {
 
     use super::*;
     use crate::{
+        Transaction,
         block_header::{
-            BlockHeaderDigest, BlockRef, BlockTimestampMs, TestBlockHeader, VerifiedBlockHeader,
-            genesis_block_headers,
+            BlockHeaderDigest, BlockRef, BlockTimestampMs, TestBlockHeader, TransactionsCommitment,
+            VerifiedBlockHeader, genesis_block_headers,
         },
+        encoder::create_encoder,
         storage::{WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
         test_dag_parser::parse_dag,
@@ -3240,6 +3259,82 @@ mod test {
                 block_ref,
                 block_ref.round
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_skip_acknowledgments_all_empty_transactions() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        // Create test blocks for round 1 ~ 10
+        let num_rounds: u32 = 10;
+        let num_authorities: u8 = 4;
+        let mut blocks = Vec::new();
+        // create blocks
+        for round in 1..=num_rounds {
+            for author in 0..num_authorities {
+                let block =
+                    VerifiedBlock::new_for_test(TestBlockHeader::new(round, author).build());
+                blocks.push(block);
+            }
+        }
+
+        // add transactions for all blocks
+        blocks.into_iter().for_each(|block| {
+            dag_state.add_transactions(block.verified_transactions, "test");
+        });
+
+        assert!(dag_state.pending_acknowledgments.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_skip_acknowledgments_some_contain_transactions() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let mut encoder = create_encoder(&context);
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        // Create test blocks for round 1 ~ 10
+        let num_rounds: u32 = 10;
+        let num_authorities: u8 = 4;
+        // create blocks
+        let mut block_refs_with_transactions = Vec::new();
+        for round in 1..=num_rounds {
+            for author in 0..num_authorities {
+                let block_ref = BlockRef::new(round, author.into(), BlockHeaderDigest::default());
+                let transactions = if round > 5 {
+                    block_refs_with_transactions.push(block_ref);
+                    vec![Transaction::random_transaction(64)]
+                } else {
+                    vec![]
+                };
+                let serialized = Transaction::serialize(&transactions).unwrap();
+                let transaction_commitment =
+                    TransactionsCommitment::compute_transactions_commitment(
+                        &serialized,
+                        &context,
+                        &mut encoder,
+                    )
+                    .unwrap();
+                let verified_transaction = VerifiedTransactions::new(
+                    transactions,
+                    block_ref,
+                    transaction_commitment,
+                    serialized,
+                );
+                dag_state.add_transactions(verified_transaction, "test");
+            }
+        }
+        assert_eq!(
+            dag_state.pending_acknowledgments.len(),
+            block_refs_with_transactions.len()
+        );
+        for block_ref in block_refs_with_transactions.iter() {
+            assert!(dag_state.pending_acknowledgments.contains(block_ref));
         }
     }
 }

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -156,6 +156,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) valid_shards_in_bundles: IntCounterVec,
     pub(crate) rejected_blocks: IntCounterVec,
     pub(crate) rejected_future_blocks: IntCounterVec,
+    pub(crate) skipped_empty_transaction_acknowledgments: IntCounterVec,
     pub(crate) subscribed_blocks: IntCounterVec,
     pub(crate) verified_blocks: IntCounterVec,
     pub(crate) committed_leaders_total: IntCounterVec,
@@ -568,6 +569,12 @@ impl NodeMetrics {
             rejected_future_blocks: register_int_counter_vec_with_registry!(
                 "rejected_future_blocks",
                 "Number of blocks rejected because their timestamp is too far in the future",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            skipped_empty_transaction_acknowledgments: register_int_counter_vec_with_registry!(
+                "skipped_empty_transaction_acknowledgments",
+                "Number of transaction acknowledgments skipped due to empty transaction vector in VerifiedTransaction",
                 &["authority"],
                 registry,
             ).unwrap(),


### PR DESCRIPTION
# Description of change
Skip acknowledging transactions and sending shards to core for `VerifiedTransactions` that have empty `transaction` vectors.
- skips the call to `DagState::add_pending_acknowledgment` if the `VerifiedTransaction` in question is empty.
- skips the call  `core_dispatcher.add_shards` in `handle_subscribed_block_bundle` if the `VerifiedTransaction` in question is empty.
- add `Transaction::random_transaction` test helper method to generate a single random transaction
- added tests to test skipping acknowledgements.

## Links to any relevant issues

fixes #8038.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
