### PR TITLE
fix(data-ingestion-core): fix for graceful shutdown using the CancellationToken

### DIFF
--- a/crates/iota-data-ingestion-core/src/reducer.rs
+++ b/crates/iota-data-ingestion-core/src/reducer.rs
@@ -207,7 +207,8 @@ pub(crate) async fn reduce<W: Worker>(
         // Handle final batch processing.
         // Check if the final batch should be committed.
         // None parameter indicates no more messages available.
-        if reducer.should_close_batch(&batch, None) && !trigger_shutdown {
+        // Only check if batch is non-empty to avoid unnecessary calls.
+        if !batch.is_empty() && reducer.should_close_batch(&batch, None) && !trigger_shutdown {
             match reducer
                 .commit_with_retry(&std::mem::take(&mut batch), reset_backoff(&backoff), &token)
                 .await

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -309,7 +309,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
                                 let checkpoint = checkpoints.pop_front().unwrap();
                                 let worker_id = idle.pop_first().unwrap();
                                 if workers[worker_id].send(checkpoint).await.is_err() {
-                                    // The worker channel closing is a sign we need to exit this loop.
+                                    // The worker channel closing is a sign we need to exit this inner loop.
                                     break;
                                 }
                             }
@@ -335,9 +335,10 @@ impl<W: Worker + 'static> WorkerPool<W> {
                         checkpoints.push_back(checkpoint);
                     } else {
                         let worker_id = idle.pop_first().unwrap();
-                        if workers[worker_id].send(checkpoint).await.is_err() {
-                            // The worker channel closing is a sign we need to exit this loop.
-                            break;
+                        // If worker channel is closed, put the checkpoint back in queue
+                        // and continue - we still need to wait for all worker shutdown signals.
+                        if let Err(send_error) = workers[worker_id].send(checkpoint).await {
+                            checkpoints.push_front(send_error.0);
                         };
                     }
                 }

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -299,9 +299,10 @@ impl<W: Worker + 'static> WorkerPool<W> {
                     match worker_progress_msg {
                         WorkerStatus::Running((worker_id, checkpoint_number, message)) => {
                             idle.insert(worker_id);
-                            if watermark_sender.send((checkpoint_number, message)).await.is_err() {
-                                break;
-                            }
+                            // Try to send progress to reducer. If it fails (reducer has exited),
+                            // we just continue - we still need to wait for all workers to shutdown.
+                            let _ = watermark_sender.send((checkpoint_number, message)).await;
+
                             // By checking if token was not cancelled we ensure that no
                             // further checkpoints will be sent to the workers.
                             while !token.is_cancelled() && !checkpoints.is_empty() && !idle.is_empty() {


### PR DESCRIPTION
# Description of change

- When using the `CancellationToken` to stop execution from within a custom `Reducer`, the executor would randomly hang. There were multiple `break` statements from within `tokio::select!` which did not break the select itself, but the outer loop, skipping the graceful shutdown handling of the workers.

- A fix was also added to avoid calling `Reducer::should_close_batch` with empty batches and no next item. Fixes #8831

## Links to any relevant issues

Fixes #8831

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

