### PR TITLE
refactor(iota-indexer): lower-case error messages

### DIFF
--- a/crates/iota-indexer-builder/src/indexer_builder.rs
+++ b/crates/iota-indexer-builder/src/indexer_builder.rs
@@ -125,7 +125,7 @@ impl<P, D, M> Indexer<P, D, M> {
                             data_mapper_clone.clone(),
                         )
                         .await
-                        .expect("Backfill task failed");
+                        .expect("backfill task failed");
                 }
             }
         });

--- a/crates/iota-indexer/src/apis/indexer_api.rs
+++ b/crates/iota-indexer/src/apis/indexer_api.rs
@@ -71,13 +71,13 @@ impl IndexerApi {
         let mut objects = futures::future::try_join_all(object_futures)
             .await
             .map_err(|e| {
-                tracing::error!("Error joining object read futures.");
+                tracing::error!("error joining object read futures.");
                 RpcClientError::Custom(format!("Error joining object read futures. {e}"))
             })
             .map_err(error_object_from_rpc)?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .tap_err(|e| tracing::error!("Error converting object to object read: {e}"))?;
+            .tap_err(|e| tracing::error!("error converting object to object read: {e}"))?;
         let has_next_page = objects.len() > limit;
         objects.truncate(limit);
 

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/tx_wrapped_or_deleted_objects.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/tx_wrapped_or_deleted_objects.rs
@@ -30,7 +30,7 @@ impl IngestionBackfill for TxWrappedOrDeletedObjectsBackfill {
 
         if checkpoint_contents.size() != transactions.len() {
             return Err(IndexerError::FullNodeReading(format!(
-                "Checkpoint content size mismatch at checkpoint {checkpoint_seq}: expected {}, found {}",
+                "checkpoint content size mismatch at checkpoint {checkpoint_seq}: expected {}, found {}",
                 checkpoint_contents.size(),
                 transactions.len()
             )));
@@ -47,7 +47,7 @@ impl IngestionBackfill for TxWrappedOrDeletedObjectsBackfill {
 
             if expected_digest != *actual_digest {
                 return Err(IndexerError::FullNodeReading(format!(
-                    "Digest mismatch at checkpoint {checkpoint_seq}: expected {expected_digest}, found {actual_digest}",
+                    "digest mismatch at checkpoint {checkpoint_seq}: expected {expected_digest}, found {actual_digest}",
                 )));
             }
 

--- a/crates/iota-indexer/src/backfill/ingestion/task.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/task.rs
@@ -103,7 +103,7 @@ impl<T: IngestionBackfill + 'static> IngestionBackfillTask<T> {
 
         tokio::spawn(async move {
             if let Err(join_err) = executor.await {
-                error!(?join_err, "Ingestion executor panicked or was cancelled");
+                error!(?join_err, "ingestion executor panicked or was cancelled");
             }
         });
 
@@ -251,20 +251,20 @@ mod tests {
             // Perform backfill for checkpoint 0..=4
             task.backfill_range(pool.clone(), &(0..=4))
                 .await
-                .expect("Backfill failed for checkpoint range 0..=4");
+                .expect("backfill failed for checkpoint range 0..=4");
 
             // Validate checkpoints 0..=4 are consumed
             for seq in 0..=4 {
                 assert!(
                     !ready_checkpoints.contains_key(&seq),
-                    "Checkpoint {seq} should have been consumed"
+                    "checkpoint {seq} should have been consumed"
                 );
             }
             // Validate checkpoints 5..=19 are still present
             for seq in 5..=19 {
                 assert!(
                     ready_checkpoints.contains_key(&seq),
-                    "Checkpoint {seq} should still be present"
+                    "checkpoint {seq} should still be present"
                 );
             }
 
@@ -273,11 +273,11 @@ mod tests {
             // Consume the rest of the checkpoints
             task.backfill_range(pool.clone(), &(5..=19))
                 .await
-                .expect("Backfill failed for checkpoint range 5..=19");
+                .expect("backfill failed for checkpoint range 5..=19");
 
             assert!(
                 ready_checkpoints.is_empty(),
-                "All checkpoints should have been consumed"
+                "all checkpoints should have been consumed"
             );
 
             // Check if the data was written correctly
@@ -285,7 +285,7 @@ mod tests {
             let RowCount { cnt } = sql_query("SELECT COUNT(*) AS cnt FROM ingestion_items")
                 .get_result(&mut conn)
                 .unwrap();
-            assert_eq!(cnt, 20, "Should have 20 items in ingestion_items table");
+            assert_eq!(cnt, 20, "should have 20 items in ingestion_items table");
         }
 
         db.drop_if_exists();

--- a/crates/iota-indexer/src/backfill/runner.rs
+++ b/crates/iota-indexer/src/backfill/runner.rs
@@ -67,7 +67,7 @@ impl BackfillRunner {
 
                     // Execute backfill for the range
                     if let Err(e) = backfill.backfill_range(pool, &range).await {
-                        error!("Chunk {start}-{end} failed. Error: {e}",);
+                        error!("chunk {start}-{end} failed. Error: {e}");
                         return Err(e);
                     }
 

--- a/crates/iota-indexer/src/backfill/sql/sql_backfill.rs
+++ b/crates/iota-indexer/src/backfill/sql/sql_backfill.rs
@@ -154,7 +154,7 @@ mod tests {
                 .get_result(&mut conn)
                 .unwrap();
 
-            assert_eq!(cnt, 20, "Should have filled exactly 5 missing rows");
+            assert_eq!(cnt, 20, "should have filled exactly 5 missing rows");
         }
 
         database.drop_if_exists();
@@ -208,7 +208,7 @@ mod tests {
             let RowCount { cnt } = sql_query("SELECT COUNT(*) AS cnt FROM target_items")
                 .get_result(&mut conn)
                 .unwrap();
-            assert_eq!(cnt, 20, "Count should remain at 20 after retry");
+            assert_eq!(cnt, 20, "count should remain at 20 after retry");
         }
 
         database.drop_if_exists();

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -267,7 +267,7 @@ impl PruningOptions {
                 return Ok(None);
             };
             warn!(
-                "Using the deprecated --epochs-to-keep argument for pruning configuration. \
+                "using the deprecated --epochs-to-keep argument for pruning configuration. \
                  Please use --pruning-config-path to specify a TOML configuration file instead."
             );
             return Ok(Some(RetentionConfig::new(
@@ -278,27 +278,27 @@ impl PruningOptions {
 
         if self.epochs_to_keep.is_some() {
             warn!(
-                "The --epochs-to-keep argument will be ignored since --pruning-config-path is also provided."
+                "the --epochs-to-keep argument will be ignored since --pruning-config-path is also provided."
             );
         };
 
         let contents = std::fs::read_to_string(config_path)
-            .context("Failed to read default retention policy and overrides from file")?;
+            .context("failed to read default retention policy and overrides from file")?;
         let retention_with_overrides = toml::de::from_str::<RetentionConfig>(&contents)
-            .context("Failed to parse into RetentionConfig struct")?;
+            .context("failed to parse into RetentionConfig struct")?;
 
         let default_retention = retention_with_overrides.epochs_to_keep;
 
         assert!(
             default_retention > 0,
-            "Default retention must be greater than 0"
+            "default retention must be greater than 0"
         );
         assert!(
             retention_with_overrides
                 .overrides
                 .values()
                 .all(|&policy| policy > 0),
-            "All retention overrides must be greater than 0"
+            "all retention overrides must be greater than 0"
         );
 
         Ok(Some(retention_with_overrides))
@@ -451,7 +451,7 @@ pub mod deprecated {
         pub fn base_connection_url(&self) -> anyhow::Result<String, anyhow::Error> {
             let url_secret = self.get_db_url()?;
             let url_str = url_secret.expose_secret();
-            let url = Url::parse(url_str).expect("Failed to parse URL");
+            let url = Url::parse(url_str).expect("failed to parse URL");
             Ok(format!(
                 "{}://{}:{}@{}:{}/",
                 url.scheme(),
@@ -488,7 +488,7 @@ pub mod deprecated {
                     db_name
                 ))),
                 _ => bail!(
-                    "Invalid db connection config, either db_url or (db_user_name, db_password, db_host, db_port, db_name) must be provided"
+                    "unvalid db connection config, either db_url or (db_user_name, db_password, db_host, db_port, db_name) must be provided"
                 ),
             }
         }
@@ -563,13 +563,13 @@ pub mod deprecated {
                     IngestionConfig::DEFAULT_CHECKPOINT_DOWNLOAD_QUEUE_SIZE.to_string()
                 })
                 .parse::<usize>()
-                .expect("Invalid DOWNLOAD_QUEUE_SIZE");
+                .expect("invalid DOWNLOAD_QUEUE_SIZE");
             let ingestion_reader_timeout_secs = std::env::var("INGESTION_READER_TIMEOUT_SECS")
                 .unwrap_or_else(|_| {
                     IngestionConfig::DEFAULT_CHECKPOINT_DOWNLOAD_TIMEOUT.to_string()
                 })
                 .parse::<u64>()
-                .expect("Invalid INGESTION_READER_TIMEOUT_SECS");
+                .expect("invalid INGESTION_READER_TIMEOUT_SECS");
             let data_limit = std::env::var("CHECKPOINT_PROCESSING_BATCH_DATA_LIMIT")
                 .unwrap_or(
                     IngestionConfig::DEFAULT_CHECKPOINT_DOWNLOAD_QUEUE_SIZE_BYTES.to_string(),
@@ -585,7 +585,7 @@ pub mod deprecated {
             let rpc_client_url_parsed = old_conf
                 .rpc_client_url
                 .parse()
-                .expect("RPC Client url should be valid");
+                .expect("rpc client url should be valid");
 
             let command = if old_conf.analytical_worker {
                 Command::AnalyticalWorker
@@ -597,7 +597,7 @@ pub mod deprecated {
                             .rpc_server_url
                             .as_str()
                             .parse()
-                            .expect("RPC Server url should be valid"),
+                            .expect("rpc server url should be valid"),
                         old_conf.rpc_server_port,
                     ),
                     rpc_client_url: old_conf.rpc_client_url,
@@ -608,7 +608,7 @@ pub mod deprecated {
                         sources: IngestionSources {
                             data_ingestion_path: old_conf.data_ingestion_path,
                             remote_store_url: old_conf.remote_store_url.map(|url| {
-                                url.parse().expect("Remote Store URL should be correct")
+                                url.parse().expect("remote store url should be correct")
                             }),
                             rpc_client_url: Some(rpc_client_url_parsed),
                         },
@@ -633,7 +633,7 @@ pub mod deprecated {
                 }
             } else {
                 return Err(IndexerError::InvalidArgument(
-                    "Worker type argument not specified".into(),
+                    "worker type argument not specified".into(),
                 ));
             };
 
@@ -642,12 +642,12 @@ pub mod deprecated {
                     db_url
                         .map_err(|e| {
                             IndexerError::PgPoolConnection(format!(
-                                "Failed parsing database url with error {e:?}"
+                                "failed parsing database url with error {e:?}"
                             ))
                         })?
                         .expose_secret()
                         .parse()
-                        .expect("Database URL should be correct"),
+                        .expect("database url should be correct"),
                 ),
                 connection_pool_config: pool_config_from_env(),
                 metrics_address,
@@ -769,7 +769,7 @@ mod test {
 
         for table in PrunableTable::iter() {
             let Some(retention) = retention_policies.get(&table).copied() else {
-                panic!("Expected a retention policy for table {table:?}");
+                panic!("expected a retention policy for table {table:?}");
             };
 
             match table {
@@ -820,7 +820,7 @@ mod test {
 
         for table in PrunableTable::iter() {
             let Some(retention) = retention_policies.get(&table).copied() else {
-                panic!("Expected a retention policy for table {table:?}");
+                panic!("expected a retention policy for table {table:?}");
             };
 
             match table {
@@ -845,12 +845,12 @@ mod test {
         "#;
 
         let result = toml::from_str::<RetentionConfig>(toml_str);
-        assert!(result.is_err(), "Expected an error, but parsing succeeded");
+        assert!(result.is_err(), "expected an error, but parsing succeeded");
 
         if let Err(e) = result {
             assert!(
                 e.to_string().contains("unknown variant `invalid_table`"),
-                "Error message doesn't mention the invalid table"
+                "error message doesn't mention the invalid table"
             );
         }
     }

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -488,7 +488,7 @@ pub mod deprecated {
                     db_name
                 ))),
                 _ => bail!(
-                    "unvalid db connection config, either db_url or (db_user_name, db_password, db_host, db_port, db_name) must be provided"
+                    "invalid db connection config, either db_url or (db_user_name, db_password, db_host, db_port, db_name) must be provided"
                 ),
             }
         }

--- a/crates/iota-indexer/src/db.rs
+++ b/crates/iota-indexer/src/db.rs
@@ -95,7 +95,7 @@ impl<T: R2D2Connection + 'static> diesel::r2d2::CustomizeConnection<T, diesel::r
                 || {
                     Err(diesel::r2d2::Error::QueryError(
                         diesel::result::Error::DeserializationError(
-                            "Failed to downcast connection to PgConnection"
+                            "failed to downcast connection to PgConnection"
                                 .to_string()
                                 .into(),
                         ),
@@ -134,7 +134,7 @@ pub fn new_connection_pool(
         .build(manager)
         .map_err(|e| {
             IndexerError::PgConnectionPoolInit(format!(
-                "Failed to initialize connection pool for {db_url} with error: {e:?}"
+                "failed to initialize connection pool for {db_url} with error: {e:?}"
             ))
         })
 }
@@ -142,7 +142,7 @@ pub fn new_connection_pool(
 pub fn get_pool_connection(pool: &ConnectionPool) -> Result<PoolConnection, IndexerError> {
     pool.get().map_err(|e| {
         IndexerError::PgPoolConnection(format!(
-            "Failed to get connection from PG connection pool with error: {e:?}"
+            "failed to get connection from PG connection pool with error: {e:?}"
         ))
     })
 }
@@ -152,7 +152,7 @@ pub fn reset_database(conn: &mut PoolConnection) -> Result<(), anyhow::Error> {
         conn.as_any_mut()
             .downcast_mut::<PoolConnection>()
             .map_or_else(
-                || Err(anyhow!("Failed to downcast connection to PgConnection")),
+                || Err(anyhow!("failed to downcast connection to PgConnection")),
                 |pg_conn| {
                     setup_postgres::reset_database(pg_conn)?;
                     Ok(())
@@ -193,14 +193,14 @@ pub async fn check_prunable_tables_valid(conn: &mut PoolConnection) -> Result<()
 
     let result: Vec<TableName> = diesel::sql_query(select_parent_tables)
         .load(conn)
-        .map_err(|e| IndexerError::DbMigration(format!("Failed to fetch tables: {e}")))?;
+        .map_err(|e| IndexerError::DbMigration(format!("failed to fetch tables: {e}")))?;
 
     let parent_tables_from_db: HashSet<_> = result.into_iter().map(|t| t.table_name).collect();
 
     for key in PrunableTable::iter() {
         if !parent_tables_from_db.contains(key.as_ref()) {
             return Err(IndexerError::Generic(format!(
-                "Invalid retention policy override provided for table {key}: does not exist in the database",
+                "invalid retention policy override provided for table {key}: does not exist in the database",
             )));
         }
     }
@@ -285,7 +285,7 @@ pub mod setup_postgres {
     /// Execute all unapplied migrations.
     pub fn run_migrations(conn: &mut PoolConnection) -> Result<(), anyhow::Error> {
         conn.run_pending_migrations(MIGRATIONS)
-            .map_err(|e| anyhow!("Failed to run migrations {e}"))?;
+            .map_err(|e| anyhow!("failed to run migrations {e}"))?;
         Ok(())
     }
 
@@ -313,7 +313,7 @@ pub mod setup_postgres {
         info!("Starting compatibility check");
         let migrations: Vec<Box<dyn Migration<Pg>>> = MIGRATIONS.migrations().map_err(|err| {
             IndexerError::DbMigration(format!(
-                "Failed to fetch local migrations from schema: {err}"
+                "failed to fetch local migrations from schema: {err}"
             ))
         })?;
 
@@ -343,26 +343,16 @@ pub mod setup_postgres {
         // We check that the local migrations is a prefix of the applied migrations.
         if local_migrations.len() > applied_migrations.len() {
             return Err(IndexerError::DbMigration(format!(
-                "The number of local migrations is greater than the number of applied migrations. Local migrations: {local_migrations:?}, Applied migrations: {applied_migrations:?}",
+                "the number of local migrations is greater than the number of applied migrations. Local migrations: {local_migrations:?}, Applied migrations: {applied_migrations:?}",
             )));
         }
         for (local_migration, applied_migration) in local_migrations.iter().zip(&applied_migrations)
         {
             if local_migration != applied_migration {
                 return Err(IndexerError::DbMigration(format!(
-                    "The next applied migration `{applied_migration:?}` diverges from the local migration `{local_migration:?}`",
+                    "the next applied migration `{applied_migration:?}` diverges from the local migration `{local_migration:?}`",
                 )));
             }
-            // let store = PgIndexerStore::new(blocking_cp,
-            // indexer_metrics.clone());
-            // return Indexer::start_reader(
-            //     &indexer_config,
-            //     store,
-            //     &registry,
-            //     db_url.to_string(),
-            //     indexer_metrics,
-            // )
-            // .await;
         }
         Ok(())
     }

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -58,7 +58,7 @@ impl Indexer {
         let primary_watermark = store
             .get_latest_checkpoint_sequence_number()
             .await
-            .expect("Failed to get latest tx checkpoint sequence number from DB")
+            .expect("failed to get latest tx checkpoint sequence number from DB")
             .map(|seq| seq + 1)
             .unwrap_or_default();
         let extra_reader_options = ReaderOptions {
@@ -200,10 +200,10 @@ impl Indexer {
         let read = IndexerReader::new(connection_pool);
         let handle = build_json_rpc_server(store, registry, read, config, metrics)
             .await
-            .expect("Json rpc server should not run into errors upon start.");
+            .expect("json rpc server should not run into errors upon start.");
         tokio::spawn(async move { handle.stopped().await })
             .await
-            .expect("Rpc server task failed");
+            .expect("rpc server task failed");
 
         Ok(())
     }

--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -129,7 +129,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
                     .collect();
                 self.persist(batch).await.map_err(|e| {
                     IndexerError::PostgresWrite(format!(
-                        "Failed to load transformed data into DB for handler {}: {e}",
+                        "failed to load transformed data into DB for handler {}: {e}",
                         self.name()
                     ))
                 })?;
@@ -137,7 +137,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
             }
         }
         Err(IndexerError::ChannelClosed(format!(
-            "Checkpoint channel is closed unexpectedly for handler {}",
+            "checkpoint channel is closed unexpectedly for handler {}",
             self.name()
         )))
     }

--- a/crates/iota-indexer/src/ingestion/common/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/common/prepare.rs
@@ -238,7 +238,7 @@ pub(crate) fn retain_latest_objects_from_checkpoint_batch(
             if let Some(existing) = deletions.remove(&id) {
                 assert!(
                     existing.version() < version.value(),
-                    "Mutation version ({version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
+                    "mutation version ({version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
                     existing.version()
                 );
             }
@@ -246,7 +246,7 @@ pub(crate) fn retain_latest_objects_from_checkpoint_batch(
             if let Some(existing) = mutations.insert(id, mutation) {
                 assert!(
                     existing.object().version() < version,
-                    "Mutation version ({version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
+                    "mutation version ({version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
                     existing.object().version()
                 );
             }
@@ -259,7 +259,7 @@ pub(crate) fn retain_latest_objects_from_checkpoint_batch(
             if let Some(existing) = mutations.remove(&id) {
                 assert!(
                     existing.object().version().value() < version,
-                    "Deletion version ({version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
+                    "deletion version ({version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
                     existing.object().version(),
                 );
             }
@@ -267,7 +267,7 @@ pub(crate) fn retain_latest_objects_from_checkpoint_batch(
             if let Some(existing) = deletions.insert(id, deletion) {
                 assert!(
                     existing.version() < version,
-                    "Deletion version ({version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
+                    "deletion version ({version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
                     existing.version()
                 );
             }

--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -175,12 +175,12 @@ impl PrimaryWriter {
                 .into_iter()
                 .map(|res| {
                     if res.is_err() {
-                        error!("Failed to persist data with error: {:?}", res);
+                        error!("failed to persist data with error: {:?}", res);
                     }
                     res
                 })
                 .collect::<IndexerResult<Vec<_>>>()
-                .expect("Persisting data into DB should not fail.");
+                .expect("persisting data into DB should not fail.");
         }
 
         self.state
@@ -199,9 +199,9 @@ impl PrimaryWriter {
                 .advance_epoch(epoch_data)
                 .await
                 .tap_err(|e| {
-                    error!("Failed to advance epoch with error: {}", e.to_string());
+                    error!("failed to advance epoch with error: {}", e.to_string());
                 })
-                .expect("Advancing epochs in DB should not fail.");
+                .expect("advancing epochs in DB should not fail.");
             self.metrics.total_epoch_committed.inc();
 
             // Refresh participation metrics after advancing epoch
@@ -209,9 +209,9 @@ impl PrimaryWriter {
                 .refresh_participation_metrics()
                 .await
                 .tap_err(|e| {
-                    error!("Failed to update participation metrics: {e}");
+                    error!("failed to update participation metrics: {e}");
                 })
-                .expect("Updating participation metrics should not fail.");
+                .expect("updating participation metrics should not fail.");
         }
 
         self.state
@@ -219,19 +219,19 @@ impl PrimaryWriter {
             .await
             .tap_err(|e| {
                 error!(
-                    "Failed to persist checkpoint data with error: {}",
+                    "failed to persist checkpoint data with error: {}",
                     e.to_string()
                 );
             })
-            .expect("Persisting data into DB should not fail.");
+            .expect("persisting data into DB should not fail.");
 
         if is_epoch_end {
             // The epoch has advanced so we update the configs for the new protocol version,
             // if it has changed.
             let chain_id = <PgIndexerStore as IndexerStore>::get_chain_identifier(&self.state)
                 .await
-                .expect("Failed to get chain identifier")
-                .expect("Chain identifier should have been indexed at this point");
+                .expect("failed to get chain identifier")
+                .expect("chain identifier should have been indexed at this point");
             let _ = self
                 .state
                 .persist_protocol_configs_and_feature_flags(chain_id);

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -107,7 +107,7 @@ impl Worker for PrimaryWorker {
             .await
             .map_err(|_| {
                 IndexerError::MpscChannel(
-                    "Failed to send checkpoint data, receiver half closed".into(),
+                    "failed to send checkpoint data, receiver half closed".into(),
                 )
             })?;
         Ok(())
@@ -179,12 +179,12 @@ impl PrimaryWorker {
         let system_state = get_iota_system_state(&checkpoint_object_store)?;
         if event.is_none() {
             warn!(
-                "No SystemEpochInfoEvent found at end of epoch {}, some epoch data will be set to default.",
+                "no SystemEpochInfoEvent found at end of epoch {}, some epoch data will be set to default.",
                 checkpoint_summary.epoch,
             );
             assert!(
                 system_state.safe_mode(),
-                "IOTA is not in safe mode but no SystemEpochInfoEvent found at end of epoch {}",
+                "iota is not in safe mode but no SystemEpochInfoEvent found at end of epoch {}",
                 checkpoint_summary.epoch
             );
         }
@@ -315,10 +315,9 @@ impl PrimaryWorker {
 
         if checkpoint_contents.size() != transactions.len() {
             return Err(IndexerError::FullNodeReading(format!(
-                "CheckpointContents has different size {} compared to Transactions {} for checkpoint {}",
+                "checkpointContents has different size {} compared to Transactions {} for checkpoint {checkpoint_seq}",
                 checkpoint_contents.size(),
-                transactions.len(),
-                checkpoint_seq
+                transactions.len()
             )));
         }
 
@@ -334,7 +333,7 @@ impl PrimaryWorker {
             let actual_tx_digest = tx.transaction.digest();
             if tx_digest != *actual_tx_digest {
                 return Err(IndexerError::FullNodeReading(format!(
-                    "Transactions has different ordering from CheckpointContents, for checkpoint {checkpoint_seq}, Mismatch found at {tx_digest} v.s. {actual_tx_digest}",
+                    "transactions has different ordering from CheckpointContents, for checkpoint {checkpoint_seq}, Mismatch found at {tx_digest} v.s. {actual_tx_digest}",
                 )));
             }
 
@@ -624,7 +623,7 @@ impl PrimaryWorker {
             return Ok(pg_state.blocking_cp());
         }
         Err(IndexerError::Uncategorized(anyhow::anyhow!(
-            "Failed to downcast state to PgIndexerStore"
+            "failed to downcast state to PgIndexerStore"
         )))
     }
 }
@@ -710,7 +709,7 @@ impl InMemTxChanges {
             self,
             effects,
             tx.input_objects().unwrap_or_else(|e| {
-                panic!("Checkpointed tx {tx_digest:?} has invalid input objects: {e}",)
+                panic!("checkpointed tx {tx_digest:?} has invalid input objects: {e}")
             }),
             None,
         )
@@ -739,8 +738,7 @@ impl ObjectProvider for InMemTxChanges {
         }
 
         panic!(
-            "Object {} is not found in TxChangesProcessor as an ObjectProvider (fn get_object)",
-            id
+            "object {id} is not found in TxChangesProcessor as an ObjectProvider (fn get_object)"
         );
     }
 
@@ -771,10 +769,8 @@ impl ObjectProvider for InMemTxChanges {
         if let Some(o) = object {
             if o.version() > *version {
                 panic!(
-                    "Found a higher version {} for object {}, expected lt_or_eq {}",
+                    "found a higher version {} for object {id}, expected lt_or_eq {version}",
                     o.version(),
-                    id,
-                    *version
                 );
             }
             if o.version() <= *version {
@@ -784,8 +780,7 @@ impl ObjectProvider for InMemTxChanges {
         }
 
         panic!(
-            "Object {} is not found in TxChangesProcessor as an ObjectProvider (fn find_object_lt_or_eq_version)",
-            id
+            "object {id} is not found in TxChangesProcessor as an ObjectProvider (fn find_object_lt_or_eq_version)"
         );
     }
 }

--- a/crates/iota-indexer/src/ingestion/snapshot/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/prepare.rs
@@ -48,7 +48,7 @@ impl Worker for ObjectsSnapshotWorker {
             .await
             .map_err(|_| {
                 IndexerError::MpscChannel(
-                    "Failed to send checkpoint object changes, receiver half closed".into(),
+                    "failed to send checkpoint object changes, receiver half closed".into(),
                 )
             })?;
         Ok(())

--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -96,9 +96,9 @@ fn get_http_client(rpc_client_url: &str) -> Result<HttpClient, IndexerError> {
         .set_headers(headers.clone())
         .build(rpc_client_url)
         .map_err(|e| {
-            warn!("Failed to get new Http client with error: {:?}", e);
+            warn!("failed to get new Http client with error: {:?}", e);
             IndexerError::HttpClientInit(format!(
-                "Failed to initialize fullnode RPC client with error: {e:?}"
+                "failed to initialize fullnode RPC client with error: {e:?}"
             ))
         })
 }

--- a/crates/iota-indexer/src/main.rs
+++ b/crates/iota-indexer/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), IndexerError> {
 
     if let Command::HelpDeprecated = opts.command {
         OldIndexerConfig::command().print_help().map_err(|e| {
-            IndexerError::Generic(format!("Failed printing deprecated CLI help: {e}"))
+            IndexerError::Generic(format!("failed printing deprecated CLI help: {e}"))
         })?;
         return Ok(());
     }
@@ -119,7 +119,7 @@ async fn main() -> Result<(), IndexerError> {
             let store = PgIndexerAnalyticalStore::new(connection_pool);
             return Indexer::start_analytical_worker(store, indexer_metrics.clone()).await;
         }
-        Command::HelpDeprecated => unreachable!("This case is handled earlier"),
+        Command::HelpDeprecated => unreachable!("this case is handled earlier"),
         Command::RunBackfill {
             start,
             end,

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -129,7 +129,7 @@ impl OptimisticTransactionExecutor {
         let tx_digest = transaction.digest();
         let (Some(input_objects), Some(output_objects)) = (input_objects, output_objects) else {
             tracing::warn!(
-                "Cannot optimistically index because of missing in/out objs for tx: {tx_digest}"
+                "cannot optimistically index because of missing in/out objs for tx: {tx_digest}"
             );
             self.metrics.optimistic_tx_with_missing_objects_counts.inc();
             return Ok(());
@@ -137,7 +137,7 @@ impl OptimisticTransactionExecutor {
 
         if input_objects.is_empty() || output_objects.is_empty() {
             tracing::warn!(
-                "Cannot optimistically index because of missing in/out objs for tx: {tx_digest}"
+                "cannot optimistically index because of missing in/out objs for tx: {tx_digest}"
             );
             self.metrics.optimistic_tx_with_missing_objects_counts.inc();
             return Ok(());
@@ -156,7 +156,7 @@ impl OptimisticTransactionExecutor {
             else => {
                 deps_timer.stop_and_discard();
                 tracing::warn!(
-                    "Transaction {tx_digest} dependencies are not indexed, skipping optimistic indexing",
+                    "transaction {tx_digest} dependencies are not indexed, skipping optimistic indexing",
                 );
                 self.metrics.optimistic_tx_with_missing_dependencies_count.inc();
                 return Ok(());
@@ -306,7 +306,7 @@ impl OptimisticTransactionExecutor {
         })
         .await
         .map_err(|e| {
-            tracing::error!("Failed to join optimistic index_transaction: {e}");
+            tracing::error!("failed to join optimistic index_transaction: {e}");
             IndexerError::from(e)
         })? {
             Ok(_) => {
@@ -349,7 +349,7 @@ impl OptimisticTransactionExecutor {
                     full_tx_data,
                     assigned_global_order
                         .optimistic_sequence_number
-                        .expect("Optimistic sequence number is always set for data read from DB")
+                        .expect("optimistic sequence number is always set for data read from DB")
                         .try_into()
                         .map_err(|e| {
                             IndexerError::PersistentStorageDataCorruption(format!(

--- a/crates/iota-indexer/src/processors/address_metrics_processor.rs
+++ b/crates/iota-indexer/src/processors/address_metrics_processor.rs
@@ -75,12 +75,12 @@ where
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()
                 .tap_err(|e| {
-                    error!("Error joining address persist tasks: {:?}", e);
+                    error!("error joining address persist tasks: {e:?}");
                 })?
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()
                 .tap_err(|e| {
-                    error!("Error persisting addresses or active addresses: {:?}", e);
+                    error!("error persisting addresses or active addresses: {e:?}");
                 })?;
             last_processed_tx_seq += self.address_processor_batch_size as i64;
             info!(

--- a/crates/iota-indexer/src/processors/move_call_metrics_processor.rs
+++ b/crates/iota-indexer/src/processors/move_call_metrics_processor.rs
@@ -74,12 +74,12 @@ where
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()
                 .tap_err(|e| {
-                    error!("Error joining move call persist tasks: {:?}", e);
+                    error!("error joining move call persist tasks: {e:?}");
                 })?
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()
                 .tap_err(|e| {
-                    error!("Error persisting move calls: {:?}", e);
+                    error!("error persisting move calls: {e:?}");
                 })?;
             last_processed_tx_seq += batch_size as i64;
             info!("Persisted move_calls at tx seq: {}", last_processed_tx_seq);

--- a/crates/iota-indexer/src/processors/network_metrics_processor.rs
+++ b/crates/iota-indexer/src/processors/network_metrics_processor.rs
@@ -120,10 +120,10 @@ where
                 .await
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| error!("Error joining network persist tasks: {:?}", e))?
+                .tap_err(|e| error!("error joining network persist tasks: {e:?}"))?
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| error!("Error persisting tx count metrics: {:?}", e))?;
+                .tap_err(|e| error!("error persisting tx count metrics: {e:?}"))?;
 
             last_processed_cp_seq += batch_size;
 
@@ -137,7 +137,7 @@ where
                 .await?
                 .first()
                 .ok_or(IndexerError::PostgresRead(
-                    "Cannot read checkpoint from PG for epoch peak TPS".to_string(),
+                    "cannot read checkpoint from PG for epoch peak TPS".to_string(),
                 ))?
                 .clone();
             for epoch in last_processed_peak_tps_epoch + 1..end_cp.epoch {

--- a/crates/iota-indexer/src/processors/processor_orchestrator.rs
+++ b/crates/iota-indexer/src/processors/processor_orchestrator.rs
@@ -35,8 +35,7 @@ where
                 if let Err(e) = network_metrics_res {
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                     error!(
-                        "Indexer network metrics processor failed with error {:?}, retrying in 5s...",
-                        e
+                        "indexer network metrics processor failed with error {e:?}, retrying in 5s..."
                     );
                 }
             }
@@ -50,8 +49,7 @@ where
                 if let Err(e) = addr_metrics_res {
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                     error!(
-                        "Indexer address metrics processor failed with error {:?}, retrying in 5s...",
-                        e
+                        "indexer address metrics processor failed with error {e:?}, retrying in 5s..."
                     );
                 }
             }
@@ -65,8 +63,7 @@ where
                 if let Err(e) = move_call_metrics_res {
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                     error!(
-                        "Indexer move call metrics processor failed with error {:?}, retrying in 5s...",
-                        e
+                        "indexer move call metrics processor failed with error {e:?}, retrying in 5s..."
                     );
                 }
             }
@@ -78,6 +75,6 @@ where
             move_call_metrics_handle,
         ])
         .await
-        .expect("Processor orchestrator should not run into errors.");
+        .expect("processor orchestrator should not run into errors.");
     }
 }

--- a/crates/iota-indexer/src/pruning/optimistic_pruner.rs
+++ b/crates/iota-indexer/src/pruning/optimistic_pruner.rs
@@ -63,7 +63,7 @@ impl OptimisticPruner {
             let current_epoch = match self.get_current_epoch().await {
                 Ok(epoch) => epoch,
                 Err(err) => {
-                    warn!("Failed to get current epoch: {err}");
+                    warn!("failed to get current epoch: {err}");
                     continue;
                 }
             };
@@ -72,7 +72,7 @@ impl OptimisticPruner {
                 info!("Epoch change detected: {last_processed_epoch:?} -> {current_epoch}");
 
                 if let Err(err) = self.prune_up_to_epoch(current_epoch).await {
-                    warn!("Failed to prune up to epoch {current_epoch}: {err}");
+                    warn!("failed to prune up to epoch {current_epoch}: {err}");
                     continue;
                 }
 

--- a/crates/iota-indexer/src/pruning/pruner.rs
+++ b/crates/iota-indexer/src/pruning/pruner.rs
@@ -135,7 +135,7 @@ impl Pruner {
                 if let Some(epochs_to_keep) = self.table_retention(table_name) {
                     if last_seen_max_epoch != *max_partition {
                         error!(
-                            "Epochs are out of sync for table {table_name}: max_epoch={last_seen_max_epoch}, max_partition={max_partition}",
+                            "epochs are out of sync for table {table_name}: max_epoch={last_seen_max_epoch}, max_partition={max_partition}",
                         );
                     }
                     for epoch in
@@ -167,7 +167,7 @@ impl Pruner {
                 }
                 info!("Pruning epoch {}", epoch);
                 if let Err(err) = self.store.prune_epoch(epoch).await {
-                    error!("Failed to prune epoch {epoch}: {err}");
+                    error!("failed to prune epoch {epoch}: {err}");
                     break;
                 };
                 self.metrics.last_pruned_epoch.set(epoch as i64);

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -128,7 +128,7 @@ impl IndexerReader {
             .connection_timeout(config.connection_timeout)
             .connection_customizer(Box::new(connection_config))
             .build(manager)
-            .map_err(|e| anyhow!("Failed to initialize connection pool. Error: {:?}. If Error is None, please check whether the configured pool size (currently {}) exceeds the maximum number of connections allowed by the database.", e, config.pool_size))?;
+            .map_err(|e| anyhow!("failed to initialize connection pool. Error: {:?}. If Error is None, please check whether the configured pool size (currently {}) exceeds the maximum number of connections allowed by the database.", e, config.pool_size))?;
 
         Ok(Self::new(pool))
     }
@@ -838,10 +838,10 @@ impl IndexerReader {
             .await
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .tap_err(|e| tracing::error!("Failed to join all tx block futures: {}", e))?
+            .tap_err(|e| tracing::error!("failed to join all tx block futures: {e}"))?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .tap_err(|e| tracing::error!("Failed to collect tx block futures: {}", e))?;
+            .tap_err(|e| tracing::error!("failed to collect tx block futures: {e}"))?;
         Ok(tx_blocks)
     }
 
@@ -1373,7 +1373,7 @@ impl IndexerReader {
                 self.stored_transaction_to_transaction_block(vec![stored_tx], options)
                     .await?
                     .pop()
-                    .expect("There should be exactly one response"),
+                    .expect("there should be exactly one response"),
             ))
         } else {
             Ok(None)
@@ -1426,7 +1426,7 @@ impl IndexerReader {
             order_map
                 .get(&tx.digest)
                 .copied()
-                .expect("All digests should have some order")
+                .expect("all digests should have some order")
         });
         Ok(transactions)
     }
@@ -1523,10 +1523,10 @@ impl IndexerReader {
             .await
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .tap_err(|e| tracing::error!("Failed to join iota event futures: {}", e))?
+            .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .tap_err(|e| tracing::error!("Failed to collect iota event futures: {}", e))?;
+            .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))?;
         Ok(iota_events)
     }
 
@@ -1733,10 +1733,10 @@ impl IndexerReader {
             .await
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .tap_err(|e| tracing::error!("Failed to join iota event futures: {}", e))?
+            .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .tap_err(|e| tracing::error!("Failed to collect iota event futures: {}", e))?;
+            .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))?;
         Ok(iota_events)
     }
 
@@ -1764,14 +1764,11 @@ impl IndexerReader {
         }
         let df_infos = futures::future::try_join_all(df_futures)
             .await
-            .tap_err(|e| tracing::error!("Error joining DF futures: {:?}", e))?
+            .tap_err(|e| tracing::error!("error joining DF futures: {e:?}"))?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
             .tap_err(|e| {
-                tracing::error!(
-                    "Error calling DF try_create_dynamic_field_info function: {:?}",
-                    e
-                )
+                tracing::error!("error calling DF try_create_dynamic_field_info function: {e:?}")
             })?
             .into_iter()
             .flatten()
@@ -2287,7 +2284,7 @@ impl IndexerReader {
         let mut cache = self
             .obj_type_cache
             .lock()
-            .inspect_err(|e| tracing::error!("cache poisoned: {:?}", e))
+            .inspect_err(|e| tracing::error!("cache poisoned: {e:?}"))
             .map_err(|_| IndexerError::Generic("failed to lock cache".into()))?;
 
         let maybe_obj = match cache.cache_get(&cache_key) {

--- a/crates/iota-indexer/src/store/mod.rs
+++ b/crates/iota-indexer/src/store/mod.rs
@@ -79,7 +79,7 @@ pub mod diesel_macro {
                     .read_write()
                     .run($query)
                     .map_err(|e| {
-                        tracing::error!("Error with persisting data into DB: {:?}, retrying...", e);
+                        tracing::error!("error with persisting data into DB: {e:?}, retrying...");
                         backoff::Error::Transient {
                             err: IndexerError::PostgresWrite(e.to_string()),
                             retry_after: None,
@@ -118,7 +118,7 @@ pub mod diesel_macro {
                     .read_write()
                     .run($query)
                     .map_err(|e| {
-                        tracing::error!("Error with persisting data into DB: {:?}, retrying...", e);
+                        tracing::error!("error with persisting data into DB: {e:?}, retrying...");
                         if $abort_condition(&e) {
                             backoff::Error::Permanent(e)
                         } else {
@@ -176,7 +176,7 @@ pub mod diesel_macro {
                 }
             })
             .await
-            .expect("Blocking call failed")
+            .expect("blocking call failed")
         }};
     }
 
@@ -184,7 +184,7 @@ pub mod diesel_macro {
     macro_rules! insert_or_ignore_into {
         ($table:expr, $values:expr, $conn:expr) => {{
             use diesel::RunQueryDsl;
-            let error_message = concat!("Failed to write to ", stringify!($table), " DB");
+            let error_message = concat!("failed to write to ", stringify!($table), " DB");
 
             diesel::insert_into($table)
                 .values($values)
@@ -266,7 +266,7 @@ pub mod diesel_macro {
                 && !CALLED_FROM_BLOCKING_POOL.with(|in_blocking_pool| *in_blocking_pool.borrow())
             {
                 panic!(
-                    "You are calling a blocking DB operation directly on an async thread. \
+                    "you are calling a blocking DB operation directly on an async thread. \
                         Please use IndexerReader::spawn_blocking instead to move the \
                         operation to a blocking thread"
                 );
@@ -344,7 +344,7 @@ pub mod diesel_macro {
                 );
             })
             .tap_err(|e| {
-                tracing::error!("Failed to persist {} with error: {}", stringify!($table), e);
+                tracing::error!("failed to persist {} with error: {e}", stringify!($table));
             })
         }};
     }

--- a/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
@@ -62,7 +62,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 .first::<StoredCheckpoint>(conn)
                 .optional()
         })
-        .context("Failed reading latest checkpoint from PostgresDB")?;
+        .context("failed reading latest checkpoint from PostgresDB")?;
         Ok(latest_cp)
     }
 
@@ -73,7 +73,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 .first::<StoredTransaction>(conn)
                 .optional()
         })
-        .context("Failed reading latest transaction from PostgresDB")?;
+        .context("failed reading latest transaction from PostgresDB")?;
         Ok(latest_tx)
     }
 
@@ -89,7 +89,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 .order(checkpoints::sequence_number.asc())
                 .load::<StoredCheckpoint>(conn)
         })
-        .context("Failed reading checkpoints from PostgresDB")?;
+        .context("failed reading checkpoints from PostgresDB")?;
         Ok(cps)
     }
 
@@ -109,7 +109,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 ))
                 .load::<StoredTransactionTimestamp>(conn)
         })
-        .context("Failed reading transaction timestamps from PostgresDB")?;
+        .context("failed reading transaction timestamps from PostgresDB")?;
         Ok(tx_timestamps)
     }
 
@@ -129,7 +129,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 ))
                 .load::<StoredTransactionCheckpoint>(conn)
         })
-        .context("Failed reading transaction checkpoints from PostgresDB")?;
+        .context("failed reading transaction checkpoints from PostgresDB")?;
         Ok(tx_checkpoints)
     }
 
@@ -151,7 +151,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 ))
                 .load::<StoredTransactionSuccessCommandCount>(conn)
         })
-        .context("Failed reading transaction success command counts from PostgresDB")?;
+        .context("failed reading transaction success command counts from PostgresDB")?;
         Ok(tx_success_cmd_counts)
     }
     async fn get_tx(&self, tx_sequence_number: i64) -> IndexerResult<Option<StoredTransaction>> {
@@ -161,7 +161,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 .first::<StoredTransaction>(conn)
                 .optional()
         })
-        .context("Failed reading transaction from PostgresDB")?;
+        .context("failed reading transaction from PostgresDB")?;
         Ok(tx)
     }
 
@@ -172,7 +172,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 .first::<StoredCheckpoint>(conn)
                 .optional()
         })
-        .context("Failed reading checkpoint from PostgresDB")?;
+        .context("failed reading checkpoint from PostgresDB")?;
         Ok(cp)
     }
 
@@ -183,7 +183,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 .first::<StoredTxCountMetrics>(conn)
                 .optional()
         })
-        .context("Failed reading latest tx count metrics from PostgresDB")?;
+        .context("failed reading latest tx count metrics from PostgresDB")?;
         Ok(latest_tx_count)
     }
 
@@ -194,7 +194,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 .first::<StoredEpochPeakTps>(conn)
                 .optional()
         })
-        .context("Failed reading latest epoch peak TPS from PostgresDB")?;
+        .context("failed reading latest epoch peak TPS from PostgresDB")?;
         Ok(latest_network_metrics)
     }
 
@@ -206,8 +206,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
         end_checkpoint: i64,
     ) -> IndexerResult<()> {
         info!(
-            "Persisting tx count metrics for checkpoints [{}-{}]",
-            start_checkpoint,
+            "Persisting tx count metrics for checkpoints [{start_checkpoint}-{}]",
             end_checkpoint - 1
         );
         transactional_blocking_with_retry!(
@@ -221,10 +220,9 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
             },
             Duration::from_secs(10)
         )
-        .context("Failed persisting tx count metrics to PostgresDB")?;
+        .context("failed persisting tx count metrics to PostgresDB")?;
         info!(
-            "Persisted tx count metrics for checkpoints [{}-{}]",
-            start_checkpoint,
+            "Persisted tx count metrics for checkpoints [{start_checkpoint}-{}]",
             end_checkpoint - 1
         );
         Ok(())
@@ -238,13 +236,13 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 diesel::sql_query(epoch_peak_tps_query),
                 conn
             ))
-            .context("Failed reading epoch peak TPS from PostgresDB")?;
+            .context("failed reading epoch peak TPS from PostgresDB")?;
         let tps_30d: Tps =
             read_only_blocking!(&self.blocking_cp, |conn| diesel::RunQueryDsl::get_result(
                 diesel::sql_query(peak_tps_30d_query),
                 conn
             ))
-            .context("Failed reading 30d peak TPS from PostgresDB")?;
+            .context("failed reading 30d peak TPS from PostgresDB")?;
 
         let epoch_peak_tps = StoredEpochPeakTps {
             epoch,
@@ -261,7 +259,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
             },
             Duration::from_secs(10)
         )
-        .context("Failed persisting epoch peak TPS to PostgresDB.")?;
+        .context("failed persisting epoch peak TPS to PostgresDB.")?;
         Ok(())
     }
 
@@ -273,7 +271,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 .first::<TxSeq>(conn)
                 .optional()
         })
