### PR TITLE
refactor(move-model-2): Rewrite normalized module for broader use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9170,6 +9170,7 @@ version = "0.0.3"
 dependencies = [
  "anyhow",
  "enum-compat-util",
+ "indexmap 2.11.0",
  "move-core-types",
  "move-proc-macros",
  "ref-cast",

--- a/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -330,7 +330,11 @@ async fn test_upgrade_package_happy_path() {
         .unwrap();
     let config = ProtocolConfig::get_for_max_version_UNSAFE();
     let binary_config = to_binary_config(&config);
-    let normalized_modules = package.move_package().normalize(&binary_config).unwrap();
+    let pool = &mut move_binary_format::normalized::RcPool::new();
+    let normalized_modules = package
+        .move_package()
+        .normalize(pool, &binary_config, /* include code */ true)
+        .unwrap();
     assert!(normalized_modules.contains_key("new_module"));
     assert!(
         normalized_modules["new_module"]

--- a/crates/iota-framework/src/lib.rs
+++ b/crates/iota-framework/src/lib.rs
@@ -13,7 +13,7 @@ use iota_types::{
     storage::ObjectStore,
 };
 use move_binary_format::{
-    CompiledModule, binary_config::BinaryConfig, compatibility::Compatibility,
+    CompiledModule, binary_config::BinaryConfig, compatibility::Compatibility, normalized,
 };
 use move_core_types::gas_algebra::InternalGas;
 use serde::{Deserialize, Serialize};
@@ -247,14 +247,17 @@ pub async fn compare_system_package<S: ObjectStore>(
         .try_as_package_mut()
         .expect("Created as package");
 
-    let cur_normalized = match cur_pkg.normalize(binary_config) {
+    let pool = &mut normalized::RcPool::new();
+    let cur_normalized = match cur_pkg.normalize(pool, binary_config, /* include code */ false) {
         Ok(v) => v,
         Err(e) => {
             error!("Could not normalize existing package: {e:?}");
             return None;
         }
     };
-    let mut new_normalized = new_pkg.normalize(binary_config).ok()?;
+    let mut new_normalized = new_pkg
+        .normalize(pool, binary_config, /* include code */ false)
+        .ok()?;
 
     for (name, cur_module) in cur_normalized {
         let new_module = new_normalized.remove(&name)?;

--- a/crates/iota-indexer/src/apis/move_utils.rs
+++ b/crates/iota-indexer/src/apis/move_utils.rs
@@ -14,7 +14,7 @@ use iota_json_rpc_types::{
 use iota_open_rpc::Module;
 use iota_types::base_types::ObjectID;
 use jsonrpsee::{RpcModule, core::RpcResult};
-use move_binary_format::normalized::Module as NormalizedModule;
+use move_binary_format::normalized;
 
 use crate::indexer_reader::IndexerReader;
 
@@ -35,9 +35,13 @@ impl MoveUtilsServer for MoveUtilsApi {
         package_id: ObjectID,
     ) -> RpcResult<BTreeMap<String, IotaMoveNormalizedModule>> {
         let resolver_modules = self.inner.get_package(package_id).await?.modules().clone();
+        let pool = &mut normalized::RcPool::new();
         let iota_normalized_modules = resolver_modules
             .into_iter()
-            .map(|(k, v)| (k, NormalizedModule::new(v.bytecode()).into()))
+            .map(|(k, v)| {
+                let m = &normalized::Module::new(pool, v.bytecode(), /* include code */ false);
+                (k, m.into())
+            })
             .collect::<BTreeMap<String, IotaMoveNormalizedModule>>();
         Ok(iota_normalized_modules)
     }

--- a/crates/iota-json-rpc-tests/tests/move_utils.rs
+++ b/crates/iota-json-rpc-tests/tests/move_utils.rs
@@ -5,8 +5,8 @@ use std::collections::HashSet;
 
 use iota_json_rpc_api::MoveUtilsClient;
 use iota_json_rpc_types::{
-    IotaMoveAbility, IotaMoveNormalizedType, IotaMoveVisibility, MoveFunctionArgType,
-    ObjectValueKind,
+    IotaMoveAbility, IotaMoveNormalizedStructType, IotaMoveNormalizedType, IotaMoveVisibility,
+    MoveFunctionArgType, ObjectValueKind,
 };
 use iota_macros::sim_test;
 use iota_types::{IOTA_FRAMEWORK_ADDRESS, base_types::ObjectID};
@@ -247,13 +247,14 @@ async fn get_normalized_move_struct() -> Result<(), anyhow::Error> {
         id_field.type_,
         IotaMoveNormalizedType::Struct { .. }
     ));
-    if let IotaMoveNormalizedType::Struct {
-        address,
-        module,
-        name,
-        type_arguments,
-    } = &id_field.type_
-    {
+    if let IotaMoveNormalizedType::Struct { inner } = &id_field.type_ {
+        let IotaMoveNormalizedStructType {
+            address,
+            module,
+            name,
+            type_arguments,
+        } = &**inner;
+
         assert_eq!(*address, IOTA_FRAMEWORK_ADDRESS.to_hex_literal());
         assert_eq!(module, "object");
         assert_eq!(name, "UID");
@@ -265,13 +266,13 @@ async fn get_normalized_move_struct() -> Result<(), anyhow::Error> {
         balance_field.type_,
         IotaMoveNormalizedType::Struct { .. }
     ));
-    if let IotaMoveNormalizedType::Struct {
-        address,
-        module,
-        name,
-        type_arguments,
-    } = &balance_field.type_
-    {
+    if let IotaMoveNormalizedType::Struct { inner } = &balance_field.type_ {
+        let IotaMoveNormalizedStructType {
+            address,
+            module,
+            name,
+            type_arguments,
+        } = &**inner;
         assert_eq!(*address, IOTA_FRAMEWORK_ADDRESS.to_hex_literal());
         assert_eq!(module, "balance");
         assert_eq!(name, "Balance");
@@ -346,13 +347,13 @@ async fn get_normalized_move_function() -> Result<(), anyhow::Error> {
             unboxed_type,
             IotaMoveNormalizedType::Struct { .. }
         ));
-        if let IotaMoveNormalizedType::Struct {
-            address,
-            module,
-            name,
-            type_arguments,
-        } = unboxed_type
-        {
+        if let IotaMoveNormalizedType::Struct { inner } = unboxed_type {
+            let IotaMoveNormalizedStructType {
+                address,
+                module,
+                name,
+                type_arguments,
+            } = &**inner;
             assert_eq!(*address, IOTA_FRAMEWORK_ADDRESS.to_hex_literal());
             assert_eq!(module, "coin");
             assert_eq!(name, "Coin");
@@ -376,13 +377,13 @@ async fn get_normalized_move_function() -> Result<(), anyhow::Error> {
             unboxed_type,
             IotaMoveNormalizedType::Struct { .. }
         ));
-        if let IotaMoveNormalizedType::Struct {
-            address,
-            module,
-            name,
-            type_arguments,
-        } = unboxed_type
-        {
+        if let IotaMoveNormalizedType::Struct { inner } = unboxed_type {
+            let IotaMoveNormalizedStructType {
+                address,
+                module,
+                name,
+                type_arguments,
+            } = &**inner;
             assert_eq!(*address, IOTA_FRAMEWORK_ADDRESS.to_hex_literal());
             assert_eq!(module, "tx_context");
             assert_eq!(name, "TxContext");
@@ -394,13 +395,13 @@ async fn get_normalized_move_function() -> Result<(), anyhow::Error> {
     assert_eq!(return_types.len(), 1);
     let return_type = &return_types[0];
     assert!(matches!(return_type, IotaMoveNormalizedType::Struct { .. }));
-    if let IotaMoveNormalizedType::Struct {
-        address,
-        module,
-        name,
-        type_arguments,
-    } = return_type
-    {
+    if let IotaMoveNormalizedType::Struct { inner } = return_type {
+        let IotaMoveNormalizedStructType {
+            address,
+            module,
+            name,
+            type_arguments,
+        } = &**inner;
         assert_eq!(*address, IOTA_FRAMEWORK_ADDRESS.to_hex_literal());
         assert_eq!(module, "coin");
         assert_eq!(name, "Coin");

--- a/crates/iota-json-rpc-types/src/iota_move.rs
+++ b/crates/iota-json-rpc-types/src/iota_move.rs
@@ -18,7 +18,7 @@ use itertools::Itertools;
 use move_binary_format::{
     file_format::{Ability, AbilitySet, DatatypeTyParameter, Visibility},
     normalized::{
-        Enum as NormalizedEnum, Field as NormalizedField, Function as IotaNormalizedFunction,
+        self, Enum as NormalizedEnum, Field as NormalizedField, Function as NormalizedFunction,
         Module as NormalizedModule, Struct as NormalizedStruct, Type as NormalizedType,
     },
 };
@@ -59,21 +59,21 @@ pub enum IotaMoveVisibility {
     Friend,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct IotaMoveStructTypeParameter {
     pub constraints: IotaMoveAbilitySet,
     pub is_phantom: bool,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct IotaMoveNormalizedField {
     pub name: String,
     #[serde(rename = "type")]
     pub type_: IotaMoveNormalizedType,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct IotaMoveNormalizedStruct {
     pub abilities: IotaMoveAbilitySet,
@@ -89,7 +89,7 @@ pub struct IotaMoveNormalizedEnum {
     pub variants: BTreeMap<String, Vec<IotaMoveNormalizedField>>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub enum IotaMoveNormalizedType {
     Bool,
     U8,
@@ -100,12 +100,9 @@ pub enum IotaMoveNormalizedType {
     U256,
     Address,
     Signer,
-    #[serde(rename_all = "camelCase")]
     Struct {
-        address: String,
-        module: String,
-        name: String,
-        type_arguments: Vec<IotaMoveNormalizedType>,
+        #[serde(flatten)]
+        inner: Box<IotaMoveNormalizedStructType>,
     },
     Vector(Box<IotaMoveNormalizedType>),
     TypeParameter(IotaMoveTypeParameterIndex),
@@ -113,7 +110,15 @@ pub enum IotaMoveNormalizedType {
     MutableReference(Box<IotaMoveNormalizedType>),
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct IotaMoveNormalizedStructType {
+    pub address: String,
+    pub module: String,
+    pub name: String,
+    pub type_arguments: Vec<IotaMoveNormalizedType>,
+}
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct IotaMoveNormalizedFunction {
     pub visibility: IotaMoveVisibility,
@@ -150,45 +155,53 @@ impl PartialEq for IotaMoveNormalizedModule {
     }
 }
 
-impl From<NormalizedModule> for IotaMoveNormalizedModule {
-    fn from(module: NormalizedModule) -> Self {
+impl<S: std::hash::Hash + Eq + ToString> From<&NormalizedModule<S>> for IotaMoveNormalizedModule {
+    fn from(module: &NormalizedModule<S>) -> Self {
         Self {
             file_format_version: module.file_format_version,
-            address: module.address.to_hex_literal(),
-            name: module.name.to_string(),
+            address: module.address().to_hex_literal(),
+            name: module.name().to_string(),
             friends: module
                 .friends
-                .into_iter()
+                .iter()
                 .map(|module_id| IotaMoveModuleId {
-                    address: module_id.address().to_hex_literal(),
-                    name: module_id.name().to_string(),
+                    address: module_id.address.to_hex_literal(),
+                    name: module_id.name.to_string(),
                 })
                 .collect::<Vec<IotaMoveModuleId>>(),
             structs: module
                 .structs
-                .into_iter()
-                .map(|(name, struct_)| (name.to_string(), IotaMoveNormalizedStruct::from(struct_)))
+                .iter()
+                .map(|(name, struct_)| {
+                    (name.to_string(), IotaMoveNormalizedStruct::from(&**struct_))
+                })
                 .collect::<BTreeMap<String, IotaMoveNormalizedStruct>>(),
             enums: module
                 .enums
-                .into_iter()
-                .map(|(name, enum_)| (name.to_string(), IotaMoveNormalizedEnum::from(enum_)))
+                .iter()
+                .map(|(name, enum_)| (name.to_string(), IotaMoveNormalizedEnum::from(&**enum_)))
                 .collect(),
             exposed_functions: module
                 .functions
-                .into_iter()
-                .filter_map(|(name, function)| {
+                .iter()
+                .filter(|(_name, function)| {
+                    function.is_entry || function.visibility != Visibility::Private
+                })
+                .map(|(name, function)| {
                     // TODO: Do we want to expose the private functions as well?
-                    (function.is_entry || function.visibility != Visibility::Private)
-                        .then(|| (name.to_string(), IotaMoveNormalizedFunction::from(function)))
+
+                    (
+                        name.to_string(),
+                        IotaMoveNormalizedFunction::from(&**function),
+                    )
                 })
                 .collect::<BTreeMap<String, IotaMoveNormalizedFunction>>(),
         }
     }
 }
 
-impl From<IotaNormalizedFunction> for IotaMoveNormalizedFunction {
-    fn from(function: IotaNormalizedFunction) -> Self {
+impl<S: ToString> From<&NormalizedFunction<S>> for IotaMoveNormalizedFunction {
+    fn from(function: &NormalizedFunction<S>) -> Self {
         Self {
             visibility: match function.visibility {
                 Visibility::Private => IotaMoveVisibility::Private,
@@ -198,53 +211,60 @@ impl From<IotaNormalizedFunction> for IotaMoveNormalizedFunction {
             is_entry: function.is_entry,
             type_parameters: function
                 .type_parameters
-                .into_iter()
+                .iter()
+                .copied()
                 .map(|a| a.into())
                 .collect::<Vec<IotaMoveAbilitySet>>(),
             parameters: function
                 .parameters
-                .into_iter()
-                .map(IotaMoveNormalizedType::from)
+                .iter()
+                .map(|t| IotaMoveNormalizedType::from(&**t))
                 .collect::<Vec<IotaMoveNormalizedType>>(),
             return_: function
                 .return_
-                .into_iter()
-                .map(IotaMoveNormalizedType::from)
+                .iter()
+                .map(|t| IotaMoveNormalizedType::from(&**t))
                 .collect::<Vec<IotaMoveNormalizedType>>(),
         }
     }
 }
 
-impl From<NormalizedStruct> for IotaMoveNormalizedStruct {
-    fn from(struct_: NormalizedStruct) -> Self {
+impl<S: ToString> From<&NormalizedStruct<S>> for IotaMoveNormalizedStruct {
+    fn from(struct_: &NormalizedStruct<S>) -> Self {
         Self {
             abilities: struct_.abilities.into(),
             type_parameters: struct_
                 .type_parameters
-                .into_iter()
+                .iter()
+                .copied()
                 .map(IotaMoveStructTypeParameter::from)
                 .collect::<Vec<IotaMoveStructTypeParameter>>(),
             fields: struct_
                 .fields
-                .into_iter()
-                .map(IotaMoveNormalizedField::from)
+                .iter()
+                .map(|f| IotaMoveNormalizedField::from(&**f))
                 .collect::<Vec<IotaMoveNormalizedField>>(),
         }
     }
 }
 
-impl From<NormalizedEnum> for IotaMoveNormalizedEnum {
-    fn from(value: NormalizedEnum) -> Self {
+impl<S: ToString> From<&NormalizedEnum<S>> for IotaMoveNormalizedEnum {
+    fn from(value: &NormalizedEnum<S>) -> Self {
         Self {
             abilities: value.abilities.into(),
-            type_parameters: value.type_parameters.into_iter().map(Into::into).collect(),
+            type_parameters: value
+                .type_parameters
+                .iter()
+                .copied()
+                .map(Into::into)
+                .collect(),
             variants: value
                 .variants
-                .into_iter()
+                .iter()
                 .map(|variant| {
                     (
                         variant.name.to_string(),
-                        variant.fields.into_iter().map(Into::into).collect(),
+                        variant.fields.iter().map(Into::into).collect(),
                     )
                 })
                 .collect(),
@@ -261,17 +281,17 @@ impl From<DatatypeTyParameter> for IotaMoveStructTypeParameter {
     }
 }
 
-impl From<NormalizedField> for IotaMoveNormalizedField {
-    fn from(normalized_field: NormalizedField) -> Self {
+impl<S: ToString> From<&NormalizedField<S>> for IotaMoveNormalizedField {
+    fn from(normalized_field: &NormalizedField<S>) -> Self {
         Self {
             name: normalized_field.name.to_string(),
-            type_: IotaMoveNormalizedType::from(normalized_field.type_),
+            type_: IotaMoveNormalizedType::from(&normalized_field.type_),
         }
     }
 }
 
-impl From<NormalizedType> for IotaMoveNormalizedType {
-    fn from(type_: NormalizedType) -> Self {
+impl<S: ToString> From<&NormalizedType<S>> for IotaMoveNormalizedType {
+    fn from(type_: &NormalizedType<S>) -> Self {
         match type_ {
             NormalizedType::Bool => IotaMoveNormalizedType::Bool,
             NormalizedType::U8 => IotaMoveNormalizedType::U8,
@@ -282,29 +302,31 @@ impl From<NormalizedType> for IotaMoveNormalizedType {
             NormalizedType::U256 => IotaMoveNormalizedType::U256,
             NormalizedType::Address => IotaMoveNormalizedType::Address,
             NormalizedType::Signer => IotaMoveNormalizedType::Signer,
-            NormalizedType::Struct {
-                address,
-                module,
-                name,
-                type_arguments,
-            } => IotaMoveNormalizedType::Struct {
-                address: address.to_hex_literal(),
-                module: module.to_string(),
-                name: name.to_string(),
-                type_arguments: type_arguments
-                    .into_iter()
-                    .map(IotaMoveNormalizedType::from)
-                    .collect::<Vec<IotaMoveNormalizedType>>(),
-            },
+            NormalizedType::Datatype(dt) => {
+                let normalized::Datatype {
+                    module,
+                    name,
+                    type_arguments,
+                } = &**dt;
+                IotaMoveNormalizedType::new_struct(
+                    module.address.to_hex_literal(),
+                    module.name.to_string(),
+                    name.to_string(),
+                    type_arguments
+                        .iter()
+                        .map(IotaMoveNormalizedType::from)
+                        .collect::<Vec<IotaMoveNormalizedType>>(),
+                )
+            }
             NormalizedType::Vector(v) => {
-                IotaMoveNormalizedType::Vector(Box::new(IotaMoveNormalizedType::from(*v)))
+                IotaMoveNormalizedType::Vector(Box::new(IotaMoveNormalizedType::from(&**v)))
             }
-            NormalizedType::TypeParameter(t) => IotaMoveNormalizedType::TypeParameter(t),
-            NormalizedType::Reference(r) => {
-                IotaMoveNormalizedType::Reference(Box::new(IotaMoveNormalizedType::from(*r)))
+            NormalizedType::TypeParameter(t) => IotaMoveNormalizedType::TypeParameter(*t),
+            NormalizedType::Reference(false, r) => {
+                IotaMoveNormalizedType::Reference(Box::new(IotaMoveNormalizedType::from(&**r)))
             }
-            NormalizedType::MutableReference(mr) => IotaMoveNormalizedType::MutableReference(
-                Box::new(IotaMoveNormalizedType::from(*mr)),
+            NormalizedType::Reference(true, mr) => IotaMoveNormalizedType::MutableReference(
+                Box::new(IotaMoveNormalizedType::from(&**mr)),
             ),
         }
     }
@@ -322,6 +344,24 @@ impl From<AbilitySet> for IotaMoveAbilitySet {
                     Ability::Store => IotaMoveAbility::Store,
                 })
                 .collect::<Vec<IotaMoveAbility>>(),
+        }
+    }
+}
+
+impl IotaMoveNormalizedType {
+    pub fn new_struct(
+        address: String,
+        module: String,
+        name: String,
+        type_arguments: Vec<IotaMoveNormalizedType>,
+    ) -> Self {
+        IotaMoveNormalizedType::Struct {
+            inner: Box::new(IotaMoveNormalizedStructType {
+                address,
+                module,
+                name,
+                type_arguments,
+            }),
         }
     }
 }
@@ -658,4 +698,9 @@ impl From<MoveStruct> for IotaMoveStruct {
                 .collect(),
         }
     }
+}
+
+#[test]
+fn enum_size() {
+    assert_eq!(std::mem::size_of::<IotaMoveNormalizedType>(), 16);
 }

--- a/crates/iota-json-rpc-types/src/iota_move.rs
+++ b/crates/iota-json-rpc-types/src/iota_move.rs
@@ -118,7 +118,7 @@ pub struct IotaMoveNormalizedStructType {
     pub name: String,
     pub type_arguments: Vec<IotaMoveNormalizedType>,
 }
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct IotaMoveNormalizedFunction {
     pub visibility: IotaMoveVisibility,

--- a/crates/iota-json-rpc-types/src/iota_move.rs
+++ b/crates/iota-json-rpc-types/src/iota_move.rs
@@ -59,21 +59,21 @@ pub enum IotaMoveVisibility {
     Friend,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct IotaMoveStructTypeParameter {
     pub constraints: IotaMoveAbilitySet,
     pub is_phantom: bool,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
 pub struct IotaMoveNormalizedField {
     pub name: String,
     #[serde(rename = "type")]
     pub type_: IotaMoveNormalizedType,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct IotaMoveNormalizedStruct {
     pub abilities: IotaMoveAbilitySet,
@@ -89,7 +89,7 @@ pub struct IotaMoveNormalizedEnum {
     pub variants: BTreeMap<String, Vec<IotaMoveNormalizedField>>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
 pub enum IotaMoveNormalizedType {
     Bool,
     U8,
@@ -110,7 +110,7 @@ pub enum IotaMoveNormalizedType {
     MutableReference(Box<IotaMoveNormalizedType>),
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct IotaMoveNormalizedStructType {
     pub address: String,

--- a/crates/iota-json-rpc/src/move_utils.rs
+++ b/crates/iota-json-rpc/src/move_utils.rs
@@ -20,10 +20,7 @@ use iota_types::{
 use jsonrpsee::{RpcModule, core::RpcResult};
 #[cfg(test)]
 use mockall::automock;
-use move_binary_format::{
-    binary_config::BinaryConfig,
-    normalized::{Module as NormalizedModule, Type},
-};
+use move_binary_format::{binary_config::BinaryConfig, normalized};
 use move_core_types::identifier::Identifier;
 use tap::TapFallible;
 use tracing::{error, instrument, warn};
@@ -34,6 +31,9 @@ use crate::{
     error::{Error, IotaRpcInputError},
     logger::FutureWithTracing as _,
 };
+
+type NormalizedModule = normalized::Module<normalized::RcIdentifier>;
+type Type = normalized::Type<normalized::RcIdentifier>;
 
 #[cfg_attr(test, automock)]
 #[async_trait]
@@ -75,9 +75,9 @@ impl MoveUtilsInternalTrait for MoveUtilsInternal {
         package: ObjectID,
         module_name: String,
     ) -> Result<NormalizedModule, Error> {
-        let normalized = self.get_move_modules_by_package(package).await?;
-        Ok(match normalized.get(&module_name) {
-            Some(module) => Ok(module.clone()),
+        let mut normalized = self.get_move_modules_by_package(package).await?;
+        Ok(match normalized.remove(&module_name) {
+            Some(module) => Ok(module),
             None => Err(IotaRpcInputError::GenericNotFound(format!(
                 "No module found with module name {module_name}"
             ))),
@@ -91,7 +91,7 @@ impl MoveUtilsInternalTrait for MoveUtilsInternal {
         let object_read = self.get_state().get_object_read(&package).tap_err(|_| {
             warn!("Failed to call get_move_modules_by_package for package: {package:?}");
         })?;
-
+        let pool = &mut normalized::RcPool::new();
         match object_read {
             ObjectRead::Exists(_obj_ref, object, _layout) => {
                 match object.into_inner().data {
@@ -100,8 +100,10 @@ impl MoveUtilsInternalTrait for MoveUtilsInternal {
                         // Move binary format
                         let binary_config = BinaryConfig::with_extraneous_bytes_check(false);
                         normalize_modules(
+                            pool,
                             p.serialized_module_map().values(),
                             &binary_config,
+                            /* include code */ false,
                         )
                         .map_err(|e| {
                             error!("Failed to call get_move_modules_by_package for package: {package:?}");
@@ -158,7 +160,7 @@ impl MoveUtilsServer for MoveUtils {
             let modules = self.internal.get_move_modules_by_package(package).await?;
             Ok(modules
                 .into_iter()
-                .map(|(name, module)| (name, module.into()))
+                .map(|(name, module)| (name, (&module).into()))
                 .collect::<BTreeMap<String, IotaMoveNormalizedModule>>())
         }
         .trace()
@@ -172,7 +174,7 @@ impl MoveUtilsServer for MoveUtils {
         module_name: String,
     ) -> RpcResult<IotaMoveNormalizedModule> {
         async move {
-            let module = self.internal.get_move_module(package, module_name).await?;
+            let module = &self.internal.get_move_module(package, module_name).await?;
             Ok(module.into())
         }
         .trace()
@@ -192,7 +194,7 @@ impl MoveUtilsServer for MoveUtils {
             let identifier = Identifier::new(struct_name.as_str())
                 .map_err(|e| IotaRpcInputError::GenericInvalid(format!("{e}")))?;
             match structs.get(&identifier) {
-                Some(struct_) => Ok(struct_.clone().into()),
+                Some(struct_) => Ok((&**struct_).into()),
                 None => Err(IotaRpcInputError::GenericNotFound(format!(
                     "No struct was found with struct name {struct_name}"
                 )))?,
@@ -215,7 +217,7 @@ impl MoveUtilsServer for MoveUtils {
             let identifier = Identifier::new(function_name.as_str())
                 .map_err(|e| IotaRpcInputError::GenericInvalid(format!("{e}")))?;
             match functions.get(&identifier) {
-                Some(function) => Ok(function.clone().into()),
+                Some(function) => Ok((&**function).into()),
                 None => Err(IotaRpcInputError::GenericNotFound(format!(
                     "No function was found with function name {function_name}",
                 )))?,
@@ -235,14 +237,21 @@ impl MoveUtilsServer for MoveUtils {
         async move {
             let object_read = self.internal.get_object_read(package)?;
 
+            let pool = &mut normalized::RcPool::new();
             let normalized = match object_read {
                 ObjectRead::Exists(_obj_ref, object, _layout) => match object.into_inner().data {
                     Data::Package(p) => {
                         // we are on the read path - it's OK to use VERSION_MAX of the supported
                         // Move binary format
                         let binary_config = BinaryConfig::with_extraneous_bytes_check(false);
-                        normalize_modules(p.serialized_module_map().values(), &binary_config)
-                            .map_err(Error::from)
+                        normalize_modules(
+                            pool,
+                            p.serialized_module_map().values(),
+                            &binary_config,
+                            // include code
+                            false,
+                        )
+                        .map_err(Error::from)
                     }
                     _ => Err(IotaRpcInputError::GenericInvalid(format!(
                         "Object is not a package with ID {package}",
@@ -262,17 +271,12 @@ impl MoveUtilsServer for MoveUtils {
             match parameters {
                 Some(parameters) => Ok(parameters
                     .iter()
-                    .map(|p| match p {
-                        Type::Struct {
-                            address: _,
-                            module: _,
-                            name: _,
-                            type_arguments: _,
-                        } => MoveFunctionArgType::Object(ObjectValueKind::ByValue),
-                        Type::Reference(_) => {
+                    .map(|p| match &**p {
+                        Type::Datatype(_) => MoveFunctionArgType::Object(ObjectValueKind::ByValue),
+                        Type::Reference(/* mut */ false, _) => {
                             MoveFunctionArgType::Object(ObjectValueKind::ByImmutableReference)
                         }
-                        Type::MutableReference(_) => {
+                        Type::Reference(/* mut */ true, _) => {
                             MoveFunctionArgType::Object(ObjectValueKind::ByMutableReference)
                         }
                         _ => MoveFunctionArgType::Pure,
@@ -306,12 +310,24 @@ mod tests {
             let mut mock_internal = MockMoveUtilsInternalTrait::new();
 
             let m = basic_test_module();
-            let normalized_module = NormalizedModule::new(&m);
-            let expected_module: IotaMoveNormalizedModule = normalized_module.clone().into();
+            let normalized_module = &NormalizedModule::new(
+                &mut normalized::RcPool::new(),
+                &m,
+                // include code
+                false,
+            );
+            let expected_module: IotaMoveNormalizedModule = normalized_module.into();
 
             mock_internal
                 .expect_get_move_module()
-                .return_once(move |_package, _module_name| Ok(normalized_module));
+                .return_once(move |_package, _module_name| {
+                    Ok(NormalizedModule::new(
+                        &mut normalized::RcPool::new(),
+                        &m,
+                        // include code
+                        false,
+                    ))
+                });
 
             let move_utils = MoveUtils {
                 internal: Arc::new(mock_internal),

--- a/crates/iota-move-build/src/lib.rs
+++ b/crates/iota-move-build/src/lib.rs
@@ -513,9 +513,10 @@ impl CompiledPackage {
     /// SDK) to enable BCS serialization/deserialization of the package's
     /// objects, tx arguments, and events.
     pub fn generate_struct_layouts(&self) -> Registry {
+        let pool = &mut normalized::RcPool::new();
         let mut package_types = BTreeSet::new();
         for m in self.get_modules() {
-            let normalized_m = normalized::Module::new(m);
+            let normalized_m = normalized::Module::new(pool, m, /* include code */ false);
             // 1. generate struct layouts for all declared types
             'structs: for (name, s) in normalized_m.structs {
                 let mut dummy_type_parameters = Vec::new();
@@ -538,15 +539,15 @@ impl CompiledPackage {
                 package_types.insert(StructTag {
                     address: *m.address(),
                     module: m.name().to_owned(),
-                    name,
+                    name: name.as_ident_str().to_owned(),
                     type_params: dummy_type_parameters,
                 });
             }
             // 2. generate struct layouts for all parameters of `entry` funs
             for (_name, f) in normalized_m.functions {
                 if f.is_entry {
-                    for t in f.parameters {
-                        let tag_opt = match t.clone() {
+                    for t in &*f.parameters {
+                        let tag_opt = match &**t {
                             Type::Address
                             | Type::Bool
                             | Type::Signer
@@ -558,8 +559,8 @@ impl CompiledPackage {
                             | Type::U128
                             | Type::U256
                             | Type::Vector(_) => continue,
-                            Type::Reference(t) | Type::MutableReference(t) => t.into_struct_tag(),
-                            s @ Type::Struct { .. } => s.into_struct_tag(),
+                            Type::Reference(_, inner) => inner.to_struct_tag(pool),
+                            Type::Datatype(_) => t.to_struct_tag(pool),
                         };
                         if let Some(tag) = tag_opt {
                             package_types.insert(tag);

--- a/crates/iota-rest-api/src/transactions/resolve.rs
+++ b/crates/iota-rest-api/src/transactions/resolve.rs
@@ -250,7 +250,7 @@ fn called_packages(
         // Despite the above this is safe given we are only using the signature
         // information (and in particular the reference kind) from the
         // normalized package.
-       let normalized_modules = package
+        let normalized_modules = package
             .normalize(&mut pool, &binary_config, /* include code */ true)
             .map_err(|e| {
                 RestError::new(
@@ -453,7 +453,8 @@ fn resolve_arg(
 
                         if matches!(
                             &**arg_type,
-                            normalized::Type::Reference(/* mut */ true, _) | normalized::Type::Datatype(_)
+                            normalized::Type::Reference(/* mut */ true, _)
+                                | normalized::Type::Datatype(_)
                         ) {
                             mutable = true;
                         }

--- a/crates/iota-rest-api/src/transactions/resolve.rs
+++ b/crates/iota-rest-api/src/transactions/resolve.rs
@@ -197,7 +197,6 @@ pub struct ResolveTransactionQueryParameters {
 }
 
 struct NormalizedPackages {
-    pool: normalized::RcPool,
     packages: HashMap<ObjectId, NormalizedPackage>,
 }
 
@@ -266,7 +265,7 @@ fn called_packages(
         packages.insert(move_call.package, package);
     }
 
-    Ok(NormalizedPackages { pool, packages })
+    Ok(NormalizedPackages { packages })
 }
 
 fn resolve_unresolved_transaction(

--- a/crates/iota-rest-api/src/transactions/resolve.rs
+++ b/crates/iota-rest-api/src/transactions/resolve.rs
@@ -109,7 +109,7 @@ async fn resolve_transaction(
 
         (system_state.reference_gas_price, protocol_config)
     };
-    let called_packages =
+    let mut called_packages =
         called_packages(&state.reader, &protocol_config, &unresolved_transaction)?;
     let user_provided_budget = unresolved_transaction
         .gas_payment
@@ -117,7 +117,7 @@ async fn resolve_transaction(
         .and_then(|payment| payment.budget);
     let mut resolved_transaction = resolve_unresolved_transaction(
         &state.reader,
-        &called_packages,
+        &mut called_packages,
         reference_gas_price,
         protocol_config.max_tx_gas(),
         unresolved_transaction,
@@ -196,18 +196,24 @@ pub struct ResolveTransactionQueryParameters {
     pub simulate_transaction_parameters: SimulateTransactionQueryParameters,
 }
 
+struct NormalizedPackages {
+    pool: normalized::RcPool,
+    packages: HashMap<ObjectId, NormalizedPackage>,
+}
+
 struct NormalizedPackage {
     #[allow(unused)]
     package: MovePackage,
-    normalized_modules: BTreeMap<String, normalized::Module>,
+    normalized_modules: BTreeMap<String, normalized::Module<normalized::RcIdentifier>>,
 }
 
 fn called_packages(
     reader: &StateReader,
     protocol_config: &ProtocolConfig,
     unresolved_transaction: &UnresolvedTransaction,
-) -> Result<HashMap<ObjectId, NormalizedPackage>> {
+) -> Result<NormalizedPackages> {
     let binary_config = iota_types::execution_config_utils::to_binary_config(protocol_config);
+    let mut pool = normalized::RcPool::new();
     let mut packages = HashMap::new();
 
     for move_call in unresolved_transaction
@@ -244,12 +250,14 @@ fn called_packages(
         // Despite the above this is safe given we are only using the signature
         // information (and in particular the reference kind) from the
         // normalized package.
-        let normalized_modules = package.normalize(&binary_config).map_err(|e| {
-            RestError::new(
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("unable to normalize package {}: {e}", move_call.package),
-            )
-        })?;
+       let normalized_modules = package
+            .normalize(&mut pool, &binary_config, /* include code */ true)
+            .map_err(|e| {
+                RestError::new(
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("unable to normalize package {}: {e}", move_call.package),
+                )
+            })?;
         let package = NormalizedPackage {
             package,
             normalized_modules,
@@ -258,12 +266,12 @@ fn called_packages(
         packages.insert(move_call.package, package);
     }
 
-    Ok(packages)
+    Ok(NormalizedPackages { pool, packages })
 }
 
 fn resolve_unresolved_transaction(
     reader: &StateReader,
-    called_packages: &HashMap<ObjectId, NormalizedPackage>,
+    called_packages: &mut NormalizedPackages,
     reference_gas_price: u64,
     max_gas_budget: u64,
     unresolved_transaction: UnresolvedTransaction,
@@ -345,7 +353,7 @@ fn resolve_object_reference(
 
 fn resolve_ptb(
     reader: &StateReader,
-    called_packages: &HashMap<ObjectId, NormalizedPackage>,
+    called_packages: &mut NormalizedPackages,
     unresolved_ptb: UnresolvedProgrammableTransaction,
 ) -> Result<ProgrammableTransaction> {
     let inputs = unresolved_ptb
@@ -376,7 +384,7 @@ fn resolve_ptb(
 
 fn resolve_arg(
     reader: &StateReader,
-    called_packages: &HashMap<ObjectId, NormalizedPackage>,
+    called_packages: &mut NormalizedPackages,
     commands: &[Command],
     arg: UnresolvedInputArgument,
     arg_idx: usize,
@@ -415,6 +423,7 @@ fn resolve_arg(
                 match (command, idx) {
                     (Command::MoveCall(move_call), Some(idx)) => {
                         let function = called_packages
+                            .packages
                             // Find the package
                             .get(&move_call.package)
                             // Find the module
@@ -443,9 +452,8 @@ fn resolve_arg(
                         })?;
 
                         if matches!(
-                            arg_type,
-                            move_binary_format::normalized::Type::MutableReference(_)
-                                | move_binary_format::normalized::Type::Struct { .. }
+                            &**arg_type,
+                            normalized::Type::Reference(/* mut */ true, _) | normalized::Type::Datatype(_)
                         ) {
                             mutable = true;
                         }

--- a/crates/iota-surfer/src/surf_strategy.rs
+++ b/crates/iota-surfer/src/surf_strategy.rs
@@ -8,7 +8,7 @@ use iota_types::{
     base_types::ObjectRef,
     transaction::{CallArg, ObjectArg},
 };
-use move_binary_format::normalized::Type;
+use move_binary_format::normalized;
 use move_core_types::language_storage::StructTag;
 use rand::{Rng, seq::SliceRandom};
 use tokio::time::Instant;
@@ -21,6 +21,8 @@ enum InputObjectPassKind {
     ByRef,
     MutRef,
 }
+
+type Type = normalized::Type<normalized::ArcIdentifier>;
 
 #[derive(Clone, Default)]
 pub struct SurfStrategy {
@@ -76,7 +78,7 @@ impl SurfStrategy {
                 Type::Address => CallArg::Pure(
                     bcs::to_bytes(&state.cluster.get_addresses().choose(&mut state.rng)).unwrap(),
                 ),
-                ty @ Type::Struct { .. } => {
+                ty @ Type::Datatype(_) => {
                     match Self::choose_object_call_arg(
                         state,
                         InputObjectPassKind::Value,
@@ -92,30 +94,14 @@ impl SurfStrategy {
                         }
                     }
                 }
-                Type::Reference(ty) => {
-                    match Self::choose_object_call_arg(
-                        state,
-                        InputObjectPassKind::ByRef,
-                        *ty,
-                        &mut chosen_owned_objects,
-                    )
-                    .await
-                    {
-                        Some(arg) => arg,
-                        None => {
-                            failed = true;
-                            break;
-                        }
-                    }
-                }
-                Type::MutableReference(ty) => {
-                    match Self::choose_object_call_arg(
-                        state,
-                        InputObjectPassKind::MutRef,
-                        *ty,
-                        &mut chosen_owned_objects,
-                    )
-                    .await
+                Type::Reference(mut_, ty) => {
+                    let kind = if mut_ {
+                        InputObjectPassKind::MutRef
+                    } else {
+                        InputObjectPassKind::ByRef
+                    };
+                    match Self::choose_object_call_arg(state, kind, *ty, &mut chosen_owned_objects)
+                        .await
                     {
                         Some(arg) => arg,
                         None => {
@@ -151,25 +137,14 @@ impl SurfStrategy {
         arg_type: Type,
         chosen_owned_objects: &mut Vec<(StructTag, ObjectRef)>,
     ) -> Option<CallArg> {
+        let pool = state.pool.read().await;
         let type_tag = match arg_type {
-            Type::Struct {
-                address,
-                module,
-                name,
-                type_arguments,
-            } => StructTag {
-                address,
-                module,
-                name,
-                type_params: type_arguments
-                    .into_iter()
-                    .map(|t| t.into_type_tag().unwrap())
-                    .collect(),
-            },
+            Type::Datatype(dt) => dt.to_struct_tag(&*pool),
             _ => {
                 return None;
             }
         };
+        drop(pool);
         let owned = state.matching_owned_objects_count(&type_tag);
         let shared = state.matching_shared_objects_count(&type_tag).await;
         let immutable = state.matching_immutable_objects_count(&type_tag).await;

--- a/crates/iota-surfer/src/surfer_state.rs
+++ b/crates/iota-surfer/src/surfer_state.rs
@@ -21,12 +21,14 @@ use iota_types::{
     storage::WriteKind,
     transaction::{CallArg, ObjectArg, TEST_ONLY_GAS_UNIT_FOR_PUBLISH, TransactionData},
 };
-use move_binary_format::{file_format::Visibility, normalized::Type};
-use move_core_types::language_storage::StructTag;
+use move_binary_format::{file_format::Visibility, normalized};
+use move_core_types::{identifier::IdentStr, language_storage::StructTag};
 use rand::rngs::StdRng;
 use test_cluster::TestCluster;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info};
+
+type Type = normalized::Type<normalized::ArcIdentifier>;
 
 #[derive(Debug, Clone)]
 pub struct EntryFunction {
@@ -109,6 +111,7 @@ pub type ImmObjects = Arc<RwLock<HashMap<StructTag, Vec<ObjectRef>>>>;
 pub type SharedObjects = Arc<RwLock<HashMap<StructTag, Vec<(ObjectID, SequenceNumber)>>>>;
 
 pub struct SurferState {
+    pub pool: Arc<RwLock<normalized::ArcPool>>,
     pub id: usize,
     pub cluster: Arc<TestCluster>,
     pub rng: StdRng,
@@ -136,6 +139,7 @@ impl SurferState {
         entry_functions: Arc<RwLock<Vec<EntryFunction>>>,
     ) -> Self {
         Self {
+            pool: Arc::new(RwLock::new(normalized::ArcPool::new())),
             id,
             cluster,
             rng,
@@ -276,8 +280,9 @@ impl SurferState {
         let proto_version = self.cluster.highest_protocol_version();
         let config = ProtocolConfig::get_for_version(proto_version, Chain::Unknown);
         let binary_config = to_binary_config(&config);
+        let pool: &mut normalized::ArcPool = &mut *self.pool.write().await;
         let entry_functions: Vec<_> = move_package
-            .normalize(&binary_config)
+            .normalize(pool, &binary_config, /* include code */ false)
             .unwrap()
             .into_iter()
             .flat_map(|(module_name, module)| {
@@ -298,7 +303,7 @@ impl SurferState {
                         if !func.type_parameters.is_empty() {
                             return None;
                         }
-                        let mut parameters = func.parameters;
+                        let mut parameters = (*func.parameters).clone();
                         if let Some(last_param) = parameters.last().as_ref() {
                             if is_type_tx_context(last_param) {
                                 parameters.pop();
@@ -308,7 +313,10 @@ impl SurferState {
                             package: package_id,
                             module: module_name.clone(),
                             function: func_name.to_string(),
-                            parameters,
+                            parameters: parameters
+                                .into_iter()
+                                .map(|rc_ty| (*rc_ty).clone())
+                                .collect(),
                         })
                     })
                     .collect::<Vec<_>>()
@@ -404,17 +412,12 @@ impl SurferState {
 
 fn is_type_tx_context(ty: &Type) -> bool {
     match ty {
-        Type::Reference(inner) | Type::MutableReference(inner) => match inner.as_ref() {
-            Type::Struct {
-                address,
-                module,
-                name,
-                type_arguments,
-            } => {
-                address == &IOTA_FRAMEWORK_ADDRESS
-                    && module == &Identifier::new("tx_context").unwrap()
-                    && name == &Identifier::new("TxContext").unwrap()
-                    && type_arguments.is_empty()
+        Type::Reference(_, inner) => match inner.as_ref() {
+            Type::Datatype(dt) => {
+                dt.module.address == IOTA_FRAMEWORK_ADDRESS
+                    && dt.module.name.as_ident_str() == IdentStr::new("tx_context").unwrap()
+                    && dt.name.as_ident_str() == IdentStr::new("TxContext").unwrap()
+                    && dt.type_arguments.is_empty()
             }
             _ => false,
         },

--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -20,6 +20,7 @@ use move_core_types::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::{Bytes, serde_as};
+use std::hash::Hash;
 
 use crate::{
     IOTA_FRAMEWORK_ADDRESS,
@@ -511,12 +512,15 @@ impl MovePackage {
             }
         })
     }
-
-    pub fn normalize(
+    /// If `include_code` is set to `false`, the normalized module will skip
+    /// function bodies but still include the signatures.
+    pub fn normalize<S: Hash + Eq + Clone + ToString, Pool: normalized::StringPool<String = S>>(
         &self,
+        pool: &mut Pool,
         binary_config: &BinaryConfig,
-    ) -> IotaResult<BTreeMap<String, normalized::Module>> {
-        normalize_modules(self.module_map.values(), binary_config)
+        include_code: bool,
+    ) -> IotaResult<BTreeMap<String, normalized::Module<S>>> {
+        normalize_modules(pool, self.module_map.values(), binary_config, include_code)
     }
 }
 
@@ -585,10 +589,19 @@ pub fn is_test_fun(name: &IdentStr, module: &CompiledModule, fn_info_map: &FnInf
     }
 }
 
-pub fn normalize_modules<'a, I>(
+/// If `include_code` is set to `false`, the normalized module will skip
+/// function bodies but still include the signatures.
+pub fn normalize_modules<
+    'a,
+    S: Hash + Eq + Clone + ToString,
+    Pool: normalized::StringPool<String = S>,
+    I,
+>(
+    pool: &mut Pool,
     modules: I,
     binary_config: &BinaryConfig,
-) -> IotaResult<BTreeMap<String, normalized::Module>>
+    include_code: bool,
+) -> IotaResult<BTreeMap<String, normalized::Module<S>>>
 where
     I: Iterator<Item = &'a Vec<u8>>,
 {
@@ -600,20 +613,31 @@ where
                     error: error.to_string(),
                 }
             })?;
-        let normalized_module = normalized::Module::new(&module);
-        normalized_modules.insert(normalized_module.name.to_string(), normalized_module);
+        let normalized_module = normalized::Module::new(pool, &module, include_code);
+        normalized_modules.insert(normalized_module.name().to_string(), normalized_module);
     }
     Ok(normalized_modules)
 }
 
-pub fn normalize_deserialized_modules<'a, I>(modules: I) -> BTreeMap<String, normalized::Module>
+/// If `include_code` is set to `false`, the normalized module will skip
+/// function bodies but still include the signatures.
+pub fn normalize_deserialized_modules<
+    'a,
+    S: Hash + Eq + Clone + ToString,
+    Pool: normalized::StringPool<String = S>,
+    I,
+>(
+    pool: &mut Pool,
+    modules: I,
+    include_code: bool,
+) -> BTreeMap<String, normalized::Module<S>>
 where
     I: Iterator<Item = &'a CompiledModule>,
 {
     let mut normalized_modules = BTreeMap::new();
     for module in modules {
-        let normalized_module = normalized::Module::new(module);
-        normalized_modules.insert(normalized_module.name.to_string(), normalized_module);
+        let normalized_module = normalized::Module::new(pool, module, include_code);
+        normalized_modules.insert(normalized_module.name().to_string(), normalized_module);
     }
     normalized_modules
 }

--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    hash::Hash,
+};
 
 use derive_more::Display;
 use fastcrypto::hash::HashFunction;
@@ -20,7 +23,6 @@ use move_core_types::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::{Bytes, serde_as};
-use std::hash::Hash;
 
 use crate::{
     IOTA_FRAMEWORK_ADDRESS,

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/tests.rs
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/tests.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use iota_move_build::{BuildConfig, IotaPackageHooks};
 use move_binary_format::{
     CompiledModule,
-    compatibility::{Compatibility, InclusionCheck},
+    compatibility::{self, Compatibility, InclusionCheck},
     normalized,
 };
 
@@ -21,11 +21,12 @@ fn run_test(path: &Path) -> datatest_stable::Result<()> {
     let base_path = pathbuf.join("base");
     let upgraded_path = pathbuf.join("upgraded");
 
+    let pool = &mut normalized::RcPool::new();
     let base = compile(&base_path)?;
-    let base_normalized = normalize(&base);
+    let base_normalized = normalize(pool, &base);
 
     let upgraded = compile(&upgraded_path)?;
-    let upgraded_normalized = normalize(&upgraded);
+    let upgraded_normalized = normalize(pool, &upgraded);
 
     check_all_compatibilities(
         base_normalized,
@@ -41,13 +42,19 @@ fn compile(path: &Path) -> anyhow::Result<Vec<CompiledModule>> {
         .into_modules())
 }
 
-fn normalize(modules: &[CompiledModule]) -> Vec<normalized::Module> {
-    modules.iter().map(normalized::Module::new).collect()
+fn normalize(
+    pool: &mut normalized::RcPool,
+    modules: &[CompiledModule],
+) -> Vec<compatibility::Module> {
+    modules
+        .iter()
+        .map(|m| compatibility::Module::new(pool, m, /* include code */ true))
+        .collect()
 }
 
 fn check_all_compatibilities(
-    base: Vec<normalized::Module>,
-    upgraded: Vec<normalized::Module>,
+    base: Vec<compatibility::Module>,
+    upgraded: Vec<compatibility::Module>,
     name: String,
 ) -> datatest_stable::Result<()> {
     assert_eq!(base.len(), upgraded.len());
@@ -71,8 +78,8 @@ fn check_all_compatibilities(
                 .map(|(base, upgraded)| {
                     format!(
                         "{}::{}:\n\tbase->upgrade: {}\n\tupgrade->base: {}",
-                        base.address,
-                        base.name,
+                        base.address(),
+                        base.name(),
                         compat.check(base, upgraded).is_ok(),
                         compat.check(upgraded, base).is_ok()
                     )
@@ -97,8 +104,8 @@ fn check_all_compatibilities(
                 .map(|(base, upgraded)| {
                     format!(
                         "{}::{}:\n\tbase->upgrade: {}\n\tupgrade->base: {}",
-                        base.address,
-                        base.name,
+                        base.address(),
+                        base.name(),
                         compat.check(base, upgraded).is_ok(),
                         compat.check(upgraded, base).is_ok()
                     )

--- a/crates/iota/src/upgrade_compatibility/formatting.rs
+++ b/crates/iota/src/upgrade_compatibility/formatting.rs
@@ -7,16 +7,15 @@ use std::{fmt, sync::LazyLock};
 use anyhow::{Context, Error};
 use move_binary_format::normalized::{Field, Type};
 use move_bytecode_source_map::source_map::SourceName;
-use move_core_types::identifier::Identifier;
 use move_ir_types::location::Loc;
 use regex::Regex;
 
-pub(super) struct FormattedType<'f> {
-    type_: &'f Type,
+pub(super) struct FormattedType<'f, S: fmt::Display> {
+    type_: &'f Type<S>,
     type_params: &'f [SourceName],
 }
 
-impl fmt::Display for FormattedType<'_> {
+impl<S: fmt::Display> fmt::Display for FormattedType<'_, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
             write!(
@@ -36,21 +35,22 @@ impl fmt::Display for FormattedType<'_> {
     }
 }
 
-pub(super) enum FormattedIdentifier<'f> {
+pub(super) enum FormattedIdentifier<'f, S: fmt::Display> {
     Positional(usize),
-    Named(&'f Identifier),
+    Named(&'f S),
 }
 
-pub(super) struct FormattedField<'f> {
-    pub(super) identifier: FormattedIdentifier<'f>,
-    pub(super) type_: FormattedType<'f>,
+pub(super) struct FormattedField<'f, S: fmt::Display> {
+    pub(super) identifier: FormattedIdentifier<'f, S>,
+    pub(super) type_: FormattedType<'f, S>,
 }
 
-impl<'f> FormattedField<'f> {
-    pub(super) fn new(f: &'f Field, type_params: &'f [SourceName]) -> Self {
+impl<'f, S: fmt::Display> FormattedField<'f, S> {
+    pub(super) fn new(f: &'f Field<S>, type_params: &'f [SourceName]) -> Self {
         static RE_POS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^pos(\d+)$").unwrap());
+        let display_name = format!("{}", f.name);
         let identifier = if let Some(ix) = RE_POS
-            .captures(f.name.as_str())
+            .captures(display_name.as_str())
             .and_then(|c| c.get(1))
             .and_then(|m| m.as_str().parse::<usize>().ok())
         {
@@ -69,7 +69,7 @@ impl<'f> FormattedField<'f> {
     }
 }
 
-impl fmt::Display for FormattedField<'_> {
+impl<S: fmt::Display> fmt::Display for FormattedField<'_, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use FormattedIdentifier as FI;
         match self.identifier {
@@ -84,8 +84,8 @@ impl fmt::Display for FormattedField<'_> {
 
 /// Returns a string representation of a parameter and updates its secondary
 /// label to include its location.
-pub(super) fn format_param(
-    param: &Type,
+pub(super) fn format_param<S: fmt::Display>(
+    param: &Type<S>,
     type_params: Vec<SourceName>,
     secondary: &mut Vec<(Loc, String)>,
 ) -> Result<String, Error> {
@@ -104,25 +104,19 @@ pub(super) fn format_param(
         Type::Vector(t) => {
             format!("vector<{}>", format_param(t, type_params, secondary)?)
         }
-        Type::MutableReference(t) => {
+        Type::Reference(true, t) => {
             format!("&mut {}", format_param(t, type_params, secondary)?)
         }
-        Type::Reference(t) => {
+        Type::Reference(false, t) => {
             format!("&{}", format_param(t, type_params, secondary)?)
         }
-        Type::Struct {
-            address,
-            module,
-            name,
-            type_arguments,
-            ..
-        } if !type_arguments.is_empty() => {
+        Type::Datatype(dt) if !dt.type_arguments.is_empty() => {
             format!(
                 "{}::{}::{}<{}>",
-                address.to_hex_literal(),
-                module,
-                name,
-                type_arguments
+                dt.module.address.to_hex_literal(),
+                dt.module.name,
+                dt.name,
+                dt.type_arguments
                     .iter()
                     .map(|t| format_param(t, type_params.clone(), secondary))
                     .collect::<Result<Vec<_>, _>>()?

--- a/crates/iota/src/upgrade_compatibility/mod.rs
+++ b/crates/iota/src/upgrade_compatibility/mod.rs
@@ -11,6 +11,7 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs,
     path::PathBuf,
+    rc::Rc,
     sync::Arc,
 };
 
@@ -32,7 +33,7 @@ use move_binary_format::{
         StructDefinitionIndex, TableIndex, Visibility,
     },
     inclusion_mode::InclusionCheckMode,
-    normalized::{Enum, Field, Function, Module, Struct, Type, Variant},
+    normalized,
 };
 use move_bytecode_source_map::source_map::SourceName;
 use move_command_line_common::files::FileHash;
@@ -51,6 +52,14 @@ use move_core_types::{
 use move_ir_types::location::{ByteIndex, Loc};
 use move_package::compilation::compiled_package::CompiledUnitWithSource;
 
+type Enum = normalized::Enum<normalized::RcIdentifier>;
+type Field = normalized::Field<normalized::RcIdentifier>;
+type Function = normalized::Function<normalized::RcIdentifier>;
+type Module = normalized::Module<normalized::RcIdentifier>;
+type Struct = normalized::Struct<normalized::RcIdentifier>;
+type Type = normalized::Type<normalized::RcIdentifier>;
+type Variant = normalized::Variant<normalized::RcIdentifier>;
+
 /// Errors that can occur during upgrade compatibility checks,
 /// one-to-one related to the underlying trait functions see:
 /// [`CompatibilityMode`].
@@ -61,46 +70,46 @@ pub(crate) enum UpgradeCompatibilityModeError {
     },
     StructAbilityMismatch {
         name: Identifier,
-        old_struct: Struct,
-        new_struct: Struct,
+        old_struct: Rc<Struct>,
+        new_struct: Rc<Struct>,
     },
     StructTypeParamMismatch {
         name: Identifier,
-        old_struct: Struct,
-        new_struct: Struct,
+        old_struct: Rc<Struct>,
+        new_struct: Rc<Struct>,
     },
     StructFieldMismatch {
         name: Identifier,
-        old_struct: Struct,
-        new_struct: Struct,
+        old_struct: Rc<Struct>,
+        new_struct: Rc<Struct>,
     },
     EnumMissing {
         name: Identifier,
     },
     EnumAbilityMismatch {
         name: Identifier,
-        old_enum: Enum,
-        new_enum: Enum,
+        old_enum: Rc<Enum>,
+        new_enum: Rc<Enum>,
     },
     EnumTypeParamMismatch {
         name: Identifier,
-        old_enum: Enum,
-        new_enum: Enum,
+        old_enum: Rc<Enum>,
+        new_enum: Rc<Enum>,
     },
     EnumNewVariant {
         name: Identifier,
-        old_enum: Enum,
-        new_enum: Enum,
+        old_enum: Rc<Enum>,
+        new_enum: Rc<Enum>,
     },
     EnumVariantMissing {
         name: Identifier,
-        old_enum: Enum,
+        old_enum: Rc<Enum>,
         tag: usize,
     },
     EnumVariantMismatch {
         name: Identifier,
-        old_enum: Enum,
-        new_enum: Enum,
+        old_enum: Rc<Enum>,
+        new_enum: Rc<Enum>,
     },
     FunctionMissingPublic {
         name: Identifier,
@@ -110,15 +119,15 @@ pub(crate) enum UpgradeCompatibilityModeError {
     },
     FunctionSignatureMismatch {
         name: Identifier,
-        old_function: Function,
-        new_function: Function,
+        old_function: Rc<Function>,
+        new_function: Rc<Function>,
     },
     FunctionLostPublicVisibility {
         name: Identifier,
     },
     FunctionEntryCompatibility {
         name: Identifier,
-        old_function: Function,
+        old_function: Rc<Function>,
     },
 
     // inclusion check specific errors
@@ -131,23 +140,23 @@ pub(crate) enum UpgradeCompatibilityModeError {
     },
     StructChange {
         name: Identifier,
-        old_struct: Struct,
-        new_struct: Struct,
+        old_struct: Rc<Struct>,
+        new_struct: Rc<Struct>,
     },
     EnumNew {
         name: Identifier,
     },
     EnumChange {
         name: Identifier,
-        new_enum: Enum,
+        new_enum: Rc<Enum>,
     },
     FunctionNew {
         name: Identifier,
     },
     FunctionChange {
         name: Identifier,
-        old_func: Function,
-        new_func: Function,
+        old_func: Rc<Function>,
+        new_func: Rc<Function>,
     },
     FunctionMissing {
         name: Identifier,
@@ -271,7 +280,7 @@ impl CompatibilityMode for CliCompatibilityMode {
     ) {
     }
 
-    fn struct_missing(&mut self, name: &Identifier, _old_struct: &Struct) {
+    fn struct_missing(&mut self, name: &Identifier, _old_struct: &Rc<Struct>) {
         self.errors
             .push(UpgradeCompatibilityModeError::StructMissing { name: name.clone() });
     }
@@ -279,8 +288,8 @@ impl CompatibilityMode for CliCompatibilityMode {
     fn struct_ability_mismatch(
         &mut self,
         name: &Identifier,
-        old_struct: &Struct,
-        new_struct: &Struct,
+        old_struct: &Rc<Struct>,
+        new_struct: &Rc<Struct>,
     ) {
         self.errors
             .push(UpgradeCompatibilityModeError::StructAbilityMismatch {
@@ -293,8 +302,8 @@ impl CompatibilityMode for CliCompatibilityMode {
     fn struct_type_param_mismatch(
         &mut self,
         name: &Identifier,
-        old_struct: &Struct,
-        new_struct: &Struct,
+        old_struct: &Rc<Struct>,
+        new_struct: &Rc<Struct>,
     ) {
         self.errors
             .push(UpgradeCompatibilityModeError::StructTypeParamMismatch {
@@ -307,8 +316,8 @@ impl CompatibilityMode for CliCompatibilityMode {
     fn struct_field_mismatch(
         &mut self,
         name: &Identifier,
-        old_struct: &Struct,
-        new_struct: &Struct,
+        old_struct: &Rc<Struct>,
+        new_struct: &Rc<Struct>,
     ) {
         self.errors
             .push(UpgradeCompatibilityModeError::StructFieldMismatch {
@@ -318,12 +327,17 @@ impl CompatibilityMode for CliCompatibilityMode {
             });
     }
 
-    fn enum_missing(&mut self, name: &Identifier, _old_enum: &Enum) {
+    fn enum_missing(&mut self, name: &Identifier, _old_enum: &Rc<Enum>) {
         self.errors
             .push(UpgradeCompatibilityModeError::EnumMissing { name: name.clone() });
     }
 
-    fn enum_ability_mismatch(&mut self, name: &Identifier, old_enum: &Enum, new_enum: &Enum) {
+    fn enum_ability_mismatch(
+        &mut self,
+        name: &Identifier,
+        old_enum: &Rc<Enum>,
+        new_enum: &Rc<Enum>,
+    ) {
         self.errors
             .push(UpgradeCompatibilityModeError::EnumAbilityMismatch {
                 name: name.clone(),
@@ -332,7 +346,12 @@ impl CompatibilityMode for CliCompatibilityMode {
             });
     }
 
-    fn enum_type_param_mismatch(&mut self, name: &Identifier, old_enum: &Enum, new_enum: &Enum) {
+    fn enum_type_param_mismatch(
+        &mut self,
+        name: &Identifier,
+        old_enum: &Rc<Enum>,
+        new_enum: &Rc<Enum>,
+    ) {
         self.errors
             .push(UpgradeCompatibilityModeError::EnumTypeParamMismatch {
                 name: name.clone(),
@@ -341,7 +360,7 @@ impl CompatibilityMode for CliCompatibilityMode {
             });
     }
 
-    fn enum_new_variant(&mut self, name: &Identifier, old_enum: &Enum, new_enum: &Enum) {
+    fn enum_new_variant(&mut self, name: &Identifier, old_enum: &Rc<Enum>, new_enum: &Rc<Enum>) {
         self.errors
             .push(UpgradeCompatibilityModeError::EnumNewVariant {
                 name: name.clone(),
@@ -350,7 +369,7 @@ impl CompatibilityMode for CliCompatibilityMode {
             });
     }
 
-    fn enum_variant_missing(&mut self, name: &Identifier, old_enum: &Enum, tag: usize) {
+    fn enum_variant_missing(&mut self, name: &Identifier, old_enum: &Rc<Enum>, tag: usize) {
         self.errors
             .push(UpgradeCompatibilityModeError::EnumVariantMissing {
                 name: name.clone(),
@@ -362,8 +381,8 @@ impl CompatibilityMode for CliCompatibilityMode {
     fn enum_variant_mismatch(
         &mut self,
         name: &Identifier,
-        old_enum: &Enum,
-        new_enum: &Enum,
+        old_enum: &Rc<Enum>,
+        new_enum: &Rc<Enum>,
         _variant_idx: usize,
     ) {
         self.errors
@@ -374,12 +393,12 @@ impl CompatibilityMode for CliCompatibilityMode {
             });
     }
 
-    fn function_missing_public(&mut self, name: &Identifier, _old_function: &Function) {
+    fn function_missing_public(&mut self, name: &Identifier, _old_function: &Rc<Function>) {
         self.errors
             .push(UpgradeCompatibilityModeError::FunctionMissingPublic { name: name.clone() });
     }
 
-    fn function_missing_entry(&mut self, name: &Identifier, _old_function: &Function) {
+    fn function_missing_entry(&mut self, name: &Identifier, _old_function: &Rc<Function>) {
         self.errors
             .push(UpgradeCompatibilityModeError::FunctionMissingEntry { name: name.clone() });
     }
@@ -387,8 +406,8 @@ impl CompatibilityMode for CliCompatibilityMode {
     fn function_signature_mismatch(
         &mut self,
         name: &Identifier,
-        old_function: &Function,
-        new_function: &Function,
+        old_function: &Rc<Function>,
+        new_function: &Rc<Function>,
     ) {
         self.errors
             .push(UpgradeCompatibilityModeError::FunctionSignatureMismatch {
@@ -398,7 +417,7 @@ impl CompatibilityMode for CliCompatibilityMode {
             });
     }
 
-    fn function_lost_public_visibility(&mut self, name: &Identifier, _old_function: &Function) {
+    fn function_lost_public_visibility(&mut self, name: &Identifier, _old_function: &Rc<Function>) {
         self.errors.push(
             UpgradeCompatibilityModeError::FunctionLostPublicVisibility { name: name.clone() },
         );
@@ -407,8 +426,8 @@ impl CompatibilityMode for CliCompatibilityMode {
     fn function_entry_compatibility(
         &mut self,
         name: &Identifier,
-        old_function: &Function,
-        _new_function: &Function,
+        old_function: &Rc<Function>,
+        _new_function: &Rc<Function>,
     ) {
         self.errors
             .push(UpgradeCompatibilityModeError::FunctionEntryCompatibility {
@@ -461,12 +480,17 @@ impl InclusionCheckMode for CliInclusionCheckMode {
             });
     }
 
-    fn struct_new(&mut self, name: &Identifier, _new_struct: &Struct) {
+    fn struct_new(&mut self, name: &Identifier, _new_struct: &Rc<Struct>) {
         self.errors
             .push(UpgradeCompatibilityModeError::StructNew { name: name.clone() });
     }
 
-    fn struct_change(&mut self, name: &Identifier, old_struct: &Struct, new_struct: &Struct) {
+    fn struct_change(
+        &mut self,
+        name: &Identifier,
+        old_struct: &Rc<Struct>,
+        new_struct: &Rc<Struct>,
+    ) {
         self.errors
             .push(UpgradeCompatibilityModeError::StructChange {
                 name: name.clone(),
@@ -475,34 +499,39 @@ impl InclusionCheckMode for CliInclusionCheckMode {
             });
     }
 
-    fn struct_missing(&mut self, name: &Identifier, _old_struct: &Struct) {
+    fn struct_missing(&mut self, name: &Identifier, _old_struct: &Rc<Struct>) {
         self.errors
             .push(UpgradeCompatibilityModeError::StructMissing { name: name.clone() });
     }
 
-    fn enum_new(&mut self, name: &Identifier, _new_enum: &Enum) {
+    fn enum_new(&mut self, name: &Identifier, _new_enum: &Rc<Enum>) {
         self.errors
             .push(UpgradeCompatibilityModeError::EnumNew { name: name.clone() });
     }
 
-    fn enum_change(&mut self, name: &Identifier, new_enum: &Enum) {
+    fn enum_change(&mut self, name: &Identifier, new_enum: &Rc<Enum>) {
         self.errors.push(UpgradeCompatibilityModeError::EnumChange {
             name: name.clone(),
             new_enum: new_enum.clone(),
         });
     }
 
-    fn enum_missing(&mut self, name: &Identifier, _old_enum: &Enum) {
+    fn enum_missing(&mut self, name: &Identifier, _old_enum: &Rc<Enum>) {
         self.errors
             .push(UpgradeCompatibilityModeError::EnumMissing { name: name.clone() });
     }
 
-    fn function_new(&mut self, name: &Identifier, _new_func: &Function) {
+    fn function_new(&mut self, name: &Identifier, _new_func: &Rc<Function>) {
         self.errors
             .push(UpgradeCompatibilityModeError::FunctionNew { name: name.clone() });
     }
 
-    fn function_change(&mut self, name: &Identifier, old_func: &Function, new_func: &Function) {
+    fn function_change(
+        &mut self,
+        name: &Identifier,
+        old_func: &Rc<Function>,
+        new_func: &Rc<Function>,
+    ) {
         self.errors
             .push(UpgradeCompatibilityModeError::FunctionChange {
                 name: name.clone(),
@@ -511,7 +540,7 @@ impl InclusionCheckMode for CliInclusionCheckMode {
             });
     }
 
-    fn function_missing(&mut self, name: &Identifier, _old_func: &Function) {
+    fn function_missing(&mut self, name: &Identifier, _old_func: &Rc<Function>) {
         self.errors
             .push(UpgradeCompatibilityModeError::FunctionMissing { name: name.clone() });
     }
@@ -813,18 +842,19 @@ fn modules_into_diags(
     lookup: &IdentifierTableLookup,
     policy: UpgradePolicy,
 ) -> Result<Diagnostics, Error> {
+    let pool = &mut normalized::RcPool::new();
     let diags_list = match policy {
         UpgradePolicy::DepOnly => InclusionCheck::Equal.check_with_mode::<CliInclusionCheckMode>(
-            &Module::new(existing_module),
-            &Module::new(new_module),
+            &Module::new(pool, existing_module, /* include code */ true),
+            &Module::new(pool, new_module, /* include code */ true),
         ),
         UpgradePolicy::Additive => InclusionCheck::Subset.check_with_mode::<CliInclusionCheckMode>(
-            &Module::new(existing_module),
-            &Module::new(new_module),
+            &Module::new(pool, existing_module, /* include code */ true),
+            &Module::new(pool, new_module, /* include code */ true),
         ),
         _ => Compatibility::upgrade_check().check_with_mode::<CliCompatibilityMode>(
-            &Module::new(existing_module),
-            &Module::new(new_module),
+            &Module::new(pool, existing_module, /* include code */ true),
+            &Module::new(pool, new_module, /* include code */ true),
         ),
     }
     .err()
@@ -1188,8 +1218,8 @@ fn function_lost_public(
 /// parameter piece wise and add a diagnostic for each mismatch.
 fn function_signature_mismatch_diag(
     function_name: &Identifier,
-    old_function: &Function,
-    new_function: &Function,
+    old_function: &Rc<Function>,
+    new_function: &Rc<Function>,
     public_visibility_related_error: bool,
     compiled_unit_with_source: &CompiledUnitWithSource,
     lookup: &IdentifierTableLookup,
@@ -1459,7 +1489,7 @@ fn function_signature_mismatch_diag(
 
 fn function_entry_mismatch(
     function_name: &Identifier,
-    old_function: &Function,
+    old_function: &Rc<Function>,
     compiled_unit_with_source: &CompiledUnitWithSource,
     lookup: &IdentifierTableLookup,
 ) -> Result<Diagnostics, Error> {
@@ -1546,8 +1576,8 @@ fn ability_mismatch_label(
 /// Returns a diagnostic for a given struct's ability mismatch.
 fn struct_ability_mismatch_diag(
     struct_name: &Identifier,
-    old_struct: &Struct,
-    new_struct: &Struct,
+    old_struct: &Rc<Struct>,
+    new_struct: &Rc<Struct>,
     public_visibility_related_error: bool,
     compiled_unit_with_source: &CompiledUnitWithSource,
     lookup: &IdentifierTableLookup,
@@ -1652,8 +1682,8 @@ fn field_mismatch_message(
 /// return a diagnostic for each mismatch.
 fn struct_field_mismatch_diag(
     struct_name: &Identifier,
-    old_struct: &Struct,
-    new_struct: &Struct,
+    old_struct: &Rc<Struct>,
+    new_struct: &Rc<Struct>,
     public_visibility_related_error: bool,
     compiled_unit_with_source: &CompiledUnitWithSource,
     lookup: &IdentifierTableLookup,
@@ -1673,21 +1703,19 @@ fn struct_field_mismatch_diag(
 
     let def_loc = struct_sourcemap.definition_location;
 
-    let dummy_field = Field {
-        name: Identifier::new("dummy_field")
-            .context("unexpected error with identifier constructor")?,
-        type_: Type::Bool,
-    };
-    let old_fields: Vec<&Field> = old_struct
+    let is_dummy_field = |f: &Field| f.name.as_str() == "dummy_field" && f.type_ == Type::Bool;
+    let old_fields: Vec<Rc<Field>> = old_struct
         .fields
         .iter()
-        .filter(|f| f != &&dummy_field)
+        .filter(|f| !is_dummy_field(f))
+        .cloned()
         .collect();
 
-    let new_fields: Vec<&Field> = new_struct
+    let new_fields: Vec<Rc<Field>> = new_struct
         .fields
         .iter()
-        .filter(|f| f != &&dummy_field)
+        .filter(|f| !is_dummy_field(f))
+        .cloned()
         .collect();
 
     let reason = if public_visibility_related_error {
@@ -1759,8 +1787,8 @@ fn struct_field_mismatch_diag(
 /// piece wise and return a diagnostic for each mismatch.
 fn struct_type_param_mismatch_diag(
     name: &Identifier,
-    old_struct: &Struct,
-    new_struct: &Struct,
+    old_struct: &Rc<Struct>,
+    new_struct: &Rc<Struct>,
     public_visibility_related_error: bool, /* give a different code for errors which are public
                                             * visibility related */
     compiled_unit_with_source: &CompiledUnitWithSource,
@@ -1793,8 +1821,8 @@ fn struct_type_param_mismatch_diag(
 /// Returns a diagnostic for enum ability mismatches.
 fn enum_ability_mismatch_diag(
     enum_name: &Identifier,
-    old_enum: &Enum,
-    new_enum: &Enum,
+    old_enum: &Rc<Enum>,
+    new_enum: &Rc<Enum>,
     public_visibility_related_error: bool, /* give a different code for errors which are public
                                             * visibility related */
     compiled_unit_with_source: &CompiledUnitWithSource,
@@ -1925,8 +1953,8 @@ fn enum_variant_field_message(
 /// piece wise and return a diagnostic for each mismatch.
 fn enum_variant_mismatch_diag(
     enum_name: &Identifier,
-    old_enum: &Enum,
-    new_enum: &Enum,
+    old_enum: &Rc<Enum>,
+    new_enum: &Rc<Enum>,
     public_visibility_related_error: bool, /* give a different code for errors which are public
                                             * visibility related */
     compiled_unit_with_source: &CompiledUnitWithSource,
@@ -1995,8 +2023,8 @@ fn enum_variant_mismatch_diag(
 /// Returns diagnostics for each new variant in an enum.
 fn enum_new_variant_diag(
     enum_name: &Identifier,
-    old_enum: &Enum,
-    new_enum: &Enum,
+    old_enum: &Rc<Enum>,
+    new_enum: &Rc<Enum>,
     compiled_unit_with_source: &CompiledUnitWithSource,
     lookup: &IdentifierTableLookup,
 ) -> Result<Diagnostics, Error> {
@@ -2016,13 +2044,13 @@ fn enum_new_variant_diag(
     let old_enum_map = old_enum
         .variants
         .iter()
-        .map(|v| &v.name)
+        .map(|v| v.name.as_ident_str())
         .collect::<HashSet<_>>();
 
     let def_loc = enum_sourcemap.definition_location;
 
     for (i, new_variant) in new_enum.variants.iter().enumerate() {
-        if !old_enum_map.contains(&new_variant.name) {
+        if !old_enum_map.contains(new_variant.name.as_ident_str()) {
             let variant_loc = enum_sourcemap
                 .variants
                 .get(i)
@@ -2057,7 +2085,7 @@ fn enum_new_variant_diag(
 /// Returns diagnostics for each missing variant in an enum.
 fn enum_variant_missing_diag(
     enum_name: &Identifier,
-    old_enum: &Enum,
+    old_enum: &Rc<Enum>,
     tag: usize,
     compiled_unit_with_source: &CompiledUnitWithSource,
     lookup: &IdentifierTableLookup,
@@ -2140,8 +2168,8 @@ fn struct_new_diag(
 /// Returns a diagnostic for an unexpected struct changed.
 fn struct_changed_diag(
     struct_name: &Identifier,
-    old_struct: &Struct,
-    new_struct: &Struct,
+    old_struct: &Rc<Struct>,
+    new_struct: &Rc<Struct>,
     compiled_unit_with_source: &CompiledUnitWithSource,
     lookup: &IdentifierTableLookup,
 ) -> Result<Diagnostics, Error> {
@@ -2211,8 +2239,8 @@ fn enum_new_diag(
 /// Returns a diagnostic for an unexpected enum change.
 fn enum_changed_diag(
     enum_name: &Identifier,
-    old_enum: &Enum,
-    new_enum: &Enum,
+    old_enum: &Rc<Enum>,
+    new_enum: &Rc<Enum>,
     compiled_unit_with_source: &CompiledUnitWithSource,
     lookup: &IdentifierTableLookup,
 ) -> Result<Diagnostics, Error> {
@@ -2285,14 +2313,14 @@ fn function_new_diag(
 /// Returns a diagnostic for an unexpected function changed.
 fn function_changed_diag(
     function_name: &Identifier,
-    old_function: &Function,
-    new_function: &Function,
+    old_function: &Rc<Function>,
+    new_function: &Rc<Function>,
     compiled_unit_with_source: &CompiledUnitWithSource,
     lookup: &IdentifierTableLookup,
 ) -> Result<Diagnostics, Error> {
     let mut diags = Diagnostics::new();
 
-    if old_function != new_function {
+    if !old_function.equals(new_function) {
         diags.extend(function_signature_mismatch_diag(
             function_name,
             old_function,
@@ -2309,8 +2337,8 @@ fn function_changed_diag(
 /// Returns a diagnostic for an enum type parameter mismatch.
 fn enum_type_param_mismatch(
     enum_name: &Identifier,
-    old_enum: &Enum,
-    new_enum: &Enum,
+    old_enum: &Rc<Enum>,
+    new_enum: &Rc<Enum>,
     public_visibility_related_error: bool, /* give a different code for errors which are public
                                             * visibility related */
     compiled_unit_with_source: &CompiledUnitWithSource,

--- a/external-crates/move/crates/move-binary-format/Cargo.toml
+++ b/external-crates/move/crates/move-binary-format/Cargo.toml
@@ -11,6 +11,7 @@ description = "Move Binary Format"
 anyhow.workspace = true
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
 enum-compat-util.workspace = true
+indexmap.workspace = true
 move-core-types.workspace = true
 move-proc-macros.workspace = true
 proptest = { workspace = true, optional = true }

--- a/external-crates/move/crates/move-binary-format/src/compatibility.rs
+++ b/external-crates/move/crates/move-binary-format/src/compatibility.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_core_types::vm_status::StatusCode;
+use std::collections::BTreeMap;
 
 use crate::{
     compatibility_mode::{CompatibilityMode, ExecutionCompatibilityMode},
@@ -11,7 +12,7 @@ use crate::{
     file_format::{Ability, AbilitySet, DatatypeTyParameter, Visibility},
     file_format_common::VERSION_5,
     inclusion_mode::{InclusionCheckExecutionMode, InclusionCheckMode},
-    normalized::Module,
+    normalized,
 };
 // ***************************************************************************
 // ******************* IMPORTANT NOTE ON COMPATIBILITY ***********************
@@ -49,6 +50,11 @@ pub struct Compatibility {
     /// The set of abilities that cannot be added to an already exisiting type.
     pub disallowed_new_abilities: AbilitySet,
 }
+
+pub type Module = normalized::Module<normalized::RcIdentifier>;
+pub type Struct = normalized::Struct<normalized::RcIdentifier>;
+pub type Enum = normalized::Enum<normalized::RcIdentifier>;
+pub type Function = normalized::Function<normalized::RcIdentifier>;
 
 impl Default for Compatibility {
     fn default() -> Self {
@@ -120,12 +126,12 @@ impl Compatibility {
         let mut context = M::default();
 
         // module's name and address are unchanged
-        if old_module.address != new_module.address || old_module.name != new_module.name {
+        if old_module.address() != new_module.address() || old_module.name() != new_module.name() {
             context.module_id_mismatch(
-                &old_module.address,
-                &old_module.name,
-                &new_module.address,
-                &new_module.name,
+                old_module.address(),
+                old_module.name(),
+                new_module.address(),
+                new_module.name(),
             );
         }
 
@@ -393,12 +399,12 @@ impl InclusionCheck {
         let mut context = M::default();
 
         // module's name and address are unchanged
-        if old_module.address != new_module.address || old_module.name != new_module.name {
+        if old_module.address() != new_module.address() || old_module.name() != new_module.name() {
             context.module_id_mismatch(
-                &old_module.address,
-                &old_module.name,
-                &new_module.address,
-                &new_module.name,
+                old_module.address(),
+                old_module.name(),
+                new_module.address(),
+                new_module.name(),
             );
         }
 
@@ -442,7 +448,7 @@ impl InclusionCheck {
                 Mark::New(name, new) => context.function_new(name, new),
                 Mark::Missing(name, old) => context.function_missing(name, old),
                 Mark::Existing(name, old, new) => {
-                    if old != new {
+                    if !old.equals(new) {
                         context.function_change(name, old, new);
                     }
                 }
@@ -480,9 +486,10 @@ where
     I: Iterator<Item = (&'a K, &'a V)> + 'a,
     J: Iterator<Item = (&'a K, &'a V)> + 'a,
 {
-    // Peeks are needed to prevent advancing the iterators when we don't need to
-    let mut old = old.peekable();
-    let mut new = new.peekable();
+    let old = old.collect::<BTreeMap<_, _>>();
+    let new = new.collect::<BTreeMap<_, _>>();
+    let mut old = old.into_iter().peekable();
+    let mut new = new.into_iter().peekable();
     std::iter::from_fn(move || match (old.peek(), new.peek()) {
         (Some((old_key, _old_value)), Some((new_key, _new_value))) => match old_key.cmp(new_key) {
             std::cmp::Ordering::Equal => {

--- a/external-crates/move/crates/move-binary-format/src/compatibility_mode.rs
+++ b/external-crates/move/crates/move-binary-format/src/compatibility_mode.rs
@@ -2,9 +2,9 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::compatibility::Compatibility;
+use std::rc::Rc;
+use crate::compatibility::{Compatibility, Enum, Function, Struct};
 use crate::file_format::Visibility;
-use crate::normalized::{Enum, Function, Struct};
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::{IdentStr, Identifier};
 
@@ -26,81 +26,91 @@ pub trait CompatibilityMode: Default {
     );
 
     /// The struct missing error occurs when a struct is present in the old module but not in the new module.
-    fn struct_missing(&mut self, name: &Identifier, old_struct: &Struct);
+    fn struct_missing(&mut self, name: &Identifier, old_struct: &Rc<Struct>);
 
     /// The struct ability mismatch error occurs when the abilities of a struct are outside of the
     /// allowed new abilities. Adding an ability is fine as long as it's not in the disallowed_new_abilities set.
     fn struct_ability_mismatch(
         &mut self,
         name: &Identifier,
-        old_struct: &Struct,
-        new_struct: &Struct,
+        old_struct: &Rc<Struct>,
+        new_struct: &Rc<Struct>,
     );
 
     /// Struct type parameters mismatch error occurs when the type parameters of a struct are not the same.
     fn struct_type_param_mismatch(
         &mut self,
         name: &Identifier,
-        old_struct: &Struct,
-        new_struct: &Struct,
+        old_struct: &Rc<Struct>,
+        new_struct: &Rc<Struct>,
     );
 
     /// Struct field mismatch error occurs when the fields of a struct are not the same.
     fn struct_field_mismatch(
         &mut self,
         name: &Identifier,
-        old_struct: &Struct,
-        new_struct: &Struct,
+        old_struct: &Rc<Struct>,
+        new_struct: &Rc<Struct>,
     );
 
     /// Enum missing error occurs when an enum is present in the old module but not in the new module.
-    fn enum_missing(&mut self, name: &Identifier, old_enum: &Enum);
+    fn enum_missing(&mut self, name: &Identifier, old_enum: &Rc<Enum>);
 
     /// Enum ability mismatch error occurs when the abilities of an enum are outside of the
     /// allowed new abilities. Adding an ability is fine as long as it's not in the disallowed_new_abilities set.
-    fn enum_ability_mismatch(&mut self, name: &Identifier, old_enum: &Enum, new_enum: &Enum);
+    fn enum_ability_mismatch(
+        &mut self,
+        name: &Identifier,
+        old_enum: &Rc<Enum>,
+        new_enum: &Rc<Enum>,
+    );
 
     /// Enum type parameters mismatch error occurs when the type parameters of an enum are not the same.
-    fn enum_type_param_mismatch(&mut self, name: &Identifier, old_enum: &Enum, new_enum: &Enum);
+    fn enum_type_param_mismatch(
+        &mut self,
+        name: &Identifier,
+        old_enum: &Rc<Enum>,
+        new_enum: &Rc<Enum>,
+    );
 
     /// Enum new variant error occurs when a new variant is added to an enum.
-    fn enum_new_variant(&mut self, name: &Identifier, old_enum: &Enum, new_enum: &Enum);
+    fn enum_new_variant(&mut self, name: &Identifier, old_enum: &Rc<Enum>, new_enum: &Rc<Enum>);
 
     /// Enum variant missing error occurs when a variant is present in the old enum but not in the new enum.
-    fn enum_variant_missing(&mut self, name: &Identifier, old_enum: &Enum, tag: usize);
+    fn enum_variant_missing(&mut self, name: &Identifier, old_enum: &Rc<Enum>, tag: usize);
 
     /// Enum variant mismatch error occurs when a variant is present in the old enum but not in the new enum.
     fn enum_variant_mismatch(
         &mut self,
         name: &Identifier,
-        old_enum: &Enum,
-        new_enum: &Enum,
+        old_enum: &Rc<Enum>,
+        new_enum: &Rc<Enum>,
         tag: usize,
     );
 
     /// Function missing public error occurs when a public function is present in the old module but not in the new module.
-    fn function_missing_public(&mut self, name: &Identifier, old_func: &Function);
+    fn function_missing_public(&mut self, name: &Identifier, old_func: &Rc<Function>);
 
     /// Function missing entry error occurs when an entry function is present in the old module but not in the new module.
-    fn function_missing_entry(&mut self, name: &Identifier, old_func: &Function);
+    fn function_missing_entry(&mut self, name: &Identifier, old_func: &Rc<Function>);
 
     /// Function signature mismatch error occurs when the signature of a function changes.
     fn function_signature_mismatch(
         &mut self,
         name: &Identifier,
-        old_func: &Function,
-        new_func: &Function,
+        old_func: &Rc<Function>,
+        new_func: &Rc<Function>,
     );
 
     /// Function lost public visibility error occurs when a function loses its public visibility.
-    fn function_lost_public_visibility(&mut self, name: &Identifier, old_func: &Function);
+    fn function_lost_public_visibility(&mut self, name: &Identifier, old_func: &Rc<Function>);
 
     /// Function entry compatibility error occurs when an entry function is not compatible.
     fn function_entry_compatibility(
         &mut self,
         name: &Identifier,
-        old_func: &Function,
-        new_func: &Function,
+        old_func: &Rc<Function>,
+        new_func: &Rc<Function>,
     );
 
     /// Finish the compatibility check and return the error if one has been accumulated from individual errors.
@@ -144,7 +154,7 @@ impl CompatibilityMode for ExecutionCompatibilityMode {
         self.datatype_and_function_linking = false;
     }
 
-    fn struct_missing(&mut self, _name: &Identifier, _old_struct: &Struct) {
+    fn struct_missing(&mut self, _name: &Identifier, _old_struct: &Rc<Struct>) {
         self.datatype_and_function_linking = false;
         self.datatype_layout = false;
     }
@@ -152,8 +162,8 @@ impl CompatibilityMode for ExecutionCompatibilityMode {
     fn struct_ability_mismatch(
         &mut self,
         _name: &Identifier,
-        _old_struct: &Struct,
-        _new_struct: &Struct,
+        _old_struct: &Rc<Struct>,
+        _new_struct: &Rc<Struct>,
     ) {
         self.datatype_and_function_linking = false;
     }
@@ -161,8 +171,8 @@ impl CompatibilityMode for ExecutionCompatibilityMode {
     fn struct_type_param_mismatch(
         &mut self,
         _name: &Identifier,
-        _old_struct: &Struct,
-        _new_struct: &Struct,
+        _old_struct: &Rc<Struct>,
+        _new_struct: &Rc<Struct>,
     ) {
         self.datatype_and_function_linking = false;
     }
@@ -170,56 +180,66 @@ impl CompatibilityMode for ExecutionCompatibilityMode {
     fn struct_field_mismatch(
         &mut self,
         _name: &Identifier,
-        _old_struct: &Struct,
-        _new_struct: &Struct,
+        _old_struct: &Rc<Struct>,
+        _new_struct: &Rc<Struct>,
     ) {
         self.datatype_layout = false;
     }
 
-    fn enum_missing(&mut self, _name: &Identifier, _old_enum: &Enum) {
+    fn enum_missing(&mut self, _name: &Identifier, _old_enum: &Rc<Enum>) {
         self.datatype_and_function_linking = false;
         self.datatype_layout = false;
     }
 
-    fn enum_ability_mismatch(&mut self, _name: &Identifier, _old_enum: &Enum, _new_enum: &Enum) {
+    fn enum_ability_mismatch(
+        &mut self,
+        _name: &Identifier,
+        _old_enum: &Rc<Enum>,
+        _new_enum: &Rc<Enum>,
+    ) {
         self.datatype_and_function_linking = false;
     }
 
-    fn enum_type_param_mismatch(&mut self, _name: &Identifier, _old_enum: &Enum, _new_enum: &Enum) {
+    fn enum_type_param_mismatch(
+        &mut self,
+        _name: &Identifier,
+        _old_enum: &Rc<Enum>,
+        _new_enum: &Rc<Enum>,
+    ) {
         self.datatype_and_function_linking = false;
     }
 
-    fn enum_new_variant(&mut self, _name: &Identifier, _old_enum: &Enum, _new_enum: &Enum) {
+    fn enum_new_variant(&mut self, _name: &Identifier, _old_enum: &Rc<Enum>, _new_enum: &Rc<Enum>) {
         self.no_new_variants = false;
     }
 
-    fn enum_variant_missing(&mut self, _name: &Identifier, _old_enum: &Enum, _tag: usize) {
+    fn enum_variant_missing(&mut self, _name: &Identifier, _old_enum: &Rc<Enum>, _tag: usize) {
         self.datatype_layout = false;
     }
 
     fn enum_variant_mismatch(
         &mut self,
         _name: &Identifier,
-        _old_enum: &Enum,
-        _new_enum: &Enum,
+        _old_enum: &Rc<Enum>,
+        _new_enum: &Rc<Enum>,
         _tag: usize,
     ) {
         self.datatype_layout = false;
     }
 
-    fn function_missing_public(&mut self, _name: &Identifier, _old_func: &Function) {
+    fn function_missing_public(&mut self, _name: &Identifier, _old_func: &Rc<Function>) {
         self.datatype_and_function_linking = false;
     }
 
-    fn function_missing_entry(&mut self, _name: &Identifier, _old_func: &Function) {
+    fn function_missing_entry(&mut self, _name: &Identifier, _old_func: &Rc<Function>) {
         self.entry_linking = false;
     }
 
     fn function_signature_mismatch(
         &mut self,
         _name: &Identifier,
-        old_func: &Function,
-        _new_func: &Function,
+        old_func: &Rc<Function>,
+        _new_func: &Rc<Function>,
     ) {
         if old_func.visibility == Visibility::Public {
             self.datatype_and_function_linking = false;
@@ -230,15 +250,15 @@ impl CompatibilityMode for ExecutionCompatibilityMode {
         }
     }
 
-    fn function_lost_public_visibility(&mut self, _name: &Identifier, _old_func: &Function) {
+    fn function_lost_public_visibility(&mut self, _name: &Identifier, _old_func: &Rc<Function>) {
         self.datatype_and_function_linking = false;
     }
 
     fn function_entry_compatibility(
         &mut self,
         _name: &Identifier,
-        _old_func: &Function,
-        _new_func: &Function,
+        _old_func: &Rc<Function>,
+        _new_func: &Rc<Function>,
     ) {
         self.entry_linking = false;
     }

--- a/external-crates/move/crates/move-binary-format/src/inclusion_mode.rs
+++ b/external-crates/move/crates/move-binary-format/src/inclusion_mode.rs
@@ -2,14 +2,11 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::compatibility::{Enum, Function, InclusionCheck, Struct};
+use std::rc::Rc;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
-};
-
-use crate::{
-    compatibility::InclusionCheck,
-    normalized::{Enum, Function, Struct},
 };
 
 pub trait InclusionCheckMode: Default {
@@ -22,15 +19,25 @@ pub trait InclusionCheckMode: Default {
         new_name: &IdentStr,
     );
     fn file_format_version_downgrade(&mut self, old_version: u32, new_version: u32);
-    fn struct_new(&mut self, name: &Identifier, new_struct: &Struct);
-    fn struct_change(&mut self, name: &Identifier, old_struct: &Struct, new_struct: &Struct);
-    fn struct_missing(&mut self, name: &Identifier, old_struct: &Struct);
-    fn enum_new(&mut self, name: &Identifier, new_enum: &Enum);
-    fn enum_change(&mut self, name: &Identifier, new_enum: &Enum);
-    fn enum_missing(&mut self, name: &Identifier, old_enum: &Enum);
-    fn function_new(&mut self, name: &Identifier, new_func: &Function);
-    fn function_change(&mut self, name: &Identifier, old_func: &Function, new_func: &Function);
-    fn function_missing(&mut self, name: &Identifier, old_func: &Function);
+    fn struct_new(&mut self, name: &Identifier, new_struct: &Rc<Struct>);
+    fn struct_change(
+        &mut self,
+        name: &Identifier,
+        old_struct: &Rc<Struct>,
+        new_struct: &Rc<Struct>,
+    );
+    fn struct_missing(&mut self, name: &Identifier, old_struct: &Rc<Struct>);
+    fn enum_new(&mut self, name: &Identifier, new_enum: &Rc<Enum>);
+    fn enum_change(&mut self, name: &Identifier, new_enum: &Rc<Enum>);
+    fn enum_missing(&mut self, name: &Identifier, old_enum: &Rc<Enum>);
+    fn function_new(&mut self, name: &Identifier, new_func: &Rc<Function>);
+    fn function_change(
+        &mut self,
+        name: &Identifier,
+        old_func: &Rc<Function>,
+        new_func: &Rc<Function>,
+    );
+    fn function_missing(&mut self, name: &Identifier, old_func: &Rc<Function>);
 
     fn friend_mismatch(&mut self, old_count: usize, new_count: usize);
 
@@ -71,44 +78,54 @@ impl InclusionCheckMode for InclusionCheckExecutionMode {
         self.is_equal = false;
     }
 
-    fn struct_new(&mut self, _name: &Identifier, _new_struct: &Struct) {
+    fn struct_new(&mut self, _name: &Identifier, _new_struct: &Rc<Struct>) {
         self.is_equal = false;
     }
 
-    fn struct_change(&mut self, _name: &Identifier, _old_struct: &Struct, _new_struct: &Struct) {
+    fn struct_change(
+        &mut self,
+        _name: &Identifier,
+        _old_struct: &Rc<Struct>,
+        _new_struct: &Rc<Struct>,
+    ) {
         self.is_subset = false;
         self.is_equal = false;
     }
 
-    fn struct_missing(&mut self, _name: &Identifier, _old_struct: &Struct) {
+    fn struct_missing(&mut self, _name: &Identifier, _old_struct: &Rc<Struct>) {
         self.is_subset = false;
         self.is_equal = false;
     }
 
-    fn enum_new(&mut self, _name: &Identifier, _new_enum: &Enum) {
+    fn enum_new(&mut self, _name: &Identifier, _new_enum: &Rc<Enum>) {
         self.is_equal = false;
     }
 
-    fn enum_change(&mut self, _name: &Identifier, _new_enum: &Enum) {
+    fn enum_change(&mut self, _name: &Identifier, _new_enum: &Rc<Enum>) {
         self.is_subset = false;
         self.is_equal = false;
     }
 
-    fn enum_missing(&mut self, _name: &Identifier, _old_enum: &Enum) {
+    fn enum_missing(&mut self, _name: &Identifier, _old_enum: &Rc<Enum>) {
         self.is_subset = false;
         self.is_equal = false;
     }
 
-    fn function_new(&mut self, _name: &Identifier, _new_func: &Function) {
+    fn function_new(&mut self, _name: &Identifier, _new_func: &Rc<Function>) {
         self.is_equal = false;
     }
 
-    fn function_change(&mut self, _name: &Identifier, _old_func: &Function, _new_func: &Function) {
+    fn function_change(
+        &mut self,
+        _name: &Identifier,
+        _old_func: &Rc<Function>,
+        _new_func: &Rc<Function>,
+    ) {
         self.is_subset = false;
         self.is_equal = false;
     }
 
-    fn function_missing(&mut self, _name: &Identifier, _old_func: &Function) {
+    fn function_missing(&mut self, _name: &Identifier, _old_func: &Rc<Function>) {
         self.is_subset = false;
         self.is_equal = false;
     }

--- a/external-crates/move/crates/move-binary-format/src/normalized.rs
+++ b/external-crates/move/crates/move-binary-format/src/normalized.rs
@@ -1,25 +1,39 @@
-// Copyright (c) The Diem Core Contributors
 // Copyright (c) The Move Contributors
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::file_format::{
-    AbilitySet, Bytecode as FBytecode, CodeOffset, CompiledModule, DatatypeTyParameter,
-    EnumDefinition, FieldDefinition, FieldHandle, FieldHandleIndex, FieldInstantiation,
-    FieldInstantiationIndex, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
-    FunctionInstantiation, JumpTableInner, LocalIndex, SignatureIndex, SignatureToken,
-    StructDefInstantiation, StructDefInstantiationIndex, StructDefinition, StructDefinitionIndex,
-    StructFieldInformation, TypeParameterIndex, VariantDefinition, VariantHandleIndex,
-    VariantInstantiationHandleIndex, VariantJumpTable as FFVariantJumpTable, Visibility,
+    self, AbilitySet, Bytecode as FBytecode, CodeOffset, CompiledModule, DatatypeHandleIndex,
+    DatatypeTyParameter, EnumDefinition, EnumDefinitionIndex, FieldDefinition, FieldHandleIndex,
+    FieldInstantiationIndex, FunctionDefinition, FunctionHandleIndex, FunctionInstantiationIndex,
+    JumpTableInner, LocalIndex, SignatureIndex, SignatureToken, StructDefInstantiationIndex,
+    StructDefinition, StructDefinitionIndex, StructFieldInformation, TypeParameterIndex,
+    VariantDefinition, VariantHandleIndex, VariantInstantiationHandleIndex, VariantTag, Visibility,
 };
+use indexmap::IndexMap;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, StructTag, TypeTag},
+    language_storage::{StructTag, TypeTag},
 };
-use move_proc_macros::test_variant_order;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::{
+    borrow::Borrow, collections::HashSet, fmt::Debug, hash::Hash, ops::Deref, rc::Rc, sync::Arc,
+};
+
+pub trait StringPool {
+    type String;
+
+    fn intern(&mut self, s: &IdentStr) -> Self::String;
+
+    fn as_ident_str<'a>(&'a self, s: &'a Self::String) -> &'a IdentStr;
+}
+
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ModuleId<S> {
+    pub address: AccountAddress,
+    pub name: S,
+}
 
 // Defines normalized representations of Move types, fields, kinds, structs, functions, and
 // modules. These representations are useful in situations that require require comparing
@@ -32,8 +46,7 @@ use std::collections::BTreeMap;
 /// struct or function declarations. Unlike `SignatureToken`s,
 /// `normalized::Type`s from different modules can safely be compared.
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
-#[test_variant_order(src/unit_tests/staged_enum_variant_order/type.yaml)]
-pub enum Type {
+pub enum Type<S> {
     #[serde(rename = "bool")]
     Bool,
     #[serde(rename = "u8")]
@@ -46,17 +59,11 @@ pub enum Type {
     Address,
     #[serde(rename = "signer")]
     Signer,
-    Struct {
-        address: AccountAddress,
-        module: Identifier,
-        name: Identifier,
-        type_arguments: Vec<Type>,
-    },
+    Datatype(Box<Datatype<S>>),
     #[serde(rename = "vector")]
-    Vector(Box<Type>),
+    Vector(Box<Type<S>>),
     TypeParameter(TypeParameterIndex),
-    Reference(Box<Type>),
-    MutableReference(Box<Type>),
+    Reference(/* is_mut */ bool, Box<Type<S>>),
     // NOTE: Added in bytecode version v6, do not reorder!
     #[serde(rename = "u16")]
     U16,
@@ -66,82 +73,133 @@ pub enum Type {
     U256,
 }
 
-/// Normalized version of a `FieldDefinition`. The `name` is included even
-/// though it is metadata that it is ignored by the VM. The reason: names are
-/// important to clients. We would want a change from `Account { bal: u64, seq:
-/// u64 }` to `Account { seq: u64, bal: u64 }` to be marked as incompatible. Not
-/// safe to compare without an enclosing `Struct`.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Field {
-    pub name: Identifier,
-    pub type_: Type,
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Datatype<S> {
+    pub module: ModuleId<S>,
+    pub name: S,
+    pub type_arguments: Vec<Type<S>>,
+}
+
+pub type Signature<S> = Rc<Vec<Rc<Type<S>>>>;
+
+#[cfg_attr(test, derive(Clone))]
+#[derive(Debug)]
+struct Tables<S> {
+    empty_signature: Signature<S>,
+    signatures: Vec<Signature<S>>,
+    constants: Vec<Rc<Constant<S>>>,
+    struct_defs: Vec<Rc<Struct<S>>>,
+    function_defs: Vec<Rc<Function<S>>>,
+    enum_defs: Vec<Rc<Enum<S>>>,
+}
+
+/// Normalized version of a `CompiledModule`: its address, name, struct declarations, and public
+/// function declarations.
+#[cfg_attr(test, derive(Clone))]
+#[derive(Debug)]
+pub struct Module<S: Hash + Eq> {
+    #[allow(unused)]
+    tables: Tables<S>,
+    code_included: bool,
+    pub id: ModuleId<S>,
+    pub file_format_version: u32,
+    pub dependencies: Vec<ModuleId<S>>,
+    pub friends: Vec<ModuleId<S>>,
+    pub structs: IndexMap<S, Rc<Struct<S>>>,
+    pub enums: IndexMap<S, Rc<Enum<S>>>,
+    pub functions: IndexMap<S, Rc<Function<S>>>,
+    pub constants: Vec<Rc<Constant<S>>>,
 }
 
 /// Normalized version of a `Constant`.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Constant {
-    pub type_: Type,
+#[cfg_attr(test, derive(Clone))]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Constant<S> {
+    pub type_: Type<S>,
     pub data: Vec<u8>,
 }
 
 /// Normalized version of a `StructDefinition`. Not safe to compare without an
 /// associated `ModuleId` or `Module`.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Struct {
+#[cfg_attr(test, derive(Clone))]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Struct<S> {
+    pub name: S,
     pub abilities: AbilitySet,
     pub type_parameters: Vec<DatatypeTyParameter>,
-    pub fields: Vec<Field>,
+    pub fields: Vec<Rc<Field<S>>>,
+}
+
+/// Normalized version of a `FieldDefinition`. The `name` is included even though it is
+/// metadata that it is ignored by the VM. The reason: names are important to clients. We would
+/// want a change from `Account { bal: u64, seq: u64 }` to `Account { seq: u64, bal: u64 }` to be
+/// marked as incompatible. Not safe to compare without an enclosing `Struct`.
+#[cfg_attr(test, derive(Clone))]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Field<S> {
+    pub name: S,
+    pub type_: Type<S>,
 }
 
 /// Normalized version of a `FunctionDefinition`. Not safe to compare without an
 /// associated `ModuleId` or `Module`.
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub struct Function {
+#[cfg_attr(test, derive(Clone))]
+#[derive(Debug)]
+pub struct Function<S> {
+    pub name: S,
     pub visibility: Visibility,
     pub is_entry: bool,
     pub type_parameters: Vec<AbilitySet>,
-    pub parameters: Vec<Type>,
-    pub return_: Vec<Type>,
-    pub code: Vec<Bytecode>,
-}
-
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub struct FieldRef {
-    pub struct_name: Identifier,
-    pub field_index: u16,
+    pub parameters: Signature<S>,
+    pub return_: Signature<S>,
+    code_included: bool,
+    jump_tables: Vec<Rc<VariantJumpTable<S>>>,
+    code: Vec<Bytecode<S>>,
 }
 
 /// Normalized version of a `EnumDefinition`. Not safe to compare without an
 /// associated `ModuleId` or `Module`.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Enum {
+#[cfg_attr(test, derive(Clone))]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Enum<S> {
+    pub name: S,
     pub abilities: AbilitySet,
     pub type_parameters: Vec<DatatypeTyParameter>,
-    pub variants: Vec<Variant>,
+    pub variants: Vec<Rc<Variant<S>>>,
 }
 
 /// Normalized version of a `VariantDefinition`. Not safe to compare without an
 /// associated `ModuleId` or `Module`.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Variant {
-    pub name: Identifier,
-    pub fields: Vec<Field>,
+#[cfg_attr(test, derive(Clone))]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Variant<S> {
+    pub name: S,
+    pub fields: Vec<Field<S>>,
 }
 
 /// Normalized version of a `VariantJumpTable`. Not safe to compare without an
 /// associated `ModuleId` or `Module`.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct VariantJumpTable {
-    pub enum_name: Identifier,
+#[cfg_attr(test, derive(Clone))]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct VariantJumpTable<S> {
+    pub enum_: Rc<Enum<S>>,
     pub jump_table: JumpTableInner,
 }
 
-/// Normalized version of a `VariantHandle` and `VariantInstantiationHandle`.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct VariantHandle {
-    pub enum_name: Identifier,
-    pub variant_index: u16,
-    pub type_parameters: Vec<Type>,
+pub type ConstantRef<S> = Rc<Constant<S>>;
+
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub struct StructRef<S> {
+    pub struct_: Rc<Struct<S>>,
+    pub type_arguments: Signature<S>,
+}
+
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub struct FieldRef<S> {
+    pub struct_: Rc<Struct<S>>,
+    pub field: Rc<Field<S>>,
+    /// Type arguments to the struct
+    pub instantiation: Signature<S>,
 }
 
 // Functions can reference external modules. We don't track the exact type
@@ -158,14 +216,25 @@ pub struct VariantHandle {
 //     the API of that
 //   function must not have changed by compatibility rules.
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub struct FunctionRef {
-    pub module_id: ModuleId,
-    pub function_ident: Identifier,
+pub struct FunctionRef<S> {
+    pub module: ModuleId<S>,
+    pub function: S,
+    pub type_arguments: Signature<S>,
 }
 
+/// Normalized version of a `VariantRef` and `VariantInstantiationHandle`.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct VariantRef<S> {
+    pub enum_: Rc<Enum<S>>,
+    pub variant: Rc<Variant<S>>,
+    /// The type arguments to the enum
+    pub instantiation: Signature<S>,
+}
+
+pub type VariantJumpTableRef<S> = Rc<VariantJumpTable<S>>;
 /// Normalized representation of bytecode.
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub enum Bytecode {
+pub enum Bytecode<S> {
     Pop,
     Ret,
     BrTrue(CodeOffset),
@@ -173,31 +242,26 @@ pub enum Bytecode {
     Branch(CodeOffset),
     LdU8(u8),
     LdU64(u64),
-    LdU128(u128),
+    LdU128(Box<u128>),
     CastU8,
     CastU64,
     CastU128,
-    LdConst(Constant),
+    LdConst(ConstantRef<S>),
     LdTrue,
     LdFalse,
     CopyLoc(LocalIndex),
     MoveLoc(LocalIndex),
     StLoc(LocalIndex),
-    Call(FunctionRef),
-    CallGeneric((FunctionRef, Vec<Type>)),
-    Pack(Identifier),
-    PackGeneric((Identifier, Vec<Type>)),
-    Unpack(Identifier),
-    UnpackGeneric((Identifier, Vec<Type>)),
+    Call(Box<FunctionRef<S>>),
+    Pack(Box<StructRef<S>>),
+    Unpack(Box<StructRef<S>>),
     ReadRef,
     WriteRef,
     FreezeRef,
     MutBorrowLoc(LocalIndex),
     ImmBorrowLoc(LocalIndex),
-    MutBorrowField(FieldRef),
-    MutBorrowFieldGeneric((FieldRef, Vec<Type>)),
-    ImmBorrowField(FieldRef),
-    ImmBorrowFieldGeneric((FieldRef, Vec<Type>)),
+    MutBorrowField(Box<FieldRef<S>>),
+    ImmBorrowField(Box<FieldRef<S>>),
     Add,
     Sub,
     Mul,
@@ -219,90 +283,382 @@ pub enum Bytecode {
     Nop,
     Shl,
     Shr,
-    VecPack(Type, u64),
-    VecLen(Type),
-    VecImmBorrow(Type),
-    VecMutBorrow(Type),
-    VecPushBack(Type),
-    VecPopBack(Type),
-    VecUnpack(Type, u64),
-    VecSwap(Type),
+    VecPack(Box<(Rc<Type<S>>, u64)>),
+    VecLen(Rc<Type<S>>),
+    VecImmBorrow(Rc<Type<S>>),
+    VecMutBorrow(Rc<Type<S>>),
+    VecPushBack(Rc<Type<S>>),
+    VecPopBack(Rc<Type<S>>),
+    VecUnpack(Box<(Rc<Type<S>>, u64)>),
+    VecSwap(Rc<Type<S>>),
     LdU16(u16),
     LdU32(u32),
-    LdU256(move_core_types::u256::U256),
+    LdU256(Box<move_core_types::u256::U256>),
     CastU16,
     CastU32,
     CastU256,
-    PackVariant(VariantHandle),
-    PackVariantGeneric(VariantHandle),
-    UnpackVariant(VariantHandle),
-    UnpackVariantImmRef(VariantHandle),
-    UnpackVariantMutRef(VariantHandle),
-    UnpackVariantGeneric(VariantHandle),
-    UnpackVariantGenericImmRef(VariantHandle),
-    UnpackVariantGenericMutRef(VariantHandle),
-    VariantSwitch(VariantJumpTable),
+    PackVariant(Box<VariantRef<S>>),
+    UnpackVariant(Box<VariantRef<S>>),
+    UnpackVariantImmRef(Box<VariantRef<S>>),
+    UnpackVariantMutRef(Box<VariantRef<S>>),
+    VariantSwitch(VariantJumpTableRef<S>),
     // ******** DEPRECATED BYTECODES ********
-    MutBorrowGlobalDeprecated(Identifier),
-    MutBorrowGlobalGenericDeprecated((Identifier, Vec<Type>)),
-    ImmBorrowGlobalDeprecated(Identifier),
-    ImmBorrowGlobalGenericDeprecated((Identifier, Vec<Type>)),
-    ExistsDeprecated(Identifier),
-    ExistsGenericDeprecated((Identifier, Vec<Type>)),
-    MoveFromDeprecated(Identifier),
-    MoveFromGenericDeprecated((Identifier, Vec<Type>)),
-    MoveToDeprecated(Identifier),
-    MoveToGenericDeprecated((Identifier, Vec<Type>)),
+    MutBorrowGlobalDeprecated(Box<StructRef<S>>),
+    ImmBorrowGlobalDeprecated(Box<StructRef<S>>),
+    ExistsDeprecated(Box<StructRef<S>>),
+    MoveFromDeprecated(Box<StructRef<S>>),
+    MoveToDeprecated(Box<StructRef<S>>),
 }
 
-impl Constant {
-    pub fn new(m: &CompiledModule, constant: &crate::file_format::Constant) -> Self {
-        Self {
-            type_: Type::new(m, &constant.type_),
-            data: constant.data.clone(),
+   impl<S> ModuleId<S> {
+    pub fn new<Pool: StringPool<String = S>>(
+        pool: &mut Pool,
+        id: &move_core_types::language_storage::ModuleId,
+    ) -> Self {
+        let address = *id.address();
+        let name = pool.intern(id.name());
+        ModuleId { address, name }
+    }
+
+    pub fn to_core_module_id<Pool: StringPool<String = S>>(
+        &self,
+        pool: &Pool,
+    ) -> move_core_types::language_storage::ModuleId {
+        move_core_types::language_storage::ModuleId::new(
+            self.address,
+            pool.as_ident_str(&self.name).to_owned(),
+        )
+    }
+}
+
+impl<S> Type<S> {
+    /// Create a normalized `Type` for `SignatureToken` `s` in module `m`.
+  pub fn new<Pool: StringPool<String = S>>(
+        pool: &mut Pool,
+        m: &CompiledModule,
+        s: &SignatureToken,
+    ) -> Self {
+        use SignatureToken as S;
+        match s {
+            S::Datatype(idx) => {
+                let dt = Datatype::new(pool, m, *idx, &[]);
+                Type::Datatype(Box::new(dt))
+            }
+            S::DatatypeInstantiation(inst) => {
+                let (idx, type_actuals) = &**inst;
+                let dt = Datatype::new(pool, m, *idx, type_actuals);
+                Type::Datatype(Box::new(dt))
+            }
+            S::Bool => Type::Bool,
+            S::U8 => Type::U8,
+            S::U16 => Type::U16,
+            S::U32 => Type::U32,
+            S::U64 => Type::U64,
+            S::U128 => Type::U128,
+            S::U256 => Type::U256,
+            S::Address => Type::Address,
+            S::Signer => Type::Signer,
+            S::Vector(t) => Type::Vector(Box::new(Type::new(pool, m, t))),
+            S::TypeParameter(i) => Type::TypeParameter(*i),
+            S::Reference(t) => Type::Reference(false, Box::new(Type::new(pool, m, t))),
+            S::MutableReference(t) => Type::Reference(true, Box::new(Type::new(pool, m, t))),
+        }
+    }
+
+    pub fn signature<Pool: StringPool<String = S>>(
+        pool: &mut Pool,
+        m: &CompiledModule,
+        signature: &file_format::Signature,
+    ) -> Signature<S> {
+        let tys = signature
+            .0
+            .iter()
+            .map(|t| Rc::new(Type::new(pool, m, t)))
+            .collect();
+        Rc::new(tys)
+     }
+
+    pub fn to_type_tag<Pool: StringPool<String = S>>(&self, pool: &Pool) -> Option<TypeTag> {
+        use Type as T;
+        if !self.is_closed() {
+            return None;
+        }
+        Some(match self {
+            T::Reference(_, _) => return None,
+            T::Bool => TypeTag::Bool,
+            T::U8 => TypeTag::U8,
+            T::U16 => TypeTag::U16,
+            T::U32 => TypeTag::U32,
+            T::U64 => TypeTag::U64,
+            T::U128 => TypeTag::U128,
+            T::U256 => TypeTag::U256,
+            T::Address => TypeTag::Address,
+            T::Signer => TypeTag::Signer,
+            T::Vector(t) => TypeTag::Vector(Box::new(
+                t.to_type_tag(pool)
+                    .expect("Invariant violation: vector type argument contains reference"),
+            )),
+            T::Datatype(dt) => TypeTag::Struct(Box::new(dt.to_struct_tag(pool))),
+            T::TypeParameter(_) => unreachable!(),
+         })
+    }
+
+pub fn to_struct_tag<Pool: StringPool<String = S>>(&self, pool: &Pool) -> Option<StructTag> {
+        match self.to_type_tag(pool)? {
+            TypeTag::Struct(s) => Some(*s),
+            _ => None,
+        }
+    }
+
+pub fn from_type_tag<Pool: StringPool<String = S>>(pool: &mut Pool, ty: &TypeTag) -> Self {
+        use Type as T;
+        match ty {
+            TypeTag::Bool => T::Bool,
+            TypeTag::U8 => T::U8,
+            TypeTag::U16 => T::U16,
+            TypeTag::U32 => T::U32,
+            TypeTag::U64 => T::U64,
+            TypeTag::U128 => T::U128,
+            TypeTag::U256 => T::U256,
+            TypeTag::Address => T::Address,
+            TypeTag::Signer => T::Signer,
+            TypeTag::Vector(ty) => T::Vector(Box::new(T::from_type_tag(pool, ty))),
+            TypeTag::Struct(s) => T::Datatype(Box::new(Datatype::from_struct_tag(pool, s))),
+        }
+    }
+    pub fn from_struct_tag<Pool: StringPool<String = S>>(pool: &mut Pool, tag: &StructTag) -> Self {
+        Type::Datatype(Box::new(Datatype::from_struct_tag(pool, tag)))
+    }
+
+    /// Return true if `self` is a closed type with no free type variables
+    pub fn is_closed(&self) -> bool {
+        use Type as T;
+        match self {
+            T::TypeParameter(_) => false,
+            T::Bool => true,
+            T::U8 => true,
+            T::U16 => true,
+            T::U32 => true,
+            T::U64 => true,
+            T::U128 => true,
+            T::U256 => true,
+            T::Address => true,
+            T::Signer => true,
+            T::Datatype(dt) => dt.is_closed(),
+            T::Vector(t) | T::Reference(_, t) => t.is_closed(),
+        }
+    }
+
+    pub fn subst(&self, type_args: &[Type<S>]) -> Self
+    where
+       S: Clone,
+    {
+        use Type as T;
+        match self {
+            T::Bool
+            | T::U8
+            | T::U16
+            | T::U32
+            | T::U64
+            | T::U128
+            | T::U256
+            | T::Address
+            | T::Signer => self.clone(),
+            T::Reference(mut_, ty) => T::Reference(*mut_, Box::new(ty.subst(type_args))),
+            T::Vector(t) => T::Vector(Box::new(t.subst(type_args))),
+            T::Datatype(dt) => T::Datatype(Box::new(dt.subst(type_args))),
+            T::TypeParameter(i) => type_args
+                .get(*i as usize)
+                .expect("Type parameter index out of bound")
+                .clone(),
         }
     }
 }
 
-/// Normalized version of a `CompiledModule`: its address, name, struct
-/// declarations, and public function declarations.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Module {
-    pub file_format_version: u32,
-    pub address: AccountAddress,
-    pub name: Identifier,
-    pub dependencies: Vec<ModuleId>,
-    pub friends: Vec<ModuleId>,
-    pub structs: BTreeMap<Identifier, Struct>,
-    pub enums: BTreeMap<Identifier, Enum>,
-    pub functions: BTreeMap<Identifier, Function>,
-    pub constants: Vec<Constant>,
+impl<S> Datatype<S> {
+    /// Case for `Datatype` and `DatatypeInst` when normalizing `SignatureToken`
+    pub fn new<Pool: StringPool<String = S>>(
+        pool: &mut Pool,
+        m: &CompiledModule,
+        idx: DatatypeHandleIndex,
+        type_arguments: &[SignatureToken],
+    ) -> Self {
+        let datatype_handle = m.datatype_handle_at(idx);
+        let defining_module_handle = m.module_handle_at(datatype_handle.module);
+        let datatype_name = pool.intern(m.identifier_at(datatype_handle.name));
+        let defining_module_address = *m.address_identifier_at(defining_module_handle.address);
+        let defining_module_name = pool.intern(m.identifier_at(defining_module_handle.name));
+        let type_arguments = type_arguments
+            .iter()
+            .map(|t| Type::new(pool, m, t))
+            .collect();
+        Datatype {
+            module: ModuleId {
+                address: defining_module_address,
+                name: defining_module_name,
+            },
+            name: datatype_name,
+            type_arguments,
+        }
+    }
+
+    pub fn to_struct_tag<Pool: StringPool<String = S>>(&self, pool: &Pool) -> StructTag {
+        let Datatype {
+            module,
+            name,
+            type_arguments,
+        } = self;
+        StructTag {
+            address: module.address,
+            module: pool.as_ident_str(&module.name).to_owned(),
+            name: pool.as_ident_str(name).to_owned(),
+            type_params: type_arguments
+                .iter()
+                .map(|t| {
+                    t.to_type_tag(pool)
+                        .expect("Invariant violation: struct type argument contains reference")
+                })
+                .collect(),
+        }
+    }
+
+    pub fn from_struct_tag<Pool: StringPool<String = S>>(pool: &mut Pool, tag: &StructTag) -> Self {
+        let StructTag {
+            address,
+            module,
+            name,
+            type_params,
+        } = tag;
+        Datatype {
+            module: ModuleId {
+                address: *address,
+                name: pool.intern(module.as_ident_str()),
+            },
+            name: pool.intern(name.as_ident_str()),
+            type_arguments: type_params
+                .iter()
+                .map(|t| Type::from_type_tag(pool, t))
+                .collect(),
+        }
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.type_arguments.iter().all(|t| t.is_closed())
+    }
+
+    pub fn subst(&self, type_args: &[Type<S>]) -> Self
+    where
+        S: Clone,
+    {
+        let Self {
+            module,
+            name,
+            type_arguments,
+        } = self;
+        let type_arguments = type_arguments.iter().map(|t| t.subst(type_args)).collect();
+        Self {
+            module: module.clone(),
+            name: name.clone(),
+            type_arguments,
+        }
+
+}
 }
 
-impl Module {
-    /// Extract a normalized module from a `CompiledModule`. The module `m`
-    /// should be verified. Nothing will break here if that is not the case,
-    /// but there is little point in computing a normalized representation
-    /// of a module that won't verify (since it can't be published).
-    pub fn new(m: &CompiledModule) -> Self {
-        let friends = m.immediate_friends();
-        let structs = m.struct_defs().iter().map(|d| Struct::new(m, d)).collect();
-        let enums = m.enum_defs().iter().map(|d| Enum::new(m, d)).collect();
-        let dependencies = m.immediate_dependencies();
-        let constants = m
-            .constant_pool()
+impl<S> Tables<S> {
+    fn new<Pool: StringPool<String = S>>(
+        pool: &mut Pool,
+        m: &CompiledModule,
+        include_code: bool,
+    ) -> Self {
+        let mut tables = Tables {
+            empty_signature: Rc::new(vec![]),
+            signatures: Vec::new(),
+            constants: Vec::new(),
+            struct_defs: Vec::new(),
+            function_defs: Vec::new(),
+            enum_defs: Vec::new(),
+        };
+        tables.signatures = m
+            .signatures
             .iter()
-            .map(|constant| Constant::new(m, constant))
+            .map(|s| Type::signature(pool, m, s))
             .collect();
-        let functions = m
-            .function_defs()
+        tables.constants = m
+            .constant_pool
             .iter()
-            .map(|func_def| Function::new(m, func_def))
+            .map(|c| Rc::new(Constant::new(pool, m, c)))
+            .collect();
+        tables.struct_defs = m
+            .struct_defs
+            .iter()
+            .map(|s| Rc::new(Struct::new(pool, m, s)))
+            .collect();
+        tables.enum_defs = m
+            .enum_defs
+            .iter()
+            .map(|e| Rc::new(Enum::new(pool, m, e)))
+            .collect();
+        tables.function_defs = m
+            .function_defs
+            .iter()
+            .map(|f| Rc::new(Function::new(&tables, pool, m, f, include_code)))
+            .collect();
+        tables
+    }
+}
+
+impl<S: Hash + Eq> Module<S> {
+    /// Extract a normalized module from a `CompiledModule`. The module `m` should be verified,
+    /// particularly with regards to correct offsets and bounds.
+    /// If `include_code` is `false`, the bodies of the functions are not included but the
+    /// signatures will still be present.
+    pub fn new<Pool: StringPool<String = S>>(
+        pool: &mut Pool,
+        m: &CompiledModule,
+        include_code: bool,
+    ) -> Self
+    where
+        S: Clone,
+    {
+        let tables = Tables::new(pool, m, include_code);
+        let id = ModuleId::new(pool, &m.self_id());
+        let friends = m
+            .immediate_friends()
+            .into_iter()
+            .map(|f| ModuleId::new(pool, &f))
+            .collect();
+        let dependencies = m
+            .immediate_dependencies()
+            .into_iter()
+            .map(|d| ModuleId::new(pool, &d))
+            .collect();
+        let constants = (0..m.constant_pool.len())
+            .map(|idx| tables.constants[idx].clone())
+            .collect();
+        let structs = (0..m.struct_defs.len())
+            .map(|idx| {
+                let def = tables.struct_defs[idx].clone();
+                (def.name.clone(), def)
+            })
+            .collect();
+        let enums = (0..m.enum_defs.len())
+            .map(|idx| {
+                let def = tables.enum_defs[idx].clone();
+                (def.name.clone(), def)
+            })
+            .collect();
+        let functions = (0..m.function_defs.len())
+            .map(|idx| {
+                let def = tables.function_defs[idx].clone();
+                (def.name.clone(), def)
+            })
             .collect();
         Self {
+            tables,
+            code_included: include_code,
+            id,
             file_format_version: m.version(),
-            address: *m.address(),
-            name: m.name().to_owned(),
             friends,
             structs,
             enums,
@@ -312,190 +668,93 @@ impl Module {
         }
     }
 
-    pub fn module_id(&self) -> ModuleId {
-        ModuleId::new(self.address, self.name.clone())
-    }
-}
-
-impl Type {
-    /// Create a normalized `Type` for `SignatureToken` `s` in module `m`.
-    pub fn new(m: &CompiledModule, s: &SignatureToken) -> Self {
-        use SignatureToken::*;
-        match s {
-            Datatype(shi) => {
-                let s_handle = m.datatype_handle_at(*shi);
-                assert!(
-                    s_handle.type_parameters.is_empty(),
-                    "A struct with N type parameters should be encoded as StructModuleInstantiation with type_arguments = [TypeParameter(1), ..., TypeParameter(N)]"
-                );
-                let m_handle = m.module_handle_at(s_handle.module);
-                Type::Struct {
-                    address: *m.address_identifier_at(m_handle.address),
-                    module: m.identifier_at(m_handle.name).to_owned(),
-                    name: m.identifier_at(s_handle.name).to_owned(),
-                    type_arguments: Vec::new(),
-                }
-            }
-            DatatypeInstantiation(inst) => {
-                let (shi, type_actuals) = &**inst;
-                let s_handle = m.datatype_handle_at(*shi);
-                let m_handle = m.module_handle_at(s_handle.module);
-                Type::Struct {
-                    address: *m.address_identifier_at(m_handle.address),
-                    module: m.identifier_at(m_handle.name).to_owned(),
-                    name: m.identifier_at(s_handle.name).to_owned(),
-                    type_arguments: type_actuals.iter().map(|t| Type::new(m, t)).collect(),
-                }
-            }
-            Bool => Type::Bool,
-            U8 => Type::U8,
-            U16 => Type::U16,
-            U32 => Type::U32,
-            U64 => Type::U64,
-            U128 => Type::U128,
-            U256 => Type::U256,
-            Address => Type::Address,
-            Signer => Type::Signer,
-            Vector(t) => Type::Vector(Box::new(Type::new(m, t))),
-            TypeParameter(i) => Type::TypeParameter(*i),
-            Reference(t) => Type::Reference(Box::new(Type::new(m, t))),
-            MutableReference(t) => Type::MutableReference(Box::new(Type::new(m, t))),
-        }
+    pub fn address(&self) -> &AccountAddress {
+        &self.id.address
     }
 
-    /// Return true if `self` is a closed type with no free type variables
-    pub fn is_closed(&self) -> bool {
-        use Type::*;
-        match self {
-            TypeParameter(_) => false,
-            Bool => true,
-            U8 => true,
-            U16 => true,
-            U32 => true,
-            U64 => true,
-            U128 => true,
-            U256 => true,
-            Address => true,
-            Signer => true,
-            Struct { type_arguments, .. } => type_arguments.iter().all(|t| t.is_closed()),
-            Vector(t) | Reference(t) | MutableReference(t) => t.is_closed(),
-        }
+    pub fn name(&self) -> &S {
+        &self.id.name
     }
 
-    pub fn into_type_tag(self) -> Option<TypeTag> {
-        use Type::*;
-        Some(if self.is_closed() {
-            match self {
-                Reference(_) | MutableReference(_) => return None,
-                Bool => TypeTag::Bool,
-                U8 => TypeTag::U8,
-                U16 => TypeTag::U16,
-                U32 => TypeTag::U32,
-                U64 => TypeTag::U64,
-                U128 => TypeTag::U128,
-                U256 => TypeTag::U256,
-                Address => TypeTag::Address,
-                Signer => TypeTag::Signer,
-                Vector(t) => TypeTag::Vector(Box::new(
-                    t.into_type_tag()
-                        .expect("Invariant violation: vector type argument contains reference"),
-                )),
-                Struct {
-                    address,
-                    module,
-                    name,
-                    type_arguments,
-                } => TypeTag::Struct(Box::new(StructTag {
-                    address,
-                    module,
-                    name,
-                    type_params: type_arguments
-                        .into_iter()
-                        .map(|t| {
-                            t.into_type_tag().expect(
-                                "Invariant violation: struct type argument contains reference",
-                            )
-                        })
-                        .collect(),
-                })),
-                TypeParameter(_) => unreachable!(),
-            }
-        } else {
-            return None;
-        })
-    }
-
-    pub fn into_struct_tag(self) -> Option<StructTag> {
-        match self.into_type_tag()? {
-            TypeTag::Struct(s) => Some(*s),
-            _ => None,
-        }
-    }
-
-    pub fn subst(&self, type_args: &[Type]) -> Self {
-        use Type::*;
-        match self {
-            Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address | Signer => self.clone(),
-            Reference(ty) => Reference(Box::new(ty.subst(type_args))),
-            MutableReference(ty) => MutableReference(Box::new(ty.subst(type_args))),
-            Vector(t) => Vector(Box::new(t.subst(type_args))),
-            Struct {
-                address,
-                module,
-                name,
-                type_arguments,
-            } => Struct {
-                address: *address,
-                module: module.clone(),
-                name: name.clone(),
-                type_arguments: type_arguments
+    /// Panics if called with `include_code` set to `false`.
+    /// Note this checks the order of functions, structs, and enums in the module.
+    pub fn equals(&self, other: &Self) -> bool {
+        fn function_equals<S: Hash + Eq>(
+            functions: &IndexMap<S, Rc<Function<S>>>,
+            other_functions: &IndexMap<S, Rc<Function<S>>>,
+        ) -> bool {
+            functions.len() == other_functions.len()
+                && functions
                     .iter()
-                    .map(|t| t.subst(type_args))
-                    .collect::<Vec<_>>(),
-            },
-            TypeParameter(i) => type_args
-                .get(*i as usize)
-                .expect("Type parameter index out of bound")
-                .clone(),
+                    .zip(other_functions)
+                    .all(|((n1, f1), (n2, f2))| n1 == n2 && f1.equals(f2))
+        }
+        let Self {
+            tables: _,
+            code_included,
+            id,
+            file_format_version,
+            dependencies,
+            friends,
+            structs,
+            enums,
+            functions,
+            constants,
+        } = self;
+        if !code_included || !other.code_included {
+            debug_assert!(false, "code_included is false when calling equals");
+            return false;
+        }
+        id == &other.id
+            && file_format_version == &other.file_format_version
+            && dependencies == &other.dependencies
+            && friends == &other.friends
+            && structs == &other.structs
+            && enums == &other.enums
+            && function_equals(functions, &other.functions)
+            && constants == &other.constants
+    }
+}
+
+impl<S> Constant<S> {
+    pub fn new<Pool: StringPool<String = S>>(
+        pool: &mut Pool,
+        m: &CompiledModule,
+        constant: &file_format::Constant,
+    ) -> Self {
+        Self {
+            type_: Type::new(pool, m, &constant.type_),
+            data: constant.data.clone(),
         }
     }
 }
 
-impl Field {
-    /// Create a `Field` for `FieldDefinition` `f` in module `m`.
-    pub fn new(m: &CompiledModule, f: &FieldDefinition) -> Self {
-        Field {
-            name: m.identifier_at(f.name).to_owned(),
-            type_: Type::new(m, &f.signature.0),
-        }
-    }
-}
-
-impl Struct {
+impl<S> Struct<S> {
     /// Create a `Struct` for `StructDefinition` `def` in module `m`. Panics if
     /// `def` is a a native struct definition.
-    pub fn new(m: &CompiledModule, def: &StructDefinition) -> (Identifier, Self) {
+   fn new<Pool: StringPool<String = S>>(
+        pool: &mut Pool,
+        m: &CompiledModule,
+        def: &StructDefinition,
+    ) -> Self {
         let handle = m.datatype_handle_at(def.struct_handle);
         let fields = match &def.field_information {
             StructFieldInformation::Native => {
                 // Pretend for compatibility checking no fields
                 vec![]
             }
-            StructFieldInformation::Declared(fields) => {
-                fields.iter().map(|f| Field::new(m, f)).collect()
-            }
+            StructFieldInformation::Declared(fields) => fields
+                .iter()
+                .map(|f| Rc::new(Field::new(pool, m, f)))
+                .collect(),
         };
-        let name = m.identifier_at(handle.name).to_owned();
-        let s = Struct {
-            abilities: handle.abilities,
-            type_parameters: handle.type_parameters.clone(),
-            fields,
-        };
-        (name, s)
-    }
-
-    pub fn from_idx(m: &CompiledModule, idx: &StructDefinitionIndex) -> (Identifier, Self) {
-        Self::new(m, m.struct_def_at(*idx))
+       let name = pool.intern(m.identifier_at(handle.name));
+       Struct {
+           name,
+           abilities: handle.abilities,
+           type_parameters: handle.type_parameters.clone(),
+           fields,
+       }
     }
 
     pub fn type_param_constraints(&self) -> impl ExactSizeIterator<Item = &AbilitySet> {
@@ -503,149 +762,306 @@ impl Struct {
     }
 }
 
-impl Function {
+impl<S> Field<S> {
+    /// Create a `Field` for `FieldDefinition` `f` in module `m`.
+    pub fn new<Pool: StringPool<String = S>>(
+        pool: &mut Pool,
+        m: &CompiledModule,
+        f: &FieldDefinition,
+    ) -> Self {
+        Field {
+            name: pool.intern(m.identifier_at(f.name)),
+            type_: Type::new(pool, m, &f.signature.0),
+        }
+    }
+}
+
+impl<S> Function<S> {
     /// Create a `FunctionSignature` for `FunctionHandle` `f` in module `m`.
-    pub fn new(m: &CompiledModule, def: &FunctionDefinition) -> (Identifier, Self) {
+    fn new<Pool: StringPool<String = S>>(
+        tables: &Tables<S>,
+        pool: &mut Pool,
+        m: &CompiledModule,
+        def: &FunctionDefinition,
+        include_code: bool,
+    ) -> Self {
         let fhandle = m.function_handle_at(def.function);
-        let name = m.identifier_at(fhandle.name).to_owned();
-        let code: Vec<_> = def
-            .code
-            .as_ref()
-            .map(|code| {
-                code.code
-                    .iter()
-                    .map(|bytecode| Bytecode::new(m, bytecode, &code.jump_tables))
-                    .collect()
-            })
-            .unwrap_or_default();
-        let f = Function {
+        let name = pool.intern(m.identifier_at(fhandle.name));
+        let (jump_tables, code) = if include_code {
+            let jump_tables = def
+                .code
+                .iter()
+                .flat_map(|code| code.jump_tables.iter())
+                .map(|jt| Rc::new(VariantJumpTable::new(tables, jt)))
+                .collect::<Vec<_>>();
+            let code = def
+                .code
+                .as_ref()
+                .map(|code| {
+                    code.code
+                        .iter()
+                        .map(|bytecode| Bytecode::new(tables, pool, m, bytecode, &jump_tables))
+                        .collect()
+                })
+                .unwrap_or_default();
+            (jump_tables, code)
+        } else {
+            (vec![], vec![])
+        };
+        Function {
+            name,
             visibility: def.visibility,
             is_entry: def.is_entry,
             type_parameters: fhandle.type_parameters.clone(),
-            parameters: m
-                .signature_at(fhandle.parameters)
-                .0
-                .iter()
-                .map(|s| Type::new(m, s))
-                .collect(),
-            return_: m
-                .signature_at(fhandle.return_)
-                .0
-                .iter()
-                .map(|s| Type::new(m, s))
-                .collect(),
+            parameters: tables.signatures[fhandle.parameters.0 as usize].clone(),
+            return_: tables.signatures[fhandle.return_.0 as usize].clone(),
+            code_included: include_code,
+            jump_tables,
             code,
-        };
-        (name, f)
-    }
-
-    /// Create a `Function` for function named `func_name` in module `m`.
-    pub fn new_from_name(m: &CompiledModule, func_name: &IdentStr) -> Option<Self> {
-        for func_defs in &m.function_defs {
-            if m.identifier_at(m.function_handle_at(func_defs.function).name) == func_name {
-                return Some(Self::new(m, func_defs).1);
-            }
-        }
-        None
-    }
-}
-
-impl From<TypeTag> for Type {
-    fn from(ty: TypeTag) -> Type {
-        use Type::*;
-        match ty {
-            TypeTag::Bool => Bool,
-            TypeTag::U8 => U8,
-            TypeTag::U16 => U16,
-            TypeTag::U32 => U32,
-            TypeTag::U64 => U64,
-            TypeTag::U128 => U128,
-            TypeTag::U256 => U256,
-            TypeTag::Address => Address,
-            TypeTag::Signer => Signer,
-            TypeTag::Vector(ty) => Vector(Box::new(Type::from(*ty))),
-            TypeTag::Struct(s) => Struct {
-                address: s.address,
-                module: s.module,
-                name: s.name,
-                type_arguments: s.type_params.into_iter().map(|ty| ty.into()).collect(),
-            },
-        }
-    }
-}
-
-impl FieldRef {
-    pub fn new(m: &CompiledModule, field_handle: &FieldHandle) -> Self {
-        Self {
-            struct_name: m.struct_name(field_handle.owner).to_owned(),
-            field_index: field_handle.field,
         }
     }
 
-    pub fn from_idx(m: &CompiledModule, field_handle_idx: &FieldHandleIndex) -> Self {
-        Self::new(m, m.field_handle_at(*field_handle_idx))
-    }
-}
-
-impl FunctionRef {
-    pub fn new(m: &CompiledModule, function_handle: &FunctionHandle) -> Self {
-        Self {
-            module_id: m.module_id_for_handle(m.module_handle_at(function_handle.module)),
-            function_ident: m.identifier_at(function_handle.name).to_owned(),
-        }
+    // Panics if `code_included` is `false`.
+    pub fn code(&self) -> &[Bytecode<S>] {
+        assert!(self.code_included);
+        &self.code
     }
 
-    pub fn from_idx(m: &CompiledModule, function_handle_idx: &FunctionHandleIndex) -> Self {
-        Self::new(m, m.function_handle_at(*function_handle_idx))
-    }
-}
-
-impl VariantHandle {
-    pub fn from_variant_handle(
-        m: &CompiledModule,
-        variant_handle: &VariantHandleIndex,
-    ) -> VariantHandle {
-        let variant_handle = m.variant_handle_at(*variant_handle);
-        let enum_def = m.enum_def_at(variant_handle.enum_def);
-        let enum_handle = m.datatype_handle_at(enum_def.enum_handle);
-        let enum_name = m.identifier_at(enum_handle.name).to_owned();
-        let type_parameters = vec![];
-        VariantHandle {
-            enum_name,
-            variant_index: variant_handle.variant,
+    /// Should not be called if `code_included` is `false`--will panic in debug builds.
+    pub fn equals(&self, other: &Self) -> bool
+    where
+        S: Eq,
+    {
+        let Self {
+            name,
+            visibility,
+            is_entry,
             type_parameters,
+            parameters,
+            return_,
+            code_included,
+            jump_tables,
+            code,
+        } = self;
+        if !code_included || !other.code_included {
+            debug_assert!(false, "code_included is false when calling equals");
+            return false;
         }
+        name == &other.name
+            && visibility == &other.visibility
+            && is_entry == &other.is_entry
+            && type_parameters == &other.type_parameters
+            && parameters == &other.parameters
+            && return_ == &other.return_
+            && jump_tables == &other.jump_tables
+            && code == &other.code
     }
+}
 
-    pub fn from_variant_instantiation_handle(
+impl<S> Enum<S> {
+    pub fn new<Pool: StringPool<String = S>>(
+        pool: &mut Pool,
         m: &CompiledModule,
-        variant_instantiation_handle: &VariantInstantiationHandleIndex,
-    ) -> VariantHandle {
-        let variant_instantiation_handle =
-            m.variant_instantiation_handle_at(*variant_instantiation_handle);
-        let enum_inst = m.enum_instantiation_at(variant_instantiation_handle.enum_def);
-        let enum_def = m.enum_def_at(enum_inst.def);
-        let enum_handle = m.datatype_handle_at(enum_def.enum_handle);
-        let enum_name = m.identifier_at(enum_handle.name).to_owned();
-        let type_parameters = m
-            .signature_at(enum_inst.type_parameters)
-            .0
+        def: &EnumDefinition,
+    ) -> Self {
+        let handle = m.datatype_handle_at(def.enum_handle);
+        let name = pool.intern(m.identifier_at(handle.name));
+        let variants = def
+            .variants
             .iter()
-            .map(|tok| Type::new(m, tok))
-            .collect();
-        VariantHandle {
-            enum_name,
-            variant_index: variant_instantiation_handle.variant,
-            type_parameters,
+            .map(|v| Rc::new(Variant::new(pool, m, v)))
+            .collect::<Vec<_>>();
+        Enum {
+            name,
+            abilities: handle.abilities,
+            type_parameters: handle.type_parameters.clone(),
+            variants,
         }
     }
 }
 
-impl Bytecode {
-    pub fn new(
+impl<S> Variant<S> {
+    pub fn new<Pool: StringPool<String = S>>(
+        pool: &mut Pool,
+        m: &CompiledModule,
+        v: &VariantDefinition,
+    ) -> Self {
+        Self {
+            name: pool.intern(m.identifier_at(v.variant_name)),
+            fields: v.fields.iter().map(|f| Field::new(pool, m, f)).collect(),
+        }
+    }
+}
+
+impl<S> VariantJumpTable<S> {
+    fn new(tables: &Tables<S>, jt: &file_format::VariantJumpTable) -> Self {
+        let enum_ = tables.enum_defs[jt.head_enum.0 as usize].clone();
+        Self {
+            enum_,
+            jump_table: jt.jump_table.clone(),
+        }
+    }
+}
+
+impl<S> StructRef<S> {
+    fn new(
+        tables: &Tables<S>,
+        struct_handle: StructDefinitionIndex,
+        type_arguments: Option<SignatureIndex>,
+    ) -> Self {
+        let struct_ = tables.struct_defs[struct_handle.0 as usize].clone();
+        let type_arguments = type_arguments
+            .map(|idx| tables.signatures[idx.0 as usize].clone())
+            .unwrap_or_else(|| tables.empty_signature.clone());
+        Self {
+            struct_,
+            type_arguments,
+        }
+    }
+
+    fn instantiated(
+        tables: &Tables<S>,
+        m: &CompiledModule,
+        idx: StructDefInstantiationIndex,
+    ) -> Self {
+        let struct_instantiation = m.struct_instantiation_at(idx);
+        Self::new(
+            tables,
+            struct_instantiation.def,
+            Some(struct_instantiation.type_parameters),
+        )
+    }
+}
+
+impl<S> FieldRef<S> {
+    fn new(
+        tables: &Tables<S>,
+        m: &CompiledModule,
+        idx: FieldHandleIndex,
+        instantiation: Option<SignatureIndex>,
+    ) -> Self {
+        let field_handle = m.field_handle_at(idx);
+        let struct_ = tables.struct_defs[field_handle.owner.0 as usize].clone();
+        let field = struct_.fields[field_handle.field as usize].clone();
+        let instantiation = instantiation
+            .map(|idx| tables.signatures[idx.0 as usize].clone())
+            .unwrap_or_else(|| tables.empty_signature.clone());
+        Self {
+            struct_,
+            field,
+            instantiation,
+        }
+    }
+
+    fn instantiated(tables: &Tables<S>, m: &CompiledModule, idx: FieldInstantiationIndex) -> Self {
+        let field_instantiation = m.field_instantiation_at(idx);
+        Self::new(
+            tables,
+            m,
+            field_instantiation.handle,
+            Some(field_instantiation.type_parameters),
+        )
+    }
+}
+
+impl<S> FunctionRef<S> {
+    fn new<Pool: StringPool<String = S>>(
+        tables: &Tables<S>,
+        pool: &mut Pool,
+        m: &CompiledModule,
+        idx: FunctionHandleIndex,
+        type_arguments: Option<SignatureIndex>,
+    ) -> Self {
+        let function_handle = m.function_handle_at(idx);
+        let module_handle = m.module_handle_at(function_handle.module);
+        let module = ModuleId {
+            address: *m.address_identifier_at(module_handle.address),
+            name: pool.intern(m.identifier_at(module_handle.name)),
+        };
+        let function = pool.intern(m.identifier_at(function_handle.name));
+        let type_arguments = type_arguments
+            .map(|idx| tables.signatures[idx.0 as usize].clone())
+            .unwrap_or_else(|| tables.empty_signature.clone());
+        Self {
+            module,
+            function,
+            type_arguments,
+        }
+    }
+
+    fn instantiated<Pool: StringPool<String = S>>(
+        tables: &Tables<S>,
+        pool: &mut Pool,
+        m: &CompiledModule,
+        idx: FunctionInstantiationIndex,
+    ) -> Self {
+        let function_instantiation = m.function_instantiation_at(idx);
+        Self::new(
+            tables,
+            pool,
+            m,
+            function_instantiation.handle,
+            Some(function_instantiation.type_parameters),
+        )
+    }
+}
+
+impl<S> VariantRef<S> {
+    fn new(
+        tables: &Tables<S>,
+        enum_def: EnumDefinitionIndex,
+        variant: VariantTag,
+        instantiation: Option<SignatureIndex>,
+    ) -> VariantRef<S> {
+        let enum_ = tables.enum_defs[enum_def.0 as usize].clone();
+        let variant = enum_.variants[variant as usize].clone();
+        let instantiation = instantiation
+            .map(|idx| tables.signatures[idx.0 as usize].clone())
+            .unwrap_or_else(|| tables.empty_signature.clone());
+        VariantRef {
+            enum_,
+            variant,
+            instantiation,
+        }
+    }
+
+    fn noninstantiated(
+        tables: &Tables<S>,
+        m: &CompiledModule,
+        idx: VariantHandleIndex,
+    ) -> VariantRef<S> {
+        let variant_handle = m.variant_handle_at(idx);
+        VariantRef::new(
+            tables,
+            variant_handle.enum_def,
+            variant_handle.variant,
+            None,
+        )
+    }
+
+    fn instantiated(
+        tables: &Tables<S>,
+        m: &CompiledModule,
+        idx: VariantInstantiationHandleIndex,
+    ) -> VariantRef<S> {
+        let variant_instantiation = m.variant_instantiation_handle_at(idx);
+        let enum_instantiation = m.enum_instantiation_at(variant_instantiation.enum_def);
+        VariantRef::new(
+            tables,
+            enum_instantiation.def,
+            variant_instantiation.variant,
+            Some(enum_instantiation.type_parameters),
+        )
+    }
+}
+
+impl<S> Bytecode<S> {
+    fn new<Pool: StringPool<String = S>>(
+        tables: &Tables<S>,
+        pool: &mut Pool,
         m: &CompiledModule,
         bytecode: &FBytecode,
-        jump_tables: &[FFVariantJumpTable],
+        jump_tables: &[Rc<VariantJumpTable<S>>],
     ) -> Self {
         use Bytecode as B;
         use FBytecode as FB;
@@ -689,177 +1105,119 @@ impl Bytecode {
             FB::Branch(x) => B::Branch(*x),
             FB::LdU8(x) => B::LdU8(*x),
             FB::LdU64(x) => B::LdU64(*x),
-            FB::LdU128(x) => B::LdU128(**x),
+            FB::LdU128(x) => B::LdU128(x.clone()),
             FB::CopyLoc(x) => B::CopyLoc(*x),
             FB::MoveLoc(x) => B::MoveLoc(*x),
             FB::StLoc(x) => B::StLoc(*x),
             FB::LdU16(x) => B::LdU16(*x),
             FB::LdU32(x) => B::LdU32(*x),
-            FB::LdU256(x) => B::LdU256(**x),
-            FB::LdConst(const_idx) => B::LdConst(Constant::new(m, m.constant_at(*const_idx))),
-            FB::Call(fh_idx) => B::Call(FunctionRef::from_idx(m, fh_idx)),
-            FB::CallGeneric(fhi_idx) => {
-                let FunctionInstantiation {
-                    handle,
-                    type_parameters,
-                } = m.function_instantiation_at(*fhi_idx);
-                let type_params = m.signature_at(*type_parameters);
-                B::CallGeneric((
-                    FunctionRef::from_idx(m, handle),
-                    type_params.0.iter().map(|tok| Type::new(m, tok)).collect(),
-                ))
-            }
-            FB::Pack(s_idx) => B::Pack(m.struct_name(*s_idx).to_owned()),
-            FB::PackGeneric(s_idx) => B::PackGeneric(struct_instantiation(m, s_idx)),
-            FB::Unpack(s_idx) => B::Unpack(m.struct_name(*s_idx).to_owned()),
-            FB::UnpackGeneric(si_idx) => B::UnpackGeneric(struct_instantiation(m, si_idx)),
+            FB::LdU256(x) => B::LdU256(x.clone()),
+            FB::LdConst(const_idx) => B::LdConst(tables.constants[const_idx.0 as usize].clone()),
+            FB::Call(fh_idx) => B::Call(Box::new(FunctionRef::new(tables, pool, m, *fh_idx, None))),
+            FB::CallGeneric(fhi_idx) => B::Call(Box::new(FunctionRef::instantiated(
+                tables, pool, m, *fhi_idx,
+            ))),
+            FB::Pack(idx) => B::Pack(Box::new(StructRef::new(tables, *idx, None))),
+            FB::PackGeneric(idx) => B::Pack(Box::new(StructRef::instantiated(tables, m, *idx))),
+            FB::Unpack(idx) => B::Unpack(Box::new(StructRef::new(tables, *idx, None))),
+            FB::UnpackGeneric(idx) => B::Unpack(Box::new(StructRef::instantiated(tables, m, *idx))),
             FB::MutBorrowLoc(x) => B::MutBorrowLoc(*x),
             FB::ImmBorrowLoc(x) => B::ImmBorrowLoc(*x),
-            FB::MutBorrowField(fh_ixd) => B::MutBorrowField(FieldRef::from_idx(m, fh_ixd)),
-            FB::MutBorrowFieldGeneric(fhi_idx) => {
-                B::MutBorrowFieldGeneric(field_instantiation(m, fhi_idx))
+            FB::MutBorrowField(fh_ixd) => {
+                B::MutBorrowField(Box::new(FieldRef::new(tables, m, *fh_ixd, None)))
             }
-            FB::ImmBorrowField(fh_idx) => B::ImmBorrowField(FieldRef::from_idx(m, fh_idx)),
+            FB::MutBorrowFieldGeneric(fhi_idx) => {
+                B::MutBorrowField(Box::new(FieldRef::instantiated(tables, m, *fhi_idx)))
+            }
+            FB::ImmBorrowField(fh_idx) => {
+                B::ImmBorrowField(Box::new(FieldRef::new(tables, m, *fh_idx, None)))
+            }
             FB::ImmBorrowFieldGeneric(fhi_idx) => {
-                B::ImmBorrowFieldGeneric(field_instantiation(m, fhi_idx))
+                B::ImmBorrowField(Box::new(FieldRef::instantiated(tables, m, *fhi_idx)))
             }
             FB::MutBorrowGlobalDeprecated(s_idx) => {
-                B::MutBorrowGlobalDeprecated(m.struct_name(*s_idx).to_owned())
+                B::MutBorrowGlobalDeprecated(Box::new(StructRef::new(tables, *s_idx, None)))
             }
             FB::MutBorrowGlobalGenericDeprecated(si_idx) => {
-                B::MutBorrowGlobalGenericDeprecated(struct_instantiation(m, si_idx))
+                B::MutBorrowGlobalDeprecated(Box::new(StructRef::instantiated(tables, m, *si_idx)))
             }
             FB::ImmBorrowGlobalDeprecated(s_idx) => {
-                B::ImmBorrowGlobalDeprecated(m.struct_name(*s_idx).to_owned())
+                B::ImmBorrowGlobalDeprecated(Box::new(StructRef::new(tables, *s_idx, None)))
             }
             FB::ImmBorrowGlobalGenericDeprecated(si_idx) => {
-                B::ImmBorrowGlobalGenericDeprecated(struct_instantiation(m, si_idx))
+                B::ImmBorrowGlobalDeprecated(Box::new(StructRef::instantiated(tables, m, *si_idx)))
             }
-            FB::ExistsDeprecated(s_idx) => B::ExistsDeprecated(m.struct_name(*s_idx).to_owned()),
+            FB::ExistsDeprecated(s_idx) => {
+                B::ExistsDeprecated(Box::new(StructRef::new(tables, *s_idx, None)))
+            }
             FB::ExistsGenericDeprecated(si_idx) => {
-                B::ExistsGenericDeprecated(struct_instantiation(m, si_idx))
+                B::ExistsDeprecated(Box::new(StructRef::instantiated(tables, m, *si_idx)))
             }
             FB::MoveFromDeprecated(s_idx) => {
-                B::MoveFromDeprecated(m.struct_name(*s_idx).to_owned())
+                B::MoveFromDeprecated(Box::new(StructRef::new(tables, *s_idx, None)))
             }
             FB::MoveFromGenericDeprecated(si_idx) => {
-                B::MoveFromGenericDeprecated(struct_instantiation(m, si_idx))
+                B::MoveFromDeprecated(Box::new(StructRef::instantiated(tables, m, *si_idx)))
             }
-            FB::MoveToDeprecated(s_idx) => B::MoveToDeprecated(m.struct_name(*s_idx).to_owned()),
+            FB::MoveToDeprecated(s_idx) => {
+                B::MoveToDeprecated(Box::new(StructRef::new(tables, *s_idx, None)))
+            }
             FB::MoveToGenericDeprecated(si_idx) => {
-                B::MoveToGenericDeprecated(struct_instantiation(m, si_idx))
+                B::MoveToDeprecated(Box::new(StructRef::instantiated(tables, m, *si_idx)))
             }
-            FB::VecPack(sig_idx, len) => B::VecPack(signature_to_single_type(m, sig_idx), *len),
-            FB::VecLen(sig_idx) => B::VecLen(signature_to_single_type(m, sig_idx)),
-            FB::VecImmBorrow(sig_idx) => B::VecImmBorrow(signature_to_single_type(m, sig_idx)),
-            FB::VecMutBorrow(sig_idx) => B::VecMutBorrow(signature_to_single_type(m, sig_idx)),
-            FB::VecPushBack(sig_idx) => B::VecPushBack(signature_to_single_type(m, sig_idx)),
-            FB::VecPopBack(sig_idx) => B::VecPopBack(signature_to_single_type(m, sig_idx)),
-            FB::VecUnpack(sig_idx, len) => B::VecUnpack(signature_to_single_type(m, sig_idx), *len),
-            FB::VecSwap(sig_idx) => B::VecSwap(signature_to_single_type(m, sig_idx)),
+            FB::VecPack(sig_idx, len) => {
+                B::VecPack(Box::new((signature_to_single_type(tables, *sig_idx), *len)))
+            }
+            FB::VecLen(sig_idx) => B::VecLen(signature_to_single_type(tables, *sig_idx)),
+            FB::VecImmBorrow(sig_idx) => {
+                B::VecImmBorrow(signature_to_single_type(tables, *sig_idx))
+            }
+            FB::VecMutBorrow(sig_idx) => {
+                B::VecMutBorrow(signature_to_single_type(tables, *sig_idx))
+            }
+            FB::VecPushBack(sig_idx) => B::VecPushBack(signature_to_single_type(tables, *sig_idx)),
+            FB::VecPopBack(sig_idx) => B::VecPopBack(signature_to_single_type(tables, *sig_idx)),
+            FB::VecUnpack(sig_idx, len) => {
+                B::VecUnpack(Box::new((signature_to_single_type(tables, *sig_idx), *len)))
+            }
+            FB::VecSwap(sig_idx) => B::VecSwap(signature_to_single_type(tables, *sig_idx)),
             FB::PackVariant(handle) => {
-                B::PackVariant(VariantHandle::from_variant_handle(m, handle))
+                B::PackVariant(Box::new(VariantRef::noninstantiated(tables, m, *handle)))
             }
             FB::PackVariantGeneric(handle) => {
-                B::PackVariantGeneric(VariantHandle::from_variant_instantiation_handle(m, handle))
+                B::PackVariant(Box::new(VariantRef::instantiated(tables, m, *handle)))
             }
             FB::UnpackVariant(handle) => {
-                B::UnpackVariant(VariantHandle::from_variant_handle(m, handle))
+                B::UnpackVariant(Box::new(VariantRef::noninstantiated(tables, m, *handle)))
             }
             FB::UnpackVariantGeneric(handle) => {
-                B::UnpackVariantGeneric(VariantHandle::from_variant_instantiation_handle(m, handle))
+                B::UnpackVariant(Box::new(VariantRef::instantiated(tables, m, *handle)))
             }
             FB::UnpackVariantImmRef(handle) => {
-                B::UnpackVariantImmRef(VariantHandle::from_variant_handle(m, handle))
+                B::UnpackVariantImmRef(Box::new(VariantRef::noninstantiated(tables, m, *handle)))
             }
-            FB::UnpackVariantGenericImmRef(handle) => B::UnpackVariantGenericImmRef(
-                VariantHandle::from_variant_instantiation_handle(m, handle),
-            ),
+            FB::UnpackVariantGenericImmRef(handle) => {
+                B::UnpackVariantImmRef(Box::new(VariantRef::instantiated(tables, m, *handle)))
+            }
             FB::UnpackVariantMutRef(handle) => {
-                B::UnpackVariantMutRef(VariantHandle::from_variant_handle(m, handle))
+                B::UnpackVariantMutRef(Box::new(VariantRef::noninstantiated(tables, m, *handle)))
             }
-            FB::UnpackVariantGenericMutRef(handle) => B::UnpackVariantGenericMutRef(
-                VariantHandle::from_variant_instantiation_handle(m, handle),
-            ),
-            FB::VariantSwitch(jti) => B::VariantSwitch(VariantJumpTable::new(
-                m,
-                jump_tables
-                    .get(jti.0 as usize)
-                    .expect("Invariant violation: invalid jump table index"),
-            )),
+            FB::UnpackVariantGenericMutRef(handle) => {
+                B::UnpackVariantMutRef(Box::new(VariantRef::instantiated(tables, m, *handle)))
+            }
+            FB::VariantSwitch(jti) => B::VariantSwitch(jump_tables[jti.0 as usize].clone()),
         }
     }
 }
 
-impl VariantJumpTable {
-    pub fn new(m: &CompiledModule, jt: &FFVariantJumpTable) -> Self {
-        let e_def = m.enum_def_at(jt.head_enum);
-        let e_handle = m.datatype_handle_at(e_def.enum_handle);
-        let enum_name = m.identifier_at(e_handle.name).to_owned();
-        Self {
-            enum_name,
-            jump_table: jt.jump_table.clone(),
-        }
-    }
+fn signature_to_single_type<S>(tables: &Tables<S>, sig_idx: SignatureIndex) -> Rc<Type<S>> {
+    tables.signatures[sig_idx.0 as usize][0].clone()
 }
 
-impl Enum {
-    pub fn new(m: &CompiledModule, def: &EnumDefinition) -> (Identifier, Self) {
-        let handle = m.datatype_handle_at(def.enum_handle);
-        let name = m.identifier_at(handle.name).to_owned();
-        let variants = def
-            .variants
-            .iter()
-            .map(|v| Variant::new(m, v))
-            .collect::<Vec<_>>();
-        let e = Enum {
-            abilities: handle.abilities,
-            type_parameters: handle.type_parameters.clone(),
-            variants,
-        };
-        (name, e)
-    }
-}
-
-impl Variant {
-    pub fn new(m: &CompiledModule, v: &VariantDefinition) -> Self {
-        Self {
-            name: m.identifier_at(v.variant_name).to_owned(),
-            fields: v
-                .fields
-                .iter()
-                .map(|f| Field::new(m, f))
-                .collect::<Vec<_>>(),
-        }
-    }
-}
-
-impl std::fmt::Display for Type {
+impl<S: std::fmt::Display> std::fmt::Display for Type<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Type::Struct {
-                address,
-                module,
-                name,
-                type_arguments,
-            } => {
-                write!(
-                    f,
-                    "0x{}::{}::{}",
-                    address.short_str_lossless(),
-                    module,
-                    name
-                )?;
-                if let Some(first_ty) = type_arguments.first() {
-                    write!(f, "<")?;
-                    write!(f, "{}", first_ty)?;
-                    for ty in type_arguments.iter().skip(1) {
-                        write!(f, ", {}", ty)?;
-                    }
-                    write!(f, ">")?;
-                }
-                Ok(())
-            }
+            Type::Datatype(dt) => std::fmt::Display::fmt(dt, f),
             Type::Vector(ty) => write!(f, "vector<{}>", ty),
             Type::U8 => write!(f, "u8"),
             Type::U16 => write!(f, "u16"),
@@ -870,46 +1228,185 @@ impl std::fmt::Display for Type {
             Type::Address => write!(f, "address"),
             Type::Signer => write!(f, "signer"),
             Type::Bool => write!(f, "bool"),
-            Type::Reference(r) => write!(f, "&{}", r),
-            Type::MutableReference(r) => write!(f, "&mut {}", r),
+            Type::Reference(false, r) => write!(f, "&{}", r),
+            Type::Reference(true, r) => write!(f, "&mut {}", r),
             Type::TypeParameter(i) => write!(f, "T{:?}", i),
         }
     }
 }
 
-fn struct_instantiation(
-    m: &CompiledModule,
-    si_idx: &StructDefInstantiationIndex,
-) -> (Identifier, Vec<Type>) {
-    let StructDefInstantiation {
-        def,
-        type_parameters,
-    } = m.struct_instantiation_at(*si_idx);
-    let (name, _) = Struct::new(m, m.struct_def_at(*def));
-    let types = m
-        .signature_at(*type_parameters)
-        .0
-        .iter()
-        .map(|tok| Type::new(m, tok))
-        .collect();
-    (name, types)
+impl<S: std::fmt::Display> std::fmt::Display for Datatype<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let Datatype {
+            module: ModuleId {
+                address,
+                name: module,
+            },
+            name,
+            type_arguments,
+        } = self;
+        write!(
+            f,
+            "0x{}::{}::{}",
+            address.short_str_lossless(),
+            module,
+            name
+        )?;
+        if let Some(first_ty) = type_arguments.first() {
+            write!(f, "<")?;
+            write!(f, "{}", first_ty)?;
+            for ty in type_arguments.iter().skip(1) {
+                write!(f, ", {}", ty)?;
+            }
+            write!(f, ">")?;
+        }
+        Ok(())
+    }
 }
 
-fn field_instantiation(m: &CompiledModule, idx: &FieldInstantiationIndex) -> (FieldRef, Vec<Type>) {
-    let FieldInstantiation {
-        handle,
-        type_parameters,
-    } = m.field_instantiation_at(*idx);
-    let field_ref = FieldRef::new(m, m.field_handle_at(*handle));
-    let types = m
-        .signature_at(*type_parameters)
-        .0
-        .iter()
-        .map(|tok| Type::new(m, tok))
-        .collect();
-    (field_ref, types)
+#[test]
+fn sizes() {
+    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    struct Big([u8; 1024]);
+
+    assert_eq!(std::mem::size_of::<Type<Big>>(), 16);
+    assert_eq!(std::mem::size_of::<Bytecode<Big>>(), 16);
 }
 
-fn signature_to_single_type(m: &CompiledModule, sig_idx: &SignatureIndex) -> Type {
-    Type::new(m, &m.signature_at(*sig_idx).0[0])
+pub struct NoPool;
+
+impl StringPool for NoPool {
+    type String = Identifier;
+
+    fn intern(&mut self, s: &IdentStr) -> Self::String {
+        s.to_owned()
+    }
+
+    fn as_ident_str<'a>(&'a self, s: &'a Identifier) -> &'a IdentStr {
+        s.as_ident_str()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct RcIdentifier(Rc<Identifier>);
+
+impl Borrow<str> for RcIdentifier {
+    fn borrow(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Borrow<IdentStr> for RcIdentifier {
+    fn borrow(&self) -> &IdentStr {
+        self.0.as_ident_str()
+    }
+}
+
+impl Borrow<Identifier> for RcIdentifier {
+    fn borrow(&self) -> &Identifier {
+        self.0.as_ref()
+    }
+}
+
+impl Deref for RcIdentifier {
+    type Target = Identifier;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl std::fmt::Display for RcIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.0.as_ident_str(), f)
+    }
+}
+
+pub struct RcPool(HashSet<RcIdentifier>);
+
+impl RcPool {
+    pub fn new() -> Self {
+        Self(HashSet::new())
+    }
+}
+
+impl StringPool for RcPool {
+    type String = RcIdentifier;
+
+    fn intern(&mut self, s: &IdentStr) -> Self::String {
+        match self.0.get(s) {
+            Some(id) => id.clone(),
+            None => {
+                let id = RcIdentifier(Rc::new(s.to_owned()));
+                self.0.insert(id.clone());
+                id
+            }
+        }
+    }
+
+    fn as_ident_str<'a>(&'a self, s: &'a Self::String) -> &'a IdentStr {
+        s.0.as_ident_str()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct ArcIdentifier(Arc<Identifier>);
+
+impl Borrow<str> for ArcIdentifier {
+    fn borrow(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Borrow<IdentStr> for ArcIdentifier {
+    fn borrow(&self) -> &IdentStr {
+        self.0.as_ident_str()
+    }
+}
+
+impl Borrow<Identifier> for ArcIdentifier {
+    fn borrow(&self) -> &Identifier {
+        self.0.as_ref()
+    }
+}
+
+impl Deref for ArcIdentifier {
+    type Target = Identifier;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl std::fmt::Display for ArcIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.0.as_ident_str(), f)
+    }
+}
+
+pub struct ArcPool(HashSet<ArcIdentifier>);
+
+impl ArcPool {
+    pub fn new() -> Self {
+        Self(HashSet::new())
+    }
+}
+
+impl StringPool for ArcPool {
+    type String = ArcIdentifier;
+
+    fn intern(&mut self, s: &IdentStr) -> Self::String {
+        match self.0.get(s) {
+            Some(id) => id.clone(),
+            None => {
+                let id = ArcIdentifier(Arc::new(s.to_owned()));
+                self.0.insert(id.clone());
+                id
+            }
+        }
+    }
+
+    fn as_ident_str<'a>(&'a self, s: &'a Self::String) -> &'a IdentStr {
+        s.0.as_ident_str()
+    }
 }

--- a/external-crates/move/crates/move-binary-format/src/unit_tests/compatibility_tests.rs
+++ b/external-crates/move/crates/move-binary-format/src/unit_tests/compatibility_tests.rs
@@ -8,13 +8,13 @@ use std::{
     rc::Rc,
 };
 
+use crate::{
+    compatibility::{Compatibility, InclusionCheck, Mark, compare_ord_iters},
+    file_format::*,
+    normalized::{self, RcIdentifier, RcPool, Type},
+};
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::Identifier};
 use proptest::prelude::*;
-use crate::{
-    compatibility::{compare_ord_iters, Compatibility, InclusionCheck, Mark},
-    file_format::*,
-   normalized::{self, RcIdentifier, RcPool, Type},
-};
 
 type NormalizedModule = normalized::Module<RcIdentifier>;
 
@@ -984,8 +984,8 @@ fn public_entry_signature_change_disallowed() {
 fn friend_entry_signature_change_allowed() {
     let pool = &mut RcPool::new();
     let module = max_version(mk_module_entry(pool, Visibility::Friend as u8, true));
-     let mut updated_module = module.clone();
-     // Update the signature of the entry fun to now take a u64 argument.
+    let mut updated_module = module.clone();
+    // Update the signature of the entry fun to now take a u64 argument.
     let function_ref = updated_module.functions.get_mut(ident_str!("fn")).unwrap();
     let new_function = {
         let mut f: normalized::Function<_> = (**function_ref).clone();

--- a/external-crates/move/crates/move-binary-format/src/unit_tests/compatibility_tests.rs
+++ b/external-crates/move/crates/move-binary-format/src/unit_tests/compatibility_tests.rs
@@ -5,16 +5,18 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     convert::TryFrom,
+    rc::Rc,
 };
 
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::Identifier};
 use proptest::prelude::*;
-
+use compatibility::{compare_ord_iters, Compatibility, InclusionCheck, Mark},
 use crate::{
-    compatibility::{Compatibility, InclusionCheck, Mark, compare_ord_iters},
     file_format::*,
-    normalized::{self, Type},
+   normalized::{self, RcIdentifier, RcPool, Type},
 };
+
+type NormalizedModule = normalized::Module<RcIdentifier>;
 
 // A way to permute pools, and index into them still.
 pub struct Permutation {
@@ -45,16 +47,16 @@ impl Permutation {
     }
 }
 
-fn mk_module(vis: u8) -> normalized::Module {
-    mk_module_entry(vis, false)
+fn mk_module(pool: &mut RcPool, vis: u8) -> NormalizedModule {
+    mk_module_entry(pool, vis, false)
 }
 
-fn max_version(mut module: normalized::Module) -> normalized::Module {
+fn max_version(mut module: NormalizedModule) -> NormalizedModule {
     module.file_format_version = crate::file_format_common::VERSION_MAX;
     module
 }
 
-fn mk_module_entry(vis: u8, is_entry: bool) -> normalized::Module {
+fn mk_module_entry(pool: &mut RcPool, vis: u8, is_entry: bool) -> NormalizedModule {
     let (visibility, is_entry) = if vis == Visibility::DEPRECATED_SCRIPT {
         (Visibility::Public, true)
     } else {
@@ -137,14 +139,19 @@ fn mk_module_entry(vis: u8, is_entry: bool) -> normalized::Module {
         variant_handles: vec![],
         variant_instantiation_handles: vec![],
     };
-    normalized::Module::new(&m)
+    NormalizedModule::new(pool, &m, /* include code */ true)
 }
 
-fn mk_module_plus_code(vis: u8, code: Vec<Bytecode>) -> normalized::Module {
-    mk_module_plus_code_perm(vis, code, Permutation::new(vec![]))
+fn mk_module_plus_code(pool: &mut RcPool, vis: u8, code: Vec<Bytecode>) -> NormalizedModule {
+    mk_module_plus_code_perm(pool, vis, code, Permutation::new(vec![]))
 }
 
-fn mk_module_plus_code_perm(vis: u8, code: Vec<Bytecode>, p: Permutation) -> normalized::Module {
+fn mk_module_plus_code_perm(
+    pool: &mut RcPool,
+    vis: u8,
+    code: Vec<Bytecode>,
+    p: Permutation,
+) -> NormalizedModule {
     let (visibility, is_entry) = if vis == Visibility::DEPRECATED_SCRIPT {
         (Visibility::Public, true)
     } else {
@@ -247,18 +254,18 @@ fn mk_module_plus_code_perm(vis: u8, code: Vec<Bytecode>, p: Permutation) -> nor
         variant_handles: vec![],
         variant_instantiation_handles: vec![],
     };
-    normalized::Module::new(&m)
+    NormalizedModule::new(pool, &m, /* include code */ true)
 }
 
-fn mk_module_plus(vis: u8) -> normalized::Module {
-    mk_module_plus_code(vis, vec![Bytecode::Ret])
+fn mk_module_plus(pool: &mut RcPool, vis: u8) -> NormalizedModule {
+    mk_module_plus_code(pool, vis, vec![Bytecode::Ret])
 }
 
-fn mk_module_plus_perm(vis: u8, permutation: Permutation) -> normalized::Module {
-    mk_module_plus_code_perm(vis, vec![Bytecode::Ret], permutation)
+fn mk_module_plus_perm(pool: &mut RcPool, vis: u8, permutation: Permutation) -> NormalizedModule {
+    mk_module_plus_code_perm(pool, vis, vec![Bytecode::Ret], permutation)
 }
 
-fn make_complex_module_perm(p: Permutation) -> normalized::Module {
+fn make_complex_module_perm(pool: &mut RcPool, p: Permutation) -> NormalizedModule {
     let m = CompiledModule {
         version: crate::file_format_common::VERSION_MAX,
         module_handles: vec![
@@ -538,15 +545,16 @@ fn make_complex_module_perm(p: Permutation) -> normalized::Module {
         ]),
         variant_instantiation_handles: vec![],
     };
-    normalized::Module::new(&m)
+    NormalizedModule::new(pool, &m, /* include code */ true)
 }
 
 fn mk_module_with_defs(
+    pool: &mut RcPool,
     struct_defs: Vec<(Identifier, StructDefinition)>,
     enum_defs: Vec<(Identifier, EnumDefinition)>,
     function_defs: Vec<(Identifier, FunctionDefinition)>,
     friend_defs: Vec<(Identifier, AccountAddress)>,
-) -> normalized::Module {
+) -> NormalizedModule {
     let mut identifiers = vec![
         Identifier::new("M").unwrap(), // Module name
     ];
@@ -666,12 +674,13 @@ fn mk_module_with_defs(
         variant_handles: vec![],
         variant_instantiation_handles: vec![],
     };
-    normalized::Module::new(&m)
+    NormalizedModule::new(pool, &m, /* include code */ true)
 }
 
 #[test]
 fn deprecated_unchanged_script_visibility() {
-    let script_module = mk_module(Visibility::DEPRECATED_SCRIPT);
+    let pool = &mut RcPool::new();
+    let script_module = mk_module(pool, Visibility::DEPRECATED_SCRIPT);
     assert!(
         Compatibility::full_check()
             .check(&script_module, &script_module)
@@ -681,23 +690,24 @@ fn deprecated_unchanged_script_visibility() {
 
 #[test]
 fn deprecated_remove_script_visibility() {
-    let script_module = mk_module(Visibility::DEPRECATED_SCRIPT);
+    let pool = &mut RcPool::new();
+    let script_module = mk_module(pool, Visibility::DEPRECATED_SCRIPT);
     // script -> private, not allowed
-    let private_module = mk_module(Visibility::Private as u8);
+    let private_module = mk_module(pool, Visibility::Private as u8);
     assert!(
         Compatibility::full_check()
             .check(&script_module, &private_module)
             .is_err()
     );
     // script -> public, not allowed
-    let public_module = mk_module(Visibility::Public as u8);
+    let public_module = mk_module(pool, Visibility::Public as u8);
     assert!(
         Compatibility::full_check()
             .check(&script_module, &public_module)
             .is_err()
     );
     // script -> friend, not allowed
-    let friend_module = mk_module(Visibility::Friend as u8);
+    let friend_module = mk_module(pool, Visibility::Friend as u8);
     assert!(
         Compatibility::full_check()
             .check(&script_module, &friend_module)
@@ -707,23 +717,24 @@ fn deprecated_remove_script_visibility() {
 
 #[test]
 fn deprecated_add_script_visibility() {
-    let script_module = mk_module(Visibility::DEPRECATED_SCRIPT);
+    let pool = &mut RcPool::new();
+    let script_module = mk_module(pool, Visibility::DEPRECATED_SCRIPT);
     // private -> script, allowed
-    let private_module = mk_module(Visibility::Private as u8);
+    let private_module = mk_module(pool, Visibility::Private as u8);
     assert!(
         Compatibility::full_check()
             .check(&private_module, &script_module)
             .is_ok()
     );
     // public -> script, not allowed
-    let public_module = mk_module(Visibility::Public as u8);
+    let public_module = mk_module(pool, Visibility::Public as u8);
     assert!(
         Compatibility::full_check()
             .check(&public_module, &script_module)
             .is_err()
     );
     // friend -> script, not allowed
-    let friend_module = mk_module(Visibility::Friend as u8);
+    let friend_module = mk_module(pool, Visibility::Friend as u8);
     assert!(
         Compatibility::full_check()
             .check(&friend_module, &script_module)
@@ -733,8 +744,9 @@ fn deprecated_add_script_visibility() {
 
 #[test]
 fn private_entry_to_public_entry_allowed() {
-    let private_module = max_version(mk_module_entry(Visibility::Private as u8, true));
-    let public_module = max_version(mk_module_entry(Visibility::Public as u8, true));
+    let pool = &mut RcPool::new();
+    let private_module = max_version(mk_module_entry(pool, Visibility::Private as u8, true));
+    let public_module = max_version(mk_module_entry(pool, Visibility::Public as u8, true));
     assert!(
         Compatibility::full_check()
             .check(&private_module, &public_module)
@@ -750,8 +762,9 @@ fn private_entry_to_public_entry_allowed() {
 
 #[test]
 fn public_loses_entry() {
-    let public_entry = max_version(mk_module_entry(Visibility::Public as u8, true));
-    let public = max_version(mk_module_entry(Visibility::Public as u8, false));
+    let pool = &mut RcPool::new();
+    let public_entry = max_version(mk_module_entry(pool, Visibility::Public as u8, true));
+    let public = max_version(mk_module_entry(pool, Visibility::Public as u8, false));
     assert!(
         Compatibility::full_check()
             .check(&public, &public_entry)
@@ -767,15 +780,18 @@ fn public_loses_entry() {
 
 #[test]
 fn private_entry_signature_change_allowed() {
+    let pool = &mut RcPool::new();
     // Create a private entry function
-    let module = max_version(mk_module_entry(Visibility::Private as u8, true));
+    let module = max_version(mk_module_entry(pool, Visibility::Private as u8, true));
     let mut updated_module = module.clone();
     // Update the signature of the entry fun to now take a u64 argument.
-    updated_module
-        .functions
-        .get_mut(ident_str!("fn"))
-        .unwrap()
-        .parameters = vec![Type::U64];
+    let function_ref = updated_module.functions.get_mut(ident_str!("fn")).unwrap();
+    let new_function = {
+        let mut f: normalized::Function<_> = (**function_ref).clone();
+        f.parameters = Rc::new(vec![Rc::new(Type::U64)]);
+        Rc::new(f)
+    };
+    *function_ref = new_function;
 
     // allow updating signatures of private entry functions
     assert!(
@@ -809,21 +825,22 @@ fn private_entry_signature_change_allowed() {
 
 #[test]
 fn entry_fun_compat_tests() {
+    let pool = &mut RcPool::new();
     // fun
-    let private_fun = max_version(mk_module_entry(Visibility::Private as u8, false));
+    let private_fun = max_version(mk_module_entry(pool, Visibility::Private as u8, false));
     // entry fun
-    let entry_fun = max_version(mk_module_entry(Visibility::Private as u8, true));
+    let entry_fun = max_version(mk_module_entry(pool, Visibility::Private as u8, true));
     // public(friend) fun
-    let friend_fun = max_version(mk_module_entry(Visibility::Friend as u8, false));
+    let friend_fun = max_version(mk_module_entry(pool, Visibility::Friend as u8, false));
     // public(friend) entry fun
-    let friend_entry_fun = max_version(mk_module_entry(Visibility::Friend as u8, true));
+    let friend_entry_fun = max_version(mk_module_entry(pool, Visibility::Friend as u8, true));
     // public fun
-    let public_fun = max_version(mk_module_entry(Visibility::Public as u8, false));
+    let public_fun = max_version(mk_module_entry(pool, Visibility::Public as u8, false));
     // public entry fun
-    let public_entry_fun = max_version(mk_module_entry(Visibility::Public as u8, true));
+    let public_entry_fun = max_version(mk_module_entry(pool, Visibility::Public as u8, true));
     // NO function
     let mut no_fun = private_fun.clone();
-    no_fun.functions = BTreeMap::new();
+    no_fun.functions.clear();
 
     let mut valid_combos = vec![
         // Can transition from a private entry fun to anything
@@ -919,9 +936,17 @@ fn entry_fun_compat_tests() {
 
 #[test]
 fn public_entry_signature_change_disallowed() {
+    let pool = &mut RcPool::new();
     // Create a public entry function
-    let module = max_version(mk_module_entry(Visibility::Public as u8, true));
+    let module = max_version(mk_module_entry(pool, Visibility::Public as u8, true));
     let mut updated_module = module.clone();
+    let function_ref = updated_module.functions.get_mut(ident_str!("fn")).unwrap();
+    let new_function = {
+        let mut f: normalized::Function<_> = (**function_ref).clone();
+        f.parameters = Rc::new(vec![Rc::new(Type::U64)]);
+        Rc::new(f)
+    };
+    *function_ref = new_function;
     // Update the signature of the entry fun to now take a u64 argument.
     updated_module
         .functions
@@ -962,14 +987,17 @@ fn public_entry_signature_change_disallowed() {
 
 #[test]
 fn friend_entry_signature_change_allowed() {
-    let module = max_version(mk_module_entry(Visibility::Friend as u8, true));
-    let mut updated_module = module.clone();
-    // Update the signature of the entry fun to now take a u64 argument.
-    updated_module
-        .functions
-        .get_mut(ident_str!("fn"))
-        .unwrap()
-        .parameters = vec![Type::U64];
+    let pool = &mut RcPool::new();
+    let module = max_version(mk_module_entry(pool, Visibility::Friend as u8, true));
+     let mut updated_module = module.clone();
+     // Update the signature of the entry fun to now take a u64 argument.
+    let function_ref = updated_module.functions.get_mut(ident_str!("fn")).unwrap();
+    let new_function = {
+        let mut f: normalized::Function<_> = (**function_ref).clone();
+        f.parameters = Rc::new(vec![Rc::new(Type::U64)]);
+        Rc::new(f)
+    };
+    *function_ref = new_function;
 
     assert!(
         Compatibility {
@@ -994,12 +1022,13 @@ fn friend_entry_signature_change_allowed() {
 
 #[test]
 fn check_exact_and_unchange_same_module() {
-    let m1 = max_version(mk_module(Visibility::Private as u8));
+    let pool = &mut RcPool::new();
+    let m1 = max_version(mk_module(pool, Visibility::Private as u8));
     assert!(InclusionCheck::Subset.check(&m1, &m1).is_ok());
     assert!(InclusionCheck::Equal.check(&m1, &m1).is_ok());
 
     // m1 + an extra function
-    let m2 = max_version(mk_module_plus(Visibility::Private as u8));
+    let m2 = max_version(mk_module_plus(pool, Visibility::Private as u8));
     assert!(InclusionCheck::Subset.check(&m1, &m2).is_ok());
     assert!(InclusionCheck::Subset.check(&m2, &m1).is_err());
     assert!(InclusionCheck::Equal.check(&m1, &m2).is_err());
@@ -1007,6 +1036,7 @@ fn check_exact_and_unchange_same_module() {
 
     // m1 + a change in the bytecode of fn
     let m3 = max_version(mk_module_plus_code(
+        pool,
         Visibility::Private as u8,
         vec![Bytecode::LdU8(0), Bytecode::Ret],
     ));
@@ -1021,13 +1051,15 @@ fn check_exact_and_unchange_same_module() {
 
 #[test]
 fn check_exact_and_unchange_same_module_permutations() {
-    let m1 = max_version(mk_module(Visibility::Private as u8));
-    let m2 = max_version(mk_module_plus(Visibility::Private as u8));
+    let pool = &mut RcPool::new();
+    let m1 = max_version(mk_module(pool, Visibility::Private as u8));
+    let m2 = max_version(mk_module_plus(pool, Visibility::Private as u8));
     let m3 = max_version(mk_module_plus_perm(
+        pool,
         Visibility::Private as u8,
         Permutation::new(vec![1, 0]),
     ));
-    assert_ne!(m2, m3);
+    assert!(!m2.equals(&m3));
     assert!(InclusionCheck::Equal.check(&m2, &m3).is_ok());
     assert!(InclusionCheck::Equal.check(&m3, &m2).is_ok());
     // double inclusion
@@ -1042,6 +1074,7 @@ fn check_exact_and_unchange_same_module_permutations() {
 
 #[test]
 fn check_exact_and_unchange_same_complex_module_permutations() {
+    let pool = &mut RcPool::new();
     let perms = vec![
         vec![0, 1, 2],
         vec![0, 2, 1],
@@ -1052,7 +1085,12 @@ fn check_exact_and_unchange_same_complex_module_permutations() {
     ];
     let modules: Vec<_> = perms
         .into_iter()
-        .map(|permutation| max_version(make_complex_module_perm(Permutation::new(permutation))))
+        .map(|permutation| {
+            max_version(make_complex_module_perm(
+                pool,
+                Permutation::new(permutation),
+            ))
+        })
         .collect();
 
     for m0 in &modules {
@@ -1067,9 +1105,11 @@ fn check_exact_and_unchange_same_complex_module_permutations() {
 
 #[test]
 fn check_new_changed_missing_declarations() {
-    let empty = mk_module_with_defs(vec![], vec![], vec![], vec![]);
+    let pool = &mut RcPool::new();
+    let empty = mk_module_with_defs(pool, vec![], vec![], vec![], vec![]);
     // struct
     let m1 = mk_module_with_defs(
+        pool,
         vec![(
             Identifier::new("S1").unwrap(),
             StructDefinition {
@@ -1087,6 +1127,7 @@ fn check_new_changed_missing_declarations() {
 
     // change struct S1 to S2
     let m2 = mk_module_with_defs(
+        pool,
         vec![(
             Identifier::new("S2").unwrap(),
             StructDefinition {
@@ -1104,6 +1145,7 @@ fn check_new_changed_missing_declarations() {
 
     // same name different type
     let m3 = mk_module_with_defs(
+        pool,
         vec![(
             Identifier::new("S1").unwrap(),
             StructDefinition {
@@ -1130,6 +1172,7 @@ fn check_new_changed_missing_declarations() {
 
     // enums
     let m1 = mk_module_with_defs(
+        pool,
         vec![],
         vec![(
             Identifier::new("E1").unwrap(),
@@ -1150,6 +1193,7 @@ fn check_new_changed_missing_declarations() {
 
     // change enum E1 to E2
     let m2 = mk_module_with_defs(
+        pool,
         vec![],
         vec![(
             Identifier::new("E2").unwrap(),
@@ -1170,6 +1214,7 @@ fn check_new_changed_missing_declarations() {
 
     // same name different type
     let m3 = mk_module_with_defs(
+        pool,
         vec![],
         vec![(
             Identifier::new("E1").unwrap(),
@@ -1201,6 +1246,7 @@ fn check_new_changed_missing_declarations() {
 
     // functions
     let m1 = mk_module_with_defs(
+        pool,
         vec![],
         vec![],
         vec![(
@@ -1222,6 +1268,7 @@ fn check_new_changed_missing_declarations() {
 
     // change function fn1 to fn2
     let m2 = mk_module_with_defs(
+        pool,
         vec![],
         vec![],
         vec![(
@@ -1243,6 +1290,7 @@ fn check_new_changed_missing_declarations() {
 
     // change fn1 bytecode to abort from return
     let m3 = mk_module_with_defs(
+        pool,
         vec![],
         vec![],
         vec![(
@@ -1275,6 +1323,7 @@ fn check_new_changed_missing_declarations() {
 
 #[test]
 fn test_friend_linking() {
+    let pool = &mut RcPool::new();
     let friend_modules = [
         (Identifier::new("M1").unwrap(), AccountAddress::random()),
         (Identifier::new("M2").unwrap(), AccountAddress::random()),
@@ -1283,10 +1332,11 @@ fn test_friend_linking() {
     ];
 
     // zero friends
-    let m0 = mk_module_with_defs(vec![], vec![], vec![], vec![]);
+    let m0 = mk_module_with_defs(pool, vec![], vec![], vec![], vec![]);
 
     // two friends
     let m1 = mk_module_with_defs(
+        pool,
         vec![],
         vec![],
         vec![],
@@ -1295,6 +1345,7 @@ fn test_friend_linking() {
 
     // 3 friends
     let m2 = mk_module_with_defs(
+        pool,
         vec![],
         vec![],
         vec![],
@@ -1307,6 +1358,7 @@ fn test_friend_linking() {
 
     // 2 friends from m1, but different order
     let m3 = mk_module_with_defs(
+        pool,
         vec![],
         vec![],
         vec![],
@@ -1315,6 +1367,7 @@ fn test_friend_linking() {
 
     // 2 friends, different from m1
     let m4 = mk_module_with_defs(
+        pool,
         vec![],
         vec![],
         vec![],

--- a/external-crates/move/crates/move-binary-format/src/unit_tests/compatibility_tests.rs
+++ b/external-crates/move/crates/move-binary-format/src/unit_tests/compatibility_tests.rs
@@ -10,8 +10,8 @@ use std::{
 
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::Identifier};
 use proptest::prelude::*;
-use compatibility::{compare_ord_iters, Compatibility, InclusionCheck, Mark};
 use crate::{
+    compatibility::{compare_ord_iters, Compatibility, InclusionCheck, Mark},
     file_format::*,
    normalized::{self, RcIdentifier, RcPool, Type},
 };
@@ -948,11 +948,6 @@ fn public_entry_signature_change_disallowed() {
     };
     *function_ref = new_function;
     // Update the signature of the entry fun to now take a u64 argument.
-    updated_module
-        .functions
-        .get_mut(ident_str!("fn"))
-        .unwrap()
-        .parameters = vec![Type::U64];
 
     assert!(
         Compatibility {

--- a/external-crates/move/crates/move-binary-format/src/unit_tests/compatibility_tests.rs
+++ b/external-crates/move/crates/move-binary-format/src/unit_tests/compatibility_tests.rs
@@ -10,7 +10,7 @@ use std::{
 
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::Identifier};
 use proptest::prelude::*;
-use compatibility::{compare_ord_iters, Compatibility, InclusionCheck, Mark},
+use compatibility::{compare_ord_iters, Compatibility, InclusionCheck, Mark};
 use crate::{
     file_format::*,
    normalized::{self, RcIdentifier, RcPool, Type},

--- a/external-crates/move/crates/move-bytecode-utils/src/layout.rs
+++ b/external-crates/move/crates/move-bytecode-utils/src/layout.rs
@@ -10,7 +10,7 @@ use move_binary_format::{
         DatatypeHandleIndex, DatatypeTyParameter, EnumDefinition, SignatureToken, StructDefinition,
         StructFieldInformation,
     },
-    normalized::{Enum, Struct, Type},
+    normalized::{self, Datatype, RcIdentifier, RcPool},
     CompiledModule,
 };
 use move_core_types::{
@@ -20,7 +20,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag, TypeTag},
 };
 use serde_reflection::{ContainerFormat, Format, Named, Registry, VariantFormat};
-use std::{borrow::Borrow, collections::BTreeMap, fmt::Write};
+use std::{borrow::Borrow, collections::BTreeMap, fmt::Write, rc::Rc};
 
 /// Name of the Move `address` type in the serde registry
 const ADDRESS: &str = "AccountAddress";
@@ -42,9 +42,14 @@ macro_rules! check_depth {
     };
 }
 
+type Struct = normalized::Struct<RcIdentifier>;
+type Enum = normalized::Enum<RcIdentifier>;
+type Module = normalized::Module<RcIdentifier>;
+type Type = normalized::Type<RcIdentifier>;
+
 enum Container {
-    Struct(Struct),
-    Enum(Enum),
+    Struct(Rc<Struct>),
+    Enum(Rc<Enum>),
 }
 
 impl Container {
@@ -60,6 +65,8 @@ impl Container {
 /// The layouts created by this type are intended to be passed to the serde-generate tool to create
 /// struct bindings for Move types in source languages that use Move-based services.
 pub struct SerdeLayoutBuilder<'a, T> {
+    pool: RcPool,
+    modules: BTreeMap<ModuleId, Module>,
     registry: Registry,
     module_resolver: &'a T,
     config: SerdeLayoutConfig,
@@ -92,6 +99,8 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
     /// Create a `LayoutBuilder` with an empty registry and deep layout resolution
     pub fn new(module_resolver: &'a T) -> Self {
         Self {
+            pool: RcPool::new(),
+            modules: BTreeMap::new(),
             registry: Self::default_registry(),
             module_resolver,
             config: SerdeLayoutConfig::default(),
@@ -101,6 +110,8 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
     /// Create a `LayoutBuilder` with an empty registry and shallow layout resolution
     pub fn new_with_config(module_resolver: &'a T, config: SerdeLayoutConfig) -> Self {
         Self {
+            pool: RcPool::new(),
+            modules: BTreeMap::new(),
             registry: Self::default_registry(),
             module_resolver,
             config,
@@ -138,8 +149,9 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
     }
 
     /// Add layouts for all types used in `t` to the registry
-    pub fn build_type_layout(&mut self, t: TypeTag) -> Result<Format> {
-        self.build_normalized_type_layout(&Type::from(t), &Vec::new(), 0)
+    pub fn build_type_layout(&mut self, t: &TypeTag) -> Result<Format> {
+        let ty = Type::from_type_tag(&mut self.pool, t);
+        self.build_normalized_type_layout(&ty, &Vec::new(), 0)
     }
 
     /// Add layouts for all types used in `t` to the registry
@@ -147,7 +159,7 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
         let serde_type_args = s
             .type_params
             .iter()
-            .map(|t| self.build_type_layout(t.clone()))
+            .map(|t| self.build_type_layout(t))
             .collect::<Result<Vec<Format>>>()?;
         self.build_data_layout_(&s.module_id(), &s.name, &serde_type_args, 0)
     }
@@ -158,33 +170,33 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
         input_type_args: &[Format],
         depth: u64,
     ) -> Result<Format> {
-        use Type::*;
+        use Type as T;
         check_depth!(depth);
         Ok(match t {
-            Bool => Format::Bool,
-            U8 => Format::U8,
-            U16 => Format::U16,
-            U32 => Format::U32,
-            U64 => Format::U64,
-            U128 => Format::U128,
-            U256 => Format::TypeName(U256_SERDE_NAME.to_string()),
-            Address => Format::TypeName(ADDRESS.to_string()),
-            Signer => Format::TypeName(SIGNER.to_string()),
-            Struct {
-                address,
-                module,
-                name,
-                type_arguments,
-            } => {
+            T::Bool => Format::Bool,
+            T::U8 => Format::U8,
+            T::U16 => Format::U16,
+            T::U32 => Format::U32,
+            T::U64 => Format::U64,
+            T::U128 => Format::U128,
+            T::U256 => Format::TypeName(U256_SERDE_NAME.to_string()),
+            T::Address => Format::TypeName(ADDRESS.to_string()),
+            T::Signer => Format::TypeName(SIGNER.to_string()),
+            T::Datatype(dt) => {
+                let Datatype {
+                    module,
+                    name,
+                    type_arguments,
+                } = &**dt;
                 let serde_type_args = type_arguments
                     .iter()
                     .map(|t| self.build_normalized_type_layout(t, input_type_args, depth + 1))
                     .collect::<Result<Vec<Format>>>()?;
-                let declaring_module = ModuleId::new(*address, module.clone());
+                let declaring_module = module.to_core_module_id(&self.pool);
                 self.build_data_layout_(&declaring_module, name, &serde_type_args, depth + 1)?
             }
-            Vector(inner_t) => {
-                if matches!(inner_t.as_ref(), U8) {
+            T::Vector(inner_t) => {
+                if matches!(inner_t.as_ref(), T::U8) {
                     // specialize vector<u8> as bytes
                     Format::Bytes
                 } else {
@@ -195,8 +207,8 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
                     )?))
                 }
             }
-            TypeParameter(i) => input_type_args[*i as usize].clone(),
-            Reference(_) | MutableReference(_) => unreachable!(), // structs cannot store references
+            T::TypeParameter(i) => input_type_args[*i as usize].clone(),
+            T::Reference(_, _) => unreachable!(), // structs cannot store references
         })
     }
 
@@ -217,20 +229,13 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
             .get_module_by_id(module_id)
             .map_err(|e| anyhow::format_err!("{:?}", e))?
             .expect("Failed to resolve module");
+        let normalized = self.normalized_module(declaring_module.borrow());
         let def = match (
-            declaring_module
-                .borrow()
-                .find_struct_def_by_name(name.as_str()),
-            declaring_module
-                .borrow()
-                .find_enum_def_by_name(name.as_str()),
+            normalized.structs.get(name.as_ident_str()),
+            normalized.enums.get(name.as_ident_str()),
         ) {
-            (Some((_, struct_def)), None) => {
-                Container::Struct(Struct::new(declaring_module.borrow(), struct_def).1)
-            }
-            (None, Some((_, enum_def))) => {
-                Container::Enum(Enum::new(declaring_module.borrow(), enum_def).1)
-            }
+            (Some(s), None) => Container::Struct(s.clone()),
+            (None, Some(e)) => Container::Enum(e.clone()),
             (Some(_), Some(_)) => bail!("Found both struct and enum with name {}", name),
             (None, None) => bail!(
                 "Could not find datatype named {} in module {}",
@@ -314,14 +319,14 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
         depth: u64,
     ) -> Result<ContainerFormat> {
         match container {
-            Container::Struct(s) => self.generate_serde_struct(s, type_arguments, depth),
-            Container::Enum(e) => self.generate_serde_enum(e, type_arguments, depth),
+            Container::Struct(s) => self.generate_serde_struct(&s, type_arguments, depth),
+            Container::Enum(e) => self.generate_serde_enum(&e, type_arguments, depth),
         }
     }
 
     fn generate_serde_struct(
         &mut self,
-        normalized_struct: Struct,
+        normalized_struct: &Struct,
         type_arguments: &[Format],
         depth: u64,
     ) -> Result<ContainerFormat> {
@@ -342,7 +347,7 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
 
     fn generate_serde_enum(
         &mut self,
-        normalized_enum: Enum,
+        normalized_enum: &Enum,
         type_arguments: &[Format],
         depth: u64,
     ) -> Result<ContainerFormat> {
@@ -385,6 +390,15 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
             })
             .collect::<Result<BTreeMap<u32, Named<VariantFormat>>>>()?;
         Ok(ContainerFormat::Enum(variants))
+    }
+
+    fn normalized_module(&mut self, module: &CompiledModule) -> &Module {
+        let id = module.self_id();
+        if !self.modules.contains_key(&id) {
+            let normalized = Module::new(&mut self.pool, module, /* include code */ false);
+            self.modules.insert(id.clone(), normalized);
+        }
+        self.modules.get(&id).unwrap()
     }
 }
 

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
@@ -165,8 +165,9 @@ pub(crate) fn explain_publish_error(
             );
 
             let old_module = state.get_module_by_id(&module_id)?.unwrap();
-            let old_api = normalized::Module::new(&old_module);
-            let new_api = normalized::Module::new(module);
+            let pool = &mut normalized::RcPool::new();
+            let old_api = normalized::Module::new(pool, &old_module, /* include code */ true);
+            let new_api = normalized::Module::new(pool, module, /* include code */ true);
 
             if (Compatibility {
                 check_datatype_layout: true,

--- a/external-crates/move/crates/move-model/src/model.rs
+++ b/external-crates/move/crates/move-model/src/model.rs
@@ -42,18 +42,17 @@ use move_binary_format::{
     file_format::{
         AddressIdentifierIndex, Bytecode, Constant as VMConstant, ConstantPoolIndex,
         DatatypeHandleIndex, EnumDefinitionIndex, FunctionDefinition, FunctionDefinitionIndex,
-        FunctionHandleIndex, FunctionInstantiation, SignatureIndex, SignatureToken,
-        StructDefinitionIndex, StructFieldInformation, VariantJumpTable, Visibility,
+        FunctionHandleIndex, SignatureIndex, SignatureToken, StructDefinitionIndex,
+        StructFieldInformation, VariantJumpTable, Visibility,
     },
-    normalized::{FunctionRef, Type as MType},
 };
+
+use move_core_types::{language_storage::StructTag, parsing::address::NumericalAddress};
 use move_bytecode_source_map::{mapping::SourceMapping, source_map::SourceMap};
 use move_command_line_common::files::FileHash;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
-    language_storage,
-    parsing::address::NumericalAddress,
     runtime_value::MoveValue,
 };
 use move_disassembler::disassembler::{Disassembler, DisassemblerOptions};
@@ -77,14 +76,6 @@ pub const SCRIPT_BYTECODE_FUN_NAME: &str = "<SELF>";
 
 /// A prefix used for structs which are backing specification ("ghost") memory.
 pub const GHOST_MEMORY_PREFIX: &str = "Ghost$";
-
-const IOTA_FRAMEWORK_ADDRESS: AccountAddress = address_from_single_byte(2);
-
-const fn address_from_single_byte(b: u8) -> AccountAddress {
-    let mut addr = [0u8; AccountAddress::LENGTH];
-    addr[AccountAddress::LENGTH - 1] = b;
-    AccountAddress::new(addr)
-}
 
 // =================================================================================================
 // # Locations
@@ -158,13 +149,6 @@ impl Default for Loc {
         let dummy_id = files.add(String::new(), String::new());
         Loc::new(dummy_id, Span::default())
     }
-}
-
-/// Return true if `f` is an IOTA framework function declared in `module` with a name in `names`
-fn is_framework_function(f: &FunctionRef, module: &str, names: Vec<&str>) -> bool {
-    *f.module_id.address() == IOTA_FRAMEWORK_ADDRESS
-        && f.module_id.name().to_string() == module
-        && names.contains(&f.function_ident.as_str())
 }
 
 /// Alias for the Loc variant of MoveIR. This uses a `&static str` instead of
@@ -1244,17 +1228,8 @@ impl GlobalEnv {
 
     /// Attempt to compute a struct tag for (`mid`, `sid`, `ts`). Returns `Some`
     /// if all types in `ts` are closed, `None` otherwise
-    pub fn get_struct_tag(
-        &self,
-        mid: ModuleId,
-        sid: DatatypeId,
-        ts: &[Type],
-    ) -> Option<language_storage::StructTag> {
-        self.get_datatype(mid, sid, ts)?.into_struct_tag()
-    }
+    pub fn get_struct_tag(&self, mid: ModuleId, sid: DatatypeId, ts: &[Type]) -> Option<StructTag> {
 
-    /// Attempt to compute a struct type for (`mid`, `sid`, `ts`).
-    pub fn get_datatype(&self, mid: ModuleId, sid: DatatypeId, ts: &[Type]) -> Option<MType> {
         let menv = self.get_module(mid);
         let name = menv
             .find_struct(sid.symbol())
@@ -1263,13 +1238,13 @@ impl GlobalEnv {
                 menv.find_enum(sid.symbol())
                     .map(|eenv| eenv.get_identifier())
             })??;
-        Some(MType::Struct {
+        Some(StructTag {
             address: *menv.self_address(),
             module: menv.get_identifier(),
             name,
-            type_arguments: ts
+            type_params: ts
                 .iter()
-                .map(|t| t.clone().into_normalized_type(self).unwrap())
+                .map(|t| t.clone().into_type_tag(self).unwrap())
                 .collect(),
         })
     }
@@ -1920,106 +1895,6 @@ impl<'env> ModuleEnv<'env> {
     /// Returns an iterator over structs in this module.
     pub fn get_enums(&'env self) -> impl Iterator<Item = EnumEnv<'env>> {
         self.clone().into_enums()
-    }
-
-    /// Returns an iterator over all object types declared by this module
-    pub fn get_objects(&'env self) -> impl Iterator<Item = StructEnv<'env>> {
-        self.clone()
-            .into_structs()
-            .filter(|s| s.get_abilities().has_key())
-    }
-
-    /// Returns the object types that are shared by code in this module
-    /// If `transitive` is false, only return objects directly shared by
-    /// functions declared in this module If `transitive` is true, return
-    /// objects shared by both functions declared in this module and by
-    /// transitive callees Note that this can include both types declared
-    /// inside this module (common case) and types declared outside
-    /// Note that objects with `store` can be shared by modules that depend on
-    /// this one (e.g., by returning the object and subsequently calling
-    /// `public_share_object`)
-    pub fn get_shared_objects(&'env self, transitive: bool) -> BTreeSet<Type> {
-        let mut shared = BTreeSet::new();
-        for f in self.get_functions() {
-            shared.extend(f.get_shared_objects(transitive));
-        }
-        shared
-    }
-
-    /// Returns the object types that are frozen by this module
-    /// If `transitive` is false, only return objects directly transferred by
-    /// functions declared in this module If `transitive` is true, return
-    /// objects transferred by both functions declared in this module and by
-    /// transitive callees Note that this function can return both types
-    /// declared inside this module (common case) and types declared outside
-    /// Note that objects with `store` can be transferred by modules that depend
-    /// on this one (e.g., by returning the object and subsequently calling
-    /// `public_transfer`), or transferred by a command in a programmable
-    /// transaction block
-    pub fn get_transferred_objects(&'env self, transitive: bool) -> BTreeSet<Type> {
-        let mut transferred = BTreeSet::new();
-        for f in self.get_functions() {
-            transferred.extend(f.get_transferred_objects(transitive))
-        }
-        transferred
-    }
-
-    /// Returns the object types that are frozen by this module
-    /// If `transitive` is false, only return objects directly frozen by
-    /// functions declared in this module If `transitive` is true, return
-    /// objects frozen by both functions declared in this module and by
-    /// transitive callees Note that this function can return both types
-    /// declared inside this module (common case) and types declared outside
-    /// Note that objects with `store` can be frozen by modules that depend on
-    /// this one (e.g., by returning the object and subsequently calling
-    /// `public_freeze`)
-    pub fn get_frozen_objects(&'env self, transitive: bool) -> BTreeSet<Type> {
-        let mut frozen = BTreeSet::new();
-        for f in self.get_functions() {
-            frozen.extend(f.get_frozen_objects(transitive))
-        }
-        frozen
-    }
-
-    /// Returns the event types that are emitted by this module
-    /// If `transitive` is false, only return events directly emitted by
-    /// functions declared in this module If `transitive` is true, return
-    /// events emitted by both functions declared in this module and by
-    /// transitive callees Note that this function can return both event
-    /// types declared inside this module (common case) and event types declared
-    /// outside
-    pub fn get_events(&'env self, transitive: bool) -> BTreeSet<Type> {
-        let mut frozen = BTreeSet::new();
-        for f in self.get_functions() {
-            frozen.extend(f.get_frozen_objects(transitive))
-        }
-        frozen
-    }
-
-    /// Returns the objects types that are returned by externally callable
-    /// (`public`, `entry`, and `friend`) functions in this module
-    /// Returned objects with `store` can be transferred, shared, frozen, or
-    /// wrapped by a different module Note that this function returns object
-    /// types both with and without `store`
-    pub fn get_externally_returned_objects(&'env self) -> BTreeSet<Type> {
-        let mut returned = BTreeSet::new();
-        for f in self.get_functions() {
-            if !f.is_exposed() {
-                continue;
-            }
-            // Objects returned by a public function can be transferred, shared, frozen, or
-            // wrapped by a different module or (in the case of transfer) by a
-            // command in a programmable transaction block.
-            for f in f.get_return_types() {
-                if let Type::Datatype(mid, sid, _) = f {
-                    let struct_env = self.env.get_module(mid).into_struct(sid);
-                    if struct_env.get_abilities().has_key() {
-                        returned.insert(f);
-                    }
-                }
-            }
-        }
-        returned
     }
 
     /// Returns iterator over structs in this module.
@@ -3602,146 +3477,6 @@ impl<'env> FunctionEnv<'env> {
             env: self.module_env.env,
             type_param_names: Some(type_param_names),
         }
-    }
-
-    /// Returns the object types that may be shared by this function
-    /// If `transitive` is false, only return objects directly shared by this
-    /// function If `transitive` is true, return objects shared by both this
-    /// function and its transitive callees
-    pub fn get_shared_objects(&'env self, transitive: bool) -> BTreeSet<Type> {
-        let mut shared = BTreeSet::new();
-        if transitive {
-            let callees = self.get_transitive_closure_of_called_functions();
-            for callee in callees {
-                let fenv = self.module_env.env.get_function(callee);
-                shared.extend(fenv.get_shared_objects(false));
-            }
-        } else {
-            let module = &self.module_env.data.module;
-            for b in self.get_bytecode() {
-                if let Bytecode::CallGeneric(fi_idx) = b {
-                    let FunctionInstantiation {
-                        handle,
-                        type_parameters,
-                    } = module.function_instantiation_at(*fi_idx);
-                    let f_ref = FunctionRef::from_idx(module, handle);
-                    if is_framework_function(
-                        &f_ref,
-                        "transfer",
-                        vec!["share_object", "public_share_object"],
-                    ) {
-                        let type_params = module.signature_at(*type_parameters);
-                        shared.insert(self.module_env.globalize_signature(&type_params.0[0]));
-                    }
-                }
-            }
-        }
-
-        shared
-    }
-
-    /// Returns the object types that may be transferred by this function
-    /// If `transitive` is false, only objects directly transferred by this
-    /// function If `transitive` is true, return objects transferred by both
-    /// this function and its transitive callees
-    pub fn get_transferred_objects(&'env self, transitive: bool) -> BTreeSet<Type> {
-        let mut transferred = BTreeSet::new();
-        if transitive {
-            let callees = self.get_transitive_closure_of_called_functions();
-            for callee in callees {
-                let fenv = self.module_env.env.get_function(callee);
-                transferred.extend(fenv.get_shared_objects(false));
-            }
-        } else {
-            let module = &self.module_env.data.module;
-            for b in self.get_bytecode() {
-                if let Bytecode::CallGeneric(fi_idx) = b {
-                    let FunctionInstantiation {
-                        handle,
-                        type_parameters,
-                    } = module.function_instantiation_at(*fi_idx);
-                    let f_ref = FunctionRef::from_idx(module, handle);
-                    if is_framework_function(
-                        &f_ref,
-                        "transfer",
-                        vec!["transfer", "public_transfer"],
-                    ) {
-                        let type_params = module.signature_at(*type_parameters);
-                        transferred.insert(self.module_env.globalize_signature(&type_params.0[0]));
-                    }
-                }
-            }
-        }
-
-        transferred
-    }
-
-    /// Returns the object types that may be frozen by this function
-    /// If `transitive` is false, only return objects directly frozen by this
-    /// function If `transitive` is true, return objects frozen by both this
-    /// function and its transitive callees
-    pub fn get_frozen_objects(&'env self, transitive: bool) -> BTreeSet<Type> {
-        let mut frozen = BTreeSet::new();
-        if transitive {
-            let callees = self.get_transitive_closure_of_called_functions();
-            for callee in callees {
-                let fenv = self.module_env.env.get_function(callee);
-                frozen.extend(fenv.get_shared_objects(false));
-            }
-        } else {
-            let module = &self.module_env.data.module;
-            for b in self.get_bytecode() {
-                if let Bytecode::CallGeneric(fi_idx) = b {
-                    let FunctionInstantiation {
-                        handle,
-                        type_parameters,
-                    } = module.function_instantiation_at(*fi_idx);
-                    let f_ref = FunctionRef::from_idx(module, handle);
-                    if is_framework_function(
-                        &f_ref,
-                        "transfer",
-                        vec!["freeze_object", "public_freeze_object"],
-                    ) {
-                        let type_params = module.signature_at(*type_parameters);
-                        frozen.insert(self.module_env.globalize_signature(&type_params.0[0]));
-                    }
-                }
-            }
-        }
-
-        frozen
-    }
-
-    /// Returns the event types that may be emitted by this function
-    /// If `transitive` is false, only return events directly emitted by this
-    /// function If `transitive` is true, return events emitted by both this
-    /// function and its transitive callees
-    pub fn get_events(&'env self, transitive: bool) -> BTreeSet<Type> {
-        let mut events = BTreeSet::new();
-        if transitive {
-            let callees = self.get_transitive_closure_of_called_functions();
-            for callee in callees {
-                let fenv = self.module_env.env.get_function(callee);
-                events.extend(fenv.get_events(false));
-            }
-        } else {
-            let module = &self.module_env.data.module;
-            for b in self.get_bytecode() {
-                if let Bytecode::CallGeneric(fi_idx) = b {
-                    let FunctionInstantiation {
-                        handle,
-                        type_parameters,
-                    } = module.function_instantiation_at(*fi_idx);
-                    let f_ref = FunctionRef::from_idx(module, handle);
-                    if is_framework_function(&f_ref, "event", vec!["emit"]) {
-                        let type_params = module.signature_at(*type_parameters);
-                        events.insert(self.module_env.globalize_signature(&type_params.0[0]));
-                    }
-                }
-            }
-        }
-
-        events
     }
 }
 

--- a/external-crates/move/crates/move-model/src/model.rs
+++ b/external-crates/move/crates/move-model/src/model.rs
@@ -46,12 +46,13 @@ use move_binary_format::{
         StructFieldInformation, VariantJumpTable, Visibility,
     },
 };
-
-use move_core_types::{language_storage::StructTag, parsing::address::NumericalAddress};
 use move_bytecode_source_map::{mapping::SourceMapping, source_map::SourceMap};
 use move_command_line_common::files::FileHash;
 use move_core_types::{
     account_address::AccountAddress,
+    language_storage,
+    language_storage::StructTag,
+    parsing::address::NumericalAddress,
     identifier::{IdentStr, Identifier},
     runtime_value::MoveValue,
 };

--- a/external-crates/move/crates/move-model/src/ty.rs
+++ b/external-crates/move/crates/move-model/src/ty.rs
@@ -11,7 +11,7 @@ use std::{
     fmt::Formatter,
 };
 
-use move_binary_format::{file_format::TypeParameterIndex, normalized::Type as MType};
+use move_binary_format::file_format::TypeParameterIndex;
 use move_core_types::language_storage::{StructTag, TypeTag};
 
 use crate::{
@@ -87,18 +87,18 @@ impl PrimitiveType {
     }
 
     /// Attempt to convert this type into a normalized::Type
-    pub fn into_normalized_type(self) -> Option<MType> {
+    pub fn into_type_tag(self) -> Option<TypeTag> {
         use PrimitiveType::*;
         Some(match self {
-            Bool => MType::Bool,
-            U8 => MType::U8,
-            U16 => MType::U16,
-            U32 => MType::U32,
-            U64 => MType::U64,
-            U128 => MType::U128,
-            U256 => MType::U256,
-            Address => MType::Address,
-            Signer => MType::Signer,
+            Bool => TypeTag::Bool,
+            U8 => TypeTag::U8,
+            U16 => TypeTag::U16,
+            U32 => TypeTag::U32,
+            U64 => TypeTag::U64,
+            U128 => TypeTag::U128,
+            U256 => TypeTag::U256,
+            Address => TypeTag::Address,
+            Signer => TypeTag::Signer,
             Num | Range | EventStore => return None,
         })
     }
@@ -393,47 +393,38 @@ impl Type {
             _ => {}
         }
     }
-
-    /// Attempt to convert this type into a normalized::Type
-    pub fn into_datatype_ty(self, env: &GlobalEnv) -> Option<MType> {
-        use Type::*;
-        match self {
-            Datatype(mid, sid, ts) => env.get_datatype(mid, sid, &ts),
+    /// Attempt to convert this type into a language_storage::StructTag
+    pub fn into_struct_tag(self, env: &GlobalEnv) -> Option<StructTag> {
+        match self.into_type_tag(env)? {
+            TypeTag::Struct(tag) => Some(*tag),
             _ => None,
         }
     }
 
-    /// Attempt to convert this type into a normalized::Type
-    pub fn into_normalized_type(self, env: &GlobalEnv) -> Option<MType> {
-        use Type::*;
-        match self {
-            Primitive(p) => Some(p.into_normalized_type().expect("Invariant violation: unexpected spec primitive")),
-            Datatype(mid, sid, ts) =>
-                env.get_datatype(mid, sid, &ts),
-            Vector(et) => Some(MType::Vector(
-                Box::new(et.into_normalized_type(env)
-                    .expect("Invariant violation: vector type argument contains incomplete, tuple, or spec type"))
-            )),
-            Reference(r, t) =>
-                if r {
-                    Some(MType::MutableReference(Box::new(t.into_normalized_type(env).expect("Invariant violation: reference type contains incomplete, tuple, or spec type"))))
-                } else {
-                    Some(MType::Reference(Box::new(t.into_normalized_type(env).expect("Invariant violation: reference type contains incomplete, tuple, or spec type"))))
-                }
-            TypeParameter(idx) => Some(MType::TypeParameter(idx)),
-            Tuple(..) | Error | Fun(..) | TypeDomain(..) | ResourceDomain(..) | Var(..) =>
-                None
-        }
-    }
-
-    /// Attempt to convert this type into a language_storage::StructTag
-    pub fn into_struct_tag(self, env: &GlobalEnv) -> Option<StructTag> {
-        self.into_datatype_ty(env)?.into_struct_tag()
-    }
-
     /// Attempt to convert this type into a language_storage::TypeTag
     pub fn into_type_tag(self, env: &GlobalEnv) -> Option<TypeTag> {
-        self.into_normalized_type(env)?.into_type_tag()
+        use Type::*;
+        match self {
+            Primitive(p) => Some(
+                p.into_type_tag()
+                    .expect("Invariant violation: unexpected spec primitive"),
+            ),
+            Datatype(mid, sid, ts) => Some(TypeTag::Struct(Box::new(
+                env.get_struct_tag(mid, sid, &ts)?,
+            ))),
+            Vector(et) => Some(TypeTag::Vector(Box::new(et.into_type_tag(env).expect(
+                "Invariant violation: vector type argument contains \
+                     incomplete, tuple, or spec type",
+            )))),
+            TypeParameter(_)
+            | Reference(_, _)
+            | Tuple(..)
+            | Error
+            | Fun(..)
+            | TypeDomain(..)
+            | ResourceDomain(..)
+            | Var(..) => None,
+        }
     }
 
     /// Create a `Type` from `t`

--- a/external-crates/move/crates/move-vm-integration-tests/src/tests/compatibility_tests.rs
+++ b/external-crates/move/crates/move-vm-integration-tests/src/tests/compatibility_tests.rs
@@ -10,10 +10,14 @@ use move_binary_format::{
 };
 use move_ir_to_bytecode::{compiler::compile_module, parser::parse_module};
 
-fn compile(prog: &str) -> normalized::Module {
+fn compile(prog: &str) -> normalized::Module<normalized::RcIdentifier> {
     let prog = parse_module(prog).unwrap();
     let (compiled_module, _) = compile_module(prog, vec![]).unwrap();
-    normalized::Module::new(&compiled_module)
+    normalized::Module::new(
+        &mut normalized::RcPool::new(),
+        &compiled_module,
+        /* include code */ true,
+    )
 }
 
 // Things to test for enum upgrades

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -730,8 +730,11 @@ mod checked {
             ));
         };
 
+        let pool = &mut normalized::RcPool::new();
         let binary_config = to_binary_config(context.protocol_config);
-        let Ok(current_normalized) = existing_package.normalize(&binary_config) else {
+        let Ok(current_normalized) =
+            existing_package.normalize(pool, &binary_config, /* include code */ true)
+        else {
             invariant_violation!("Tried to normalize modules in existing package but failed")
         };
 
@@ -752,8 +755,12 @@ mod checked {
                 ),
             ));
         }
-        let mut new_normalized = normalize_deserialized_modules(upgrading_modules.iter());
-
+        let mut new_normalized = normalize_deserialized_modules(
+            pool,
+            upgrading_modules.iter(),
+            // include code
+            true,
+        );
         for (name, cur_module) in current_normalized {
             let Some(new_module) = new_normalized.remove(&name) else {
                 return Err(ExecutionError::new_with_source(
@@ -781,8 +788,8 @@ mod checked {
     /// layout, public function linking, and struct type parameters.
     fn check_module_compatibility(
         policy: &UpgradePolicy,
-        cur_module: &normalized::Module,
-        new_module: &normalized::Module,
+        cur_module: &move_binary_format::compatibility::Module,
+        new_module: &move_binary_format::compatibility::Module,
     ) -> Result<(), ExecutionError> {
         match policy {
             UpgradePolicy::Additive => InclusionCheck::Subset.check(cur_module, new_module),


### PR DESCRIPTION
# Description of change

- Improved efficiency of normalized module through use of Rcs
- Generalized Identifiers to allow for different "interned” symbols

This change refactors how Move modules are normalized. The old normalization created new copies of strings and types every time, which was wasteful. Now it uses RcPool for interning identifiers and sharing common data, so normalization is faster and uses less memory.
It also makes the normalized representation reusable across tools (CLI, RPC, indexer, etc.) instead of rebuilding everything each time.
The normalize() API changed - it now takes a mutable RcPool and a flag that decides whether to include function code or not.
Adjusted JSON-RPC types, indexer helpers, CLI build code, and compatibility logic to handle the new normalized data layout.

In short:
- moved normalization to a pooled model (RcPool)
- updated all normalize() calls to new signature
- aligned data types across RPC / indexer / CLI
- improved performance and consistency of normalized output
- added indexmap for deterministic ordering

According to [changes](https://github.com/MystenLabs/sui/commit/a196bc33bd1f2a7aa6fd33efde6fdc5c4998931c).

Not ported changes for files:

- `crates/sui-indexer-alt-jsonrpc/src/api/move_utils/response.rs`
- `‎crates/sui-rpc-api/src/service/transactions/resolve/literal.rs`
- `crates/sui-rpc-api/src/service/transactions/resolve/mod.rs` was ported into -> `crates/iota-rest-api/src/transactions/resolve.rs`

## Links to any relevant issues

Fixes #8335 .

## How the change has been tested

Run external-crates test