### PR TITLE
refactor(iota-graphql): lower-case error messages

### DIFF
--- a/crates/iota-graphql-config/src/lib.rs
+++ b/crates/iota-graphql-config/src/lib.rs
@@ -34,7 +34,7 @@ pub fn GraphQLConfig(_attr: TokenStream, input: TokenStream) -> TokenStream {
         semi_token,
     }) = data
     else {
-        panic!("GraphQL configs must be structs.");
+        panic!("graphQL configs must be structs.");
     };
 
     let Fields::Named(FieldsNamed {
@@ -42,7 +42,7 @@ pub fn GraphQLConfig(_attr: TokenStream, input: TokenStream) -> TokenStream {
         named,
     }) = fields
     else {
-        panic!("GraphQL configs must have named fields.");
+        panic!("graphQL configs must have named fields.");
     };
 
     // Figure out which derives need to be added to meet the criteria of a config

--- a/crates/iota-graphql-rpc/src/data/pg.rs
+++ b/crates/iota-graphql-rpc/src/data/pg.rs
@@ -64,7 +64,7 @@ impl QueryExecutor for PgExecutor {
         self.metrics
             .observe_db_data(instant.elapsed(), result.is_ok());
         if let Err(e) = &result {
-            error!("DB query error: {e:?}");
+            error!("db query error: {e:?}");
         }
         result.map_err(|e| Error::Internal(e.to_string()))
     }
@@ -88,7 +88,7 @@ impl QueryExecutor for PgExecutor {
         self.metrics
             .observe_db_data(instant.elapsed(), result.is_ok());
         if let Err(e) = &result {
-            error!("DB query error: {e:?}");
+            error!("db query error: {e:?}");
         }
         result.map_err(|e| Error::Internal(e.to_string()))
     }

--- a/crates/iota-graphql-rpc/src/extensions/timeout.rs
+++ b/crates/iota-graphql-rpc/src/extensions/timeout.rs
@@ -70,7 +70,7 @@ impl Extension for TimeoutExt {
     ) -> Response {
         let cfg: &ServiceConfig = ctx
             .data()
-            .expect("No service config provided in schema data");
+            .expect("no service config provided in schema data");
 
         // increase the timeout if the request is a mutation
         let is_mutation = self.is_mutation.load(Ordering::Relaxed);

--- a/crates/iota-graphql-rpc/src/functional_group.rs
+++ b/crates/iota-graphql-rpc/src/functional_group.rs
@@ -38,7 +38,7 @@ impl FunctionalGroup {
     /// the GraphQL API. Not a suitable `Display` implementation because it
     /// enquotes the representation.
     pub(crate) fn name(&self) -> String {
-        json::ser::to_string(self).expect("Serializing `FunctionalGroup` cannot fail.")
+        json::ser::to_string(self).expect("serializing `FunctionalGroup` cannot fail.")
     }
 
     /// List of all functional groups
@@ -145,7 +145,7 @@ mod tests {
             };
 
             panic!(
-                "Field '{type_}.{field}' is marked as unimplemented in this test, but it's in the \
+                "field '{type_}.{field}' is marked as unimplemented in this test, but it's in the \
                  schema.  Fix this by removing it from the `unimplemented` set."
             );
         }
@@ -156,12 +156,12 @@ mod tests {
             }
 
             let Some(meta_type) = registry.concrete_type_by_name(type_) else {
-                panic!("Type '{type_}' from functional group configs does not appear in schema.");
+                panic!("type '{type_}' from functional group configs does not appear in schema.");
             };
 
             let Some(_) = meta_type.field_by_name(field) else {
                 panic!(
-                    "Field '{type_}.{field}' from functional group configs does not appear in \
+                    "field '{type_}.{field}' from functional group configs does not appear in \
                      schema."
                 );
             };

--- a/crates/iota-graphql-rpc/src/main.rs
+++ b/crates/iota-graphql-rpc/src/main.rs
@@ -31,11 +31,11 @@ async fn main() {
     match cmd {
         Command::GenerateConfig { output } => {
             let config = ServiceConfig::default();
-            let toml = toml::to_string_pretty(&config).expect("Failed to serialize configuration");
+            let toml = toml::to_string_pretty(&config).expect("failed to serialize configuration");
 
             if let Some(path) = output {
                 fs::write(&path, toml).unwrap_or_else(|e| {
-                    panic!("Failed to write configuration to {}: {e}", path.display())
+                    panic!("failed to write configuration to {}: {e}", path.display())
                 });
             } else {
                 println!("{toml}");
@@ -113,6 +113,6 @@ fn service_config(path: Option<PathBuf>) -> ServiceConfig {
         return ServiceConfig::default();
     };
 
-    let contents = fs::read_to_string(path).expect("Reading configuration");
-    ServiceConfig::read(&contents).expect("Deserializing configuration")
+    let contents = fs::read_to_string(path).expect("reading configuration");
+    ServiceConfig::read(&contents).expect("deserializing configuration")
 }

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -269,9 +269,9 @@ impl ServerBuilder {
         (
             address,
             schema.finish(),
-            db_reader.expect("DB reader not initialized"),
-            resolver.expect("Package resolver not initialized"),
-            router.expect("Router not initialized"),
+            db_reader.expect("db reader not initialized"),
+            resolver.expect("package resolver not initialized"),
+            router.expect("router not initialized"),
         )
     }
 
@@ -756,7 +756,7 @@ pub mod tests {
             connection_config.db_pool_size,
             service_config.limits.request_timeout_ms.into(),
         )
-        .expect("Failed to create pg connection pool");
+        .expect("failed to create pg connection pool");
 
         let version = Version::for_testing();
         let metrics = metrics();
@@ -864,7 +864,7 @@ pub mod tests {
         test_timeout(delay, timeout, query, optimistic_tx_executor)
             .await
             .into_result()
-            .expect("Should complete successfully");
+            .expect("should complete successfully");
 
         // Should timeout
         let errs: Vec<_> = test_timeout(delay, delay, query, optimistic_tx_executor)
@@ -943,7 +943,7 @@ pub mod tests {
         exec_query_depth_limit(1, "{ chainIdentifier }")
             .await
             .into_result()
-            .expect("Should complete successfully");
+            .expect("should complete successfully");
 
         exec_query_depth_limit(
             5,
@@ -951,7 +951,7 @@ pub mod tests {
         )
         .await
         .into_result()
-        .expect("Should complete successfully");
+        .expect("should complete successfully");
 
         // Should fail
         let errs: Vec<_> = exec_query_depth_limit(0, "{ chainIdentifier }")
@@ -995,7 +995,7 @@ pub mod tests {
         exec_query_node_limit(1, "{ chainIdentifier }")
             .await
             .into_result()
-            .expect("Should complete successfully");
+            .expect("should complete successfully");
 
         exec_query_node_limit(
             5,
@@ -1003,7 +1003,7 @@ pub mod tests {
         )
         .await
         .into_result()
-        .expect("Should complete successfully");
+        .expect("should complete successfully");
 
         // Should fail
         let err: Vec<_> = exec_query_node_limit(0, "{ chainIdentifier }")
@@ -1080,7 +1080,7 @@ pub mod tests {
             .execute("{ objects(first: 1) { nodes { version } } }")
             .await
             .into_result()
-            .expect("Should complete successfully");
+            .expect("should complete successfully");
 
         // Should fail
         let err: Vec<_> = schema
@@ -1108,7 +1108,7 @@ pub mod tests {
             .execute("{ chainIdentifier }")
             .await
             .into_result()
-            .expect("Should complete successfully");
+            .expect("should complete successfully");
 
         let req_metrics = metrics.request_metrics;
         assert_eq!(req_metrics.input_nodes.get_sample_count(), 1);
@@ -1122,7 +1122,7 @@ pub mod tests {
             .execute("{ chainIdentifier protocolConfig { configs { value key }} }")
             .await
             .into_result()
-            .expect("Should complete successfully");
+            .expect("should complete successfully");
 
         assert_eq!(req_metrics.input_nodes.get_sample_count(), 2);
         assert_eq!(req_metrics.output_nodes.get_sample_count(), 2);

--- a/crates/iota-graphql-rpc/src/server/exchange_rates_task.rs
+++ b/crates/iota-graphql-rpc/src/server/exchange_rates_task.rs
@@ -43,14 +43,14 @@ impl TriggerExchangeRatesTask {
                     info!("Detected epoch boundary, triggering call to exchange rates");
                     let latest_iota_system_state = self.db.inner.spawn_blocking(move |this|
                         this.get_latest_iota_system_state()
-                    ).await.map_err(|_| error!("Failed to fetch latest IOTA system state"));
+                    ).await.map_err(|_| error!("failed to fetch latest IOTA system state"));
 
                     if let Ok(latest_iota_system_state) = latest_iota_system_state {
                         let db = self.db.clone();
                         let governance_api = GovernanceReadApi::new(db.inner) ;
                         governance_api.exchange_rates( &latest_iota_system_state)
                             .await
-                            .map_err(|e| error!("Failed to fetch exchange rates: {:?}", e))
+                            .map_err(|e| error!("failed to fetch exchange rates: {e:?}"))
                             .ok();
                         info!("Finished fetching exchange rates");
                     }

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -224,7 +224,7 @@ pub async fn wait_for_graphql_checkpoint_pruned(
         }
     })
     .await
-    .expect("Timeout waiting for checkpoint to be pruned");
+    .expect("timeout waiting for checkpoint to be pruned");
 }
 
 pub async fn start_graphql_server(
@@ -289,7 +289,7 @@ async fn wait_for_graphql_server(client: &SimpleClient) {
         }
     })
     .await
-    .expect("Timeout waiting for graphql server to start");
+    .expect("timeout waiting for graphql server to start");
 }
 
 /// Ping the GraphQL server until its background task has updated the checkpoint
@@ -341,7 +341,7 @@ async fn wait_for_graphql_checkpoint_catchup(
         }
     })
     .await
-    .expect("Timeout waiting for graphql to catchup to checkpoint");
+    .expect("timeout waiting for graphql to catchup to checkpoint");
 }
 
 impl Cluster {
@@ -423,7 +423,7 @@ impl ExecutorCluster {
             }
         })
         .await
-        .unwrap_or_else(|_| panic!("Timeout waiting for indexer to update objects snapshot - latest_cp: {latest_cp}, latest_snapshot_cp: {latest_snapshot_cp}"));
+        .unwrap_or_else(|_| panic!("timeout waiting for indexer to update objects snapshot - latest_cp: {latest_cp}, latest_snapshot_cp: {latest_snapshot_cp}"));
     }
 
     /// Sends a cancellation signal to the graphql and indexer services, waits

--- a/crates/iota-graphql-rpc/src/types/base64.rs
+++ b/crates/iota-graphql-rpc/src/types/base64.rs
@@ -65,7 +65,7 @@ mod tests {
     fn assert_input_value_error<T, U>(result: Result<T, InputValueError<U>>) {
         match result {
             Err(InputValueError { .. }) => {}
-            _ => panic!("Expected InputValueError"),
+            _ => panic!("expected InputValueError"),
         }
     }
 

--- a/crates/iota-graphql-rpc/src/types/date_time.rs
+++ b/crates/iota-graphql-rpc/src/types/date_time.rs
@@ -68,14 +68,14 @@ mod tests {
         let dt: &str = "2023-08-19T15:37:24.761850Z";
         let date_time = DateTime::from_str(dt).unwrap();
         let Value::String(s) = async_graphql::ScalarType::to_value(&date_time) else {
-            panic!("Invalid date time scalar");
+            panic!("invalid date time scalar");
         };
         assert_eq!(dt, s);
 
         let dt: &str = "2023-08-19T15:37:24.700Z";
         let date_time = DateTime::from_str(dt).unwrap();
         let Value::String(s) = async_graphql::ScalarType::to_value(&date_time) else {
-            panic!("Invalid date time scalar");
+            panic!("invalid date time scalar");
         };
         assert_eq!(dt, s);
 

--- a/crates/iota-graphql-rpc/src/types/move_value.rs
+++ b/crates/iota-graphql-rpc/src/types/move_value.rs
@@ -499,7 +499,7 @@ mod tests {
     macro_rules! struct_layout {
         ($type:literal { $($name:literal : $layout:expr),* $(,)?}) => {
             A::MoveTypeLayout::Struct(Box::new(S {
-                type_: StructTag::from_str($type).expect("Failed to parse struct"),
+                type_: StructTag::from_str($type).expect("failed to parse struct"),
                 fields: vec![$(MoveFieldLayout {
                     name: ident_str!($name).to_owned(),
                     layout: $layout,


### PR DESCRIPTION
# Description of change

This PR aims to refactor all error messages to be consistent and use lower-case first letters.

## Links to any relevant issues

fixes #6000.

## How the change has been tested

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.