-        .context("Failed to read address metrics last processed tx sequence.")?;
+        .context("failed to read address metrics last processed tx sequence.")?;
         Ok(last_processed_tx_seq)
     }
 
@@ -299,7 +297,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
             },
             Duration::from_secs(10)
         )
-        .context("Failed persisting address analytics to PostgresDB")?;
+        .context("failed persisting address analytics to PostgresDB")?;
         Ok(())
     }
 
@@ -355,7 +353,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
             },
             Duration::from_secs(60)
         )
-        .context("Failed persisting address metrics to PostgresDB")?;
+        .context("failed persisting address metrics to PostgresDB")?;
         Ok(())
     }
 
@@ -396,7 +394,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
             },
             Duration::from_secs(10)
         )
-        .context("Failed persisting move calls to PostgresDB")?;
+        .context("failed persisting move calls to PostgresDB")?;
         Ok(())
     }
 
@@ -429,12 +427,12 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
             .tap_err(|e| {
-                error!("Error joining move call calculation tasks: {:?}", e);
+                error!("error joining move call calculation tasks: {e:?}");
             })?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
             .tap_err(|e| {
-                error!("Error calculating move call metrics: {:?}", e);
+                error!("error calculating move call metrics: {e:?}");
             })?
             .into_iter()
             .flatten()
