### PR TITLE
refactor: add a new `Validation` execution mode and refactor `AuthContext` creation

### DIFF
--- a/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context.move
+++ b/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context.move
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0
+
+//# publish
+
+module Test::M;
+
+use iota::auth_context::AuthContext;
+
+public fun authenticate(_: &AuthContext, _: &TxContext) {}
+
+public fun authenticate_with_mut_auth_context(_: &mut AuthContext, _: &TxContext) {}
+
+public fun authenticate_with_auth_context_value(_: AuthContext, _: &TxContext) {}
+
+public fun authenticate_with_miss_placed_auth_context(_: &AuthContext, _: u64, _: &TxContext) {}
+
+public fun authenticate_with_only_auth_context(_: &AuthContext) {}
+
+// using `iota::auth_context::AuthContext` is not allowed in this execution mode
+//# run Test::M::authenticate
+
+// using a mutable reference to `iota::auth_context::AuthContext` is not allowed
+//# run Test::M::authenticate_with_mut_auth_context
+
+// using `iota::auth_context::AuthContext` by value is not allowed
+//# run Test::M::authenticate_with_auth_context_value
+
+// `iota::auth_context::AuthContext` must be the second last argument
+//# run Test::M::authenticate_with_miss_placed_auth_context
+
+// `iota::auth_context::AuthContext` must be the second last argument
+//# run Test::M::authenticate_with_only_auth_context

--- a/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context.snap
+++ b/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context.snap
@@ -1,0 +1,35 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+task 1, lines 6-22:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5920400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 23-25:
+//# run Test::M::authenticate
+Error: Transaction Effects Status: MOVE VM INVARIANT VIOLATION.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMInvariantViolation, source: Some("`iota::auth_context::AuthContext` can't be used as a parameter in this execution mode"), command: Some(0) } }
+
+task 3, lines 26-28:
+//# run Test::M::authenticate_with_mut_auth_context
+Error: Transaction Effects Status: Arity mismatch for Move function. The number of arguments does not match the number of parameters
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ArityMismatch, source: Some("Expected 2 arguments calling function 'authenticate_with_mut_auth_context', but found 1"), command: Some(0) } }
+
+task 4, lines 29-31:
+//# run Test::M::authenticate_with_auth_context_value
+Error: Transaction Effects Status: Arity mismatch for Move function. The number of arguments does not match the number of parameters
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ArityMismatch, source: Some("Expected 2 arguments calling function 'authenticate_with_auth_context_value', but found 1"), command: Some(0) } }
+
+task 5, lines 32-34:
+//# run Test::M::authenticate_with_miss_placed_auth_context
+Error: Transaction Effects Status: Arity mismatch for Move function. The number of arguments does not match the number of parameters
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ArityMismatch, source: Some("Expected 3 arguments calling function 'authenticate_with_miss_placed_auth_context', but found 1"), command: Some(0) } }
+
+task 6, line 35:
+//# run Test::M::authenticate_with_only_auth_context
+Error: Transaction Effects Status: Arity mismatch for Move function. The number of arguments does not match the number of parameters
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ArityMismatch, source: Some("Expected 1 argument calling function 'authenticate_with_only_auth_context', but found 0"), command: Some(0) } }

--- a/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context_disabled.move
+++ b/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context_disabled.move
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 --move-auth false
+
+//# publish
+
+module Test::M;
+
+use iota::auth_context::AuthContext;
+
+public fun authenticate(_: &AuthContext, _: &TxContext) {}
+
+// using `iota::auth_context::AuthContext` is not allowed by the protocol config
+//# run Test::M::authenticate

--- a/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context_disabled.snap
+++ b/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context_disabled.snap
@@ -1,0 +1,15 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+task 1, lines 6-14:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4202800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 15:
+//# run Test::M::authenticate
+Error: Transaction Effects Status: MOVE VM INVARIANT VIOLATION.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMInvariantViolation, source: Some("`iota::auth_context::AuthContext` can't be used as a parameter if the `move_auth` feature is disabled"), command: Some(0) } }

