### PR TITLE
refactor(iota-cluster-test): lower-case error messages and small changes

### DIFF
--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -96,13 +96,15 @@ impl Cluster for RemoteRunningCluster {
                 options
                     .fullnode_address
                     .clone()
-                    .expect("Expect 'fullnode_address' for Env::Custom"),
+                    .expect("expect 'fullnode_address' for Env::Custom"),
                 options
                     .faucet_address
                     .clone()
-                    .expect("Expect 'faucet_address' for Env::Custom"),
+                    .expect("expect 'faucet_address' for Env::Custom"),
             ),
-            Env::NewLocal => unreachable!("NewLocal shouldn't use RemoteRunningCluster"),
+            Env::NewLocal => {
+                unreachable!("the NewLocal variant shouldn't use RemoteRunningCluster")
+            }
         };
 
         // TODO: test connectivity before proceeding?
@@ -162,12 +164,12 @@ impl Cluster for LocalNewCluster {
         // TODO: options should contain port instead of address
         let fullnode_rpc_addr = options.fullnode_address.as_ref().map(|addr| {
             addr.parse::<SocketAddr>()
-                .expect("Unable to parse fullnode address")
+                .expect("unable to parse fullnode address")
         });
 
         let indexer_address = options.indexer_address.as_ref().map(|addr| {
             addr.parse::<SocketAddr>()
-                .expect("Unable to parse indexer address")
+                .expect("unable to parse indexer address")
         });
 
         let mut cluster_builder = TestClusterBuilder::new()
@@ -185,7 +187,7 @@ impl Cluster for LocalNewCluster {
                 committee_with_network: _,
             } = PersistedConfig::read(&network_config_path).map_err(|err| {
                 err.context(format!(
-                    "Cannot open IOTA network config file at {network_config_path:?}"
+                    "cannot open IOTA network config file at {network_config_path:?}"
                 ))
             })?;
 
@@ -327,7 +329,7 @@ impl Cluster for LocalNewCluster {
 impl Cluster for Box<dyn Cluster + Send + Sync> {
     async fn start(_options: &ClusterTestOpt) -> Result<Self, anyhow::Error> {
         unreachable!(
-            "If we already have a boxed Cluster trait object we wouldn't have to call this function"
+            "if we already have a boxed Cluster trait object we wouldn't have to call this function"
         );
     }
     fn fullnode_url(&self) -> &str {
@@ -361,7 +363,7 @@ pub fn new_wallet_context_from_cluster(
     let config_dir = cluster.config_directory();
     let wallet_config_path = config_dir.join("client.yaml");
     let fullnode_url = cluster.fullnode_url();
-    info!("Use RPC: {}", &fullnode_url);
+    info!("Use RPC: {fullnode_url}");
     let keystore_path = config_dir.join(IOTA_KEYSTORE_FILENAME);
     let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
     let address: IotaAddress = key_pair.public().into();
@@ -382,6 +384,6 @@ pub fn new_wallet_context_from_cluster(
     );
 
     WalletContext::new(&wallet_config_path, None, None).unwrap_or_else(|e| {
-        panic!("Failed to init wallet context from path {wallet_config_path:?}, error: {e}")
+        panic!("failed to init wallet context from path {wallet_config_path:?}, error: {e}")
     })
 }

--- a/crates/iota-cluster-test/src/faucet.rs
+++ b/crates/iota-cluster-test/src/faucet.rs
@@ -28,7 +28,7 @@ impl FaucetClientFactory {
             None => {
                 let key = cluster
                     .local_faucet_key()
-                    .expect("Expect local faucet key for local cluster")
+                    .expect("expect local faucet key for local cluster")
                     .copy();
                 let wallet_context = new_wallet_context_from_cluster(cluster, key)
                     .instrument(info_span!("init_wallet_context_for_faucet"));
@@ -65,7 +65,7 @@ pub struct RemoteFaucetClient {
 
 impl RemoteFaucetClient {
     fn new(url: String) -> Self {
-        info!("Use remote faucet: {}", url);
+        info!("Use remote faucet: {url}");
         Self { remote_url: url }
     }
 }
@@ -76,7 +76,7 @@ impl FaucetClient for RemoteFaucetClient {
     /// It also verifies the effects are observed by fullnode.
     async fn request_iota_coins(&self, request_address: IotaAddress) -> FaucetResponse {
         let gas_url = format!("{}/gas", self.remote_url);
-        debug!("Getting coin from remote faucet {}", gas_url);
+        debug!("Getting coin from remote faucet {gas_url}");
         let data = HashMap::from([("recipient", Hex::encode(request_address))]);
         let map = HashMap::from([("FixedAmountRequest", data)]);
 
@@ -91,21 +91,21 @@ impl FaucetClient for RemoteFaucetClient {
             .json(&map)
             .send()
             .await
-            .unwrap_or_else(|e| panic!("Failed to talk to remote faucet {gas_url:?}: {e:?}"));
+            .unwrap_or_else(|e| panic!("failed to talk to remote faucet {gas_url:?}: {e:?}"));
         let full_bytes = response.bytes().await.unwrap();
         let faucet_response: FaucetResponse = serde_json::from_slice(&full_bytes)
-            .map_err(|e| anyhow::anyhow!("json deser failed with bytes {:?}: {e}", full_bytes))
+            .map_err(|e| anyhow::anyhow!("json deser failed with bytes {full_bytes:?}: {e}"))
             .unwrap();
 
         if let Some(error) = faucet_response.error {
-            panic!("Failed to get gas tokens with error: {error}")
+            panic!("failed to get gas tokens with error: {error}")
         };
 
         faucet_response
     }
     async fn batch_request_iota_coins(&self, request_address: IotaAddress) -> BatchFaucetResponse {
         let gas_url = format!("{}/v1/gas", self.remote_url);
-        debug!("Getting coin from remote faucet {}", gas_url);
+        debug!("Getting coin from remote faucet {gas_url}");
         let data = HashMap::from([("recipient", Hex::encode(request_address))]);
         let map = HashMap::from([("FixedAmountRequest", data)]);
 
@@ -120,14 +120,14 @@ impl FaucetClient for RemoteFaucetClient {
             .json(&map)
             .send()
             .await
-            .unwrap_or_else(|e| panic!("Failed to talk to remote faucet {gas_url:?}: {e:?}"));
+            .unwrap_or_else(|e| panic!("failed to talk to remote faucet {gas_url:?}: {e:?}"));
         let full_bytes = response.bytes().await.unwrap();
         let faucet_response: BatchFaucetResponse = serde_json::from_slice(&full_bytes)
-            .map_err(|e| anyhow::anyhow!("json deser failed with bytes {:?}: {e}", full_bytes))
+            .map_err(|e| anyhow::anyhow!("json deser failed with bytes {full_bytes:?}: {e}"))
             .unwrap();
 
         if let Some(error) = faucet_response.error {
-            panic!("Failed to get gas tokens with error: {error}")
+            panic!("failed to get gas tokens with error: {error}")
         };
 
         faucet_response
@@ -135,9 +135,8 @@ impl FaucetClient for RemoteFaucetClient {
     async fn get_batch_send_status(&self, task_id: Uuid) -> BatchStatusFaucetResponse {
         let status_url = format!("{}/v1/status/{}", self.remote_url, task_id);
         debug!(
-            "Checking status for task {} from remote faucet {}",
-            task_id.to_string(),
-            status_url
+            "Checking status for task {} from remote faucet {status_url}",
+            task_id.to_string()
         );
 
         let auth_header = match env::var("FAUCET_AUTH_HEADER") {
@@ -150,10 +149,10 @@ impl FaucetClient for RemoteFaucetClient {
             .header("Authorization", auth_header)
             .send()
             .await
-            .unwrap_or_else(|e| panic!("Failed to talk to remote faucet {status_url:?}: {e:?}"));
+            .unwrap_or_else(|e| panic!("failed to talk to remote faucet {status_url:?}: {e:?}"));
         let full_bytes = response.bytes().await.unwrap();
         let faucet_response: BatchStatusFaucetResponse = serde_json::from_slice(&full_bytes)
-            .map_err(|e| anyhow::anyhow!("json deser failed with bytes {:?}: {e}", full_bytes))
+            .map_err(|e| anyhow::anyhow!("json deser failed with bytes {full_bytes:?}: {e}"))
             .unwrap();
 
         faucet_response
@@ -178,7 +177,7 @@ impl FaucetClient for LocalFaucetClient {
             .simple_faucet
             .send(Uuid::new_v4(), request_address, &[200_000_000_000; 5])
             .await
-            .unwrap_or_else(|err| panic!("Failed to get gas tokens with error: {err}"));
+            .unwrap_or_else(|err| panic!("failed to get gas tokens with error: {err}"));
 
         receipt.into()
     }
@@ -187,7 +186,7 @@ impl FaucetClient for LocalFaucetClient {
             .simple_faucet
             .batch_send(Uuid::new_v4(), request_address, &[200_000_000_000; 5])
             .await
-            .unwrap_or_else(|err| panic!("Failed to get gas tokens with error: {err}"));
+            .unwrap_or_else(|err| panic!("failed to get gas tokens with error: {err}"));
 
         receipt.into()
     }
@@ -196,7 +195,7 @@ impl FaucetClient for LocalFaucetClient {
             .simple_faucet
             .get_batch_send_status(task_id)
             .await
-            .unwrap_or_else(|err| panic!("Failed to get gas tokens with error: {err}"));
+            .unwrap_or_else(|err| panic!("failed to get gas tokens with error: {err}"));
 
         status.into()
     }

--- a/crates/iota-cluster-test/src/helper.rs
+++ b/crates/iota-cluster-test/src/helper.rs
@@ -81,15 +81,14 @@ impl ObjectChecker {
                     .with_bcs(),
             )
             .await
-            .or_else(|err| bail!("Failed to get object info (id: {}), err: {err}", object_id))?;
+            .or_else(|err| bail!("failed to get object info (id: {object_id}), err: {err}"))?;
 
         trace!("getting object {object_id}, info :: {object_info:?}");
 
         match (object_info.data, object_info.error) {
             (None, Some(IotaObjectResponseError::NotExists { object_id })) => {
                 panic!(
-                    "Node can't find gas object {} with client {:?}",
-                    object_id,
+                    "node can't find gas object {object_id} with client {:?}",
                     client.read_api()
                 )
             }
@@ -100,8 +99,7 @@ impl ObjectChecker {
                 }),
             ) => {
                 panic!(
-                    "Node can't find dynamic field for {} with client {:?}",
-                    object_id,
+                    "node can't find dynamic field for {object_id} with client {:?}",
                     client.read_api()
                 )
             }
@@ -114,30 +112,30 @@ impl ObjectChecker {
                 }),
             ) => {
                 if !self.is_deleted {
-                    panic!("Gas object {object_id} was deleted");
+                    panic!("gas object {object_id} was deleted");
                 }
                 Ok(CheckerResultObject::new(None, None))
             }
             (Some(object), _) => {
                 if self.is_deleted {
-                    panic!("Expect Gas object {object_id} deleted, but it is not");
+                    panic!("expect gas object {object_id} deleted, but it is not");
                 }
                 if let Some(owner) = self.owner {
                     let object_owner = object
                         .owner
-                        .unwrap_or_else(|| panic!("Object {object_id} does not have owner"));
+                        .unwrap_or_else(|| panic!("object {object_id} does not have owner"));
                     assert_eq!(
                         object_owner, owner,
-                        "Gas coin {object_id} does not belong to {owner}, but {object_owner}"
+                        "gas coin {object_id} does not belong to {owner}, but {object_owner}"
                     );
                 }
                 if self.is_iota_coin == Some(true) {
                     let move_obj = object
                         .bcs
                         .as_ref()
-                        .unwrap_or_else(|| panic!("Object {object_id} does not have bcs data"))
+                        .unwrap_or_else(|| panic!("object {object_id} does not have bcs data"))
                         .try_as_move()
-                        .unwrap_or_else(|| panic!("Object {object_id} is not a move object"));
+                        .unwrap_or_else(|| panic!("object {object_id} is not a move object"));
 
                     let gas_coin = move_obj.deserialize()?;
                     return Ok(CheckerResultObject::new(Some(gas_coin), Some(object)));
@@ -145,10 +143,10 @@ impl ObjectChecker {
                 Ok(CheckerResultObject::new(None, Some(object)))
             }
             (None, Some(IotaObjectResponseError::Display { error })) => {
-                panic!("Display Error: {error:?}");
+                panic!("display error: {error:?}");
             }
             (None, None) | (None, Some(IotaObjectResponseError::Unknown)) => {
-                panic!("Unexpected response: object not found and no specific error provided");
+                panic!("unexpected response: object not found and no specific error provided");
             }
         }
     }
@@ -177,7 +175,7 @@ macro_rules! assert_eq_if_present {
         match (&$left, &$right) {
             (Some(left_val), right_val) => {
                  if !(&left_val == right_val) {
-                    panic!("{} does not match, left: {:?}, right: {:?}", $($arg)+, left_val, right_val);
+                    panic!("{} does not match, left: {left_val:?}, right: {right_val:?}", $($arg)+);
                 }
             }
             _ => ()

--- a/crates/iota-cluster-test/src/lib.rs
+++ b/crates/iota-cluster-test/src/lib.rs
@@ -79,7 +79,7 @@ impl TestContext {
 
         if gas_coins.len() < minimum_coins {
             panic!(
-                "Expect to get at least {minimum_coins} IOTA Coins for address {addr}, but only got {}",
+                "expect to get at least {minimum_coins} IOTA Coins for address {addr}, but only got {}",
                 gas_coins.len()
             )
         }
@@ -166,13 +166,13 @@ impl TestContext {
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await
-            .unwrap_or_else(|e| panic!("Failed to execute transaction for {desc}. {e}"));
+            .unwrap_or_else(|e| panic!("failed to execute transaction for {desc}. {e}"));
         assert!(
             matches!(
                 resp.effects.as_ref().unwrap().status(),
                 IotaExecutionStatus::Success
             ),
-            "Failed to execute transaction for {desc}: {resp:?}"
+            "failed to execute transaction for {desc}: {resp:?}"
         );
         resp
     }
@@ -202,7 +202,7 @@ impl TestContext {
         loop {
             tokio::select! {
                 _ = &mut sleep => {
-                    panic!("Fullnode does not know all of {digests:?} after {timeout_sec} secs.");
+                    panic!("fullnode does not know all of {digests:?} after {timeout_sec} secs.");
                 }
                 res = futures.next() => {
                     match res {
@@ -282,7 +282,7 @@ impl<'a> TestCase<'a> {
                 true
             }
             Err(e) => {
-                error!("Test {test_name} failed with error: {e}.");
+                error!("test {test_name} failed with error: {e}.");
                 false
             }
         }
@@ -302,7 +302,7 @@ impl ClusterTest {
     pub async fn run(options: ClusterTestOpt) {
         let mut ctx = TestContext::setup(options)
             .await
-            .unwrap_or_else(|e| panic!("Failed to set up TestContext, e: {e}"));
+            .unwrap_or_else(|e| panic!("failed to set up TestContext, e: {e}"));
 
         // TODO: collect tests from each test_case file instead.
         let tests = vec![

--- a/crates/iota-cluster-test/src/test_case/coin_index_test.rs
+++ b/crates/iota-cluster-test/src/test_case/coin_index_test.rs
@@ -136,9 +136,7 @@ impl TestCaseImpl for CoinIndexTest {
         assert_eq!(
             total_balance,
             (old_total_balance as i128 + balance_change.amount) as u128,
-            "total_balance: {}, old_total_balance: {}, iota_balance_change.amount: {}",
-            total_balance,
-            old_total_balance,
+            "total_balance: {total_balance}, old_total_balance: {old_total_balance}, iota_balance_change.amount: {}",
             balance_change.amount
         );
         old_coin_object_count = coin_object_count;
@@ -149,13 +147,10 @@ impl TestCaseImpl for CoinIndexTest {
             client.coin_read_api().get_balance(account, None).await?;
         old_total_balance = total_balance;
 
-        info!(
-            "token package published, package: {:?}, cap: {:?}",
-            package, cap
-        );
+        info!("token package published, package: {package:?}, cap: {cap:?}",);
         let iota_type_str = "0x2::iota::IOTA";
         let coin_type_str = format!("{}::managed::MANAGED", package.0);
-        info!("coin type: {}", coin_type_str);
+        info!("coin type: {coin_type_str}");
 
         // 4. Mint 1 MANAGED coin to account, balance 10000
         let args = vec![
@@ -199,9 +194,7 @@ impl TestCaseImpl for CoinIndexTest {
         assert_eq!(
             total_balance,
             (old_total_balance as i128 + iota_balance_change.amount) as u128,
-            "total_balance: {}, old_total_balance: {}, iota_balance_change.amount: {}",
-            total_balance,
-            old_total_balance,
+            "total_balance: {total_balance}, old_total_balance: {old_total_balance}, iota_balance_change.amount: {}",
             iota_balance_change.amount
         );
         old_coin_object_count = coin_object_count;
@@ -648,7 +641,7 @@ async fn publish_managed_coin_package(
         .await?;
     let response = ctx.sign_and_execute(data, "publish ft package").await;
     let changes = response.object_changes.unwrap();
-    info!("changes: {:?}", changes);
+    info!("changes: {changes:?}");
     let pkg = changes
         .iter()
         .find(|change| matches!(change, ObjectChange::Published { .. }))

--- a/crates/iota-cluster-test/src/test_case/coin_merge_split_test.rs
+++ b/crates/iota-cluster-test/src/test_case/coin_merge_split_test.rs
@@ -69,13 +69,10 @@ impl TestCaseImpl for CoinMergeSplitTest {
         // be locked
         for new_coin in new_coins {
             let coin_to_merge = new_coin.reference.object_id;
-            debug!(
-                "Merging coin {} back to {}.",
-                coin_to_merge, primary_coin_id
-            );
+            debug!("Merging coin {coin_to_merge} back to {primary_coin_id}.",);
             let response =
                 Self::merge_coin(ctx, signer, primary_coin_id, coin_to_merge, *gas_obj.id()).await;
-            debug!("Verifying the merged coin {} is deleted.", coin_to_merge);
+            debug!("Verifying the merged coin {coin_to_merge} is deleted.");
             coins_merged.push(coin_to_merge);
             txes.push(response.digest);
         }
@@ -110,8 +107,7 @@ impl TestCaseImpl for CoinMergeSplitTest {
         assert_eq!(
             primary_after_merge.value(),
             original_value,
-            "Split-then-merge yields unexpected coin value, expect {}, got {}",
-            original_value,
+            "split-then-merge yields unexpected coin value, expect {original_value}, got {}",
             primary_after_merge.value(),
         );
         Ok(())

--- a/crates/iota-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
+++ b/crates/iota-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
@@ -23,7 +23,7 @@ impl FullNodeExecuteTransactionTest {
             .get_transaction_with_options(tx_digest, IotaTransactionBlockResponseOptions::new())
             .await
             .unwrap_or_else(|e| {
-                panic!("Failed get transaction {tx_digest:?} from fullnode: {e:?}")
+                panic!("failed get transaction {tx_digest:?} from fullnode: {e:?}")
             });
     }
 }
@@ -45,8 +45,7 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
         let mut txns = ctx.make_transactions(txn_count).await;
         assert!(
             txns.len() >= txn_count,
-            "Expect at least {} txns, but only got {}. Do we generate enough gas objects during genesis?",
-            txn_count,
+            "expect at least {} txns, but only got {txn_count}. Do we generate enough gas objects during genesis?",
             txns.len(),
         );
 
@@ -70,8 +69,7 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
         let effects = response.effects.unwrap();
         if !matches!(effects.status(), IotaExecutionStatus::Success) {
             panic!(
-                "Failed to execute transfer transaction {:?}: {:?}",
-                txn_digest,
+                "failed to execute transfer transaction {txn_digest:?}: {:?}",
                 effects.status()
             )
         }
@@ -96,8 +94,7 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
         let effects = response.effects.unwrap();
         if !matches!(effects.status(), IotaExecutionStatus::Success) {
             panic!(
-                "Failed to execute transfer transaction {:?}: {:?}",
-                txn_digest,
+                "failed to execute transfer transaction {txn_digest:?}: {:?}",
                 effects.status()
             )
         }

--- a/crates/iota-cluster-test/src/test_case/native_transfer_test.rs
+++ b/crates/iota-cluster-test/src/test_case/native_transfer_test.rs
@@ -26,7 +26,7 @@ impl TestCaseImpl for NativeTransferTest {
     }
 
     fn description(&self) -> &'static str {
-        "Test tranferring IOTA coins natively"
+        "Test transferring IOTA coins natively"
     }
 
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
@@ -86,7 +86,7 @@ impl NativeTransferTest {
         assert_eq!(
             balance_changes.len(),
             2,
-            "Expect 2 balance changes emitted, but got {}",
+            "expect 2 balance changes emitted, but got {}",
             balance_changes.len()
         );
         // Order of balance change is not fixed so need to check who's balance come

--- a/crates/iota-cluster-test/src/test_case/random_beacon_test.rs
+++ b/crates/iota-cluster-test/src/test_case/random_beacon_test.rs
@@ -36,7 +36,7 @@ impl TestCaseImpl for RandomBeaconTest {
         assert_eq!(
             *response.effects.as_ref().unwrap().status(),
             IotaExecutionStatus::Success,
-            "Generate new random value txn failed: {:?}",
+            "generate new random value txn failed: {:?}",
             *response.effects.as_ref().unwrap().status()
         );
 
@@ -45,7 +45,7 @@ impl TestCaseImpl for RandomBeaconTest {
         assert_eq!(
             1,
             events.data.len(),
-            "Expected 1 event, got {:?}",
+            "expected 1 event, got {:?}",
             events.data.len()
         );
         assert_eq!(

--- a/crates/iota-cluster-test/src/test_case/shared_object_test.rs
+++ b/crates/iota-cluster-test/src/test_case/shared_object_test.rs
@@ -45,7 +45,7 @@ impl TestCaseImpl for SharedCounterTest {
         assert_eq!(
             *response.effects.as_ref().unwrap().status(),
             IotaExecutionStatus::Success,
-            "Increment counter txn failed: {:?}",
+            "increment counter txn failed: {:?}",
             *response.effects.as_ref().unwrap().status()
         );
 
@@ -56,7 +56,7 @@ impl TestCaseImpl for SharedCounterTest {
             .shared_objects()
             .iter()
             .find(|o| o.object_id == counter_id)
-            .unwrap_or_else(|| panic!("Expect obj {counter_id} in shared_objects"));
+            .unwrap_or_else(|| panic!("expect obj {counter_id} in shared_objects"));
 
         let counter_version = response
             .effects
@@ -80,7 +80,7 @@ impl TestCaseImpl for SharedCounterTest {
                     None
                 }
             })
-            .unwrap_or_else(|| panic!("Expect obj {counter_id} in mutated"));
+            .unwrap_or_else(|| panic!("expect obj {counter_id} in mutated"));
 
         // Verify fullnode observes the txn
         ctx.let_fullnode_sync(vec![response.digest], 5).await;
@@ -94,7 +94,7 @@ impl TestCaseImpl for SharedCounterTest {
 
         assert_eq!(
             counter_object.version, counter_version,
-            "Expect sequence number to be 2"
+            "expect sequence number to be 2"
         );
 
         Ok(())

--- a/crates/iota-cluster-test/src/wallet_client.rs
+++ b/crates/iota-cluster-test/src/wallet_client.rs
@@ -30,7 +30,7 @@ impl WalletClient {
             .instrument(info_span!("init_wallet_context_for_test_user"));
 
         let rpc_url = String::from(cluster.fullnode_url());
-        info!("Use fullnode rpc: {}", &rpc_url);
+        info!("Use fullnode rpc: {rpc_url}");
         let fullnode_client = IotaClientBuilder::default().build(rpc_url).await.unwrap();
 
         Self {
@@ -61,6 +61,6 @@ impl WalletClient {
             .config()
             .keystore()
             .sign_secure(&self.address, txn_data, Intent::iota_transaction())
-            .unwrap_or_else(|e| panic!("Failed to sign transaction for {desc}. {e}"))
+            .unwrap_or_else(|e| panic!("failed to sign transaction for {desc}. {e}"))
     }
 }

--- a/crates/iota-cluster-test/tests/local_cluster_test.rs
+++ b/crates/iota-cluster-test/tests/local_cluster_test.rs
@@ -24,7 +24,7 @@ async fn test_iota_cluster() {
     let fullnode_rpc_port: u16 = 9020;
     let indexer_rpc_port: u16 = 9124;
     let pg_address = "postgres://postgres:postgrespw@localhost:5432/iota_indexer".to_string();
-    let graphql_address = format!("127.0.0.1:{}", 8000);
+    let graphql_address = "127.0.0.1:8000";
 
     let opts = ClusterTestOpt {
         env: Env::NewLocal,
@@ -34,14 +34,14 @@ async fn test_iota_cluster() {
         indexer_address: Some(format!("127.0.0.1:{indexer_rpc_port}")),
         pg_address: Some(pg_address),
         config_dir: None,
-        graphql_address: Some(graphql_address),
+        graphql_address: Some(graphql_address.into()),
         local_migration_snapshots: Default::default(),
         remote_migration_snapshots: Default::default(),
     };
 
     let _cluster = LocalNewCluster::start(&opts).await.unwrap();
 
-    let grphql_url: String = format!("http://127.0.0.1:{}", 8000);
+    let grphql_url = "http://127.0.0.1:8000";
 
     sleep(std::time::Duration::from_secs(20)).await;
 


### PR DESCRIPTION
# Description of change

This PR aims to refactor all error messages to be consistent and use lower-case first letters.

## Links to any relevant issues

fixes #6000.

## How the change has been tested

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.