@@ -448,7 +446,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                     Some(p) => p.to_canonical_string(/* with_prefix */ true),
                     None => {
                         tracing::error!(
-                            "Failed to parse move package ID: {:?}",
+                            "failed to parse move package ID: {:?}",
                             queried_move_metrics.move_package
                         );
                         return None;
@@ -476,7 +474,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
             },
             Duration::from_secs(60)
         )
-        .context("Failed persisting move call metrics to PostgresDB")?;
+        .context("failed persisting move call metrics to PostgresDB")?;
         Ok(())
     }
 }

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -147,7 +147,7 @@ impl PgIndexerStore {
             .parse::<usize>()
             .unwrap();
         let partition_manager = PgPartitionManager::new(blocking_cp.clone())
-            .expect("Failed to initialize partition manager");
+            .expect("failed to initialize partition manager");
         let config = PgIndexerStoreConfig {
             parallel_chunk_size,
             parallel_objects_chunk_size,
@@ -521,7 +521,7 @@ impl PgIndexerStore {
             info!(elapsed, "Persisted {len} chunked objects");
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist object mutations with error: {e}");
+            tracing::error!("failed to persist object mutations with error: {e}");
         })
     }
 
@@ -568,7 +568,7 @@ impl PgIndexerStore {
             info!(elapsed, "Deleted {len} chunked objects");
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist object deletions with error: {e}");
+            tracing::error!("failed to persist object deletions with error: {e}");
         })
     }
 
