### PR TITLE
refactor: remove support for view calls in mainnet and testnet

### DIFF
--- a/crates/iota-graphql-rpc/src/error.rs
+++ b/crates/iota-graphql-rpc/src/error.rs
@@ -82,6 +82,8 @@ pub enum Error {
     IotaNames(#[from] IotaNamesError),
     #[error("{0}")]
     ServerInit(String),
+    #[error("Unsupported feature: {0}")]
+    UnsupportedFeature(String),
 }
 
 impl ErrorExtensions for Error {
@@ -101,6 +103,9 @@ impl ErrorExtensions for Error {
             }
             Error::ServerInit(_) => {
                 e.set("code", code::UNKNOWN);
+            }
+            Error::UnsupportedFeature(_) => {
+                e.set("code", code::BAD_REQUEST);
             }
         })
     }

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -100,8 +100,10 @@ impl Query {
     ) -> Result<MoveViewResult> {
         let chain_id_cache: &ChainIdentifierCache = ctx.data_unchecked();
 
+        let db = ctx.data_unchecked();
+        let metrics = ctx.data_unchecked();
         let chain = chain_id_cache
-            .read(ctx.data_unchecked(), ctx.data_unchecked())
+            .read(db, metrics)
             .await
             .extend()?
             .into_inner()

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -12,6 +12,7 @@ use iota_json_rpc_types::{DevInspectArgs, IotaTypeTag};
 use iota_types::{
     TypeTag,
     gas_coin::GAS,
+    supported_protocol_versions::Chain,
     transaction::{TransactionData, TransactionDataAPI, TransactionKind},
 };
 use move_core_types::account_address::AccountAddress;
@@ -97,6 +98,21 @@ impl Query {
         type_args: Option<Vec<String>>,
         arguments: Option<Vec<serde_json::Value>>,
     ) -> Result<MoveViewResult> {
+        let chain_id_cache: &ChainIdentifierCache = ctx.data_unchecked();
+
+        let chain = chain_id_cache
+            .read(ctx.data_unchecked(), ctx.data_unchecked())
+            .await
+            .extend()?
+            .into_inner()
+            .chain();
+        if !matches!(chain, Chain::Unknown) {
+            return Err(Error::UnsupportedFeature(format!(
+                "View calls are not yet supported on {}",
+                chain.as_str()
+            )))
+            .extend();
+        }
         let type_args = type_args.map(|args| args.into_iter().map(IotaTypeTag::new).collect());
         let call_args = arguments
             .unwrap_or_default()

--- a/crates/iota-indexer/src/apis/error.rs
+++ b/crates/iota-indexer/src/apis/error.rs
@@ -1,0 +1,22 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use jsonrpsee::types::{ErrorObject, ErrorObjectOwned, error::ErrorCode};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("Unsupported Feature: {0}")]
+    UnsupportedFeature(String),
+}
+
+impl From<Error> for ErrorObjectOwned {
+    fn from(e: Error) -> ErrorObjectOwned {
+        match e {
+            Error::UnsupportedFeature(_) => {
+                ErrorObject::owned::<()>(ErrorCode::InvalidRequest.code(), e.to_string(), None)
+            }
+        }
+    }
+}

--- a/crates/iota-indexer/src/apis/mod.rs
+++ b/crates/iota-indexer/src/apis/mod.rs
@@ -12,6 +12,7 @@ pub(crate) use transaction_builder_api::TransactionBuilderApi;
 pub use write_api::{OptimisticWriteApi, WriteApi};
 
 mod coin_api;
+pub(crate) mod error;
 mod extended_api;
 pub mod governance_api;
 mod indexer_api;

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -15,6 +15,7 @@ use iota_json_rpc_types::{
     MoveFunctionName,
 };
 use iota_open_rpc::Module;
+use iota_protocol_config::Chain;
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
     base_types::IotaAddress, iota_serde::BigInt, quorum_driver_types::ExecuteTransactionRequestType,
@@ -22,7 +23,8 @@ use iota_types::{
 use jsonrpsee::{RpcModule, core::RpcResult, http_client::HttpClient};
 
 use crate::{
-    errors::IndexerError, optimistic_indexing::OptimisticTransactionExecutor, read::IndexerReader,
+    apis::error::Error as ApiError, errors::IndexerError,
+    optimistic_indexing::OptimisticTransactionExecutor, read::IndexerReader,
     store::package_resolver::IndexerStorePackageResolver,
     types::IotaTransactionBlockResponseWithOptions,
 };
@@ -204,6 +206,20 @@ impl WriteApiServer for OptimisticWriteApi {
         type_args: Option<Vec<IotaTypeTag>>,
         call_args: Vec<IotaJsonValue>,
     ) -> RpcResult<IotaMoveViewCallResults> {
+        let chain = self
+            .optimistic_tx_executor
+            .read
+            .get_chain_identifier_in_blocking_task()
+            .await?
+            .chain();
+        if !matches!(chain, Chain::Unknown) {
+            return Err(ApiError::UnsupportedFeature(format!(
+                "View calls are not yet supported on {}",
+                chain.as_str()
+            ))
+            .into());
+        }
+
         self.write_api
             .view_function_call(function_name, type_args, call_args)
             .await

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -50,7 +50,7 @@ type TransactionDataToCommit = (
 #[derive(Clone)]
 pub struct OptimisticTransactionExecutor {
     rpc_client: iota_rest_api::Client,
-    read: IndexerReader,
+    pub(crate) read: IndexerReader,
     store: PgIndexerStore,
     metrics: IndexerMetrics,
 }

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -20,6 +20,7 @@ use iota_json_rpc_types::{
 use iota_metrics::spawn_monitored_task;
 use iota_open_rpc::Module;
 use iota_package_resolver::{Package, PackageStore, error::Error as PackageResolverError};
+use iota_protocol_config::Chain;
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
     base_types::IotaAddress,
@@ -369,6 +370,18 @@ impl WriteApiServer for TransactionExecutionApi {
         type_args: Option<Vec<IotaTypeTag>>,
         call_args: Vec<IotaJsonValue>,
     ) -> RpcResult<IotaMoveViewCallResults> {
+        let chain = self
+            .state
+            .get_chain_identifier()
+            .map_err(Error::from)?
+            .chain();
+        if !matches!(chain, Chain::Unknown) {
+            return Err(Error::UnsupportedFeature(format!(
+                "View function calls not supported yet on {}",
+                chain.as_str()
+            ))
+            .into());
+        }
         let MoveFunctionName {
             package,
             module,


### PR DESCRIPTION
# Description of change

We restrict usage of the move-view calls through JSON-RPC and GraphQL on networks other than `mainnet`, `testnet`. 

## Links to any relevant issues

Fixes #8843

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

### Release Notes

- [x] JSON-RPC: Calls to the `iota_view` endpoint are only supported on  `devnet` , as the feature is still in alpha.
- [x] GraphQL: Usage of the `Query.moveViewCall` are only supported on `devnet`, as the feature is still in alpha.
