### PR TITLE
refactor(iota-rest-kv): lower-case error messages

### DIFF
--- a/crates/iota-rest-kv/src/aws.rs
+++ b/crates/iota-rest-kv/src/aws.rs
@@ -291,7 +291,7 @@ impl KvStoreClient {
             Ok(response) => {
                 // Get bytes from the response
                 let data = response.bytes().await.map_err(|err| {
-                    anyhow::anyhow!("Failed to read data from remote store: {err}")
+                    anyhow::anyhow!("failed to read data from remote store: {err}")
                 })?;
 
                 Ok(Some(data))

--- a/crates/iota-rest-kv/src/main.rs
+++ b/crates/iota-rest-kv/src/main.rs
@@ -77,7 +77,7 @@ fn shutdown_signal_listener(token: CancellationToken) {
         #[cfg(unix)]
         let terminate = async {
             tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-                .expect("Cannot listen to SIGTERM signal")
+                .expect("cannot listen to SIGTERM signal")
                 .recv()
                 .await;
         };
@@ -86,8 +86,8 @@ fn shutdown_signal_listener(token: CancellationToken) {
         let terminate = std::future::pending::<()>();
 
         tokio::select! {
-            _ = tokio::signal::ctrl_c() => tracing::info!("CTRL+C signal received, shutting down"),
-            _ = terminate => tracing::info!("SIGTERM signal received, shutting down")
+            _ = tokio::signal::ctrl_c() => tracing::info!("shutting down, CTRL+C signal received"),
+            _ = terminate => tracing::info!("shutting down, SIGTERM signal received")
         };
 
         token.cancel();


### PR DESCRIPTION
# Description of change

This PR aims to refactor all error messages to be consistent and use lower-case first letters.

## Links to any relevant issues

fixes #6000.

## How the change has been tested

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.