@@ -680,7 +680,7 @@ impl PgIndexerStore {
             );
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist object snapshot with error: {}", e);
+            tracing::error!("failed to persist object snapshot with error: {e}");
         })
     }
 
@@ -717,7 +717,7 @@ impl PgIndexerStore {
             );
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist object history with error: {}", e);
+            tracing::error!("failed to persist object history with error: {e}");
         })
     }
 
@@ -750,7 +750,7 @@ impl PgIndexerStore {
             );
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist object versions with error: {e}");
+            tracing::error!("failed to persist object versions with error: {e}");
         })
     }
 
@@ -802,7 +802,7 @@ impl PgIndexerStore {
             );
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist pruner_cp_watermark with error: {}", e);
+            tracing::error!("failed to persist pruner_cp_watermark with error: {e}");
         })?;
 
         let stored_checkpoints = checkpoints
@@ -845,7 +845,7 @@ impl PgIndexerStore {
             );
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist checkpoints with error: {}", e);
+            tracing::error!("failed to persist checkpoints with error: {e}");
         })
     }
 
@@ -886,7 +886,7 @@ impl PgIndexerStore {
             );
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist transactions with error: {}", e);
+            tracing::error!("failed to persist transactions with error: {e}");
         })
     }
 
@@ -918,7 +918,7 @@ impl PgIndexerStore {
             );
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist txs insertion order with error: {e}");
+            tracing::error!("failed to persist txs insertion order with error: {e}");
         })
     }
 