--- a/crates/iota-framework-snapshot/manifest.json
+++ b/crates/iota-framework-snapshot/manifest.json
@@ -365,7 +365,7 @@
     ]
   },
   "14": {
-    "git_revision": "a04b77022f5dd29f1878c9bdec5160a45f6286fe-dirty",
+    "git_revision": "f9591aae2d7e93cc8dfad26fd2d71e7123990367",
     "packages": [
       {
         "name": "MoveStdlib",

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2419,6 +2419,10 @@ impl ProtocolConfig {
         self.feature_flags
             .select_committee_supporting_next_epoch_version = val;
     }
+
+    pub fn set_move_auth_for_testing(&mut self, val: bool) {
+        self.feature_flags.move_auth = val;
+    }
 }
 
 type OverrideFn = dyn Fn(ProtocolVersion, ProtocolConfig) -> ProtocolConfig + Send + Sync;

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -8,7 +8,7 @@ system_state_version: 1
 iota_treasury_cap:
   inner:
     id:
-      id: "0xe6aa04ffe9b3b0cdca6f5e857e58065f2e9eefc05a99b8c9b54501bb133f94cc"
+      id: "0x595034671b309e58e2365aed521f002e3715a764e5e2bb3204945c7f5bf71571"
     total_supply:
       value: "751500000000000000"
 validators:
@@ -244,13 +244,13 @@ validators:
         next_epoch_primary_address: ~
         extra_fields:
           id:
-            id: "0xbe99faa84a18bb90c1a0d266006860113a56c0ae9e6a157d5892475ce3ce0668"
+            id: "0x4bd9dbd9eb364d0ba5bf1f23a190db6456491788bdb541520e527129260ce3a3"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x3a1a76cfbf6c91eeb2f84861a3d6a24677060c84e72fcd4638abd4af7c1a1d35"
+      operation_cap_id: "0x553c95aefcb1fd92a17b9e8bc11d2a470ad054d3c9e2664316dd8715e4443320"
       gas_price: 1000
       staking_pool:
-        id: "0x8a749910b72955479e671af0bc8d72410d945f1c9952eec08e87e3eeda1a04ed"
+        id: "0x2520808012a842f68332be489b0736d76e4bfef87e9dc2a61864c0b1876ca479"
         activation_epoch: 0
         deactivation_epoch: ~
         iota_balance: 1500000000000000
@@ -258,14 +258,14 @@ validators:
           value: 0
         pool_token_balance: 1500000000000000
         exchange_rates:
-          id: "0xdd7d9e2b4f334b4a5c62b17a0bdfa376481c70792852e47df105f7cbdc932de1"
+          id: "0x73e8d03c0c2af8c3d9c90f3dbf73d46f3049ac855593c9c31d0729fc3830ee1f"
           size: 1
         pending_stake: 0
         pending_total_iota_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xfaffa8361deb65caaa792ebe236ffb1a3232e78b35dc4a25ecc215257bf1013e"
+            id: "0xc6c02dc96b6cca6ec464a357dc8fd3d470cf2f133fefb03591e74bac2081b7a8"
           size: 0
       commission_rate: 200
       next_epoch_stake: 1500000000000000
@@ -273,27 +273,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x4cafe82b47e7cec232c1ff8a59b5f7f0dd515a481cdba4c15a5e247a6dda4a7a"
+          id: "0x21d5f28dea7dee1c5390dfc891fd923e0a0abbeb9ad89df3321b59e57e764751"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xa1ee681b5c4d854eed368c7e119588c1a7d5afb1e636255b42a4023c1a8b661a"
+      id: "0xd7d1e91569f10145f5a2ff4d7e35616dd99243fdfe591b1bf1df89f829417a4a"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xff5ef46d5b1dbf4641bca4c7dfa3d696abd198729d76611a53ded66f190e017b"
+    id: "0x79fcb88dfb69fe42870ae1352eabbd5539bde9a1aa18efd0494883701f8739d4"
     size: 1
   inactive_validators:
-    id: "0xb3a2ae25ee7f320500ab3b8c5f19402a1db26c49efebaf8535af78e5e17ab37b"
+    id: "0x08badb3350e28d398742878b82e072c933158d1d714686276e5bb753a8bfad57"
     size: 0
   validator_candidates:
-    id: "0x21ebee73bea9c91d12cc53ae2b037db70df372c187895831b55ac514990de774"
+    id: "0x783dc484a2abd44443b28a152f222f95eaf4e0d9d66e8ed01df8e59ca1172b85"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xbb005e9d3177deb068defc47ca93b3c3a7104d9df529d9cb91c2a198eae87291"
+      id: "0x442ce75e655e18f130e1046255c69c01c9645d2b2732e9ac732bd48656f91f21"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -310,7 +310,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0xdd99f05eba04bdfe32b3c104e96860c5748e87e1fc7d9696ba3d8b1ee15767d6"
+      id: "0xb6c55ed5232306a3fd4ebb9e2fa4701f0202e64c550da1da3439acb032334a6d"
     size: 0
 iota_system_admin_cap:
   dummy_field: false
@@ -327,5 +327,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x73f6ebdf2a869a4cb8fadb856e568e5de769a670e6c008747ab4f3862d1db1fb"
+    id: "0xa3c0ab10c321278d1189dfb55aaff6cd80a567f7318e71a32e033cace76efb9c"
   size: 0

--- a/crates/iota-transactional-test-runner/src/args.rs
+++ b/crates/iota-transactional-test-runner/src/args.rs
@@ -70,6 +70,8 @@ pub struct IotaInitArgs {
     pub reference_gas_price: Option<u64>,
     #[arg(long)]
     pub default_gas_price: Option<u64>,
+    #[clap(long = "move-auth")]
+    pub move_auth: Option<bool>,
     #[command(flatten)]
     pub snapshot_config: SnapshotLagConfig,
     #[arg(long)]

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -201,6 +201,7 @@ impl AdapterInitConfig {
             custom_validator_account,
             reference_gas_price,
             default_gas_price,
+            move_auth,
             snapshot_config,
             flavor,
             epochs_to_keep,
@@ -226,6 +227,9 @@ impl AdapterInitConfig {
                 panic!("Cannot set max gas in simulator mode");
             }
             protocol_config.set_max_tx_gas_for_testing(mx_tx_gas_override)
+        }
+        if let Some(enable) = move_auth {
+            protocol_config.set_move_auth_for_testing(enable);
         }
         if custom_validator_account && !simulator {
             panic!("Can only set custom validator account in simulator mode");

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -28,6 +28,7 @@ pub use shared_in_memory_store::{SharedInMemoryStore, SingleCheckpointSharedInMe
 pub use write_store::WriteStore;
 
 use crate::{
+    auth_context::AuthContext,
     base_types::{ObjectID, ObjectRef, SequenceNumber, TransactionDigest, VersionNumber},
     committee::EpochId,
     error::{ExecutionError, IotaError, IotaResult},
@@ -220,6 +221,8 @@ pub trait Storage {
     /// Check coin denylist during execution,
     /// and the number of non-gas-coin owners.
     fn check_coin_deny_list(&self, written_objects: &BTreeMap<ObjectID, Object>) -> DenyListResult;
+
+    fn read_auth_context(&self) -> Option<&AuthContext>;
 }
 
 pub type PackageFetchResults<Package> = Result<Vec<Package>, Vec<ObjectID>>;

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -505,6 +505,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "const-str",
  "git-version",
@@ -1778,7 +1800,7 @@ dependencies = [
  "hex",
  "iota-keys",
  "iota-move-build",
- "iota-sdk 1.5.0-alpha",
+ "iota-sdk 1.9.0-alpha",
  "iota-types",
  "move-binary-format",
  "move-core-types",
@@ -2168,6 +2190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,7 +2542,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.7.1",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util",
@@ -3014,13 +3042,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3100,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3111,6 +3140,7 @@ dependencies = [
  "dirs 5.0.1",
  "fastcrypto",
  "iota-genesis-common",
+ "iota-grpc-api",
  "iota-keys",
  "iota-names",
  "iota-rest-api",
@@ -3163,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "serde_yaml",
 ]
@@ -3187,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "bcs",
  "iota-types",
@@ -3199,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3214,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3223,8 +3253,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-grpc-api"
+version = "1.9.0-alpha"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "bcs",
+ "futures",
+ "iota-grpc-types",
+ "iota-json-rpc-types",
+ "iota-types",
+ "move-core-types",
+ "prost",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tonic-build",
+ "tracing",
+]
+
+[[package]]
+name = "iota-grpc-types"
+version = "1.9.0-alpha"
+dependencies = [
+ "iota-types",
+ "serde",
+]
+
+[[package]]
 name = "iota-http"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "bytes",
  "http",
@@ -3243,7 +3304,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3259,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3278,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3311,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3331,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3341,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3366,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3394,7 +3455,7 @@ dependencies = [
  "fastcrypto",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
- "indexmap 2.7.1",
+ "indexmap 2.11.4",
  "iota-protocol-config",
  "iota-types",
  "iota-verifier-latest",
@@ -3410,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3422,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anemo",
  "bcs",
@@ -3450,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "schemars",
  "serde",
@@ -3460,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3472,13 +3533,13 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.5.0-alpha",
+ "iota-sdk 1.9.0-alpha",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -3488,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3503,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -3513,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3527,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3536,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anyhow",
  "axum",
@@ -3565,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "iota-rust-sdk"
 version = "0.0.0"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=93580286f3714248398d17e4481daf608508856a#93580286f3714248398d17e4481daf608508856a"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d7084eaf0564f4e2381b2e8408ee1f7d51468450#d7084eaf0564f4e2381b2e8408ee1f7d51468450"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3616,7 +3677,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3649,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3665,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3684,7 +3745,7 @@ dependencies = [
  "fastcrypto-zkp",
  "hex",
  "im",
- "indexmap 2.7.1",
+ "indexmap 2.11.4",
  "iota-enum-compat-util",
  "iota-macros",
  "iota-network-stack",
@@ -3716,6 +3777,7 @@ dependencies = [
  "serde_with",
  "shared-crypto",
  "signature 1.6.4",
+ "starfish-config",
  "static_assertions",
  "strum 0.26.3",
  "strum_macros 0.26.4",
@@ -4354,10 +4416,10 @@ name = "move-bytecode-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 2.7.1",
+ "indexmap 2.11.4",
  "move-binary-format",
  "move-core-types",
- "petgraph",
+ "petgraph 0.5.1",
  "serde",
  "serde-reflection",
 ]
@@ -4373,7 +4435,7 @@ dependencies = [
  "move-bytecode-verifier-meter",
  "move-core-types",
  "move-vm-config",
- "petgraph",
+ "petgraph 0.5.1",
 ]
 
 [[package]]
@@ -4397,6 +4459,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "once_cell",
+ "packed_struct",
  "serde",
  "sha2 0.9.9",
  "vfs",
@@ -4426,7 +4489,7 @@ dependencies = [
  "move-proc-macros",
  "move-symbol-pool",
  "once_cell",
- "petgraph",
+ "petgraph 0.5.1",
  "rayon",
  "regex",
  "serde",
@@ -4472,14 +4535,14 @@ dependencies = [
  "clap",
  "codespan",
  "colored",
- "indexmap 2.7.1",
+ "indexmap 2.11.4",
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
  "move-core-types",
  "move-ir-types",
- "petgraph",
+ "petgraph 0.5.1",
  "serde",
 ]
 
@@ -4573,6 +4636,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "codespan-reporting",
+ "indexmap 2.11.4",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
@@ -4592,6 +4656,7 @@ dependencies = [
  "anyhow",
  "clap",
  "colored",
+ "dunce",
  "itertools 0.10.5",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -4605,7 +4670,7 @@ dependencies = [
  "move-symbol-pool",
  "named-lock",
  "once_cell",
- "petgraph",
+ "petgraph 0.5.1",
  "regex",
  "serde",
  "serde_yaml",
@@ -4786,6 +4851,12 @@ dependencies = [
  "syn 1.0.109",
  "synstructure 0.12.6",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "named-lock"
@@ -5082,7 +5153,7 @@ name = "openapiv3"
 version = "2.0.0"
 source = "git+https://github.com/bmwill/openapiv3.git?rev=ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963#ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.11.4",
  "schemars",
  "serde",
  "serde_json",
@@ -5156,6 +5227,28 @@ checksum = "e9567693dd2f9a4339cb0a54adfcc0cb431c0ac88b2e46c6ddfb5f5d11a1cc4f"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "packed_struct"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
+dependencies = [
+ "bitvec 1.0.1",
+ "packed_struct_codegen",
+ "serde",
+]
+
+[[package]]
+name = "packed_struct_codegen"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -5293,7 +5386,7 @@ dependencies = [
  "data-encoding",
  "getrandom 0.2.15",
  "hmac",
- "indexmap 2.7.1",
+ "indexmap 2.11.4",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -5385,8 +5478,18 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.2.0",
  "indexmap 1.9.3",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.11.4",
 ]
 
 [[package]]
@@ -5557,6 +5660,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5680,7 +5793,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -5728,6 +5841,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.13.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph 0.6.5",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.96",
+ "tempfile",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5738,6 +5871,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -6234,6 +6376,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
+name = "rs_merkle"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb09b49230ba22e8c676e7b75dfe2887dea8121f18b530ae0ba519ce442d2b21"
+dependencies = [
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "rsa"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6620,10 +6771,11 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -6668,10 +6820,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.217"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6695,7 +6856,7 @@ version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.11.4",
  "itoa",
  "memchr",
  "ryu",
@@ -6745,7 +6906,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.1",
+ "indexmap 2.11.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6846,7 +7007,7 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "bcs",
  "eyre",
@@ -7041,6 +7202,18 @@ dependencies = [
  "libc",
  "psm",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "starfish-config"
+version = "0.1.0"
+dependencies = [
+ "fastcrypto",
+ "iota-network-stack",
+ "rand 0.8.5",
+ "rs_merkle",
+ "serde",
+ "shared-crypto",
 ]
 
 [[package]]
@@ -7559,7 +7732,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.11.4",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -7570,7 +7743,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.11.4",
  "toml_datetime",
  "winnow 0.6.26",
 ]
@@ -7603,6 +7776,20 @@ dependencies = [
  "tower-service",
  "tracing",
  "zstd",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7646,7 +7833,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.7.1",
+ "indexmap 2.11.4",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -7774,7 +7961,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.5.0-alpha"
+version = "1.9.0-alpha"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -8719,7 +8906,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.7.1",
+ "indexmap 2.11.4",
  "memchr",
  "thiserror 2.0.11",
  "zopfli",

--- a/docs/examples/rust/aa/iotaccount.rs
+++ b/docs/examples/rust/aa/iotaccount.rs
@@ -40,7 +40,7 @@ const MAIN_ADDRESS_MNEMONIC: &str = "rain flip mad lamp owner siren tower buddy 
 
 pub const GAS_BUDGET: u64 = 100_000_000;
 
-const IOTACCOUNT_PACKAGE_PATH: &str = "../../../examples/move/iota_account/";
+const IOTACCOUNT_PACKAGE_PATH: &str = "../../../examples/move/iotaccount/";
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -193,7 +193,7 @@ pub async fn create_iota_account<K: AccountKeystore>(
         // create auth info
         let arguments = vec![
             builder.pure(iotaccount_package_id)?,
-            builder.pure("iota_account")?,
+            builder.pure("keyed_iotaccount")?,
             builder.pure("authenticate_ed25519")?,
         ];
         if let Argument::Result(authenticator_info_v1) = builder.programmable_move_call(
@@ -210,7 +210,7 @@ pub async fn create_iota_account<K: AccountKeystore>(
             ];
             builder.programmable_move_call(
                 iotaccount_package_id,
-                ident_str!("iota_account").to_owned(),
+                ident_str!("keyed_iotaccount").to_owned(),
                 ident_str!("create").to_owned(),
                 vec![],
                 arguments,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -64,7 +64,7 @@ mod checked {
 
     use crate::{
         adapter::new_move_vm,
-        execution_mode::{self, ExecutionMode, Normal},
+        execution_mode::{self, ExecutionMode, Validation},
         gas_charger::GasCharger,
         programmable_transactions,
         temporary_store::TemporaryStore,
@@ -339,13 +339,17 @@ mod checked {
             AuthContext::new_from_components(authenticator.digest(), &ptb)
         };
 
-        // Setup a move authenticator transaction; push the authenticator context as the
-        // last argument.
+        // Store the authenticator context in the temporary store.
+        // It will be added to the authenticator's parameter list later, just before
+        // execution.
+        temporary_store.store_auth_context(auth_ctx);
+
+        // Setup a move authenticator transaction.
         let authenticator_move_call =
-            setup_authenticator_move_call(authenticator, authenticator_info, auth_ctx)?;
+            setup_authenticator_move_call(authenticator, authenticator_info)?;
 
         // Execute the authenticator transaction.
-        let (computation_gas_cost, execution_result) = execute_authenticator_move_call::<Normal>(
+        let (computation_gas_cost, execution_result) = execute_authenticator_move_call::<Validation>(
             &mut temporary_store,
             authenticator_move_call,
             gas_charger,
@@ -1648,26 +1652,19 @@ mod checked {
 
     /// Construct a PTB with a single move call. This calls the authenticator
     /// function found in `AuthenticatorInfo`. The inputs for the function are
-    /// found in `MoveAuthenticator`. Then, the `AuthContext` is pushed as the
-    /// last input.
+    /// found in `MoveAuthenticator`.
     fn setup_authenticator_move_call(
         authenticator: MoveAuthenticator,
         authenticator_info: AuthenticatorInfoV1,
-        auth_ctx: AuthContext,
     ) -> Result<ProgrammableTransaction, ExecutionError> {
         let mut builder = ProgrammableTransactionBuilder::new();
-
-        // Add `AuthContext` as the last argument; `TxContext` will be added later
-        // if required.
-        let mut args = authenticator.call_args().clone();
-        args.push(CallArg::Pure(auth_ctx.to_bcs_bytes()));
 
         let res = builder.move_call(
             authenticator_info.package,
             Identifier::new(authenticator_info.module.clone()).unwrap(),
             Identifier::new(authenticator_info.function.clone()).unwrap(),
-            authenticator.type_arguments().clone(),
-            args,
+            authenticator.type_arguments().to_owned(),
+            authenticator.call_args().to_owned(),
         );
 
         assert_invariant!(

--- a/iota-execution/latest/iota-adapter/src/execution_mode.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_mode.rs
@@ -52,6 +52,10 @@ pub trait ExecutionMode {
         argument_updates: Self::ArgumentUpdates,
         command_result: &[Value],
     ) -> Result<(), ExecutionError>;
+
+    /// Whether to allow passing in `AuthContext` as an argument to Move
+    /// functions.
+    fn allow_auth_context() -> bool;
 }
 
 #[derive(Copy, Clone)]
@@ -98,6 +102,10 @@ impl ExecutionMode for Normal {
     ) -> Result<(), ExecutionError> {
         Ok(())
     }
+
+    fn allow_auth_context() -> bool {
+        false
+    }
 }
 
 #[derive(Copy, Clone)]
@@ -143,6 +151,10 @@ impl ExecutionMode for Genesis {
         _command_result: &[Value],
     ) -> Result<(), ExecutionError> {
         Ok(())
+    }
+
+    fn allow_auth_context() -> bool {
+        false
     }
 }
 
@@ -195,6 +207,60 @@ impl ExecutionMode for System {
         _command_result: &[Value],
     ) -> Result<(), ExecutionError> {
         Ok(())
+    }
+
+    fn allow_auth_context() -> bool {
+        false
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct Validation;
+
+impl ExecutionMode for Validation {
+    type ArgumentUpdates = ();
+    type ExecutionResults = ();
+
+    fn allow_arbitrary_function_calls() -> bool {
+        false
+    }
+
+    fn allow_arbitrary_values() -> bool {
+        false
+    }
+
+    fn skip_conservation_checks() -> bool {
+        false
+    }
+
+    fn packages_are_predefined() -> bool {
+        false
+    }
+
+    fn empty_arguments() -> Self::ArgumentUpdates {}
+
+    fn empty_results() -> Self::ExecutionResults {}
+
+    fn add_argument_update(
+        _resolver: &impl TypeTagResolver,
+        _acc: &mut Self::ArgumentUpdates,
+        _arg: Argument,
+        _new_value: &Value,
+    ) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+
+    fn finish_command(
+        _resolver: &impl TypeTagResolver,
+        _acc: &mut Self::ExecutionResults,
+        _argument_updates: Self::ArgumentUpdates,
+        _command_result: &[Value],
+    ) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+
+    fn allow_auth_context() -> bool {
+        true
     }
 }
 
@@ -254,6 +320,10 @@ impl<const SKIP_ALL_CHECKS: bool> ExecutionMode for DevInspect<SKIP_ALL_CHECKS> 
             .collect::<Result<_, _>>()?;
         acc.push((argument_updates, command_bytes));
         Ok(())
+    }
+
+    fn allow_auth_context() -> bool {
+        false
     }
 }
 

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -417,7 +417,7 @@ mod checked {
             is_init,
         )?;
         // build the arguments, storing meta data about by-mut-ref args
-        let (tx_context_kind, by_mut_ref, serialized_arguments) =
+        let (tx_context_kind, has_auth_context, by_mut_ref, serialized_arguments) =
             build_move_args::<Mode>(context, runtime_id, function, kind, &signature, &arguments)?;
         // invoke the VM
         let SerializedReturnValues {
@@ -429,6 +429,7 @@ mod checked {
             function,
             type_arguments,
             tx_context_kind,
+            has_auth_context,
             serialized_arguments,
             trace_builder_opt,
         )?;
@@ -871,9 +872,18 @@ mod checked {
         function: &IdentStr,
         type_arguments: Vec<Type>,
         tx_context_kind: TxContextKind,
+        has_auth_context: bool,
         mut serialized_arguments: Vec<Vec<u8>>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> Result<SerializedReturnValues, ExecutionError> {
+        if has_auth_context {
+            let auth_context = context.state_view.read_auth_context();
+            assert_invariant!(
+                auth_context.is_some(),
+                "The `iota::auth_context::AuthContext` value is expected to be read from the storage"
+            );
+            serialized_arguments.push(auth_context.unwrap().to_bcs_bytes());
+        }
         match tx_context_kind {
             TxContextKind::None => (),
             TxContextKind::Mutable | TxContextKind::Immutable => {
@@ -1294,6 +1304,7 @@ mod checked {
 
     type ArgInfo = (
         TxContextKind,
+        bool,
         // mut ref
         Vec<(LocalIndex, ValueKind)>,
         Vec<Vec<u8>>,
@@ -1315,13 +1326,31 @@ mod checked {
             Some(t) => is_tx_context(context, t)?,
             None => TxContextKind::None,
         };
+        // Check if the second last parameter is an auth context.
+        // According to the current design, authenticators must contain `TxContext` as
+        // the last parameter and `AuthContext` as the second last.
+        let has_auth_context = match parameters.iter().rev().nth(1) {
+            Some(t) => is_auth_context(context, t)?,
+            None => false,
+        };
+        assert_invariant!(
+            !has_auth_context || context.protocol_config.move_auth(),
+            "`iota::auth_context::AuthContext` can't be used as a parameter if the `move_auth` feature is disabled"
+        );
+        assert_invariant!(
+            !has_auth_context || Mode::allow_auth_context(),
+            "`iota::auth_context::AuthContext` can't be used as a parameter in this execution mode"
+        );
         // an init function can have one or two arguments, with the last one always
         // being of type &mut TxContext and the additional (first) one
         // representing a one time witness type (see one_time_witness verifier
         // pass for additional explanation)
         let has_one_time_witness = function_kind == FunctionKind::Init && parameters.len() == 2;
         let has_tx_context = tx_ctx_kind != TxContextKind::None;
-        let num_args = args.len() + (has_one_time_witness as usize) + (has_tx_context as usize);
+        let num_args = args.len()
+            + (has_one_time_witness as usize)
+            + (has_auth_context as usize)
+            + (has_tx_context as usize);
         if num_args != parameters.len() {
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::ArityMismatch,
@@ -1395,21 +1424,7 @@ mod checked {
                     idx,
                 ));
             }
-            // We allow passing in the `AuthContext` as an argument to authenticate
-            // functions.
-            // It must be the last one in the arguments list since the `TxContext` is not
-            // injected yet.
-            //
-            // TODO: We must check the `AuthContext` parameter here because it is added
-            // to the `args` list when the authenticator transaction is created. It leads to
-            // having a more complex validation logic, so we need to refactor this and
-            // inject `AuthContext` in the same way how it is done for `TxContext`.
-            let is_last_arg = idx == (args.len() - 1);
-            if is_last_arg && is_auth_context(context, non_ref_param_ty)? {
-                check_auth_context_value(context, idx, &value)?;
-            } else {
-                check_param_type::<Mode>(context, idx, &value, non_ref_param_ty)?;
-            }
+            check_param_type::<Mode>(context, idx, &value, non_ref_param_ty)?;
             let bytes = {
                 let mut v = vec![];
                 value.write_bcs_bytes(&mut v, None)?;
@@ -1417,7 +1432,7 @@ mod checked {
             };
             serialized_args.push(bytes);
         }
-        Ok((tx_ctx_kind, by_mut_ref, serialized_args))
+        Ok((tx_ctx_kind, has_auth_context, by_mut_ref, serialized_args))
     }
 
     /// checks that the value is compatible with the specified type
@@ -1427,11 +1442,6 @@ mod checked {
         value: &Value,
         param_ty: &Type,
     ) -> Result<(), ExecutionError> {
-        assert_invariant!(
-            !is_auth_context(context, param_ty)?,
-            "`iota::auth_context::AuthContext` struct is not expected to be used here"
-        );
-
         match value {
             // For dev-spect, allow any BCS bytes. This does mean internal invariants for types can
             // be violated (like for string or Option)
@@ -1519,30 +1529,6 @@ mod checked {
         Ok(())
     }
 
-    /// Checks that the value represents the `iota::auth_context::AuthContext`
-    /// type.
-    fn check_auth_context_value(
-        context: &mut ExecutionContext<'_, '_, '_>,
-        idx: usize,
-        value: &Value,
-    ) -> Result<(), ExecutionError> {
-        assert_invariant!(
-            context.protocol_config.move_auth(),
-            "`iota::auth_context::AuthContext` can't be used as a parameter if the `move_auth` feature is disabled"
-        );
-
-        // TODO: Consider creating a MOVE_AUTHENTICATION execution mode to make sure
-        // that `AuthContext` is used only for authentication.
-        if matches!(value, Value::Raw(RawValueType::Any, _)) {
-            return Ok(());
-        }
-
-        Err(command_argument_error(
-            CommandArgumentError::TypeMismatch,
-            idx,
-        ))
-    }
-
     fn to_identifier(
         context: &mut ExecutionContext<'_, '_, '_>,
         ident: String,
@@ -1628,7 +1614,12 @@ mod checked {
         context: &ExecutionContext<'_, '_, '_>,
         t: &Type,
     ) -> Result<bool, ExecutionError> {
-        let Type::Datatype(idx) = t else {
+        let inner = match t {
+            Type::Reference(inner) => inner,
+            _ => return Ok(false),
+        };
+
+        let Type::Datatype(idx) = &**inner else {
             return Ok(false);
         };
 

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -1333,14 +1333,20 @@ mod checked {
             Some(t) => is_auth_context(context, t)?,
             None => false,
         };
-        assert_invariant!(
-            !has_auth_context || context.protocol_config.move_auth(),
-            "`iota::auth_context::AuthContext` can't be used as a parameter if the `move_auth` feature is disabled"
-        );
-        assert_invariant!(
-            !has_auth_context || Mode::allow_auth_context(),
-            "`iota::auth_context::AuthContext` can't be used as a parameter in this execution mode"
-        );
+        if has_auth_context {
+            if !context.protocol_config.move_auth() {
+                return Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::VMInvariantViolation,
+                    "`iota::auth_context::AuthContext` can't be used as a parameter if the `move_auth` feature is disabled",
+                ));
+            }
+            if !Mode::allow_auth_context() {
+                return Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::VMInvariantViolation,
+                    "`iota::auth_context::AuthContext` can't be used as a parameter in this execution mode",
+                ));
+            }
+        }
         // an init function can have one or two arguments, with the last one always
         // being of type &mut TxContext and the additional (first) one
         // representing a one time witness type (see one_time_witness verifier

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -8,6 +8,7 @@ use iota_metrics::monitored_scope;
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
     IOTA_DENY_LIST_OBJECT_ID, IOTA_SYSTEM_STATE_OBJECT_ID,
+    auth_context::AuthContext,
     base_types::{
         IotaAddress, ObjectID, ObjectRef, SequenceNumber, TransactionDigest, VersionDigest,
     },
@@ -78,6 +79,9 @@ pub struct TemporaryStore<'backing> {
     /// and are not in the input objects. This allows us to commit them to
     /// the effects.
     loaded_per_epoch_config_objects: RwLock<BTreeSet<ObjectID>>,
+
+    /// The auth context used to verify the transaction.
+    auth_context: Option<AuthContext>,
 }
 
 impl<'backing> TemporaryStore<'backing> {
@@ -125,6 +129,7 @@ impl<'backing> TemporaryStore<'backing> {
             receiving_objects,
             cur_epoch,
             loaded_per_epoch_config_objects: RwLock::new(BTreeSet::new()),
+            auth_context: None,
         }
     }
 
@@ -652,6 +657,11 @@ impl TemporaryStore<'_> {
         }
         Ok(())
     }
+
+    pub fn store_auth_context(&mut self, auth_context: AuthContext) {
+        debug_assert!(self.auth_context.is_none());
+        self.auth_context = Some(auth_context);
+    }
 }
 
 impl TemporaryStore<'_> {
@@ -1085,6 +1095,10 @@ impl Storage for TemporaryStore<'_> {
                 .insert(IOTA_DENY_LIST_OBJECT_ID);
         }
         result
+    }
+
+    fn read_auth_context(&self) -> Option<&AuthContext> {
+        self.auth_context.as_ref()
     }
 }
 


### PR DESCRIPTION
# Description of change

Added a new Move execution mode named `Validation`. It is allowed to use the `iota::auth_context::AuthContext` type only in this execution mode.
`iota::auth_context::AuthContext` is added to a transaction parameters list in the same way as it is implemented for `iota::tx_context::TxContext`

## Links to any relevant issues

fixes #8845 
