### PR TITLE
refactor(iota-rosetta): lower-case error messages

### DIFF
--- a/crates/iota-rosetta/src/construction.rs
+++ b/crates/iota-rosetta/src/construction.rs
@@ -79,7 +79,7 @@ pub async fn payloads(
     let intent_msg_bytes = bcs::to_bytes(&intent_msg)?;
 
     let mut hasher = DefaultHash::default();
-    hasher.update(bcs::to_bytes(&intent_msg).expect("Message serialization should not fail"));
+    hasher.update(bcs::to_bytes(&intent_msg).expect("message serialization should not fail"));
     let digest = hasher.finalize().digest;
 
     Ok(ConstructionPayloadsResponse {
@@ -180,7 +180,7 @@ pub async fn submit(
 
     if let IotaExecutionStatus::Failure { error } = response
         .effects
-        .expect("Execute transaction should return effects")
+        .expect("execute transaction should return effects")
         .status()
     {
         return Err(Error::TransactionExecution(error.to_string()));

--- a/crates/iota-rosetta/src/main.rs
+++ b/crates/iota-rosetta/src/main.rs
@@ -92,7 +92,7 @@ impl RosettaServerCommand {
 
                 // Set network.
                 let network = config.pointer_mut("/network").ok_or_else(|| {
-                    anyhow!("Cannot find construction config in default config file.")
+                    anyhow!("cannot find construction config in default config file.")
                 })?;
                 network
                     .as_object_mut()
@@ -101,7 +101,7 @@ impl RosettaServerCommand {
 
                 // Add prefunded accounts.
                 let construction = config.pointer_mut("/construction").ok_or_else(|| {
-                    anyhow!("Cannot find construction config in default config file.")
+                    anyhow!("cannot find construction config in default config file.")
                 })?;
 
                 let construction = construction.as_object_mut().unwrap();
@@ -187,7 +187,7 @@ async fn wait_for_iota_client(rpc_address: String) -> IotaClient {
             Ok(client) => return client,
             Err(e) => {
                 warn!(
-                    "Error connecting to IOTA RPC server [{rpc_address}]: {e}, retrying in 5 seconds."
+                    "error connecting to IOTA RPC server [{rpc_address}]: {e}, retrying in 5 seconds."
                 );
                 tokio::time::sleep(Duration::from_millis(5000)).await;
             }

--- a/crates/iota-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/iota-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -753,7 +753,7 @@ async fn test_transaction(
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await
-        .map_err(|e| anyhow!("TX execution failed for {data:#?}, error : {e}"))
+        .map_err(|e| anyhow!("tx execution failed for {data:#?}, error : {e}"))
         .unwrap();
 
     let effects = response.effects.as_ref().unwrap();
@@ -762,7 +762,7 @@ async fn test_transaction(
         assert_eq!(
             IotaExecutionStatus::Success,
             *effects.status(),
-            "TX execution failed for {data:#?}"
+            "tx execution failed for {data:#?}"
         );
     } else {
         assert!(matches!(


### PR DESCRIPTION
# Description of change

This PR aims to refactor all error messages to be consistent and use lower-case first letters.

## Links to any relevant issues

fixes #6000.

## How the change has been tested

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.