@@ -970,7 +970,7 @@ impl PgIndexerStore {
             );
         })
         .tap_err(|e| {
-            tracing::error!("Failed to update `tx_global_order` with error: {e}");
+            tracing::error!("failed to update `tx_global_order` with error: {e}");
         })
     }
 
@@ -1000,7 +1000,7 @@ impl PgIndexerStore {
             info!(elapsed, "Persisted {} chunked events", len);
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist events with error: {}", e);
+            tracing::error!("failed to persist events with error: {e}");
         })
     }
 
@@ -1040,7 +1040,7 @@ impl PgIndexerStore {
             info!(elapsed, "Persisted {} packages", packages.len());
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist packages with error: {}", e);
+            tracing::error!("failed to persist packages with error: {e}");
         })
     }
 
@@ -1157,7 +1157,7 @@ impl PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to join event indices futures in a chunk: {}", e);
+                tracing::error!("failed to join event indices futures in a chunk: {e}");
                 IndexerError::from(e)
             })?
             .into_iter()
@@ -1248,7 +1248,7 @@ impl PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to join tx indices futures in a chunk: {}", e);
+                tracing::error!("failed to join tx indices futures in a chunk: {e}");
                 IndexerError::from(e)
             })?
             .into_iter()
@@ -1291,7 +1291,7 @@ impl PgIndexerStore {
             info!(elapsed, epoch_id, "Persisted epoch beginning info");
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist epoch with error: {}", e);
+            tracing::error!("failed to persist epoch with error: {e}");
         })
     }
 
