### PR TITLE
feat(starfish): Port median-based timestamp handling 

### DIFF
--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -15,7 +15,9 @@ use iota_types::{
 };
 use prometheus::Registry;
 use starfish_config::{Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
-use starfish_core::{CommitConsumer, CommitConsumerMonitor, CommitIndex, ConsensusAuthority};
+use starfish_core::{
+    Clock, CommitConsumer, CommitConsumerMonitor, CommitIndex, ConsensusAuthority,
+};
 use tokio::sync::Mutex;
 use tracing::info;
 
@@ -170,12 +172,14 @@ impl ConsensusManagerTrait for StarfishManager {
         }
 
         let authority = ConsensusAuthority::start(
+            epoch_store.epoch_start_config().epoch_start_timestamp_ms(),
             own_index,
             committee.clone(),
             parameters.clone(),
             protocol_config.clone(),
             self.protocol_keypair.clone(),
             self.network_keypair.clone(),
+            Arc::new(Clock::default()),
             Arc::new(tx_validator.clone()),
             consumer,
             registry.clone(),

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -57,6 +57,7 @@ impl ConsensusAuthority {
     /// It ensures that the authority node is fully initialized and
     /// ready to participate in the consensus process.
     pub async fn start(
+        epoch_start_timestamp_ms: u64,
         own_index: AuthorityIndex,
         committee: Committee,
         parameters: Parameters,
@@ -65,6 +66,7 @@ impl ConsensusAuthority {
         // kept in Core.
         protocol_keypair: ProtocolKeyPair,
         network_keypair: NetworkKeyPair,
+        clock: Arc<Clock>,
         transaction_verifier: Arc<dyn TransactionVerifier>,
         commit_consumer: CommitConsumer,
         registry: Registry,
@@ -89,12 +91,13 @@ impl ConsensusAuthority {
         info!("Consensus parameters: {:?}", parameters);
         info!("Consensus committee: {:?}", committee);
         let context = Arc::new(Context::new(
+            epoch_start_timestamp_ms,
             own_index,
             committee,
             parameters,
             protocol_config,
             initialise_metrics(registry),
-            Arc::new(Clock::new()),
+            clock,
         ));
         let start_time = Instant::now();
 
@@ -383,12 +386,14 @@ mod tests {
         let commit_consumer = CommitConsumer::new(sender, 0);
 
         let authority = ConsensusAuthority::start(
+            0,
             own_index,
             committee,
             parameters,
             ProtocolConfig::get_for_max_version_UNSAFE(),
             protocol_keypair,
             network_keypair,
+            Arc::new(Clock::default()),
             Arc::new(txn_verifier),
             commit_consumer,
             registry,
@@ -896,12 +901,14 @@ mod tests {
         let consensus_consumer_monitor = commit_consumer.monitor();
 
         let authority = ConsensusAuthority::start(
+            0,
             index,
             committee,
             parameters,
             protocol_config,
             protocol_keypair,
             network_keypair,
+            Arc::new(Clock::default()),
             Arc::new(txn_verifier),
             commit_consumer,
             registry,

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1442,7 +1442,7 @@ mod tests {
         ));
         let mut encoder = create_encoder(&context);
 
-        // Test rejecting block with time drift.
+        // Test that block with timestamp drift to the future is not rejected.
         let now = context.clock.timestamp_utc_ms();
         let max_drift = context.parameters.max_forward_time_drift;
         let input_block = VerifiedBlock::new_for_test(
@@ -1453,24 +1453,6 @@ mod tests {
 
         let serialized_block_bundle = SerializedBlockBundle::try_from(input_block.clone()).unwrap();
 
-        let result = authority_service
-            .handle_subscribed_block_bundle(
-                context.committee.to_authority_index(0).unwrap(),
-                serialized_block_bundle.clone(),
-                &mut encoder,
-            )
-            .await;
-
-        match result {
-            Err(ConsensusError::BlockRejected { reason, .. }) => {
-                assert!(reason.contains("timestamp is too far in the future"));
-            }
-            _ => panic!("Expected BlockRejected error, got {result:?}"),
-        }
-
-        // After this sleep time drift is within the limit, so we would not reject the
-        // block but wait
-        sleep(max_drift / 2).await;
         tokio::spawn(async move {
             authority_service
                 .handle_subscribed_block_bundle(
@@ -1481,6 +1463,9 @@ mod tests {
                 .await
                 .unwrap();
         });
+
+        // Give it some time to process
+        sleep(max_drift / 2).await;
 
         let blocks = core_dispatcher.get_blocks();
         assert_eq!(blocks.len(), 1);

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -17,10 +17,7 @@ use futures::{Stream, StreamExt, ready, stream, task};
 use iota_macros::fail_point_async;
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
-use tokio::{
-    sync::{Mutex, broadcast, mpsc::Sender},
-    time::sleep,
-};
+use tokio::sync::{Mutex, broadcast, mpsc::Sender};
 use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, info, warn};
 
@@ -281,50 +278,16 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let block_ref = verified_block.reference();
         debug!("Received block {} via stream block bundle.", block_ref);
 
-        // 2. Reject a block with a timestamp too far in the future.
+        // 2. Record timestamp drift metric (NEW mode - no waiting or rejection)
         let now = self.context.clock.timestamp_utc_ms();
         let forward_time_drift =
             Duration::from_millis(verified_block.timestamp_ms().saturating_sub(now));
-        if forward_time_drift > self.context.parameters.max_forward_time_drift {
-            self.context
-                .metrics
-                .node_metrics
-                .rejected_future_blocks
-                .with_label_values(&[peer_hostname])
-                .inc();
-            debug!(
-                "Block {:?} timestamp ({} > {}) is too far in the future, rejected.",
-                block_ref,
-                verified_block.timestamp_ms(),
-                now,
-            );
-            return Err(ConsensusError::BlockRejected {
-                block_ref,
-                reason: format!(
-                    "Block timestamp is too far in the future: {} > {}",
-                    verified_block.timestamp_ms(),
-                    now
-                ),
-            });
-        }
-
-        // 3. Wait until the block's timestamp is current.
-        if forward_time_drift > Duration::ZERO {
-            self.context
-                .metrics
-                .node_metrics
-                .block_timestamp_drift_wait_ms
-                .with_label_values(&[peer_hostname.as_str(), "handle_subscribed_block_bundle"])
-                .inc_by(forward_time_drift.as_millis() as u64);
-            debug!(
-                "Block {:?} timestamp ({} > {}) is in the future, waiting for {}ms",
-                block_ref,
-                verified_block.timestamp_ms(),
-                now,
-                forward_time_drift.as_millis(),
-            );
-            sleep(forward_time_drift).await;
-        }
+        self.context
+            .metrics
+            .node_metrics
+            .block_timestamp_drift_ms
+            .with_label_values(&[peer_hostname.as_str(), "handle_subscribed_block_bundle"])
+            .inc_by(forward_time_drift.as_millis() as u64);
 
         // 4. Create block headers from bytes from a bundle
         // 4.a. Truncate headers in bundle to max_headers_per_bundle
@@ -1518,10 +1481,7 @@ mod tests {
                 .await
                 .unwrap();
         });
-        assert!(core_dispatcher.get_blocks().is_empty());
 
-        // wait for the max_drift time to pass, so that the block can be processed
-        sleep(max_drift).await;
         let blocks = core_dispatcher.get_blocks();
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0], input_block);

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -203,12 +203,12 @@ impl BlockHeaderV1 {
         )
     }
 
-    fn genesis_block_header(epoch: Epoch, author: AuthorityIndex) -> Self {
+    fn genesis_block_header(context: &Context, author: AuthorityIndex) -> Self {
         Self {
-            epoch,
+            epoch: context.committee.epoch(),
             round: GENESIS_ROUND,
             author,
-            timestamp_ms: 0,
+            timestamp_ms: context.epoch_start_timestamp_ms,
             references: vec![],
             overlap_start_index: 0,
             overlap_end_index: 0,
@@ -1033,13 +1033,13 @@ impl Deref for VerifiedBlock {
 
 /// Generates the genesis blocks for the current Committee.
 /// The blocks are returned in authority index order.
-pub(crate) fn genesis_blocks(context: Arc<Context>) -> Vec<VerifiedBlock> {
+pub(crate) fn genesis_blocks(context: &Context) -> Vec<VerifiedBlock> {
     context
         .committee
         .authorities()
         .map(|(authority_index, _)| {
             let signed_block = SignedBlockHeader::new_genesis(BlockHeader::V1(
-                BlockHeaderV1::genesis_block_header(context.committee.epoch(), authority_index),
+                BlockHeaderV1::genesis_block_header(context, authority_index),
             ));
             let serialized = signed_block
                 .serialize()
@@ -1059,13 +1059,13 @@ pub(crate) fn genesis_blocks(context: Arc<Context>) -> Vec<VerifiedBlock> {
         .collect::<Vec<VerifiedBlock>>()
 }
 
-pub(crate) fn genesis_block_headers(context: Arc<Context>) -> Vec<VerifiedBlockHeader> {
+pub(crate) fn genesis_block_headers(context: &Context) -> Vec<VerifiedBlockHeader> {
     context
         .committee
         .authorities()
         .map(|(authority_index, _)| {
             let signed_block = SignedBlockHeader::new_genesis(BlockHeader::V1(
-                BlockHeaderV1::genesis_block_header(context.committee.epoch(), authority_index),
+                BlockHeaderV1::genesis_block_header(context, authority_index),
             ));
             let serialized = signed_block
                 .serialize()
@@ -1219,7 +1219,10 @@ mod tests {
     use fastcrypto::error::FastCryptoError;
 
     use crate::{
-        block_header::{BlockHeaderDigest, SignedBlockHeader, TestBlockHeader},
+        BlockHeaderAPI,
+        block_header::{
+            BlockHeaderDigest, SignedBlockHeader, TestBlockHeader, genesis_block_headers,
+        },
         context::Context,
         error::ConsensusError,
     };
@@ -1256,6 +1259,20 @@ mod tests {
             err => panic!("Unexpected error: {err:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn test_genesis_block_headers() {
+        let (context, _) = Context::new_for_test(4);
+        const TIMESTAMP_MS: u64 = 1000;
+        let context = Arc::new(context.with_epoch_start_timestamp_ms(TIMESTAMP_MS));
+        let block_headers = genesis_block_headers(&context);
+        for (i, header) in block_headers.into_iter().enumerate() {
+            assert_eq!(header.author().value(), i);
+            assert_eq!(header.round(), 0);
+            assert_eq!(header.timestamp_ms(), TIMESTAMP_MS);
+        }
+    }
+
     #[tokio::test]
     async fn test_compress_references() {
         use crate::block_header::BlockRef;

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -23,14 +23,13 @@ mod block_suspender;
 pub(crate) mod block_suspender;
 
 use crate::{
+    Round,
     block_header::{
-        BlockHeaderAPI, BlockRef, BlockTimestampMs, VerifiedBlock, VerifiedBlockHeader,
-        VerifiedTransactions,
+        BlockHeaderAPI, BlockRef, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
     },
     block_manager::block_suspender::BlockSuspender,
     context::Context,
     dag_state::DagState,
-    Round,
 };
 
 /// Block manager suspends incoming blocks until they are connected to the
@@ -364,7 +363,7 @@ mod tests {
     use std::{collections::BTreeSet, sync::Arc};
 
     use parking_lot::RwLock;
-    use rand::{prelude::StdRng, seq::SliceRandom, SeedableRng};
+    use rand::{SeedableRng, prelude::StdRng, seq::SliceRandom};
     use starfish_config::AuthorityIndex;
 
     use crate::{

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -23,7 +23,6 @@ mod block_suspender;
 pub(crate) mod block_suspender;
 
 use crate::{
-    Round,
     block_header::{
         BlockHeaderAPI, BlockRef, BlockTimestampMs, VerifiedBlock, VerifiedBlockHeader,
         VerifiedTransactions,
@@ -31,7 +30,7 @@ use crate::{
     block_manager::block_suspender::BlockSuspender,
     context::Context,
     dag_state::DagState,
-    error::{ConsensusError, ConsensusResult},
+    Round,
 };
 
 /// Block manager suspends incoming blocks until they are connected to the
@@ -133,13 +132,8 @@ impl BlockManager {
         }
         // Find missing ancestors for the provided block headers in the DAG state.
         let missing_ancestors = self.find_missing_ancestors(block_headers);
-        let (processed_block_headers, ancestors_to_fetch) = self
-            .block_suspender
-            .accept_or_suspend_received_headers(missing_ancestors);
-        // Verify block timestamps
-        let accepted_block_headers =
-            self.verify_block_timestamps_and_accept(processed_block_headers);
-        (accepted_block_headers, ancestors_to_fetch)
+        self.block_suspender
+            .accept_or_suspend_received_headers(missing_ancestors)
     }
 
     fn write_block_headers_and_transactions_to_dag_state(
@@ -255,100 +249,7 @@ impl BlockManager {
 
         blocks_to_fetch
     }
-    /// Verifies a block w.r.t. ancestor blocks.
-    /// This is called after a block has complete causal history locally,
-    /// and is ready to be accepted into the DAG.
-    ///
-    /// Caller must make sure ancestors correspond to block.ancestors() 1-to-1,
-    /// in the same order.
-    fn check_ancestors(
-        &self,
-        block: &VerifiedBlockHeader,
-        ancestors: &[VerifiedBlockHeader],
-    ) -> ConsensusResult<()> {
-        assert_eq!(block.ancestors().len(), ancestors.len());
-        // This checks the invariant that block timestamp >= max ancestor timestamp.
-        let mut max_timestamp_ms = BlockTimestampMs::MIN;
-        for (ancestor_ref, ancestor_block) in block.ancestors().iter().zip(ancestors.iter()) {
-            assert_eq!(ancestor_ref, &ancestor_block.reference());
-            max_timestamp_ms = max_timestamp_ms.max(ancestor_block.timestamp_ms());
-        }
-        if max_timestamp_ms > block.timestamp_ms() {
-            return Err(ConsensusError::InvalidBlockTimestamp {
-                max_timestamp_ms,
-                block_timestamp_ms: block.timestamp_ms(),
-            });
-        }
-        Ok(())
-    }
-    // TODO: remove once timestamping is refactored to the new approach.
-    // Verifies each block's timestamp based on its ancestors, and persists in store
-    // all the valid blocks that should be accepted. Method returns the accepted
-    // and persisted blocks.
-    fn verify_block_timestamps_and_accept(
-        &mut self,
-        unsuspended_blocks: impl IntoIterator<Item = VerifiedBlockHeader>,
-    ) -> Vec<VerifiedBlockHeader> {
-        // Try to verify the block and its children for timestamp, with ancestor blocks.
-        let mut blocks_to_accept: BTreeMap<BlockRef, VerifiedBlockHeader> = BTreeMap::new();
-        let mut blocks_to_reject: BTreeMap<BlockRef, VerifiedBlockHeader> = BTreeMap::new();
-        {
-            'block: for b in unsuspended_blocks {
-                let ancestors = self.dag_state.read().get_block_headers(b.ancestors());
-                assert_eq!(b.ancestors().len(), ancestors.len());
-                let mut ancestor_blocks = vec![];
-                'ancestor: for (ancestor_ref, found) in
-                    b.ancestors().iter().zip(ancestors.into_iter())
-                {
-                    if let Some(found_block) = found {
-                        // This invariant should be guaranteed by DagState.
-                        assert_eq!(ancestor_ref, &found_block.reference());
-                        ancestor_blocks.push(found_block);
-                        continue 'ancestor;
-                    }
-                    // blocks_to_accept have not been added to DagState yet, but they
-                    // can appear in ancestors.
-                    if blocks_to_accept.contains_key(ancestor_ref) {
-                        ancestor_blocks.push(blocks_to_accept[ancestor_ref].clone());
-                        continue 'ancestor;
-                    }
-                    // If an ancestor is already rejected, reject this block as well.
-                    if blocks_to_reject.contains_key(ancestor_ref) {
-                        blocks_to_reject.insert(b.reference(), b);
-                        continue 'block;
-                    }
-                    {
-                        panic!(
-                            "Unsuspended block {b:?} has a missing ancestor! Ancestor not found in DagState: {ancestor_ref:?}",
-                        );
-                    }
-                }
-                if let Err(e) = self.check_ancestors(&b, &ancestor_blocks) {
-                    warn!("Block {:?} failed to verify ancestors: {}", b, e);
-                    blocks_to_reject.insert(b.reference(), b);
-                } else {
-                    blocks_to_accept.insert(b.reference(), b);
-                }
-            }
-        }
 
-        // TODO: report blocks_to_reject to peers.
-        for (block_ref, block) in &blocks_to_reject {
-            self.context
-                .metrics
-                .node_metrics
-                .invalid_block_headers
-                .with_label_values(&[
-                    self.context.authority_hostname(block_ref.author),
-                    "accept_block",
-                    "InvalidAncestors",
-                ])
-                .inc();
-            warn!("Invalid block {:?} is rejected", block);
-        }
-
-        blocks_to_accept.values().cloned().collect::<Vec<_>>()
-    }
     fn update_block_received_metrics(&mut self, block: &VerifiedBlockHeader) {
         let (min_round, max_round) =
             if let Some((curr_min, curr_max)) = self.received_block_rounds[block.author()] {
@@ -463,16 +364,14 @@ mod tests {
     use std::{collections::BTreeSet, sync::Arc};
 
     use parking_lot::RwLock;
-    use rand::{SeedableRng, prelude::StdRng, seq::SliceRandom};
+    use rand::{prelude::StdRng, seq::SliceRandom, SeedableRng};
     use starfish_config::AuthorityIndex;
 
     use crate::{
-        TestBlockHeader,
-        block_header::{BlockHeaderAPI, BlockRef, BlockTimestampMs, VerifiedBlockHeader},
+        block_header::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader},
         block_manager::BlockManager,
         context::Context,
         dag_state::DagState,
-        error::ConsensusError,
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
     };
@@ -767,15 +666,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reject_blocks_failing_verifications() {
+    async fn accept_blocks_with_timestamp_variations() {
         let (context, _key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
 
         // create a DAG of rounds 1 ~ 5.
         let mut dag_builder = DagBuilder::new(context.clone());
         dag_builder.layer(1).build();
-        // trigger failed verification by setting a timestamp delay
-        // on layer 2 which are ancestors to round 3.
+        // Set a timestamp delay on layer 2. With median-based timestamp,
+        // blocks are no longer rejected for timestamp violations.
         dag_builder
             .layer(2)
             .configure_timestamp_delay_ms(5000)
@@ -816,15 +715,10 @@ mod tests {
                 .cloned()
                 .collect(),
         );
-        // Only round 1 and round 2 blocks should be accepted.
-        assert_eq!(accepted_block_headers.len(), 8);
-        accepted_block_headers.iter().for_each(|block_header| {
-            assert!(block_header.round() <= 2);
-        });
+        // With median-based timestamp, all blocks should be accepted regardless of
+        // timestamp violations.
+        assert_eq!(accepted_block_headers.len(), 20); // 4 blocks * 5 rounds
         assert!(missing_refs.is_empty());
-
-        // Other blocks should be rejected and there should be no suspended block
-        // remaining.
         assert!(block_manager.suspended_blocks_refs().is_empty());
     }
 
@@ -922,58 +816,5 @@ mod tests {
                 .chain(missing_block_refs_from_find.into_iter())
                 .collect()
         );
-    }
-
-    #[tokio::test]
-    async fn test_check_ancestors() {
-        let num_authorities = 4;
-        let (context, _keypairs) = Context::new_for_test(num_authorities);
-        let context = Arc::new(context);
-        let store = Arc::new(MemStore::new());
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-
-        let block_manager = BlockManager::new(context.clone(), dag_state);
-
-        let mut ancestor_blocks = vec![];
-        for i in 0..num_authorities {
-            let test_block = TestBlockHeader::new(10, i as u8)
-                .set_timestamp_ms(1000 + 100 * i as BlockTimestampMs)
-                .build();
-            ancestor_blocks.push(VerifiedBlockHeader::new_for_test(test_block));
-        }
-        let ancestor_refs = ancestor_blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>();
-
-        // Block respecting timestamp invariant.
-        {
-            let block = TestBlockHeader::new(11, 0)
-                .set_ancestors(ancestor_refs.clone())
-                .set_timestamp_ms(1500)
-                .build();
-            let verified_block = VerifiedBlockHeader::new_for_test(block);
-            assert!(
-                block_manager
-                    .check_ancestors(&verified_block, &ancestor_blocks)
-                    .is_ok()
-            );
-        }
-
-        // Block not respecting timestamp invariant.
-        {
-            let block = TestBlockHeader::new(11, 0)
-                .set_ancestors(ancestor_refs.clone())
-                .set_timestamp_ms(1000)
-                .build();
-            let verified_block = VerifiedBlockHeader::new_for_test(block);
-            assert!(matches!(
-                block_manager.check_ancestors(&verified_block, &ancestor_blocks,),
-                Err(ConsensusError::InvalidBlockTimestamp {
-                    max_timestamp_ms: _,
-                    block_timestamp_ms: _
-                })
-            ));
-        }
     }
 }

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -38,7 +38,7 @@ impl SignedBlockVerifier {
         context: Arc<Context>,
         transaction_verifier: Arc<dyn TransactionVerifier>,
     ) -> Self {
-        let genesis = genesis_block_headers(context.clone())
+        let genesis = genesis_block_headers(&context)
             .into_iter()
             .map(|b| b.reference())
             .collect();

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -469,12 +469,26 @@ mod tests {
         for (idx, subdag) in commits.iter().enumerate() {
             info!("{subdag:?}");
             assert_eq!(subdag.leader, leaders[idx].reference());
+
+            // Calculate expected timestamp using median of parents (NEW mode)
+            let block_refs = leaders[idx]
+                .ancestors()
+                .iter()
+                .filter(|block_ref| block_ref.round == leaders[idx].round() - 1)
+                .cloned()
+                .collect::<Vec<_>>();
+            let blocks = dag_state
+                .read()
+                .get_block_headers(&block_refs)
+                .into_iter()
+                .map(|block_opt| block_opt.expect("We should have all blocks in dag state."));
+            let calculated_ts =
+                crate::linearizer::median_timestamp_by_stake(&context, blocks).unwrap();
+
             let expected_ts = if idx == 0 {
-                leaders[idx].timestamp_ms()
+                calculated_ts
             } else {
-                leaders[idx]
-                    .timestamp_ms()
-                    .max(commits[idx - 1].timestamp_ms)
+                calculated_ts.max(commits[idx - 1].timestamp_ms)
             };
             assert_eq!(expected_ts, subdag.timestamp_ms);
             if idx == 0 {

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -678,8 +678,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             }
         }
 
-        // 8. Make sure fetched block headers (and votes) timestamps are lower than
-        //    current time.
+        // 8. Record timestamp drift metric
         for block_header in voting_block_headers
             .iter()
             .chain(fetched_block_headers.values())
@@ -694,18 +693,9 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 .context
                 .metrics
                 .node_metrics
-                .block_timestamp_drift_wait_ms
+                .block_timestamp_drift_ms
                 .with_label_values(&[peer_hostname.as_str(), "commit_syncer"])
                 .inc_by(forward_drift);
-            let forward_drift = Duration::from_millis(forward_drift);
-            if forward_drift >= inner.context.parameters.max_forward_time_drift {
-                warn!(
-                    "Local clock is behind a quorum of peers: local ts {}, certified block header ts {}",
-                    now_ms,
-                    block_header.timestamp_ms()
-                );
-            }
-            sleep(forward_drift).await;
         }
 
         // 9. Now create the Certified commits by assigning the block headers to each

--- a/crates/starfish/core/src/context.rs
+++ b/crates/starfish/core/src/context.rs
@@ -20,6 +20,8 @@ use crate::{block_header::BlockTimestampMs, metrics::Metrics};
 /// components of this authority.
 #[derive(Clone)]
 pub(crate) struct Context {
+    /// Timestamp of the start of the current epoch.
+    pub epoch_start_timestamp_ms: u64,
     /// Index of this authority in the committee.
     pub own_index: AuthorityIndex,
     /// Committee of the current epoch.
@@ -36,6 +38,7 @@ pub(crate) struct Context {
 
 impl Context {
     pub(crate) fn new(
+        epoch_start_timestamp_ms: u64,
         own_index: AuthorityIndex,
         committee: Committee,
         parameters: Parameters,
@@ -44,6 +47,7 @@ impl Context {
         clock: Arc<Clock>,
     ) -> Self {
         Self {
+            epoch_start_timestamp_ms,
             own_index,
             committee,
             parameters,
@@ -66,9 +70,10 @@ impl Context {
             starfish_config::local_committee_and_keys(0, vec![1; committee_size]);
         let metrics = test_metrics();
         let temp_dir = TempDir::new().unwrap();
-        let clock = Arc::new(Clock::new());
+        let clock = Arc::new(Clock::default());
 
         let context = Context::new(
+            0,
             AuthorityIndex::new_for_test(0),
             committee,
             Parameters {
@@ -80,6 +85,12 @@ impl Context {
             clock,
         );
         (context, keypairs)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_epoch_start_timestamp_ms(mut self, epoch_start_timestamp_ms: u64) -> Self {
+        self.epoch_start_timestamp_ms = epoch_start_timestamp_ms;
+        self
     }
 
     #[cfg(test)]
@@ -107,22 +118,38 @@ impl Context {
 /// `[Clock]` cloneable to ensure that a single instance is shared behind an
 /// `[Arc]` wherever is needed in order to make sure that consecutive calls to
 /// receive the system timestamp will remain monotonically increasing.
-pub(crate) struct Clock {
+pub struct Clock {
     initial_instant: Instant,
     initial_system_time: SystemTime,
+    // `clock_drift` should be used only for testing
+    #[cfg(any(test, msim))]
+    clock_drift: BlockTimestampMs,
 }
 
-impl Clock {
-    pub fn new() -> Self {
+impl Default for Clock {
+    fn default() -> Self {
         Self {
             initial_instant: Instant::now(),
             initial_system_time: SystemTime::now(),
+            #[cfg(any(test, msim))]
+            clock_drift: 0,
+        }
+    }
+}
+
+impl Clock {
+    #[cfg(any(test, msim))]
+    pub fn new_for_test(clock_drift: BlockTimestampMs) -> Self {
+        Self {
+            initial_instant: Instant::now(),
+            initial_system_time: SystemTime::now(),
+            clock_drift,
         }
     }
 
-    // Returns the current time expressed as UNIX timestamp in milliseconds.
-    // Calculated with Tokio Instant to ensure monotonicity,
-    // and to allow testing with tokio clock.
+    // Returns the current time expressed as a UNIX timestamp in milliseconds.
+    // Calculated with Tokio Instant to ensure monotonicity
+    // and to allow testing with a tokio clock.
     pub(crate) fn timestamp_utc_ms(&self) -> BlockTimestampMs {
         let now: Instant = Instant::now();
         let monotonic_system_time = self
@@ -137,7 +164,7 @@ impl Clock {
                     }),
             )
             .expect("Computing system time should not overflow");
-        monotonic_system_time
+        let timestamp = monotonic_system_time
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap_or_else(|_| {
                 panic!(
@@ -146,6 +173,17 @@ impl Clock {
                     SystemTime::UNIX_EPOCH,
                 )
             })
-            .as_millis() as BlockTimestampMs
+            .as_millis() as BlockTimestampMs;
+        // Apply clock drift only in test/msim environments to simulate clock skew
+        // between nodes. In production builds, the clock_drift field doesn't exist,
+        // and this returns the timestamp directly.
+        #[cfg(any(test, msim))]
+        {
+            timestamp + self.clock_drift
+        }
+        #[cfg(not(any(test, msim)))]
+        {
+            timestamp
+        }
     }
 }

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -196,7 +196,7 @@ impl Core {
             .scope_processing_time
             .with_label_values(&["Core::recover"])
             .start_timer();
-        // Ensure local time is after max ancestor timestamp.
+        // Check ancestor timestamps
         let ancestor_block_headers = self
             .dag_state
             .read()
@@ -205,12 +205,13 @@ impl Core {
             .iter()
             .fold(0, |ts, (b, _)| ts.max(b.timestamp_ms()));
         let wait_ms = max_ancestor_timestamp.saturating_sub(self.context.clock.timestamp_utc_ms());
+
+        // NEW mode: no waiting on timestamp drift
         if wait_ms > 0 {
-            warn!(
-                "Waiting for {} ms while recovering ancestors from storage",
+            info!(
+                "Median based timestamp is enabled. Will not wait for {} ms while recovering ancestors from storage",
                 wait_ms
             );
-            std::thread::sleep(Duration::from_millis(wait_ms));
         }
 
         // Try to commit and propose, since they may not have run after the last write
@@ -636,15 +637,19 @@ impl Core {
                 .observe(clock_round.saturating_sub(ancestor.round()).into());
         }
 
-        // Ensure ancestor timestamps are not more advanced than the current time.
-        // Also catch the issue if system's clock go backwards.
+        // Record timestamp drift but don't enforce ancestor timestamp checks.
         let now = self.context.clock.timestamp_utc_ms();
         ancestors.iter().for_each(|block| {
-            assert!(
-                block.timestamp_ms() <= now,
-                "Violation: ancestor block {:?} has timestamp {}, greater than current timestamp {now}. Proposing for round {}.",
-                block, block.timestamp_ms(), clock_round
-            );
+            if block.timestamp_ms() > now {
+                trace!("Ancestor block {block:?} has timestamp {}, greater than current timestamp {now}. Proposing for round {clock_round}.",  block.timestamp_ms());
+                let authority = &self.context.committee.authority(block.author()).hostname;
+                self.context
+                    .metrics
+                    .node_metrics
+                    .proposed_block_ancestors_timestamp_drift_ms
+                    .with_label_values(&[authority])
+                    .inc_by(block.timestamp_ms().saturating_sub(now));
+            }
         });
 
         // Consume the next transactions to be included. Do not drop the guards yet as
@@ -1466,7 +1471,7 @@ mod test {
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
 
         // Create test blocks for all authorities except our's (index = 0).
-        let mut last_round_blocks = genesis_blocks(context.clone());
+        let mut last_round_blocks = genesis_blocks(&context);
         let mut all_blocks = last_round_blocks.clone();
         for round in 1..=4 {
             let mut this_round_blocks = Vec::new();
@@ -1715,7 +1720,7 @@ mod test {
         assert_eq!(verified_block.acknowledgments().len(), num_acks);
 
         // genesis blocks should be referenced
-        let all_genesis = genesis_block_headers(context);
+        let all_genesis = genesis_block_headers(&context);
 
         for ancestor in verified_block.ancestors() {
             all_genesis

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -3145,8 +3145,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "cannot be accepted! Block header timestamp")]
-    async fn test_panic_on_future_timestamp() {
+    async fn test_no_panic_on_future_timestamp() {
         // GIVEN
         let (context, _) = Context::new_for_test(4);
 
@@ -3160,7 +3159,14 @@ mod test {
                 .set_timestamp_ms(future_timestamp)
                 .build(),
         );
-        dag_state.accept_block_header(block_header);
+        dag_state.accept_block_header(block_header.clone());
+
+        let accepted_header = dag_state
+            .recent_block_headers
+            .get(&block_header.reference())
+            .unwrap();
+
+        assert_eq!(accepted_header, &block_header);
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -16,7 +16,7 @@ use bytes::Bytes;
 use itertools::Itertools as _;
 use starfish_config::AuthorityIndex;
 use tokio::time::Instant;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     block_header::{
@@ -157,7 +157,7 @@ impl DagState {
         let cached_rounds = context.parameters.dag_state_cached_rounds as Round;
         let num_authorities = context.committee.size();
 
-        let genesis = genesis_blocks(context.clone())
+        let genesis = genesis_blocks(&context)
             .into_iter()
             .map(|block| (block.reference(), block))
             .collect();
@@ -289,13 +289,20 @@ impl DagState {
 
         let now = self.context.clock.timestamp_utc_ms();
         if block_header.timestamp_ms() > now {
-            panic!(
-                "Block header {:?} cannot be accepted! Block header timestamp {} is greater than local timestamp {}.",
-                block_header,
+            // blocks can have timestamps in the future, just log it
+            trace!(
+                "Block header {block_header:?} with timestamp {} is greater than local timestamp {now}.",
                 block_header.timestamp_ms(),
-                now,
             );
         }
+        // Record the time drift metric
+        let hostname = &self.context.committee.authority(block_ref.author).hostname;
+        self.context
+            .metrics
+            .node_metrics
+            .accepted_block_time_drift_ms
+            .with_label_values(&[hostname])
+            .inc_by(block_header.timestamp_ms().saturating_sub(now));
 
         // TODO: Move this check to core
         // Ensure we don't write multiple blocks per slot for our own index
@@ -1173,7 +1180,7 @@ impl DagState {
     // Buffers a new commit in memory and updates last committed rounds.
     // REQUIRED: must not skip over any commit index.
     pub(crate) fn add_commit(&mut self, commit: TrustedCommit) {
-        if let Some(last_commit) = &self.last_commit {
+        let time_diff = if let Some(last_commit) = &self.last_commit {
             if commit.index() <= last_commit.index() {
                 error!(
                     "New commit index {} <= last commit index {}!",
@@ -1189,9 +1196,19 @@ impl DagState {
                     "Commit timestamps do not monotonically increment, prev commit {last_commit:?}, new commit {commit:?}"
                 );
             }
+            commit
+                .timestamp_ms()
+                .saturating_sub(last_commit.timestamp_ms())
         } else {
             assert_eq!(commit.index(), 1);
-        }
+            0
+        };
+
+        self.context
+            .metrics
+            .node_metrics
+            .last_commit_time_diff
+            .observe(time_diff as f64);
 
         // Ensure that commit rounds are strictly increasing
         assert!(
@@ -2943,7 +2960,7 @@ mod test {
 
         // WHEN no block headers exist, then genesis should be returned
         {
-            let genesis = genesis_block_headers(context.clone());
+            let genesis = genesis_block_headers(&context);
 
             assert_eq!(dag_state.read().last_quorum(), genesis);
         }
@@ -2998,7 +3015,7 @@ mod test {
 
         // WHEN no block headers exist, then genesis should be returned
         {
-            let genesis_headers = genesis_block_headers(context.clone());
+            let genesis_headers = genesis_block_headers(&context);
             let my_genesis_header = genesis_headers
                 .into_iter()
                 .find(|block| block.author() == context.own_index)
@@ -3008,7 +3025,7 @@ mod test {
                 dag_state.read().get_last_proposed_block_header(),
                 my_genesis_header
             );
-            let genesis_blocks = genesis_blocks(context.clone());
+            let genesis_blocks = genesis_blocks(&context);
             let my_genesis_block = genesis_blocks
                 .into_iter()
                 .find(|block| block.author() == context.own_index)
@@ -3299,6 +3316,23 @@ mod test {
                 block_ref.round
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_accept_block_not_panics_when_timestamp_is_ahead() {
+        // GIVEN
+        let context = Arc::new(Context::new_for_test(4).0);
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+        // Set a timestamp for the block that is ahead of the current time
+        let block_timestamp = context.clock.timestamp_utc_ms() + 5_000;
+        let block = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(10, 0)
+                .set_timestamp_ms(block_timestamp)
+                .build(),
+        );
+        // Try to accept the block - it should not panic
+        dag_state.accept_block_header(block);
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -282,7 +282,7 @@ mod tests {
 
             // Add genesis blocks if round 0 is included
             if included_rounds.contains(&0) {
-                let genesis_blocks = genesis_blocks(self.context.clone());
+                let genesis_blocks = genesis_blocks(&self.context);
                 for (i, block) in genesis_blocks.iter().enumerate() {
                     state.accept_block_header(block.verified_block_header.clone());
                     if !excluded_transactions.contains(&(0, i)) {
@@ -331,7 +331,7 @@ mod tests {
             let mut state = dag_state.write();
             for &(round, block_index) in blocks {
                 if round == 0 {
-                    let genesis_blocks = genesis_blocks(self.context.clone());
+                    let genesis_blocks = genesis_blocks(&self.context);
                     if let Some(block) = genesis_blocks.get(block_index) {
                         state.add_transactions(block.verified_transactions.clone(), "test");
                     }
@@ -410,7 +410,7 @@ mod tests {
 
         fn with_committed_refs_from_round(mut self, round: u32) -> Self {
             let refs = if round == 0 {
-                genesis_blocks(self.setup.context.clone())
+                genesis_blocks(&self.setup.context)
                     .iter()
                     .map(|b| b.reference())
                     .collect()
@@ -434,7 +434,7 @@ mod tests {
         fn build(self) -> PendingSubDag {
             // Get leader block
             let leader = if self.leader_round == 0 {
-                genesis_blocks(self.setup.context.clone())[self.leader_index].reference()
+                genesis_blocks(&self.setup.context)[self.leader_index].reference()
             } else {
                 self.setup
                     .dag_builder
@@ -447,7 +447,7 @@ mod tests {
 
             for spec in &self.block_specs {
                 let headers = if spec.round == 0 {
-                    genesis_block_headers(self.setup.context.clone())
+                    genesis_block_headers(&self.setup.context)
                 } else {
                     self.setup
                         .dag_builder
@@ -473,7 +473,7 @@ mod tests {
 
             // Add a leader block if not already included
             let leader_header = if self.leader_round == 0 {
-                genesis_blocks(self.setup.context.clone())[self.leader_index]
+                genesis_blocks(&self.setup.context)[self.leader_index]
                     .verified_block_header
                     .clone()
             } else {

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -152,12 +152,6 @@ pub(crate) enum ConsensusError {
     #[error("Invalid transaction: {0}")]
     InvalidTransaction(String),
 
-    #[error("Ancestors max timestamp {max_timestamp_ms} > block timestamp {block_timestamp_ms}")]
-    InvalidBlockTimestamp {
-        max_timestamp_ms: u64,
-        block_timestamp_ms: u64,
-    },
-
     #[error("Received no commit from peer {peer}")]
     NoCommitReceived { peer: AuthorityIndex },
 

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -62,9 +62,10 @@ pub use authority_node::ConsensusAuthority;
 pub use block_header::TestBlockHeader;
 pub use block_header::{BlockHeaderAPI, BlockRef, Round};
 /// Exported API for testing.
-pub use block_header::{Transaction, VerifiedBlockHeader};
+pub use block_header::{BlockTimestampMs, Transaction, VerifiedBlockHeader};
 pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
 pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
+pub use context::Clock;
 pub use network::tonic_network::to_socket_addr;
 #[cfg(msim)]
 pub use transaction::NoopTransactionVerifier;

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -776,7 +776,23 @@ mod tests {
 
             tracing::info!("{subdag:?}");
             assert_eq!(subdag.leader, leaders[idx].reference());
-            assert_eq!(subdag.timestamp_ms, leaders[idx].timestamp_ms());
+
+            let block_refs = leaders[idx]
+                .ancestors()
+                .iter()
+                .filter(|block_ref| block_ref.round == leaders[idx].round() - 1)
+                .cloned()
+                .collect::<Vec<_>>();
+            let blocks = dag_state
+                .read()
+                .get_block_headers(&block_refs)
+                .into_iter()
+                .map(|block_opt| block_opt.expect("We should have all blocks in dag state."));
+
+            let expected_ts = median_timestamp_by_stake(&context, blocks).unwrap();
+
+            assert_eq!(subdag.timestamp_ms, expected_ts);
+
             if idx == 0 {
                 // First subdag includes the leader block only
                 assert_eq!(subdag.blocks.len(), 1);
@@ -1053,7 +1069,7 @@ mod tests {
         let context = Arc::new(Context::new_for_test(num_authorities).0);
         // No blocks provided
         let err = median_timestamp_by_stake(&context, vec![].into_iter()).unwrap_err();
-        assert_eq!(err, "No blocks provided");
+        assert_eq!(err, "No block headers provided");
         // Blocks provided but total stake is less than a quorum threshold
         let block = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 0).build());
         let err = median_timestamp_by_stake(&context, vec![block].into_iter()).unwrap_err();

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -411,8 +411,6 @@ fn median_timestamps_by_stake_inner(
 
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
-
     use super::*;
     use crate::{
         CommitIndex, TestBlockHeader,
@@ -920,23 +918,17 @@ mod tests {
         }
     }
 
-    #[rstest]
-    #[case(false, 5_000, 5_000, 6_000)]
-    #[case(true, 3_000, 3_000, 6_000)]
     #[tokio::test]
-    async fn test_calculate_commit_timestamp(
-        #[case] consensus_median_timestamp: bool,
-        #[case] timestamp_1: u64,
-        #[case] timestamp_2: u64,
-        #[case] timestamp_3: u64,
-    ) {
+    async fn test_calculate_commit_timestamp() {
+        let timestamp_1 = 3_000;
+        let timestamp_2 = 3_000;
+        let timestamp_3 = 6_000;
         // GIVEN
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let mut dag_state_guard = dag_state.write();
         let ancestors = vec![
             VerifiedBlockHeader::new_for_test(
                 TestBlockHeader::new(4, 0).set_timestamp_ms(1_000).build(),
@@ -962,8 +954,11 @@ mod tests {
                 )
                 .build(),
         );
-        for block in &ancestors {
-            dag_state_guard.accept_block_header(block.clone());
+        {
+            let mut dag_state_guard = dag_state.write();
+            for block in &ancestors {
+                dag_state_guard.accept_block_header(block.clone());
+            }
         }
         let last_commit_timestamp_ms = 0;
         // WHEN
@@ -1026,11 +1021,7 @@ mod tests {
             &leader_block,
             last_commit_timestamp_ms,
         );
-        if consensus_median_timestamp {
-            assert_eq!(timestamp, 1_000);
-        } else {
-            assert_eq!(timestamp, leader_block.timestamp_ms());
-        }
+        assert_eq!(timestamp, 1_000);
     }
     #[test]
     fn test_median_timestamps_by_stake() {

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -8,12 +8,14 @@ use std::{
 };
 
 use parking_lot::RwLock;
-use starfish_config::AuthorityIndex;
+use starfish_config::{AuthorityIndex, Stake};
 use tracing::instrument;
 
 use crate::{
     Round,
-    block_header::{BlockHeaderAPI, BlockHeaderDigest, BlockRef, VerifiedBlockHeader},
+    block_header::{
+        BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, VerifiedBlockHeader,
+    },
     commit::{Commit, CommitAPI, PendingSubDag, TrustedCommit, sort_sub_dag_blocks},
     context::Context,
     dag_state::DagState,
@@ -80,7 +82,6 @@ impl Linearizer {
         let last_commit_digest = dag_state_guard.last_commit_digest();
         let last_commit_timestamp_ms = dag_state_guard.last_commit_timestamp_ms();
         let last_committed_rounds = dag_state_guard.last_committed_rounds();
-        let timestamp_ms = leader_block.timestamp_ms().max(last_commit_timestamp_ms);
 
         // Now linearize the sub-dag starting from the leader block
         let to_commit = Self::linearize_sub_dag(
@@ -88,6 +89,14 @@ impl Linearizer {
             last_committed_rounds,
             &dag_state_guard,
             self.context.protocol_config.gc_depth(),
+        );
+
+        // Calculate commit timestamp using median of leader's parents (NEW mode)
+        let timestamp_ms = Self::calculate_commit_timestamp(
+            &self.context,
+            &dag_state_guard,
+            &leader_block,
+            last_commit_timestamp_ms,
         );
 
         drop(dag_state_guard);
@@ -313,13 +322,100 @@ impl Linearizer {
 
         acknowledged_map
     }
+
+    /// Calculates the commit's timestamp using the median of leader's parents
+    /// (leader.round - 1) timestamps by stake. To ensure that commit timestamp
+    /// monotonicity is respected, it is compared against the
+    /// `last_commit_timestamp_ms` and the maximum of the two is returned.
+    pub(crate) fn calculate_commit_timestamp(
+        context: &Context,
+        dag_state: &impl BlockStoreAPI,
+        leader_block: &VerifiedBlockHeader,
+        last_commit_timestamp_ms: BlockTimestampMs,
+    ) -> BlockTimestampMs {
+        // Select leaders' parent blocks (blocks at round - 1)
+        let block_refs = leader_block
+            .ancestors()
+            .iter()
+            .filter(|block_ref| block_ref.round == leader_block.round() - 1)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        // Get the blocks from dag state which should not fail
+        let block_headers = dag_state
+            .get_block_headers(&block_refs)
+            .into_iter()
+            .map(|block_opt| block_opt.expect("We should have all block headers in dag state."));
+
+        let timestamp_ms = median_timestamp_by_stake(context, block_headers).unwrap_or_else(|e| {
+            panic!(
+                "Cannot compute median timestamp for leader block {:?} ancestors: {}",
+                leader_block.reference(),
+                e
+            )
+        });
+
+        // Always make sure that commit timestamps are monotonic, so override if
+        // necessary
+        timestamp_ms.max(last_commit_timestamp_ms)
+    }
+}
+
+/// Computes the median timestamp of the blocks weighted by the stake of their
+/// authorities. This function assumes each block comes from a different
+/// authority of the same round. Error is returned if no blocks are provided or
+///  the total stake is less than a quorum threshold.
+pub(crate) fn median_timestamp_by_stake(
+    context: &Context,
+    block_headers: impl Iterator<Item = VerifiedBlockHeader>,
+) -> Result<BlockTimestampMs, String> {
+    let mut total_stake = 0;
+    let mut timestamps = vec![];
+    for header in block_headers {
+        let stake = context.committee.authority(header.author()).stake;
+        timestamps.push((header.timestamp_ms(), stake));
+        total_stake += stake;
+    }
+
+    if timestamps.is_empty() {
+        return Err("No block headers provided".to_string());
+    }
+    if total_stake < context.committee.quorum_threshold() {
+        return Err(format!(
+            "Total stake {} < quorum threshold {}",
+            total_stake,
+            context.committee.quorum_threshold()
+        )
+        .to_string());
+    }
+
+    Ok(median_timestamps_by_stake_inner(timestamps, total_stake))
+}
+
+fn median_timestamps_by_stake_inner(
+    mut timestamps: Vec<(BlockTimestampMs, Stake)>,
+    total_stake: Stake,
+) -> BlockTimestampMs {
+    timestamps.sort_by_key(|(ts, _)| *ts);
+
+    let mut cumulative_stake = 0;
+    for (ts, stake) in &timestamps {
+        cumulative_stake += stake;
+        if cumulative_stake > total_stake / 2 {
+            return *ts;
+        }
+    }
+
+    timestamps.last().unwrap().0
 }
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
     use crate::{
-        CommitIndex,
+        CommitIndex, TestBlockHeader,
         commit::{CommitDigest, WAVE_LENGTH},
         context::Context,
         leader_schedule::{LeaderSchedule, LeaderSwapTable},
@@ -361,7 +457,22 @@ mod tests {
         for (idx, subdag) in commits.into_iter().enumerate() {
             tracing::info!("{subdag:?}");
             assert_eq!(subdag.leader, leaders[idx].reference());
-            assert_eq!(subdag.timestamp_ms, leaders[idx].timestamp_ms());
+
+            let block_refs = leaders[idx]
+                .ancestors()
+                .iter()
+                .filter(|block_ref| block_ref.round == leaders[idx].round() - 1)
+                .cloned()
+                .collect::<Vec<_>>();
+            let blocks = dag_state
+                .read()
+                .get_block_headers(&block_refs)
+                .into_iter()
+                .map(|block_opt| block_opt.expect("We should have all blocks in dag state."));
+            let expected_ts = median_timestamp_by_stake(&context, blocks).unwrap();
+
+            assert_eq!(subdag.timestamp_ms, expected_ts);
+
             if idx == 0 {
                 // First subdag includes the leader block only and no committed data
                 assert_eq!(subdag.blocks.len(), 1);
@@ -510,8 +621,8 @@ mod tests {
             0,
             first_leader.reference(),
             block_headers_wave_1
-                .into_iter()
-                .map(|block| block.reference())
+                .iter()
+                .map(|block_header| block_header.reference())
                 .collect(),
             vec![],
         );
@@ -563,8 +674,21 @@ mod tests {
         let subdag = &commit[0];
         tracing::info!("{subdag:?}");
         assert_eq!(subdag.leader, leader.reference());
-        assert_eq!(subdag.timestamp_ms, leader.timestamp_ms());
         assert_eq!(subdag.commit_ref.index, expected_second_commit.index());
+
+        let expected_ts = median_timestamp_by_stake(
+            &context,
+            subdag.blocks.iter().filter_map(|block| {
+                if block.round() == subdag.leader.round - 1 {
+                    Some(block.clone())
+                } else {
+                    None
+                }
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(subdag.timestamp_ms, expected_ts);
 
         // Using the same sorting as used in CommittedSubDag::sort
         block_refs_wave_2
@@ -778,5 +902,161 @@ mod tests {
                 assert_eq!(ack_authors.len(), 4);
             }
         }
+    }
+
+    #[rstest]
+    #[case(false, 5_000, 5_000, 6_000)]
+    #[case(true, 3_000, 3_000, 6_000)]
+    #[tokio::test]
+    async fn test_calculate_commit_timestamp(
+        #[case] consensus_median_timestamp: bool,
+        #[case] timestamp_1: u64,
+        #[case] timestamp_2: u64,
+        #[case] timestamp_3: u64,
+    ) {
+        // GIVEN
+        telemetry_subscribers::init_for_testing();
+        let num_authorities = 4;
+        let context = Arc::new(Context::new_for_test(num_authorities).0);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let mut dag_state_guard = dag_state.write();
+        let ancestors = vec![
+            VerifiedBlockHeader::new_for_test(
+                TestBlockHeader::new(4, 0).set_timestamp_ms(1_000).build(),
+            ),
+            VerifiedBlockHeader::new_for_test(
+                TestBlockHeader::new(4, 1).set_timestamp_ms(2_000).build(),
+            ),
+            VerifiedBlockHeader::new_for_test(
+                TestBlockHeader::new(4, 2).set_timestamp_ms(3_000).build(),
+            ),
+            VerifiedBlockHeader::new_for_test(
+                TestBlockHeader::new(4, 3).set_timestamp_ms(4_000).build(),
+            ),
+        ];
+        let leader_block = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(5, 0)
+                .set_timestamp_ms(5_000)
+                .set_ancestors(
+                    ancestors
+                        .iter()
+                        .map(|block| block.reference())
+                        .collect::<Vec<_>>(),
+                )
+                .build(),
+        );
+        for block in &ancestors {
+            dag_state_guard.accept_block_header(block.clone());
+        }
+        let last_commit_timestamp_ms = 0;
+        // WHEN
+        let dag_state_guard = dag_state.read();
+
+        let timestamp = Linearizer::calculate_commit_timestamp(
+            &context,
+            &dag_state_guard,
+            &leader_block,
+            last_commit_timestamp_ms,
+        );
+        assert_eq!(timestamp, timestamp_1);
+        // AND skip the block of authority 0 and round 4.
+        let leader_block = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(5, 0)
+                .set_timestamp_ms(5_000)
+                .set_ancestors(
+                    ancestors
+                        .iter()
+                        .skip(1)
+                        .map(|block| block.reference())
+                        .collect::<Vec<_>>(),
+                )
+                .build(),
+        );
+        let timestamp = Linearizer::calculate_commit_timestamp(
+            &context,
+            &dag_state_guard,
+            &leader_block,
+            last_commit_timestamp_ms,
+        );
+        assert_eq!(timestamp, timestamp_2);
+        // AND set the `last_commit_timestamp_ms` to 6_000
+        let last_commit_timestamp_ms = 6_000;
+        let timestamp = Linearizer::calculate_commit_timestamp(
+            &context,
+            &dag_state_guard,
+            &leader_block,
+            last_commit_timestamp_ms,
+        );
+        assert_eq!(timestamp, timestamp_3);
+        // AND there is only one ancestor block to commit
+        let (context, _) = Context::new_for_test(1);
+        let leader_block = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(5, 0)
+                .set_timestamp_ms(5_000)
+                .set_ancestors(
+                    ancestors
+                        .iter()
+                        .take(1)
+                        .map(|block| block.reference())
+                        .collect::<Vec<_>>(),
+                )
+                .build(),
+        );
+        let last_commit_timestamp_ms = 0;
+        let timestamp = Linearizer::calculate_commit_timestamp(
+            &context,
+            &dag_state_guard,
+            &leader_block,
+            last_commit_timestamp_ms,
+        );
+        if consensus_median_timestamp {
+            assert_eq!(timestamp, 1_000);
+        } else {
+            assert_eq!(timestamp, leader_block.timestamp_ms());
+        }
+    }
+    #[test]
+    fn test_median_timestamps_by_stake() {
+        // One total stake.
+        let timestamps = vec![(1_000, 1)];
+        assert_eq!(median_timestamps_by_stake_inner(timestamps, 1), 1_000);
+        // Odd number of total stakes.
+        let timestamps = vec![(1_000, 1), (2_000, 1), (3_000, 1)];
+        assert_eq!(median_timestamps_by_stake_inner(timestamps, 3), 2_000);
+        // Even the number of total stakes.
+        let timestamps = vec![(1_000, 1), (2_000, 1), (3_000, 1), (4_000, 1)];
+        assert_eq!(median_timestamps_by_stake_inner(timestamps, 4), 3_000);
+        // Even number of total stakes, different order.
+        let timestamps = vec![(4_000, 1), (3_000, 1), (1_000, 1), (2_000, 1)];
+        assert_eq!(median_timestamps_by_stake_inner(timestamps, 4), 3_000);
+        // Unequal stakes.
+        let timestamps = vec![(2_000, 2), (4_000, 2), (1_000, 3), (3_000, 3)];
+        assert_eq!(median_timestamps_by_stake_inner(timestamps, 10), 3_000);
+        // Unequal stakes.
+        let timestamps = vec![
+            (500, 2),
+            (4_000, 2),
+            (2_500, 3),
+            (1_000, 5),
+            (3_000, 3),
+            (2_000, 4),
+        ];
+        assert_eq!(median_timestamps_by_stake_inner(timestamps, 19), 2_000);
+        // One authority dominates.
+        let timestamps = vec![(1_000, 1), (2_000, 1), (3_000, 1), (4_000, 1), (5_000, 10)];
+        assert_eq!(median_timestamps_by_stake_inner(timestamps, 14), 5_000);
+    }
+    #[tokio::test]
+    async fn test_median_timestamps_by_stake_errors() {
+        let num_authorities = 4;
+        let context = Arc::new(Context::new_for_test(num_authorities).0);
+        // No blocks provided
+        let err = median_timestamp_by_stake(&context, vec![].into_iter()).unwrap_err();
+        assert_eq!(err, "No blocks provided");
+        // Blocks provided but total stake is less than a quorum threshold
+        let block = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 0).build());
+        let err = median_timestamp_by_stake(&context, vec![block].into_iter()).unwrap_err();
+        assert_eq!(err, "Total stake 1 < quorum threshold 3");
     }
 }

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -104,6 +104,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) proposed_block_transactions: Histogram,
     pub(crate) proposed_block_ancestors: Histogram,
     pub(crate) proposed_block_ancestors_depth: HistogramVec,
+    pub(crate) proposed_block_ancestors_timestamp_drift_ms: IntCounterVec,
     pub(crate) proposed_block_acknowledgments: Histogram,
     pub(crate) proposed_block_acknowledgments_depth: HistogramVec,
     pub(crate) gap_to_available_commit: IntGauge,
@@ -113,7 +114,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) block_proposal_interval: Histogram,
     pub(crate) block_proposal_leader_wait_ms: IntCounterVec,
     pub(crate) block_proposal_leader_wait_count: IntCounterVec,
-    pub(crate) block_timestamp_drift_wait_ms: IntCounterVec,
+    pub(crate) block_timestamp_drift_ms: IntCounterVec,
     pub(crate) blocks_per_commit_count: Histogram,
     pub(crate) core_add_blocks_batch_size: Histogram,
     pub(crate) core_lock_dequeued: IntCounter,
@@ -128,6 +129,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) core_skipped_proposals: IntCounterVec,
     pub(crate) highest_accepted_authority_round: IntGaugeVec,
     pub(crate) highest_accepted_round: IntGauge,
+    pub(crate) accepted_block_time_drift_ms: IntCounterVec,
     pub(crate) accepted_block_headers: IntCounterVec,
     pub(crate) dag_state_recent_transactions: IntGauge,
     pub(crate) dag_state_recent_headers: IntGauge,
@@ -155,7 +157,6 @@ pub(crate) struct NodeMetrics {
     pub(crate) invalid_shard_in_bundles: IntCounterVec,
     pub(crate) valid_shards_in_bundles: IntCounterVec,
     pub(crate) rejected_blocks: IntCounterVec,
-    pub(crate) rejected_future_blocks: IntCounterVec,
     pub(crate) skipped_empty_transaction_acknowledgments: IntCounterVec,
     pub(crate) subscribed_blocks: IntCounterVec,
     pub(crate) verified_blocks: IntCounterVec,
@@ -163,6 +164,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) last_committed_authority_round: IntGaugeVec,
     pub(crate) last_committed_leader_round: IntGauge,
     pub(crate) last_commit_index: IntGauge,
+    pub(crate) last_commit_time_diff: Histogram,
     pub(crate) last_known_own_block_round: IntGauge,
     pub(crate) sync_last_known_own_block_retries: IntCounter,
     pub(crate) commit_round_advancement_interval: Histogram,
@@ -264,6 +266,12 @@ impl NodeMetrics {
                 exponential_buckets(1.0, 2.0, 14).unwrap(),
                 registry,
             ).unwrap(),
+            proposed_block_ancestors_timestamp_drift_ms: register_int_counter_vec_with_registry!(
+                "proposed_block_ancestors_timestamp_drift_ms",
+                "The drift in ms of ancestors' timestamps included in newly proposed blocks",
+                &["authority"],
+                registry,
+            ).unwrap(),
             proposed_block_acknowledgments: register_histogram_with_registry!(
                 "proposed_block_acknowledgments",
                 "Number of acknowledgments in proposed blocks",
@@ -307,9 +315,9 @@ impl NodeMetrics {
                 &["authority"],
                 registry,
             ).unwrap(),
-            block_timestamp_drift_wait_ms: register_int_counter_vec_with_registry!(
-                "block_timestamp_drift_wait_ms",
-                "Total time in ms spent waiting, when a received block has timestamp in future.",
+            block_timestamp_drift_ms: register_int_counter_vec_with_registry!(
+                "block_timestamp_drift_ms",
+                "The clock drift time between a received block and the current node's time.",
                 &["authority", "source"],
                 registry,
             ).unwrap(),
@@ -382,6 +390,12 @@ impl NodeMetrics {
             highest_accepted_round: register_int_gauge_with_registry!(
                 "highest_accepted_round",
                 "The highest round where a block has been accepted. Resets on restart.",
+                registry,
+            ).unwrap(),
+            accepted_block_time_drift_ms: register_int_counter_vec_with_registry!(
+                "accepted_block_time_drift_ms",
+                "The time drift in ms of an accepted block compared to local time",
+                &["authority"],
                 registry,
             ).unwrap(),
             accepted_block_headers: register_int_counter_vec_with_registry!(
@@ -566,12 +580,6 @@ impl NodeMetrics {
                 &["reason"],
                 registry,
             ).unwrap(),
-            rejected_future_blocks: register_int_counter_vec_with_registry!(
-                "rejected_future_blocks",
-                "Number of blocks rejected because their timestamp is too far in the future",
-                &["authority"],
-                registry,
-            ).unwrap(),
             skipped_empty_transaction_acknowledgments: register_int_counter_vec_with_registry!(
                 "skipped_empty_transaction_acknowledgments",
                 "Number of transaction acknowledgments skipped due to empty transaction vector in VerifiedTransaction",
@@ -610,6 +618,12 @@ impl NodeMetrics {
             last_commit_index: register_int_gauge_with_registry!(
                 "last_commit_index",
                 "Index of the last commit.",
+                registry,
+            ).unwrap(),
+            last_commit_time_diff: register_histogram_with_registry!(
+                "last_commit_time_diff",
+                "The time diff between the last commit and previous one.",
+                LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             ).unwrap(),
             commit_round_advancement_interval: register_histogram_with_registry!(

--- a/crates/starfish/core/src/test_dag.rs
+++ b/crates/starfish/core/src/test_dag.rs
@@ -39,7 +39,7 @@ pub(crate) fn build_dag(
             );
             start
         }
-        None => genesis_block_headers(context.clone())
+        None => genesis_block_headers(&context)
             .iter()
             .map(|x| x.reference())
             .collect::<Vec<_>>(),

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -147,7 +147,7 @@ pub(crate) enum AncestorConnectionSpec {
 impl DagBuilder {
     pub(crate) fn new(context: Arc<Context>) -> Self {
         let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
-        let genesis_blocks = genesis_block_headers(context.clone());
+        let genesis_blocks = genesis_block_headers(&context);
         let genesis: BTreeMap<BlockRef, VerifiedBlockHeader> = genesis_blocks
             .into_iter()
             .map(|block| (block.reference(), block))
@@ -250,14 +250,18 @@ impl DagBuilder {
             // the tuple represents the block and whether it is committed
             // blocks: BTreeMap<BlockRef, (VerifiedBlock, bool)>,
             block_headers: BTreeMap<BlockRef, (VerifiedBlockHeader, bool)>,
+            genesis: BTreeMap<BlockRef, VerifiedBlockHeader>,
         }
         impl BlockStoreAPI for BlockStorage {
             fn get_block_headers(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlockHeader>> {
                 refs.iter()
                     .map(|block_ref| {
+                        if block_ref.round == 0 {
+                            return self.genesis.get(block_ref).cloned();
+                        }
                         self.block_headers
                             .get(block_ref)
-                            .map(|(block, _committed)| block.clone())
+                            .map(|(header, _committed)| header.clone())
                     })
                     .collect()
             }
@@ -269,6 +273,7 @@ impl DagBuilder {
                 .into_iter()
                 .map(|(k, v)| (k, (v, false)))
                 .collect(),
+            genesis: self.genesis.clone(),
         };
 
         // Create any remaining committed sub dags
@@ -281,10 +286,17 @@ impl DagBuilder {
             last_timestamp_ms = leader_block.timestamp_ms().max(last_timestamp_ms);
 
             let to_commit = Linearizer::linearize_sub_dag(
-                leader_block,
+                leader_block.clone(),
                 self.last_committed_rounds.clone(),
                 &storage,
                 self.context.protocol_config.gc_depth(),
+            );
+
+            last_timestamp_ms = Linearizer::calculate_commit_timestamp(
+                &self.context.clone(),
+                &storage,
+                &leader_block,
+                last_timestamp_ms,
             );
 
             // Update the last committed rounds
@@ -659,6 +671,11 @@ pub struct LayerBuilder<'a> {
     fully_linked_acknowledgments: bool,
     // Ancestors to link to the current layer
     ancestors: Vec<BlockRef>,
+
+    // The block timestamps for the layer for each specified authority. This will work as base
+    // timestamp and the round will be added to make sure that timestamps do offset.
+    timestamps: Vec<BlockTimestampMs>,
+
     // add timestamp delay
     timestamp_delay_ms: Option<u64>,
 
@@ -695,6 +712,7 @@ impl<'a> LayerBuilder<'a> {
             only_acknowledge: None,
             timestamp_delay_ms: None,
             ancestors,
+            timestamps: vec![],
             block_headers: vec![],
             transactions: vec![],
         }
@@ -797,6 +815,18 @@ impl<'a> LayerBuilder<'a> {
     pub fn only_acknowledge(mut self, only_acknowledge: Vec<AuthorityIndex>) -> Self {
         self.only_acknowledge = Some(only_acknowledge);
         self.fully_linked_acknowledgments = false;
+        self
+    }
+
+    pub fn with_timestamps(mut self, timestamps: Vec<BlockTimestampMs>) -> Self {
+        // authorities must be specified for this to apply
+        assert!(self.specified_authorities.is_some());
+        assert_eq!(
+            self.specified_authorities.as_ref().unwrap().len(),
+            timestamps.len(),
+            "Timestamps should be provided for each specified authority"
+        );
+        self.timestamps = timestamps;
         self
     }
 
@@ -1054,11 +1084,7 @@ impl<'a> LayerBuilder<'a> {
             let num_blocks = self.num_blocks_to_create(authority);
 
             for num_block in 0..num_blocks {
-                let author = authority.value() as u8;
-                let base_ts = match self.timestamp_delay_ms {
-                    Some(delay) => (round as BlockTimestampMs * 1000) + delay,
-                    None => round as BlockTimestampMs * 1000,
-                };
+                let timestamp = self.block_timestamp(authority, round, num_block);
 
                 // Create random transactions and their commitment.
                 let mut tx_bytes = [0u8; 32];
@@ -1072,7 +1098,7 @@ impl<'a> LayerBuilder<'a> {
                 )
                 .unwrap();
 
-                let test_block_header = TestBlockHeader::new(round, author)
+                let test_block_header = TestBlockHeader::new(round, authority.value() as u8)
                     .set_ancestors(ancestors.clone())
                     .set_acknowledgments(
                         transaction_acknowledgments
@@ -1080,14 +1106,14 @@ impl<'a> LayerBuilder<'a> {
                             .cloned()
                             .unwrap_or_default(),
                     )
-                    .set_timestamp_ms(base_ts + (author as u32 + round + num_block) as u64)
+                    .set_timestamp_ms(timestamp)
                     .set_commitment(commitment)
                     .build();
                 let block_header =
                     if let Some(protocol_keypair) = self.dag_builder.protocol_keypair.as_ref() {
                         VerifiedBlockHeader::new_from_header_with_signature(
                             test_block_header,
-                            &protocol_keypair[author as usize],
+                            &protocol_keypair[authority.value()],
                         )
                     } else {
                         VerifiedBlockHeader::new_for_test(test_block_header)
@@ -1127,6 +1153,25 @@ impl<'a> LayerBuilder<'a> {
         } else {
             1
         }
+    }
+
+    fn block_timestamp(
+        &self,
+        authority: AuthorityIndex,
+        round: Round,
+        num_block: u32,
+    ) -> BlockTimestampMs {
+        if self.specified_authorities.is_some() && !self.timestamps.is_empty() {
+            let specified_authorities = self.specified_authorities.as_ref().unwrap();
+            if let Some(position) = specified_authorities.iter().position(|&x| x == authority) {
+                return self.timestamps[position]
+                    + (round + num_block) as u64
+                    + self.timestamp_delay_ms.unwrap_or_default();
+            }
+        }
+        let author = authority.value() as u32;
+        let base_ts = round as BlockTimestampMs * 1000;
+        base_ts + (author + round + num_block) as u64 + self.timestamp_delay_ms.unwrap_or_default()
     }
 
     fn should_skip_block(&self, round: Round, authority: AuthorityIndex) -> bool {

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -15,8 +15,8 @@ use parking_lot::Mutex;
 use prometheus::Registry;
 use starfish_config::{AuthorityIndex, Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
 use starfish_core::{
-    Clock, CommitConsumer, CommitConsumerMonitor, CommittedSubDag, ConsensusAuthority,
-    TransactionClient, network::tonic_network::to_socket_addr,
+    BlockTimestampMs, Clock, CommitConsumer, CommitConsumerMonitor, CommittedSubDag,
+    ConsensusAuthority, TransactionClient, network::tonic_network::to_socket_addr,
     transaction::NoopTransactionVerifier,
 };
 use tempfile::TempDir;

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -15,8 +15,9 @@ use parking_lot::Mutex;
 use prometheus::Registry;
 use starfish_config::{AuthorityIndex, Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
 use starfish_core::{
-    CommitConsumer, CommitConsumerMonitor, CommittedSubDag, ConsensusAuthority, TransactionClient,
-    network::tonic_network::to_socket_addr, transaction::NoopTransactionVerifier,
+    Clock, CommitConsumer, CommitConsumerMonitor, CommittedSubDag, ConsensusAuthority,
+    TransactionClient, network::tonic_network::to_socket_addr,
+    transaction::NoopTransactionVerifier,
 };
 use tempfile::TempDir;
 use tracing::{info, trace};
@@ -30,6 +31,7 @@ pub(crate) struct Config {
     pub keypairs: Vec<(NetworkKeyPair, ProtocolKeyPair)>,
     pub network_type: ConsensusNetwork,
     pub boot_counter: u64,
+    pub clock_drift: BlockTimestampMs,
     pub protocol_config: ProtocolConfig,
 }
 
@@ -247,6 +249,7 @@ pub(crate) async fn make_authority(
         keypairs,
         network_type,
         boot_counter,
+        clock_drift,
         protocol_config,
     } = config;
 
@@ -272,12 +275,14 @@ pub(crate) async fn make_authority(
     let commit_consumer_monitor = commit_consumer.monitor();
 
     let authority = ConsensusAuthority::start(
+        0,
         authority_index,
         committee,
         parameters,
         protocol_config,
         protocol_keypair,
         network_keypair,
+        Arc::new(Clock::new_for_test(clock_drift)),
         Arc::new(txn_verifier),
         commit_consumer,
         registry,

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -66,7 +66,7 @@ mod test {
                 committee: committee.clone(),
                 keypairs: keypairs.clone(),
                 network_type: iota_protocol_config::ConsensusNetwork::Tonic,
-                boot_counter: boot_counters[index],
+                boot_counter: boot_counters[authority_index.value() as usize],
                 protocol_config: protocol_config.clone(),
                 clock_drift: clock_drifts[authority_index.value() as usize],
             };

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -54,20 +54,25 @@ mod test {
         let mut authorities = Vec::with_capacity(committee.size());
         let mut transaction_clients = Vec::with_capacity(committee.size());
         let mut boot_counters = [0; NUM_OF_AUTHORITIES];
+        let mut clock_drifts = [0; NUM_OF_AUTHORITIES];
+        clock_drifts[0] = 50;
+        clock_drifts[1] = 100;
+        clock_drifts[2] = 120;
 
-        for (index, _authority_info) in committee.authorities() {
+        for (authority_index, _authority_info) in committee.authorities() {
             let config = Config {
-                authority_index: index,
+                authority_index,
                 db_dir: Arc::new(TempDir::new().unwrap()),
                 committee: committee.clone(),
                 keypairs: keypairs.clone(),
                 network_type: iota_protocol_config::ConsensusNetwork::Tonic,
                 boot_counter: boot_counters[index],
                 protocol_config: protocol_config.clone(),
+                clock_drift: clock_drifts[authority_index.value() as usize],
             };
             let node = AuthorityNode::new(config);
 
-            if index != AuthorityIndex::new_for_test(NUM_OF_AUTHORITIES as u8 - 1) {
+            if authority_index != AuthorityIndex::new_for_test(NUM_OF_AUTHORITIES as u8 - 1) {
                 node.start().await.unwrap();
                 node.spawn_committed_subdag_consumer().unwrap();
 
@@ -75,7 +80,7 @@ mod test {
                 transaction_clients.push(client);
             }
 
-            boot_counters[index] += 1;
+            boot_counters[authority_index] += 1;
             authorities.push(node);
         }
 


### PR DESCRIPTION
# Description of change

Ported timestamp refactoring from Mysticeti PRs. The new protocol parameters are not needed because Starfish is not enabled on any permanent network. 
* https://github.com/iotaledger/iota/pull/8756/
* https://github.com/iotaledger/iota/pull/8762/
* https://github.com/iotaledger/iota/pull/8757

## Links to any relevant issues

Resolves #8871 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
