### PR TITLE
refactor(indexer): Split primary and snapshot executors

### DIFF
--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -2,23 +2,14 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, env, time::Duration};
+use std::env;
 
 use anyhow::{Context, Result};
-use async_trait::async_trait;
-use iota_data_ingestion_core::{
-    DataIngestionMetrics, IndexerExecutor, ProgressStore, ReaderOptions,
-};
+use iota_data_ingestion_core::ReaderOptions;
 use iota_metrics::spawn_monitored_task;
-use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use prometheus::Registry;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
-
-use crate::ingestion::common::persist::Writer;
-
-/// Timeout for waiting for tasks to shutdown gracefully after cancellation
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+use tracing::{info, warn};
 
 use crate::{
     build_json_rpc_server,
@@ -26,8 +17,7 @@ use crate::{
     db::ConnectionPool,
     errors::IndexerError,
     ingestion::{
-        primary::orchestration::{setup_primary, start_primary_writer_task},
-        snapshot::orchestration::setup_snapshot,
+        primary::orchestration::PrimaryPipeline, snapshot::orchestration::SnapshotPipeline,
     },
     metrics::IndexerMetrics,
     processors::processor_orchestrator::ProcessorOrchestrator,
@@ -54,34 +44,22 @@ impl Indexer {
         );
 
         info!("IOTA Indexer Writer config: {config:?}",);
-
-        let primary_watermark = store
-            .get_latest_checkpoint_sequence_number()
-            .await
-            .expect("failed to get latest tx checkpoint sequence number from DB")
-            .map(|seq| seq + 1)
-            .unwrap_or_default();
         let extra_reader_options = ReaderOptions {
             batch_size: config.checkpoint_download_queue_size,
             timeout_secs: config.checkpoint_download_timeout,
             data_limit: config.checkpoint_download_queue_size_bytes,
             ..Default::default()
         };
-
-        // Start objects snapshot processor, which is a separate pipeline with its
-        // ingestion pipeline.
-        let (object_snapshot_worker_pool, object_snapshot_writer, object_snapshot_receiver) =
-            setup_snapshot(
-                store.clone(),
-                metrics.clone(),
-                snapshot_config,
-                config.checkpoint_download_queue_size,
-            )
-            .await?;
-        let object_snapshot_watermark = object_snapshot_writer
-            .get_watermark_hi()
-            .await?
-            .unwrap_or_default();
+        let data_ingestion_path = config
+            .sources
+            .data_ingestion_path
+            .clone()
+            .unwrap_or(tempfile::tempdir().unwrap().keep());
+        let remote_store_url = config
+            .sources
+            .remote_store_url
+            .as_ref()
+            .map(|url| url.as_str().to_owned());
 
         if let Some(retention_config) = retention_config {
             let pruner = Pruner::new(store.clone(), retention_config, metrics.clone())?;
@@ -110,78 +88,102 @@ impl Indexer {
             store.persist_protocol_configs_and_feature_flags(chain_id)?;
         }
 
-        let mut executor = IndexerExecutor::new(
-            ShimIndexerProgressStore::new(vec![
-                ("primary".to_string(), primary_watermark),
-                ("object_snapshot".to_string(), object_snapshot_watermark),
-            ]),
-            1,
-            DataIngestionMetrics::new(&Registry::new()),
-            cancel.child_token(),
-        );
-        let (primary_worker_pool, primary_writer) = setup_primary(
+        let mut primary_pipeline = PrimaryPipeline::setup(
             store.clone(),
             metrics.clone(),
             config.checkpoint_download_queue_size,
+            cancel.clone(),
         )
         .await?;
-        executor.register(primary_worker_pool).await?;
-        let cancel_clone = cancel.clone();
-        spawn_monitored_task!(start_primary_writer_task(
-            primary_writer,
-            primary_watermark,
-            cancel_clone
-        ));
 
-        executor.register(object_snapshot_worker_pool).await?;
-        let object_snapshot_cancel = cancel.clone();
-        let mut object_snapshot_task_handle = spawn_monitored_task!(
-            object_snapshot_writer
-                .persist_sequentially(object_snapshot_receiver, object_snapshot_cancel)
-        );
+        // data_ingestion_path can only feed data to one executor,
+        // but if we have remote_store_url we can use many executors
+        let use_separate_executors = remote_store_url.is_some();
+        let snapshot_pipeline = if use_separate_executors {
+            // SnapshotPipeline::setup will create a separate executor
+            SnapshotPipeline::setup(
+                store.clone(),
+                metrics.clone(),
+                snapshot_config,
+                config.checkpoint_download_queue_size,
+                cancel.clone(),
+            )
+            .await?
+        } else {
+            warn!(
+                "Sharing the same executor between Primary and Snapshot pipelines due to not \
+                 provided --remote-store-url argument. Limited possibilities for Snapshot lag \
+                 config. This may be deprecated in the future."
+            );
+            SnapshotPipeline::setup_with_shared_executor(
+                store.clone(),
+                metrics.clone(),
+                snapshot_config,
+                config.checkpoint_download_queue_size,
+                &mut primary_pipeline.primary_executor,
+            )
+            .await?
+        };
 
         info!("Starting data ingestion executor...");
-        let mut executor_handle = tokio::spawn(
-            executor.run(
-                config
-                    .sources
-                    .data_ingestion_path
-                    .clone()
-                    .unwrap_or(tempfile::tempdir().unwrap().keep()),
-                config
-                    .sources
-                    .remote_store_url
-                    .as_ref()
-                    .map(|url| url.as_str().to_owned()),
-                vec![],
-                extra_reader_options,
-            ),
-        );
+        let (mut primary_executor_handle, mut primary_writer_handle) = primary_pipeline
+            .run(
+                data_ingestion_path.clone(),
+                remote_store_url.clone(),
+                extra_reader_options.clone(),
+                cancel.clone(),
+            )
+            .await?;
 
-        tokio::select! {
-            executor_result = &mut executor_handle => {
-                // Executor completed first - cancel snapshot task and check result
-                cancel.cancel();
-                let snapshot_result = tokio::time::timeout(
-                    SHUTDOWN_TIMEOUT,
-                    object_snapshot_task_handle
-                ).await
-                .context("timeout waiting for snapshot task to shutdown");
-                executor_result.context("failed to join data ingestion executor")?.context("data ingestion executor failed")?;
-                snapshot_result?.context("failed to join snapshot task during shutdown")?.context("snapshot task failed during shutdown")?;
+        // Wait for max committable checkpoint > 0 before starting snapshot executor
+        // Also monitor primary_executor_handle - if it finishes, no point in waiting
+        let (mut snapshot_executor_handle, mut snapshot_persist_task_handle) = tokio::select! {
+            snapshot_pipeline_with_snapshottable_data = snapshot_pipeline.wait_for_snapshottable_data(cancel.clone()) => {
+                snapshot_pipeline_with_snapshottable_data?.run(
+                    remote_store_url,
+                    extra_reader_options,
+                    cancel.clone(),
+                ).await?
             },
-            snapshot_result = &mut object_snapshot_task_handle => {
-                // Snapshot task completed first - cancel executor and check result
-                cancel.cancel();
-                let executor_result = tokio::time::timeout(
-                    SHUTDOWN_TIMEOUT,
-                    executor_handle
-                ).await
-                .context("timeout waiting for executor to shutdown");
-                snapshot_result.context("failed to join snapshot task")?.context("snapshot task failed")?;
-                executor_result?.context("failed to join data ingestion executor during shutdown")?.context("data ingestion executor failed during shutdown")?;
+            result = &mut primary_executor_handle => {
+                result.context("failed to join primary executor")?.context("primary executor failed")?;
+                return Ok(());
             }
         };
+
+        let mut primary_executor_done = false;
+        let mut primary_writer_done = false;
+        let mut snapshot_executor_done = false;
+        let mut snapshot_persist_task_done = false;
+        while !primary_executor_done
+            || !primary_writer_done
+            || !snapshot_executor_done
+            || !snapshot_persist_task_done
+        {
+            tokio::select! {
+                result = &mut primary_executor_handle, if !primary_executor_done => {
+                    result.context("failed to join primary executor")?.context("primary executor failed")?;
+                    info!("Primary executor finished successfully");
+                    primary_executor_done = true;
+                },
+                result = &mut primary_writer_handle, if !primary_writer_done => {
+                    result.context("failed to join primary writer")?.context("primary writer failed")?;
+                    info!("Primary writer finished successfully");
+                    primary_writer_done = true;
+                },
+                result = &mut snapshot_executor_handle, if !snapshot_executor_done => {
+                    result.context("failed to join snapshot executor")?.context("snapshot executor failed")?;
+                    info!("Snapshot executor finished successfully");
+                    snapshot_executor_done = true;
+                },
+                result = &mut snapshot_persist_task_handle, if !snapshot_persist_task_done => {
+                    result.context("failed to join snapshot persist task")?.context("snapshot persist task failed")?;
+                    info!("Snapshot persist task finished successfully");
+                    snapshot_persist_task_done = true;
+                }
+            }
+            cancel.cancel();
+        }
 
         Ok(())
     }
@@ -219,31 +221,6 @@ impl Indexer {
         );
         let mut processor_orchestrator = ProcessorOrchestrator::new(store, metrics);
         processor_orchestrator.run_forever().await;
-        Ok(())
-    }
-}
-
-struct ShimIndexerProgressStore {
-    watermarks: HashMap<String, CheckpointSequenceNumber>,
-}
-
-impl ShimIndexerProgressStore {
-    fn new(watermarks: Vec<(String, CheckpointSequenceNumber)>) -> Self {
-        Self {
-            watermarks: watermarks.into_iter().collect(),
-        }
-    }
-}
-
-#[async_trait]
-impl ProgressStore for ShimIndexerProgressStore {
-    type Error = IndexerError;
-
-    async fn load(&mut self, task_name: String) -> Result<CheckpointSequenceNumber, Self::Error> {
-        Ok(*self.watermarks.get(&task_name).expect("missing watermark"))
-    }
-
-    async fn save(&mut self, _: String, _: CheckpointSequenceNumber) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -120,7 +120,7 @@ impl Indexer {
                 metrics.clone(),
                 snapshot_config,
                 config.checkpoint_download_queue_size,
-                &mut primary_pipeline.primary_executor,
+                &mut primary_pipeline.executor,
             )
             .await?
         };

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -96,10 +96,6 @@ impl Indexer {
         )
         .await?;
 
-        // data_ingestion_path can only feed data to one executor,
-        // but if we have remote_store_url we can use many executors
-        let use_separate_executors = remote_store_url.is_some();
-
         let snapshot_pipeline_builder = SnapshotPipelineBuilder::new(
             store.clone(),
             metrics.clone(),
@@ -109,6 +105,9 @@ impl Indexer {
         )
         .await?;
 
+        // data_ingestion_path can only feed data to one executor,
+        // but if we have remote_store_url we can use many executors
+        let use_separate_executors = remote_store_url.is_some();
         let snapshot_pipeline = if use_separate_executors {
             snapshot_pipeline_builder
                 .finalize_with_dedicated_executor()
@@ -125,60 +124,32 @@ impl Indexer {
         };
 
         info!("Starting data ingestion executor...");
-        let (mut primary_executor_handle, mut primary_writer_handle) = primary_pipeline
+        let mut primary_pipeline_handle = primary_pipeline
             .run(
                 data_ingestion_path.clone(),
                 remote_store_url.clone(),
                 extra_reader_options.clone(),
-                cancel.clone(),
             )
+            .await;
+
+        let mut snapshot_pipeline_handle = snapshot_pipeline
+            .run(remote_store_url, extra_reader_options)
             .await?;
 
-        // Wait for max committable checkpoint > 0 before starting snapshot executor
-        // Also monitor primary_executor_handle - if it finishes, no point in waiting
-        let (mut snapshot_executor_handle, mut snapshot_persist_task_handle) = tokio::select! {
-            snapshot_pipeline_with_snapshottable_data = snapshot_pipeline.wait_for_snapshottable_data() => {
-                snapshot_pipeline_with_snapshottable_data?.run(
-                    remote_store_url,
-                    extra_reader_options,
-                ).await?
-            },
-            result = &mut primary_executor_handle => {
-                result.context("failed to join primary executor")?.context("primary executor failed")?;
-                return Ok(());
-            }
-        };
-
-        let mut primary_executor_done = false;
-        let mut primary_writer_done = false;
-        let mut snapshot_executor_done = false;
-        let mut snapshot_persist_task_done = false;
-        while !primary_executor_done
-            || !primary_writer_done
-            || !snapshot_executor_done
-            || !snapshot_persist_task_done
-        {
+        let mut primary_pipeline_done = false;
+        let mut snapshot_pipeline_done = false;
+        while !primary_pipeline_done || !snapshot_pipeline_done {
             tokio::select! {
-                result = &mut primary_executor_handle, if !primary_executor_done => {
-                    result.context("failed to join primary executor")?.context("primary executor failed")?;
-                    info!("Primary executor finished successfully");
-                    primary_executor_done = true;
+                result = &mut primary_pipeline_handle, if !primary_pipeline_done => {
+                    result.context("failed to join primary pipeline")?.context("primary pipeline failed")?;
+                    info!("Primary pipeline finished successfully");
+                    primary_pipeline_done = true;
                 },
-                result = &mut primary_writer_handle, if !primary_writer_done => {
-                    result.context("failed to join primary writer")?.context("primary writer failed")?;
-                    info!("Primary writer finished successfully");
-                    primary_writer_done = true;
+                result = &mut snapshot_pipeline_handle, if !snapshot_pipeline_done => {
+                    result.context("failed to join snapshot pipeline")?.context("snapshot pipeline failed")?;
+                    info!("Snapshot pipeline finished successfully");
+                    snapshot_pipeline_done = true;
                 },
-                result = &mut snapshot_executor_handle, if !snapshot_executor_done => {
-                    result.context("failed to join snapshot executor")?.context("snapshot executor failed")?;
-                    info!("Snapshot executor finished successfully");
-                    snapshot_executor_done = true;
-                },
-                result = &mut snapshot_persist_task_handle, if !snapshot_persist_task_done => {
-                    result.context("failed to join snapshot persist task")?.context("snapshot persist task failed")?;
-                    info!("Snapshot persist task finished successfully");
-                    snapshot_persist_task_done = true;
-                }
             }
             cancel.cancel();
         }

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -134,7 +134,7 @@ impl Indexer {
 
         let mut snapshot_pipeline_handle = snapshot_pipeline
             .run(remote_store_url, extra_reader_options)
-            .await?;
+            .await;
 
         let mut primary_pipeline_done = false;
         let mut snapshot_pipeline_done = false;

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -17,7 +17,7 @@ use crate::{
     db::ConnectionPool,
     errors::IndexerError,
     ingestion::{
-        primary::orchestration::PrimaryPipeline, snapshot::orchestration::SnapshotPipeline,
+        primary::orchestration::PrimaryPipeline, snapshot::orchestration::SnapshotPipelineBuilder,
     },
     metrics::IndexerMetrics,
     processors::processor_orchestrator::ProcessorOrchestrator,
@@ -99,30 +99,29 @@ impl Indexer {
         // data_ingestion_path can only feed data to one executor,
         // but if we have remote_store_url we can use many executors
         let use_separate_executors = remote_store_url.is_some();
+
+        let snapshot_pipeline_builder = SnapshotPipelineBuilder::new(
+            store.clone(),
+            metrics.clone(),
+            snapshot_config,
+            config.checkpoint_download_queue_size,
+            cancel.clone(),
+        )
+        .await?;
+
         let snapshot_pipeline = if use_separate_executors {
-            // SnapshotPipeline::setup will create a separate executor
-            SnapshotPipeline::setup(
-                store.clone(),
-                metrics.clone(),
-                snapshot_config,
-                config.checkpoint_download_queue_size,
-                cancel.clone(),
-            )
-            .await?
+            snapshot_pipeline_builder
+                .finalize_with_dedicated_executor()
+                .await?
         } else {
             warn!(
                 "Sharing the same executor between Primary and Snapshot pipelines due to not \
                  provided --remote-store-url argument. Limited possibilities for Snapshot lag \
                  config. This may be deprecated in the future."
             );
-            SnapshotPipeline::setup_with_shared_executor(
-                store.clone(),
-                metrics.clone(),
-                snapshot_config,
-                config.checkpoint_download_queue_size,
-                &mut primary_pipeline.executor,
-            )
-            .await?
+            snapshot_pipeline_builder
+                .finalize_with_shared_executor(&mut primary_pipeline.executor)
+                .await?
         };
 
         info!("Starting data ingestion executor...");
@@ -138,11 +137,10 @@ impl Indexer {
         // Wait for max committable checkpoint > 0 before starting snapshot executor
         // Also monitor primary_executor_handle - if it finishes, no point in waiting
         let (mut snapshot_executor_handle, mut snapshot_persist_task_handle) = tokio::select! {
-            snapshot_pipeline_with_snapshottable_data = snapshot_pipeline.wait_for_snapshottable_data(cancel.clone()) => {
+            snapshot_pipeline_with_snapshottable_data = snapshot_pipeline.wait_for_snapshottable_data() => {
                 snapshot_pipeline_with_snapshottable_data?.run(
                     remote_store_url,
                     extra_reader_options,
-                    cancel.clone(),
                 ).await?
             },
             result = &mut primary_executor_handle => {

--- a/crates/iota-indexer/src/ingestion/common/mod.rs
+++ b/crates/iota-indexer/src/ingestion/common/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod orchestration;
 pub(crate) mod persist;
 pub mod prepare;

--- a/crates/iota-indexer/src/ingestion/common/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/common/orchestration.rs
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+//
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use iota_data_ingestion_core::ProgressStore;
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
+
+use crate::IndexerError;
+
+pub(crate) struct ShimIndexerProgressStore {
+    watermarks: HashMap<String, CheckpointSequenceNumber>,
+}
+
+impl ShimIndexerProgressStore {
+    pub fn new(watermarks: Vec<(String, CheckpointSequenceNumber)>) -> Self {
+        Self {
+            watermarks: watermarks.into_iter().collect(),
+        }
+    }
+}
+
+#[async_trait]
+impl ProgressStore for ShimIndexerProgressStore {
+    type Error = IndexerError;
+
+    async fn load(&mut self, task_name: String) -> Result<CheckpointSequenceNumber, Self::Error> {
+        let err_msg = format!("missing watermark for {task_name}");
+        Ok(*self.watermarks.get(&task_name).expect(&err_msg))
+    }
+
+    async fn save(
+        &mut self,
+        task_name: String,
+        checkpoint: CheckpointSequenceNumber,
+    ) -> Result<(), Self::Error> {
+        self.watermarks.insert(task_name, checkpoint);
+        Ok(())
+    }
+}

--- a/crates/iota-indexer/src/ingestion/common/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/common/orchestration.rs
@@ -4,8 +4,10 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use iota_data_ingestion_core::ProgressStore;
+use iota_data_ingestion_core::{DataIngestionMetrics, IndexerExecutor, ProgressStore};
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
+use prometheus::Registry;
+use tokio_util::sync::CancellationToken;
 
 use crate::IndexerError;
 
@@ -38,4 +40,18 @@ impl ProgressStore for ShimIndexerProgressStore {
         self.watermarks.insert(task_name, checkpoint);
         Ok(())
     }
+}
+
+pub(crate) fn new_executor(
+    task_name: String,
+    watermark: CheckpointSequenceNumber,
+    cancel: CancellationToken,
+) -> IndexerExecutor<ShimIndexerProgressStore> {
+    let progress_store = ShimIndexerProgressStore::new(vec![(task_name, watermark)]);
+    IndexerExecutor::new(
+        progress_store,
+        1,
+        DataIngestionMetrics::new(&Registry::new()),
+        cancel.child_token(),
+    )
 }

--- a/crates/iota-indexer/src/ingestion/primary/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/primary/orchestration.rs
@@ -5,17 +5,16 @@
 use std::collections::HashMap;
 
 use anyhow::Context;
-use iota_data_ingestion_core::{DataIngestionMetrics, IndexerExecutor, WorkerPool};
+use iota_data_ingestion_core::{IndexerExecutor, WorkerPool};
 use iota_metrics::get_metrics;
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
-use prometheus::Registry;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::{
     ingestion::{
-        common::orchestration::ShimIndexerProgressStore,
+        common::orchestration::{ShimIndexerProgressStore, new_executor},
         primary::{persist::PrimaryWriter, prepare::PrimaryWorker},
     },
     metrics::IndexerMetrics,
@@ -46,14 +45,7 @@ impl PrimaryPipeline {
             .expect("failed to get latest tx checkpoint sequence number from DB")
             .map(|seq| seq + 1)
             .unwrap_or_default();
-        let progress_store =
-            ShimIndexerProgressStore::new(vec![("primary".to_string(), watermark)]);
-        let mut executor = IndexerExecutor::new(
-            progress_store,
-            1,
-            DataIngestionMetrics::new(&Registry::new()),
-            cancel.child_token(),
-        );
+        let mut executor = new_executor("primary".to_string(), watermark, cancel.clone());
         let checkpoint_queue_size = std::env::var("CHECKPOINT_QUEUE_SIZE")
             .unwrap_or(CHECKPOINT_QUEUE_SIZE.to_string())
             .parse::<usize>()

--- a/crates/iota-indexer/src/ingestion/primary/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/primary/orchestration.rs
@@ -86,7 +86,9 @@ impl PrimaryPipeline {
         reader_options: iota_data_ingestion_core::ReaderOptions,
         cancel: CancellationToken,
     ) -> IndexerResult<(
-        JoinHandle<iota_data_ingestion_core::IngestionResult<impl std::fmt::Debug>>,
+        JoinHandle<
+            iota_data_ingestion_core::IngestionResult<HashMap<String, CheckpointSequenceNumber>>,
+        >,
         JoinHandle<IndexerResult<()>>,
     )> {
         info!("Starting primary writer...");

--- a/crates/iota-indexer/src/ingestion/primary/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/primary/orchestration.rs
@@ -26,9 +26,9 @@ use crate::{
 const CHECKPOINT_QUEUE_SIZE: usize = 100;
 
 pub(crate) struct PrimaryPipeline {
-    pub primary_executor: IndexerExecutor<ShimIndexerProgressStore>,
-    pub primary_writer: PrimaryWriter,
-    pub primary_watermark: CheckpointSequenceNumber,
+    pub executor: IndexerExecutor<ShimIndexerProgressStore>,
+    pub writer: PrimaryWriter,
+    pub watermark: CheckpointSequenceNumber,
 }
 
 impl PrimaryPipeline {
@@ -38,16 +38,16 @@ impl PrimaryPipeline {
         checkpoint_download_queue_size: usize,
         cancel: CancellationToken,
     ) -> IndexerResult<PrimaryPipeline> {
-        let primary_watermark = state
+        let watermark = state
             .get_latest_checkpoint_sequence_number()
             .await
             .expect("failed to get latest tx checkpoint sequence number from DB")
             .map(|seq| seq + 1)
             .unwrap_or_default();
-        let primary_progress_store =
-            ShimIndexerProgressStore::new(vec![("primary".to_string(), primary_watermark)]);
-        let mut primary_executor = IndexerExecutor::new(
-            primary_progress_store,
+        let progress_store =
+            ShimIndexerProgressStore::new(vec![("primary".to_string(), watermark)]);
+        let mut executor = IndexerExecutor::new(
+            progress_store,
             1,
             DataIngestionMetrics::new(&Registry::new()),
             cancel.child_token(),
@@ -64,18 +64,18 @@ impl PrimaryPipeline {
                     .channel_inflight
                     .with_label_values(&["checkpoint_indexing"]),
             );
-        let primary_worker_pool = WorkerPool::new(
+        let worker_pool = WorkerPool::new(
             PrimaryWorker::new(metrics.clone(), indexed_checkpoint_sender),
             "primary".to_string(),
             checkpoint_download_queue_size,
             Default::default(),
         );
-        let primary_writer = PrimaryWriter::new(state, metrics, indexed_checkpoint_receiver);
-        primary_executor.register(primary_worker_pool).await?;
+        let writer = PrimaryWriter::new(state, metrics, indexed_checkpoint_receiver);
+        executor.register(worker_pool).await?;
         Ok(PrimaryPipeline {
-            primary_executor,
-            primary_writer,
-            primary_watermark,
+            executor,
+            writer,
+            watermark,
         })
     }
 
@@ -90,26 +90,26 @@ impl PrimaryPipeline {
         JoinHandle<IndexerResult<()>>,
     )> {
         info!("Starting primary writer...");
-        let primary_writer_task_handle = spawn_monitored_task!(start_primary_writer_task(
-            self.primary_writer,
-            self.primary_watermark,
+        let writer_task_handle = spawn_monitored_task!(start_writer_task(
+            self.writer,
+            self.watermark,
             cancel.clone()
         ));
 
         info!("Starting primary executor...");
-        let primary_executor_handle = tokio::spawn(self.primary_executor.run(
+        let executor_handle = tokio::spawn(self.executor.run(
             data_ingestion_path,
             remote_store_url,
             vec![],
             reader_options,
         ));
 
-        Ok((primary_executor_handle, primary_writer_task_handle))
+        Ok((executor_handle, writer_task_handle))
     }
 }
 
-async fn start_primary_writer_task(
-    mut primary_writer: PrimaryWriter,
+async fn start_writer_task(
+    mut writer: PrimaryWriter,
     mut next_checkpoint_sequence_number: CheckpointSequenceNumber,
     cancel: CancellationToken,
 ) -> IndexerResult<()> {
@@ -119,7 +119,7 @@ async fn start_primary_writer_task(
     let mut unprocessed = HashMap::new();
     let mut batch = vec![];
 
-    while let Some(indexed_checkpoint_batch) = primary_writer.stream.next().await {
+    while let Some(indexed_checkpoint_batch) = writer.stream.next().await {
         if cancel.is_cancelled() {
             break;
         }
@@ -132,13 +132,13 @@ async fn start_primary_writer_task(
             let epoch = checkpoint.epoch.clone();
             batch.push(checkpoint);
             next_checkpoint_sequence_number += 1;
-            if batch.len() == primary_writer.checkpoint_commit_batch_size || epoch.is_some() {
-                primary_writer.commit_checkpoints(batch, epoch).await;
+            if batch.len() == writer.checkpoint_commit_batch_size || epoch.is_some() {
+                writer.commit_checkpoints(batch, epoch).await;
                 batch = vec![];
             }
         }
         if !batch.is_empty() {
-            primary_writer.commit_checkpoints(batch, None).await;
+            writer.commit_checkpoints(batch, None).await;
             batch = vec![];
         }
     }

--- a/crates/iota-indexer/src/ingestion/primary/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/primary/orchestration.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashMap;
 
+use anyhow::Context;
 use iota_data_ingestion_core::{DataIngestionMetrics, IndexerExecutor, WorkerPool};
 use iota_metrics::get_metrics;
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
@@ -27,8 +28,9 @@ const CHECKPOINT_QUEUE_SIZE: usize = 100;
 
 pub(crate) struct PrimaryPipeline {
     pub executor: IndexerExecutor<ShimIndexerProgressStore>,
-    pub writer: PrimaryWriter,
-    pub watermark: CheckpointSequenceNumber,
+    writer: PrimaryWriter,
+    watermark: CheckpointSequenceNumber,
+    cancel: CancellationToken,
 }
 
 impl PrimaryPipeline {
@@ -76,6 +78,7 @@ impl PrimaryPipeline {
             executor,
             writer,
             watermark,
+            cancel,
         })
     }
 
@@ -84,29 +87,48 @@ impl PrimaryPipeline {
         data_ingestion_path: std::path::PathBuf,
         remote_store_url: Option<String>,
         reader_options: iota_data_ingestion_core::ReaderOptions,
-        cancel: CancellationToken,
-    ) -> IndexerResult<(
-        JoinHandle<
-            iota_data_ingestion_core::IngestionResult<HashMap<String, CheckpointSequenceNumber>>,
-        >,
-        JoinHandle<IndexerResult<()>>,
-    )> {
-        info!("Starting primary writer...");
-        let writer_task_handle = spawn_monitored_task!(start_writer_task(
-            self.writer,
-            self.watermark,
-            cancel.clone()
-        ));
+    ) -> JoinHandle<IndexerResult<()>> {
+        let writer_cancel = self.cancel.clone();
+        let cancel = self.cancel.clone();
 
-        info!("Starting primary executor...");
-        let executor_handle = tokio::spawn(self.executor.run(
-            data_ingestion_path,
-            remote_store_url,
-            vec![],
-            reader_options,
-        ));
+        let handle = tokio::spawn(async move {
+            info!("Starting primary writer...");
+            let mut writer_handle = spawn_monitored_task!(start_writer_task(
+                self.writer,
+                self.watermark,
+                writer_cancel
+            ));
 
-        Ok((executor_handle, writer_task_handle))
+            info!("Starting primary executor...");
+            let mut executor_handle = tokio::spawn(self.executor.run(
+                data_ingestion_path,
+                remote_store_url,
+                vec![],
+                reader_options,
+            ));
+
+            let mut executor_done = false;
+            let mut writer_done = false;
+            while !executor_done || !writer_done {
+                tokio::select! {
+                    result = &mut executor_handle, if !executor_done => {
+                        result.context("failed to join primary executor")?.context("primary executor failed")?;
+                        info!("Primary executor finished successfully");
+                        executor_done = true;
+                    },
+                    result = &mut writer_handle, if !writer_done => {
+                        result.context("failed to join primary writer")?.context("primary writer failed")?;
+                        info!("Primary writer finished successfully");
+                        writer_done = true;
+                    }
+                }
+                cancel.cancel();
+            }
+
+            Ok(())
+        });
+
+        handle
     }
 }
 

--- a/crates/iota-indexer/src/ingestion/primary/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/primary/orchestration.rs
@@ -4,52 +4,111 @@
 
 use std::collections::HashMap;
 
-use iota_data_ingestion_core::WorkerPool;
+use iota_data_ingestion_core::{DataIngestionMetrics, IndexerExecutor, WorkerPool};
 use iota_metrics::get_metrics;
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
+use prometheus::Registry;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::{
-    errors::IndexerError,
-    ingestion::primary::{persist::PrimaryWriter, prepare::PrimaryWorker},
+    ingestion::{
+        common::orchestration::ShimIndexerProgressStore,
+        primary::{persist::PrimaryWriter, prepare::PrimaryWorker},
+    },
     metrics::IndexerMetrics,
-    store::PgIndexerStore,
+    spawn_monitored_task,
+    store::{PgIndexerStore, indexer_store::IndexerStore},
     types::IndexerResult,
 };
+
 const CHECKPOINT_QUEUE_SIZE: usize = 100;
 
-pub async fn setup_primary(
-    state: PgIndexerStore,
-    metrics: IndexerMetrics,
-    checkpoint_download_queue_size: usize,
-) -> Result<(WorkerPool<PrimaryWorker>, PrimaryWriter), IndexerError> {
-    let checkpoint_queue_size = std::env::var("CHECKPOINT_QUEUE_SIZE")
-        .unwrap_or(CHECKPOINT_QUEUE_SIZE.to_string())
-        .parse::<usize>()
-        .unwrap();
-    let global_metrics = get_metrics().unwrap();
-    let (indexed_checkpoint_sender, indexed_checkpoint_receiver) =
-        iota_metrics::metered_channel::channel(
-            checkpoint_queue_size,
-            &global_metrics
-                .channel_inflight
-                .with_label_values(&["checkpoint_indexing"]),
-        );
-    let worker_pool = WorkerPool::new(
-        PrimaryWorker::new(metrics.clone(), indexed_checkpoint_sender),
-        "primary".to_string(),
-        checkpoint_download_queue_size,
-        Default::default(),
-    );
-
-    Ok((
-        worker_pool,
-        PrimaryWriter::new(state, metrics, indexed_checkpoint_receiver),
-    ))
+pub(crate) struct PrimaryPipeline {
+    pub primary_executor: IndexerExecutor<ShimIndexerProgressStore>,
+    pub primary_writer: PrimaryWriter,
+    pub primary_watermark: CheckpointSequenceNumber,
 }
 
-pub(crate) async fn start_primary_writer_task(
+impl PrimaryPipeline {
+    pub async fn setup(
+        state: PgIndexerStore,
+        metrics: IndexerMetrics,
+        checkpoint_download_queue_size: usize,
+        cancel: CancellationToken,
+    ) -> IndexerResult<PrimaryPipeline> {
+        let primary_watermark = state
+            .get_latest_checkpoint_sequence_number()
+            .await
+            .expect("failed to get latest tx checkpoint sequence number from DB")
+            .map(|seq| seq + 1)
+            .unwrap_or_default();
+        let primary_progress_store =
+            ShimIndexerProgressStore::new(vec![("primary".to_string(), primary_watermark)]);
+        let mut primary_executor = IndexerExecutor::new(
+            primary_progress_store,
+            1,
+            DataIngestionMetrics::new(&Registry::new()),
+            cancel.child_token(),
+        );
+        let checkpoint_queue_size = std::env::var("CHECKPOINT_QUEUE_SIZE")
+            .unwrap_or(CHECKPOINT_QUEUE_SIZE.to_string())
+            .parse::<usize>()
+            .unwrap();
+        let global_metrics = get_metrics().unwrap();
+        let (indexed_checkpoint_sender, indexed_checkpoint_receiver) =
+            iota_metrics::metered_channel::channel(
+                checkpoint_queue_size,
+                &global_metrics
+                    .channel_inflight
+                    .with_label_values(&["checkpoint_indexing"]),
+            );
+        let primary_worker_pool = WorkerPool::new(
+            PrimaryWorker::new(metrics.clone(), indexed_checkpoint_sender),
+            "primary".to_string(),
+            checkpoint_download_queue_size,
+            Default::default(),
+        );
+        let primary_writer = PrimaryWriter::new(state, metrics, indexed_checkpoint_receiver);
+        primary_executor.register(primary_worker_pool).await?;
+        Ok(PrimaryPipeline {
+            primary_executor,
+            primary_writer,
+            primary_watermark,
+        })
+    }
+
+    pub async fn run(
+        self,
+        data_ingestion_path: std::path::PathBuf,
+        remote_store_url: Option<String>,
+        reader_options: iota_data_ingestion_core::ReaderOptions,
+        cancel: CancellationToken,
+    ) -> IndexerResult<(
+        JoinHandle<iota_data_ingestion_core::IngestionResult<impl std::fmt::Debug>>,
+        JoinHandle<IndexerResult<()>>,
+    )> {
+        info!("Starting primary writer...");
+        let primary_writer_task_handle = spawn_monitored_task!(start_primary_writer_task(
+            self.primary_writer,
+            self.primary_watermark,
+            cancel.clone()
+        ));
+
+        info!("Starting primary executor...");
+        let primary_executor_handle = tokio::spawn(self.primary_executor.run(
+            data_ingestion_path,
+            remote_store_url,
+            vec![],
+            reader_options,
+        ));
+
+        Ok((primary_executor_handle, primary_writer_task_handle))
+    }
+}
+
+async fn start_primary_writer_task(
     mut primary_writer: PrimaryWriter,
     mut next_checkpoint_sequence_number: CheckpointSequenceNumber,
     cancel: CancellationToken,

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -30,73 +30,65 @@ use crate::{
 
 const OBJECT_SNAPSHOT_CHANNEL_CAPACITY: usize = 600;
 
-pub(crate) struct SnapshotPipeline {
-    pub executor: Option<IndexerExecutor<ShimIndexerProgressStore>>,
-    pub writer: ObjectSnapshotWriter,
-    pub receiver: iota_metrics::metered_channel::Receiver<(u64, TransactionObjectChangesToCommit)>,
+pub(crate) struct SnapshotPipelineBuilder {
+    writer: ObjectSnapshotWriter,
+    checkpoint_download_queue_size: usize,
+    cancel: CancellationToken,
+    metrics: IndexerMetrics,
+    watermark: u64,
 }
 
-impl SnapshotPipeline {
-    pub async fn setup(
+impl SnapshotPipelineBuilder {
+    pub async fn new(
         state: PgIndexerStore,
         metrics: IndexerMetrics,
         lag_config: SnapshotLagConfig,
         checkpoint_download_queue_size: usize,
         cancel: CancellationToken,
-    ) -> IndexerResult<SnapshotPipeline> {
+    ) -> IndexerResult<SnapshotPipelineBuilder> {
         let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone(), lag_config);
-
         let watermark = writer.get_watermark_hi().await?.unwrap_or_default();
+        Ok(SnapshotPipelineBuilder {
+            writer,
+            checkpoint_download_queue_size,
+            cancel,
+            metrics,
+            watermark,
+        })
+    }
+
+    pub async fn finalize_with_dedicated_executor(self) -> IndexerResult<SnapshotPipeline> {
         let mut executor = IndexerExecutor::new(
             ShimIndexerProgressStore::new(Default::default()),
             1,
             DataIngestionMetrics::new(&Registry::new()),
-            cancel.child_token(),
+            self.cancel.child_token(),
         );
-        let receiver = Self::register_on_executor(
-            &mut executor,
-            metrics.clone(),
-            checkpoint_download_queue_size,
-            watermark,
-        )
-        .await?;
+        let receiver = self.register_on_executor(&mut executor).await?;
         Ok(SnapshotPipeline {
             executor: Some(executor),
-            writer,
+            writer: self.writer,
             receiver,
+            cancel: self.cancel,
         })
     }
 
-    pub async fn setup_with_shared_executor(
-        state: PgIndexerStore,
-        metrics: IndexerMetrics,
-        lag_config: SnapshotLagConfig,
-        checkpoint_download_queue_size: usize,
+    pub async fn finalize_with_shared_executor(
+        self,
         executor: &mut IndexerExecutor<ShimIndexerProgressStore>,
     ) -> IndexerResult<SnapshotPipeline> {
-        let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone(), lag_config);
-
-        let watermark = writer.get_watermark_hi().await?.unwrap_or_default();
-        let receiver = Self::register_on_executor(
-            executor,
-            metrics.clone(),
-            checkpoint_download_queue_size,
-            watermark,
-        )
-        .await?;
-
+        let receiver = self.register_on_executor(executor).await?;
         Ok(SnapshotPipeline {
             executor: None,
-            writer,
+            writer: self.writer,
             receiver,
+            cancel: self.cancel,
         })
     }
 
     async fn register_on_executor(
+        &self,
         executor: &mut IndexerExecutor<ShimIndexerProgressStore>,
-        metrics: IndexerMetrics,
-        checkpoint_download_queue_size: usize,
-        watermark: CheckpointSequenceNumber,
     ) -> IndexerResult<
         iota_metrics::metered_channel::Receiver<(u64, TransactionObjectChangesToCommit)>,
     > {
@@ -109,18 +101,27 @@ impl SnapshotPipeline {
         );
 
         let worker_pool = WorkerPool::new(
-            ObjectsSnapshotWorker::new(sender, metrics),
+            ObjectsSnapshotWorker::new(sender, self.metrics.clone()),
             "object_snapshot".to_string(),
-            checkpoint_download_queue_size,
+            self.checkpoint_download_queue_size,
             Default::default(),
         );
         executor
-            .update_watermark("object_snapshot".to_string(), watermark)
+            .update_watermark("object_snapshot".to_string(), self.watermark)
             .await?;
         executor.register(worker_pool).await?;
         Ok(receiver)
     }
+}
 
+pub(crate) struct SnapshotPipeline {
+    executor: Option<IndexerExecutor<ShimIndexerProgressStore>>,
+    writer: ObjectSnapshotWriter,
+    receiver: iota_metrics::metered_channel::Receiver<(u64, TransactionObjectChangesToCommit)>,
+    cancel: CancellationToken,
+}
+
+impl SnapshotPipeline {
     fn spawn_writer_task(
         writer: ObjectSnapshotWriter,
         receiver: iota_metrics::metered_channel::Receiver<(u64, TransactionObjectChangesToCommit)>,
@@ -129,10 +130,7 @@ impl SnapshotPipeline {
         spawn_monitored_task!(writer.persist_sequentially(receiver, cancel))
     }
 
-    pub async fn wait_for_snapshottable_data(
-        self,
-        cancel: CancellationToken,
-    ) -> IndexerResult<Self> {
+    pub async fn wait_for_snapshottable_data(self) -> IndexerResult<Self> {
         info!("Waiting for data for the Snapshot Pipeline");
         loop {
             match self.writer.get_max_committable_checkpoint().await {
@@ -154,7 +152,7 @@ impl SnapshotPipeline {
                 }
             }
 
-            if cancel.is_cancelled() {
+            if self.cancel.is_cancelled() {
                 return Err(crate::errors::IndexerError::Generic(
                     "cancelled while waiting for snapshottable data".to_string(),
                 ));
@@ -167,14 +165,13 @@ impl SnapshotPipeline {
         self,
         remote_store_url: Option<String>,
         reader_options: ReaderOptions,
-        cancel: CancellationToken,
     ) -> IndexerResult<(
-        JoinHandle<IngestionResult<impl std::fmt::Debug>>,
+        JoinHandle<IngestionResult<HashMap<String, CheckpointSequenceNumber>>>,
         JoinHandle<IndexerResult<()>>,
     )> {
         info!("Starting snapshot writer");
         let persist_task_handle =
-            Self::spawn_writer_task(self.writer.clone(), self.receiver, cancel.clone());
+            Self::spawn_writer_task(self.writer.clone(), self.receiver, self.cancel.clone());
         let dummy_ingestion_path = tempfile::tempdir().unwrap().keep();
         let executor_handle = if let Some(executor) = self.executor {
             info!("Starting snapshot executor");
@@ -188,7 +185,7 @@ impl SnapshotPipeline {
             info!("Using shared executor - skipping creation of snapshot executor");
             // Create a dummy executor handle that only completes when cancelled
             tokio::spawn(async move {
-                cancel.cancelled().await;
+                self.cancel.cancelled().await;
                 Ok(HashMap::new())
             })
         };

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -134,9 +134,9 @@ impl SnapshotPipeline {
         self,
         remote_store_url: Option<String>,
         reader_options: ReaderOptions,
-    ) -> IndexerResult<JoinHandle<IndexerResult<()>>> {
+    ) -> JoinHandle<IndexerResult<()>> {
         let handle = tokio::spawn(async move {
-            wait_for_snapshottable_data(&self.writer, &self.cancel).await?;
+            wait_for_initial_snapshot_lag(&self.writer, &self.cancel).await?;
             let cancel_clone = self.cancel.clone();
 
             info!("Starting snapshot writer");
@@ -181,11 +181,14 @@ impl SnapshotPipeline {
             Ok(())
         });
 
-        Ok(handle)
+        handle
     }
 }
 
-async fn wait_for_snapshottable_data(
+/// Waits until initial snapshot lag is reached,
+/// meaning that the snapshot pipeline is allowed to process the genesis
+/// checkpoint.
+async fn wait_for_initial_snapshot_lag(
     writer: &ObjectSnapshotWriter,
     cancel: &CancellationToken,
 ) -> IndexerResult<()> {

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -1,50 +1,206 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_data_ingestion_core::WorkerPool;
+use std::collections::HashMap;
+
+use iota_data_ingestion_core::{
+    DataIngestionMetrics, IndexerExecutor, IngestionResult, ReaderOptions, WorkerPool,
+};
 use iota_metrics::get_metrics;
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
+use prometheus::Registry;
+use tokio::{
+    task::JoinHandle,
+    time::{Duration, sleep},
+};
 use tracing::info;
 
 use crate::{
-    PgIndexerStore,
+    CancellationToken, PgIndexerStore,
     config::SnapshotLagConfig,
     ingestion::{
+        common::{orchestration::ShimIndexerProgressStore, persist::Writer},
         primary::persist::TransactionObjectChangesToCommit,
         snapshot::{persist::ObjectSnapshotWriter, prepare::ObjectsSnapshotWorker},
     },
     metrics::IndexerMetrics,
+    spawn_monitored_task,
     types::IndexerResult,
 };
 
 const OBJECT_SNAPSHOT_CHANNEL_CAPACITY: usize = 600;
 
-pub async fn setup_snapshot(
-    store: PgIndexerStore,
-    metrics: IndexerMetrics,
-    snapshot_config: SnapshotLagConfig,
-    checkpoint_download_queue_size: usize,
-) -> IndexerResult<(
-    WorkerPool<ObjectsSnapshotWorker>,
-    ObjectSnapshotWriter,
-    iota_metrics::metered_channel::Receiver<(u64, TransactionObjectChangesToCommit)>,
-)> {
-    info!("Starting object snapshot handler...");
+pub(crate) struct SnapshotPipeline {
+    pub snapshot_executor: Option<IndexerExecutor<ShimIndexerProgressStore>>,
+    pub object_snapshot_writer: ObjectSnapshotWriter,
+    pub object_snapshot_receiver:
+        iota_metrics::metered_channel::Receiver<(u64, TransactionObjectChangesToCommit)>,
+}
 
-    let global_metrics = get_metrics().unwrap();
-    let (sender, receiver) = iota_metrics::metered_channel::channel(
-        OBJECT_SNAPSHOT_CHANNEL_CAPACITY,
-        &global_metrics
-            .channel_inflight
-            .with_label_values(&["objects_snapshot_handler_checkpoint_data"]),
-    );
+impl SnapshotPipeline {
+    pub async fn setup(
+        state: PgIndexerStore,
+        metrics: IndexerMetrics,
+        snapshot_config: SnapshotLagConfig,
+        checkpoint_download_queue_size: usize,
+        cancel: CancellationToken,
+    ) -> IndexerResult<SnapshotPipeline> {
+        let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone(), snapshot_config);
 
-    let worker_pool = WorkerPool::new(
-        ObjectsSnapshotWorker::new(sender, metrics.clone()),
-        "object_snapshot".to_string(),
-        checkpoint_download_queue_size,
-        Default::default(),
-    );
+        let object_snapshot_watermark = writer.get_watermark_hi().await?.unwrap_or_default();
+        let mut snapshot_executor = IndexerExecutor::new(
+            ShimIndexerProgressStore::new(Default::default()),
+            1,
+            DataIngestionMetrics::new(&Registry::new()),
+            cancel.child_token(),
+        );
+        let receiver = Self::register_on_executor(
+            &mut snapshot_executor,
+            metrics.clone(),
+            checkpoint_download_queue_size,
+            object_snapshot_watermark,
+        )
+        .await?;
+        Ok(SnapshotPipeline {
+            snapshot_executor: Some(snapshot_executor),
+            object_snapshot_writer: writer,
+            object_snapshot_receiver: receiver,
+        })
+    }
 
-    let writer = ObjectSnapshotWriter::new(store.clone(), metrics.clone(), snapshot_config);
-    Ok((worker_pool, writer, receiver))
+    pub async fn setup_with_shared_executor(
+        state: PgIndexerStore,
+        metrics: IndexerMetrics,
+        snapshot_config: SnapshotLagConfig,
+        checkpoint_download_queue_size: usize,
+        executor: &mut IndexerExecutor<ShimIndexerProgressStore>,
+    ) -> IndexerResult<SnapshotPipeline> {
+        let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone(), snapshot_config);
+
+        let object_snapshot_watermark = writer.get_watermark_hi().await?.unwrap_or_default();
+        let receiver = Self::register_on_executor(
+            executor,
+            metrics.clone(),
+            checkpoint_download_queue_size,
+            object_snapshot_watermark,
+        )
+        .await?;
+
+        Ok(SnapshotPipeline {
+            snapshot_executor: None,
+            object_snapshot_writer: writer,
+            object_snapshot_receiver: receiver,
+        })
+    }
+
+    async fn register_on_executor(
+        executor: &mut IndexerExecutor<ShimIndexerProgressStore>,
+        metrics: IndexerMetrics,
+        checkpoint_download_queue_size: usize,
+        watermark: CheckpointSequenceNumber,
+    ) -> IndexerResult<
+        iota_metrics::metered_channel::Receiver<(u64, TransactionObjectChangesToCommit)>,
+    > {
+        let global_metrics = get_metrics().unwrap();
+        let (sender, receiver) = iota_metrics::metered_channel::channel(
+            OBJECT_SNAPSHOT_CHANNEL_CAPACITY,
+            &global_metrics
+                .channel_inflight
+                .with_label_values(&["objects_snapshot_handler_checkpoint_data"]),
+        );
+
+        let worker_pool = WorkerPool::new(
+            ObjectsSnapshotWorker::new(sender, metrics),
+            "object_snapshot".to_string(),
+            checkpoint_download_queue_size,
+            Default::default(),
+        );
+        executor
+            .update_watermark("object_snapshot".to_string(), watermark)
+            .await?;
+        executor.register(worker_pool).await?;
+        Ok(receiver)
+    }
+
+    fn spawn_writer_task(
+        writer: ObjectSnapshotWriter,
+        receiver: iota_metrics::metered_channel::Receiver<(u64, TransactionObjectChangesToCommit)>,
+        cancel: CancellationToken,
+    ) -> JoinHandle<IndexerResult<()>> {
+        spawn_monitored_task!(writer.persist_sequentially(receiver, cancel))
+    }
+
+    pub async fn wait_for_snapshottable_data(
+        self,
+        cancel: CancellationToken,
+    ) -> IndexerResult<Self> {
+        info!("Waiting for data for the Snapshot Pipeline");
+        loop {
+            match self
+                .object_snapshot_writer
+                .get_max_committable_checkpoint()
+                .await
+            {
+                Ok(max_committable) if max_committable > 0 => {
+                    info!(
+                        "Max committable checkpoint is {max_committable}, snapshottable data present",
+                    );
+                    break;
+                }
+                Ok(max_committable) => {
+                    info!(
+                        "Max committable checkpoint is {max_committable}, waiting for snapshottable data",
+                    );
+                    sleep(Duration::from_secs(1)).await;
+                }
+                Err(e) => {
+                    info!("Error getting max committable checkpoint: {e}, waiting",);
+                    sleep(Duration::from_secs(1)).await;
+                }
+            }
+
+            if cancel.is_cancelled() {
+                return Err(crate::errors::IndexerError::Generic(
+                    "cancelled while waiting for snapshottable data".to_string(),
+                ));
+            }
+        }
+        Ok(self)
+    }
+
+    pub async fn run(
+        self,
+        remote_store_url: Option<String>,
+        reader_options: ReaderOptions,
+        cancel: CancellationToken,
+    ) -> IndexerResult<(
+        JoinHandle<IngestionResult<impl std::fmt::Debug>>,
+        JoinHandle<IndexerResult<()>>,
+    )> {
+        info!("Starting snapshot writer");
+        let snapshot_persist_task_handle = Self::spawn_writer_task(
+            self.object_snapshot_writer.clone(),
+            self.object_snapshot_receiver,
+            cancel.clone(),
+        );
+        let dummy_ingestion_path = tempfile::tempdir().unwrap().keep();
+        let snapshot_executor_handle = if let Some(executor) = self.snapshot_executor {
+            info!("Starting snapshot executor");
+            tokio::spawn(executor.run(
+                dummy_ingestion_path,
+                remote_store_url,
+                vec![],
+                reader_options,
+            ))
+        } else {
+            info!("Using shared executor - skipping creation of snapshot executor");
+            // Create a dummy executor handle that only completes when cancelled
+            tokio::spawn(async move {
+                cancel.cancelled().await;
+                Ok(HashMap::new())
+            })
+        };
+
+        Ok((snapshot_executor_handle, snapshot_persist_task_handle))
+    }
 }

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -27,6 +27,7 @@ use crate::{
 };
 
 const OBJECT_SNAPSHOT_CHANNEL_CAPACITY: usize = 600;
+const WAIT_FOR_SNAPSHOTTABLE_DATA_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 pub(crate) struct SnapshotPipelineBuilder {
     writer: ObjectSnapshotWriter,
@@ -200,11 +201,11 @@ async fn wait_for_snapshottable_data(
                 info!(
                     "Max committable checkpoint is {max_committable}, waiting for snapshottable data",
                 );
-                sleep(Duration::from_secs(1)).await;
+                sleep(WAIT_FOR_SNAPSHOTTABLE_DATA_POLL_INTERVAL).await;
             }
             Err(e) => {
                 info!("Error getting max committable checkpoint: {e}, waiting",);
-                sleep(Duration::from_secs(1)).await;
+                sleep(WAIT_FOR_SNAPSHOTTABLE_DATA_POLL_INTERVAL).await;
             }
         }
 

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -3,11 +3,9 @@
 
 use std::collections::HashMap;
 
-use iota_data_ingestion_core::{
-    DataIngestionMetrics, IndexerExecutor, IngestionResult, ReaderOptions, WorkerPool,
-};
+use anyhow::Context;
+use iota_data_ingestion_core::{DataIngestionMetrics, IndexerExecutor, ReaderOptions, WorkerPool};
 use iota_metrics::get_metrics;
-use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use prometheus::Registry;
 use tokio::{
     task::JoinHandle,
@@ -130,66 +128,91 @@ impl SnapshotPipeline {
         spawn_monitored_task!(writer.persist_sequentially(receiver, cancel))
     }
 
-    pub async fn wait_for_snapshottable_data(self) -> IndexerResult<Self> {
-        info!("Waiting for data for the Snapshot Pipeline");
-        loop {
-            match self.writer.get_max_committable_checkpoint().await {
-                Ok(max_committable) if max_committable > 0 => {
-                    info!(
-                        "Max committable checkpoint is {max_committable}, snapshottable data present",
-                    );
-                    break;
-                }
-                Ok(max_committable) => {
-                    info!(
-                        "Max committable checkpoint is {max_committable}, waiting for snapshottable data",
-                    );
-                    sleep(Duration::from_secs(1)).await;
-                }
-                Err(e) => {
-                    info!("Error getting max committable checkpoint: {e}, waiting",);
-                    sleep(Duration::from_secs(1)).await;
-                }
-            }
-
-            if self.cancel.is_cancelled() {
-                return Err(crate::errors::IndexerError::Generic(
-                    "cancelled while waiting for snapshottable data".to_string(),
-                ));
-            }
-        }
-        Ok(self)
-    }
-
     pub async fn run(
         self,
         remote_store_url: Option<String>,
         reader_options: ReaderOptions,
-    ) -> IndexerResult<(
-        JoinHandle<IngestionResult<HashMap<String, CheckpointSequenceNumber>>>,
-        JoinHandle<IndexerResult<()>>,
-    )> {
-        info!("Starting snapshot writer");
-        let persist_task_handle =
-            Self::spawn_writer_task(self.writer.clone(), self.receiver, self.cancel.clone());
-        let dummy_ingestion_path = tempfile::tempdir().unwrap().keep();
-        let executor_handle = if let Some(executor) = self.executor {
-            info!("Starting snapshot executor");
-            tokio::spawn(executor.run(
-                dummy_ingestion_path,
-                remote_store_url,
-                vec![],
-                reader_options,
-            ))
-        } else {
-            info!("Using shared executor - skipping creation of snapshot executor");
-            // Create a dummy executor handle that only completes when cancelled
-            tokio::spawn(async move {
-                self.cancel.cancelled().await;
-                Ok(HashMap::new())
-            })
-        };
+    ) -> IndexerResult<JoinHandle<IndexerResult<()>>> {
+        let handle = tokio::spawn(async move {
+            wait_for_snapshottable_data(&self.writer, &self.cancel).await?;
+            let cancel_clone = self.cancel.clone();
 
-        Ok((executor_handle, persist_task_handle))
+            info!("Starting snapshot writer");
+            let mut persist_task_handle =
+                Self::spawn_writer_task(self.writer.clone(), self.receiver, self.cancel.clone());
+            let dummy_ingestion_path = tempfile::tempdir().unwrap().keep();
+            let mut executor_handle = if let Some(executor) = self.executor {
+                info!("Starting snapshot executor");
+                tokio::spawn(executor.run(
+                    dummy_ingestion_path,
+                    remote_store_url,
+                    vec![],
+                    reader_options,
+                ))
+            } else {
+                info!("Using shared executor - skipping creation of snapshot executor");
+                // Create a dummy executor handle that only completes when cancelled
+                tokio::spawn(async move {
+                    self.cancel.cancelled().await;
+                    Ok(HashMap::new())
+                })
+            };
+
+            let mut executor_done = false;
+            let mut persist_done = false;
+            while !executor_done || !persist_done {
+                tokio::select! {
+                    result = &mut executor_handle, if !executor_done => {
+                        result.context("failed to join snapshot executor")?.context("snapshot executor failed")?;
+                        info!("Snapshot executor finished successfully");
+                        executor_done = true;
+                    },
+                    result = &mut persist_task_handle, if !persist_done => {
+                        result.context("failed to join snapshot persist task")?.context("snapshot persist task failed")?;
+                        info!("Snapshot persist task finished successfully");
+                        persist_done = true;
+                    }
+                }
+                cancel_clone.cancel();
+            }
+
+            Ok(())
+        });
+
+        Ok(handle)
     }
+}
+
+async fn wait_for_snapshottable_data(
+    writer: &ObjectSnapshotWriter,
+    cancel: &CancellationToken,
+) -> IndexerResult<()> {
+    info!("Waiting for data for the Snapshot Pipeline");
+    loop {
+        match writer.get_max_committable_checkpoint().await {
+            Ok(max_committable) if max_committable > 0 => {
+                info!(
+                    "Max committable checkpoint is {max_committable}, snapshottable data present",
+                );
+                break;
+            }
+            Ok(max_committable) => {
+                info!(
+                    "Max committable checkpoint is {max_committable}, waiting for snapshottable data",
+                );
+                sleep(Duration::from_secs(1)).await;
+            }
+            Err(e) => {
+                info!("Error getting max committable checkpoint: {e}, waiting",);
+                sleep(Duration::from_secs(1)).await;
+            }
+        }
+
+        if cancel.is_cancelled() {
+            return Err(crate::errors::IndexerError::Generic(
+                "cancelled while waiting for snapshottable data".to_string(),
+            ));
+        }
+    }
+    Ok(())
 }

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -4,9 +4,8 @@
 use std::collections::HashMap;
 
 use anyhow::Context;
-use iota_data_ingestion_core::{DataIngestionMetrics, IndexerExecutor, ReaderOptions, WorkerPool};
+use iota_data_ingestion_core::{IndexerExecutor, ReaderOptions, WorkerPool};
 use iota_metrics::get_metrics;
-use prometheus::Registry;
 use tokio::{
     task::JoinHandle,
     time::{Duration, sleep},
@@ -17,7 +16,10 @@ use crate::{
     CancellationToken, PgIndexerStore,
     config::SnapshotLagConfig,
     ingestion::{
-        common::{orchestration::ShimIndexerProgressStore, persist::Writer},
+        common::{
+            orchestration::{ShimIndexerProgressStore, new_executor},
+            persist::Writer,
+        },
         primary::persist::TransactionObjectChangesToCommit,
         snapshot::{persist::ObjectSnapshotWriter, prepare::ObjectsSnapshotWorker},
     },
@@ -57,11 +59,10 @@ impl SnapshotPipelineBuilder {
     }
 
     pub async fn finalize_with_dedicated_executor(self) -> IndexerResult<SnapshotPipeline> {
-        let mut executor = IndexerExecutor::new(
-            ShimIndexerProgressStore::new(Default::default()),
-            1,
-            DataIngestionMetrics::new(&Registry::new()),
-            self.cancel.child_token(),
+        let mut executor = new_executor(
+            "object_snapshot".to_string(),
+            self.watermark,
+            self.cancel.clone(),
         );
         let receiver = self.register_on_executor(&mut executor).await?;
         Ok(SnapshotPipeline {
@@ -76,6 +77,9 @@ impl SnapshotPipelineBuilder {
         self,
         executor: &mut IndexerExecutor<ShimIndexerProgressStore>,
     ) -> IndexerResult<SnapshotPipeline> {
+        executor
+            .update_watermark("object_snapshot".to_string(), self.watermark)
+            .await?;
         let receiver = self.register_on_executor(executor).await?;
         Ok(SnapshotPipeline {
             executor: None,
@@ -105,9 +109,6 @@ impl SnapshotPipelineBuilder {
             self.checkpoint_download_queue_size,
             Default::default(),
         );
-        executor
-            .update_watermark("object_snapshot".to_string(), self.watermark)
-            .await?;
         executor.register(worker_pool).await?;
         Ok(receiver)
     }

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -31,65 +31,64 @@ use crate::{
 const OBJECT_SNAPSHOT_CHANNEL_CAPACITY: usize = 600;
 
 pub(crate) struct SnapshotPipeline {
-    pub snapshot_executor: Option<IndexerExecutor<ShimIndexerProgressStore>>,
-    pub object_snapshot_writer: ObjectSnapshotWriter,
-    pub object_snapshot_receiver:
-        iota_metrics::metered_channel::Receiver<(u64, TransactionObjectChangesToCommit)>,
+    pub executor: Option<IndexerExecutor<ShimIndexerProgressStore>>,
+    pub writer: ObjectSnapshotWriter,
+    pub receiver: iota_metrics::metered_channel::Receiver<(u64, TransactionObjectChangesToCommit)>,
 }
 
 impl SnapshotPipeline {
     pub async fn setup(
         state: PgIndexerStore,
         metrics: IndexerMetrics,
-        snapshot_config: SnapshotLagConfig,
+        lag_config: SnapshotLagConfig,
         checkpoint_download_queue_size: usize,
         cancel: CancellationToken,
     ) -> IndexerResult<SnapshotPipeline> {
-        let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone(), snapshot_config);
+        let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone(), lag_config);
 
-        let object_snapshot_watermark = writer.get_watermark_hi().await?.unwrap_or_default();
-        let mut snapshot_executor = IndexerExecutor::new(
+        let watermark = writer.get_watermark_hi().await?.unwrap_or_default();
+        let mut executor = IndexerExecutor::new(
             ShimIndexerProgressStore::new(Default::default()),
             1,
             DataIngestionMetrics::new(&Registry::new()),
             cancel.child_token(),
         );
         let receiver = Self::register_on_executor(
-            &mut snapshot_executor,
+            &mut executor,
             metrics.clone(),
             checkpoint_download_queue_size,
-            object_snapshot_watermark,
+            watermark,
         )
         .await?;
         Ok(SnapshotPipeline {
-            snapshot_executor: Some(snapshot_executor),
-            object_snapshot_writer: writer,
-            object_snapshot_receiver: receiver,
+            executor: Some(executor),
+            writer,
+            receiver,
         })
     }
 
     pub async fn setup_with_shared_executor(
         state: PgIndexerStore,
         metrics: IndexerMetrics,
-        snapshot_config: SnapshotLagConfig,
+        lag_config: SnapshotLagConfig,
         checkpoint_download_queue_size: usize,
         executor: &mut IndexerExecutor<ShimIndexerProgressStore>,
     ) -> IndexerResult<SnapshotPipeline> {
-        let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone(), snapshot_config);
+        let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone(), lag_config);
 
-        let object_snapshot_watermark = writer.get_watermark_hi().await?.unwrap_or_default();
+        let watermark = writer.get_watermark_hi().await?.unwrap_or_default();
         let receiver = Self::register_on_executor(
             executor,
             metrics.clone(),
             checkpoint_download_queue_size,
-            object_snapshot_watermark,
+            watermark,
         )
         .await?;
 
         Ok(SnapshotPipeline {
-            snapshot_executor: None,
-            object_snapshot_writer: writer,
-            object_snapshot_receiver: receiver,
+            executor: None,
+            writer,
+            receiver,
         })
     }
 
@@ -136,11 +135,7 @@ impl SnapshotPipeline {
     ) -> IndexerResult<Self> {
         info!("Waiting for data for the Snapshot Pipeline");
         loop {
-            match self
-                .object_snapshot_writer
-                .get_max_committable_checkpoint()
-                .await
-            {
+            match self.writer.get_max_committable_checkpoint().await {
                 Ok(max_committable) if max_committable > 0 => {
                     info!(
                         "Max committable checkpoint is {max_committable}, snapshottable data present",
@@ -178,13 +173,10 @@ impl SnapshotPipeline {
         JoinHandle<IndexerResult<()>>,
     )> {
         info!("Starting snapshot writer");
-        let snapshot_persist_task_handle = Self::spawn_writer_task(
-            self.object_snapshot_writer.clone(),
-            self.object_snapshot_receiver,
-            cancel.clone(),
-        );
+        let persist_task_handle =
+            Self::spawn_writer_task(self.writer.clone(), self.receiver, cancel.clone());
         let dummy_ingestion_path = tempfile::tempdir().unwrap().keep();
-        let snapshot_executor_handle = if let Some(executor) = self.snapshot_executor {
+        let executor_handle = if let Some(executor) = self.executor {
             info!("Starting snapshot executor");
             tokio::spawn(executor.run(
                 dummy_ingestion_path,
@@ -201,6 +193,6 @@ impl SnapshotPipeline {
             })
         };
 
-        Ok((snapshot_executor_handle, snapshot_persist_task_handle))
+        Ok((executor_handle, persist_task_handle))
     }
 }


### PR DESCRIPTION
# Description of change

This PR splits executors for Primary and Snapshot pipelines in case it's possible (so in situation where user passes the remote_store_url as the source of checkpoints).
The code was refactored to leverage the fact that those are separate pipelines with separate executors.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/8841

## How the change has been tested

colocated setup tested with `iota start` command
non colocated setup tested by running `iota start` and starting indexer separately
sync from genesis for mainnet data was NOT tested yet

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] Indexer:
   Passing `--remote-store-url` as the source of checkpoints will run the snapshot indexing pipeline using a separate executor, allowing much bigger config parameters for snapshot lag.
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