@@ -1335,7 +1335,7 @@ impl PgIndexerStore {
                     );
                 }
             } else {
-                tracing::error!("Last epoch: {} from PostgresDB is None.", last_epoch_id);
+                tracing::error!("last epoch: {last_epoch_id} from PostgresDB is None.");
             }
         }
 
@@ -1538,7 +1538,7 @@ impl PgIndexerStore {
             info!("Successfully refreshed participation_metrics");
         })
         .tap_err(|e| {
-            tracing::error!("Failed to refresh participation_metrics: {e}");
+            tracing::error!("failed to refresh participation_metrics: {e}");
         })
     }
 
@@ -1673,10 +1673,7 @@ impl IndexerStore for PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!(
-                    "Failed to join backfill_objects_snapshot_chunk futures: {}",
-                    e
-                );
+                tracing::error!("failed to join backfill_objects_snapshot_chunk futures: {e}");
                 IndexerError::from(e)
             })?
             .into_iter()
@@ -1721,10 +1718,7 @@ impl IndexerStore for PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!(
-                    "Failed to join persist_objects_history_chunk futures: {}",
-                    e
-                );
+                tracing::error!("failed to join persist_objects_history_chunk futures: {e}");
                 IndexerError::from(e)
             })?
             .into_iter()
@@ -1763,7 +1757,7 @@ impl IndexerStore for PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to join persist_object_version_chunk futures: {}", e);
+                tracing::error!("failed to join persist_object_version_chunk futures: {e}");
                 IndexerError::from(e)
             })?
             .into_iter()
@@ -1804,7 +1798,7 @@ impl IndexerStore for PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to join persist_transactions_chunk futures: {}", e);
+                tracing::error!("failed to join persist_transactions_chunk futures: {e}");
                 IndexerError::from(e)
             })?
             .into_iter()
@@ -1845,7 +1839,7 @@ impl IndexerStore for PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to join persist_events_chunk futures: {}", e);
+                tracing::error!("failed to join persist_events_chunk futures: {e}");
                 IndexerError::from(e)
             })?
             .into_iter()
@@ -1923,7 +1917,7 @@ impl IndexerStore for PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to join persist_event_indices_chunk futures: {}", e);
+                tracing::error!("failed to join persist_event_indices_chunk futures: {e}");
                 IndexerError::from(e)
             })?
             .into_iter()
@@ -1981,7 +1975,7 @@ impl IndexerStore for PgIndexerStore {
             self.execute_in_blocking_worker(move |this| this.prune_checkpoints_table(cp))
                 .await
                 .unwrap_or_else(|e| {
-                    tracing::error!("Failed to prune checkpoint {}: {}", cp, e);
+                    tracing::error!("failed to prune checkpoint {cp}: {e}");
                 });
 
             let (min_tx, max_tx) = self.get_transaction_range_for_checkpoint(cp)?;
@@ -1990,7 +1984,7 @@ impl IndexerStore for PgIndexerStore {
             })
             .await
             .unwrap_or_else(|e| {
-                tracing::error!("Failed to prune transactions for cp {}: {}", cp, e);
+                tracing::error!("failed to prune transactions for cp {cp}: {e}");
             });
             info!(
                 "Pruned transactions for checkpoint {} from tx {} to tx {}",
@@ -2001,26 +1995,17 @@ impl IndexerStore for PgIndexerStore {
             })
             .await
             .unwrap_or_else(|e| {
-                tracing::error!(
-                    "Failed to prune events of transactions for cp {}: {}",
-                    cp,
-                    e
-                );
+                tracing::error!("failed to prune events of transactions for cp {cp}: {e}");
             });
             info!(
-                "Pruned events of transactions for checkpoint {} from tx {} to tx {}",
-                cp, min_tx, max_tx
+                "Pruned events of transactions for checkpoint {cp} from tx {min_tx} to tx {max_tx}"
             );
             self.metrics.last_pruned_transaction.set(max_tx as i64);
 
             self.execute_in_blocking_worker(move |this| this.prune_cp_tx_table(cp))
                 .await
                 .unwrap_or_else(|e| {
-                    tracing::error!(
-                        "Failed to prune pruner_cp_watermark table for cp {}: {}",
-                        cp,
-                        e
-                    );
+                    tracing::error!("failed to prune pruner_cp_watermark table for cp {cp}: {e}");
                 });
             info!("Pruned checkpoint {} of epoch {}", cp, epoch);
             self.metrics.last_pruned_checkpoint.set(cp as i64);
@@ -2055,7 +2040,7 @@ impl IndexerStore for PgIndexerStore {
         chain_id: Vec<u8>,
     ) -> Result<(), IndexerError> {
         let chain_id = ChainIdentifier::from(
-            CheckpointDigest::try_from(chain_id).expect("Unable to convert chain id"),
+            CheckpointDigest::try_from(chain_id).expect("unable to convert chain id"),
         );
 
         let mut all_configs = vec![];
@@ -2135,7 +2120,7 @@ impl IndexerStore for PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to join persist_tx_indices_chunk futures: {}", e);
+                tracing::error!("failed to join persist_tx_indices_chunk futures: {e}");
                 IndexerError::from(e)
             })?
             .into_iter()
@@ -2179,7 +2164,7 @@ impl IndexerStore for PgIndexerStore {
         futures::future::try_join_all(mutation_futures.chain(deletion_futures))
             .await
             .map_err(|e| {
-                tracing::error!("Failed to join futures for persisting objects: {e}");
+                tracing::error!("failed to join futures for persisting objects: {e}");
                 IndexerError::from(e)
             })?
             .into_iter()
@@ -2217,7 +2202,7 @@ impl IndexerStore for PgIndexerStore {
             .await
             .map_err(|e| {
                 tracing::error!(
-                    "Failed to join update_status_for_checkpoint_transactions_chunk futures: {e}",
+                    "failed to join update_status_for_checkpoint_transactions_chunk futures: {e}",
                 );
                 IndexerError::from(e)
             })?
@@ -2254,7 +2239,7 @@ impl IndexerStore for PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to join persist_tx_global_order_chunk futures: {e}",);
+                tracing::error!("failed to join persist_tx_global_order_chunk futures: {e}",);
                 IndexerError::from(e)
             })?
             .into_iter()
