### PR TITLE
feat(consensus): add `block_headers` and `transactions` to the `dag_state` atomicaly

### DIFF
--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -26,6 +26,7 @@ use crate::{
     Round,
     block_header::{
         BlockHeaderAPI, BlockRef, BlockTimestampMs, VerifiedBlock, VerifiedBlockHeader,
+        VerifiedTransactions,
     },
     block_manager::block_suspender::BlockSuspender,
     context::Context,
@@ -76,25 +77,18 @@ impl BlockManager {
             .iter()
             .map(|b| b.verified_block_header.clone())
             .collect();
-        let (accepted_block_headers, missing_block_headers) =
-            self.try_accept_block_headers_internal(block_headers);
+        let (block_headers_to_accept, missing_block_headers) =
+            self.process_block_headers(block_headers);
+        // collect suspended transactions for accepted headers.
+        let accepted_transactions =
+            self.resolve_transactions(&block_headers_to_accept, Some(blocks));
 
-        let block_refs = blocks
-            .iter()
-            .map(|b| b.verified_block_header.reference())
-            .collect();
-        let exists = self.dag_state.read().contains_block_headers(block_refs);
-        for (i, block) in blocks.into_iter().enumerate() {
-            if exists[i] {
-                self.dag_state
-                    .write()
-                    .add_transactions(block.verified_transactions, "Block streaming");
-            } else {
-                self.suspended_blocks.insert(block.reference(), block);
-            }
-        }
+        self.write_block_headers_and_transactions_to_dag_state(
+            block_headers_to_accept.clone(),
+            accepted_transactions,
+        );
 
-        (accepted_block_headers, missing_block_headers)
+        (block_headers_to_accept, missing_block_headers)
     }
 
     /// Tries to accept the provided block headers assuming that all their
@@ -111,11 +105,21 @@ impl BlockManager {
         let _s = monitored_scope("BlockManager::try_accept_block_headers");
         // Headers are added through synchronizer, commit syncer and cordial
         // dissemination.
-        self.try_accept_block_headers_internal(block_headers)
+        let (block_headers_to_accept, ancestors_to_fetch) =
+            self.process_block_headers(block_headers);
+        // collect transactions we already have for accepted headers.
+        let accepted_transactions = self.resolve_transactions(&block_headers_to_accept, None);
+        self.write_block_headers_and_transactions_to_dag_state(
+            block_headers_to_accept.clone(),
+            accepted_transactions,
+        );
+        (block_headers_to_accept, ancestors_to_fetch)
     }
 
-    /// Attempts to accept the provided blocks.
-    fn try_accept_block_headers_internal(
+    /// Processes received block headers to determine which should be accepted,
+    /// suspended, or fetched, and returns the accepted headers and missing
+    /// ancestors
+    fn process_block_headers(
         &mut self,
         block_headers: Vec<VerifiedBlockHeader>,
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
@@ -135,26 +139,57 @@ impl BlockManager {
         // Verify block timestamps
         let accepted_block_headers =
             self.verify_block_timestamps_and_accept(processed_block_headers);
+        (accepted_block_headers, ancestors_to_fetch)
+    }
 
-        // Insert the accepted blocks into DAG state so future blocks including them as
-        // ancestors do not get suspended.
-        self.dag_state
-            .write()
-            .accept_block_headers(accepted_block_headers.clone());
+    fn write_block_headers_and_transactions_to_dag_state(
+        &self,
+        block_headers: Vec<VerifiedBlockHeader>,
+        transactions: Vec<VerifiedTransactions>,
+    ) {
+        let mut write_guard = self.dag_state.write();
+        write_guard.accept_block_headers(block_headers);
+        for verified_transaction in transactions {
+            write_guard.add_transactions(verified_transaction, "Block streaming");
+        }
+    }
 
-        // check if we already have blocks for this accepted header. If yes, add them to
-        // dag_state
-        for block_header in accepted_block_headers.iter() {
-            if let Some(block) = self.suspended_blocks.remove(&block_header.reference()) {
-                // for this accepted header we already have a block, so we add it to dag_state
-                self.dag_state
-                    .write()
-                    .add_transactions(block.verified_transactions, "Block streaming");
+    /// Resolves transactions from the provided blocks and accepted block
+    /// headers.
+    ///
+    /// Moves transactions from suspended blocks whose headers are now accepted,
+    /// and optionally processes newly received blocks, adding their
+    /// transactions if accepted or re-suspending them otherwise.
+    fn resolve_transactions(
+        &mut self,
+        block_headers_to_be_accepted: &[VerifiedBlockHeader],
+        blocks: Option<Vec<VerifiedBlock>>,
+    ) -> Vec<VerifiedTransactions> {
+        let block_refs_to_be_accepted = block_headers_to_be_accepted
+            .iter()
+            .map(|h| h.reference())
+            .collect::<BTreeSet<_>>();
+        let mut all_accepted_transactions = vec![];
+        for block_ref in block_refs_to_be_accepted.iter() {
+            if let Some(block) = self.suspended_blocks.remove(block_ref) {
+                // for this accepted header we already have a block, so we add it to
+                // accepted transactions
+                all_accepted_transactions.push(block.verified_transactions);
             }
         }
 
-        // Figure out the new missing blocks
-        (accepted_block_headers, ancestors_to_fetch)
+        if let Some(blocks) = blocks {
+            let mut accepted_transactions_from_blocks = vec![];
+            for block in blocks {
+                if block_refs_to_be_accepted.contains(&block.reference()) {
+                    accepted_transactions_from_blocks.push(block.verified_transactions);
+                } else {
+                    self.suspended_blocks.insert(block.reference(), block);
+                }
+            }
+            all_accepted_transactions.extend(accepted_transactions_from_blocks);
+        }
+        all_accepted_transactions
     }
 
     /// Tries to find the provided block_refs in DagState and BlockManager,


### PR DESCRIPTION
# Description of change

This PR refactors the `BlockManager` to streamline how block headers and transactions are written into the DAG state.  
Previously, the logic acquired the DAG state write lock three separate times in `try_accept_blocks` (twice in `try_accept_block_headers_internal` and once more for received blocks transactions).  
The refactor extracts DAG write operations out of the header acceptance logic and consolidates them into a single step, ensuring the lock is acquired only once.

### Key changes
- Renamed `try_accept_block_headers_internal` to `process_block_headers` method and refactored it to perform only classification and validation.
- Introduced `resolve_transactions` suspend/unsuspend transactions from incoming blocks and accepted headers.
- Added `write_block_headers_and_transactions_to_dag_state` to atomically persist both block headers and transactions to the DAG.
- Updated `try_accept_blocks` and `try_accept_block_headers` to use the new processing flow.

This results in cleaner separation of responsibilities, reduced lock contention, and improved overall concurrency behavior within the `BlockManager`.

## Links to any relevant issues

Fixes #8900

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