@@ -2311,7 +2296,7 @@ fn retain_latest_indexed_objects(
             if let Some(existing) = deletions.remove(&id) {
                 assert!(
                     existing.object_version < version.value(),
-                    "Mutation version ({version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
+                    "mutation version ({version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
                     existing.object_version
                 );
             }
@@ -2319,7 +2304,7 @@ fn retain_latest_indexed_objects(
             if let Some(existing) = mutations.insert(id, mutation) {
                 assert!(
                     existing.object.version() < version,
-                    "Mutation version ({version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
+                    "mutation version ({version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
                     existing.object.version()
                 );
             }
@@ -2332,7 +2317,7 @@ fn retain_latest_indexed_objects(
             if let Some(existing) = mutations.remove(&id) {
                 assert!(
                     existing.object.version().value() < version,
-                    "Deletion version ({version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
+                    "deletion version ({version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
                     existing.object.version(),
                 );
             }
@@ -2340,7 +2325,7 @@ fn retain_latest_indexed_objects(
             if let Some(existing) = deletions.insert(id, deletion) {
                 assert!(
                     existing.object_version < version,
-                    "Deletion version ({version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
+                    "deletion version ({version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
                     existing.object_version
                 );
             }

--- a/crates/iota-indexer/src/store/pg_partition_manager.rs
+++ b/crates/iota-indexer/src/store/pg_partition_manager.rs
@@ -205,8 +205,8 @@ impl PgPartitionManager {
             // skip when the partition is already advanced once, which is possible when
             // indexer crashes and restarts; error otherwise.
             error!(
-                "Epoch partition for table {} is not in sync with the last epoch {}.",
-                table, data.last_epoch
+                "epoch partition for table {table} is not in sync with the last epoch {}.",
+                data.last_epoch
             );
         } else {
             info!(

--- a/crates/iota-indexer/src/system_package_task.rs
+++ b/crates/iota-indexer/src/system_package_task.rs
@@ -55,7 +55,7 @@ impl SystemPackageTask {
                         }) {
                         Ok(epoch) => epoch,
                         Err(e) => {
-                            tracing::error!("Failed to fetch latest epoch: {:?}", e);
+                            tracing::error!("failed to fetch latest epoch: {e:?}");
                             continue;
                         }
                     };

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -270,7 +270,7 @@ pub fn create_pg_store(db_url: &str, reset_database: bool) -> PgIndexerStore {
 }
 
 fn replace_db_name(db_url: &str, new_db_name: &str) -> (String, String) {
-    let pos = db_url.rfind('/').expect("Unable to find / in db_url");
+    let pos = db_url.rfind('/').expect("unable to find / in db_url");
     let old_db_name = &db_url[pos + 1..];
 
     (

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -174,7 +174,7 @@ pub async fn indexer_wait_for_checkpoint(
         }
     })
     .await
-    .expect("Timeout waiting for indexer to catchup to checkpoint");
+    .expect("timeout waiting for indexer to catchup to checkpoint");
 }
 
 /// Wait for the indexer to catch up to the latest node checkpoint sequence
@@ -214,7 +214,7 @@ pub async fn indexer_wait_for_object(
         }
     })
     .await
-    .expect("Timeout waiting for indexer to catchup to given object's sequence number");
+    .expect("timeout waiting for indexer to catchup to given object's sequence number");
 }
 
 pub async fn get_optimistic_transactions_count(pg_store: &PgIndexerStore) -> u64 {
@@ -245,7 +245,7 @@ pub async fn indexer_wait_for_optimistic_transactions_count(
         }
     })
     .await
-    .expect("Timeout waiting for indexer to prune optimistic transactions");
+    .expect("timeout waiting for indexer to prune optimistic transactions");
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -264,7 +264,7 @@ pub async fn indexer_wait_for_checkpoint_pruned(
             let (min, _max) = pg_store
                 .get_available_checkpoint_range()
                 .await
-                .expect("Failed to get available checkpoint range");
+                .expect("failed to get available checkpoint range");
 
             if min > checkpoint_sequence_number {
                 break;
@@ -274,7 +274,7 @@ pub async fn indexer_wait_for_checkpoint_pruned(
         }
     })
     .await
-    .expect("Timeout waiting for indexer to prune checkpoint");
+    .expect("timeout waiting for indexer to prune checkpoint");
 }
 
 pub async fn indexer_wait_for_transaction(
@@ -297,7 +297,7 @@ pub async fn indexer_wait_for_transaction(
         }
     })
     .await
-    .expect("Timeout waiting for indexer to catchup to given transaction");
+    .expect("timeout waiting for indexer to catchup to given transaction");
 }
 
 pub async fn execute_tx_and_wait_for_indexer(
@@ -330,7 +330,7 @@ pub async fn execute_tx_must_succeed(
     assert_eq!(
         indexer_tx_response.status_ok(),
         Some(true),
-        "Transaction failed: {indexer_tx_response:?}"
+        "transaction failed: {indexer_tx_response:?}"
     );
     *txn.digest()
 }
@@ -353,7 +353,7 @@ fn start_indexer_reader(fullnode_rpc_url: impl Into<String>, database_name: Opti
             ..Default::default()
         },
     )
-    .expect("Creating new connection pool should succeed");
+    .expect("creating new connection pool should succeed");
 
     let registry = prometheus::Registry::default();
     init_metrics(&registry);
@@ -471,6 +471,6 @@ pub async fn wait_for_objects_snapshot(
         }
     })
     .await
-    .expect("Timeout waiting for indexer to catchup to checkpoint for objects snapshot");
+    .expect("timeout waiting for indexer to catchup to checkpoint for objects snapshot");
     Ok(())
 }

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -112,7 +112,7 @@ mod ingestion_tests {
                 .filter(transactions::transaction_digest.eq(digest.inner().to_vec()))
                 .first::<StoredTransaction>(conn)
         })
-        .context("Failed reading transaction from PostgresDB")?;
+        .context("failed reading transaction from PostgresDB")?;
 
         // Check that the transaction was stored correctly.
         assert_eq!(db_txn.tx_sequence_number, 1);
@@ -224,7 +224,7 @@ mod ingestion_tests {
                 .limit(1)
                 .first::<i64>(conn)
         })
-        .context("Failed reading max checkpoint_sequence_number from PostgresDB")?;
+        .context("failed reading max checkpoint_sequence_number from PostgresDB")?;
 
         assert_eq!(
             max_checkpoint_sequence_number,
@@ -245,7 +245,7 @@ mod ingestion_tests {
                 )
                 .first::<StoredObjectSnapshot>(conn)
         })
-        .context("Failed reading snapshot object from PostgresDB")?;
+        .context("failed reading snapshot object from PostgresDB")?;
         // Assert that the object state is as expected at checkpoint
         // max_expected_checkpoint_sequence_number
         assert_eq!(snapshot_object.object_id, obj_id.to_vec());
@@ -292,7 +292,7 @@ mod ingestion_tests {
                 .select(StoredTxDigest::as_select())
                 .first::<StoredTxDigest>(conn)
         })
-        .context("Failed reading `tx_global_order` from PostgresDB")?;
+        .context("failed reading `tx_global_order` from PostgresDB")?;
 
         let stored_global_order = read_only_blocking!(&pg_store.blocking_cp(), |conn| {
             tx_global_order::table
@@ -300,7 +300,7 @@ mod ingestion_tests {
                 .select(TxGlobalOrder::as_select())
                 .first::<TxGlobalOrder>(conn)
         })
-        .context("Failed reading `tx_global_order` from PostgresDB")?;
+        .context("failed reading `tx_global_order` from PostgresDB")?;
 
         assert_eq!(
             stored_global_order.global_sequence_number,
@@ -368,7 +368,7 @@ mod ingestion_tests {
                 .select(TxGlobalOrder::as_select())
                 .first::<TxGlobalOrder>(conn)
         })
-        .context("Failed reading `tx_global_order` from PostgresDB")?;
+        .context("failed reading `tx_global_order` from PostgresDB")?;
 
         assert_eq!(stored.global_sequence_number, global_sequence_number);
         let expected_optimistic_sequence_number = 1;

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -1287,11 +1287,11 @@ fn test_get_dynamic_fields() -> Result<(), anyhow::Error> {
         let dynamic_fields = client
             .get_dynamic_fields(bag_object_ref.0, None, None)
             .await
-            .expect("Failed to get dynamic fields");
+            .expect("failed to get dynamic fields");
 
         assert!(
             !dynamic_fields.data.is_empty(),
-            "Dynamic field was not added"
+            "dynamic field was not added"
         );
 
         Ok(())
@@ -1428,11 +1428,11 @@ fn test_get_dynamic_field_objects() -> Result<(), anyhow::Error> {
         let dynamic_fields = client
             .get_dynamic_field_object(bag_object_ref.0, name)
             .await
-            .expect("Failed to get dynamic field object");
+            .expect("failed to get dynamic field object");
 
         assert!(
             dynamic_fields.data.is_some(),
-            "Dynamic field object was not added"
+            "dynamic field object was not added"
         );
 
         Ok(())

--- a/crates/iota-indexer/tests/rpc-tests/move_utils.rs
+++ b/crates/iota-indexer/tests/rpc-tests/move_utils.rs
@@ -29,7 +29,7 @@ fn get_move_function_arg_types_empty() {
 
         assert!(
             indexer_function_args_type.is_empty(),
-            "Should not have any function args"
+            "should not have any function args"
         )
     });
 }

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -572,7 +572,6 @@ fn get_checkpoints_by_cursor_and_limit_descending() {
             .unwrap();
 
         assert_eq!(
-            // vec![2, 1, 5],
             vec![2, 1, 0],
             indexer_checkpoint
                 .data
@@ -1485,12 +1484,12 @@ fn try_get_past_object_object_not_exists() {
         let result = client
             .try_get_past_object(object_id, version, None)
             .await
-            .expect("RPC call should succeed");
+            .expect("rpc call should succeed");
 
         assert_eq!(
             result,
             IotaPastObjectResponse::ObjectNotExists(object_id),
-            "Mismatch in ObjectNotExists response"
+            "mismatch in ObjectNotExists response"
         );
     });
 }
@@ -1522,17 +1521,17 @@ fn try_get_past_object_version_found() {
         let result = client
             .try_get_past_object(gas_ref.0, gas_ref.1, None)
             .await
-            .expect("RPC call should succeed");
+            .expect("rpc call should succeed");
 
         match result {
             IotaPastObjectResponse::VersionFound(ref data) => {
                 assert_eq!(
                     data.version, gas_ref.1,
-                    "Expected object version {:?} but got {:?}",
+                    "expected object version {:?} but got {:?}",
                     gas_ref.1, data.version
                 );
             }
-            _ => panic!("Expected VersionFound response, got: {result:?}"),
+            _ => panic!("expected VersionFound response, got: {result:?}"),
         }
     });
 }
@@ -1561,17 +1560,17 @@ fn try_get_past_object_version_not_found() {
 
         wait_for_objects_history().await;
 
-        let missing_version = gas_ref.1.one_before().expect("Version should be > 0");
+        let missing_version = gas_ref.1.one_before().expect("version should be > 0");
 
         let result = client
             .try_get_past_object(gas_ref.0, missing_version, None)
             .await
-            .expect("RPC call should succeed");
+            .expect("rpc call should succeed");
 
         assert_eq!(
             result,
             IotaPastObjectResponse::VersionNotFound(gas_ref.0, missing_version),
-            "Mismatch in VersionNotFound response"
+            "mismatch in VersionNotFound response"
         );
     });
 }
@@ -1606,7 +1605,7 @@ fn try_get_past_object_version_too_high() {
         let result = client
             .try_get_past_object(gas_ref.0, asked_version, None)
             .await
-            .expect("RPC call should succeed");
+            .expect("rpc call should succeed");
 
         assert_eq!(
             result,
@@ -1615,7 +1614,7 @@ fn try_get_past_object_version_too_high() {
                 asked_version,
                 latest_version,
             },
-            "Mismatch in VersionTooHigh response"
+            "mismatch in VersionTooHigh response"
         );
     });
 }
@@ -1650,7 +1649,7 @@ fn try_get_past_object_object_deleted() {
         let result = client
             .try_get_object_before_version(nft_object_id, SequenceNumber::MAX_VALID_EXCL)
             .await
-            .expect("RPC call should succeed");
+            .expect("rpc call should succeed");
 
         assert_eq!(
             result,
@@ -1659,14 +1658,14 @@ fn try_get_past_object_object_deleted() {
                 version: deleted_version,
                 digest: ObjectDigest::OBJECT_DIGEST_DELETED,
             }),
-            "Mismatch in ObjectDeleted response"
+            "mismatch in ObjectDeleted response"
         );
 
         // Retrieve the deleted object at that version
         let result = client
             .try_get_past_object(nft_object_id, deleted_version, None)
             .await
-            .expect("RPC call should succeed");
+            .expect("rpc call should succeed");
 
         assert_eq!(
             result,
@@ -1675,24 +1674,24 @@ fn try_get_past_object_object_deleted() {
                 version: deleted_version,
                 digest: ObjectDigest::OBJECT_DIGEST_DELETED,
             }),
-            "Mismatch in ObjectDeleted response"
+            "mismatch in ObjectDeleted response"
         );
 
         // Try fetching the object before the deleted version.
         let result = client
             .try_get_past_object(nft_object_id, deleted_version.one_before().unwrap(), None)
             .await
-            .expect("RPC call should succeed");
+            .expect("rpc call should succeed");
 
         match result {
             IotaPastObjectResponse::VersionFound(ref data) => {
                 assert_eq!(
                     data.version, nft_object_ref.1,
-                    "Expected object version {:?} but got {:?}",
+                    "expected object version {:?} but got {:?}",
                     nft_object_ref.1, data.version
                 );
             }
-            _ => panic!("Expected VersionFound response, got: {result:?}"),
+            _ => panic!("expected VersionFound response, got: {result:?}"),
         }
     });
 }
@@ -1734,9 +1733,9 @@ fn try_multi_get_past_objects() {
         let results = client
             .try_multi_get_past_objects(requests, None)
             .await
-            .expect("RPC call should succeed");
+            .expect("rpc call should succeed");
 
-        assert_eq!(results.len(), 3, "Expected results for all objects");
+        assert_eq!(results.len(), 3, "expected results for all objects");
 
         let expected_responses = vec![
             IotaPastObjectResponse::ObjectNotExists(object_1),
@@ -1746,7 +1745,7 @@ fn try_multi_get_past_objects() {
 
         assert_eq!(
             results, expected_responses,
-            "Mismatch in multi-get response results"
+            "mismatch in multi-get response results"
         );
 
         // Create valid objects
@@ -1787,38 +1786,38 @@ fn try_multi_get_past_objects() {
         let results = client
             .try_multi_get_past_objects(requests, None)
             .await
-            .expect("RPC call should succeed");
+            .expect("rpc call should succeed");
 
         let past_object_response_1 = client
             .try_get_past_object(gas_ref_1.0, gas_ref_1.1, None)
             .await
-            .expect("RPC call should succeed");
+            .expect("rpc call should succeed");
 
         let past_object_response_2 = client
             .try_get_past_object(gas_ref_2.0, gas_ref_2.1, None)
             .await
-            .expect("RPC call should succeed");
+            .expect("rpc call should succeed");
 
         match past_object_response_1 {
             IotaPastObjectResponse::VersionFound(ref data) => {
                 assert_eq!(
                     data.version, gas_ref_1.1,
-                    "Expected object version {:?} but got {:?}",
+                    "expected object version {:?} but got {:?}",
                     gas_ref_1.1, data.version
                 );
             }
-            _ => panic!("Expected VersionFound response, got: {past_object_response_1:?}"),
+            _ => panic!("expected VersionFound response, got: {past_object_response_1:?}"),
         }
 
         match past_object_response_2 {
             IotaPastObjectResponse::VersionFound(ref data) => {
                 assert_eq!(
                     data.version, gas_ref_2.1,
-                    "Expected object version {:?} but got {:?}",
+                    "expected object version {:?} but got {:?}",
                     gas_ref_2.1, data.version
                 );
             }
-            _ => panic!("Expected VersionFound response, got: {past_object_response_2:?}"),
+            _ => panic!("expected VersionFound response, got: {past_object_response_2:?}"),
         }
 
         let expected_responses = vec![
@@ -1829,7 +1828,7 @@ fn try_multi_get_past_objects() {
 
         assert_eq!(
             results, expected_responses,
-            "Mismatch in multi-get response results after creating objects"
+            "mismatch in multi-get response results after creating objects"
         );
     });
 }
@@ -1876,7 +1875,7 @@ fn try_get_object_before_version() {
                 receiver,
             )
             .await
-            .expect("Transfer should succeed");
+            .expect("transfer should succeed");
         execute_tx_and_wait_for_indexer(client, store, tx_bytes, &keypair).await;
         wait_for_objects_history().await;
 
@@ -1884,27 +1883,27 @@ fn try_get_object_before_version() {
 
         assert_eq!(
             latest_object, gas_ref.0,
-            "Latest object should match gas_ref.0"
+            "latest object should match gas_ref.0"
         );
         assert!(
             latest_version > gas_ref.1,
-            "Latest version should be greater than initial version"
+            "latest version should be greater than initial version"
         );
 
         let result = client
             .try_get_object_before_version(gas_ref.0, latest_version)
             .await
-            .expect("RPC call should succeed");
+            .expect("rpc call should succeed");
 
         match result {
             IotaPastObjectResponse::VersionFound(ref data) => {
                 assert_eq!(
                     data.version, gas_ref.1,
-                    "Expected object version {:?} but got {:?}",
+                    "expected object version {:?} but got {:?}",
                     gas_ref.1, data.version
                 );
             }
-            _ => panic!("Expected VersionFound response, got: {result:?}"),
+            _ => panic!("expected VersionFound response, got: {result:?}"),
         }
     });
 }

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -235,12 +235,12 @@ fn dev_inspect_transaction_block() {
 
         assert_eq!(
             actual_object_data.version, seq_num,
-            "The object sequence number should not mutate"
+            "the object sequence number should not mutate"
         );
         assert_eq!(
             actual_object_data.owner.unwrap(),
             Owner::AddressOwner(sender),
-            "The initial owner of the object should not change"
+            "the initial owner of the object should not change"
         );
     });
 }
@@ -625,7 +625,7 @@ fn test_parallel_shared_object_updates() {
                         .collect();
                     assert!(
                         relevant_deps.is_subset(&seen_digests),
-                        "Tx: {tx_digest:?} should have bigger order than it's deps: {relevant_deps:?}",
+                        "tx: {tx_digest:?} should have bigger order than it's deps: {relevant_deps:?}",
 
                     );
                     seen_digests.insert(tx_digest);


### PR DESCRIPTION
# Description of change

This PR aims to refactor all error messages to be consistent and use lower-case first letters.

## Links to any relevant issues

fixes #6000.

## How the change has been tested

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.