### PR TITLE
feat(starfish): cordial knowledge as separate component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13609,6 +13609,7 @@ dependencies = [
 name = "starfish-core"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "arc-swap",
  "async-trait",

--- a/crates/starfish/core/Cargo.toml
+++ b/crates/starfish/core/Cargo.toml
@@ -58,6 +58,7 @@ iota-tls.workspace = true
 shared-crypto.workspace = true
 starfish-config.workspace = true
 typed-store.workspace = true
+ahash = "0.8.11"
 
 [dev-dependencies]
 # external dependencies

--- a/crates/starfish/core/Cargo.toml
+++ b/crates/starfish/core/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 # external dependencies
+ahash = "0.8.11"
 anyhow.workspace = true
 arc-swap.workspace = true
 async-trait.workspace = true
@@ -48,7 +49,6 @@ tower-http.workspace = true
 tracing.workspace = true
 
 # internal dependencies
-ahash = "0.8.11"
 iota-common.workspace = true
 iota-http.workspace = true
 iota-macros.workspace = true

--- a/crates/starfish/core/Cargo.toml
+++ b/crates/starfish/core/Cargo.toml
@@ -48,6 +48,7 @@ tower-http.workspace = true
 tracing.workspace = true
 
 # internal dependencies
+ahash = "0.8.11"
 iota-common.workspace = true
 iota-http.workspace = true
 iota-macros.workspace = true
@@ -58,7 +59,6 @@ iota-tls.workspace = true
 shared-crypto.workspace = true
 starfish-config.workspace = true
 typed-store.workspace = true
-ahash = "0.8.11"
 
 [dev-dependencies]
 # external dependencies

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -20,6 +20,7 @@ use crate::{
     commit_syncer::{CommitSyncer, CommitSyncerHandle},
     commit_vote_monitor::CommitVoteMonitor,
     context::{Clock, Context},
+    cordial_knowledge::{CordialKnowledge, CordialKnowledgeHandle},
     core::{Core, CoreSignals},
     core_thread::{ChannelCoreThreadDispatcher, CoreThreadHandle},
     dag_state::DagState,
@@ -34,7 +35,6 @@ use crate::{
     transaction::{TransactionClient, TransactionConsumer, TransactionVerifier},
     transactions_synchronizer::{TransactionsSynchronizer, TransactionsSynchronizerHandle},
 };
-use crate::cordial_knowledge::{CordialKnowledge, CordialKnowledgeHandle};
 
 pub struct ConsensusAuthority {
     context: Arc<Context>,
@@ -117,13 +117,9 @@ impl ConsensusAuthority {
 
         let store_path = context.parameters.db_path.as_path().to_str().unwrap();
         let store = Arc::new(RocksDBStore::new(store_path));
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
-        let cordial_knowledge = CordialKnowledge::start(context.clone());
-
-        let dag_state = DagState::new(context.clone(), store.clone())
-            .with_cordial_knowledge_sender(cordial_knowledge.cordial_knowledge_sender());
-        let dag_state = Arc::new(RwLock::new(dag_state));
-
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let highest_known_commit_at_startup = dag_state.read().last_commit_index();
 
@@ -236,6 +232,7 @@ impl ConsensusAuthority {
             store,
             shard_reconstructor.transaction_message_sender(),
             cordial_knowledge.connection_knowledge_senders(),
+            cordial_knowledge.cordial_knowledge_sender(),
         ));
 
         let subscriber = Subscriber::new(
@@ -312,7 +309,7 @@ impl ConsensusAuthority {
                 e
             );
         };
-        
+
         if let Err(e) = self.cordial_knowledge.stop().await {
             if e.is_panic() {
                 std::panic::resume_unwind(e.into_panic());

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -231,8 +231,7 @@ impl ConsensusAuthority {
             dag_state.clone(),
             store,
             shard_reconstructor.transaction_message_sender(),
-            cordial_knowledge.connection_knowledge_senders(),
-            cordial_knowledge.cordial_knowledge_sender(),
+            cordial_knowledge.clone(),
         ));
 
         let subscriber = Subscriber::new(

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -34,6 +34,7 @@ use crate::{
     transaction::{TransactionClient, TransactionConsumer, TransactionVerifier},
     transactions_synchronizer::{TransactionsSynchronizer, TransactionsSynchronizerHandle},
 };
+use crate::cordial_knowledge::{CordialKnowledge, CordialKnowledgeHandle};
 
 pub struct ConsensusAuthority {
     context: Arc<Context>,
@@ -43,6 +44,7 @@ pub struct ConsensusAuthority {
     transactions_synchronizer: Arc<TransactionsSynchronizerHandle>,
     commit_consumer_monitor: Arc<CommitConsumerMonitor>,
     shard_reconstructor: Arc<ShardReconstructorHandle>,
+    cordial_knowledge: Arc<CordialKnowledgeHandle>,
     commit_syncer_handle: CommitSyncerHandle,
     leader_timeout_handle: LeaderTimeoutTaskHandle,
     core_thread_handle: CoreThreadHandle,
@@ -115,7 +117,13 @@ impl ConsensusAuthority {
 
         let store_path = context.parameters.db_path.as_path().to_str().unwrap();
         let store = Arc::new(RocksDBStore::new(store_path));
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+
+        let cordial_knowledge = CordialKnowledge::start(context.clone());
+
+        let dag_state = DagState::new(context.clone(), store.clone())
+            .with_cordial_knowledge_sender(cordial_knowledge.cordial_knowledge_sender());
+        let dag_state = Arc::new(RwLock::new(dag_state));
+
 
         let highest_known_commit_at_startup = dag_state.read().last_commit_index();
 
@@ -227,6 +235,7 @@ impl ConsensusAuthority {
             dag_state.clone(),
             store,
             shard_reconstructor.transaction_message_sender(),
+            cordial_knowledge.connection_knowledge_senders(),
         ));
 
         let subscriber = Subscriber::new(
@@ -254,6 +263,7 @@ impl ConsensusAuthority {
             transaction_client: Arc::new(tx_client),
             synchronizer,
             shard_reconstructor,
+            cordial_knowledge,
             transactions_synchronizer,
             commit_consumer_monitor,
             commit_syncer_handle,
@@ -302,6 +312,16 @@ impl ConsensusAuthority {
                 e
             );
         };
+        
+        if let Err(e) = self.cordial_knowledge.stop().await {
+            if e.is_panic() {
+                std::panic::resume_unwind(e.into_panic());
+            }
+            warn!(
+                "Failed to stop cordial knowledge manager when shutting down consensus: {:?}",
+                e
+            );
+        }
 
         self.commit_syncer_handle.stop().await;
         self.leader_timeout_handle.stop().await;

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1224,7 +1224,6 @@ mod tests {
         sync::{broadcast, mpsc},
         time::sleep,
     };
-    use telemetry_subscribers::init_for_testing;
     use crate::{
         CommitConsumer, Round, Transaction, TransactionClient,
         authority_service::{
@@ -2392,7 +2391,7 @@ mod tests {
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
-
+        tokio::task::yield_now().await;
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -16,11 +16,7 @@ use futures::{Stream, StreamExt, ready, stream, task};
 use iota_macros::fail_point_async;
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
-use tokio::sync::{
-    Mutex, broadcast,
-    mpsc::{Sender},
-    oneshot,
-};
+use tokio::sync::{Mutex, broadcast, mpsc::Sender, oneshot};
 use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, info, warn};
 
@@ -36,8 +32,7 @@ use crate::{
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     cordial_knowledge::{
-        AdditionalPartsForBundle,
-        ConnectionKnowledgeMessage::TakeAdditionalPartForBundle,
+        AdditionalPartsForBundle, ConnectionKnowledgeMessage::TakeAdditionalPartForBundle,
         CordialKnowledgeHandle,
     },
     core_thread::CoreThreadDispatcher,

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1224,7 +1224,7 @@ mod tests {
         sync::{broadcast, mpsc},
         time::sleep,
     };
-
+    use telemetry_subscribers::init_for_testing;
     use crate::{
         CommitConsumer, Round, Transaction, TransactionClient,
         authority_service::{
@@ -2378,6 +2378,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_subscribe_block_bundles_request() {
+        telemetry_subscribers::init_for_testing();
         // GIVEN
         let rounds = 10;
         let validators = 4;
@@ -2390,8 +2391,6 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
-
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -52,7 +52,7 @@ use crate::{
     synchronizer::SynchronizerHandle,
     transactions_synchronizer::TransactionsSynchronizerHandle,
 };
-use crate::cordial_knowledge::CordialKnowledgeMessage;
+use crate::cordial_knowledge::{CordialKnowledgeHandle, CordialKnowledgeMessage};
 
 pub(crate) const COMMIT_LAG_MULTIPLIER: u32 = 5;
 
@@ -138,8 +138,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         dag_state: Arc<RwLock<DagState>>,
         store: Arc<dyn Store>,
         transaction_message_sender: Sender<Vec<TransactionMessage>>,
-        connection_knowledge_senders: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
-        cordial_knowledge_sender: UnboundedSender<CordialKnowledgeMessage>,
+        cordial_knowledge_handle: Arc<CordialKnowledgeHandle>,
     ) -> Self {
         let subscription_counter = Arc::new(SubscriptionCounter::new(
             context.clone(),
@@ -159,8 +158,8 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             store,
             received_block_headers: FilterForHeaders::new(),
             transaction_message_sender,
-            connection_knowledge_senders,
-            cordial_knowledge_sender
+            connection_knowledge_senders: cordial_knowledge_handle.connection_knowledge_senders(),
+            cordial_knowledge_sender: cordial_knowledge_handle.cordial_knowledge_sender(),
         }
     }
 }
@@ -1318,15 +1317,15 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size())
-            .map(|_| mpsc::channel(100))
-            .collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
-            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(
+            context.clone(),
+            dag_state.clone(),
+        );
+
         let transactions_synchronizer = TransactionsSynchronizer::start(
             network_client.clone(),
             context.clone(),
@@ -1357,7 +1356,7 @@ mod tests {
             dag_state,
             store,
             tx_message_sender,
-            connection_knowledge_senders,
+            cordial_knowledge,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -1400,15 +1399,14 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size())
-            .map(|_| mpsc::channel(100))
-            .collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
-            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(
+            context.clone(),
+            dag_state.clone(),
+        );
         let transactions_synchronizer = TransactionsSynchronizer::start(
             network_client.clone(),
             context.clone(),
@@ -1439,7 +1437,7 @@ mod tests {
             dag_state,
             store,
             tx_message_sender,
-            connection_knowledge_senders,
+            cordial_knowledge,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -1492,15 +1490,15 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size())
-            .map(|_| mpsc::channel(100))
-            .collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
-            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(
+            context.clone(),
+            dag_state.clone(),
+        );
+
         let transactions_synchronizer = TransactionsSynchronizer::start(
             network_client.clone(),
             context.clone(),
@@ -1531,7 +1529,7 @@ mod tests {
             dag_state,
             store,
             tx_message_sender,
-            connection_knowledge_senders,
+            cordial_knowledge,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -1576,15 +1574,14 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size())
-            .map(|_| mpsc::channel(100))
-            .collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
-            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(
+            context.clone(),
+            dag_state.clone(),
+        );
         let transactions_synchronizer = TransactionsSynchronizer::start(
             network_client.clone(),
             context.clone(),
@@ -1615,7 +1612,7 @@ mod tests {
             dag_state,
             store,
             tx_message_sender,
-            connection_knowledge_senders,
+            cordial_knowledge,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -1718,15 +1715,14 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size())
-            .map(|_| mpsc::channel(100))
-            .collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
-            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(
+            context.clone(),
+            dag_state.clone(),
+        );
         let transactions_synchronizer = TransactionsSynchronizer::start(
             network_client.clone(),
             context.clone(),
@@ -1757,7 +1753,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
-            connection_knowledge_senders,
+            cordial_knowledge,
         ));
 
         // Create some blocks for a few authorities. Create some equivocations as well
@@ -1808,6 +1804,10 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(
+            context.clone(),
+            dag_state.clone(),
+        );
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -1850,11 +1850,6 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size())
-            .map(|_| mpsc::channel(100))
-            .collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
-            channels.into_iter().unzip();
         let network_client = Arc::new(FakeNetworkClient::default());
 
         // Set up synchronizers
@@ -1889,7 +1884,7 @@ mod tests {
             dag_state.clone(),
             store.clone(),
             tx_message_sender,
-            connection_knowledge_senders,
+            cordial_knowledge,
         ));
 
         // Set up DAG with blocks
@@ -2081,6 +2076,10 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(
+            context.clone(),
+            dag_state.clone(),
+        );
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -2121,11 +2120,6 @@ mod tests {
         });
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size())
-            .map(|_| mpsc::channel(100))
-            .collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
-            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -2158,7 +2152,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
-            connection_knowledge_senders,
+            cordial_knowledge,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -2242,6 +2236,10 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(
+            context.clone(),
+            dag_state.clone(),
+        );
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -2282,11 +2280,6 @@ mod tests {
         });
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size())
-            .map(|_| mpsc::channel(100))
-            .collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
-            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let transactions_synchronizer = TransactionsSynchronizer::start(
@@ -2318,7 +2311,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
-            connection_knowledge_senders,
+            cordial_knowledge,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -2417,6 +2410,11 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(
+            context.clone(),
+            dag_state.clone(),
+        );
+
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
@@ -2491,7 +2489,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
-            cordial_knowledge.connection_knowledge_senders(),
+            cordial_knowledge,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -2685,6 +2683,11 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(
+            context.clone(),
+            dag_state.clone(),
+        );
+
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -2723,11 +2726,6 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size())
-            .map(|_| mpsc::channel(100))
-            .collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
-            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -2763,7 +2761,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
-            connection_knowledge_senders,
+            cordial_knowledge,
         ));
 
         // Set up DAG with blocks
@@ -2831,6 +2829,10 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(
+            context.clone(),
+            dag_state.clone(),
+        );
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -2869,11 +2871,6 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size())
-            .map(|_| mpsc::channel(100))
-            .collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
-            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -2909,7 +2906,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
-            connection_knowledge_senders,
+            cordial_knowledge,
         ));
 
         // Set up DAG with blocks
@@ -2994,6 +2991,10 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(
+            context.clone(),
+            dag_state.clone(),
+        );
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -3036,11 +3037,6 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size())
-            .map(|_| mpsc::channel(100))
-            .collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
-            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -3076,7 +3072,7 @@ mod tests {
             dag_state.clone(),
             store.clone(),
             tx_message_sender,
-            connection_knowledge_senders,
+            cordial_knowledge,
         ));
 
         // Set up DAG with blocks
@@ -3187,6 +3183,10 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(
+            context.clone(),
+            dag_state.clone(),
+        );
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -3225,11 +3225,6 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size())
-            .map(|_| mpsc::channel(100))
-            .collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
-            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -3265,7 +3260,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
-            connection_knowledge_senders,
+            cordial_knowledge,
         ));
         let mut encoder = create_encoder(&context);
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    cmp::max,
-    collections::{BTreeMap, BTreeSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
     pin::Pin,
     sync::Arc,
     time::Duration,
@@ -17,10 +16,13 @@ use futures::{Stream, StreamExt, ready, stream, task};
 use iota_macros::fail_point_async;
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
-use tokio::sync::{Mutex, broadcast, mpsc::Sender};
+use tokio::{
+    sync::{Mutex, broadcast, mpsc::Sender, oneshot},
+    time::sleep,
+};
+use tokio::sync::mpsc::UnboundedSender;
 use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, info, warn};
-
 use crate::{
     CommitIndex, Round, Transaction, VerifiedBlockHeader,
     block_header::{
@@ -32,6 +34,10 @@ use crate::{
     commit::{CommitAPI as _, CommitRange, TrustedCommit},
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
+    cordial_knowledge::{
+        AdditionalPartsForBundle, ConnectionKnowledgeMessage,
+        ConnectionKnowledgeMessage::TakeAdditionalPartForBundle, CordialKnowledge,
+    },
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
     encoder::ShardEncoder,
@@ -46,7 +52,7 @@ use crate::{
     synchronizer::SynchronizerHandle,
     transactions_synchronizer::TransactionsSynchronizerHandle,
 };
-use crate::cordial_knowledge::ConnectionKnowledgeMessage;
+use crate::cordial_knowledge::CordialKnowledgeMessage;
 
 pub(crate) const COMMIT_LAG_MULTIPLIER: u32 = 5;
 
@@ -113,26 +119,11 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     received_block_headers: FilterForHeaders,
     /// Sender to send received transaction messages to the shard reconstructor
     transaction_message_sender: Sender<Vec<TransactionMessage>>,
-    /// For each peer, the set of authorities whose block headers the local node
-    /// considered useful when receiving a block bundle from that peer.
-    /// Keyed by the peer’s AuthorityIndex.
-    useful_headers_authors_from_peer:
-        Arc<RwLock<BTreeMap<AuthorityIndex, BTreeSet<AuthorityIndex>>>>,
-    /// For each peer, the set of local authorities that the peer reported as
-    /// useful to them (communicated inside their block bundles).
-    /// Keyed by the peer’s AuthorityIndex.
-    useful_headers_authors_to_peer: Arc<RwLock<BTreeMap<AuthorityIndex, BTreeSet<AuthorityIndex>>>>,
-    /// For each peer, stores the latest round in which a received block bundle
-    /// from any peer included a useful shard originating from a block
-    /// created by authority `i`.
-    last_round_with_useful_shards_by_block_author: Arc<RwLock<Vec<Round>>>,
-    /// For each peer `i`, stores a set of authority indices representing the
-    /// authors of blocks whose shards were reported as useful by peer `i`.
-    useful_shards_authors_to_peer: Arc<RwLock<Vec<BTreeSet<AuthorityIndex>>>>,
-    /// Senders to send connection knowledge messages to the respected Connection Knowledge
-    /// It is used to retrieve block refs for headers and shards potentially unknown to the peer
+    /// Senders to send connection knowledge messages to the respected
+    /// Connection Knowledge It is used to retrieve block refs for headers
+    /// and shards potentially unknown to the peer
     connection_knowledge_senders: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
-
+    cordial_knowledge_sender: UnboundedSender<CordialKnowledgeMessage>,
 }
 
 impl<C: CoreThreadDispatcher> AuthorityService<C> {
@@ -148,12 +139,12 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         store: Arc<dyn Store>,
         transaction_message_sender: Sender<Vec<TransactionMessage>>,
         connection_knowledge_senders: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
+        cordial_knowledge_sender: UnboundedSender<CordialKnowledgeMessage>,
     ) -> Self {
         let subscription_counter = Arc::new(SubscriptionCounter::new(
             context.clone(),
             core_dispatcher.clone(),
         ));
-        let committee_size = context.committee.size();
 
         Self {
             context,
@@ -167,18 +158,9 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             dag_state,
             store,
             received_block_headers: FilterForHeaders::new(),
-            useful_headers_authors_from_peer: Arc::new(RwLock::new(BTreeMap::new())),
-            useful_headers_authors_to_peer: Arc::new(RwLock::new(BTreeMap::new())),
             transaction_message_sender,
-            last_round_with_useful_shards_by_block_author: Arc::new(RwLock::new(vec![
-                GENESIS_ROUND;
-                committee_size
-            ])),
-            useful_shards_authors_to_peer: Arc::new(RwLock::new(vec![
-                BTreeSet::new();
-                committee_size
-            ])),
             connection_knowledge_senders,
+            cordial_knowledge_sender
         }
     }
 }
@@ -194,27 +176,15 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         fail_point_async!("consensus-rpc-response");
 
         let peer_hostname = &self.context.committee.authority(peer).hostname;
-        let serialized_block_bundle_parts =
+        let mut serialized_block_bundle_parts =
             SerializedBlockBundleParts::try_from(serialized_block_bundle)?;
-
-        // Cache authorities this peer finds useful for cordial
-        let useful_authorities_to_peer = serialized_block_bundle_parts.useful_headers_authors();
-        {
-            let mut guard = self.useful_headers_authors_to_peer.write();
-            guard.insert(peer, useful_authorities_to_peer);
-        }
-        let useful_shards_authors_to_peer = serialized_block_bundle_parts.useful_shards_authors();
-        {
-            let mut guard = self.useful_shards_authors_to_peer.write();
-            guard[peer] = useful_shards_authors_to_peer;
-        }
 
         // 1. Create a verified block and make some preliminary checks
         let SerializedHeaderAndTransactions {
             serialized_block_header,
             serialized_transactions,
         } = SerializedHeaderAndTransactions::try_from(SerializedBlock {
-            serialized_block: serialized_block_bundle_parts.serialized_block,
+            serialized_block: serialized_block_bundle_parts.serialized_block.clone(),
         })?;
 
         let signed_block_header: SignedBlockHeader =
@@ -298,17 +268,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // 4. Create block headers from bytes from a bundle
         // 4.a. Truncate headers in bundle to max_headers_per_bundle
-        let serialized_headers = if serialized_block_bundle_parts.serialized_headers.len()
+        let mut serialized_headers = std::mem::take(&mut serialized_block_bundle_parts.serialized_headers);
+        if serialized_headers.len()
             > self.context.parameters.max_headers_per_bundle
         {
             warn!("BlockBundle: {block_ref} exceeds max_headers_per_bundle.");
-            serialized_block_bundle_parts
-                .serialized_headers
-                .into_iter()
-                .take(self.context.parameters.max_headers_per_bundle)
-                .collect::<Vec<_>>()
-        } else {
-            serialized_block_bundle_parts.serialized_headers
+            serialized_headers.truncate(self.context.parameters.max_headers_per_bundle);
         };
 
         let mut additional_block_headers = vec![];
@@ -383,18 +348,13 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // 5. Collect shards from a bundle and check their proofs.
         // 5.a. Truncate shards in bundle to max_shards_per_bundle.
-        let serialized_shards = if serialized_block_bundle_parts.serialized_shards.len()
-            > self.context.parameters.max_shards_per_bundle
-        {
+
+        let mut serialized_shards = std::mem::take(&mut serialized_block_bundle_parts.serialized_shards);
+
+        if serialized_shards.len() > self.context.parameters.max_shards_per_bundle {
             warn!("BlockBundle: {block_ref} exceeds max_shards_per_bundle.");
-            serialized_block_bundle_parts
-                .serialized_shards
-                .into_iter()
-                .take(self.context.parameters.max_shards_per_bundle)
-                .collect::<Vec<_>>()
-        } else {
-            serialized_block_bundle_parts.serialized_shards
-        };
+            serialized_shards.truncate(self.context.parameters.max_shards_per_bundle);
+        }
 
         let mut verified_shards: Vec<ShardWithProof> = vec![];
         for serialized_shard in &serialized_shards {
@@ -595,40 +555,18 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .map_err(|_| ConsensusError::Shutdown)?;
         }
 
-        // 13. update `useful_headers_authors_from_peer`
-        // create a set of authority indexes from the `additional_block_headers`
-        // and `missing_ancestors`
-        {
-            let useful_headers_authors = additional_block_headers
-                .iter()
-                .map(|block_header| block_header.author())
-                .chain(missing_ancestors.iter().map(|block_ref| block_ref.author))
-                .collect::<BTreeSet<_>>();
+        // 13. Report useful info for cordial and connection knowledge
+        CordialKnowledge::report_useful_info(
+            &self.connection_knowledge_senders[peer],
+            &self.cordial_knowledge_sender,
+            &serialized_block_bundle_parts,
+            &additional_block_headers,
+            &missing_ancestors,
+            block_round,
+        )
+        .await;
 
-            let mut useful_authorities_from_peer_write_guard =
-                self.useful_headers_authors_from_peer.write();
-            useful_authorities_from_peer_write_guard.insert(peer, useful_headers_authors);
-        }
-        // 14. Update `last_round_with_useful_shards_by_block_author`:
-        // For each validator whose block is in `additional_block_headers`,
-        // set their entry to the maximum of its current value and the round of the
-        // received block.
-        {
-            let useful_shard_authors = additional_block_headers
-                .iter()
-                .map(|block_header| block_header.author())
-                .collect::<Vec<_>>();
-            let mut last_round_with_useful_shards_from_peer_write_guard =
-                self.last_round_with_useful_shards_by_block_author.write();
-            for author in useful_shard_authors {
-                last_round_with_useful_shards_from_peer_write_guard[author] = max(
-                    last_round_with_useful_shards_from_peer_write_guard[author],
-                    block_round,
-                );
-            }
-        }
-
-        // 15. schedule the fetching of missing ancestors (if any) from this peer
+        // 14. schedule the fetching of missing ancestors (if any) from this peer
         if !missing_ancestors.is_empty() {
             if let Err(err) = self
                 .synchronizer
@@ -689,77 +627,44 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // Return a stream of blocks that first yields missed blocks as requested, then
         // new blocks.
         Ok(Box::pin(missed_blocks.chain({
-            let dag_state = Arc::clone(&self.dag_state);
-            let useful_headers_authors_from_peer =
-                Arc::clone(&self.useful_headers_authors_from_peer);
-            let useful_headers_authors_to_peer = Arc::clone(&self.useful_headers_authors_to_peer);
-            let last_round_with_useful_shards_by_block_author =
-                Arc::clone(&self.last_round_with_useful_shards_by_block_author);
-            let useful_shards_authors_to_peer = Arc::clone(&self.useful_shards_authors_to_peer);
-            let committee = self
-                .context
-                .committee
-                .authorities()
-                .map(|(index, _)| index)
-                .collect::<BTreeSet<_>>();
-
+            let connection_knowledge_sender = self.connection_knowledge_senders[peer].clone();
             broadcasted_blocks.filter_map(move |block| {
-                let useful_headers_authors_to_peer_guard = useful_headers_authors_to_peer.read();
-                let useful_headers_authors_to_peer_read = useful_headers_authors_to_peer_guard
-                    .get(&peer)
-                    .map(|authorities| authorities.iter().cloned().collect::<BTreeSet<_>>());
-                drop(useful_headers_authors_to_peer_guard);
-
-                let useful_shards_authors_to_peer_guard = useful_shards_authors_to_peer.read();
-                let useful_shards_authors_to_peer_read =
-                    useful_shards_authors_to_peer_guard[peer].clone();
-                drop(useful_shards_authors_to_peer_guard);
-
-                let useful_headers_authors_from_peer_guard =
-                    useful_headers_authors_from_peer.read();
-                let useful_headers_authors_from_peer_read =
-                    match useful_headers_authors_from_peer_guard.get(&peer) {
-                        None => committee.clone(),
-                        Some(useful_authorities) => useful_authorities.clone(),
-                    };
-                drop(useful_headers_authors_from_peer_guard);
-
-                let last_round_with_useful_shards_by_block_author_guard =
-                    last_round_with_useful_shards_by_block_author.read();
-                let last_round_with_useful_shards_by_block_author_read =
-                    last_round_with_useful_shards_by_block_author_guard.clone();
-                drop(last_round_with_useful_shards_by_block_author_guard);
-
-                let mut dag_state_guard = dag_state.write();
-                let block_headers = match useful_headers_authors_to_peer_read {
-                    None => dag_state_guard.take_unknown_headers_for_authority(peer, block.round()),
-                    Some(authorities) => dag_state_guard.take_useful_headers_for_authority(
-                        peer,
-                        block.round(),
-                        authorities,
-                    ),
-                };
-
-                let serialized_shards = dag_state_guard.take_useful_shards_for_authority(
-                    peer,
-                    block.round(),
-                    useful_shards_authors_to_peer_read,
-                );
-                drop(dag_state_guard);
-
-                let useful_shards_authors = DagState::get_useful_shards_authors(
-                    last_round_with_useful_shards_by_block_author_read,
-                    block.round(),
-                );
-
-                let block_bundle = BlockBundle {
-                    verified_block: block,
-                    verified_headers: block_headers,
-                    serialized_shards,
-                    useful_headers_authors: useful_headers_authors_from_peer_read,
-                    useful_shards_authors,
-                };
+                let connection_knowledge_sender = connection_knowledge_sender.clone();
                 async move {
+                    let (tx, rx) = oneshot::channel();
+
+                    let msg = TakeAdditionalPartForBundle {
+                        round_upper_bound_exclusive: block.round(),
+                        respond_to: tx,
+                    };
+
+                    // Send message asynchronously to corresponding ConnectionKnowledge task
+                    if let Err(e) = connection_knowledge_sender.send(vec![msg]).await {
+                        warn!("Failed to send TakeAdditionalPartForBundle to Connection Knowledge: {e}");
+                        return None;
+                    }
+
+                    // Await response from ConnectionKnowledge
+                    let block_bundle = match rx.await {
+                        Ok(AdditionalPartsForBundle {
+                               headers,
+                               shards,
+                               useful_headers_authors_from_peer,
+                               useful_shards_authors_from_peer,
+                           }) => BlockBundle {
+                            verified_block: block,
+                            verified_headers: headers,
+                            serialized_shards: shards,
+                            useful_headers_authors: useful_headers_authors_from_peer,
+                            useful_shards_authors: useful_shards_authors_from_peer,
+                        },
+                        Err(_) => {
+                            warn!("Connection Knowledge oneshot dropped before response");
+                            // Construct bundle (fill in your actual vars)
+                            return None;
+                        }
+                    };
+
                     match SerializedBlockBundle::try_from(block_bundle) {
                         Ok(serialized_block_bundle) => Some(serialized_block_bundle),
                         Err(e) => {
@@ -1332,6 +1237,7 @@ mod tests {
         commit_observer::CommitObserver,
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
+        cordial_knowledge::CordialKnowledge,
         core::{Core, CoreSignals},
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
         dag_state::{DagState, TransactionSource},
@@ -1412,10 +1318,11 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
-
-
+        let channels: Vec<_> = (0..context.committee.size())
+            .map(|_| mpsc::channel(100))
+            .collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
+            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
@@ -1450,7 +1357,7 @@ mod tests {
             dag_state,
             store,
             tx_message_sender,
-            connection_knowledge_senders
+            connection_knowledge_senders,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -1493,9 +1400,11 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
-
+        let channels: Vec<_> = (0..context.committee.size())
+            .map(|_| mpsc::channel(100))
+            .collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
+            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
@@ -1530,7 +1439,7 @@ mod tests {
             dag_state,
             store,
             tx_message_sender,
-            connection_knowledge_senders
+            connection_knowledge_senders,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -1583,9 +1492,11 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
-
+        let channels: Vec<_> = (0..context.committee.size())
+            .map(|_| mpsc::channel(100))
+            .collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
+            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
@@ -1620,7 +1531,7 @@ mod tests {
             dag_state,
             store,
             tx_message_sender,
-            connection_knowledge_senders
+            connection_knowledge_senders,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -1665,9 +1576,11 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
-
+        let channels: Vec<_> = (0..context.committee.size())
+            .map(|_| mpsc::channel(100))
+            .collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
+            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
@@ -1702,7 +1615,7 @@ mod tests {
             dag_state,
             store,
             tx_message_sender,
-            connection_knowledge_senders
+            connection_knowledge_senders,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -1805,9 +1718,11 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
-
+        let channels: Vec<_> = (0..context.committee.size())
+            .map(|_| mpsc::channel(100))
+            .collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
+            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
@@ -1842,6 +1757,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
+            connection_knowledge_senders,
         ));
 
         // Create some blocks for a few authorities. Create some equivocations as well
@@ -1934,8 +1850,11 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+        let channels: Vec<_> = (0..context.committee.size())
+            .map(|_| mpsc::channel(100))
+            .collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
+            channels.into_iter().unzip();
         let network_client = Arc::new(FakeNetworkClient::default());
 
         // Set up synchronizers
@@ -2202,9 +2121,11 @@ mod tests {
         });
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
-
+        let channels: Vec<_> = (0..context.committee.size())
+            .map(|_| mpsc::channel(100))
+            .collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
+            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -2361,9 +2282,11 @@ mod tests {
         });
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
-
+        let channels: Vec<_> = (0..context.committee.size())
+            .map(|_| mpsc::channel(100))
+            .collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
+            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let transactions_synchronizer = TransactionsSynchronizer::start(
@@ -2494,6 +2417,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -2535,10 +2459,6 @@ mod tests {
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
         let network_client = Arc::new(FakeNetworkClient::default());
 
-        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
-
-
         // Set up synchronizers
         let transactions_synchronizer = TransactionsSynchronizer::start(
             network_client.clone(),
@@ -2571,7 +2491,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
-            connection_knowledge_senders,
+            cordial_knowledge.connection_knowledge_senders(),
         ));
         let mut encoder = create_encoder(&context);
 
@@ -2611,8 +2531,8 @@ mod tests {
         let mut received_bundles = Vec::new();
 
         // Collect expected blocks from the first batch
-        let expected_blocks = first_batch_end_exclusive - 1 - last_received_round;
-        for _ in 0..expected_blocks {
+        let expected_number = first_batch_end_exclusive - 1 - last_received_round;
+        for _ in 0..expected_number {
             if let Some(bundle) = stream.next().await {
                 received_bundles.push(bundle);
             }
@@ -2624,8 +2544,8 @@ mod tests {
 
         assert_eq!(
             received_bundles.len() as u32,
-            expected_blocks,
-            "Should receive {expected_blocks} missed blocks",
+            expected_number,
+            "Should receive {expected_number} missed blocks",
         );
 
         // Check the correctness of the received blocks
@@ -2803,9 +2723,11 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
-
+        let channels: Vec<_> = (0..context.committee.size())
+            .map(|_| mpsc::channel(100))
+            .collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
+            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -2947,9 +2869,11 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
-
+        let channels: Vec<_> = (0..context.committee.size())
+            .map(|_| mpsc::channel(100))
+            .collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
+            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -3112,9 +3036,11 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
-
+        let channels: Vec<_> = (0..context.committee.size())
+            .map(|_| mpsc::channel(100))
+            .collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
+            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -3299,9 +3225,11 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
-        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
-
+        let channels: Vec<_> = (0..context.committee.size())
+            .map(|_| mpsc::channel(100))
+            .collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) =
+            channels.into_iter().unzip();
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -3337,7 +3265,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
-            connection_knowledge_senders
+            connection_knowledge_senders,
         ));
         let mut encoder = create_encoder(&context);
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -17,12 +17,16 @@ use iota_macros::fail_point_async;
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
 use tokio::{
-    sync::{Mutex, broadcast, mpsc::Sender, oneshot},
+    sync::{
+        Mutex, broadcast,
+        mpsc::{Sender, UnboundedSender},
+        oneshot,
+    },
     time::sleep,
 };
-use tokio::sync::mpsc::UnboundedSender;
 use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, info, warn};
+
 use crate::{
     CommitIndex, Round, Transaction, VerifiedBlockHeader,
     block_header::{
@@ -37,6 +41,7 @@ use crate::{
     cordial_knowledge::{
         AdditionalPartsForBundle, ConnectionKnowledgeMessage,
         ConnectionKnowledgeMessage::TakeAdditionalPartForBundle, CordialKnowledge,
+        CordialKnowledgeHandle, CordialKnowledgeMessage,
     },
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
@@ -52,7 +57,6 @@ use crate::{
     synchronizer::SynchronizerHandle,
     transactions_synchronizer::TransactionsSynchronizerHandle,
 };
-use crate::cordial_knowledge::{CordialKnowledgeHandle, CordialKnowledgeMessage};
 
 pub(crate) const COMMIT_LAG_MULTIPLIER: u32 = 5;
 
@@ -267,10 +271,9 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // 4. Create block headers from bytes from a bundle
         // 4.a. Truncate headers in bundle to max_headers_per_bundle
-        let mut serialized_headers = std::mem::take(&mut serialized_block_bundle_parts.serialized_headers);
-        if serialized_headers.len()
-            > self.context.parameters.max_headers_per_bundle
-        {
+        let mut serialized_headers =
+            std::mem::take(&mut serialized_block_bundle_parts.serialized_headers);
+        if serialized_headers.len() > self.context.parameters.max_headers_per_bundle {
             warn!("BlockBundle: {block_ref} exceeds max_headers_per_bundle.");
             serialized_headers.truncate(self.context.parameters.max_headers_per_bundle);
         };
@@ -348,7 +351,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // 5. Collect shards from a bundle and check their proofs.
         // 5.a. Truncate shards in bundle to max_shards_per_bundle.
 
-        let mut serialized_shards = std::mem::take(&mut serialized_block_bundle_parts.serialized_shards);
+        let mut serialized_shards =
+            std::mem::take(&mut serialized_block_bundle_parts.serialized_shards);
 
         if serialized_shards.len() > self.context.parameters.max_shards_per_bundle {
             warn!("BlockBundle: {block_ref} exceeds max_shards_per_bundle.");
@@ -1321,10 +1325,7 @@ mod tests {
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(
-            context.clone(),
-            dag_state.clone(),
-        );
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let transactions_synchronizer = TransactionsSynchronizer::start(
             network_client.clone(),
@@ -1403,10 +1404,7 @@ mod tests {
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(
-            context.clone(),
-            dag_state.clone(),
-        );
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
         let transactions_synchronizer = TransactionsSynchronizer::start(
             network_client.clone(),
             context.clone(),
@@ -1494,10 +1492,7 @@ mod tests {
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(
-            context.clone(),
-            dag_state.clone(),
-        );
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let transactions_synchronizer = TransactionsSynchronizer::start(
             network_client.clone(),
@@ -1578,10 +1573,7 @@ mod tests {
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(
-            context.clone(),
-            dag_state.clone(),
-        );
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
         let transactions_synchronizer = TransactionsSynchronizer::start(
             network_client.clone(),
             context.clone(),
@@ -1719,10 +1711,7 @@ mod tests {
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(
-            context.clone(),
-            dag_state.clone(),
-        );
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
         let transactions_synchronizer = TransactionsSynchronizer::start(
             network_client.clone(),
             context.clone(),
@@ -1804,10 +1793,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(
-            context.clone(),
-            dag_state.clone(),
-        );
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -2076,10 +2062,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(
-            context.clone(),
-            dag_state.clone(),
-        );
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -2236,10 +2219,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(
-            context.clone(),
-            dag_state.clone(),
-        );
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -2410,10 +2390,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(
-            context.clone(),
-            dag_state.clone(),
-        );
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
@@ -2683,11 +2660,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(
-            context.clone(),
-            dag_state.clone(),
-        );
-
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -2829,10 +2802,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(
-            context.clone(),
-            dag_state.clone(),
-        );
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -2991,10 +2961,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(
-            context.clone(),
-            dag_state.clone(),
-        );
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -3183,10 +3150,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(
-            context.clone(),
-            dag_state.clone(),
-        );
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -2485,7 +2485,11 @@ mod tests {
         let first_batch_end_exclusive = 5;
         for round in 1..first_batch_end_exclusive {
             core_dispatcher
-                .add_blocks(all_blocks[round as usize].clone())
+                .add_blocks(all_blocks[round as usize - 1].clone())
+                .await
+                .expect("blocks are expected to be added successfully");
+            core_dispatcher
+                .add_blocks(vec![all_blocks[round as usize][0].clone()])
                 .await
                 .expect("blocks are expected to be added successfully");
             sleep(Duration::from_millis(50)).await;
@@ -2572,19 +2576,22 @@ mod tests {
                 all_blocks[i + (last_received_round + 1) as usize][0],
             );
         }
+        received_bundles = vec![];
 
         for round in first_batch_end_exclusive..=rounds {
             core_dispatcher
-                .add_blocks(all_blocks[round as usize].clone())
+                .add_blocks(all_blocks[round as usize - 1].clone())
                 .await
                 .expect("blocks are expected to be added successfully");
+            core_dispatcher
+                .add_blocks(vec![all_blocks[round as usize][0].clone()])
+                .await
+                .expect("blocks are expected to be added successfully");
+            sleep(Duration::from_millis(50)).await;
             tx_block_broadcast
                 .send(all_blocks[round as usize][0].clone())
                 .expect("We expect that block is sent successfully");
-        }
-
-        received_bundles = vec![];
-        for _ in first_batch_end_exclusive..rounds {
+            sleep(Duration::from_millis(50)).await;
             if let Some(bundle) = stream.next().await {
                 received_bundles.push(bundle);
             }
@@ -2592,13 +2599,13 @@ mod tests {
 
         // Check blocks from the second batch
         for (i, bundle) in received_bundles.into_iter().enumerate() {
-            let serialized_block_and_headers =
+            let serialized_block_bundle_parts =
                 SerializedBlockBundleParts::try_from(bundle).unwrap();
             let SerializedHeaderAndTransactions {
                 serialized_block_header,
                 serialized_transactions,
             } = SerializedHeaderAndTransactions::try_from(SerializedBlock {
-                serialized_block: serialized_block_and_headers.serialized_block,
+                serialized_block: serialized_block_bundle_parts.serialized_block,
             })
             .unwrap();
 
@@ -2637,6 +2644,29 @@ mod tests {
                 verified_block,
                 all_blocks[i + first_batch_end_exclusive as usize][0],
             );
+
+            let mut authorities = vec![];
+            for serialized_header in serialized_block_bundle_parts.serialized_headers {
+                let signed_header: SignedBlockHeader = bcs::from_bytes(&serialized_header)
+                    .map_err(ConsensusError::MalformedHeader)
+                    .unwrap();
+                assert_eq!(
+                    verified_block.round(),
+                    signed_header.round() + 1,
+                    "Headers should be from the previous round"
+                );
+                authorities.push(signed_header.author());
+            }
+            authorities.sort();
+            assert_eq!(
+                authorities,
+                vec![
+                    AuthorityIndex::new_for_test(2),
+                    AuthorityIndex::new_for_test(3)
+                ],
+                "We should have pushed headers from other authorities in round {:?}", verified_block.round(),
+            );
+
         }
     }
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -46,6 +46,7 @@ use crate::{
     synchronizer::SynchronizerHandle,
     transactions_synchronizer::TransactionsSynchronizerHandle,
 };
+use crate::cordial_knowledge::ConnectionKnowledgeMessage;
 
 pub(crate) const COMMIT_LAG_MULTIPLIER: u32 = 5;
 
@@ -128,6 +129,10 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     /// For each peer `i`, stores a set of authority indices representing the
     /// authors of blocks whose shards were reported as useful by peer `i`.
     useful_shards_authors_to_peer: Arc<RwLock<Vec<BTreeSet<AuthorityIndex>>>>,
+    /// Senders to send connection knowledge messages to the respected Connection Knowledge
+    /// It is used to retrieve block refs for headers and shards potentially unknown to the peer
+    connection_knowledge_senders: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
+
 }
 
 impl<C: CoreThreadDispatcher> AuthorityService<C> {
@@ -142,6 +147,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         dag_state: Arc<RwLock<DagState>>,
         store: Arc<dyn Store>,
         transaction_message_sender: Sender<Vec<TransactionMessage>>,
+        connection_knowledge_senders: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
     ) -> Self {
         let subscription_counter = Arc::new(SubscriptionCounter::new(
             context.clone(),
@@ -172,6 +178,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 BTreeSet::new();
                 committee_size
             ])),
+            connection_knowledge_senders,
         }
     }
 }
@@ -1405,6 +1412,10 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+
+
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
@@ -1439,6 +1450,7 @@ mod tests {
             dag_state,
             store,
             tx_message_sender,
+            connection_knowledge_senders
         ));
         let mut encoder = create_encoder(&context);
 
@@ -1481,6 +1493,9 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
@@ -1515,6 +1530,7 @@ mod tests {
             dag_state,
             store,
             tx_message_sender,
+            connection_knowledge_senders
         ));
         let mut encoder = create_encoder(&context);
 
@@ -1567,6 +1583,9 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
@@ -1601,6 +1620,7 @@ mod tests {
             dag_state,
             store,
             tx_message_sender,
+            connection_knowledge_senders
         ));
         let mut encoder = create_encoder(&context);
 
@@ -1645,6 +1665,9 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
@@ -1679,6 +1702,7 @@ mod tests {
             dag_state,
             store,
             tx_message_sender,
+            connection_knowledge_senders
         ));
         let mut encoder = create_encoder(&context);
 
@@ -1781,6 +1805,9 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
@@ -1907,6 +1934,8 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
         let network_client = Arc::new(FakeNetworkClient::default());
 
         // Set up synchronizers
@@ -1941,6 +1970,7 @@ mod tests {
             dag_state.clone(),
             store.clone(),
             tx_message_sender,
+            connection_knowledge_senders,
         ));
 
         // Set up DAG with blocks
@@ -2172,6 +2202,9 @@ mod tests {
         });
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -2204,6 +2237,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
+            connection_knowledge_senders,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -2327,6 +2361,9 @@ mod tests {
         });
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+
 
         let network_client = Arc::new(FakeNetworkClient::default());
         let transactions_synchronizer = TransactionsSynchronizer::start(
@@ -2358,6 +2395,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
+            connection_knowledge_senders,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -2497,6 +2535,10 @@ mod tests {
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
         let network_client = Arc::new(FakeNetworkClient::default());
 
+        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+
+
         // Set up synchronizers
         let transactions_synchronizer = TransactionsSynchronizer::start(
             network_client.clone(),
@@ -2529,6 +2571,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
+            connection_knowledge_senders,
         ));
         let mut encoder = create_encoder(&context);
 
@@ -2760,6 +2803,9 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -2795,6 +2841,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
+            connection_knowledge_senders,
         ));
 
         // Set up DAG with blocks
@@ -2900,6 +2947,9 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -2935,6 +2985,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
+            connection_knowledge_senders,
         ));
 
         // Set up DAG with blocks
@@ -3061,6 +3112,10 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+
+
         let network_client = Arc::new(FakeNetworkClient::default());
 
         // Set up synchronizers
@@ -3095,6 +3150,7 @@ mod tests {
             dag_state.clone(),
             store.clone(),
             tx_message_sender,
+            connection_knowledge_senders,
         ));
 
         // Set up DAG with blocks
@@ -3243,6 +3299,9 @@ mod tests {
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let channels: Vec<_> = (0..context.committee.size()).map(|_| mpsc::channel(100)).collect();
+        let (connection_knowledge_senders, _tx_message_receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+
 
         let network_client = Arc::new(FakeNetworkClient::default());
 
@@ -3278,6 +3337,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
+            connection_knowledge_senders
         ));
         let mut encoder = create_encoder(&context);
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -567,7 +567,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             &missing_ancestors,
             block_round,
         )
-        .await;
+        .await?;
 
         // 14. schedule the fetching of missing ancestors (if any) from this peer
         if !missing_ancestors.is_empty() {

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -628,6 +628,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             self.rx_block_broadcaster.resubscribe(),
             self.subscription_counter.clone(),
         );
+        let context = self.context.clone();
 
         // Return a stream of blocks that first yields missed blocks as requested, then
         // new blocks.
@@ -635,6 +636,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             let connection_knowledge_sender = self.connection_knowledge_senders[peer].clone();
             broadcasted_blocks.filter_map(move |block| {
                 let connection_knowledge_sender = connection_knowledge_sender.clone();
+                let context = context.clone();
+                let ts = block.timestamp_ms();
                 async move {
                     let (tx, rx) = oneshot::channel();
 
@@ -670,7 +673,9 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                         }
                     };
 
-                    debug!("Block bundle {block_bundle:?}");
+
+                    let now = context.clock.timestamp_utc_ms();
+                    context.metrics.node_metrics.delay_in_sending_blocks.observe((now - ts) as f64);
 
                     match SerializedBlockBundle::try_from(block_bundle) {
                         Ok(serialized_block_bundle) => Some(serialized_block_bundle),

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -18,7 +18,7 @@ use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
 use tokio::sync::{
     Mutex, broadcast,
-    mpsc::{Sender, UnboundedSender},
+    mpsc::{Sender},
     oneshot,
 };
 use tokio_util::sync::ReusableBoxFuture;
@@ -36,9 +36,9 @@ use crate::{
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     cordial_knowledge::{
-        AdditionalPartsForBundle, ConnectionKnowledgeMessage,
-        ConnectionKnowledgeMessage::TakeAdditionalPartForBundle, CordialKnowledge,
-        CordialKnowledgeHandle, CordialKnowledgeMessage,
+        AdditionalPartsForBundle,
+        ConnectionKnowledgeMessage::TakeAdditionalPartForBundle,
+        CordialKnowledgeHandle,
     },
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
@@ -120,16 +120,11 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     received_block_headers: FilterForHeaders,
     /// Sender to send received transaction messages to the shard reconstructor
     transaction_message_sender: Sender<Vec<TransactionMessage>>,
-    /// Senders to send messages to the respected
-    /// Connection Knowledge. One sender is intended for one peer. These senders
-    /// are used to update useful authors for blocks and shards. In addition,
-    /// one retrieves additional parts for block bundles when streaming own
-    /// blocks.
-    connection_knowledge_senders: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
-    /// Sender to send messages to Cordial Knowledge. This sender is used to
-    /// update information shards of which authors should be requested in future
-    /// block bundles from peers.
-    cordial_knowledge_sender: UnboundedSender<CordialKnowledgeMessage>,
+    /// CordialKnowledge allows to update cordial knowledge about the DAG (which
+    /// blocks are know by which peer). In addition, one can retrieve some
+    /// useful information such as which headers and shards are needed to a
+    /// specific peer
+    cordial_knowledge: Arc<CordialKnowledgeHandle>,
 }
 
 impl<C: CoreThreadDispatcher> AuthorityService<C> {
@@ -144,7 +139,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         dag_state: Arc<RwLock<DagState>>,
         store: Arc<dyn Store>,
         transaction_message_sender: Sender<Vec<TransactionMessage>>,
-        cordial_knowledge_handle: Arc<CordialKnowledgeHandle>,
+        cordial_knowledge: Arc<CordialKnowledgeHandle>,
     ) -> Self {
         let subscription_counter = Arc::new(SubscriptionCounter::new(
             context.clone(),
@@ -164,8 +159,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             store,
             received_block_headers: FilterForHeaders::new(),
             transaction_message_sender,
-            connection_knowledge_senders: cordial_knowledge_handle.connection_knowledge_senders(),
-            cordial_knowledge_sender: cordial_knowledge_handle.cordial_knowledge_sender(),
+            cordial_knowledge,
         }
     }
 }
@@ -561,15 +555,15 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         // 13. Report useful info for cordial and connection knowledge
-        CordialKnowledge::report_useful_info(
-            &self.connection_knowledge_senders[peer],
-            &self.cordial_knowledge_sender,
-            &serialized_block_bundle_parts,
-            &additional_block_headers,
-            &missing_ancestors,
-            block_round,
-        )
-        .await?;
+        self.cordial_knowledge
+            .report_useful_authors(
+                peer,
+                &serialized_block_bundle_parts,
+                &additional_block_headers,
+                &missing_ancestors,
+                block_round,
+            )
+            .await?;
 
         // 14. schedule the fetching of missing ancestors (if any) from this peer
         if !missing_ancestors.is_empty() {
@@ -629,11 +623,10 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             self.subscription_counter.clone(),
         );
         let context = self.context.clone();
-
+        let connection_knowledge_sender = self.cordial_knowledge.connection_knowledge_sender(peer);
         // Return a stream of blocks that first yields missed blocks as requested, then
         // new blocks.
         Ok(Box::pin(missed_blocks.chain({
-            let connection_knowledge_sender = self.connection_knowledge_senders[peer].clone();
             broadcasted_blocks.filter_map(move |block| {
                 let connection_knowledge_sender = connection_knowledge_sender.clone();
                 let context = context.clone();
@@ -2506,7 +2499,7 @@ mod tests {
 
         // Inject useful info
         let connection_knowledge_sender =
-            cordial_knowledge.connection_knowledge_senders()[to_whom_authority].clone();
+            cordial_knowledge.connection_knowledge_sender(to_whom_authority);
         let msg = ConnectionKnowledgeMessage::UsefulAuthors {
             useful_headers_to_peer: BTreeMap::from([
                 (AuthorityIndex::new_for_test(2), GENESIS_ROUND),

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -123,10 +123,15 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     received_block_headers: FilterForHeaders,
     /// Sender to send received transaction messages to the shard reconstructor
     transaction_message_sender: Sender<Vec<TransactionMessage>>,
-    /// Senders to send connection knowledge messages to the respected
-    /// Connection Knowledge It is used to retrieve block refs for headers
-    /// and shards potentially unknown to the peer
+    /// Senders to send messages to the respected
+    /// Connection Knowledge. One sender is intented for one peer. These senders
+    /// are used to update useful authors for blocks and shards. In addition,
+    /// one retrieves additional parts for block bundles when streaming own
+    /// blocks.
     connection_knowledge_senders: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
+    /// Sender to send messages to Cordial Knowledge. This sender is used to
+    /// update information shards of which authors should be requested in future
+    /// block bundles from peers.
     cordial_knowledge_sender: UnboundedSender<CordialKnowledgeMessage>,
 }
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -22,7 +22,6 @@ use tokio::{
         mpsc::{Sender, UnboundedSender},
         oneshot,
     },
-    time::sleep,
 };
 use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, info, warn};

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1260,6 +1260,8 @@ mod tests {
         transaction::TransactionConsumer,
         transactions_synchronizer::TransactionsSynchronizer,
     };
+    use crate::block_header::GENESIS_ROUND;
+    use crate::cordial_knowledge::ConnectionKnowledgeMessage;
 
     #[derive(Default)]
     struct FakeNetworkClient {}
@@ -2384,6 +2386,7 @@ mod tests {
         // GIVEN
         let rounds = 10;
         let validators = 4;
+        let to_whom_authority = AuthorityIndex::new_for_test(1);
         let (context, key_pairs) = Context::new_for_test(validators);
         let context = Arc::new(context);
         let block_verifier = Arc::new(SignedBlockVerifier::new(
@@ -2466,7 +2469,7 @@ mod tests {
             dag_state.clone(),
             store,
             tx_message_sender,
-            cordial_knowledge,
+            cordial_knowledge.clone(),
         ));
         let mut encoder = create_encoder(&context);
 
@@ -2495,12 +2498,31 @@ mod tests {
             sleep(Duration::from_millis(50)).await;
         }
 
+        // Inject useful info
+        let connection_knowledge_sender = cordial_knowledge.connection_knowledge_senders()[to_whom_authority].clone();
+        let msg = ConnectionKnowledgeMessage::UsefulInfo {
+            useful_headers_to_peer: BTreeMap::from([
+                (AuthorityIndex::new_for_test(2), GENESIS_ROUND),
+                (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
+            ]),
+            useful_shards_to_peer: BTreeMap::from([
+                (AuthorityIndex::new_for_test(2), GENESIS_ROUND),
+                (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
+            ]),
+            useful_headers_from_peer: BTreeMap::from([
+                (AuthorityIndex::new_for_test(1), GENESIS_ROUND),
+                (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
+            ]),
+            useful_shards_from_peers: vec![None,Some(GENESIS_ROUND),None,Some(GENESIS_ROUND)]
+        };
+        let _ = connection_knowledge_sender.send(vec![msg]).await;
+
         // WHEN
         // Call handle_subscribe_block_bundles_request with last_received = 2
         let last_received_round = 2;
         let block_bundle_stream = authority_service
             .handle_subscribe_block_bundles_request(
-                context.committee.to_authority_index(1).unwrap(),
+                to_whom_authority,
                 last_received_round,
             )
             .await

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -2664,9 +2664,9 @@ mod tests {
                     AuthorityIndex::new_for_test(2),
                     AuthorityIndex::new_for_test(3)
                 ],
-                "We should have pushed headers from other authorities in round {:?}", verified_block.round(),
+                "We should have pushed headers from other authorities in round {:?}",
+                verified_block.round(),
             );
-
         }
     }
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1224,6 +1224,7 @@ mod tests {
         sync::{broadcast, mpsc},
         time::sleep,
     };
+
     use crate::{
         CommitConsumer, Round, Transaction, TransactionClient,
         authority_service::{
@@ -2391,7 +2392,6 @@ mod tests {
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
-        tokio::task::yield_now().await;
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
@@ -2486,6 +2486,7 @@ mod tests {
                 .add_blocks(all_blocks[round as usize].clone())
                 .await
                 .expect("blocks are expected to be added successfully");
+            sleep(Duration::from_millis(50)).await;
         }
 
         // WHEN

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1233,8 +1233,9 @@ mod tests {
             AuthorityService, BroadcastedBlockStream, MAX_FILTER_SIZE, SubscriptionCounter,
         },
         block_header::{
-            BlockHeaderAPI, BlockRef, SignedBlockHeader, TestBlockHeader, TransactionsCommitment,
-            VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
+            BlockHeaderAPI, BlockRef, GENESIS_ROUND, SignedBlockHeader, TestBlockHeader,
+            TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard,
+            VerifiedTransactions,
         },
         block_manager::BlockManager,
         block_verifier::SignedBlockVerifier,
@@ -1242,7 +1243,7 @@ mod tests {
         commit_observer::CommitObserver,
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
-        cordial_knowledge::CordialKnowledge,
+        cordial_knowledge::{ConnectionKnowledgeMessage, CordialKnowledge},
         core::{Core, CoreSignals},
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
         dag_state::{DagState, TransactionSource},
@@ -1260,8 +1261,6 @@ mod tests {
         transaction::TransactionConsumer,
         transactions_synchronizer::TransactionsSynchronizer,
     };
-    use crate::block_header::GENESIS_ROUND;
-    use crate::cordial_knowledge::ConnectionKnowledgeMessage;
 
     #[derive(Default)]
     struct FakeNetworkClient {}
@@ -2499,7 +2498,8 @@ mod tests {
         }
 
         // Inject useful info
-        let connection_knowledge_sender = cordial_knowledge.connection_knowledge_senders()[to_whom_authority].clone();
+        let connection_knowledge_sender =
+            cordial_knowledge.connection_knowledge_senders()[to_whom_authority].clone();
         let msg = ConnectionKnowledgeMessage::UsefulInfo {
             useful_headers_to_peer: BTreeMap::from([
                 (AuthorityIndex::new_for_test(2), GENESIS_ROUND),
@@ -2513,7 +2513,7 @@ mod tests {
                 (AuthorityIndex::new_for_test(1), GENESIS_ROUND),
                 (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
             ]),
-            useful_shards_from_peers: vec![None,Some(GENESIS_ROUND),None,Some(GENESIS_ROUND)]
+            useful_shards_from_peers: vec![None, Some(GENESIS_ROUND), None, Some(GENESIS_ROUND)],
         };
         let _ = connection_knowledge_sender.send(vec![msg]).await;
 
@@ -2521,10 +2521,7 @@ mod tests {
         // Call handle_subscribe_block_bundles_request with last_received = 2
         let last_received_round = 2;
         let block_bundle_stream = authority_service
-            .handle_subscribe_block_bundles_request(
-                to_whom_authority,
-                last_received_round,
-            )
+            .handle_subscribe_block_bundles_request(to_whom_authority, last_received_round)
             .await
             .expect("Should return a valid stream");
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -16,12 +16,10 @@ use futures::{Stream, StreamExt, ready, stream, task};
 use iota_macros::fail_point_async;
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
-use tokio::{
-    sync::{
-        Mutex, broadcast,
-        mpsc::{Sender, UnboundedSender},
-        oneshot,
-    },
+use tokio::sync::{
+    Mutex, broadcast,
+    mpsc::{Sender, UnboundedSender},
+    oneshot,
 };
 use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, info, warn};

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -668,6 +668,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                         }
                     };
 
+                    debug!("Block bundle {block_bundle:?}");
+
                     match SerializedBlockBundle::try_from(block_bundle) {
                         Ok(serialized_block_bundle) => Some(serialized_block_bundle),
                         Err(e) => {

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -124,7 +124,7 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     /// Sender to send received transaction messages to the shard reconstructor
     transaction_message_sender: Sender<Vec<TransactionMessage>>,
     /// Senders to send messages to the respected
-    /// Connection Knowledge. One sender is intented for one peer. These senders
+    /// Connection Knowledge. One sender is intended for one peer. These senders
     /// are used to update useful authors for blocks and shards. In addition,
     /// one retrieves additional parts for block bundles when streaming own
     /// blocks.
@@ -2505,7 +2505,7 @@ mod tests {
         // Inject useful info
         let connection_knowledge_sender =
             cordial_knowledge.connection_knowledge_senders()[to_whom_authority].clone();
-        let msg = ConnectionKnowledgeMessage::UsefulInfo {
+        let msg = ConnectionKnowledgeMessage::UsefulAuthors {
             useful_headers_to_peer: BTreeMap::from([
                 (AuthorityIndex::new_for_test(2), GENESIS_ROUND),
                 (AuthorityIndex::new_for_test(3), GENESIS_ROUND),

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -356,7 +356,10 @@ impl CordialKnowledge {
 
     /// Called when a new own shard (created locally) is added to dag state.
     async fn handle_new_shard(&mut self, block_ref: BlockRef) {
-        for tx in &self.connections {
+        for (index, tx) in self.connections.iter().enumerate() {
+            if index == block_ref.author.value() || index == self.context.own_index.value() {
+                continue;
+            }
             let msg = ConnectionKnowledgeMessage::NewShard { block_ref };
             let _ = tx.send(vec![msg]).await;
         }
@@ -660,12 +663,18 @@ impl ConnectionKnowledge {
         let num_authorities = context.committee.size();
         let headers_not_known = vec![BTreeMap::new(); num_authorities];
         let shards_not_known = vec![BTreeMap::new(); num_authorities];
+        let mut last_useful_headers_from_peer_round =  vec![GENESIS_ROUND; num_authorities];
+        // We should not request headers for own blocks
+        last_useful_headers_from_peer_round[context.own_index] = Round::MAX;
+        let mut last_useful_shards_from_peer_round = vec![GENESIS_ROUND; num_authorities];
+        // We should not request shards for own blocks
+        last_useful_shards_from_peer_round[context.own_index] = Round::MAX;
         Self {
             dag_state,
             last_useful_headers_to_peer_round: vec![GENESIS_ROUND; num_authorities],
             last_useful_shards_to_peer_round: vec![GENESIS_ROUND; num_authorities],
-            last_useful_headers_from_peer_round: vec![GENESIS_ROUND; num_authorities],
-            last_useful_shards_from_peer_round: vec![GENESIS_ROUND; num_authorities],
+            last_useful_headers_from_peer_round,
+            last_useful_shards_from_peer_round,
             context,
             peer_index,
             headers_not_known,
@@ -1072,6 +1081,7 @@ mod tests {
         storage::mem_store::MemStore,
         test_dag_parser::parse_dag,
     };
+    use crate::test_dag_builder::DagBuilder;
 
     #[tokio::test]
     async fn test_cordial_knowledge_bundle_with_byzantine() {
@@ -1080,14 +1090,14 @@ mod tests {
         let validators = 4;
         let our_index = AuthorityIndex::new_for_test(0);
         let to_whom_index = AuthorityIndex::new_for_test(1);
-        let (context, key_pairs) = Context::new_for_test(validators);
+        let byzantine_index = AuthorityIndex::new_for_test(3);
+        let (context, _key_pairs) = Context::new_for_test(validators);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
-        // Set up DAG with blocks
-        let protocol_keypairs = key_pairs.iter().map(|kp| kp.1.clone()).collect();
-        // Validator D does not disseminate its blocks.
+        // Set up DAG with blocks from all validators.
+        // Validator D does not disseminate its blocks, so they are not referenced.
         // Validator A will learn about D's blocks only at round 6.
         // After that, A should be able to send all D's blocks to B.
         let dag_str = "DAG {
@@ -1123,29 +1133,55 @@ mod tests {
                     C -> [-D5],
                     D -> [*],
                 },
-
+                Round 7 : { * },
              }";
-        let rounds = 6;
+        let final_round = 6;
         let result = parse_dag(dag_str);
         assert!(result.is_ok());
 
-        let mut dag_builder = result.unwrap().set_protocol_keypair(protocol_keypairs);
-        dag_builder.layers(1..=rounds).build();
+        let dag_builder = result.unwrap();
 
         // Get all blocks by rounds
         let mut all_blocks: Vec<Vec<VerifiedBlock>> = vec![];
-        for round in 0..=rounds {
+        for round in 0..=final_round {
             all_blocks.push(dag_builder.blocks(round..=round));
         }
 
         let connection_knowledge =
             cordial_knowledge.connection_knowledge_senders[to_whom_index].clone();
 
+        // get all blocks of D. They will be injected to dag state at final_round
+        let d_blocks = all_blocks
+            .iter()
+            .flat_map(|blocks| {
+                blocks
+                    .iter()
+                    .filter(|b| b.author() == byzantine_index)
+            })
+            .cloned()
+            .collect::<Vec<VerifiedBlock>>();
         // Add block to DAG state and automatically update cordial knowledge
-        for round in 0..=rounds - 1 {
+        for round in 1..=final_round - 1 {
+            if round == final_round - 1 {
+                // Add D's blocks to DAG state only at final_round-1
+                for block in d_blocks.iter() {
+                    let VerifiedBlock {
+                        verified_block_header,
+                        verified_transactions,
+                    } = block.clone();
+                    dag_state
+                        .write()
+                        .accept_block_header(verified_block_header);
+                    let shard_for_core = VerifiedOwnShard {
+                        serialized_shard: Bytes::from([0u8; 32].to_vec()), // put some dummy shard data
+                        block_ref: verified_transactions.block_ref(),
+                    };
+                    dag_state.write().add_shard(shard_for_core);
+                }
+            }
             // add all blocks of this round and our block of next round to dag state
             for block in all_blocks[round as usize]
-                .iter()
+                .iter().filter(|b|b.author() != our_index && b.author() != byzantine_index)
                 .chain(std::iter::once(&all_blocks[round as usize + 1][our_index]))
             {
                 let VerifiedBlock {
@@ -1172,26 +1208,79 @@ mod tests {
             let AdditionalPartsForBundle {
                 headers, shards, ..
             } = additional_parts;
-            // In rounds 0..=5, A should not know any of D's blocks, so no headers or shards
+            // In rounds 1..final_round, A should not know any of D's blocks, so no headers or shards
             // should be sent to B.
-            if round <= 5 {
-                assert!(
-                    headers
-                        .iter()
-                        .all(|h| h.author() != AuthorityIndex::new_for_test(3))
-                );
-                assert_eq!(headers.len(), 1);
+            if round < final_round - 1 {
+                // Only headers of C's block of previous round should be sent
+                assert_eq!(headers.len(), 1,  "In round {}, unexpected headers found: {:?}", round, headers);
+                assert_eq!(headers[0].digest(), all_blocks[round as usize][2].verified_block_header.digest());
+                assert_eq!(shards.len(), 1,  "In round {}, unexpected shards found: {:?}", round, shards);
             } else {
                 // In round 6, A should know about D's blocks and send them all to B
-                let d_headers: Vec<&VerifiedBlockHeader> = headers
+                let d_headers_in_bundle: Vec<&VerifiedBlockHeader> = headers
                     .iter()
-                    .filter(|h| h.author() == AuthorityIndex::new_for_test(3))
+                    .filter(|h| h.author() == byzantine_index)
                     .collect();
-                assert_eq!(d_headers.len(), 5);
-                // Validator A sends to B all 5 shards of D's blocks and 1 shard of C's block of
+                assert_eq!(d_headers_in_bundle.len(), final_round as usize-1); // All 5 headers of D's blocks
+                // Validator A sends to B all 5 shards of D's blocks and 1 header/shard of C's block of
                 // round 5
-                assert_eq!(shards.len(), 6);
+                assert_eq!(headers.len(), final_round as usize,  "In round {}, unexpected headers found: {:?}", round, headers);
+                assert_eq!(shards.len(), final_round as usize);
             }
         }
     }
+
+    #[tokio::test]
+    async fn test_connection_knowledge_take_additional_parts() {
+        telemetry_subscribers::init_for_testing();
+        // GIVEN
+        let validators = 4;
+        let our_index = AuthorityIndex::new_for_test(0);
+        let to_whom_index = AuthorityIndex::new_for_test(1);
+        let (context, key_pairs) = Context::new_for_test(validators);
+        let protocol_keypairs = key_pairs.iter().map(|kp| kp.1.clone()).collect();
+        let context = Arc::new(context);
+        let final_round: Round = 6;
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
+        let _dag_builder = DagBuilder::new(context.clone())
+            .set_protocol_keypair(protocol_keypairs)
+            .layers(1..=final_round)
+            .build()
+            .persist_layers(dag_state.clone());
+        sleep(std::time::Duration::from_millis(1)).await;
+        let connection_knowledge_sender = cordial_knowledge
+            .connection_knowledge_senders[to_whom_index]
+            .clone();
+        let (tx, rx) = oneshot::channel();
+        let msg = ConnectionKnowledgeMessage::TakeAdditionalPartForBundle {
+            round_upper_bound_exclusive: final_round + 1,
+            respond_to: tx,
+        };
+        let _ = connection_knowledge_sender.send(vec![msg]).await;
+        let additional_parts = rx.await.unwrap();
+        let AdditionalPartsForBundle {
+            headers, shards, useful_headers_authors_from_peer, useful_shards_authors_from_peer
+        } = additional_parts;
+        // Only headers and shards from authorities 2 and 3 should be included
+        assert_eq!(headers.len(), 2);
+        assert!(headers.iter().all(|h| h.author() != our_index || h.author() == to_whom_index));
+        assert_eq!(useful_headers_authors_from_peer, BTreeSet::from([1,2,3].map(AuthorityIndex::new_for_test)));
+        assert_eq!(useful_shards_authors_from_peer, BTreeSet::from([1,2,3].map(AuthorityIndex::new_for_test)));
+        // Repeat the request, should get no headers this time
+        let (tx, rx) = oneshot::channel();
+        let msg = ConnectionKnowledgeMessage::TakeAdditionalPartForBundle {
+            round_upper_bound_exclusive: final_round + 1,
+            respond_to: tx,
+        };
+        let _ = connection_knowledge_sender.send(vec![msg]).await;
+        let additional_parts = rx.await.unwrap();
+        let AdditionalPartsForBundle {
+            headers,..
+        } = additional_parts;
+        assert_eq!(headers.len(), 0);
+
+    }
+
 }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -336,7 +336,6 @@ impl CordialKnowledge {
         }
     }
 
-
     /// Update global knowledge about shards from which authors will be useful
     /// for us
     async fn handle_useful_shards_from(
@@ -929,9 +928,9 @@ impl ConnectionKnowledge {
             .iter()
             .enumerate()
             .filter_map(|(i, &opt_round)| {
-                opt_round.filter(|&r| {
-                    r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive
-                }).map(|_| i)
+                opt_round
+                    .filter(|&r| r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive)
+                    .map(|_| i)
             })
             .collect();
 
@@ -961,9 +960,9 @@ impl ConnectionKnowledge {
             .iter()
             .enumerate()
             .filter_map(|(i, &opt_round)| {
-                opt_round.filter(|&r| {
-                    r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive
-                }).map(|_| i)
+                opt_round
+                    .filter(|&r| r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive)
+                    .map(|_| i)
             })
             .collect();
         let useful_shards_block_refs_to_peer = self.take_useful_shard_block_refs_round(
@@ -985,9 +984,9 @@ impl ConnectionKnowledge {
             .iter()
             .enumerate()
             .filter_map(|(i, &opt_round)| {
-                opt_round.filter(|&r| {
-                    r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive
-                }).map(|_| AuthorityIndex::from(i as u8))
+                opt_round
+                    .filter(|&r| r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive)
+                    .map(|_| AuthorityIndex::from(i as u8))
             })
             .collect::<BTreeSet<AuthorityIndex>>();
         debug!(
@@ -1001,9 +1000,9 @@ impl ConnectionKnowledge {
             .iter()
             .enumerate()
             .filter_map(|(i, &opt_round)| {
-                opt_round.filter(|&r| {
-                    r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive
-                }).map(|_| AuthorityIndex::from(i as u8))
+                opt_round
+                    .filter(|&r| r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive)
+                    .map(|_| AuthorityIndex::from(i as u8))
             })
             .collect::<BTreeSet<AuthorityIndex>>();
         debug!(
@@ -1086,9 +1085,9 @@ mod tests {
         context::Context,
         dag_state::DagState,
         storage::mem_store::MemStore,
+        test_dag_builder::DagBuilder,
         test_dag_parser::parse_dag,
     };
-    use crate::test_dag_builder::DagBuilder;
 
     #[tokio::test]
     async fn test_cordial_knowledge_bundle_with_byzantine() {
@@ -1155,9 +1154,8 @@ mod tests {
         }
 
         // Report useful info to connection knowledge corresponding to to_whom_index
-        let connection_knowledge_sender = cordial_knowledge
-            .connection_knowledge_senders[to_whom_index]
-            .clone();
+        let connection_knowledge_sender =
+            cordial_knowledge.connection_knowledge_senders[to_whom_index].clone();
         // Inject useful info
         let msg = ConnectionKnowledgeMessage::UsefulInfo {
             useful_headers_to_peer: BTreeMap::from([
@@ -1172,18 +1170,14 @@ mod tests {
                 (AuthorityIndex::new_for_test(1), GENESIS_ROUND),
                 (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
             ]),
-            useful_shards_from_peers: vec![None,Some(GENESIS_ROUND),None,Some(GENESIS_ROUND)]
+            useful_shards_from_peers: vec![None, Some(GENESIS_ROUND), None, Some(GENESIS_ROUND)],
         };
         let _ = connection_knowledge_sender.send(vec![msg]).await;
 
         // get all blocks of D. They will be injected to dag state at final_round
         let d_blocks = all_blocks
             .iter()
-            .flat_map(|blocks| {
-                blocks
-                    .iter()
-                    .filter(|b| b.author() == byzantine_index)
-            })
+            .flat_map(|blocks| blocks.iter().filter(|b| b.author() == byzantine_index))
             .cloned()
             .collect::<Vec<VerifiedBlock>>();
         // Add block to DAG state and automatically update cordial knowledge
@@ -1195,11 +1189,10 @@ mod tests {
                         verified_block_header,
                         verified_transactions,
                     } = block.clone();
-                    dag_state
-                        .write()
-                        .accept_block_header(verified_block_header);
+                    dag_state.write().accept_block_header(verified_block_header);
                     let shard_for_core = VerifiedOwnShard {
-                        serialized_shard: Bytes::from([0u8; 32].to_vec()), // put some dummy shard data
+                        serialized_shard: Bytes::from([0u8; 32].to_vec()), /* put some dummy
+                                                                            * shard data */
                         block_ref: verified_transactions.block_ref(),
                     };
                     dag_state.write().add_shard(shard_for_core);
@@ -1207,7 +1200,8 @@ mod tests {
             }
             // add all blocks of this round and our block of next round to dag state
             for block in all_blocks[round as usize]
-                .iter().filter(|b|b.author() != our_index && b.author() != byzantine_index)
+                .iter()
+                .filter(|b| b.author() != our_index && b.author() != byzantine_index)
                 .chain(std::iter::once(&all_blocks[round as usize + 1][our_index]))
             {
                 let VerifiedBlock {
@@ -1234,23 +1228,44 @@ mod tests {
             let AdditionalPartsForBundle {
                 headers, shards, ..
             } = additional_parts;
-            // In rounds 1..final_round, A should not know any of D's blocks, so no headers or shards
-            // should be sent to B.
+            // In rounds 1..final_round, A should not know any of D's blocks, so no headers
+            // or shards should be sent to B.
             if round < final_round - 1 {
                 // Only headers of C's block of previous round should be sent
-                assert_eq!(headers.len(), 1,  "In round {}, unexpected headers found: {:?}", round, headers);
-                assert_eq!(headers[0].digest(), all_blocks[round as usize][2].verified_block_header.digest());
-                assert_eq!(shards.len(), 1,  "In round {}, unexpected shards found: {:?}", round, shards);
+                assert_eq!(
+                    headers.len(),
+                    1,
+                    "In round {}, unexpected headers found: {:?}",
+                    round,
+                    headers
+                );
+                assert_eq!(
+                    headers[0].digest(),
+                    all_blocks[round as usize][2].verified_block_header.digest()
+                );
+                assert_eq!(
+                    shards.len(),
+                    1,
+                    "In round {}, unexpected shards found: {:?}",
+                    round,
+                    shards
+                );
             } else {
                 // In round 6, A should know about D's blocks and send them all to B
                 let d_headers_in_bundle: Vec<&VerifiedBlockHeader> = headers
                     .iter()
                     .filter(|h| h.author() == byzantine_index)
                     .collect();
-                assert_eq!(d_headers_in_bundle.len(), final_round as usize-1); // All 5 headers of D's blocks
-                // Validator A sends to B all 5 shards of D's blocks and 1 header/shard of C's block of
-                // round 5
-                assert_eq!(headers.len(), final_round as usize,  "In round {}, unexpected headers found: {:?}", round, headers);
+                assert_eq!(d_headers_in_bundle.len(), final_round as usize - 1); // All 5 headers of D's blocks
+                // Validator A sends to B all 5 shards of D's blocks and 1 header/shard of C's
+                // block of round 5
+                assert_eq!(
+                    headers.len(),
+                    final_round as usize,
+                    "In round {}, unexpected headers found: {:?}",
+                    round,
+                    headers
+                );
                 assert_eq!(shards.len(), final_round as usize);
             }
         }
@@ -1271,9 +1286,8 @@ mod tests {
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
         // Report useful info to connection knowledge corresponding to to_whom_index
-        let connection_knowledge_sender = cordial_knowledge
-            .connection_knowledge_senders[to_whom_index]
-            .clone();
+        let connection_knowledge_sender =
+            cordial_knowledge.connection_knowledge_senders[to_whom_index].clone();
         // Inject useful info
         let msg = ConnectionKnowledgeMessage::UsefulInfo {
             useful_headers_to_peer: BTreeMap::from([
@@ -1288,10 +1302,11 @@ mod tests {
                 (AuthorityIndex::new_for_test(1), GENESIS_ROUND),
                 (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
             ]),
-            useful_shards_from_peers: vec![None,Some(GENESIS_ROUND),None,Some(GENESIS_ROUND)]
+            useful_shards_from_peers: vec![None, Some(GENESIS_ROUND), None, Some(GENESIS_ROUND)],
         };
         let _ = connection_knowledge_sender.send(vec![msg]).await;
-        // Build DAG with blocks from all validators up to final_round and add to dag_state
+        // Build DAG with blocks from all validators up to final_round and add to
+        // dag_state
         let _dag_builder = DagBuilder::new(context.clone())
             .set_protocol_keypair(protocol_keypairs)
             .layers(1..=final_round)
@@ -1307,13 +1322,26 @@ mod tests {
         let _ = connection_knowledge_sender.send(vec![msg]).await;
         let additional_parts = rx.await.unwrap();
         let AdditionalPartsForBundle {
-            headers, shards: _, useful_headers_authors_from_peer, useful_shards_authors_from_peer
+            headers,
+            shards: _,
+            useful_headers_authors_from_peer,
+            useful_shards_authors_from_peer,
         } = additional_parts;
         // Only headers and shards from authorities 2 and 3 should be included
         assert_eq!(headers.len(), 2);
-        assert!(headers.iter().all(|h| h.author() != our_index || h.author() == to_whom_index));
-        assert_eq!(useful_headers_authors_from_peer, BTreeSet::from([1,3].map(AuthorityIndex::new_for_test)));
-        assert_eq!(useful_shards_authors_from_peer, BTreeSet::from([1,3].map(AuthorityIndex::new_for_test)));
+        assert!(
+            headers
+                .iter()
+                .all(|h| h.author() != our_index || h.author() == to_whom_index)
+        );
+        assert_eq!(
+            useful_headers_authors_from_peer,
+            BTreeSet::from([1, 3].map(AuthorityIndex::new_for_test))
+        );
+        assert_eq!(
+            useful_shards_authors_from_peer,
+            BTreeSet::from([1, 3].map(AuthorityIndex::new_for_test))
+        );
         // Repeat the request, should get no headers this time
         let (tx, rx) = oneshot::channel();
         let msg = ConnectionKnowledgeMessage::TakeAdditionalPartForBundle {
@@ -1322,11 +1350,7 @@ mod tests {
         };
         let _ = connection_knowledge_sender.send(vec![msg]).await;
         let additional_parts = rx.await.unwrap();
-        let AdditionalPartsForBundle {
-            headers,..
-        } = additional_parts;
+        let AdditionalPartsForBundle { headers, .. } = additional_parts;
         assert_eq!(headers.len(), 0);
-
     }
-
 }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -79,7 +79,9 @@ pub(crate) struct CordialKnowledge {
     cordial_knowledge_receiver: UnboundedReceiver<CordialKnowledgeMessage>,
     /// Keeps track of the last round for which each peer's shards were
     /// considered useful to us. This is a global knowledge and is shared with
-    /// all connection tasks.
+    /// all connection tasks. Initialized to None for all authorities and
+    /// updated over time once Authority Service reports useful shards from
+    /// peers.
     last_useful_shards_from_peer_round: Vec<Option<Round>>,
     /// Keeps track of the most recent DAG cordial
     /// knowledge (who knows which blocks) for each authority. This is a helper
@@ -88,14 +90,17 @@ pub(crate) struct CordialKnowledge {
     /// persisted. To access the cordial knowledge of a given block_ref, one
     /// shall retrieve it from `cordial_knowledge[block_ref.
     /// author][block_ref.round][block_ref.digest]`. The provided value is a
-    /// tuple of (parents, who knows the block header).
+    /// tuple of (ancestors, who knows the block header).
     cordial_knowledge:
         Vec<BTreeMap<Round, AHashMap<BlockHeaderDigest, (Ancestors, SubsetAuthorities)>>>,
-    /// Per-connection message channels
+    /// Per-connection message channels. They are used to notify each
+    /// connection task about updates from cordial knowledge.
     connections: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
 }
 
 /// High-level messages sent to the CordialKnowledge task.
+/// NewHeader, NewShard, EvictBelow are received from DAG state.
+/// UsefulShardsFromPeers is received from Authority Service.
 #[derive(Debug)]
 pub enum CordialKnowledgeMessage {
     /// A new verified block header to integrate into cordial knowledge.
@@ -123,7 +128,7 @@ impl CordialKnowledgeHandle {
     pub fn cordial_knowledge_sender(&self) -> UnboundedSender<CordialKnowledgeMessage> {
         self.cordial_knowledge_sender.clone()
     }
-    /// Get a sender to send messages to a specific ConnectionKnowledge task.
+    /// Get all senders to send messages to all ConnectionKnowledge task.
     pub fn connection_knowledge_senders(&self) -> Vec<Sender<Vec<ConnectionKnowledgeMessage>>> {
         self.connection_knowledge_senders.clone()
     }
@@ -204,7 +209,9 @@ impl CordialKnowledge {
         )
     }
 
-    /// Start the CordialKnowledge task and return a handle to it.
+    /// Start the CordialKnowledge task and all ConnectionKnowledge tasks.
+    /// Updates the DAG state with the sender to the CordialKnowledge task.
+    /// Return a handle to these tasks.
     pub fn start(
         context: Arc<Context>,
         dag_state: Arc<RwLock<DagState>>,
@@ -1163,7 +1170,9 @@ mod tests {
         // Report useful info to connection knowledge corresponding to to_whom_index
         let connection_knowledge_sender =
             cordial_knowledge.connection_knowledge_senders[to_whom_index].clone();
-        // Inject useful info
+        // Inject useful info for connection knowledge of peer 1 (B)
+        // A says that C and D are useful for headers and shards when receiving from B
+        // B says that A and C are useful for headers and shards when sending from A
         let msg = ConnectionKnowledgeMessage::UsefulInfo {
             useful_headers_to_peer: BTreeMap::from([
                 (AuthorityIndex::new_for_test(2), GENESIS_ROUND),

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -77,7 +77,7 @@ impl SubsetAuthorities {
 pub(crate) struct CordialKnowledge {
     context: Arc<Context>,
     /// Receives high-level updates from DAG state (new headers, new own shards,
-    /// evictions)
+    /// evictions) and Authority Service
     cordial_knowledge_receiver: UnboundedReceiver<CordialKnowledgeMessage>,
     /// Keeps track of the last round for which each peer's shards were
     /// considered useful to us. This is a global knowledge and is shared with
@@ -137,13 +137,13 @@ pub struct CordialKnowledgeHandle {
 }
 
 impl CordialKnowledgeHandle {
-    /// Get a sender to send messages to the CordialKnowledge task.
-    pub fn cordial_knowledge_sender(&self) -> UnboundedSender<CordialKnowledgeMessage> {
-        self.cordial_knowledge_sender.clone()
-    }
-    /// Get all senders to send messages to all ConnectionKnowledge task.
-    pub fn connection_knowledge_senders(&self) -> Vec<Sender<Vec<ConnectionKnowledgeMessage>>> {
-        self.connection_knowledge_senders.clone()
+    /// Get a specific sender to send messages to the respected
+    /// ConnectionKnowledge task.
+    pub fn connection_knowledge_sender(
+        &self,
+        authority_index: AuthorityIndex,
+    ) -> Sender<Vec<ConnectionKnowledgeMessage>> {
+        self.connection_knowledge_senders[authority_index].clone()
     }
     /// Gracefully stop the CordialKnowledge background task and all connection
     /// tasks.
@@ -172,6 +172,80 @@ impl CordialKnowledgeHandle {
                 }
             }
         }
+
+        Ok(())
+    }
+
+    // Report from Authority Service useful information about headers and
+    /// shards to global knowledge and connection knowledge.
+    pub async fn report_useful_authors(
+        &self,
+        peer: AuthorityIndex,
+        serialized_block_bundle_parts: &SerializedBlockBundleParts,
+        additional_block_headers: &[VerifiedBlockHeader],
+        missing_ancestors: &BTreeSet<BlockRef>,
+        block_round: Round,
+    ) -> ConsensusResult<()> {
+        let connection_knowledge_sender = &self.connection_knowledge_senders[peer];
+        let cordial_knowledge_sender = &self.cordial_knowledge_sender;
+        // Extract authorities this peer has useful headers from
+        let useful_headers_authors_from_peer = additional_block_headers
+            .iter()
+            .map(|block_header| block_header.author())
+            .chain(missing_ancestors.iter().map(|block_ref| block_ref.author))
+            .collect::<BTreeSet<_>>();
+        let useful_headers_from_peer = useful_headers_authors_from_peer
+            .into_iter()
+            .map(|a| (a, block_round))
+            .collect();
+
+        // Extract authorities this peer has useful shards from
+        let mut useful_shard_authors: BTreeMap<AuthorityIndex, Round> = BTreeMap::new();
+        // Since headers showed up in the filter before the corresponding full blocks
+        // we consider all authors of additional headers as useful shard authors too.
+        for header in additional_block_headers {
+            let author = header.author();
+            let round = header.round();
+
+            // Insert or update if newer round
+            useful_shard_authors
+                .entry(author)
+                .and_modify(|was_round| *was_round = (*was_round).max(round))
+                .or_insert(round);
+        }
+
+        // Extract authorities this peer finds useful for cordial dissemination from our
+        // side
+        let useful_headers_to_peer = serialized_block_bundle_parts.useful_headers_authors();
+        let useful_headers_to_peer = useful_headers_to_peer
+            .iter()
+            .map(|&a| (a, block_round))
+            .collect::<BTreeMap<_, _>>();
+        // Extract authorities this peer finds useful shards from our side
+        let useful_shards_to_peer = serialized_block_bundle_parts.useful_shards_authors();
+        let useful_shards_to_peer = useful_shards_to_peer
+            .iter()
+            .map(|&a| (a, block_round))
+            .collect::<BTreeMap<_, _>>();
+
+        // Notify connection knowledge about useful headers and shards to/from this peer
+        let connection_knowledge_message = ConnectionKnowledgeMessage::UsefulAuthors {
+            useful_headers_to_peer,
+            useful_shards_to_peer,
+            useful_headers_from_peer,
+            useful_shards_from_peers: vec![],
+        };
+        connection_knowledge_sender
+            .send(vec![connection_knowledge_message])
+            .await
+            .map_err(|_err| ConsensusError::Shutdown)?;
+
+        // Notify global cordial knowledge about useful shards from this peer
+        let cordial_knowledge_message =
+            CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shard_authors);
+        cordial_knowledge_sender
+            .send(cordial_knowledge_message)
+            .map_err(|_err| ConsensusError::Shutdown)?;
 
         Ok(())
     }
@@ -533,78 +607,6 @@ impl CordialKnowledge {
                 let _ = self.connections[index].send(msg).await;
             }
         }
-    }
-
-    /// Report from Authority Service useful information about headers and
-    /// shards to global knowledge and connection knowledge.
-    pub async fn report_useful_info(
-        connection_knowledge_sender: &Sender<Vec<ConnectionKnowledgeMessage>>,
-        cordial_knowledge_sender: &UnboundedSender<CordialKnowledgeMessage>,
-        serialized_block_bundle_parts: &SerializedBlockBundleParts,
-        additional_block_headers: &[VerifiedBlockHeader],
-        missing_ancestors: &BTreeSet<BlockRef>,
-        block_round: Round,
-    ) -> ConsensusResult<()> {
-        // Extract authorities this peer has useful headers from
-        let useful_headers_authors_from_peer = additional_block_headers
-            .iter()
-            .map(|block_header| block_header.author())
-            .chain(missing_ancestors.iter().map(|block_ref| block_ref.author))
-            .collect::<BTreeSet<_>>();
-        let useful_headers_from_peer = useful_headers_authors_from_peer
-            .into_iter()
-            .map(|a| (a, block_round))
-            .collect();
-
-        // Extract authorities this peer has useful shards from
-        let mut useful_shard_authors: BTreeMap<AuthorityIndex, Round> = BTreeMap::new();
-        // Since headers showed up in the filter before the corresponding full blocks
-        // we consider all authors of additional headers as useful shard authors too.
-        for header in additional_block_headers {
-            let author = header.author();
-            let round = header.round();
-
-            // Insert or update if newer round
-            useful_shard_authors
-                .entry(author)
-                .and_modify(|was_round| *was_round = (*was_round).max(round))
-                .or_insert(round);
-        }
-
-        // Extract authorities this peer finds useful for cordial dissemination from our
-        // side
-        let useful_headers_to_peer = serialized_block_bundle_parts.useful_headers_authors();
-        let useful_headers_to_peer = useful_headers_to_peer
-            .iter()
-            .map(|&a| (a, block_round))
-            .collect::<BTreeMap<_, _>>();
-        // Extract authorities this peer finds useful shards from our side
-        let useful_shards_to_peer = serialized_block_bundle_parts.useful_shards_authors();
-        let useful_shards_to_peer = useful_shards_to_peer
-            .iter()
-            .map(|&a| (a, block_round))
-            .collect::<BTreeMap<_, _>>();
-
-        // Notify connection knowledge about useful headers and shards to/from this peer
-        let connection_knowledge_message = ConnectionKnowledgeMessage::UsefulAuthors {
-            useful_headers_to_peer,
-            useful_shards_to_peer,
-            useful_headers_from_peer,
-            useful_shards_from_peers: vec![],
-        };
-        connection_knowledge_sender
-            .send(vec![connection_knowledge_message])
-            .await
-            .map_err(|_err| ConsensusError::Shutdown)?;
-
-        // Notify global cordial knowledge about useful shards from this peer
-        let cordial_knowledge_message =
-            CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shard_authors);
-        cordial_knowledge_sender
-            .send(cordial_knowledge_message)
-            .map_err(|_err| ConsensusError::Shutdown)?;
-
-        Ok(())
     }
 }
 

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -845,10 +845,10 @@ impl ConnectionKnowledge {
         taken
     }
 
-    fn evict_below(&mut self, rounds: Vec<Round>) {
+    fn evict_below(&mut self, rounds_exclusive: Vec<Round>) {
         for (index, deque) in self.headers_not_known.iter_mut().enumerate() {
             while let Some((front_round, _)) = deque.front() {
-                if *front_round < rounds[index] {
+                if *front_round < rounds_exclusive[index] {
                     deque.pop_front();
                 } else {
                     break;
@@ -857,7 +857,7 @@ impl ConnectionKnowledge {
         }
         for (index, deque) in self.shards_not_known.iter_mut().enumerate() {
             while let Some((front_round, _)) = deque.front() {
-                if *front_round < rounds[index] {
+                if *front_round < rounds_exclusive[index] {
                     deque.pop_front();
                 } else {
                     break;
@@ -948,24 +948,30 @@ impl ConnectionKnowledge {
         self.last_useful_shards_from_peer_round = useful_shards_from_peer_round;
     }
 
-    fn handle_useful_headers_from(&mut self, authorities: BTreeMap<AuthorityIndex, Round>) {
-        for (authority, round) in authorities {
+    fn handle_useful_headers_from(
+        &mut self,
+        authorities_with_round: BTreeMap<AuthorityIndex, Round>,
+    ) {
+        for (authority, round) in authorities_with_round {
             if round > self.last_useful_headers_from_peer_round[authority] {
                 self.last_useful_headers_from_peer_round[authority] = round;
             }
         }
     }
 
-    fn handle_useful_shards_to(&mut self, authorities: BTreeMap<AuthorityIndex, Round>) {
-        for (authority, round) in authorities {
+    fn handle_useful_shards_to(&mut self, authorities_with_round: BTreeMap<AuthorityIndex, Round>) {
+        for (authority, round) in authorities_with_round {
             if round > self.last_useful_shards_to_peer_round[authority] {
                 self.last_useful_shards_to_peer_round[authority] = round;
             }
         }
     }
 
-    fn handle_useful_headers_to(&mut self, authorities: BTreeMap<AuthorityIndex, Round>) {
-        for (authority, round) in authorities {
+    fn handle_useful_headers_to(
+        &mut self,
+        authorities_with_round: BTreeMap<AuthorityIndex, Round>,
+    ) {
+        for (authority, round) in authorities_with_round {
             if round > self.last_useful_headers_to_peer_round[authority] {
                 self.last_useful_headers_to_peer_round[authority] = round;
             }
@@ -977,7 +983,14 @@ impl ConnectionKnowledge {
         round_upper_bound_exclusive: Round,
         respond_to: oneshot::Sender<AdditionalPartsForBundle>,
     ) {
-        // 1. Identify useful authorities for headers and take the corresponding headers
+        // 1. Own headers and shards for round up to round_upper_bound_exclusive should
+        //    be marked as known
+        let own_index = self.context.own_index;
+        let mut rounds = vec![Round::MIN; self.context.committee.size()];
+        rounds[own_index] = round_upper_bound_exclusive + 1; // We are supposed to send own block of this round in a bundle when calling this function with this parameter
+
+        self.evict_below(rounds);
+        // 2. Identify useful authorities for headers and take the corresponding headers
         //    from the DAG state
         let useful_headers_authors_to_peer: Vec<usize> = self
             .last_useful_headers_to_peer_round
@@ -992,6 +1005,11 @@ impl ConnectionKnowledge {
             })
             .collect();
 
+        debug!(
+            "Useful header authors: {:?}",
+            useful_headers_authors_to_peer
+        );
+
         let useful_headers_block_refs_to_peer = self.take_useful_block_refs_round(
             round_upper_bound_exclusive,
             &useful_headers_authors_to_peer,
@@ -1005,7 +1023,7 @@ impl ConnectionKnowledge {
                 .flatten() // Filter out None values
                 .collect()
         };
-        // 2. Identify useful authorities for shards and take the corresponding shards
+        // 3. Identify useful authorities for shards and take the corresponding shards
         //    from the DAG state
         let useful_shards_authors_to_peer: Vec<usize> = self
             .last_useful_shards_to_peer_round
@@ -1031,7 +1049,7 @@ impl ConnectionKnowledge {
                 .flatten() // Filter out None values
                 .collect()
         };
-        // 3. Get useful header authors from peer
+        // 4. Get useful header authors from peer
         let useful_headers_authors_from_peer = self
             .last_useful_headers_from_peer_round
             .iter()
@@ -1044,7 +1062,7 @@ impl ConnectionKnowledge {
                 }
             })
             .collect::<BTreeSet<AuthorityIndex>>();
-        // 4. Get useful shard authors from peer
+        // 5. Get useful shard authors from peer
         let useful_shards_authors_from_peer = self
             .last_useful_shards_from_peer_round
             .iter()
@@ -1057,7 +1075,8 @@ impl ConnectionKnowledge {
                 }
             })
             .collect::<BTreeSet<AuthorityIndex>>();
-        // 5. Build a response message and send it back
+
+        // 6. Build a response message and send it back
         let message = AdditionalPartsForBundle {
             headers: useful_headers_to_peer,
             shards: useful_shards,

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -8,7 +8,6 @@ use std::{
 
 use ahash::{AHashMap, AHashSet};
 use bytes::Bytes;
-use iota_macros::fail_point_async;
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
 use tokio::{
@@ -118,12 +117,12 @@ pub enum CordialKnowledgeMessage {
 }
 
 impl CordialKnowledgeMessage {
-    fn display_type(&self) -> &'static str {
+    fn type_label(&self) -> &'static str {
         match self {
-            CordialKnowledgeMessage::NewHeader(_) => "New Header",
-            CordialKnowledgeMessage::NewShard(_) => "New Shard",
+            CordialKnowledgeMessage::NewHeader(_) => "New header",
+            CordialKnowledgeMessage::NewShard(_) => "New shard",
             CordialKnowledgeMessage::EvictBelow(_) => "Eviction",
-            CordialKnowledgeMessage::UsefulShardsFromPeers(_) => "Useful Authors for Shards",
+            CordialKnowledgeMessage::UsefulShardsFromPeers(_) => "Useful authors for shards",
         }
     }
 }
@@ -305,36 +304,30 @@ impl CordialKnowledge {
 
     /// Processes a single high-level cordial knowledge message.
     async fn process_message(&mut self, cordial_knowledge_message: CordialKnowledgeMessage) {
-        debug!(
-            "Processing Cordial Message: {:?}",
-            cordial_knowledge_message
-        );
-        let message_type: &'static str = match cordial_knowledge_message {
-            CordialKnowledgeMessage::NewHeader(header) => {
-                self.update_cordial_knowledge(&header).await;
-                "header"
-            }
-            CordialKnowledgeMessage::NewShard(block_ref) => {
-                self.handle_new_shard(block_ref).await;
-                "shard"
-            }
-            CordialKnowledgeMessage::EvictBelow(round) => {
-                self.handle_evict_below(round).await;
-                "eviction"
-            }
-            CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shards_from_peer) => {
-                self.handle_useful_shards_from(useful_shards_from_peer)
-                    .await;
-                "useful_shards"
-            }
-        };
-
+        // Report the type of message
         self.context
             .metrics
             .node_metrics
             .cordial_knowledge_processed_messages
-            .with_label_values(&[message_type])
+            .with_label_values(&[cordial_knowledge_message.type_label()])
             .inc();
+
+        // Handle the cordial knowledge message depending on its type
+        match cordial_knowledge_message {
+            CordialKnowledgeMessage::NewHeader(header) => {
+                self.update_cordial_knowledge(&header).await;
+            }
+            CordialKnowledgeMessage::NewShard(block_ref) => {
+                self.handle_new_shard(block_ref).await;
+            }
+            CordialKnowledgeMessage::EvictBelow(round) => {
+                self.handle_evict_below(round).await;
+            }
+            CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shards_from_peer) => {
+                self.handle_useful_shards_from(useful_shards_from_peer)
+                    .await;
+            }
+        };
     }
 
     // Helper function to update authority rounds if the new round is greater
@@ -380,7 +373,6 @@ impl CordialKnowledge {
             }
         }
     }
-
 
     /// Called when a new own shard (created locally) is added to dag state.
     async fn handle_new_shard(&mut self, block_ref: BlockRef) {

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -1,15 +1,35 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    sync::Arc,
+    time::Duration,
+};
+
 use ahash::{AHashMap, AHashSet};
+use bytes::Bytes;
+use iota_macros::fail_point_async;
 use parking_lot::RwLock;
-use tokio::sync::mpsc::{channel, unbounded_channel, Receiver, Sender, UnboundedReceiver, UnboundedSender};
-use tokio::sync::Mutex;
-use tokio::task::{yield_now, JoinError};
-use tracing::{debug, warn};
 use starfish_config::AuthorityIndex;
-use crate::block_header::BlockHeaderDigest;
-use crate::{BlockHeaderAPI, BlockRef, Round, VerifiedBlockHeader};
-use crate::context::Context;
+use tokio::{
+    sync::{
+        Mutex,
+        mpsc::{Receiver, Sender, UnboundedReceiver, UnboundedSender, channel, unbounded_channel},
+        oneshot,
+    },
+    task::JoinError,
+    time::{Instant, sleep_until},
+};
+use tracing::{debug, log::warn};
+
+use crate::{
+    BlockHeaderAPI, BlockRef, Round, VerifiedBlockHeader,
+    block_header::{BlockHeaderDigest, GENESIS_ROUND},
+    context::Context,
+    dag_state::DagState,
+    network::SerializedBlockBundleParts,
+};
+
+const MAX_ROUND_GAP_FOR_USEFUL_SHARDS: Round = 5;
+const MAX_ROUND_GAP_FOR_USEFUL_HEADERS: Round = 50;
 
 /// Represents a subset of authorities using a bitmask.
 /// Each bit in the `low` and `high` fields corresponds to an authority index.
@@ -21,8 +41,7 @@ pub(crate) struct SubsetAuthorities {
 }
 
 pub type Ancestors = Arc<[BlockRef]>;
-impl SubsetAuthorities  {
-
+impl SubsetAuthorities {
     #[inline]
     pub fn new_with(author: usize, own: usize) -> Self {
         let mut s = Self { low: 0, high: 0 };
@@ -31,7 +50,8 @@ impl SubsetAuthorities  {
         s
     }
 
-    /// Insert an authority into the subset. Returns true if the authority was not already present.
+    /// Insert an authority into the subset. Returns true if the authority was
+    /// not already present.
     #[inline]
     pub fn insert(&mut self, i: usize) -> bool {
         if i < 128 {
@@ -51,8 +71,10 @@ impl SubsetAuthorities  {
 
 pub(crate) struct CordialKnowledge {
     context: Arc<Context>,
-    /// Receives high-level updates from DAG state (new headers, new own shards, evictions)
+    /// Receives high-level updates from DAG state (new headers, new own shards,
+    /// evictions)
     cordial_knowledge_receiver: UnboundedReceiver<CordialKnowledgeMessage>,
+    last_useful_shards_from_peer_round: Vec<Round>,
     /// Keeps track of the most recent DAG cordial
     /// knowledge (who knows which blocks) for each authority. This is a helper
     /// structure that is used primarily for traversing the recent DAG. This
@@ -61,8 +83,12 @@ pub(crate) struct CordialKnowledge {
     /// shall retrieve it from `cordial_knowledge[block_ref.
     /// author][(block_ref.round, block_ref.digest)]`. The value is a tuple
     /// of (parents, who knows the block header).
-    cordial_knowledge:
-        Vec<VecDeque<(Round, AHashMap<BlockHeaderDigest, (Ancestors, SubsetAuthorities)>)>>,
+    cordial_knowledge: Vec<
+        VecDeque<(
+            Round,
+            AHashMap<BlockHeaderDigest, (Ancestors, SubsetAuthorities)>,
+        )>,
+    >,
     /// Per-connection message channels
     connections: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
 }
@@ -74,7 +100,7 @@ pub struct CordialKnowledgeHandle {
     join_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
-impl CordialKnowledgeHandle{
+impl CordialKnowledgeHandle {
     /// Get a sender to send messages to the CordialKnowledge task.
     pub fn cordial_knowledge_sender(&self) -> UnboundedSender<CordialKnowledgeMessage> {
         self.cordial_knowledge_sender.clone()
@@ -83,7 +109,8 @@ impl CordialKnowledgeHandle{
     pub fn connection_knowledge_senders(&self) -> Vec<Sender<Vec<ConnectionKnowledgeMessage>>> {
         self.connection_knowledge_senders.clone()
     }
-    /// Gracefully stop the CordialKnowledge background task and all connection tasks.
+    /// Gracefully stop the CordialKnowledge background task and all connection
+    /// tasks.
     pub async fn stop(&self) -> Result<(), JoinError> {
         // Stop main CordialKnowledge loop
         let mut guard = self.join_handle.lock().await;
@@ -150,6 +177,7 @@ impl CordialKnowledge {
                 connections,
                 cordial_knowledge_receiver,
                 cordial_knowledge: vec![VecDeque::new(); num_authorities],
+                last_useful_shards_from_peer_round: vec![GENESIS_ROUND; num_authorities],
             },
             cordial_knowledge_sender,
             receivers,
@@ -159,6 +187,7 @@ impl CordialKnowledge {
     /// Start the CordialKnowledge task and return a handle to it.
     pub fn start(
         context: Arc<Context>,
+        dag_state: Arc<RwLock<DagState>>,
     ) -> Arc<CordialKnowledgeHandle> {
         // Build main CordialKnowledge and associated channels
         let (cordial_knowledge, sender, receivers) = CordialKnowledge::new(context.clone());
@@ -172,6 +201,7 @@ impl CordialKnowledge {
         for (authority_index, receiver) in receivers.into_iter().enumerate() {
             let connection_knowledge = ConnectionKnowledge::new(
                 context.clone(),
+                dag_state.clone(),
                 authority_index,
                 receiver,
             );
@@ -184,11 +214,14 @@ impl CordialKnowledge {
             connection_handles.push(Some(task_handle));
         }
 
-
         // Spawn the main CordialKnowledge loop
         let join_handle = tokio::spawn(async move {
             cordial_knowledge.run().await;
         });
+
+        dag_state
+            .write()
+            .set_cordial_knowledge_sender(sender.clone());
 
         // Return handle with all pieces assembled
         Arc::new(CordialKnowledgeHandle {
@@ -199,31 +232,83 @@ impl CordialKnowledge {
         })
     }
 
-    /// Main async loop: receives high-level updates (headers, shards, evictions) from DAG state
-    /// and updates global knowledge + notifies per-connection tasks.
-    pub async fn run(
-        mut self,
-    ) {
+    /// Main async loop: receives high-level updates (headers, shards,
+    /// evictions) from DAG state and updates global knowledge + notifies
+    /// per-connection tasks.
+    pub async fn run(mut self) {
+        fail_point_async!("consensus-rpc-response");
+
         debug!("Cordial Knowledge main loop started");
 
-        while let Some(message) = self.cordial_knowledge_receiver.recv().await {
-            match message {
-                CordialKnowledgeMessage::NewHeader(header) => {
-                    self.handle_new_header(header);
+        const DISSEMINATE_TO_CONNECTION_KNOWLEDGE_TIMEOUT: Duration = Duration::from_millis(10);
+
+        // Start a recurring timeout timer (if you plan to use it later)
+        let dissemination_timeout =
+            sleep_until(Instant::now() + DISSEMINATE_TO_CONNECTION_KNOWLEDGE_TIMEOUT);
+        tokio::pin!(dissemination_timeout);
+
+        loop {
+            tokio::select! {
+                // Main channel to receive message for updating the state and propogate to connection tasks
+                maybe_msg = self.cordial_knowledge_receiver.recv() => {
+                    match maybe_msg {
+                        Some(cordial_knowledge_message) => {
+                            match cordial_knowledge_message {
+                                CordialKnowledgeMessage::NewHeader(header) => {
+                                    self.handle_new_header(header);
+                                }
+                                CordialKnowledgeMessage::NewShard(block_ref) => {
+                                    self.handle_new_shard(block_ref);
+                                }
+                                CordialKnowledgeMessage::EvictBelow(round) => {
+                                    self.handle_evict_below(round);
+                                }
+                                CordialKnowledgeMessage::UsefulShardsFromPeer(useful_shards_from_peer) => {
+                                    self.handle_useful_shards_from(useful_shards_from_peer);
+                                }
+                            }
+                        }
+                        None => {
+                            debug!("Cordial Knowledge channel closed; exiting loop");
+                            break;
+                        }
+                    }
                 }
 
-                CordialKnowledgeMessage::NewShard(block_ref) => {
-                    self.handle_new_shard(block_ref);
-                }
-
-                CordialKnowledgeMessage::EvictBelow(rounds) => {
-                    self.handle_evict_below(rounds);
+                //
+                _ = &mut dissemination_timeout => {
+                    dissemination_timeout.as_mut().reset(Instant::now() + DISSEMINATE_TO_CONNECTION_KNOWLEDGE_TIMEOUT);
+                        self.disseminate_useful_info_to_connection_tasks().await;
                 }
             }
-            yield_now().await;
         }
 
         debug!("Cordial Knowledge main loop finished");
+    }
+
+    fn handle_useful_shards_from(
+        &mut self,
+        useful_shards_from_peer: BTreeMap<AuthorityIndex, Round>,
+    ) {
+        for (authority, round) in useful_shards_from_peer {
+            if round > self.last_useful_shards_from_peer_round[authority] {
+                self.last_useful_shards_from_peer_round[authority] = round;
+            }
+        }
+    }
+
+    async fn disseminate_useful_info_to_connection_tasks(&mut self) {
+        for connection_sender in &self.connections {
+            let msg = ConnectionKnowledgeMessage::UsefulInfo {
+                useful_shards_from_peer: self.last_useful_shards_from_peer_round.clone(),
+                useful_headers_from_peer: BTreeMap::new(),
+                useful_headers_to_peer: BTreeMap::new(),
+                useful_shards_to_peer: BTreeMap::new(),
+            };
+            if let Err(e) = connection_sender.send(vec![msg]).await {
+                warn!("Failed to send useful info to connection task: {}", e);
+            }
+        }
     }
 
     /// Called when a new verified block header is received.
@@ -233,9 +318,9 @@ impl CordialKnowledge {
 
     /// Called when a new *own shard* (produced locally) is added.
     fn handle_new_shard(&mut self, block_ref: BlockRef) {
-        let msg = ConnectionKnowledgeMessage::NewShard { block_ref };
         for tx in &self.connections {
-            let _ = tx.try_send(vec![msg.clone()]);
+            let msg = ConnectionKnowledgeMessage::NewShard { block_ref };
+            let _ = tx.try_send(vec![msg]);
         }
     }
 
@@ -255,17 +340,17 @@ impl CordialKnowledge {
         // Notify per-connection tasks about eviction
         self.notify_connection_tasks_for_eviction(rounds);
     }
-
     #[inline]
     fn notify_connection_tasks_for_eviction(&self, rounds: Vec<Round>) {
-        let msg = ConnectionKnowledgeMessage::EvictBelow(rounds);
         for tx in &self.connections {
-            let _ = tx.try_send(vec![msg.clone()]);
+            let msg = ConnectionKnowledgeMessage::EvictBelow(rounds.clone());
+            let _ = tx.try_send(vec![msg]);
         }
     }
 
     /// Map a round to an index inside a per-author VecDeque<(Round, T)>.
-    /// Returns None if `round` is outside the current rolling window stored in the deque.
+    /// Returns None if `round` is outside the current rolling window stored in
+    /// the deque.
     #[inline]
     fn round_to_index<T>(dq: &VecDeque<(Round, T)>, round: Round) -> Option<usize> {
         let (front_round, _) = dq.front()?;
@@ -273,62 +358,63 @@ impl CordialKnowledge {
             return None;
         }
         let idx = (round - *front_round) as usize;
-        if idx < dq.len() {
-            Some(idx)
-        } else {
-            None
-        }
+        if idx < dq.len() { Some(idx) } else { None }
     }
 
-    /// Ensure the author's deque contains `round`, extending **only that author's deque**
-    /// forward as needed. Returns a mutable handle to
+    /// Ensure the author's deque contains `round`, extending **only that
+    /// author's deque** forward as needed. Returns a mutable handle to
     /// the (Round, Map) entry for `round`.
     #[inline]
     fn ensure_author_round_map(
         &mut self,
         author_value: usize,
-        round: Round,
-    ) -> &mut (Round, AHashMap<BlockHeaderDigest, (Ancestors, SubsetAuthorities)>) {
-        let dq = &mut self.cordial_knowledge[author_value];
-        match dq.back() {
+        target_round: Round,
+    ) -> &mut AHashMap<BlockHeaderDigest, (Ancestors, SubsetAuthorities)> {
+        let deque = &mut self.cordial_knowledge[author_value];
+        match deque.back() {
             // Empty -> push exactly this round
             None => {
-                dq.push_back((round, AHashMap::default()));
+                deque.push_back((target_round, AHashMap::default()));
             }
             Some((last_round, _)) => {
-                if *last_round < round {
+                if *last_round < target_round {
                     // Extend forward up to `round`
                     let mut r = *last_round + 1;
-                    while r <= round {
-                        dq.push_back((r, AHashMap::default()));
+                    while r <= target_round {
+                        deque.push_back((r, AHashMap::default()));
                         r += 1;
                     }
                 }
             }
         }
 
-        let idx = Self::round_to_index(dq, round)
-            .expect("We should expect round to be within or equal to the deque window");
-        &mut dq[idx]
+        let index = Self::round_to_index(deque, target_round).expect(
+            "We should expect round to be within or equal to the deque window after adjustments",
+        );
+        &mut deque[index].1
     }
 
     /// Update cordial knowledge for exactly one new header.
-    /// Assumes all parents are already stored somewhere in `recent_dag_cordial_knowledge`
+    /// Assumes all parents are already stored somewhere in
+    /// `recent_dag_cordial_knowledge`
     /// - Only grows the author's deque if needed.
-    /// - For other authorities' "unknown headers" deques, we add the block only if
-    ///   the round bucket already exists (no growth).
+    /// - For other authorities' "unknown headers" deques, we add the block only
+    ///   if the round bucket already exists (no growth).
     fn update_cordial_knowledge(&mut self, header: &VerifiedBlockHeader) {
         let block_ref = header.reference();
         let block_author = block_ref.author.value();
-        let round = block_ref.round;
-        let digest = block_ref.digest;
+        let block_round = block_ref.round;
+        let block_digest = block_ref.digest;
         let own_index = self.context.own_index.value();
         let mut vec_knowledge_msgs: Vec<Vec<ConnectionKnowledgeMessage>> =
-            vec![Vec::new(); self.context.committee.size()];
+            (0..self.context.committee.size())
+                .map(|_| Vec::new())
+                .collect();
 
-        //  === 1) Get (or create forward) the author's round bucket and insert if missing  ===
-        let (_, round_map) = self.ensure_author_round_map(block_author, round);
-        if round_map.contains_key(&digest) {
+        //  === 1) Get (or create forward) the author's round bucket and insert if
+        // missing  ===
+        let author_round_map = self.ensure_author_round_map(block_author, block_round);
+        if author_round_map.contains_key(&block_digest) {
             // Already recorded — nothing else to do here.
             return;
         }
@@ -336,28 +422,28 @@ impl CordialKnowledge {
         let ancestors: Ancestors = Arc::from(header.ancestors());
 
         // (who_knows initially marks: author + self)
-        let who_knows = SubsetAuthorities::new_with(block_author, own_index);
-        round_map.insert(digest, (ancestors, who_knows));
+        let who_knows_this_block = SubsetAuthorities::new_with(block_author, own_index);
+        author_round_map.insert(block_digest, (ancestors, who_knows_this_block));
 
         //  === 2) Mark this header as "unknown" for other authorities  ===
-        let msg = ConnectionKnowledgeMessage::NewHeader { block_ref };
         for other_idx in 0..self.context.committee.size() {
             if other_idx == block_author || other_idx == own_index {
                 continue;
             }
-            vec_knowledge_msgs[other_idx].push(msg.clone());
+            let msg = ConnectionKnowledgeMessage::NewHeader { block_ref };
+            vec_knowledge_msgs[other_idx].push(msg);
         }
 
-        //  === 3) Notify that the block_author now knows transaction data for certain blocks ===
+        //  === 3) Notify that the block_author now knows transaction data for certain
+        // blocks ===
         for acknowledgment in header.acknowledgments() {
             vec_knowledge_msgs[block_author].push(ConnectionKnowledgeMessage::RemoveShard {
                 block_ref: *acknowledgment,
             });
         }
 
-
-        // === 4) Traverse the DAG and update the knowledge of block author about the causal past ===
-        // We do a DFS traversal using a stack (buffer).
+        // === 4) Traverse the DAG and update the knowledge of block author about the
+        // causal past === We do a DFS traversal using a stack (buffer).
         // For each parent, if the block_author does not know it yet, we mark it
         // as known by block_author, send a message to the corresponding connection,
         // and push the parent onto the stack for further traversal.
@@ -377,7 +463,7 @@ impl CordialKnowledge {
                 // Get this block’s entry
                 let parents = match map.get(&current_digest) {
                     Some((ancestors, _)) => ancestors.clone(),
-                    None => continue, // skip unknown block
+                    None => continue, // skip block which is not stored in cordial knowledge
                 };
 
                 // Iterate over the parents
@@ -388,67 +474,122 @@ impl CordialKnowledge {
 
                     // Find the parent’s round bucket
                     let deque_parent_author = &mut self.cordial_knowledge[parent_author.value()];
-                    if let Some(parent_index) = Self::round_to_index(deque_parent_author, parent_round) {
-                        let (_, parents_of_parent_map) = &mut deque_parent_author[parent_index];
+                    if let Some(parent_index) =
+                        Self::round_to_index(deque_parent_author, parent_round)
+                    {
+                        let (_, parent_map) = &mut deque_parent_author[parent_index];
 
-                        if let Some((_anc, who_knows_parent)) = parents_of_parent_map.get_mut(&parent_digest) {
+                        if let Some((_, who_knows_parent)) = parent_map.get_mut(&parent_digest) {
                             // Insert new knowledge as block_author knows this parent
                             if who_knows_parent.insert(block_author) {
-                                vec_knowledge_msgs[block_author].push(ConnectionKnowledgeMessage::RemoveHeader {
-                                    block_ref: *parent,
-                                });
+                                vec_knowledge_msgs[block_author].push(
+                                    ConnectionKnowledgeMessage::RemoveHeader { block_ref: *parent },
+                                );
                                 // Push parent to buffer for further propagation
                                 buffer.push(*parent);
                             }
+                        } else {
+                            // Parent not found in cordial knowledge — skip
+                            continue;
                         }
                     }
                 }
             }
         }
-        self.send_knowledge_messages(vec_knowledge_msgs);
+        self.send_connection_knowledge_messages(vec_knowledge_msgs);
     }
 
-    fn send_knowledge_messages(&self, msgs: Vec<Vec<ConnectionKnowledgeMessage>>) {
-        for (idx, tx) in self.connections.iter().enumerate() {
-            if !msgs[idx].is_empty() {
-                let _ = tx.try_send(msgs[idx].clone());
+    fn send_connection_knowledge_messages(&self, msgs: Vec<Vec<ConnectionKnowledgeMessage>>) {
+        for (index, msg) in msgs.into_iter().enumerate() {
+            if !msg.is_empty() {
+                let _ = self.connections[index].try_send(msg);
             }
         }
     }
 
+    pub async fn report_useful_info(
+        connection_knowledge_sender: &Sender<Vec<ConnectionKnowledgeMessage>>,
+        cordial_knowledge_sender: &UnboundedSender<CordialKnowledgeMessage>,
+        serialized_block_bundle_parts: &SerializedBlockBundleParts,
+        additional_block_headers: &[VerifiedBlockHeader],
+        missing_ancestors: &BTreeSet<BlockRef>,
+        block_round: Round,
+    ) {
+        let useful_headers_authors = additional_block_headers
+            .iter()
+            .map(|block_header| block_header.author())
+            .chain(missing_ancestors.iter().map(|block_ref| block_ref.author))
+            .collect::<BTreeSet<_>>();
 
+        let mut useful_shard_authors: BTreeMap<AuthorityIndex, Round> = BTreeMap::new();
+        for header in additional_block_headers {
+            let author = header.author();
+            let round = header.round();
+
+            // Insert or update if newer round
+            useful_shard_authors
+                .entry(author)
+                .and_modify(|was_round| *was_round = (*was_round).max(round))
+                .or_insert(round);
+        }
+
+        // Extract authorities this peer finds useful for cordial dissemination
+        let useful_headers_to_peer = serialized_block_bundle_parts.useful_headers_authors();
+        let useful_headers_to_peer = useful_headers_to_peer
+            .iter()
+            .map(|&a| (a, block_round))
+            .collect::<BTreeMap<_, _>>();
+        let useful_shards_to_peer = serialized_block_bundle_parts.useful_shards_authors();
+        let useful_shards_to_peer = useful_shards_to_peer
+            .iter()
+            .map(|&a| (a, block_round))
+            .collect::<BTreeMap<_, _>>();
+
+        // Notify connection knowledge about useful headers and shards to/from this peer
+        let connection_knowledge_message = ConnectionKnowledgeMessage::UsefulInfo {
+            useful_headers_to_peer,
+            useful_shards_to_peer,
+            useful_headers_from_peer: useful_headers_authors
+                .into_iter()
+                .map(|a| (a, GENESIS_ROUND))
+                .collect(),
+            useful_shards_from_peer: vec![],
+        };
+        let _ = connection_knowledge_sender
+            .send(vec![connection_knowledge_message])
+            .await;
+
+        // Notify global cordial knowledge about useful shards from this peer
+        let cordial_knowledge_message =
+            CordialKnowledgeMessage::UsefulShardsFromPeer(useful_shard_authors);
+        let _ = cordial_knowledge_sender
+            .send(cordial_knowledge_message);
+    }
 }
 
-#[derive(Clone, Debug)]
 pub enum ConnectionKnowledgeMessage {
     /// A new block header was added globally.
-    NewHeader {
-        block_ref: BlockRef,
-    },
+    NewHeader { block_ref: BlockRef },
     /// Remove a block header from the "unknown" set .
-    RemoveHeader {
-        block_ref: BlockRef,
-    },
+    RemoveHeader { block_ref: BlockRef },
     /// A new shard was added globally.
-    NewShard {
-        block_ref: BlockRef,
-    },
+    NewShard { block_ref: BlockRef },
     /// Remove a header from the "unknown" set.
-    RemoveShard {
-        block_ref: BlockRef,
+    RemoveShard { block_ref: BlockRef },
+    /// Update useful info about which authorities are useful to/from the peer.
+    UsefulInfo {
+        useful_headers_to_peer: BTreeMap<AuthorityIndex, Round>,
+        useful_shards_to_peer: BTreeMap<AuthorityIndex, Round>,
+        useful_headers_from_peer: BTreeMap<AuthorityIndex, Round>,
+        useful_shards_from_peer: Vec<Round>,
     },
-    /// Take useful headers for the given authorities, up to the given round (exclusive).
-    TakeUsefulHeaders {
+    /// Take useful headers and shards for authorities, up to the given round
+    /// (exclusive).
+    TakeAdditionalPartForBundle {
         round_upper_bound_exclusive: Round,
-        useful_authorities: Vec<usize>,
-        respond_to: Sender<Vec<BlockRef>>,
+        respond_to: oneshot::Sender<AdditionalPartsForBundle>,
     },
-    /// Take useful shards for the given authorities, up to the given round (exclusive).
-    TakeUsefulShards {
-        round_upper_bound_exclusive: Round,
-        useful_authorities: Vec<usize>,
-        respond_to: Sender<Vec<BlockRef>>,
-    },
+
     /// Global eviction (prune below round)
     EvictBelow(Vec<Round>),
 }
@@ -461,23 +602,38 @@ pub enum CordialKnowledgeMessage {
     NewShard(BlockRef),
     /// Evict old rounds globally.
     EvictBelow(Vec<Round>),
+    /// Update internal state about shards from which authorities are useful for
+    /// us
+    UsefulShardsFromPeer(BTreeMap<AuthorityIndex, Round>),
 }
-
 
 /// Manages the knowledge state for a single connection to a peer.
 /// Receives updates from the global cordial knowledge
 pub struct ConnectionKnowledge {
     context: Arc<Context>,
+    dag_state: Arc<RwLock<DagState>>,
     peer_index: usize,
     headers_not_known: Vec<VecDeque<(Round, AHashSet<BlockRef>)>>,
     shards_not_known: Vec<VecDeque<(Round, AHashSet<BlockRef>)>>,
+    last_useful_shards_to_peer_round: Vec<Round>,
+    last_useful_headers_to_peer_round: Vec<Round>,
+    last_useful_shards_from_peer_round: Vec<Round>,
+    last_useful_headers_from_peer_round: Vec<Round>,
     /// Receives updates from the global cordial knowledge
     receiver: Receiver<Vec<ConnectionKnowledgeMessage>>,
+}
+
+pub(crate) struct AdditionalPartsForBundle {
+    pub headers: Vec<VerifiedBlockHeader>,
+    pub shards: Vec<Bytes>,
+    pub useful_headers_authors_from_peer: BTreeSet<AuthorityIndex>,
+    pub useful_shards_authors_from_peer: BTreeSet<AuthorityIndex>,
 }
 
 impl ConnectionKnowledge {
     pub fn new(
         context: Arc<Context>,
+        dag_state: Arc<RwLock<DagState>>,
         peer_index: usize,
         receiver: Receiver<Vec<ConnectionKnowledgeMessage>>,
     ) -> Self {
@@ -485,6 +641,11 @@ impl ConnectionKnowledge {
         let headers_not_known = Vec::with_capacity(num_authorities);
         let shards_not_known = Vec::with_capacity(num_authorities);
         Self {
+            dag_state,
+            last_useful_headers_to_peer_round: vec![GENESIS_ROUND; num_authorities],
+            last_useful_shards_to_peer_round: vec![GENESIS_ROUND; num_authorities],
+            last_useful_headers_from_peer_round: vec![GENESIS_ROUND; num_authorities],
+            last_useful_shards_from_peer_round: vec![GENESIS_ROUND; num_authorities],
             context,
             peer_index,
             headers_not_known,
@@ -496,7 +657,9 @@ impl ConnectionKnowledge {
     #[inline]
     fn round_to_index<T>(deque: &VecDeque<(Round, T)>, round: Round) -> Option<usize> {
         let (front_round, _) = deque.front()?;
-        if round < *front_round { return None; }
+        if round < *front_round {
+            return None;
+        }
         let index = (round - *front_round) as usize;
         (index < deque.len()).then_some(index)
     }
@@ -521,8 +684,7 @@ impl ConnectionKnowledge {
     fn ensure_round_in_deque(
         deque: &mut VecDeque<(Round, AHashSet<BlockRef>)>,
         target_round: Round,
-    ) -> Option<usize>    {
-
+    ) -> Option<usize> {
         // 1. If deque is empty, initialize with this round
         if deque.is_empty() {
             deque.push_back((target_round, AHashSet::default()));
@@ -567,7 +729,9 @@ impl ConnectionKnowledge {
         }
 
         // Start from the earliest front round across the selected authorities.
-        let Some(min_round) = Self::min_front_round(&self.headers_not_known, useful_authorities.iter()) else {
+        let Some(min_round) =
+            Self::min_front_round(&self.headers_not_known, useful_authorities.iter())
+        else {
             return Vec::new();
         };
 
@@ -618,7 +782,9 @@ impl ConnectionKnowledge {
             return Vec::new();
         }
 
-        let Some(min_round) = Self::min_front_round(&self.shards_not_known, useful_authorities.iter()) else {
+        let Some(min_round) =
+            Self::min_front_round(&self.shards_not_known, useful_authorities.iter())
+        else {
             return Vec::new();
         };
 
@@ -676,12 +842,10 @@ impl ConnectionKnowledge {
         }
     }
 
-    /// Async task loop — just receives messages and dispatches to processing logic.
+    /// Async task loop — just receives messages and dispatches to processing
+    /// logic.
     pub async fn run(mut self) {
-        tracing::debug!(
-            "Connection Knowledge started for peer {}",
-            self.peer_index
-        );
+        tracing::debug!("Connection Knowledge started for peer {}", self.peer_index);
 
         while let Some(knowledge_msgs) = self.receiver.recv().await {
             for knowledge_msg in knowledge_msgs {
@@ -697,7 +861,8 @@ impl ConnectionKnowledge {
     }
 
     /// Processes a batch of knowledge updates synchronously (non-async).
-    /// This isolates all mutation logic so it can be tested without async context.
+    /// This isolates all mutation logic so it can be tested without async
+    /// context.
     async fn process_message(&mut self, message: ConnectionKnowledgeMessage) {
         match message {
             ConnectionKnowledgeMessage::NewHeader { block_ref } => {
@@ -715,58 +880,189 @@ impl ConnectionKnowledge {
             ConnectionKnowledgeMessage::EvictBelow(rounds) => {
                 self.evict_below(rounds);
             }
-            ConnectionKnowledgeMessage::TakeUsefulHeaders {
-                round_upper_bound_exclusive,
-                useful_authorities,
-                respond_to,
+            ConnectionKnowledgeMessage::UsefulInfo {
+                useful_headers_to_peer,
+                useful_shards_to_peer,
+                useful_headers_from_peer,
+                useful_shards_from_peer,
             } => {
-                let taken = self.take_useful_block_refs_round(
-                    round_upper_bound_exclusive,
-                    &useful_authorities,
+                self.handle_useful_info(
+                    useful_headers_to_peer,
+                    useful_shards_to_peer,
+                    useful_headers_from_peer,
+                    useful_shards_from_peer,
                 );
-                if let Err(e) = respond_to.send(taken).await {
-                    warn!("Failed to respond to useful headers: {} for connection task with peer index {}", e, self.peer_index);
-                }
             }
-            ConnectionKnowledgeMessage::TakeUsefulShards {
+            ConnectionKnowledgeMessage::TakeAdditionalPartForBundle {
                 round_upper_bound_exclusive,
-                useful_authorities,
                 respond_to,
             } => {
-                let taken = self.take_useful_shard_block_refs_round(
+                self.handle_take_additional_parts_for_bundle(
                     round_upper_bound_exclusive,
-                    &useful_authorities,
-                );
-                if let Err(e) = respond_to.send(taken).await {
-                    warn!("Failed to respond to useful shards: {} for connection task with peer index {}", e, self.peer_index);
-                }
+                    respond_to,
+                )
+                .await;
             }
         }
+    }
+    fn handle_useful_info(
+        &mut self,
+        useful_headers_to_peer: BTreeMap<AuthorityIndex, Round>,
+        useful_shards_to_peer: BTreeMap<AuthorityIndex, Round>,
+        useful_headers_from_peer: BTreeMap<AuthorityIndex, Round>,
+        useful_shards_from_peer: Vec<Round>,
+    ) {
+        // Update local state
+        self.handle_useful_headers_to(useful_headers_to_peer);
+        self.handle_useful_shards_to(useful_shards_to_peer);
+        self.handle_useful_headers_from(useful_headers_from_peer);
+        self.handle_useful_shards_from(useful_shards_from_peer);
+    }
+
+    fn handle_useful_shards_from(&mut self, useful_shards_from_peer_round: Vec<Round>) {
+        self.last_useful_shards_from_peer_round = useful_shards_from_peer_round;
+    }
+
+    fn handle_useful_headers_from(&mut self, authorities: BTreeMap<AuthorityIndex, Round>) {
+        for (authority, round) in authorities {
+            if round > self.last_useful_headers_from_peer_round[authority] {
+                self.last_useful_headers_from_peer_round[authority] = round;
+            }
+        }
+    }
+
+    fn handle_useful_shards_to(&mut self, authorities: BTreeMap<AuthorityIndex, Round>) {
+        for (authority, round) in authorities {
+            if round > self.last_useful_shards_to_peer_round[authority] {
+                self.last_useful_shards_to_peer_round[authority] = round;
+            }
+        }
+    }
+
+    fn handle_useful_headers_to(&mut self, authorities: BTreeMap<AuthorityIndex, Round>) {
+        for (authority, round) in authorities {
+            if round > self.last_useful_headers_to_peer_round[authority] {
+                self.last_useful_headers_to_peer_round[authority] = round;
+            }
+        }
+    }
+
+    async fn handle_take_additional_parts_for_bundle(
+        &mut self,
+        round_upper_bound_exclusive: Round,
+        respond_to: oneshot::Sender<AdditionalPartsForBundle>,
+    ) {
+        // 1. Identify useful authorities for headers and take the corresponding headers
+        //    from the DAG state
+        let useful_headers_authors_to_peer: Vec<usize> = self
+            .last_useful_headers_to_peer_round
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &r)| {
+                if r + MAX_ROUND_GAP_FOR_USEFUL_HEADERS >= round_upper_bound_exclusive {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let useful_headers_block_refs_to_peer = self.take_useful_block_refs_round(
+            round_upper_bound_exclusive,
+            &useful_headers_authors_to_peer,
+        );
+
+        let useful_headers_to_peer: Vec<VerifiedBlockHeader> = {
+            let dag_state_read = self.dag_state.read();
+            dag_state_read
+                .get_cached_block_headers(&useful_headers_block_refs_to_peer)
+                .into_iter()
+                .filter_map(|opt| opt) // Filter out None values
+                .collect()
+        };
+        // 2. Identify useful authorities for shards and take the corresponding shards
+        //    from the DAG state
+        let useful_shards_authors_to_peer: Vec<usize> = self
+            .last_useful_shards_to_peer_round
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &r)| {
+                if r + MAX_ROUND_GAP_FOR_USEFUL_SHARDS >= round_upper_bound_exclusive {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let useful_shards_block_refs_to_peer = self.take_useful_shard_block_refs_round(
+            round_upper_bound_exclusive,
+            &useful_shards_authors_to_peer,
+        );
+        let useful_shards: Vec<Bytes> = {
+            let dag_state_read = self.dag_state.read();
+            dag_state_read
+                .get_cached_shards(&useful_shards_block_refs_to_peer)
+                .into_iter()
+                .filter_map(|opt| opt) // Filter out None values
+                .collect()
+        };
+        // 3. Get useful header authors from peer
+        let useful_headers_authors_from_peer = self
+            .last_useful_headers_from_peer_round
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &r)| {
+                if r + MAX_ROUND_GAP_FOR_USEFUL_HEADERS >= round_upper_bound_exclusive {
+                    Some(AuthorityIndex::from(i as u8))
+                } else {
+                    None
+                }
+            })
+            .collect::<BTreeSet<AuthorityIndex>>();
+        // 4. Get useful shard authors from peer
+        let useful_shards_authors_from_peer = self
+            .last_useful_shards_from_peer_round
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &r)| {
+                if r + MAX_ROUND_GAP_FOR_USEFUL_SHARDS >= round_upper_bound_exclusive {
+                    Some(AuthorityIndex::from(i as u8))
+                } else {
+                    None
+                }
+            })
+            .collect::<BTreeSet<AuthorityIndex>>();
+        // 5. Build a response message and send it back
+        let message = AdditionalPartsForBundle {
+            headers: useful_headers_to_peer,
+            shards: useful_shards,
+            useful_headers_authors_from_peer,
+            useful_shards_authors_from_peer,
+        };
+
+        respond_to.send(message).ok();
     }
 
     /// Handles adding a new block to the unknown set.
     fn handle_new_header(&mut self, block_ref: BlockRef) {
         let round = block_ref.round;
         let authority = block_ref.author.value();
-        if let Some(index) = Self::ensure_round_in_deque(
-            &mut self.headers_not_known[authority],
-            round,
-        ) {
+        if let Some(index) =
+            Self::ensure_round_in_deque(&mut self.headers_not_known[authority], round)
+        {
             let (_r, set) = &mut self.headers_not_known[authority][index];
             set.insert(block_ref);
         }
     }
-
 
     /// Handles adding a new shard to the unknown set.
     fn handle_new_shard(&mut self, block_ref: BlockRef) {
         let round = block_ref.round;
         let authority = block_ref.author.value();
 
-        if let Some(index) = Self::ensure_round_in_deque(
-            &mut self.shards_not_known[authority],
-            round,
-        ) {
+        if let Some(index) =
+            Self::ensure_round_in_deque(&mut self.shards_not_known[authority], round)
+        {
             let (_r, set) = &mut self.shards_not_known[authority][index];
             set.insert(block_ref);
         }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -285,7 +285,7 @@ impl CordialKnowledge {
             CordialKnowledgeMessage::EvictBelow(round) => {
                 self.handle_evict_below(round).await;
             }
-            CordialKnowledgeMessage::UsefulShardsFromPeer(useful_shards_from_peer) => {
+            CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shards_from_peer) => {
                 self.handle_useful_shards_from(useful_shards_from_peer)
                     .await;
             }
@@ -312,7 +312,7 @@ impl CordialKnowledge {
     async fn disseminate_useful_info_to_connection_tasks(&mut self) {
         for connection_sender in &self.connections {
             let msg = ConnectionKnowledgeMessage::UsefulInfo {
-                useful_shards_from_peer: self.last_useful_shards_from_peer_round.clone(),
+                useful_shards_from_peers: self.last_useful_shards_from_peer_round.clone(),
                 useful_headers_from_peer: BTreeMap::new(),
                 useful_headers_to_peer: BTreeMap::new(),
                 useful_shards_to_peer: BTreeMap::new(),
@@ -349,11 +349,7 @@ impl CordialKnowledge {
                 .with_label_values(&[&index.to_string()])
                 .set(btree_map.len() as i64);
         }
-        let largest_round = self.cordial_knowledge
-            .iter()
-            .filter_map(|btree_map| btree_map.keys().max())
-            .max()
-            .cloned()
+        let largest_round = self.cordial_knowledge[self.context.own_index].keys().max().cloned()
             .unwrap_or(GENESIS_ROUND);
         let useful_shards_from_peer_count = self
             .last_useful_shards_from_peer_round
@@ -513,16 +509,17 @@ impl CordialKnowledge {
             .iter()
             .map(|&a| (a, block_round))
             .collect::<BTreeMap<_, _>>();
+        let useful_headers_from_peer =  useful_headers_authors
+            .into_iter()
+            .map(|a| (a, block_round))
+            .collect();
 
         // Notify connection knowledge about useful headers and shards to/from this peer
         let connection_knowledge_message = ConnectionKnowledgeMessage::UsefulInfo {
             useful_headers_to_peer,
             useful_shards_to_peer,
-            useful_headers_from_peer: useful_headers_authors
-                .into_iter()
-                .map(|a| (a, GENESIS_ROUND))
-                .collect(),
-            useful_shards_from_peer: vec![],
+            useful_headers_from_peer,
+            useful_shards_from_peers: vec![],
         };
         let _ = connection_knowledge_sender
             .send(vec![connection_knowledge_message])
@@ -530,7 +527,7 @@ impl CordialKnowledge {
 
         // Notify global cordial knowledge about useful shards from this peer
         let cordial_knowledge_message =
-            CordialKnowledgeMessage::UsefulShardsFromPeer(useful_shard_authors);
+            CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shard_authors);
         let _ = cordial_knowledge_sender.send(cordial_knowledge_message);
     }
 }
@@ -550,7 +547,7 @@ pub enum ConnectionKnowledgeMessage {
         useful_headers_to_peer: BTreeMap<AuthorityIndex, Round>,
         useful_shards_to_peer: BTreeMap<AuthorityIndex, Round>,
         useful_headers_from_peer: BTreeMap<AuthorityIndex, Round>,
-        useful_shards_from_peer: Vec<Round>,
+        useful_shards_from_peers: Vec<Round>,
     },
     /// Take useful headers and shards for authorities, up to the given round
     /// (exclusive).
@@ -573,7 +570,7 @@ pub enum CordialKnowledgeMessage {
     EvictBelow(Vec<Round>),
     /// Update internal state about shards from which authorities are useful for
     /// us
-    UsefulShardsFromPeer(BTreeMap<AuthorityIndex, Round>),
+    UsefulShardsFromPeers(BTreeMap<AuthorityIndex, Round>),
 }
 
 /// Manages the knowledge state for a single connection to a peer.
@@ -762,7 +759,7 @@ impl ConnectionKnowledge {
                 useful_headers_to_peer,
                 useful_shards_to_peer,
                 useful_headers_from_peer,
-                useful_shards_from_peer,
+                useful_shards_from_peers: useful_shards_from_peer,
             } => {
                 self.handle_useful_info(
                     useful_headers_to_peer,

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -562,8 +562,7 @@ impl CordialKnowledge {
         // Notify global cordial knowledge about useful shards from this peer
         let cordial_knowledge_message =
             CordialKnowledgeMessage::UsefulShardsFromPeer(useful_shard_authors);
-        let _ = cordial_knowledge_sender
-            .send(cordial_knowledge_message);
+        let _ = cordial_knowledge_sender.send(cordial_knowledge_message);
     }
 }
 

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -298,32 +298,32 @@ impl CordialKnowledge {
             "Processing Cordial Message: {:?}",
             cordial_knowledge_message
         );
-        let message_type: &str;
-        match cordial_knowledge_message {
+        let message_type: &'static str = match cordial_knowledge_message {
             CordialKnowledgeMessage::NewHeader(header) => {
                 self.handle_new_header(header).await;
-                message_type = "header";
+                "header"
             }
             CordialKnowledgeMessage::NewShard(block_ref) => {
                 self.handle_new_shard(block_ref).await;
-                message_type = "shard";
+                "shard"
             }
             CordialKnowledgeMessage::EvictBelow(round) => {
                 self.handle_evict_below(round).await;
-                message_type = "eviction";
+                "eviction"
             }
             CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shards_from_peer) => {
-                self.handle_useful_shards_from(useful_shards_from_peer)
-                    .await;
-                message_type = "useful_shards";
+                self.handle_useful_shards_from(useful_shards_from_peer).await;
+                "useful_shards"
             }
-        }
+        };
+
         self.context
             .metrics
             .node_metrics
             .cordial_knowledge_processed_messages
             .with_label_values(&[message_type])
             .inc();
+
     }
 
     // Helper function to update authority rounds if the new round is greater

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -28,8 +28,8 @@ use crate::{
 };
 
 /// Maximum round gap to consider a peer's useful shards/headers as still
-/// relevant.
-const MAX_ROUND_GAP_FOR_USEFUL_PARTS: Round = 10;
+/// relevant. 20 rounds correspond to around 1 second
+const MAX_ROUND_GAP_FOR_USEFUL_PARTS: Round = 20;
 
 /// Represents a subset of authorities using a bitmask.
 /// Each bit in the `low` and `high` fields corresponds to an authority index.
@@ -80,7 +80,7 @@ pub(crate) struct CordialKnowledge {
     /// Keeps track of the last round for which each peer's shards were
     /// considered useful to us. This is a global knowledge and is shared with
     /// all connection tasks.
-    last_useful_shards_from_peer_round: Vec<Round>,
+    last_useful_shards_from_peer_round: Vec<Option<Round>>,
     /// Keeps track of the most recent DAG cordial
     /// knowledge (who knows which blocks) for each authority. This is a helper
     /// structure that is used primarily for traversing the recent DAG. This
@@ -197,7 +197,7 @@ impl CordialKnowledge {
                 connections,
                 cordial_knowledge_receiver,
                 cordial_knowledge: vec![BTreeMap::new(); num_authorities],
-                last_useful_shards_from_peer_round: vec![GENESIS_ROUND; num_authorities],
+                last_useful_shards_from_peer_round: vec![None; num_authorities],
             },
             cordial_knowledge_sender,
             receivers,
@@ -320,17 +320,33 @@ impl CordialKnowledge {
             .inc();
     }
 
+    // Helper function to update authority rounds if the new round is greater
+    fn update_authority_rounds_if_greater(
+        target: &mut Vec<Option<Round>>,
+        updates: BTreeMap<AuthorityIndex, Round>,
+    ) {
+        for (authority, new_round) in updates {
+            if let Some(existing_round) = &mut target[authority] {
+                if new_round > *existing_round {
+                    *existing_round = new_round;
+                }
+            } else {
+                target[authority] = Some(new_round);
+            }
+        }
+    }
+
+
     /// Update global knowledge about shards from which authors will be useful
     /// for us
     async fn handle_useful_shards_from(
         &mut self,
         useful_shards_from_peer: BTreeMap<AuthorityIndex, Round>,
     ) {
-        for (authority, round) in useful_shards_from_peer {
-            if round > self.last_useful_shards_from_peer_round[authority] {
-                self.last_useful_shards_from_peer_round[authority] = round;
-            }
-        }
+        Self::update_authority_rounds_if_greater(
+            &mut self.last_useful_shards_from_peer_round,
+            useful_shards_from_peer,
+        );
         self.disseminate_useful_info_to_connection_tasks().await;
     }
 
@@ -386,6 +402,7 @@ impl CordialKnowledge {
         let useful_shards_from_peer_count = self
             .last_useful_shards_from_peer_round
             .iter()
+            .flatten()
             .filter(|&&r| r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= largest_round)
             .count();
         self.context
@@ -604,7 +621,7 @@ pub enum ConnectionKnowledgeMessage {
         useful_headers_to_peer: BTreeMap<AuthorityIndex, Round>,
         useful_shards_to_peer: BTreeMap<AuthorityIndex, Round>,
         useful_headers_from_peer: BTreeMap<AuthorityIndex, Round>,
-        useful_shards_from_peers: Vec<Round>,
+        useful_shards_from_peers: Vec<Option<Round>>,
     },
     /// Take useful headers and shards for authorities, up to the given round
     /// (exclusive).
@@ -629,16 +646,16 @@ pub struct ConnectionKnowledge {
     shards_not_known: Vec<BTreeMap<Round, AHashSet<BlockRef>>>,
     /// Last rounds for (potentially) useful shards that can be sent to this
     /// peer
-    last_useful_shards_to_peer_round: Vec<Round>,
+    last_useful_shards_to_peer_round: Vec<Option<Round>>,
     /// Last rounds for (potentially) useful headers that can be sent to this
     /// peer
-    last_useful_headers_to_peer_round: Vec<Round>,
+    last_useful_headers_to_peer_round: Vec<Option<Round>>,
     /// Last rounds for potentially useful shards that could be received from
     /// this peer
-    last_useful_shards_from_peer_round: Vec<Round>,
+    last_useful_shards_from_peer_round: Vec<Option<Round>>,
     /// Last rounds for (potentially) useful headers that could be received from
     /// this peer
-    last_useful_headers_from_peer_round: Vec<Round>,
+    last_useful_headers_from_peer_round: Vec<Option<Round>>,
     /// Receives updates from the global cordial knowledge
     receiver: Receiver<Vec<ConnectionKnowledgeMessage>>,
 }
@@ -661,24 +678,17 @@ impl ConnectionKnowledge {
         receiver: Receiver<Vec<ConnectionKnowledgeMessage>>,
     ) -> Self {
         let num_authorities = context.committee.size();
-        let headers_not_known = vec![BTreeMap::new(); num_authorities];
-        let shards_not_known = vec![BTreeMap::new(); num_authorities];
-        let mut last_useful_headers_from_peer_round =  vec![GENESIS_ROUND; num_authorities];
-        // We should not request headers for own blocks
-        last_useful_headers_from_peer_round[context.own_index] = Round::MAX;
-        let mut last_useful_shards_from_peer_round = vec![GENESIS_ROUND; num_authorities];
-        // We should not request shards for own blocks
-        last_useful_shards_from_peer_round[context.own_index] = Round::MAX;
+
         Self {
             dag_state,
-            last_useful_headers_to_peer_round: vec![GENESIS_ROUND; num_authorities],
-            last_useful_shards_to_peer_round: vec![GENESIS_ROUND; num_authorities],
-            last_useful_headers_from_peer_round,
-            last_useful_shards_from_peer_round,
+            last_useful_headers_to_peer_round: vec![None; num_authorities],
+            last_useful_shards_to_peer_round: vec![None; num_authorities],
+            last_useful_headers_from_peer_round: vec![None; num_authorities],
+            last_useful_shards_from_peer_round: vec![None; num_authorities],
             context,
             peer_index,
-            headers_not_known,
-            shards_not_known,
+            headers_not_known: vec![BTreeMap::new(); num_authorities],
+            shards_not_known: vec![BTreeMap::new(); num_authorities],
             receiver,
         }
     }
@@ -855,7 +865,7 @@ impl ConnectionKnowledge {
         useful_headers_to_peer: BTreeMap<AuthorityIndex, Round>,
         useful_shards_to_peer: BTreeMap<AuthorityIndex, Round>,
         useful_headers_from_peer: BTreeMap<AuthorityIndex, Round>,
-        useful_shards_from_peer: Vec<Round>,
+        useful_shards_from_peer: Vec<Option<Round>>,
     ) {
         // Update local state
         self.handle_useful_headers_to(useful_headers_to_peer);
@@ -864,7 +874,7 @@ impl ConnectionKnowledge {
         self.handle_useful_shards_from(useful_shards_from_peer);
     }
 
-    fn handle_useful_shards_from(&mut self, useful_shards_from_peer_round: Vec<Round>) {
+    fn handle_useful_shards_from(&mut self, useful_shards_from_peer_round: Vec<Option<Round>>) {
         self.last_useful_shards_from_peer_round = useful_shards_from_peer_round;
     }
 
@@ -872,30 +882,27 @@ impl ConnectionKnowledge {
         &mut self,
         authorities_with_round: BTreeMap<AuthorityIndex, Round>,
     ) {
-        for (authority, round) in authorities_with_round {
-            if round > self.last_useful_headers_from_peer_round[authority] {
-                self.last_useful_headers_from_peer_round[authority] = round;
-            }
-        }
+        CordialKnowledge::update_authority_rounds_if_greater(
+            &mut self.last_useful_headers_from_peer_round,
+            authorities_with_round,
+        );
     }
 
     fn handle_useful_shards_to(&mut self, authorities_with_round: BTreeMap<AuthorityIndex, Round>) {
-        for (authority, round) in authorities_with_round {
-            if round > self.last_useful_shards_to_peer_round[authority] {
-                self.last_useful_shards_to_peer_round[authority] = round;
-            }
-        }
+        CordialKnowledge::update_authority_rounds_if_greater(
+            &mut self.last_useful_shards_to_peer_round,
+            authorities_with_round,
+        );
     }
 
     fn handle_useful_headers_to(
         &mut self,
         authorities_with_round: BTreeMap<AuthorityIndex, Round>,
     ) {
-        for (authority, round) in authorities_with_round {
-            if round > self.last_useful_headers_to_peer_round[authority] {
-                self.last_useful_headers_to_peer_round[authority] = round;
-            }
-        }
+        CordialKnowledge::update_authority_rounds_if_greater(
+            &mut self.last_useful_headers_to_peer_round,
+            authorities_with_round,
+        );
     }
 
     /// Handles taking additional parts (headers, shards) for a block bundle
@@ -921,17 +928,15 @@ impl ConnectionKnowledge {
             .last_useful_headers_to_peer_round
             .iter()
             .enumerate()
-            .filter_map(|(i, &r)| {
-                if r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive {
-                    Some(i)
-                } else {
-                    None
-                }
+            .filter_map(|(i, &opt_round)| {
+                opt_round.filter(|&r| {
+                    r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive
+                }).map(|_| i)
             })
             .collect();
 
         debug!(
-            "Useful header authors: {:?}",
+            "Useful header authors to peer: {:?}",
             useful_headers_authors_to_peer
         );
 
@@ -955,12 +960,10 @@ impl ConnectionKnowledge {
             .last_useful_shards_to_peer_round
             .iter()
             .enumerate()
-            .filter_map(|(i, &r)| {
-                if r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive {
-                    Some(i)
-                } else {
-                    None
-                }
+            .filter_map(|(i, &opt_round)| {
+                opt_round.filter(|&r| {
+                    r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive
+                }).map(|_| i)
             })
             .collect();
         let useful_shards_block_refs_to_peer = self.take_useful_shard_block_refs_round(
@@ -981,28 +984,32 @@ impl ConnectionKnowledge {
             .last_useful_headers_from_peer_round
             .iter()
             .enumerate()
-            .filter_map(|(i, &r)| {
-                if r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive {
-                    Some(AuthorityIndex::from(i as u8))
-                } else {
-                    None
-                }
+            .filter_map(|(i, &opt_round)| {
+                opt_round.filter(|&r| {
+                    r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive
+                }).map(|_| AuthorityIndex::from(i as u8))
             })
             .collect::<BTreeSet<AuthorityIndex>>();
+        debug!(
+            "Useful header authors from peer: {:?}",
+            useful_headers_authors_from_peer
+        );
 
         // 5. Get useful shard authors from peer
         let useful_shards_authors_from_peer = self
             .last_useful_shards_from_peer_round
             .iter()
             .enumerate()
-            .filter_map(|(i, &r)| {
-                if r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive {
-                    Some(AuthorityIndex::from(i as u8))
-                } else {
-                    None
-                }
+            .filter_map(|(i, &opt_round)| {
+                opt_round.filter(|&r| {
+                    r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive
+                }).map(|_| AuthorityIndex::from(i as u8))
             })
             .collect::<BTreeSet<AuthorityIndex>>();
+        debug!(
+            "Useful shard authors from peer: {:?}",
+            useful_shards_authors_from_peer
+        );
 
         // 6. Build a response message and send it back
         let message = AdditionalPartsForBundle {
@@ -1147,8 +1154,27 @@ mod tests {
             all_blocks.push(dag_builder.blocks(round..=round));
         }
 
-        let connection_knowledge =
-            cordial_knowledge.connection_knowledge_senders[to_whom_index].clone();
+        // Report useful info to connection knowledge corresponding to to_whom_index
+        let connection_knowledge_sender = cordial_knowledge
+            .connection_knowledge_senders[to_whom_index]
+            .clone();
+        // Inject useful info
+        let msg = ConnectionKnowledgeMessage::UsefulInfo {
+            useful_headers_to_peer: BTreeMap::from([
+                (AuthorityIndex::new_for_test(2), GENESIS_ROUND),
+                (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
+            ]),
+            useful_shards_to_peer: BTreeMap::from([
+                (AuthorityIndex::new_for_test(2), GENESIS_ROUND),
+                (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
+            ]),
+            useful_headers_from_peer: BTreeMap::from([
+                (AuthorityIndex::new_for_test(1), GENESIS_ROUND),
+                (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
+            ]),
+            useful_shards_from_peers: vec![None,Some(GENESIS_ROUND),None,Some(GENESIS_ROUND)]
+        };
+        let _ = connection_knowledge_sender.send(vec![msg]).await;
 
         // get all blocks of D. They will be injected to dag state at final_round
         let d_blocks = all_blocks
@@ -1203,7 +1229,7 @@ mod tests {
                 round_upper_bound_exclusive: round + 1,
                 respond_to: tx,
             };
-            connection_knowledge.send(vec![msg]).await.unwrap();
+            let _ = connection_knowledge_sender.send(vec![msg]).await;
             let additional_parts = rx.await.unwrap();
             let AdditionalPartsForBundle {
                 headers, shards, ..
@@ -1244,15 +1270,35 @@ mod tests {
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
+        // Report useful info to connection knowledge corresponding to to_whom_index
+        let connection_knowledge_sender = cordial_knowledge
+            .connection_knowledge_senders[to_whom_index]
+            .clone();
+        // Inject useful info
+        let msg = ConnectionKnowledgeMessage::UsefulInfo {
+            useful_headers_to_peer: BTreeMap::from([
+                (AuthorityIndex::new_for_test(2), GENESIS_ROUND),
+                (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
+            ]),
+            useful_shards_to_peer: BTreeMap::from([
+                (AuthorityIndex::new_for_test(2), GENESIS_ROUND),
+                (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
+            ]),
+            useful_headers_from_peer: BTreeMap::from([
+                (AuthorityIndex::new_for_test(1), GENESIS_ROUND),
+                (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
+            ]),
+            useful_shards_from_peers: vec![None,Some(GENESIS_ROUND),None,Some(GENESIS_ROUND)]
+        };
+        let _ = connection_knowledge_sender.send(vec![msg]).await;
+        // Build DAG with blocks from all validators up to final_round and add to dag_state
         let _dag_builder = DagBuilder::new(context.clone())
             .set_protocol_keypair(protocol_keypairs)
             .layers(1..=final_round)
             .build()
             .persist_layers(dag_state.clone());
         sleep(std::time::Duration::from_millis(1)).await;
-        let connection_knowledge_sender = cordial_knowledge
-            .connection_knowledge_senders[to_whom_index]
-            .clone();
+
         let (tx, rx) = oneshot::channel();
         let msg = ConnectionKnowledgeMessage::TakeAdditionalPartForBundle {
             round_upper_bound_exclusive: final_round + 1,
@@ -1261,13 +1307,13 @@ mod tests {
         let _ = connection_knowledge_sender.send(vec![msg]).await;
         let additional_parts = rx.await.unwrap();
         let AdditionalPartsForBundle {
-            headers, shards, useful_headers_authors_from_peer, useful_shards_authors_from_peer
+            headers, shards: _, useful_headers_authors_from_peer, useful_shards_authors_from_peer
         } = additional_parts;
         // Only headers and shards from authorities 2 and 3 should be included
         assert_eq!(headers.len(), 2);
         assert!(headers.iter().all(|h| h.author() != our_index || h.author() == to_whom_index));
-        assert_eq!(useful_headers_authors_from_peer, BTreeSet::from([1,2,3].map(AuthorityIndex::new_for_test)));
-        assert_eq!(useful_shards_authors_from_peer, BTreeSet::from([1,2,3].map(AuthorityIndex::new_for_test)));
+        assert_eq!(useful_headers_authors_from_peer, BTreeSet::from([1,3].map(AuthorityIndex::new_for_test)));
+        assert_eq!(useful_shards_authors_from_peer, BTreeSet::from([1,3].map(AuthorityIndex::new_for_test)));
         // Repeat the request, should get no headers this time
         let (tx, rx) = oneshot::channel();
         let msg = ConnectionKnowledgeMessage::TakeAdditionalPartForBundle {

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -744,7 +744,7 @@ impl ConnectionKnowledge {
                     }
                 }
             }
-            current_round = current_round + 1;
+            current_round += 1;
         }
 
         // Remove the taken blocks from the corresponding authorities
@@ -1267,9 +1267,7 @@ mod tests {
                 assert_eq!(
                     headers.len(),
                     1,
-                    "In round {}, unexpected headers found: {:?}",
-                    round,
-                    headers
+                    "In round {round}, unexpected headers found: {headers:?}",
                 );
                 assert_eq!(
                     headers[0].digest(),
@@ -1278,9 +1276,7 @@ mod tests {
                 assert_eq!(
                     shards.len(),
                     1,
-                    "In round {}, unexpected shards found: {:?}",
-                    round,
-                    shards
+                    "In round {round}, unexpected shards found: {shards:?}",
                 );
             } else {
                 // In round 6, A should know about D's blocks and send them all to B
@@ -1294,9 +1290,7 @@ mod tests {
                 assert_eq!(
                     headers.len(),
                     final_round as usize,
-                    "In round {}, unexpected headers found: {:?}",
-                    round,
-                    headers
+                    "In round {round}, unexpected headers found: {headers:?}",
                 );
                 assert_eq!(shards.len(), final_round as usize);
             }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -23,11 +23,13 @@ use crate::{
     block_header::{BlockHeaderDigest, GENESIS_ROUND},
     context::Context,
     dag_state::DagState,
+    error::{ConsensusError, ConsensusResult},
     network::SerializedBlockBundleParts,
 };
 
-const MAX_ROUND_GAP_FOR_USEFUL_SHARDS: Round = 5;
-const MAX_ROUND_GAP_FOR_USEFUL_HEADERS: Round = 50;
+/// Maximum round gap to consider a peer's useful shards/headers as still
+/// relevant.
+const MAX_ROUND_GAP_FOR_USEFUL_PARTS: Round = 10;
 
 /// Represents a subset of authorities using a bitmask.
 /// Each bit in the `low` and `high` fields corresponds to an authority index.
@@ -67,11 +69,17 @@ impl SubsetAuthorities {
     }
 }
 
+/// Manages the global cordial knowledge state.
+/// Receives high-level updates from DAG state and Authority service and
+/// notifies per-connection tasks.
 pub(crate) struct CordialKnowledge {
     context: Arc<Context>,
     /// Receives high-level updates from DAG state (new headers, new own shards,
     /// evictions)
     cordial_knowledge_receiver: UnboundedReceiver<CordialKnowledgeMessage>,
+    /// Keeps track of the last round for which each peer's shards were
+    /// considered useful to us. This is a global knowledge and is shared with
+    /// all connection tasks.
     last_useful_shards_from_peer_round: Vec<Round>,
     /// Keeps track of the most recent DAG cordial
     /// knowledge (who knows which blocks) for each authority. This is a helper
@@ -79,18 +87,30 @@ pub(crate) struct CordialKnowledge {
     /// struct is evicted after flushing the dag state to storage and is not
     /// persisted. To access the cordial knowledge of a given block_ref, one
     /// shall retrieve it from `cordial_knowledge[block_ref.
-    /// author][(block_ref.round, block_ref.digest)]`. The value is a tuple
-    /// of (parents, who knows the block header).
-    cordial_knowledge: Vec<
-        BTreeMap<
-            Round,
-            AHashMap<BlockHeaderDigest, (Ancestors, SubsetAuthorities)>,
-        >,
-    >,
+    /// author][block_ref.round][block_ref.digest]`. The provided value is a
+    /// tuple of (parents, who knows the block header).
+    cordial_knowledge:
+        Vec<BTreeMap<Round, AHashMap<BlockHeaderDigest, (Ancestors, SubsetAuthorities)>>>,
     /// Per-connection message channels
     connections: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
 }
 
+/// High-level messages sent to the CordialKnowledge task.
+#[derive(Debug)]
+pub enum CordialKnowledgeMessage {
+    /// A new verified block header to integrate into cordial knowledge.
+    NewHeader(VerifiedBlockHeader),
+    /// A new verified own shard to integrate into cordial knowledge.
+    NewShard(BlockRef),
+    /// Evict old rounds globally.
+    EvictBelow(Vec<Round>),
+    /// Update internal state about shards from which authorities are useful for
+    /// us
+    UsefulShardsFromPeers(BTreeMap<AuthorityIndex, Round>),
+}
+
+/// Handle to the CordialKnowledge task, allowing interaction and graceful
+/// shutdown.
 pub struct CordialKnowledgeHandle {
     cordial_knowledge_sender: UnboundedSender<CordialKnowledgeMessage>,
     connection_knowledge_senders: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
@@ -140,6 +160,8 @@ impl CordialKnowledgeHandle {
 }
 
 impl CordialKnowledge {
+    /// Create a new CordialKnowledge instance along with its associated
+    /// channels.
     pub fn new(
         context: Arc<Context>,
     ) -> (
@@ -270,6 +292,7 @@ impl CordialKnowledge {
         debug!("Cordial Knowledge main loop finished");
     }
 
+    /// Processes a single high-level cordial knowledge message.
     async fn process_message(&mut self, cordial_knowledge_message: CordialKnowledgeMessage) {
         debug!(
             "Processing Cordial Message: {:?}",
@@ -297,6 +320,8 @@ impl CordialKnowledge {
             .inc();
     }
 
+    /// Update global knowledge about shards from which authors will be useful
+    /// for us
     async fn handle_useful_shards_from(
         &mut self,
         useful_shards_from_peer: BTreeMap<AuthorityIndex, Round>,
@@ -309,6 +334,7 @@ impl CordialKnowledge {
         self.disseminate_useful_info_to_connection_tasks().await;
     }
 
+    /// Disseminate updated useful info to all connection tasks.
     async fn disseminate_useful_info_to_connection_tasks(&mut self) {
         for connection_sender in &self.connections {
             let msg = ConnectionKnowledgeMessage::UsefulInfo {
@@ -328,7 +354,7 @@ impl CordialKnowledge {
         self.update_cordial_knowledge(&header).await;
     }
 
-    /// Called when a new *own shard* (created locally) is added to dag state.
+    /// Called when a new own shard (created locally) is added to dag state.
     async fn handle_new_shard(&mut self, block_ref: BlockRef) {
         for tx in &self.connections {
             let msg = ConnectionKnowledgeMessage::NewShard { block_ref };
@@ -349,14 +375,21 @@ impl CordialKnowledge {
                 .with_label_values(&[&index.to_string()])
                 .set(btree_map.len() as i64);
         }
-        let largest_round = self.cordial_knowledge[self.context.own_index].keys().max().cloned()
+        let largest_round = self.cordial_knowledge[self.context.own_index]
+            .keys()
+            .max()
+            .cloned()
             .unwrap_or(GENESIS_ROUND);
         let useful_shards_from_peer_count = self
             .last_useful_shards_from_peer_round
             .iter()
-            .filter(|&&r| r + MAX_ROUND_GAP_FOR_USEFUL_HEADERS >= largest_round)
+            .filter(|&&r| r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= largest_round)
             .count();
-        self.context.metrics.node_metrics.cordial_knowledge_useful_shards.set(useful_shards_from_peer_count as i64);
+        self.context
+            .metrics
+            .node_metrics
+            .cordial_knowledge_useful_shards
+            .set(useful_shards_from_peer_count as i64);
 
         // Notify per-connection tasks about eviction
         self.notify_connection_tasks_for_eviction(rounds).await;
@@ -371,10 +404,12 @@ impl CordialKnowledge {
 
     /// Update cordial knowledge for exactly one new header.
     /// Assumes all parents are already stored somewhere in
-    /// `recent_dag_cordial_knowledge`
-    /// - Only grows the author's deque if needed.
-    /// - For other authorities' "unknown headers" deques, we add the block only
-    ///   if the round bucket already exists (no growth).
+    /// `recent_dag_cordial_knowledge` (if not, they will be skipped).
+    /// We traverse back the causal past of the new header and mark all
+    /// ancestors as known by the block author. All acknowledged blocks are
+    /// marked as known by the block author as well.
+    /// At the end, we notify all connections about new
+    /// knowledge changes.
     async fn update_cordial_knowledge(&mut self, header: &VerifiedBlockHeader) {
         let block_ref = header.reference();
         let block_author = block_ref.author.value();
@@ -384,9 +419,12 @@ impl CordialKnowledge {
 
         // Pre-allocate message buffers
         let mut vec_knowledge_msgs: Vec<Vec<ConnectionKnowledgeMessage>> =
-            (0..self.context.committee.size()).map(|_| Vec::new()).collect();
+            (0..self.context.committee.size())
+                .map(|_| Vec::new())
+                .collect();
 
-        // === 1) Ensure we have a round map for this author and insert the block ===
+        // === 1) Ensure we have a round map for this author and insert the block if new
+        // ===
         let btree_map = &mut self.cordial_knowledge[block_author];
         let round_map = btree_map.entry(block_round).or_insert_with(AHashMap::new);
 
@@ -400,7 +438,8 @@ impl CordialKnowledge {
         let who_knows_this_block = SubsetAuthorities::new_with(block_author, own_index);
         round_map.insert(block_digest, (ancestors.clone(), who_knows_this_block));
 
-        // === 2) Notify all *other* authorities (except self and block_author) ===
+        // === 2) Notify all *other* authorities (except self and block_author) about
+        // new header ===
         for (authority, msgs) in vec_knowledge_msgs.iter_mut().enumerate() {
             if authority == block_author || authority == own_index {
                 continue;
@@ -415,7 +454,8 @@ impl CordialKnowledge {
             });
         }
 
-        // === 4) Traversing back and marking the causal past as known by block_author ===
+        // === 4) Traversing back and marking the causal past as known by block_author
+        // ===
         let mut stack = vec![block_ref];
         while let Some(current_ref) = stack.pop() {
             let current_author = current_ref.author.value();
@@ -423,7 +463,7 @@ impl CordialKnowledge {
             let current_digest = current_ref.digest;
 
             // ---- Get parents of current block ----
-            let parents_buf: Vec<BlockRef> = {
+            let parents_buf: Ancestors = {
                 let author_map = &self.cordial_knowledge[current_author];
                 let Some(current_round_map) = author_map.get(&current_round) else {
                     continue;
@@ -431,11 +471,11 @@ impl CordialKnowledge {
                 let Some((parents, _)) = current_round_map.get(&current_digest) else {
                     continue;
                 };
-                parents.iter().copied().collect()
+                parents.clone()
             };
 
             // Traverse parents
-            for parent_ref in parents_buf {
+            for parent_ref in parents_buf.iter() {
                 let parent_author = parent_ref.author.value();
                 let parent_round = parent_ref.round;
                 let parent_digest = parent_ref.digest;
@@ -448,22 +488,22 @@ impl CordialKnowledge {
                         if who_knows_parent.insert(block_author) {
                             vec_knowledge_msgs[block_author].push(
                                 ConnectionKnowledgeMessage::RemoveHeader {
-                                    block_ref: parent_ref,
+                                    block_ref: *parent_ref,
                                 },
                             );
-                            stack.push(parent_ref);
+                            stack.push(*parent_ref);
                         }
                     }
                 }
             }
         }
 
-
         // === 5) Send all accumulated knowledge messages ===
-        self.send_connection_knowledge_messages(vec_knowledge_msgs).await;
+        self.send_connection_knowledge_messages(vec_knowledge_msgs)
+            .await;
     }
 
-
+    /// Send accumulated connection knowledge messages to all connection tasks.
     async fn send_connection_knowledge_messages(&self, msgs: Vec<Vec<ConnectionKnowledgeMessage>>) {
         for (index, msg) in msgs.into_iter().enumerate() {
             if !msg.is_empty() {
@@ -472,6 +512,8 @@ impl CordialKnowledge {
         }
     }
 
+    /// Report from Authority Service useful information about headers and
+    /// shards to global knowledge and connection knowledge.
     pub async fn report_useful_info(
         connection_knowledge_sender: &Sender<Vec<ConnectionKnowledgeMessage>>,
         cordial_knowledge_sender: &UnboundedSender<CordialKnowledgeMessage>,
@@ -479,14 +521,22 @@ impl CordialKnowledge {
         additional_block_headers: &[VerifiedBlockHeader],
         missing_ancestors: &BTreeSet<BlockRef>,
         block_round: Round,
-    ) {
-        let useful_headers_authors = additional_block_headers
+    ) -> ConsensusResult<()> {
+        // Extract authorities this peer has useful headers from
+        let useful_headers_authors_from_peer = additional_block_headers
             .iter()
             .map(|block_header| block_header.author())
             .chain(missing_ancestors.iter().map(|block_ref| block_ref.author))
             .collect::<BTreeSet<_>>();
+        let useful_headers_from_peer = useful_headers_authors_from_peer
+            .into_iter()
+            .map(|a| (a, block_round))
+            .collect();
 
+        // Extract authorities this peer has useful shards from
         let mut useful_shard_authors: BTreeMap<AuthorityIndex, Round> = BTreeMap::new();
+        // Since headers showed up in the filter before the corresponding full blocks
+        // we consider all authors of additional headers as useful shard authors too.
         for header in additional_block_headers {
             let author = header.author();
             let round = header.round();
@@ -498,21 +548,19 @@ impl CordialKnowledge {
                 .or_insert(round);
         }
 
-        // Extract authorities this peer finds useful for cordial dissemination
+        // Extract authorities this peer finds useful for cordial dissemination from our
+        // side
         let useful_headers_to_peer = serialized_block_bundle_parts.useful_headers_authors();
         let useful_headers_to_peer = useful_headers_to_peer
             .iter()
             .map(|&a| (a, block_round))
             .collect::<BTreeMap<_, _>>();
+        // Extract authorities this peer finds useful shards from our side
         let useful_shards_to_peer = serialized_block_bundle_parts.useful_shards_authors();
         let useful_shards_to_peer = useful_shards_to_peer
             .iter()
             .map(|&a| (a, block_round))
             .collect::<BTreeMap<_, _>>();
-        let useful_headers_from_peer =  useful_headers_authors
-            .into_iter()
-            .map(|a| (a, block_round))
-            .collect();
 
         // Notify connection knowledge about useful headers and shards to/from this peer
         let connection_knowledge_message = ConnectionKnowledgeMessage::UsefulInfo {
@@ -521,17 +569,23 @@ impl CordialKnowledge {
             useful_headers_from_peer,
             useful_shards_from_peers: vec![],
         };
-        let _ = connection_knowledge_sender
+        connection_knowledge_sender
             .send(vec![connection_knowledge_message])
-            .await;
+            .await
+            .map_err(|_err| ConsensusError::Shutdown)?;
 
         // Notify global cordial knowledge about useful shards from this peer
         let cordial_knowledge_message =
             CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shard_authors);
-        let _ = cordial_knowledge_sender.send(cordial_knowledge_message);
+        cordial_knowledge_sender
+            .send(cordial_knowledge_message)
+            .map_err(|_err| ConsensusError::Shutdown)?;
+
+        Ok(())
     }
 }
 
+/// Messages sent to a ConnectionKnowledge task to update its state.
 #[derive(Debug)]
 pub enum ConnectionKnowledgeMessage {
     /// A new block header was added globally.
@@ -555,22 +609,8 @@ pub enum ConnectionKnowledgeMessage {
         round_upper_bound_exclusive: Round,
         respond_to: oneshot::Sender<AdditionalPartsForBundle>,
     },
-
     /// Global eviction (prune below round)
     EvictBelow(Vec<Round>),
-}
-
-#[derive(Debug)]
-pub enum CordialKnowledgeMessage {
-    /// A new verified block header to integrate into cordial knowledge.
-    NewHeader(VerifiedBlockHeader),
-    /// A new verified own shard to integrate into cordial knowledge.
-    NewShard(BlockRef),
-    /// Evict old rounds globally.
-    EvictBelow(Vec<Round>),
-    /// Update internal state about shards from which authorities are useful for
-    /// us
-    UsefulShardsFromPeers(BTreeMap<AuthorityIndex, Round>),
 }
 
 /// Manages the knowledge state for a single connection to a peer.
@@ -578,17 +618,30 @@ pub enum CordialKnowledgeMessage {
 pub struct ConnectionKnowledge {
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
+    /// Index of the peer authority this connection knowledge is for
     peer_index: usize,
+    /// Keeps track of which headers are not known by the peer yet.
     headers_not_known: Vec<BTreeMap<Round, AHashSet<BlockRef>>>,
+    /// Keeps track of which shards are not known by the peer yet.
     shards_not_known: Vec<BTreeMap<Round, AHashSet<BlockRef>>>,
+    /// Last rounds for (potentially) useful shards that can be sent to this
+    /// peer
     last_useful_shards_to_peer_round: Vec<Round>,
+    /// Last rounds for (potentially) useful headers that can be sent to this
+    /// peer
     last_useful_headers_to_peer_round: Vec<Round>,
+    /// Last rounds for potentially useful shards that could be received from
+    /// this peer
     last_useful_shards_from_peer_round: Vec<Round>,
+    /// Last rounds for (potentially) useful headers that could be received from
+    /// this peer
     last_useful_headers_from_peer_round: Vec<Round>,
     /// Receives updates from the global cordial knowledge
     receiver: Receiver<Vec<ConnectionKnowledgeMessage>>,
 }
 
+/// Additional parts (headers, shards, useful_headers_authors,
+/// useful_shards_authors) to include in a block bundle for a peer.
 #[derive(Debug)]
 pub(crate) struct AdditionalPartsForBundle {
     pub headers: Vec<VerifiedBlockHeader>,
@@ -620,6 +673,9 @@ impl ConnectionKnowledge {
             receiver,
         }
     }
+    /// Take useful block refs (headers or shards) for the given authorities
+    /// up to the given round (exclusive), up to max_take total.
+    /// Used for both headers and shards.
     fn take_useful_refs_round(
         maps: &mut Vec<BTreeMap<Round, AHashSet<BlockRef>>>,
         round_upper_bound_exclusive: Round,
@@ -672,6 +728,8 @@ impl ConnectionKnowledge {
         taken
     }
 
+    /// Take useful header block refs from the given authorities up to the given
+    /// round (exclusive).
     fn take_useful_header_block_refs_round(
         &mut self,
         round_upper_bound_exclusive: Round,
@@ -686,6 +744,8 @@ impl ConnectionKnowledge {
         )
     }
 
+    /// Take useful shard block refs from the given authorities up to the given
+    /// round (exclusive).
     fn take_useful_shard_block_refs_round(
         &mut self,
         round_upper_bound_exclusive: Round,
@@ -700,8 +760,7 @@ impl ConnectionKnowledge {
         )
     }
 
-
-
+    /// Evict al connection knowledge below the given rounds (exclusive)
     fn evict_below(&mut self, rounds_exclusive: Vec<Round>) {
         for (index, map) in self.headers_not_known.iter_mut().enumerate() {
             let threshold_round = rounds_exclusive[index];
@@ -714,7 +773,6 @@ impl ConnectionKnowledge {
             *map = map.split_off(&threshold_round);
         }
     }
-
 
     /// Async task loop — just receives messages and dispatches to processing
     /// logic.
@@ -735,9 +793,9 @@ impl ConnectionKnowledge {
         );
     }
 
-    /// Processes a batch of knowledge updates synchronously (non-async).
-    /// This isolates all mutation logic so it can be tested without async
-    /// context.
+    /// Processes a batch of knowledge updates for this connection.
+    /// The only async message is `TakeAdditionalPartForBundle`, which awaits
+    /// and provides the additional parts for the bundle
     async fn process_message(&mut self, message: ConnectionKnowledgeMessage) {
         match message {
             ConnectionKnowledgeMessage::NewHeader { block_ref } => {
@@ -780,6 +838,9 @@ impl ConnectionKnowledge {
             }
         }
     }
+
+    /// Handle useful info update from global CordialKnowledge or
+    /// AuthorityService.
     fn handle_useful_info(
         &mut self,
         useful_headers_to_peer: BTreeMap<AuthorityIndex, Round>,
@@ -828,6 +889,10 @@ impl ConnectionKnowledge {
         }
     }
 
+    /// Handles taking additional parts (headers, shards) for a block bundle
+    /// to send to the peer.
+    /// This is an async function because it reads from the DAG state and
+    /// sends the response back via oneshot channel.
     async fn handle_take_additional_parts_for_bundle(
         &mut self,
         round_upper_bound_exclusive: Round,
@@ -840,6 +905,7 @@ impl ConnectionKnowledge {
         rounds[own_index] = round_upper_bound_exclusive + 1; // We are supposed to send own block of this round in a bundle when calling this function with this parameter
 
         self.evict_below(rounds);
+
         // 2. Identify useful authorities for headers and take the corresponding headers
         //    from the DAG state
         let useful_headers_authors_to_peer: Vec<usize> = self
@@ -847,7 +913,7 @@ impl ConnectionKnowledge {
             .iter()
             .enumerate()
             .filter_map(|(i, &r)| {
-                if r + MAX_ROUND_GAP_FOR_USEFUL_HEADERS >= round_upper_bound_exclusive {
+                if r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive {
                     Some(i)
                 } else {
                     None
@@ -873,6 +939,7 @@ impl ConnectionKnowledge {
                 .flatten() // Filter out None values
                 .collect()
         };
+
         // 3. Identify useful authorities for shards and take the corresponding shards
         //    from the DAG state
         let useful_shards_authors_to_peer: Vec<usize> = self
@@ -880,7 +947,7 @@ impl ConnectionKnowledge {
             .iter()
             .enumerate()
             .filter_map(|(i, &r)| {
-                if r + MAX_ROUND_GAP_FOR_USEFUL_SHARDS >= round_upper_bound_exclusive {
+                if r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive {
                     Some(i)
                 } else {
                     None
@@ -899,26 +966,28 @@ impl ConnectionKnowledge {
                 .flatten() // Filter out None values
                 .collect()
         };
+
         // 4. Get useful header authors from peer
         let useful_headers_authors_from_peer = self
             .last_useful_headers_from_peer_round
             .iter()
             .enumerate()
             .filter_map(|(i, &r)| {
-                if r + MAX_ROUND_GAP_FOR_USEFUL_HEADERS >= round_upper_bound_exclusive {
+                if r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive {
                     Some(AuthorityIndex::from(i as u8))
                 } else {
                     None
                 }
             })
             .collect::<BTreeSet<AuthorityIndex>>();
+
         // 5. Get useful shard authors from peer
         let useful_shards_authors_from_peer = self
             .last_useful_shards_from_peer_round
             .iter()
             .enumerate()
             .filter_map(|(i, &r)| {
-                if r + MAX_ROUND_GAP_FOR_USEFUL_SHARDS >= round_upper_bound_exclusive {
+                if r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive {
                     Some(AuthorityIndex::from(i as u8))
                 } else {
                     None
@@ -986,5 +1055,4 @@ impl ConnectionKnowledge {
             }
         }
     }
-
 }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -312,7 +312,8 @@ impl CordialKnowledge {
                 "eviction"
             }
             CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shards_from_peer) => {
-                self.handle_useful_shards_from(useful_shards_from_peer).await;
+                self.handle_useful_shards_from(useful_shards_from_peer)
+                    .await;
                 "useful_shards"
             }
         };
@@ -323,7 +324,6 @@ impl CordialKnowledge {
             .cordial_knowledge_processed_messages
             .with_label_values(&[message_type])
             .inc();
-
     }
 
     // Helper function to update authority rounds if the new round is greater
@@ -1313,8 +1313,9 @@ mod tests {
         let _ = connection_knowledge_sender.send(vec![msg]).await;
         // Build DAG with blocks from all validators up to final_round and add to
         // dag_state
-        let _dag_builder = DagBuilder::new(context.clone())
-            .set_protocol_keypair(protocol_keypairs)
+        let mut dag_builder =
+            DagBuilder::new(context.clone()).set_protocol_keypair(protocol_keypairs);
+        dag_builder
             .layers(1..=final_round)
             .build()
             .persist_layers(dag_state.clone());
@@ -1358,5 +1359,34 @@ mod tests {
         let additional_parts = rx.await.unwrap();
         let AdditionalPartsForBundle { headers, .. } = additional_parts;
         assert_eq!(headers.len(), 0);
+
+        // Add more rounds to DAG
+        let last_round = final_round + MAX_ROUND_GAP_FOR_USEFUL_PARTS;
+        dag_builder
+            .layers(final_round + 1..=last_round)
+            .build()
+            .persist_layers(dag_state.clone());
+        sleep(std::time::Duration::from_millis(1)).await;
+
+        // Make a request for a last round, should get no headers, no shards and no
+        // useful authorities as the last useful rounds are beyond
+        // MAX_ROUND_GAP_FOR_USEFUL_PARTS from last_round
+        let (tx, rx) = oneshot::channel();
+        let msg = ConnectionKnowledgeMessage::TakeAdditionalPartForBundle {
+            round_upper_bound_exclusive: last_round + 1,
+            respond_to: tx,
+        };
+        let _ = connection_knowledge_sender.send(vec![msg]).await;
+        let additional_parts = rx.await.unwrap();
+        let AdditionalPartsForBundle {
+            headers,
+            shards,
+            useful_headers_authors_from_peer,
+            useful_shards_authors_from_peer,
+        } = additional_parts;
+        assert!(headers.is_empty());
+        assert!(shards.is_empty());
+        assert!(useful_headers_authors_from_peer.is_empty());
+        assert!(useful_shards_authors_from_peer.is_empty());
     }
 }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -82,10 +82,10 @@ pub(crate) struct CordialKnowledge {
     /// author][(block_ref.round, block_ref.digest)]`. The value is a tuple
     /// of (parents, who knows the block header).
     cordial_knowledge: Vec<
-        VecDeque<(
+        BTreeMap<
             Round,
             AHashMap<BlockHeaderDigest, (Ancestors, SubsetAuthorities)>,
-        )>,
+        >,
     >,
     /// Per-connection message channels
     connections: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
@@ -174,7 +174,7 @@ impl CordialKnowledge {
                 context,
                 connections,
                 cordial_knowledge_receiver,
-                cordial_knowledge: vec![VecDeque::new(); num_authorities],
+                cordial_knowledge: vec![BTreeMap::new(); num_authorities],
                 last_useful_shards_from_peer_round: vec![GENESIS_ROUND; num_authorities],
             },
             cordial_knowledge_sender,
@@ -328,7 +328,7 @@ impl CordialKnowledge {
         self.update_cordial_knowledge(&header).await;
     }
 
-    /// Called when a new *own shard* (produced locally) is added.
+    /// Called when a new *own shard* (created locally) is added to dag state.
     async fn handle_new_shard(&mut self, block_ref: BlockRef) {
         for tx in &self.connections {
             let msg = ConnectionKnowledgeMessage::NewShard { block_ref };
@@ -339,23 +339,28 @@ impl CordialKnowledge {
     /// Called when older rounds should be pruned globally.
     async fn handle_evict_below(&mut self, rounds: Vec<Round>) {
         // Evict locally
-        for (index, deque) in &mut self.cordial_knowledge.iter_mut().enumerate() {
-            while let Some((front_round, _)) = deque.front() {
-                if *front_round < rounds[index] {
-                    deque.pop_front();
-                } else {
-                    break;
-                }
-                self.context
-                    .metrics
-                    .node_metrics
-                    .cordial_knowledge_rounds
-                    .with_label_values(&[&index.to_string()])
-                    .set(deque.len() as i64);
-            }
+        for (index, btree_map) in &mut self.cordial_knowledge.iter_mut().enumerate() {
+            let split_round = rounds[index];
+            *btree_map = btree_map.split_off(&split_round);
+            self.context
+                .metrics
+                .node_metrics
+                .cordial_knowledge_rounds
+                .with_label_values(&[&index.to_string()])
+                .set(btree_map.len() as i64);
         }
-
-        self.context.metrics.node_metrics.cordial_knowledge_useful_shards.set()
+        let largest_round = self.cordial_knowledge
+            .iter()
+            .filter_map(|btree_map| btree_map.keys().max())
+            .max()
+            .cloned()
+            .unwrap_or(GENESIS_ROUND);
+        let useful_shards_from_peer_count = self
+            .last_useful_shards_from_peer_round
+            .iter()
+            .filter(|&&r| r + MAX_ROUND_GAP_FOR_USEFUL_HEADERS >= largest_round)
+            .count();
+        self.context.metrics.node_metrics.cordial_knowledge_useful_shards.set(useful_shards_from_peer_count as i64);
 
         // Notify per-connection tasks about eviction
         self.notify_connection_tasks_for_eviction(rounds).await;
@@ -366,52 +371,6 @@ impl CordialKnowledge {
             let msg = ConnectionKnowledgeMessage::EvictBelow(rounds.clone());
             let _ = tx.send(vec![msg]).await;
         }
-    }
-
-    /// Map a round to an index inside a per-author VecDeque<(Round, T)>.
-    /// Returns None if `round` is outside the current rolling window stored in
-    /// the deque.
-    #[inline]
-    fn round_to_index<T>(dq: &VecDeque<(Round, T)>, round: Round) -> Option<usize> {
-        let (front_round, _) = dq.front()?;
-        if round < *front_round {
-            return None;
-        }
-        let idx = (round - *front_round) as usize;
-        if idx < dq.len() { Some(idx) } else { None }
-    }
-
-    /// Ensure the author's deque contains `round`, extending **only that
-    /// author's deque** forward as needed. Returns a mutable handle to
-    /// the (Round, Map) entry for `round`.
-    #[inline]
-    fn ensure_author_round_map(
-        &mut self,
-        author_value: usize,
-        target_round: Round,
-    ) -> &mut AHashMap<BlockHeaderDigest, (Ancestors, SubsetAuthorities)> {
-        let deque = &mut self.cordial_knowledge[author_value];
-        match deque.back() {
-            // Empty -> push exactly this round
-            None => {
-                deque.push_back((target_round, AHashMap::default()));
-            }
-            Some((last_round, _)) => {
-                if *last_round < target_round {
-                    // Extend forward up to `round`
-                    let mut r = *last_round + 1;
-                    while r <= target_round {
-                        deque.push_back((r, AHashMap::default()));
-                        r += 1;
-                    }
-                }
-            }
-        }
-
-        let index = Self::round_to_index(deque, target_round).expect(
-            "We should expect round to be within or equal to the deque window after adjustments",
-        );
-        &mut deque[index].1
     }
 
     /// Update cordial knowledge for exactly one new header.
@@ -426,103 +385,88 @@ impl CordialKnowledge {
         let block_round = block_ref.round;
         let block_digest = block_ref.digest;
         let own_index = self.context.own_index.value();
-        let mut vec_knowledge_msgs: Vec<Vec<ConnectionKnowledgeMessage>> =
-            (0..self.context.committee.size())
-                .map(|_| Vec::new())
-                .collect();
 
-        //  === 1) Get (or create forward) the author's round bucket and insert if
-        // missing  ===
-        let author_round_map = self.ensure_author_round_map(block_author, block_round);
-        if author_round_map.contains_key(&block_digest) {
-            // Already recorded — nothing else to do here.
+        // Pre-allocate message buffers
+        let mut vec_knowledge_msgs: Vec<Vec<ConnectionKnowledgeMessage>> =
+            (0..self.context.committee.size()).map(|_| Vec::new()).collect();
+
+        // === 1) Ensure we have a round map for this author and insert the block ===
+        let btree_map = &mut self.cordial_knowledge[block_author];
+        let round_map = btree_map.entry(block_round).or_insert_with(AHashMap::new);
+
+        // Already recorded — nothing else to do.
+        if round_map.contains_key(&block_digest) {
             return;
         }
 
+        // Insert block into cordial knowledge
         let ancestors: Ancestors = Arc::from(header.ancestors());
-
-        // (who_knows initially marks: author + self)
         let who_knows_this_block = SubsetAuthorities::new_with(block_author, own_index);
-        author_round_map.insert(block_digest, (ancestors, who_knows_this_block));
+        round_map.insert(block_digest, (ancestors.clone(), who_knows_this_block));
 
-        //  === 2) Mark this header as "unknown" for other authorities  ===
-        for (other_idx, item) in vec_knowledge_msgs
-            .iter_mut()
-            .enumerate()
-            .take(self.context.committee.size())
-        {
-            if other_idx == block_author || other_idx == own_index {
+        // === 2) Notify all *other* authorities (except self and block_author) ===
+        for (authority, msgs) in vec_knowledge_msgs.iter_mut().enumerate() {
+            if authority == block_author || authority == own_index {
                 continue;
             }
-            let msg = ConnectionKnowledgeMessage::NewHeader { block_ref };
-            item.push(msg);
+            msgs.push(ConnectionKnowledgeMessage::NewHeader { block_ref });
         }
 
-        //  === 3) Notify that the block_author now knows transaction data for certain
-        // blocks ===
+        // === 3) The block_author now acknowledges previously known transactions ===
         for acknowledgment in header.acknowledgments() {
             vec_knowledge_msgs[block_author].push(ConnectionKnowledgeMessage::RemoveShard {
                 block_ref: *acknowledgment,
             });
         }
 
-        // === 4) Traverse the DAG and update the knowledge of block author about the
-        // causal past === We do a DFS traversal using a stack (buffer).
-        // For each parent, if the block_author does not know it yet, we mark it
-        // as known by block_author, send a message to the corresponding connection,
-        // and push the parent onto the stack for further traversal.
-        let mut buffer = vec![block_ref];
+        // === 4) Traversing back and marking the causal past as known by block_author ===
+        let mut stack = vec![block_ref];
+        while let Some(current_ref) = stack.pop() {
+            let current_author = current_ref.author.value();
+            let current_round = current_ref.round;
+            let current_digest = current_ref.digest;
 
-        while let Some(traversed_ref) = buffer.pop() {
-            let current_author = traversed_ref.author.value();
-            let current_round = traversed_ref.round;
-            let current_digest = traversed_ref.digest;
-
-            // Locate the round bucket for this traversed block
-            let deque = &mut self.cordial_knowledge[current_author];
-            if let Some(index) = Self::round_to_index(deque, current_round) {
-                // Found correct round bucket
-                let (_r, map) = &mut deque[index];
-
-                // Get this block’s entry
-                let parents = match map.get(&current_digest) {
-                    Some((ancestors, _)) => ancestors.clone(),
-                    None => continue, // skip block which is not stored in cordial knowledge
+            // ---- Get parents of current block ----
+            let parents_buf: Vec<BlockRef> = {
+                let author_map = &self.cordial_knowledge[current_author];
+                let Some(current_round_map) = author_map.get(&current_round) else {
+                    continue;
                 };
+                let Some((parents, _)) = current_round_map.get(&current_digest) else {
+                    continue;
+                };
+                parents.iter().copied().collect()
+            };
 
-                // Iterate over the parents
-                for parent in parents.iter() {
-                    let parent_author = parent.author;
-                    let parent_round = parent.round;
-                    let parent_digest = parent.digest;
+            // Traverse parents
+            for parent_ref in parents_buf {
+                let parent_author = parent_ref.author.value();
+                let parent_round = parent_ref.round;
+                let parent_digest = parent_ref.digest;
 
-                    // Find the parent’s round bucket
-                    let deque_parent_author = &mut self.cordial_knowledge[parent_author.value()];
-                    if let Some(parent_index) =
-                        Self::round_to_index(deque_parent_author, parent_round)
-                    {
-                        let (_, parent_map) = &mut deque_parent_author[parent_index];
+                let parent_author_map = &mut self.cordial_knowledge[parent_author];
 
-                        if let Some((_, who_knows_parent)) = parent_map.get_mut(&parent_digest) {
-                            // Insert new knowledge as block_author knows this parent
-                            if who_knows_parent.insert(block_author) {
-                                vec_knowledge_msgs[block_author].push(
-                                    ConnectionKnowledgeMessage::RemoveHeader { block_ref: *parent },
-                                );
-                                // Push parent to buffer for further propagation
-                                buffer.push(*parent);
-                            }
-                        } else {
-                            // Parent not found in cordial knowledge — skip
-                            continue;
+                if let Some(parent_round_map) = parent_author_map.get_mut(&parent_round) {
+                    if let Some((_, who_knows_parent)) = parent_round_map.get_mut(&parent_digest) {
+                        // Mark that block_author now knows this parent
+                        if who_knows_parent.insert(block_author) {
+                            vec_knowledge_msgs[block_author].push(
+                                ConnectionKnowledgeMessage::RemoveHeader {
+                                    block_ref: parent_ref,
+                                },
+                            );
+                            stack.push(parent_ref);
                         }
                     }
                 }
             }
         }
-        self.send_connection_knowledge_messages(vec_knowledge_msgs)
-            .await;
+
+
+        // === 5) Send all accumulated knowledge messages ===
+        self.send_connection_knowledge_messages(vec_knowledge_msgs).await;
     }
+
 
     async fn send_connection_knowledge_messages(&self, msgs: Vec<Vec<ConnectionKnowledgeMessage>>) {
         for (index, msg) in msgs.into_iter().enumerate() {
@@ -638,8 +582,8 @@ pub struct ConnectionKnowledge {
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
     peer_index: usize,
-    headers_not_known: Vec<VecDeque<(Round, AHashSet<BlockRef>)>>,
-    shards_not_known: Vec<VecDeque<(Round, AHashSet<BlockRef>)>>,
+    headers_not_known: Vec<BTreeMap<Round, AHashSet<BlockRef>>>,
+    shards_not_known: Vec<BTreeMap<Round, AHashSet<BlockRef>>>,
     last_useful_shards_to_peer_round: Vec<Round>,
     last_useful_headers_to_peer_round: Vec<Round>,
     last_useful_shards_from_peer_round: Vec<Round>,
@@ -664,8 +608,8 @@ impl ConnectionKnowledge {
         receiver: Receiver<Vec<ConnectionKnowledgeMessage>>,
     ) -> Self {
         let num_authorities = context.committee.size();
-        let headers_not_known = vec![VecDeque::new(); num_authorities];
-        let shards_not_known = vec![VecDeque::new(); num_authorities];
+        let headers_not_known = vec![BTreeMap::new(); num_authorities];
+        let shards_not_known = vec![BTreeMap::new(); num_authorities];
         Self {
             dag_state,
             last_useful_headers_to_peer_round: vec![GENESIS_ROUND; num_authorities],
@@ -679,194 +623,101 @@ impl ConnectionKnowledge {
             receiver,
         }
     }
-
-    #[inline]
-    fn round_to_index<T>(deque: &VecDeque<(Round, T)>, round: Round) -> Option<usize> {
-        let (front_round, _) = deque.front()?;
-        if round < *front_round {
-            return None;
-        }
-        let index = (round - *front_round) as usize;
-        (index < deque.len()).then_some(index)
-    }
-
-    /// Find the minimum front round among the given authorities’ deques.
-    /// Returns `None` if all selected deques are empty.
-    #[inline]
-    fn min_front_round<'a, T>(
-        all_deques: &[VecDeque<(Round, T)>],
-        authorities: impl IntoIterator<Item = &'a usize>,
-    ) -> Option<Round> {
-        let mut min_round: Option<Round> = None;
-        for authority in authorities {
-            if let Some((round, _)) = all_deques[*authority].front() {
-                min_round = Some(min_round.map_or(*round, |m| m.min(*round)));
-            }
-        }
-        min_round
-    }
-
-    #[inline]
-    fn ensure_round_in_deque(
-        deque: &mut VecDeque<(Round, AHashSet<BlockRef>)>,
-        target_round: Round,
-    ) -> Option<usize> {
-        // 1. If deque is empty, initialize with this round
-        if deque.is_empty() {
-            deque.push_back((target_round, AHashSet::default()));
-            return Some(0);
-        }
-
-        let front_round = deque.front().unwrap().0;
-        let back_round = deque.back().unwrap().0;
-
-        // 2. If round is older than the current window → skip (already evicted)
-        if target_round < front_round {
-            return None;
-        }
-
-        // 3. Extend forward up to the requested round
-        if target_round > back_round {
-            for current_round in (back_round + 1)..=target_round {
-                deque.push_back((current_round, AHashSet::default()));
-            }
-        }
-
-        // 4. Compute index for this round
-        let idx = (target_round - front_round) as usize;
-        Some(idx)
-    }
-    /// Block ref selection:
-    ///  - iterate rounds from the earliest available among `useful_authorities`
-    ///    up to (but excluding) `round_upper_bound_exclusive`,
-    ///  - for each round, scan only the given `useful_authorities`,
-    ///  - collect up to `max_headers_per_bundle`,
-    ///  - then remove them from this connection’s unknown sets.
-    fn take_useful_block_refs_round(
-        &mut self,
+    fn take_useful_refs_round(
+        maps: &mut Vec<BTreeMap<Round, AHashSet<BlockRef>>>,
         round_upper_bound_exclusive: Round,
         useful_authorities: &[usize],
+        max_take: usize,
     ) -> Vec<BlockRef> {
-        let max_take = self.context.parameters.max_headers_per_bundle;
-
-        // Nothing to do
         if useful_authorities.is_empty() || max_take == 0 {
             return Vec::new();
         }
 
-        // Start from the earliest front round across the selected authorities.
-        let Some(min_round) =
-            Self::min_front_round(&self.headers_not_known, useful_authorities.iter())
-        else {
+        // Find the smallest existing round among all useful authorities.
+        let min_round = useful_authorities
+            .iter()
+            .filter_map(|&auth| maps[auth].keys().next().copied())
+            .min();
+
+        let Some(mut current_round) = min_round else {
             return Vec::new();
         };
 
-        let mut current_round = min_round;
-
-        let mut taken: Vec<BlockRef> = Vec::with_capacity(max_take);
+        let mut taken = Vec::with_capacity(max_take);
 
         'outer: while current_round < round_upper_bound_exclusive {
-            for authority in useful_authorities {
-                let deque = &self.headers_not_known[*authority];
-
-                // If this authority has this round bucket, take from it.
-                if let Some(index) = Self::round_to_index(deque, current_round) {
-                    // Iterate the set without mutating it yet.
-                    for block_ref in deque[index].1.iter() {
-                        taken.push(*block_ref);
+            for &authority in useful_authorities {
+                let map = &maps[authority];
+                if let Some(blocks) = map.get(&current_round) {
+                    for &block_ref in blocks {
+                        taken.push(block_ref);
                         if taken.len() >= max_take {
                             break 'outer;
                         }
                     }
                 }
             }
-            // advance round
             current_round = current_round.saturating_add(1);
         }
 
-        // Remove the selected ones from local unknown sets.
+        // Remove the taken blocks from the corresponding authorities
         for block_ref in &taken {
             let authority = block_ref.author.value();
-            let deque = &mut self.headers_not_known[authority];
-            if let Some(index) = Self::round_to_index(deque, block_ref.round) {
-                deque[index].1.remove(block_ref);
+            if let Some(set) = maps[authority].get_mut(&block_ref.round) {
+                set.remove(block_ref);
+                // Optional cleanup: remove empty rounds to keep map small
+                if set.is_empty() {
+                    maps[authority].remove(&block_ref.round);
+                }
             }
         }
 
         taken
     }
 
-    /// Same as `take_useful_block_refs_round` but for shards.
+    fn take_useful_header_block_refs_round(
+        &mut self,
+        round_upper_bound_exclusive: Round,
+        useful_authorities: &[usize],
+    ) -> Vec<BlockRef> {
+        let max_take = self.context.parameters.max_headers_per_bundle;
+        Self::take_useful_refs_round(
+            &mut self.headers_not_known,
+            round_upper_bound_exclusive,
+            useful_authorities,
+            max_take,
+        )
+    }
+
     fn take_useful_shard_block_refs_round(
         &mut self,
         round_upper_bound_exclusive: Round,
         useful_authorities: &[usize],
     ) -> Vec<BlockRef> {
         let max_take = self.context.parameters.max_shards_per_bundle;
-
-        if useful_authorities.is_empty() || max_take == 0 {
-            return Vec::new();
-        }
-
-        let Some(min_round) =
-            Self::min_front_round(&self.shards_not_known, useful_authorities.iter())
-        else {
-            return Vec::new();
-        };
-
-        let mut current_round = min_round;
-
-        let mut taken: Vec<BlockRef> = Vec::with_capacity(max_take);
-
-        'outer: while current_round < round_upper_bound_exclusive {
-            for authority in useful_authorities {
-                let deque = &self.shards_not_known[*authority];
-
-                if let Some(index) = Self::round_to_index(deque, current_round) {
-                    for block_ref in deque[index].1.iter() {
-                        taken.push(*block_ref);
-                        if taken.len() >= max_take {
-                            break 'outer;
-                        }
-                    }
-                }
-            }
-            // Advance round
-            current_round = current_round.saturating_add(1);
-        }
-
-        // Remove the selected ones from unknown sets
-        for block_ref in &taken {
-            let authority = block_ref.author.value();
-            let deque = &mut self.shards_not_known[authority];
-            if let Some(index) = Self::round_to_index(deque, block_ref.round) {
-                deque[index].1.remove(block_ref);
-            }
-        }
-
-        taken
+        Self::take_useful_refs_round(
+            &mut self.shards_not_known,
+            round_upper_bound_exclusive,
+            useful_authorities,
+            max_take,
+        )
     }
+
+
 
     fn evict_below(&mut self, rounds_exclusive: Vec<Round>) {
-        for (index, deque) in self.headers_not_known.iter_mut().enumerate() {
-            while let Some((front_round, _)) = deque.front() {
-                if *front_round < rounds_exclusive[index] {
-                    deque.pop_front();
-                } else {
-                    break;
-                }
-            }
+        for (index, map) in self.headers_not_known.iter_mut().enumerate() {
+            let threshold_round = rounds_exclusive[index];
+            // Keep only entries >= threshold
+            *map = map.split_off(&threshold_round);
         }
-        for (index, deque) in self.shards_not_known.iter_mut().enumerate() {
-            while let Some((front_round, _)) = deque.front() {
-                if *front_round < rounds_exclusive[index] {
-                    deque.pop_front();
-                } else {
-                    break;
-                }
-            }
+
+        for (index, map) in self.shards_not_known.iter_mut().enumerate() {
+            let threshold_round = rounds_exclusive[index];
+            *map = map.split_off(&threshold_round);
         }
     }
+
 
     /// Async task loop — just receives messages and dispatches to processing
     /// logic.
@@ -1012,7 +863,7 @@ impl ConnectionKnowledge {
             useful_headers_authors_to_peer
         );
 
-        let useful_headers_block_refs_to_peer = self.take_useful_block_refs_round(
+        let useful_headers_block_refs_to_peer = self.take_useful_header_block_refs_round(
             round_upper_bound_exclusive,
             &useful_headers_authors_to_peer,
         );
@@ -1093,12 +944,12 @@ impl ConnectionKnowledge {
     fn handle_new_header(&mut self, block_ref: BlockRef) {
         let round = block_ref.round;
         let authority = block_ref.author.value();
-        if let Some(index) =
-            Self::ensure_round_in_deque(&mut self.headers_not_known[authority], round)
-        {
-            let (_r, set) = &mut self.headers_not_known[authority][index];
-            set.insert(block_ref);
-        }
+
+        // Insert the block into the set for that (authority, round)
+        self.headers_not_known[authority]
+            .entry(round)
+            .or_default()
+            .insert(block_ref);
     }
 
     /// Handles adding a new shard to the unknown set.
@@ -1106,31 +957,37 @@ impl ConnectionKnowledge {
         let round = block_ref.round;
         let authority = block_ref.author.value();
 
-        if let Some(index) =
-            Self::ensure_round_in_deque(&mut self.shards_not_known[authority], round)
-        {
-            let (_r, set) = &mut self.shards_not_known[authority][index];
-            set.insert(block_ref);
-        }
+        self.shards_not_known[authority]
+            .entry(round)
+            .or_default()
+            .insert(block_ref);
     }
 
     /// Handles removing a header that this peer now knows.
     fn handle_remove_header(&mut self, block_ref: BlockRef) {
         let authority = block_ref.author.value();
         let round = block_ref.round;
-        if let Some(index) = Self::round_to_index(&self.headers_not_known[authority], round) {
-            let (_r, set) = &mut self.headers_not_known[authority][index];
+
+        if let Some(set) = self.headers_not_known[authority].get_mut(&round) {
             set.remove(&block_ref);
+            // Optional: remove empty round entries to keep map clean
+            if set.is_empty() {
+                self.headers_not_known[authority].remove(&round);
+            }
         }
     }
 
     /// Handles removing a shard that this peer now knows.
     fn handle_remove_shard(&mut self, block_ref: BlockRef) {
-        let round = block_ref.round;
         let authority = block_ref.author.value();
-        if let Some(index) = Self::round_to_index(&self.shards_not_known[authority], round) {
-            let (_r, set) = &mut self.shards_not_known[authority][index];
+        let round = block_ref.round;
+
+        if let Some(set) = self.shards_not_known[authority].get_mut(&round) {
             set.remove(&block_ref);
+            if set.is_empty() {
+                self.shards_not_known[authority].remove(&round);
+            }
         }
     }
+
 }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -117,6 +117,17 @@ pub enum CordialKnowledgeMessage {
     UsefulShardsFromPeers(BTreeMap<AuthorityIndex, Round>),
 }
 
+impl CordialKnowledgeMessage {
+    fn display_type(&self) -> &'static str {
+        match self {
+            CordialKnowledgeMessage::NewHeader(_) => "New Header",
+            CordialKnowledgeMessage::NewShard(_) => "New Shard",
+            CordialKnowledgeMessage::EvictBelow(_) => "Eviction",
+            CordialKnowledgeMessage::UsefulShardsFromPeers(_) => "Useful Authors for Shards",
+        }
+    }
+}
+
 /// Handle to the CordialKnowledge task, allowing interaction and graceful
 /// shutdown.
 pub struct CordialKnowledgeHandle {
@@ -266,8 +277,6 @@ impl CordialKnowledge {
     /// evictions) from DAG state and updates global knowledge + notifies
     /// per-connection tasks.
     pub async fn run(mut self) {
-        fail_point_async!("consensus-rpc-response");
-
         debug!("Cordial Knowledge main loop started");
 
         loop {
@@ -302,7 +311,7 @@ impl CordialKnowledge {
         );
         let message_type: &'static str = match cordial_knowledge_message {
             CordialKnowledgeMessage::NewHeader(header) => {
-                self.handle_new_header(header).await;
+                self.update_cordial_knowledge(&header).await;
                 "header"
             }
             CordialKnowledgeMessage::NewShard(block_ref) => {
@@ -372,10 +381,6 @@ impl CordialKnowledge {
         }
     }
 
-    /// Called when a new verified block header is received.
-    async fn handle_new_header(&mut self, header: VerifiedBlockHeader) {
-        self.update_cordial_knowledge(&header).await;
-    }
 
     /// Called when a new own shard (created locally) is added to dag state.
     async fn handle_new_shard(&mut self, block_ref: BlockRef) {
@@ -468,6 +473,7 @@ impl CordialKnowledge {
         // === 2) Notify all *other* authorities (except self and block_author) about
         // new header ===
         for (authority, msgs) in vec_knowledge_msgs.iter_mut().enumerate() {
+            // don't send shard to self nor to the author of the block
             if authority == block_author || authority == own_index {
                 continue;
             }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -811,7 +811,6 @@ impl ConnectionKnowledge {
             for knowledge_msg in knowledge_msgs {
                 self.process_message(knowledge_msg).await;
             }
-            tokio::task::yield_now().await;
         }
 
         debug!(

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -283,14 +283,6 @@ impl CordialKnowledge {
                         .node_metrics
                         .cordial_knowledge_buffer_size
                         .set(buffer_size as i64);
-
-                    // Drain the rest of the buffer without awaiting
-                    while let Ok(msg) = self.cordial_knowledge_receiver.try_recv() {
-                        self.process_message(msg).await;
-                    }
-
-                    // Yield to give other tasks a chance before looping again
-                    tokio::task::yield_now().await;
                 }
                 None => {
                     debug!("Cordial Knowledge channel closed; exiting loop");

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
+    collections::{BTreeMap, BTreeSet},
     sync::Arc,
 };
 
@@ -426,7 +426,7 @@ impl CordialKnowledge {
         // === 1) Ensure we have a round map for this author and insert the block if new
         // ===
         let btree_map = &mut self.cordial_knowledge[block_author];
-        let round_map = btree_map.entry(block_round).or_insert_with(AHashMap::new);
+        let round_map = btree_map.entry(block_round).or_default();
 
         // Already recorded — nothing else to do.
         if round_map.contains_key(&block_digest) {
@@ -677,7 +677,7 @@ impl ConnectionKnowledge {
     /// up to the given round (exclusive), up to max_take total.
     /// Used for both headers and shards.
     fn take_useful_refs_round(
-        maps: &mut Vec<BTreeMap<Round, AHashSet<BlockRef>>>,
+        maps: &mut [BTreeMap<Round, AHashSet<BlockRef>>],
         round_upper_bound_exclusive: Round,
         useful_authorities: &[usize],
         max_take: usize,
@@ -1052,6 +1052,145 @@ impl ConnectionKnowledge {
             set.remove(&block_ref);
             if set.is_empty() {
                 self.shards_not_known[authority].remove(&round);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+    use tokio::time::sleep;
+
+    use super::*;
+    use crate::{
+        block_header::{VerifiedBlock, VerifiedOwnShard},
+        context::Context,
+        dag_state::DagState,
+        storage::mem_store::MemStore,
+        test_dag_parser::parse_dag,
+    };
+
+    #[tokio::test]
+    async fn test_cordial_knowledge_bundle_with_byzantine() {
+        telemetry_subscribers::init_for_testing();
+        // GIVEN
+        let validators = 4;
+        let our_index = AuthorityIndex::new_for_test(0);
+        let to_whom_index = AuthorityIndex::new_for_test(1);
+        let (context, key_pairs) = Context::new_for_test(validators);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
+        // Set up DAG with blocks
+        let protocol_keypairs = key_pairs.iter().map(|kp| kp.1.clone()).collect();
+        // Validator D does not disseminate its blocks.
+        // Validator A will learn about D's blocks only at round 6.
+        // After that, A should be able to send all D's blocks to B.
+        let dag_str = "DAG {
+                Round 0 : { 4 },
+                Round 1 :  { * },
+                Round 2 : {
+                    A -> [-D1],
+                    B -> [-D1],
+                    C -> [-D1],
+                    D -> [*],
+                },
+                Round 3 : {
+                    A -> [-D2],
+                    B -> [-D2],
+                    C -> [-D2],
+                    D -> [*],
+                },
+                Round 4 : {
+                    A -> [-D3],
+                    B -> [-D3],
+                    C -> [-D3],
+                    D -> [*],
+                },
+                Round 5 : {
+                    A -> [-D4],
+                    B -> [-D4],
+                    C -> [-D4],
+                    D -> [*],
+                },
+                Round 6 : {
+                    A -> [*],
+                    B -> [-D5],
+                    C -> [-D5],
+                    D -> [*],
+                },
+
+             }";
+        let rounds = 6;
+        let result = parse_dag(dag_str);
+        assert!(result.is_ok());
+
+        let mut dag_builder = result.unwrap().set_protocol_keypair(protocol_keypairs);
+        dag_builder.layers(1..=rounds).build();
+
+        // Get all blocks by rounds
+        let mut all_blocks: Vec<Vec<VerifiedBlock>> = vec![];
+        for round in 0..=rounds {
+            all_blocks.push(dag_builder.blocks(round..=round));
+        }
+
+        let connection_knowledge =
+            cordial_knowledge.connection_knowledge_senders[to_whom_index].clone();
+
+        // Add block to DAG state and automatically update cordial knowledge
+        for round in 0..=rounds - 1 {
+            // add all blocks of this round and our block of next round to dag state
+            for block in all_blocks[round as usize]
+                .iter()
+                .chain(std::iter::once(&all_blocks[round as usize + 1][our_index]))
+            {
+                let VerifiedBlock {
+                    verified_block_header,
+                    verified_transactions,
+                } = block.clone();
+                dag_state.write().accept_block_header(verified_block_header);
+                let shard_for_core = VerifiedOwnShard {
+                    serialized_shard: Bytes::from([0u8; 32].to_vec()), // put some dummy shard data
+                    block_ref: verified_transactions.block_ref(),
+                };
+                dag_state.write().add_shard(shard_for_core);
+            }
+            sleep(std::time::Duration::from_millis(1)).await; // give some time for cordial knowledge to update
+            // By default, for MAX_ROUND_GAP_FOR_USEFUL_PARTS rounds, all unknown
+            // shards/headers are useful
+            let (tx, rx) = oneshot::channel();
+            let msg = ConnectionKnowledgeMessage::TakeAdditionalPartForBundle {
+                round_upper_bound_exclusive: round + 1,
+                respond_to: tx,
+            };
+            connection_knowledge.send(vec![msg]).await.unwrap();
+            let additional_parts = rx.await.unwrap();
+            let AdditionalPartsForBundle {
+                headers, shards, ..
+            } = additional_parts;
+            // In rounds 0..=5, A should not know any of D's blocks, so no headers or shards
+            // should be sent to B.
+            if round <= 5 {
+                assert!(
+                    headers
+                        .iter()
+                        .all(|h| h.author() != AuthorityIndex::new_for_test(3))
+                );
+                assert_eq!(headers.len(), 1);
+            } else {
+                // In round 6, A should know about D's blocks and send them all to B
+                let d_headers: Vec<&VerifiedBlockHeader> = headers
+                    .iter()
+                    .filter(|h| h.author() == AuthorityIndex::new_for_test(3))
+                    .collect();
+                assert_eq!(d_headers.len(), 5);
+                // Validator A sends to B all 5 shards of D's blocks and 1 shard of C's block of
+                // round 5
+                assert_eq!(shards.len(), 6);
             }
         }
     }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -447,8 +447,7 @@ impl CordialKnowledge {
                 .map(|_| Vec::new())
                 .collect();
 
-        // === 1) Ensure we have a round map for this author and insert the block if new
-        // ===
+        // 1) Ensure we have a round map for this author and insert the block if new
         let btree_map = &mut self.cordial_knowledge[block_author];
         let round_map = btree_map.entry(block_round).or_default();
 
@@ -462,8 +461,8 @@ impl CordialKnowledge {
         let who_knows_this_block = SubsetAuthorities::new_with(block_author, own_index);
         round_map.insert(block_digest, (ancestors.clone(), who_knows_this_block));
 
-        // === 2) Notify all *other* authorities (except self and block_author) about
-        // new header ===
+        // 2) Notify all *other* authorities (except self and block_author) about new
+        //    header
         for (authority, msgs) in vec_knowledge_msgs.iter_mut().enumerate() {
             // don't send shard to self nor to the author of the block
             if authority == block_author || authority == own_index {
@@ -472,15 +471,14 @@ impl CordialKnowledge {
             msgs.push(ConnectionKnowledgeMessage::NewHeader { block_ref });
         }
 
-        // === 3) The block_author now acknowledges previously known transactions ===
+        // 3) The block_author now acknowledges previously known transactions
         for acknowledgment in header.acknowledgments() {
             vec_knowledge_msgs[block_author].push(ConnectionKnowledgeMessage::RemoveShard {
                 block_ref: *acknowledgment,
             });
         }
 
-        // === 4) Traversing back and marking the causal past as known by block_author
-        // ===
+        // 4) Traversing back and marking the causal past as known by block_author
         let mut stack = vec![block_ref];
         while let Some(current_ref) = stack.pop() {
             let current_author = current_ref.author.value();
@@ -523,7 +521,7 @@ impl CordialKnowledge {
             }
         }
 
-        // === 5) Send all accumulated knowledge messages ===
+        // 5) Send all accumulated knowledge messages
         self.send_connection_knowledge_messages(vec_knowledge_msgs)
             .await;
     }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -638,8 +638,8 @@ impl ConnectionKnowledge {
         receiver: Receiver<Vec<ConnectionKnowledgeMessage>>,
     ) -> Self {
         let num_authorities = context.committee.size();
-        let headers_not_known = Vec::with_capacity(num_authorities);
-        let shards_not_known = Vec::with_capacity(num_authorities);
+        let headers_not_known = vec![VecDeque::new(); num_authorities];
+        let shards_not_known = vec![VecDeque::new(); num_authorities];
         Self {
             dag_state,
             last_useful_headers_to_peer_round: vec![GENESIS_ROUND; num_authorities],
@@ -845,7 +845,7 @@ impl ConnectionKnowledge {
     /// Async task loop — just receives messages and dispatches to processing
     /// logic.
     pub async fn run(mut self) {
-        tracing::debug!("Connection Knowledge started for peer {}", self.peer_index);
+        debug!("Connection Knowledge started for peer {}", self.peer_index);
 
         while let Some(knowledge_msgs) = self.receiver.recv().await {
             for knowledge_msg in knowledge_msgs {
@@ -854,7 +854,7 @@ impl ConnectionKnowledge {
             tokio::task::yield_now().await;
         }
 
-        tracing::debug!(
+        debug!(
             "Connection Knowledge loop ended for peer {}",
             self.peer_index
         );

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -911,7 +911,8 @@ impl ConnectionKnowledge {
     }
 
     /// Handles taking additional parts (headers, shards) for a block bundle
-    /// to send to the peer.
+    /// to send to the peer. In addition, it returns block from which authors
+    /// have useful headers and shards from the peer.
     /// This is an async function because it reads from the DAG state and
     /// sends the response back via oneshot channel.
     async fn handle_take_additional_parts_for_bundle(

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     sync::Arc,
-    time::Duration,
 };
 
 use ahash::{AHashMap, AHashSet};
@@ -16,7 +15,6 @@ use tokio::{
         oneshot,
     },
     task::JoinError,
-    time::{Instant, sleep_until},
 };
 use tracing::{debug, warn};
 
@@ -240,46 +238,31 @@ impl CordialKnowledge {
 
         debug!("Cordial Knowledge main loop started");
 
-        const DISSEMINATE_TO_CONNECTION_KNOWLEDGE_TIMEOUT: Duration = Duration::from_millis(10);
-
-        // Start a recurring timeout timer (if you plan to use it later)
-        let dissemination_timeout =
-            sleep_until(Instant::now() + DISSEMINATE_TO_CONNECTION_KNOWLEDGE_TIMEOUT);
-        tokio::pin!(dissemination_timeout);
-
         loop {
-            tokio::select! {
-                // Main channel to receive message for updating the state and propogate to connection tasks
-                maybe_msg = self.cordial_knowledge_receiver.recv() => {
-                    debug!("Cordial knowledge message {maybe_msg:?} received");
-                    match maybe_msg {
-                        Some(cordial_knowledge_message) => {
-                            match cordial_knowledge_message {
-                                CordialKnowledgeMessage::NewHeader(header) => {
-                                    self.handle_new_header(header);
-                                }
-                                CordialKnowledgeMessage::NewShard(block_ref) => {
-                                    self.handle_new_shard(block_ref);
-                                }
-                                CordialKnowledgeMessage::EvictBelow(round) => {
-                                    self.handle_evict_below(round);
-                                }
-                                CordialKnowledgeMessage::UsefulShardsFromPeer(useful_shards_from_peer) => {
-                                    self.handle_useful_shards_from(useful_shards_from_peer);
-                                }
-                            }
-                        }
-                        None => {
-                            debug!("Cordial Knowledge channel closed; exiting loop");
-                            break;
-                        }
-                    }
-                }
+            match self.cordial_knowledge_receiver.recv().await {
+                Some(msg) => {
+                    // Handle the first received message
+                    self.process_message(msg).await;
 
-                //
-                _ = &mut dissemination_timeout => {
-                    dissemination_timeout.as_mut().reset(Instant::now() + DISSEMINATE_TO_CONNECTION_KNOWLEDGE_TIMEOUT);
-                        self.disseminate_useful_info_to_connection_tasks().await;
+                    // Report the buffer size after processing the first message
+                    let buffer_size = self.cordial_knowledge_receiver.len() + 1;
+                    self.context
+                        .metrics
+                        .node_metrics
+                        .cordial_knowledge_buffer_size
+                        .set(buffer_size as i64);
+
+                    // Drain the rest of the buffer without awaiting
+                    while let Ok(msg) = self.cordial_knowledge_receiver.try_recv() {
+                        self.process_message(msg).await;
+                    }
+
+                    // Yield to give other tasks a chance before looping again
+                    tokio::task::yield_now().await;
+                }
+                None => {
+                    debug!("Cordial Knowledge channel closed; exiting loop");
+                    break;
                 }
             }
         }
@@ -287,7 +270,34 @@ impl CordialKnowledge {
         debug!("Cordial Knowledge main loop finished");
     }
 
-    fn handle_useful_shards_from(
+    async fn process_message(&mut self, cordial_knowledge_message: CordialKnowledgeMessage) {
+        debug!(
+            "Processing Cordial Message: {:?}",
+            cordial_knowledge_message
+        );
+        match cordial_knowledge_message {
+            CordialKnowledgeMessage::NewHeader(header) => {
+                self.handle_new_header(header).await;
+            }
+            CordialKnowledgeMessage::NewShard(block_ref) => {
+                self.handle_new_shard(block_ref).await;
+            }
+            CordialKnowledgeMessage::EvictBelow(round) => {
+                self.handle_evict_below(round).await;
+            }
+            CordialKnowledgeMessage::UsefulShardsFromPeer(useful_shards_from_peer) => {
+                self.handle_useful_shards_from(useful_shards_from_peer)
+                    .await;
+            }
+        }
+        self.context
+            .metrics
+            .node_metrics
+            .cordial_knowledge_processed_messages
+            .inc();
+    }
+
+    async fn handle_useful_shards_from(
         &mut self,
         useful_shards_from_peer: BTreeMap<AuthorityIndex, Round>,
     ) {
@@ -296,6 +306,7 @@ impl CordialKnowledge {
                 self.last_useful_shards_from_peer_round[authority] = round;
             }
         }
+        self.disseminate_useful_info_to_connection_tasks().await;
     }
 
     async fn disseminate_useful_info_to_connection_tasks(&mut self) {
@@ -313,20 +324,20 @@ impl CordialKnowledge {
     }
 
     /// Called when a new verified block header is received.
-    fn handle_new_header(&mut self, header: VerifiedBlockHeader) {
-        self.update_cordial_knowledge(&header);
+    async fn handle_new_header(&mut self, header: VerifiedBlockHeader) {
+        self.update_cordial_knowledge(&header).await;
     }
 
     /// Called when a new *own shard* (produced locally) is added.
-    fn handle_new_shard(&mut self, block_ref: BlockRef) {
+    async fn handle_new_shard(&mut self, block_ref: BlockRef) {
         for tx in &self.connections {
             let msg = ConnectionKnowledgeMessage::NewShard { block_ref };
-            let _ = tx.try_send(vec![msg]);
+            let _ = tx.send(vec![msg]).await;
         }
     }
 
     /// Called when older rounds should be pruned globally.
-    fn handle_evict_below(&mut self, rounds: Vec<Round>) {
+    async fn handle_evict_below(&mut self, rounds: Vec<Round>) {
         // Evict locally
         for (index, deque) in &mut self.cordial_knowledge.iter_mut().enumerate() {
             while let Some((front_round, _)) = deque.front() {
@@ -335,17 +346,23 @@ impl CordialKnowledge {
                 } else {
                     break;
                 }
+                self.context
+                    .metrics
+                    .node_metrics
+                    .cordial_knowledge_rounds
+                    .with_label_values(&[&index.to_string()])
+                    .set(deque.len() as i64);
             }
         }
 
         // Notify per-connection tasks about eviction
-        self.notify_connection_tasks_for_eviction(rounds);
+        self.notify_connection_tasks_for_eviction(rounds).await;
     }
     #[inline]
-    fn notify_connection_tasks_for_eviction(&self, rounds: Vec<Round>) {
+    async fn notify_connection_tasks_for_eviction(&self, rounds: Vec<Round>) {
         for tx in &self.connections {
             let msg = ConnectionKnowledgeMessage::EvictBelow(rounds.clone());
-            let _ = tx.try_send(vec![msg]);
+            let _ = tx.send(vec![msg]).await;
         }
     }
 
@@ -401,7 +418,7 @@ impl CordialKnowledge {
     /// - Only grows the author's deque if needed.
     /// - For other authorities' "unknown headers" deques, we add the block only
     ///   if the round bucket already exists (no growth).
-    fn update_cordial_knowledge(&mut self, header: &VerifiedBlockHeader) {
+    async fn update_cordial_knowledge(&mut self, header: &VerifiedBlockHeader) {
         let block_ref = header.reference();
         let block_author = block_ref.author.value();
         let block_round = block_ref.round;
@@ -427,7 +444,11 @@ impl CordialKnowledge {
         author_round_map.insert(block_digest, (ancestors, who_knows_this_block));
 
         //  === 2) Mark this header as "unknown" for other authorities  ===
-        for (other_idx, item) in vec_knowledge_msgs.iter_mut().enumerate().take(self.context.committee.size()) {
+        for (other_idx, item) in vec_knowledge_msgs
+            .iter_mut()
+            .enumerate()
+            .take(self.context.committee.size())
+        {
             if other_idx == block_author || other_idx == own_index {
                 continue;
             }
@@ -497,13 +518,14 @@ impl CordialKnowledge {
                 }
             }
         }
-        self.send_connection_knowledge_messages(vec_knowledge_msgs);
+        self.send_connection_knowledge_messages(vec_knowledge_msgs)
+            .await;
     }
 
-    fn send_connection_knowledge_messages(&self, msgs: Vec<Vec<ConnectionKnowledgeMessage>>) {
+    async fn send_connection_knowledge_messages(&self, msgs: Vec<Vec<ConnectionKnowledgeMessage>>) {
         for (index, msg) in msgs.into_iter().enumerate() {
             if !msg.is_empty() {
-                let _ = self.connections[index].try_send(msg);
+                let _ = self.connections[index].send(msg).await;
             }
         }
     }
@@ -567,6 +589,7 @@ impl CordialKnowledge {
     }
 }
 
+#[derive(Debug)]
 pub enum ConnectionKnowledgeMessage {
     /// A new block header was added globally.
     NewHeader { block_ref: BlockRef },
@@ -623,6 +646,7 @@ pub struct ConnectionKnowledge {
     receiver: Receiver<Vec<ConnectionKnowledgeMessage>>,
 }
 
+#[derive(Debug)]
 pub(crate) struct AdditionalPartsForBundle {
     pub headers: Vec<VerifiedBlockHeader>,
     pub shards: Vec<Bytes>,
@@ -848,6 +872,7 @@ impl ConnectionKnowledge {
         debug!("Connection Knowledge started for peer {}", self.peer_index);
 
         while let Some(knowledge_msgs) = self.receiver.recv().await {
+            debug!("Received knowledge message: {:?}", knowledge_msgs);
             for knowledge_msg in knowledge_msgs {
                 self.process_message(knowledge_msg).await;
             }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -18,7 +18,7 @@ use tokio::{
     task::JoinError,
     time::{Instant, sleep_until},
 };
-use tracing::{debug, log::warn};
+use tracing::{debug, warn};
 
 use crate::{
     BlockHeaderAPI, BlockRef, Round, VerifiedBlockHeader,
@@ -426,12 +426,12 @@ impl CordialKnowledge {
         author_round_map.insert(block_digest, (ancestors, who_knows_this_block));
 
         //  === 2) Mark this header as "unknown" for other authorities  ===
-        for other_idx in 0..self.context.committee.size() {
+        for (other_idx, item) in vec_knowledge_msgs.iter_mut().enumerate().take(self.context.committee.size()) {
             if other_idx == block_author || other_idx == own_index {
                 continue;
             }
             let msg = ConnectionKnowledgeMessage::NewHeader { block_ref };
-            vec_knowledge_msgs[other_idx].push(msg);
+            item.push(msg);
         }
 
         //  === 3) Notify that the block_author now knows transaction data for certain
@@ -667,7 +667,7 @@ impl ConnectionKnowledge {
     /// Returns `None` if all selected deques are empty.
     #[inline]
     fn min_front_round<'a, T>(
-        all_deques: &Vec<VecDeque<(Round, T)>>,
+        all_deques: &[VecDeque<(Round, T)>],
         authorities: impl IntoIterator<Item = &'a usize>,
     ) -> Option<Round> {
         let mut min_round: Option<Round> = None;
@@ -976,7 +976,7 @@ impl ConnectionKnowledge {
             dag_state_read
                 .get_cached_block_headers(&useful_headers_block_refs_to_peer)
                 .into_iter()
-                .filter_map(|opt| opt) // Filter out None values
+                .flatten() // Filter out None values
                 .collect()
         };
         // 2. Identify useful authorities for shards and take the corresponding shards
@@ -1002,7 +1002,7 @@ impl ConnectionKnowledge {
             dag_state_read
                 .get_cached_shards(&useful_shards_block_refs_to_peer)
                 .into_iter()
-                .filter_map(|opt| opt) // Filter out None values
+                .flatten() // Filter out None values
                 .collect()
         };
         // 3. Get useful header authors from peer

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -298,40 +298,46 @@ impl CordialKnowledge {
             "Processing Cordial Message: {:?}",
             cordial_knowledge_message
         );
+        let message_type: &str;
         match cordial_knowledge_message {
             CordialKnowledgeMessage::NewHeader(header) => {
                 self.handle_new_header(header).await;
+                message_type = "header";
             }
             CordialKnowledgeMessage::NewShard(block_ref) => {
                 self.handle_new_shard(block_ref).await;
+                message_type = "shard";
             }
             CordialKnowledgeMessage::EvictBelow(round) => {
                 self.handle_evict_below(round).await;
+                message_type = "eviction";
             }
             CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shards_from_peer) => {
                 self.handle_useful_shards_from(useful_shards_from_peer)
                     .await;
+                message_type = "useful_shards";
             }
         }
         self.context
             .metrics
             .node_metrics
             .cordial_knowledge_processed_messages
+            .with_label_values(&[message_type])
             .inc();
     }
 
     // Helper function to update authority rounds if the new round is greater
     fn update_authority_rounds_if_greater(
-        target: &mut Vec<Option<Round>>,
+        target: &mut [Option<Round>],
         updates: BTreeMap<AuthorityIndex, Round>,
     ) {
         for (authority, new_round) in updates {
-            if let Some(existing_round) = &mut target[authority] {
+            if let Some(existing_round) = &mut target[authority.value()] {
                 if new_round > *existing_round {
                     *existing_round = new_round;
                 }
             } else {
-                target[authority] = Some(new_round);
+                target[authority.value()] = Some(new_round);
             }
         }
     }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -355,6 +355,8 @@ impl CordialKnowledge {
             }
         }
 
+        self.context.metrics.node_metrics.cordial_knowledge_useful_shards.set()
+
         // Notify per-connection tasks about eviction
         self.notify_connection_tasks_for_eviction(rounds).await;
     }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,
@@ -365,7 +368,7 @@ impl CordialKnowledge {
     /// Disseminate updated useful info to all connection tasks.
     async fn disseminate_useful_info_to_connection_tasks(&mut self) {
         for connection_sender in &self.connections {
-            let msg = ConnectionKnowledgeMessage::UsefulInfo {
+            let msg = ConnectionKnowledgeMessage::UsefulAuthors {
                 useful_shards_from_peers: self.last_useful_shards_from_peer_round.clone(),
                 useful_headers_from_peer: BTreeMap::new(),
                 useful_headers_to_peer: BTreeMap::new(),
@@ -595,7 +598,7 @@ impl CordialKnowledge {
             .collect::<BTreeMap<_, _>>();
 
         // Notify connection knowledge about useful headers and shards to/from this peer
-        let connection_knowledge_message = ConnectionKnowledgeMessage::UsefulInfo {
+        let connection_knowledge_message = ConnectionKnowledgeMessage::UsefulAuthors {
             useful_headers_to_peer,
             useful_shards_to_peer,
             useful_headers_from_peer,
@@ -629,7 +632,7 @@ pub enum ConnectionKnowledgeMessage {
     /// Remove a header from the "unknown" set.
     RemoveShard { block_ref: BlockRef },
     /// Update useful info about which authorities are useful to/from the peer.
-    UsefulInfo {
+    UsefulAuthors {
         useful_headers_to_peer: BTreeMap<AuthorityIndex, Round>,
         useful_shards_to_peer: BTreeMap<AuthorityIndex, Round>,
         useful_headers_from_peer: BTreeMap<AuthorityIndex, Round>,
@@ -732,8 +735,8 @@ impl ConnectionKnowledge {
         'outer: while current_round < round_upper_bound_exclusive {
             for &authority in useful_authorities {
                 let map = &maps[authority];
-                if let Some(blocks) = map.get(&current_round) {
-                    for &block_ref in blocks {
+                if let Some(block_refs_from_authority_in_round) = map.get(&current_round) {
+                    for &block_ref in block_refs_from_authority_in_round {
                         taken.push(block_ref);
                         if taken.len() >= max_take {
                             break 'outer;
@@ -741,16 +744,18 @@ impl ConnectionKnowledge {
                     }
                 }
             }
-            current_round = current_round.saturating_add(1);
+            current_round = current_round + 1;
         }
 
         // Remove the taken blocks from the corresponding authorities
         for block_ref in &taken {
             let authority = block_ref.author.value();
-            if let Some(set) = maps[authority].get_mut(&block_ref.round) {
-                set.remove(block_ref);
-                // Optional cleanup: remove empty rounds to keep map small
-                if set.is_empty() {
+            if let Some(block_refs_from_authority_in_round) =
+                maps[authority].get_mut(&block_ref.round)
+            {
+                block_refs_from_authority_in_round.remove(block_ref);
+                // Remove empty rounds to keep map small
+                if block_refs_from_authority_in_round.is_empty() {
                     maps[authority].remove(&block_ref.round);
                 }
             }
@@ -791,7 +796,7 @@ impl ConnectionKnowledge {
         )
     }
 
-    /// Evict al connection knowledge below the given rounds (exclusive)
+    /// Evict all connection knowledge below the given rounds (exclusive)
     fn evict_below(&mut self, rounds_exclusive: Vec<Round>) {
         for (index, map) in self.headers_not_known.iter_mut().enumerate() {
             let threshold_round = rounds_exclusive[index];
@@ -805,13 +810,12 @@ impl ConnectionKnowledge {
         }
     }
 
-    /// Async task loop — just receives messages and dispatches to processing
+    /// Async task loop —  receives messages and dispatches to processing
     /// logic.
     pub async fn run(mut self) {
         debug!("Connection Knowledge started for peer {}", self.peer_index);
 
         while let Some(knowledge_msgs) = self.receiver.recv().await {
-            debug!("Received knowledge message: {:?}", knowledge_msgs);
             for knowledge_msg in knowledge_msgs {
                 self.process_message(knowledge_msg).await;
             }
@@ -844,13 +848,13 @@ impl ConnectionKnowledge {
             ConnectionKnowledgeMessage::EvictBelow(rounds) => {
                 self.evict_below(rounds);
             }
-            ConnectionKnowledgeMessage::UsefulInfo {
+            ConnectionKnowledgeMessage::UsefulAuthors {
                 useful_headers_to_peer,
                 useful_shards_to_peer,
                 useful_headers_from_peer,
                 useful_shards_from_peers: useful_shards_from_peer,
             } => {
-                self.handle_useful_info(
+                self.handle_useful_authors(
                     useful_headers_to_peer,
                     useful_shards_to_peer,
                     useful_headers_from_peer,
@@ -872,7 +876,7 @@ impl ConnectionKnowledge {
 
     /// Handle useful info update from global CordialKnowledge or
     /// AuthorityService.
-    fn handle_useful_info(
+    fn handle_useful_authors(
         &mut self,
         useful_headers_to_peer: BTreeMap<AuthorityIndex, Round>,
         useful_shards_to_peer: BTreeMap<AuthorityIndex, Round>,
@@ -886,10 +890,14 @@ impl ConnectionKnowledge {
         self.handle_useful_shards_from(useful_shards_from_peer);
     }
 
+    /// Update last useful shards from peer rounds by copying the given vector
+    /// from Cordial Knowledge.
     fn handle_useful_shards_from(&mut self, useful_shards_from_peer_round: Vec<Option<Round>>) {
         self.last_useful_shards_from_peer_round = useful_shards_from_peer_round;
     }
 
+    /// Update last rounds of useful headers from peer. Iterate over the given
+    /// map (authority, round) and update only if the new round is greater.
     fn handle_useful_headers_from(
         &mut self,
         authorities_with_round: BTreeMap<AuthorityIndex, Round>,
@@ -900,6 +908,8 @@ impl ConnectionKnowledge {
         );
     }
 
+    /// Update last rounds of useful shards to peer. Iterate over the given map
+    /// (authority, round) and update only if the new round is greater.
     fn handle_useful_shards_to(&mut self, authorities_with_round: BTreeMap<AuthorityIndex, Round>) {
         CordialKnowledge::update_authority_rounds_if_greater(
             &mut self.last_useful_shards_to_peer_round,
@@ -907,6 +917,8 @@ impl ConnectionKnowledge {
         );
     }
 
+    /// Update last rounds of useful headers to peer. Iterate over the given map
+    /// (authority, round) and update only if the new round is greater.
     fn handle_useful_headers_to(
         &mut self,
         authorities_with_round: BTreeMap<AuthorityIndex, Round>,
@@ -918,8 +930,8 @@ impl ConnectionKnowledge {
     }
 
     /// Handles taking additional parts (headers, shards) for a block bundle
-    /// to send to the peer. In addition, it returns block from which authors
-    /// have useful headers and shards from the peer.
+    /// to send to the peer. In addition, it returns from which authors
+    /// the peer can send additional headers and shards to the peer.
     /// This is an async function because it reads from the DAG state and
     /// sends the response back via oneshot channel.
     async fn handle_take_additional_parts_for_bundle(
@@ -943,15 +955,13 @@ impl ConnectionKnowledge {
             .enumerate()
             .filter_map(|(i, &opt_round)| {
                 opt_round
-                    .filter(|&r| r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive)
+                    .filter(|&r| {
+                        r.saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS)
+                            >= round_upper_bound_exclusive
+                    })
                     .map(|_| i)
             })
             .collect();
-
-        debug!(
-            "Useful header authors to peer: {:?}",
-            useful_headers_authors_to_peer
-        );
 
         let useful_headers_block_refs_to_peer = self.take_useful_header_block_refs_round(
             round_upper_bound_exclusive,
@@ -975,7 +985,10 @@ impl ConnectionKnowledge {
             .enumerate()
             .filter_map(|(i, &opt_round)| {
                 opt_round
-                    .filter(|&r| r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive)
+                    .filter(|&r| {
+                        r.saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS)
+                            >= round_upper_bound_exclusive
+                    })
                     .map(|_| i)
             })
             .collect();
@@ -992,37 +1005,38 @@ impl ConnectionKnowledge {
                 .collect()
         };
 
-        // 4. Get useful header authors from peer
+        // 4. Get useful header authors from peer. Authority is (potentially) useful if
+        //    the
+        // last known useful round + MAX_ROUND_GAP_FOR_USEFUL_PARTS >=
+        // round_upper_bound_exclusive
         let useful_headers_authors_from_peer = self
             .last_useful_headers_from_peer_round
             .iter()
             .enumerate()
-            .filter_map(|(i, &opt_round)| {
+            .filter_map(|(index, &opt_round)| {
                 opt_round
-                    .filter(|&r| r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive)
-                    .map(|_| AuthorityIndex::from(i as u8))
+                    .filter(|&r| {
+                        r.saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS)
+                            >= round_upper_bound_exclusive
+                    })
+                    .map(|_| AuthorityIndex::from(index as u8))
             })
             .collect::<BTreeSet<AuthorityIndex>>();
-        debug!(
-            "Useful header authors from peer: {:?}",
-            useful_headers_authors_from_peer
-        );
 
         // 5. Get useful shard authors from peer
         let useful_shards_authors_from_peer = self
             .last_useful_shards_from_peer_round
             .iter()
             .enumerate()
-            .filter_map(|(i, &opt_round)| {
+            .filter_map(|(index, &opt_round)| {
                 opt_round
-                    .filter(|&r| r + MAX_ROUND_GAP_FOR_USEFUL_PARTS >= round_upper_bound_exclusive)
-                    .map(|_| AuthorityIndex::from(i as u8))
+                    .filter(|&r| {
+                        r.saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS)
+                            >= round_upper_bound_exclusive
+                    })
+                    .map(|_| AuthorityIndex::from(index as u8))
             })
             .collect::<BTreeSet<AuthorityIndex>>();
-        debug!(
-            "Useful shard authors from peer: {:?}",
-            useful_shards_authors_from_peer
-        );
 
         // 6. Build a response message and send it back
         let message = AdditionalPartsForBundle {
@@ -1035,7 +1049,7 @@ impl ConnectionKnowledge {
         respond_to.send(message).ok();
     }
 
-    /// Handles adding a new block to the unknown set.
+    /// Handles adding a new header to the set of potentially unknown headers
     fn handle_new_header(&mut self, block_ref: BlockRef) {
         let round = block_ref.round;
         let authority = block_ref.author.value();
@@ -1047,7 +1061,7 @@ impl ConnectionKnowledge {
             .insert(block_ref);
     }
 
-    /// Handles adding a new shard to the unknown set.
+    /// Handles adding a new shard to the set of potentially unknown shards.
     fn handle_new_shard(&mut self, block_ref: BlockRef) {
         let round = block_ref.round;
         let authority = block_ref.author.value();
@@ -1103,6 +1117,8 @@ mod tests {
         test_dag_parser::parse_dag,
     };
 
+    /// Test that cordial knowledge correctly tracks blocks from a byzantine
+    /// validator that does not disseminate its blocks until a certain round.
     #[tokio::test]
     async fn test_cordial_knowledge_bundle_with_byzantine() {
         telemetry_subscribers::init_for_testing();
@@ -1173,7 +1189,7 @@ mod tests {
         // Inject useful info for connection knowledge of peer 1 (B)
         // A says that C and D are useful for headers and shards when receiving from B
         // B says that A and C are useful for headers and shards when sending from A
-        let msg = ConnectionKnowledgeMessage::UsefulInfo {
+        let msg = ConnectionKnowledgeMessage::UsefulAuthors {
             useful_headers_to_peer: BTreeMap::from([
                 (AuthorityIndex::new_for_test(2), GENESIS_ROUND),
                 (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
@@ -1287,6 +1303,8 @@ mod tests {
         }
     }
 
+    /// Test that connection knowledge correctly takes additional parts for
+    /// a bundle based on useful authorities info.
     #[tokio::test]
     async fn test_connection_knowledge_take_additional_parts() {
         telemetry_subscribers::init_for_testing();
@@ -1305,7 +1323,7 @@ mod tests {
         let connection_knowledge_sender =
             cordial_knowledge.connection_knowledge_senders[to_whom_index].clone();
         // Inject useful info
-        let msg = ConnectionKnowledgeMessage::UsefulInfo {
+        let msg = ConnectionKnowledgeMessage::UsefulAuthors {
             useful_headers_to_peer: BTreeMap::from([
                 (AuthorityIndex::new_for_test(2), GENESIS_ROUND),
                 (AuthorityIndex::new_for_test(3), GENESIS_ROUND),

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -1,0 +1,794 @@
+use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
+use std::sync::Arc;
+use ahash::{AHashMap, AHashSet};
+use parking_lot::RwLock;
+use tokio::sync::mpsc::{channel, unbounded_channel, Receiver, Sender, UnboundedReceiver, UnboundedSender};
+use tokio::sync::Mutex;
+use tokio::task::{yield_now, JoinError};
+use tracing::{debug, warn};
+use starfish_config::AuthorityIndex;
+use crate::block_header::BlockHeaderDigest;
+use crate::{BlockHeaderAPI, BlockRef, Round, VerifiedBlockHeader};
+use crate::context::Context;
+
+/// Represents a subset of authorities using a bitmask.
+/// Each bit in the `low` and `high` fields corresponds to an authority index.
+/// The maximum number of authorities supported is 256 (0-255).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SubsetAuthorities {
+    low: u128,
+    high: u128,
+}
+
+pub type Ancestors = Arc<[BlockRef]>;
+impl SubsetAuthorities  {
+
+    #[inline]
+    pub fn new_with(author: usize, own: usize) -> Self {
+        let mut s = Self { low: 0, high: 0 };
+        s.insert(author);
+        s.insert(own);
+        s
+    }
+
+    /// Insert an authority into the subset. Returns true if the authority was not already present.
+    #[inline]
+    pub fn insert(&mut self, i: usize) -> bool {
+        if i < 128 {
+            let mask = 1u128 << i;
+            let already_present = (self.low & mask) != 0;
+            self.low |= mask;
+            !already_present
+        } else {
+            let bit = i - 128;
+            let mask = 1u128 << bit;
+            let already_present = (self.high & mask) != 0;
+            self.high |= mask;
+            !already_present
+        }
+    }
+}
+
+pub(crate) struct CordialKnowledge {
+    context: Arc<Context>,
+    /// Receives high-level updates from DAG state (new headers, new own shards, evictions)
+    cordial_knowledge_receiver: UnboundedReceiver<CordialKnowledgeMessage>,
+    /// Keeps track of the most recent DAG cordial
+    /// knowledge (who knows which blocks) for each authority. This is a helper
+    /// structure that is used primarily for traversing the recent DAG. This
+    /// struct is evicted after flushing the dag state to storage and is not
+    /// persisted. To access the cordial knowledge of a given block_ref, one
+    /// shall retrieve it from `cordial_knowledge[block_ref.
+    /// author][(block_ref.round, block_ref.digest)]`. The value is a tuple
+    /// of (parents, who knows the block header).
+    cordial_knowledge:
+        Vec<VecDeque<(Round, AHashMap<BlockHeaderDigest, (Ancestors, SubsetAuthorities)>)>>,
+    /// Per-connection message channels
+    connections: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
+}
+
+pub struct CordialKnowledgeHandle {
+    cordial_knowledge_sender: UnboundedSender<CordialKnowledgeMessage>,
+    connection_knowledge_senders: Vec<Sender<Vec<ConnectionKnowledgeMessage>>>,
+    connection_handles: Mutex<Vec<Option<tokio::task::JoinHandle<()>>>>,
+    join_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+impl CordialKnowledgeHandle{
+    /// Get a sender to send messages to the CordialKnowledge task.
+    pub fn cordial_knowledge_sender(&self) -> UnboundedSender<CordialKnowledgeMessage> {
+        self.cordial_knowledge_sender.clone()
+    }
+    /// Get a sender to send messages to a specific ConnectionKnowledge task.
+    pub fn connection_knowledge_senders(&self) -> Vec<Sender<Vec<ConnectionKnowledgeMessage>>> {
+        self.connection_knowledge_senders.clone()
+    }
+    /// Gracefully stop the CordialKnowledge background task and all connection tasks.
+    pub async fn stop(&self) -> Result<(), JoinError> {
+        // Stop main CordialKnowledge loop
+        let mut guard = self.join_handle.lock().await;
+
+        if let Some(main_handle) = guard.take() {
+            main_handle.abort();
+            match main_handle.await {
+                Ok(_) => (),
+                Err(e) if e.is_cancelled() => (),
+                Err(e) => return Err(e),
+            }
+        }
+
+        // --- Stop all per-connection tasks ---
+        let mut conn_guard = self.connection_handles.lock().await;
+        for handle_opt in conn_guard.iter_mut() {
+            if let Some(handle) = handle_opt.take() {
+                handle.abort();
+                match handle.await {
+                    Ok(_) => (),
+                    Err(e) if e.is_cancelled() => (),
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl CordialKnowledge {
+    pub fn new(
+        context: Arc<Context>,
+    ) -> (
+        Self,
+        UnboundedSender<CordialKnowledgeMessage>,
+        Vec<Receiver<Vec<ConnectionKnowledgeMessage>>>,
+    ) {
+        let num_authorities = context.committee.size();
+
+        // Main unbounded channel for high-level DAG updates
+        let (cordial_knowledge_sender, cordial_knowledge_receiver): (
+            UnboundedSender<CordialKnowledgeMessage>,
+            UnboundedReceiver<CordialKnowledgeMessage>,
+        ) = unbounded_channel();
+
+        // Bounded per-connection channels for controlled flow
+        let mut connections = Vec::new();
+        let mut receivers = Vec::new();
+
+        for _ in 0..num_authorities {
+            let (connection_sender, connection_receiver): (
+                Sender<Vec<ConnectionKnowledgeMessage>>,
+                Receiver<Vec<ConnectionKnowledgeMessage>>,
+            ) = channel(512);
+
+            connections.push(connection_sender);
+            receivers.push(connection_receiver);
+        }
+
+        (
+            Self {
+                context,
+                connections,
+                cordial_knowledge_receiver,
+                cordial_knowledge: vec![VecDeque::new(); num_authorities],
+            },
+            cordial_knowledge_sender,
+            receivers,
+        )
+    }
+
+    /// Start the CordialKnowledge task and return a handle to it.
+    pub fn start(
+        context: Arc<Context>,
+    ) -> Arc<CordialKnowledgeHandle> {
+        // Build main CordialKnowledge and associated channels
+        let (cordial_knowledge, sender, receivers) = CordialKnowledge::new(context.clone());
+        let num_authorities = context.committee.size();
+
+        let connection_knowledge_sender = cordial_knowledge.connections.clone();
+
+        // Spawn one ConnectionKnowledge task per authority
+        let mut connection_handles = Vec::with_capacity(num_authorities);
+
+        for (authority_index, receiver) in receivers.into_iter().enumerate() {
+            let connection_knowledge = ConnectionKnowledge::new(
+                context.clone(),
+                authority_index,
+                receiver,
+            );
+
+            // Spawn async run() for each peer connection
+            let task_handle = tokio::spawn(async move {
+                connection_knowledge.run().await;
+            });
+
+            connection_handles.push(Some(task_handle));
+        }
+
+
+        // Spawn the main CordialKnowledge loop
+        let join_handle = tokio::spawn(async move {
+            cordial_knowledge.run().await;
+        });
+
+        // Return handle with all pieces assembled
+        Arc::new(CordialKnowledgeHandle {
+            cordial_knowledge_sender: sender,
+            connection_knowledge_senders: connection_knowledge_sender,
+            connection_handles: Mutex::new(connection_handles),
+            join_handle: Mutex::new(Some(join_handle)),
+        })
+    }
+
+    /// Main async loop: receives high-level updates (headers, shards, evictions) from DAG state
+    /// and updates global knowledge + notifies per-connection tasks.
+    pub async fn run(
+        mut self,
+    ) {
+        debug!("Cordial Knowledge main loop started");
+
+        while let Some(message) = self.cordial_knowledge_receiver.recv().await {
+            match message {
+                CordialKnowledgeMessage::NewHeader(header) => {
+                    self.handle_new_header(header);
+                }
+
+                CordialKnowledgeMessage::NewShard(block_ref) => {
+                    self.handle_new_shard(block_ref);
+                }
+
+                CordialKnowledgeMessage::EvictBelow(rounds) => {
+                    self.handle_evict_below(rounds);
+                }
+            }
+            yield_now().await;
+        }
+
+        debug!("Cordial Knowledge main loop finished");
+    }
+
+    /// Called when a new verified block header is received.
+    fn handle_new_header(&mut self, header: VerifiedBlockHeader) {
+        self.update_cordial_knowledge(&header);
+    }
+
+    /// Called when a new *own shard* (produced locally) is added.
+    fn handle_new_shard(&mut self, block_ref: BlockRef) {
+        let msg = ConnectionKnowledgeMessage::NewShard { block_ref };
+        for tx in &self.connections {
+            let _ = tx.try_send(vec![msg.clone()]);
+        }
+    }
+
+    /// Called when older rounds should be pruned globally.
+    fn handle_evict_below(&mut self, rounds: Vec<Round>) {
+        // Evict locally
+        for (index, deque) in &mut self.cordial_knowledge.iter_mut().enumerate() {
+            while let Some((front_round, _)) = deque.front() {
+                if *front_round < rounds[index] {
+                    deque.pop_front();
+                } else {
+                    break;
+                }
+            }
+        }
+
+        // Notify per-connection tasks about eviction
+        self.notify_connection_tasks_for_eviction(rounds);
+    }
+
+    #[inline]
+    fn notify_connection_tasks_for_eviction(&self, rounds: Vec<Round>) {
+        let msg = ConnectionKnowledgeMessage::EvictBelow(rounds);
+        for tx in &self.connections {
+            let _ = tx.try_send(vec![msg.clone()]);
+        }
+    }
+
+    /// Map a round to an index inside a per-author VecDeque<(Round, T)>.
+    /// Returns None if `round` is outside the current rolling window stored in the deque.
+    #[inline]
+    fn round_to_index<T>(dq: &VecDeque<(Round, T)>, round: Round) -> Option<usize> {
+        let (front_round, _) = dq.front()?;
+        if round < *front_round {
+            return None;
+        }
+        let idx = (round - *front_round) as usize;
+        if idx < dq.len() {
+            Some(idx)
+        } else {
+            None
+        }
+    }
+
+    /// Ensure the author's deque contains `round`, extending **only that author's deque**
+    /// forward as needed. Returns a mutable handle to
+    /// the (Round, Map) entry for `round`.
+    #[inline]
+    fn ensure_author_round_map(
+        &mut self,
+        author_value: usize,
+        round: Round,
+    ) -> &mut (Round, AHashMap<BlockHeaderDigest, (Ancestors, SubsetAuthorities)>) {
+        let dq = &mut self.cordial_knowledge[author_value];
+        match dq.back() {
+            // Empty -> push exactly this round
+            None => {
+                dq.push_back((round, AHashMap::default()));
+            }
+            Some((last_round, _)) => {
+                if *last_round < round {
+                    // Extend forward up to `round`
+                    let mut r = *last_round + 1;
+                    while r <= round {
+                        dq.push_back((r, AHashMap::default()));
+                        r += 1;
+                    }
+                }
+            }
+        }
+
+        let idx = Self::round_to_index(dq, round)
+            .expect("We should expect round to be within or equal to the deque window");
+        &mut dq[idx]
+    }
+
+    /// Update cordial knowledge for exactly one new header.
+    /// Assumes all parents are already stored somewhere in `recent_dag_cordial_knowledge`
+    /// - Only grows the author's deque if needed.
+    /// - For other authorities' "unknown headers" deques, we add the block only if
+    ///   the round bucket already exists (no growth).
+    fn update_cordial_knowledge(&mut self, header: &VerifiedBlockHeader) {
+        let block_ref = header.reference();
+        let block_author = block_ref.author.value();
+        let round = block_ref.round;
+        let digest = block_ref.digest;
+        let own_index = self.context.own_index.value();
+        let mut vec_knowledge_msgs: Vec<Vec<ConnectionKnowledgeMessage>> =
+            vec![Vec::new(); self.context.committee.size()];
+
+        //  === 1) Get (or create forward) the author's round bucket and insert if missing  ===
+        let (_, round_map) = self.ensure_author_round_map(block_author, round);
+        if round_map.contains_key(&digest) {
+            // Already recorded — nothing else to do here.
+            return;
+        }
+
+        let ancestors: Ancestors = Arc::from(header.ancestors());
+
+        // (who_knows initially marks: author + self)
+        let who_knows = SubsetAuthorities::new_with(block_author, own_index);
+        round_map.insert(digest, (ancestors, who_knows));
+
+        //  === 2) Mark this header as "unknown" for other authorities  ===
+        let msg = ConnectionKnowledgeMessage::NewHeader { block_ref };
+        for other_idx in 0..self.context.committee.size() {
+            if other_idx == block_author || other_idx == own_index {
+                continue;
+            }
+            vec_knowledge_msgs[other_idx].push(msg.clone());
+        }
+
+        //  === 3) Notify that the block_author now knows transaction data for certain blocks ===
+        for acknowledgment in header.acknowledgments() {
+            vec_knowledge_msgs[block_author].push(ConnectionKnowledgeMessage::RemoveShard {
+                block_ref: *acknowledgment,
+            });
+        }
+
+
+        // === 4) Traverse the DAG and update the knowledge of block author about the causal past ===
+        // We do a DFS traversal using a stack (buffer).
+        // For each parent, if the block_author does not know it yet, we mark it
+        // as known by block_author, send a message to the corresponding connection,
+        // and push the parent onto the stack for further traversal.
+        let mut buffer = vec![block_ref];
+
+        while let Some(traversed_ref) = buffer.pop() {
+            let current_author = traversed_ref.author.value();
+            let current_round = traversed_ref.round;
+            let current_digest = traversed_ref.digest;
+
+            // Locate the round bucket for this traversed block
+            let deque = &mut self.cordial_knowledge[current_author];
+            if let Some(index) = Self::round_to_index(deque, current_round) {
+                // Found correct round bucket
+                let (_r, map) = &mut deque[index];
+
+                // Get this block’s entry
+                let parents = match map.get(&current_digest) {
+                    Some((ancestors, _)) => ancestors.clone(),
+                    None => continue, // skip unknown block
+                };
+
+                // Iterate over the parents
+                for parent in parents.iter() {
+                    let parent_author = parent.author;
+                    let parent_round = parent.round;
+                    let parent_digest = parent.digest;
+
+                    // Find the parent’s round bucket
+                    let deque_parent_author = &mut self.cordial_knowledge[parent_author.value()];
+                    if let Some(parent_index) = Self::round_to_index(deque_parent_author, parent_round) {
+                        let (_, parents_of_parent_map) = &mut deque_parent_author[parent_index];
+
+                        if let Some((_anc, who_knows_parent)) = parents_of_parent_map.get_mut(&parent_digest) {
+                            // Insert new knowledge as block_author knows this parent
+                            if who_knows_parent.insert(block_author) {
+                                vec_knowledge_msgs[block_author].push(ConnectionKnowledgeMessage::RemoveHeader {
+                                    block_ref: *parent,
+                                });
+                                // Push parent to buffer for further propagation
+                                buffer.push(*parent);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.send_knowledge_messages(vec_knowledge_msgs);
+    }
+
+    fn send_knowledge_messages(&self, msgs: Vec<Vec<ConnectionKnowledgeMessage>>) {
+        for (idx, tx) in self.connections.iter().enumerate() {
+            if !msgs[idx].is_empty() {
+                let _ = tx.try_send(msgs[idx].clone());
+            }
+        }
+    }
+
+
+}
+
+#[derive(Clone, Debug)]
+pub enum ConnectionKnowledgeMessage {
+    /// A new block header was added globally.
+    NewHeader {
+        block_ref: BlockRef,
+    },
+    /// Remove a block header from the "unknown" set .
+    RemoveHeader {
+        block_ref: BlockRef,
+    },
+    /// A new shard was added globally.
+    NewShard {
+        block_ref: BlockRef,
+    },
+    /// Remove a header from the "unknown" set.
+    RemoveShard {
+        block_ref: BlockRef,
+    },
+    /// Take useful headers for the given authorities, up to the given round (exclusive).
+    TakeUsefulHeaders {
+        round_upper_bound_exclusive: Round,
+        useful_authorities: Vec<usize>,
+        respond_to: Sender<Vec<BlockRef>>,
+    },
+    /// Take useful shards for the given authorities, up to the given round (exclusive).
+    TakeUsefulShards {
+        round_upper_bound_exclusive: Round,
+        useful_authorities: Vec<usize>,
+        respond_to: Sender<Vec<BlockRef>>,
+    },
+    /// Global eviction (prune below round)
+    EvictBelow(Vec<Round>),
+}
+
+#[derive(Debug)]
+pub enum CordialKnowledgeMessage {
+    /// A new verified block header to integrate into cordial knowledge.
+    NewHeader(VerifiedBlockHeader),
+    /// A new verified own shard to integrate into cordial knowledge.
+    NewShard(BlockRef),
+    /// Evict old rounds globally.
+    EvictBelow(Vec<Round>),
+}
+
+
+/// Manages the knowledge state for a single connection to a peer.
+/// Receives updates from the global cordial knowledge
+pub struct ConnectionKnowledge {
+    context: Arc<Context>,
+    peer_index: usize,
+    headers_not_known: Vec<VecDeque<(Round, AHashSet<BlockRef>)>>,
+    shards_not_known: Vec<VecDeque<(Round, AHashSet<BlockRef>)>>,
+    /// Receives updates from the global cordial knowledge
+    receiver: Receiver<Vec<ConnectionKnowledgeMessage>>,
+}
+
+impl ConnectionKnowledge {
+    pub fn new(
+        context: Arc<Context>,
+        peer_index: usize,
+        receiver: Receiver<Vec<ConnectionKnowledgeMessage>>,
+    ) -> Self {
+        let num_authorities = context.committee.size();
+        let headers_not_known = Vec::with_capacity(num_authorities);
+        let shards_not_known = Vec::with_capacity(num_authorities);
+        Self {
+            context,
+            peer_index,
+            headers_not_known,
+            shards_not_known,
+            receiver,
+        }
+    }
+
+    #[inline]
+    fn round_to_index<T>(deque: &VecDeque<(Round, T)>, round: Round) -> Option<usize> {
+        let (front_round, _) = deque.front()?;
+        if round < *front_round { return None; }
+        let index = (round - *front_round) as usize;
+        (index < deque.len()).then_some(index)
+    }
+
+    /// Find the minimum front round among the given authorities’ deques.
+    /// Returns `None` if all selected deques are empty.
+    #[inline]
+    fn min_front_round<'a, T>(
+        all_deques: &Vec<VecDeque<(Round, T)>>,
+        authorities: impl IntoIterator<Item = &'a usize>,
+    ) -> Option<Round> {
+        let mut min_round: Option<Round> = None;
+        for authority in authorities {
+            if let Some((round, _)) = all_deques[*authority].front() {
+                min_round = Some(min_round.map_or(*round, |m| m.min(*round)));
+            }
+        }
+        min_round
+    }
+
+    #[inline]
+    fn ensure_round_in_deque(
+        deque: &mut VecDeque<(Round, AHashSet<BlockRef>)>,
+        target_round: Round,
+    ) -> Option<usize>    {
+
+        // 1. If deque is empty, initialize with this round
+        if deque.is_empty() {
+            deque.push_back((target_round, AHashSet::default()));
+            return Some(0);
+        }
+
+        let front_round = deque.front().unwrap().0;
+        let back_round = deque.back().unwrap().0;
+
+        // 2. If round is older than the current window → skip (already evicted)
+        if target_round < front_round {
+            return None;
+        }
+
+        // 3. Extend forward up to the requested round
+        if target_round > back_round {
+            for current_round in (back_round + 1)..=target_round {
+                deque.push_back((current_round, AHashSet::default()));
+            }
+        }
+
+        // 4. Compute index for this round
+        let idx = (target_round - front_round) as usize;
+        Some(idx)
+    }
+    /// Block ref selection:
+    ///  - iterate rounds from the earliest available among `useful_authorities`
+    ///    up to (but excluding) `round_upper_bound_exclusive`,
+    ///  - for each round, scan only the given `useful_authorities`,
+    ///  - collect up to `max_headers_per_bundle`,
+    ///  - then remove them from this connection’s unknown sets.
+    fn take_useful_block_refs_round(
+        &mut self,
+        round_upper_bound_exclusive: Round,
+        useful_authorities: &[usize],
+    ) -> Vec<BlockRef> {
+        let max_take = self.context.parameters.max_headers_per_bundle;
+
+        // Nothing to do
+        if useful_authorities.is_empty() || max_take == 0 {
+            return Vec::new();
+        }
+
+        // Start from the earliest front round across the selected authorities.
+        let Some(min_round) = Self::min_front_round(&self.headers_not_known, useful_authorities.iter()) else {
+            return Vec::new();
+        };
+
+        let mut current_round = min_round;
+
+        let mut taken: Vec<BlockRef> = Vec::with_capacity(max_take);
+
+        'outer: while current_round < round_upper_bound_exclusive {
+            for authority in useful_authorities {
+                let deque = &self.headers_not_known[*authority];
+
+                // If this authority has this round bucket, take from it.
+                if let Some(index) = Self::round_to_index(deque, current_round) {
+                    // Iterate the set without mutating it yet.
+                    for block_ref in deque[index].1.iter() {
+                        taken.push(*block_ref);
+                        if taken.len() >= max_take {
+                            break 'outer;
+                        }
+                    }
+                }
+            }
+            // advance round
+            current_round = current_round.saturating_add(1);
+        }
+
+        // Remove the selected ones from local unknown sets.
+        for block_ref in &taken {
+            let authority = block_ref.author.value();
+            let deque = &mut self.headers_not_known[authority];
+            if let Some(index) = Self::round_to_index(deque, block_ref.round) {
+                deque[index].1.remove(block_ref);
+            }
+        }
+
+        taken
+    }
+
+    /// Same as `take_useful_block_refs_round` but for shards.
+    fn take_useful_shard_block_refs_round(
+        &mut self,
+        round_upper_bound_exclusive: Round,
+        useful_authorities: &[usize],
+    ) -> Vec<BlockRef> {
+        let max_take = self.context.parameters.max_shards_per_bundle;
+
+        if useful_authorities.is_empty() || max_take == 0 {
+            return Vec::new();
+        }
+
+        let Some(min_round) = Self::min_front_round(&self.shards_not_known, useful_authorities.iter()) else {
+            return Vec::new();
+        };
+
+        let mut current_round = min_round;
+
+        let mut taken: Vec<BlockRef> = Vec::with_capacity(max_take);
+
+        'outer: while current_round < round_upper_bound_exclusive {
+            for authority in useful_authorities {
+                let deque = &self.shards_not_known[*authority];
+
+                if let Some(index) = Self::round_to_index(deque, current_round) {
+                    for block_ref in deque[index].1.iter() {
+                        taken.push(*block_ref);
+                        if taken.len() >= max_take {
+                            break 'outer;
+                        }
+                    }
+                }
+            }
+            // Advance round
+            current_round = current_round.saturating_add(1);
+        }
+
+        // Remove the selected ones from unknown sets
+        for block_ref in &taken {
+            let authority = block_ref.author.value();
+            let deque = &mut self.shards_not_known[authority];
+            if let Some(index) = Self::round_to_index(deque, block_ref.round) {
+                deque[index].1.remove(block_ref);
+            }
+        }
+
+        taken
+    }
+
+    fn evict_below(&mut self, rounds: Vec<Round>) {
+        for (index, deque) in self.headers_not_known.iter_mut().enumerate() {
+            while let Some((front_round, _)) = deque.front() {
+                if *front_round < rounds[index] {
+                    deque.pop_front();
+                } else {
+                    break;
+                }
+            }
+        }
+        for (index, deque) in self.shards_not_known.iter_mut().enumerate() {
+            while let Some((front_round, _)) = deque.front() {
+                if *front_round < rounds[index] {
+                    deque.pop_front();
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Async task loop — just receives messages and dispatches to processing logic.
+    pub async fn run(mut self) {
+        tracing::debug!(
+            "Connection Knowledge started for peer {}",
+            self.peer_index
+        );
+
+        while let Some(knowledge_msgs) = self.receiver.recv().await {
+            for knowledge_msg in knowledge_msgs {
+                self.process_message(knowledge_msg).await;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        tracing::debug!(
+            "Connection Knowledge loop ended for peer {}",
+            self.peer_index
+        );
+    }
+
+    /// Processes a batch of knowledge updates synchronously (non-async).
+    /// This isolates all mutation logic so it can be tested without async context.
+    async fn process_message(&mut self, message: ConnectionKnowledgeMessage) {
+        match message {
+            ConnectionKnowledgeMessage::NewHeader { block_ref } => {
+                self.handle_new_header(block_ref);
+            }
+            ConnectionKnowledgeMessage::RemoveHeader { block_ref } => {
+                self.handle_remove_header(block_ref);
+            }
+            ConnectionKnowledgeMessage::NewShard { block_ref } => {
+                self.handle_new_shard(block_ref);
+            }
+            ConnectionKnowledgeMessage::RemoveShard { block_ref } => {
+                self.handle_remove_shard(block_ref);
+            }
+            ConnectionKnowledgeMessage::EvictBelow(rounds) => {
+                self.evict_below(rounds);
+            }
+            ConnectionKnowledgeMessage::TakeUsefulHeaders {
+                round_upper_bound_exclusive,
+                useful_authorities,
+                respond_to,
+            } => {
+                let taken = self.take_useful_block_refs_round(
+                    round_upper_bound_exclusive,
+                    &useful_authorities,
+                );
+                if let Err(e) = respond_to.send(taken).await {
+                    warn!("Failed to respond to useful headers: {} for connection task with peer index {}", e, self.peer_index);
+                }
+            }
+            ConnectionKnowledgeMessage::TakeUsefulShards {
+                round_upper_bound_exclusive,
+                useful_authorities,
+                respond_to,
+            } => {
+                let taken = self.take_useful_shard_block_refs_round(
+                    round_upper_bound_exclusive,
+                    &useful_authorities,
+                );
+                if let Err(e) = respond_to.send(taken).await {
+                    warn!("Failed to respond to useful shards: {} for connection task with peer index {}", e, self.peer_index);
+                }
+            }
+        }
+    }
+
+    /// Handles adding a new block to the unknown set.
+    fn handle_new_header(&mut self, block_ref: BlockRef) {
+        let round = block_ref.round;
+        let authority = block_ref.author.value();
+        if let Some(index) = Self::ensure_round_in_deque(
+            &mut self.headers_not_known[authority],
+            round,
+        ) {
+            let (_r, set) = &mut self.headers_not_known[authority][index];
+            set.insert(block_ref);
+        }
+    }
+
+
+    /// Handles adding a new shard to the unknown set.
+    fn handle_new_shard(&mut self, block_ref: BlockRef) {
+        let round = block_ref.round;
+        let authority = block_ref.author.value();
+
+        if let Some(index) = Self::ensure_round_in_deque(
+            &mut self.shards_not_known[authority],
+            round,
+        ) {
+            let (_r, set) = &mut self.shards_not_known[authority][index];
+            set.insert(block_ref);
+        }
+    }
+
+    /// Handles removing a header that this peer now knows.
+    fn handle_remove_header(&mut self, block_ref: BlockRef) {
+        let authority = block_ref.author.value();
+        let round = block_ref.round;
+        if let Some(index) = Self::round_to_index(&self.headers_not_known[authority], round) {
+            let (_r, set) = &mut self.headers_not_known[authority][index];
+            set.remove(&block_ref);
+        }
+    }
+
+    /// Handles removing a shard that this peer now knows.
+    fn handle_remove_shard(&mut self, block_ref: BlockRef) {
+        let round = block_ref.round;
+        let authority = block_ref.author.value();
+        if let Some(index) = Self::round_to_index(&self.shards_not_known[authority], round) {
+            let (_r, set) = &mut self.shards_not_known[authority][index];
+            set.remove(&block_ref);
+        }
+    }
+}

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -251,6 +251,7 @@ impl CordialKnowledge {
             tokio::select! {
                 // Main channel to receive message for updating the state and propogate to connection tasks
                 maybe_msg = self.cordial_knowledge_receiver.recv() => {
+                    debug!("Cordial knowledge message {maybe_msg:?} received");
                     match maybe_msg {
                         Some(cordial_knowledge_message) => {
                             match cordial_knowledge_message {

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -31,8 +31,8 @@ use crate::{
 };
 
 /// Maximum round gap to consider a peer's useful shards/headers as still
-/// relevant. 20 rounds correspond to around 1 second
-const MAX_ROUND_GAP_FOR_USEFUL_PARTS: Round = 20;
+/// relevant. 40 rounds correspond to around 2 seconds
+const MAX_ROUND_GAP_FOR_USEFUL_PARTS: Round = 40;
 
 /// Represents a subset of authorities using a bitmask.
 /// Each bit in the `low` and `high` fields corresponds to an authority index.

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -14,6 +14,7 @@ use std::{
 
 use bytes::Bytes;
 use itertools::Itertools as _;
+use tokio::sync::mpsc::UnboundedSender;
 use starfish_config::AuthorityIndex;
 use tokio::time::Instant;
 use tracing::{debug, error, info, trace, warn};
@@ -32,6 +33,7 @@ use crate::{
     storage::{Store, WriteBatch},
     threshold_clock::ThresholdClock,
 };
+use crate::cordial_knowledge::{CordialKnowledge, CordialKnowledgeMessage};
 
 /// Represents the source from which transactions were received and added to the
 /// DAG state. This is used for metrics tracking and debugging.
@@ -194,6 +196,9 @@ pub(crate) struct DagState {
 
     /// The number of cached rounds
     cached_rounds: Round,
+
+    /// Cordial Knowledge sender
+    cordial_knowledge_sender: Option<UnboundedSender<CordialKnowledgeMessage>>,
 }
 
 impl DagState {
@@ -280,6 +285,7 @@ impl DagState {
             store: store.clone(),
             cached_rounds,
             evicted_rounds: vec![0; num_authorities],
+            cordial_knowledge_sender: None,
         };
 
         for (i, round) in last_committed_rounds.into_iter().enumerate() {
@@ -317,6 +323,14 @@ impl DagState {
             );
         }
         state
+    }
+
+    pub(crate) fn with_cordial_knowledge_sender(
+        mut self,
+        sender: UnboundedSender<CordialKnowledgeMessage>,
+    ) -> Self {
+        self.cordial_knowledge_sender = Some(sender);
+        self
     }
 
     /// Accepts a block header into DagState and keeps it in memory.
@@ -444,6 +458,12 @@ impl DagState {
                 }
                 self.shards_not_known_by_authority[authority_index].insert(block_ref);
             }
+            if let Some(sender) = &self.cordial_knowledge_sender {
+                let cordial_message = CordialKnowledgeMessage::NewShard(block_ref);
+                if let Err(e) = sender.send(cordial_message) {
+                    warn!("Failed to send cordial knowledge update: {e}");
+                }
+            }
         }
     }
 
@@ -491,91 +511,17 @@ impl DagState {
             .highest_accepted_authority_round
             .with_label_values(&[hostname])
             .set(highest_accepted_round_for_author as i64);
-        self.update_cordial_knowledge(block_header);
+        if let Some(sender) = &self.cordial_knowledge_sender {
+            let cordial_message = CordialKnowledgeMessage::NewHeader(block_header.clone());
+            if let Err(e) = sender.send(cordial_message) {
+                warn!("Failed to send cordial knowledge update: {e}");
+            }
+        }
     }
 
     fn update_transaction_metadata(&mut self, transaction: &VerifiedTransactions) {
         self.recent_transactions
             .insert(transaction.block_ref(), transaction.clone());
-    }
-
-    /// Updates the cordial knowledge about which authorities know which block
-    /// headers after accepting a new block header. In particular, it
-    /// traverses the DAG from the given block header and updates the
-    /// knowledge for the corresponding authority.
-    fn update_cordial_knowledge(&mut self, block_header: &VerifiedBlockHeader) {
-        let block_reference = block_header.reference();
-        let block_author = block_reference.author;
-        let round_digest = (block_reference.round, block_reference.digest);
-
-        // Collect parents of the block header, which are not genesis
-        let parents = block_header
-            .ancestors()
-            .iter()
-            .filter(|parent| parent.round > GENESIS_ROUND)
-            .cloned()
-            .collect::<Vec<_>>();
-
-        // If the block header is in the recent_dag_cordial_knowledge, then
-        // don't update it
-        if self.recent_dag_cordial_knowledge[block_author.value()].contains_key(&round_digest) {
-            return;
-        }
-
-        // update information about block_reference
-        self.recent_dag_cordial_knowledge[block_author.value()].insert(
-            round_digest,
-            (
-                parents,
-                vec![block_reference.author, self.context.own_index]
-                    .into_iter()
-                    .collect::<HashSet<_>>(),
-            ),
-        );
-
-        // Assume that only this authority and the author know the block header
-        for authority_index in 0..self.block_headers_not_known_by_authority.len() {
-            if authority_index == self.context.own_index.value()
-                || authority_index == block_reference.author.value()
-            {
-                continue;
-            }
-            self.block_headers_not_known_by_authority[authority_index].insert(block_reference);
-        }
-
-        // traverse the DAG from block_reference and update the blocks known by the
-        // author of this block
-        let mut buffer = vec![block_reference];
-
-        while let Some(traversed_block_reference) = buffer.pop() {
-            let traversed_block_author = traversed_block_reference.author;
-            let traversed_block_round_digest = (
-                traversed_block_reference.round,
-                traversed_block_reference.digest,
-            );
-            let (parents, _) = self.recent_dag_cordial_knowledge[traversed_block_author.value()]
-                .get(&traversed_block_round_digest)
-                .expect("We should expect having an element with given BlockRef")
-                .clone();
-            for parent in parents {
-                let traversed_parent_author = parent.author;
-                let traversed_parent_round_digest = (parent.round, parent.digest);
-
-                if self.recent_dag_cordial_knowledge[traversed_parent_author.value()]
-                    .contains_key(&traversed_parent_round_digest)
-                {
-                    let (_, who_knows_given_parent) = self.recent_dag_cordial_knowledge
-                        [traversed_parent_author.value()]
-                    .get_mut(&traversed_parent_round_digest)
-                    .expect("We should have this value as it is checked");
-                    if who_knows_given_parent.insert(block_author) {
-                        self.block_headers_not_known_by_authority[block_author.value()]
-                            .remove(&parent);
-                        buffer.push(parent);
-                    }
-                }
-            }
-        }
     }
 
     /// Accepts block headers into DagState and keeps it in memory.
@@ -1547,6 +1493,8 @@ impl DagState {
         }
         useful_shard_authors
     }
+
+
     pub(crate) fn take_commit_votes(&mut self, limit: usize) -> Vec<CommitVote> {
         let mut votes = Vec::new();
         while !self.pending_commit_votes.is_empty() && votes.len() < limit {
@@ -1630,27 +1578,22 @@ impl DagState {
         self.pending_acknowledgments = self.pending_acknowledgments.split_off(&lower_bound);
     }
 
-    /// Evicts old cordial knowledge and pending acknowledgments. It is aligned
+    /// Evicts old cordial knowledge from CordialKnowledge. It is aligned
     /// with the eviction method, thereby should be called every time the
     /// eviction happens.
     pub(crate) fn evict_cordial_knowledge(&mut self) {
-        // === 1. Evict from recent_dag_cordial_knowledge ===
-        for (authority_index, map) in self.recent_dag_cordial_knowledge.iter_mut().enumerate() {
-            let evict_round = self.evicted_rounds[authority_index];
-
-            // Only keep entries with round > evict_round
-            let keep_from = (evict_round + 1, BlockHeaderDigest::MIN);
-            *map = map.split_off(&keep_from);
-        }
-        // === 2. Evict from block_headers_not_known_by_authority ===
-        for authority_index in 0..self.context.committee.size() {
-            let old_set = &mut self.block_headers_not_known_by_authority[authority_index];
-            old_set.retain(|block_ref| block_ref.round > self.evicted_rounds[block_ref.author]);
-        }
-        // === 3. Evict from shards_not_known_by_authority ===
-        for authority_index in 0..self.context.committee.size() {
-            let old_set = &mut self.shards_not_known_by_authority[authority_index];
-            old_set.retain(|block_ref| block_ref.round > self.evicted_rounds[block_ref.author]);
+        if let Some(cordial_knowledge_sender) = &self.cordial_knowledge_sender {
+            let mut eviction_rounds = vec![];
+            for (authority_index,_) in self.context.committee.authorities() {
+                let eviction_round = self.calculate_authority_eviction_round(authority_index);
+                eviction_rounds.push(eviction_round);
+            }
+            let cordial_message = CordialKnowledgeMessage::EvictBelow(
+                eviction_rounds,
+            );
+            if let Err(e) = cordial_knowledge_sender.send(cordial_message) {
+                warn!("Failed to send cordial knowledge eviction message: {e}");
+            }
         }
     }
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -4,7 +4,7 @@
 
 use std::{
     cmp::{max, min},
-    collections::{BTreeMap, BTreeSet, HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet,  VecDeque},
     mem,
     ops::Bound::{Excluded, Included, Unbounded},
     panic,

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -14,10 +14,9 @@ use std::{
 
 use bytes::Bytes;
 use itertools::Itertools as _;
-use tokio::sync::mpsc::UnboundedSender;
 use starfish_config::AuthorityIndex;
-use tokio::time::Instant;
-use tracing::{debug, error, info, warn};
+use tokio::{sync::mpsc::UnboundedSender, time::Instant};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     block_header::{

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -17,7 +17,7 @@ use itertools::Itertools as _;
 use tokio::sync::mpsc::UnboundedSender;
 use starfish_config::AuthorityIndex;
 use tokio::time::Instant;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     block_header::{
@@ -29,6 +29,7 @@ use crate::{
         GENESIS_COMMIT_INDEX, SubDagBase, TrustedCommit, load_pending_subdag_from_store,
     },
     context::Context,
+    cordial_knowledge::{CordialKnowledgeMessage},
     leader_scoring::{ReputationScores, ScoringSubdag},
     storage::{Store, WriteBatch},
     threshold_clock::ThresholdClock,
@@ -159,27 +160,6 @@ pub(crate) struct DagState {
     /// corresponding blocks
     pending_acknowledgments: BTreeSet<BlockRef>,
 
-    // TODO: add metrics for recent_dag_cordial_knowledge and block_headers_not_known_by_authority
-    // and pending_acknowledgments
-    /// Keeps track of the most recent BlockHeaderDAG cordial
-    /// knowledge (who knows which blocks) for each authority. This is a helper
-    /// structure that is used primarily for traversing the recent DAG. This
-    /// struct is evicted after flushing the dag state to storage and is not
-    /// persisted. To access the cordial knowledge of a given block_ref, one
-    /// shall retrieve it from `recent_dag_cordial_knowledge[block_ref.
-    /// author][(block_ref.round, block_ref.digest)]`. The value is a tuple
-    /// of (parents, who knows the block header).
-    recent_dag_cordial_knowledge:
-        Vec<BTreeMap<(Round, BlockHeaderDigest), (Vec<BlockRef>, HashSet<AuthorityIndex>)>>,
-    /// Keeps tracks of block headers that are not known by the authority.
-    /// Is used to ensure that we send block headers that are really needed
-    /// to the authority, and not the ones that they already know.
-    block_headers_not_known_by_authority: Vec<BTreeSet<BlockRef>>,
-
-    /// Keeps tracks of all shards we know and haven't sent yet to the
-    /// authority.
-    shards_not_known_by_authority: Vec<BTreeSet<BlockRef>>,
-
     /// Transactions to be flushed to storage.
     transactions_to_write: Vec<VerifiedTransactions>,
     block_headers_to_write: Vec<VerifiedBlockHeader>,
@@ -250,13 +230,13 @@ impl DagState {
                 });
         }
 
-        tracing::info!(
+        info!(
             "DagState was initialized with the following state: \
             {last_commit:?}; {last_committed_rounds:?}; {} unscored committed subdags;",
             unscored_committed_subdags.len()
         );
 
-        scoring_subdag.add_subdags(std::mem::take(&mut unscored_committed_subdags));
+        scoring_subdag.add_subdags(mem::take(&mut unscored_committed_subdags));
 
         let mut state = Self {
             context,
@@ -278,9 +258,6 @@ impl DagState {
             commits_to_write: vec![],
             commit_info_to_write: vec![],
             pending_acknowledgments: BTreeSet::new(),
-            recent_dag_cordial_knowledge: vec![BTreeMap::new(); num_authorities],
-            block_headers_not_known_by_authority: vec![BTreeSet::new(); num_authorities],
-            shards_not_known_by_authority: vec![BTreeSet::new(); num_authorities],
             scoring_subdag,
             store: store.clone(),
             cached_rounds,
@@ -325,12 +302,11 @@ impl DagState {
         state
     }
 
-    pub(crate) fn with_cordial_knowledge_sender(
-        mut self,
+    pub fn set_cordial_knowledge_sender(
+        &mut self,
         sender: UnboundedSender<CordialKnowledgeMessage>,
-    ) -> Self {
+    ) {
         self.cordial_knowledge_sender = Some(sender);
-        self
     }
 
     /// Accepts a block header into DagState and keeps it in memory.
@@ -447,17 +423,7 @@ impl DagState {
             .insert(block_ref, shard.serialized_shard)
             .is_none()
         {
-            tracing::debug!("Adding shard for block ref: {block_ref}");
-            for authority_index in 0..self.shards_not_known_by_authority.len() {
-                // we are going to send shard to every authority except our own and the author
-                // of the block
-                if (authority_index == block_ref.author.value())
-                    || (authority_index == self.context.own_index.value())
-                {
-                    continue;
-                }
-                self.shards_not_known_by_authority[authority_index].insert(block_ref);
-            }
+            debug!("Adding shard for block ref: {block_ref}");
             if let Some(sender) = &self.cordial_knowledge_sender {
                 let cordial_message = CordialKnowledgeMessage::NewShard(block_ref);
                 if let Err(e) = sender.send(cordial_message) {
@@ -675,6 +641,16 @@ impl DagState {
         }
 
         block_headers
+    }
+    /// Gets shards by checking cached recent shards in memory.
+    pub(crate) fn get_cached_shards(&self, block_refs: &[BlockRef]) -> Vec<Option<Bytes>> {
+        let mut shards: Vec<Option<Bytes>> = vec![None; block_refs.len()];
+        for (index, block_ref) in block_refs.iter().enumerate() {
+            if let Some(shard) = self.recent_shards.get(block_ref) {
+                shards[index] = Some(shard.clone());
+            }
+        }
+        shards
     }
 
     /// Gets all uncommitted block headers in a slot.
@@ -1275,225 +1251,6 @@ impl DagState {
         self.commit_info_to_write
             .push((last_commit.reference(), commit_info));
     }
-    /// Removes and returns up to `MAX_HEADERS_PER_BUNDLE` block references that
-    /// the given authority has not yet seen, limited to rounds strictly
-    /// below `round_upper_bound_exclusive`.
-    ///
-    /// Side effects:
-    /// - Updates `block_headers_not_known_by_authority` so these refs are no
-    ///   longer considered "unknown" for the authority.
-    /// - Marks the given authority as knowing these blocks inside
-    ///   `recent_dag_cordial_knowledge`.
-    ///
-    /// Returns:
-    /// - A vector of `BlockRef`s corresponding to the unknown blocks that were
-    ///   revealed to the authority.
-    fn take_unknown_block_refs_for_authority(
-        &mut self,
-        authority_index: AuthorityIndex,
-        round_upper_bound_exclusive: Round,
-    ) -> Vec<BlockRef> {
-        let mut set =
-            mem::take(&mut self.block_headers_not_known_by_authority[authority_index.value()]);
-
-        let split_point = {
-            let round_bound = BlockRef::new(
-                round_upper_bound_exclusive,
-                AuthorityIndex::MIN,
-                BlockHeaderDigest::MIN,
-            );
-            let nth_element = set
-                .iter()
-                .nth(self.context.parameters.max_headers_per_bundle)
-                .map_or(round_bound, |x| *x);
-            min(nth_element, round_bound)
-        };
-
-        self.block_headers_not_known_by_authority[authority_index.value()] =
-            set.split_off(&split_point);
-        let mut block_refs: Vec<BlockRef> = vec![];
-        for block_ref in set.into_iter() {
-            block_refs.push(block_ref);
-            let opt_block_knowledge = self.recent_dag_cordial_knowledge[block_ref.author.value()]
-                .get_mut(&(block_ref.round, block_ref.digest));
-            let (_, who_knows_given_block) = opt_block_knowledge
-                .expect("We expect block ref to be in recent dag cordial knowledge");
-            who_knows_given_block.insert(authority_index);
-        }
-        block_refs
-    }
-
-    /// Removes and returns up to `context.parameters.max_headers_per_bundle`
-    /// block references that the given authority has not yet seen, limited
-    /// to rounds strictly below `round_upper_bound_exclusive` and filtered
-    /// by the provided authors `useful_authorities`.
-    ///
-    /// Side effects:
-    /// - Updates `block_headers_not_known_by_authority` so these refs are no
-    ///   longer considered "unknown" for the authority.
-    /// - Marks the given authority as knowing these blocks inside
-    ///   `recent_dag_cordial_knowledge`.
-    ///
-    /// Returns:
-    /// - A vector of `BlockRef`s corresponding to the unknown blocks that were
-    ///   revealed to the authority.
-    fn take_useful_block_refs_for_authority(
-        &mut self,
-        authority_index: AuthorityIndex,
-        round_upper_bound_exclusive: Round,
-        useful_authorities: BTreeSet<AuthorityIndex>,
-    ) -> Vec<BlockRef> {
-        let set = &mut self.block_headers_not_known_by_authority[authority_index.value()];
-
-        // Collect candidate block_refs we want to take out
-        let mut to_take = Vec::new();
-
-        for block_ref in set.iter() {
-            if to_take.len() >= self.context.parameters.max_headers_per_bundle
-                || block_ref.round >= round_upper_bound_exclusive
-            {
-                break;
-            }
-            if useful_authorities.contains(&block_ref.author) {
-                to_take.push(*block_ref);
-            }
-        }
-
-        // Remove the references from the set and update cordial knowledge
-        for block_ref in &to_take {
-            set.remove(block_ref);
-
-            if let Some((_, who_knows_given_block)) = self.recent_dag_cordial_knowledge
-                [block_ref.author.value()]
-            .get_mut(&(block_ref.round, block_ref.digest))
-            {
-                who_knows_given_block.insert(authority_index);
-            } else {
-                warn!("Block_ref {block_ref} missing in recent_dag_cordial_knowledge");
-            }
-        }
-
-        to_take
-    }
-
-    fn take_block_refs_of_useful_shards_for_authority(
-        &mut self,
-        authority_index: AuthorityIndex,
-        round_upper_bound_exclusive: Round,
-        useful_authorities: BTreeSet<AuthorityIndex>,
-    ) -> Vec<BlockRef> {
-        let set = &mut self.shards_not_known_by_authority[authority_index.value()];
-
-        // Collect candidate block_refs we want to take out
-        let mut to_take = Vec::new();
-
-        for block_ref in set.iter() {
-            if to_take.len() >= self.context.parameters.max_shards_per_bundle
-                || block_ref.round >= round_upper_bound_exclusive
-            {
-                break;
-            }
-            if useful_authorities.contains(&block_ref.author) {
-                to_take.push(*block_ref);
-            }
-        }
-
-        // Remove the references from the set and update cordial knowledge
-        for block_ref in &to_take {
-            set.remove(block_ref);
-        }
-
-        to_take
-    }
-
-    /// Retrieves up to `MAX_HEADERS_PER_BUNDLE` previously unknown block
-    /// headers for the given authority, restricted to rounds strictly below
-    /// `round_upper_bound_exclusive`.
-    ///
-    /// This builds on [`take_unknown_block_refs_for_authority`], resolving the
-    /// returned block references into full `VerifiedBlockHeader`s.
-    ///
-    /// Panics if any of the block headers are missing from `DagState` or disk.
-    pub(crate) fn take_unknown_headers_for_authority(
-        &mut self,
-        authority_index: AuthorityIndex,
-        round_upper_bound_exclusive: Round,
-    ) -> Vec<VerifiedBlockHeader> {
-        let block_refs = self
-            .take_unknown_block_refs_for_authority(authority_index, round_upper_bound_exclusive);
-
-        self.get_block_headers(&block_refs)
-            .into_iter()
-            .map(|opt| opt.expect("All headers should be in DagState or on disk"))
-            .collect()
-    }
-    /// Retrieves up to `MAX_HEADERS_PER_BUNDLE` unknown block headers for the
-    /// given authority, but only those authored by peers listed in
-    /// `useful_authorities`. Excludes blocks from other authorities.
-    ///
-    /// This builds on [`take_unknown_block_refs_for_authority`], filtering the
-    /// result with `useful_authorities` and resolving the returned block
-    /// references into full `VerifiedBlockHeader`s.
-    ///
-    /// Panics if any of the block headers are missing from `DagState` or disk.
-    pub(crate) fn take_useful_headers_for_authority(
-        &mut self,
-        authority_index: AuthorityIndex,
-        round_upper_bound_exclusive: Round,
-        useful_authorities: BTreeSet<AuthorityIndex>,
-    ) -> Vec<VerifiedBlockHeader> {
-        let block_refs = self.take_useful_block_refs_for_authority(
-            authority_index,
-            round_upper_bound_exclusive,
-            useful_authorities,
-        );
-
-        self.get_block_headers(&block_refs)
-            .into_iter()
-            .map(|opt| opt.expect("All headers should be in DagState or on disk"))
-            .collect()
-    }
-
-    pub(crate) fn take_useful_shards_for_authority(
-        &mut self,
-        authority_index: AuthorityIndex,
-        round_upper_bound_exclusive: Round,
-        useful_authorities: BTreeSet<AuthorityIndex>,
-    ) -> Vec<Bytes> {
-        let block_refs = self.take_block_refs_of_useful_shards_for_authority(
-            authority_index,
-            round_upper_bound_exclusive,
-            useful_authorities,
-        );
-        block_refs
-            .iter()
-            .map(|block_ref| {
-                self.recent_shards
-                    .get(block_ref)
-                    .expect("Shard should be in DagState")
-                    .clone()
-            })
-            .collect::<Vec<_>>()
-    }
-
-    pub(crate) fn get_useful_shards_authors(
-        last_useful_round: Vec<Round>,
-        block_round: Round,
-    ) -> BTreeSet<AuthorityIndex> {
-        let mut useful_shard_authors = BTreeSet::new();
-        for (i, round) in last_useful_round.iter().enumerate() {
-            // Check that block_round >= round to avoid underflow. This can happen if we've
-            // received a block from a more recent round than the block we are about to
-            // send, especially during startup when we're sending older blocks.
-            if block_round >= *round
-                && block_round - round <= MAX_ROUND_GAP_FOR_USEFUL_SHARDS as u32
-            {
-                useful_shard_authors.insert(AuthorityIndex::from(i as u8));
-            }
-        }
-        useful_shard_authors
-    }
-
 
     pub(crate) fn take_commit_votes(&mut self, limit: usize) -> Vec<CommitVote> {
         let mut votes = Vec::new();
@@ -1584,13 +1341,11 @@ impl DagState {
     pub(crate) fn evict_cordial_knowledge(&mut self) {
         if let Some(cordial_knowledge_sender) = &self.cordial_knowledge_sender {
             let mut eviction_rounds = vec![];
-            for (authority_index,_) in self.context.committee.authorities() {
+            for (authority_index, _) in self.context.committee.authorities() {
                 let eviction_round = self.calculate_authority_eviction_round(authority_index);
                 eviction_rounds.push(eviction_round);
             }
-            let cordial_message = CordialKnowledgeMessage::EvictBelow(
-                eviction_rounds,
-            );
+            let cordial_message = CordialKnowledgeMessage::EvictBelow(eviction_rounds);
             if let Err(e) = cordial_knowledge_sender.send(cordial_message) {
                 warn!("Failed to send cordial knowledge eviction message: {e}");
             }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -28,12 +28,11 @@ use crate::{
         GENESIS_COMMIT_INDEX, SubDagBase, TrustedCommit, load_pending_subdag_from_store,
     },
     context::Context,
-    cordial_knowledge::CordialKnowledgeMessage,
+    cordial_knowledge::{CordialKnowledgeMessage},
     leader_scoring::{ReputationScores, ScoringSubdag},
     storage::{Store, WriteBatch},
     threshold_clock::ThresholdClock,
 };
-use crate::cordial_knowledge::{CordialKnowledge, CordialKnowledgeMessage};
 
 /// Represents the source from which transactions were received and added to the
 /// DAG state. This is used for metrics tracking and debugging.
@@ -79,11 +78,6 @@ impl std::fmt::Display for TransactionSource {
         write!(f, "{}", self.as_str())
     }
 }
-
-/// If a shard from a block created by authority v1 is useful to authority v2 at
-/// round r, then shards from v1 will be sent to v2 up to round r +
-/// MAX_ROUND_GAP_FOR_USEFUL_SHARDS.
-const MAX_ROUND_GAP_FOR_USEFUL_SHARDS: usize = 5;
 
 /// DagState provides the API to write and read accepted blocks from the DAG.
 /// Only uncommitted and last committed blocks are cached in memory.

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -4,7 +4,7 @@
 
 use std::{
     cmp::{max, min},
-    collections::{BTreeMap, BTreeSet,  VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     mem,
     ops::Bound::{Excluded, Included, Unbounded},
     panic,
@@ -29,7 +29,7 @@ use crate::{
         GENESIS_COMMIT_INDEX, SubDagBase, TrustedCommit, load_pending_subdag_from_store,
     },
     context::Context,
-    cordial_knowledge::{CordialKnowledgeMessage},
+    cordial_knowledge::CordialKnowledgeMessage,
     leader_scoring::{ReputationScores, ScoringSubdag},
     storage::{Store, WriteBatch},
     threshold_clock::ThresholdClock,

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -28,7 +28,7 @@ use crate::{
         GENESIS_COMMIT_INDEX, SubDagBase, TrustedCommit, load_pending_subdag_from_store,
     },
     context::Context,
-    cordial_knowledge::{CordialKnowledgeMessage},
+    cordial_knowledge::CordialKnowledgeMessage,
     leader_scoring::{ReputationScores, ScoringSubdag},
     storage::{Store, WriteBatch},
     threshold_clock::ThresholdClock,

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -45,6 +45,7 @@ mod universal_committer;
 #[path = "tests/randomized_tests.rs"]
 mod randomized_tests;
 
+mod cordial_knowledge;
 mod data_manager;
 mod decoder;
 mod encoder;
@@ -55,7 +56,6 @@ mod test_dag;
 mod test_dag_builder;
 #[cfg(test)]
 mod test_dag_parser;
-mod cordial_knowledge;
 
 /// Exported consensus API.
 pub use authority_node::ConsensusAuthority;

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -55,6 +55,7 @@ mod test_dag;
 mod test_dag_builder;
 #[cfg(test)]
 mod test_dag_parser;
+mod cordial_knowledge;
 
 /// Exported consensus API.
 pub use authority_node::ConsensusAuthority;

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -136,7 +136,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) dag_state_recent_shards: IntGauge,
     pub(crate) dag_state_recent_refs: IntGauge,
     pub(crate) cordial_knowledge_buffer_size: IntGauge,
-    pub(crate) cordial_knowledge_processed_messages: IntCounter,
+    pub(crate) cordial_knowledge_processed_messages: IntCounterVec,
     pub(crate) cordial_knowledge_rounds: IntGaugeVec,
     pub(crate) cordial_knowledge_useful_shards: IntGauge,
     pub(crate) dag_state_store_read_count: IntCounterVec,
@@ -453,9 +453,10 @@ impl NodeMetrics {
             "The number of authorities with useful shards",
             registry,
             ).unwrap(),
-            cordial_knowledge_processed_messages: register_int_counter_with_registry!(
+            cordial_knowledge_processed_messages: register_int_counter_vec_with_registry!(
                 "cordial_knowledge_processed_messages",
                 "Number of cordial knowledge messages processed",
+                &["type"],
                 registry,
             ).unwrap(),
             cordial_knowledge_rounds: register_int_gauge_vec_with_registry!(

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -455,13 +455,13 @@ impl NodeMetrics {
             ).unwrap(),
             cordial_knowledge_processed_messages: register_int_counter_vec_with_registry!(
                 "cordial_knowledge_processed_messages",
-                "Number of cordial knowledge messages processed",
+                "Number of Cordial Knowledge messages processed",
                 &["type"],
                 registry,
             ).unwrap(),
             cordial_knowledge_rounds: register_int_gauge_vec_with_registry!(
                 "cordial_knowledge_rounds",
-                "Number of cordial knowledge rounds processed per authority",
+                "Number of rounds in DAG of Cordial Knowledge stored per authority",
                 &["authority"],
                 registry,
             ).unwrap(),

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -138,6 +138,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) cordial_knowledge_buffer_size: IntGauge,
     pub(crate) cordial_knowledge_processed_messages: IntCounter,
     pub(crate) cordial_knowledge_rounds: IntGaugeVec,
+    pub(crate) cordial_knowledge_useful_shards: IntGauge,
     pub(crate) dag_state_store_read_count: IntCounterVec,
     pub(crate) dag_state_store_write_count: IntCounter,
     pub(crate) fetch_block_headers_scheduler_inflight: IntGauge,
@@ -446,6 +447,11 @@ impl NodeMetrics {
                 "cordial_knowledge_buffer_size",
                 "Size of the cordial knowledge buffer received",
                 registry,
+            ).unwrap(),
+            cordial_knowledge_useful_shards: register_int_gauge_with_registry!(
+            "cordial_knowledge_useful_shards",
+            "The number of authorities with useful shards",
+            registry,
             ).unwrap(),
             cordial_knowledge_processed_messages: register_int_counter_with_registry!(
                 "cordial_knowledge_processed_messages",

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -98,6 +98,7 @@ pub(crate) fn test_metrics() -> Arc<Metrics> {
 }
 
 pub(crate) struct NodeMetrics {
+    pub(crate) delay_in_sending_blocks: Histogram,
     pub(crate) block_commit_latency: Histogram,
     pub(crate) proposed_blocks: IntCounterVec,
     pub(crate) proposed_block_size: Histogram,
@@ -227,6 +228,12 @@ pub(crate) struct NodeMetrics {
 impl NodeMetrics {
     pub(crate) fn new(registry: &Registry) -> Self {
         Self {
+            delay_in_sending_blocks: register_histogram_with_registry!(
+                "delay_in_sending_blocks",
+                "The time taken between block creation and block sending.",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
             block_commit_latency: register_histogram_with_registry!(
                 "block_commit_latency",
                 "The time taken between block creation and block commit.",

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -135,6 +135,9 @@ pub(crate) struct NodeMetrics {
     pub(crate) dag_state_recent_headers: IntGauge,
     pub(crate) dag_state_recent_shards: IntGauge,
     pub(crate) dag_state_recent_refs: IntGauge,
+    pub(crate) cordial_knowledge_buffer_size: IntGauge,
+    pub(crate) cordial_knowledge_processed_messages: IntCounter,
+    pub(crate) cordial_knowledge_rounds: IntGaugeVec,
     pub(crate) dag_state_store_read_count: IntCounterVec,
     pub(crate) dag_state_store_write_count: IntCounter,
     pub(crate) fetch_block_headers_scheduler_inflight: IntGauge,
@@ -437,6 +440,22 @@ impl NodeMetrics {
             dag_state_recent_refs: register_int_gauge_with_registry!(
                 "dag_state_recent_refs",
                 "Number of recent refs cached in the DagState",
+                registry,
+            ).unwrap(),
+            cordial_knowledge_buffer_size: register_int_gauge_with_registry!(
+                "cordial_knowledge_buffer_size",
+                "Size of the cordial knowledge buffer received",
+                registry,
+            ).unwrap(),
+            cordial_knowledge_processed_messages: register_int_counter_with_registry!(
+                "cordial_knowledge_processed_messages",
+                "Number of cordial knowledge messages processed",
+                registry,
+            ).unwrap(),
+            cordial_knowledge_rounds: register_int_gauge_vec_with_registry!(
+                "cordial_knowledge_rounds",
+                "Number of cordial knowledge rounds processed per authority",
+                &["authority"],
                 registry,
             ).unwrap(),
             dag_state_store_read_count: register_int_counter_vec_with_registry!(

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -221,7 +221,7 @@ impl Codec {
 /// One field, transaction_message_sender, can be cloned to send transaction
 /// messages to the internal ShardReconstructor
 pub struct ShardReconstructorHandle {
-    pub transaction_message_sender: Sender<Vec<TransactionMessage>>,
+    transaction_message_sender: Sender<Vec<TransactionMessage>>,
     join_handle: Mutex<Option<JoinHandle<()>>>,
 }
 

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -554,7 +554,7 @@ pub fn init_for_testing() {
         let subscriber = ::tracing_subscriber::FmtSubscriber::builder()
             .with_env_filter(
                 EnvFilter::builder()
-                    .with_default_directive(LevelFilter::INFO.into())
+                    .with_default_directive(LevelFilter::DEBUG.into())
                     .from_env_lossy(),
             )
             .with_file(true)

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -554,7 +554,7 @@ pub fn init_for_testing() {
         let subscriber = ::tracing_subscriber::FmtSubscriber::builder()
             .with_env_filter(
                 EnvFilter::builder()
-                    .with_default_directive(LevelFilter::DEBUG.into())
+                    .with_default_directive(LevelFilter::INFO.into())
                     .from_env_lossy(),
             )
             .with_file(true)


### PR DESCRIPTION
# Description of change

The new `CordialKnowledge` module centralizes and synchronizes knowledge about:
- which headers and shards are locally available, and  
- which ones are known or unknown to each peer.

It acts as a hub between the `DagState`, `AuthorityService`, and per-peer `ConnectionKnowledge` tasks.

### Flow Description

1. **DAG → CordialKnowledge**
When a new header or shard is produced or received:
- `DagState` sends a message (`NewHeader` or `NewShard`) to `CordialKnowledge`.
- `CordialKnowledge` updates its internal DAG knowledge and propagates the relevant info to each `ConnectionKnowledge` instance:
  - Which headers/shards are new.
  - Which should be removed as “unknown” for certain peers.

2. **CordialKnowledge → ConnectionKnowledge**
Each `ConnectionKnowledge` task (one per peer):
- Tracks what *that peer* knows or doesn’t know.
- Receives batched updates from the central `CordialKnowledge` loop through a bounded channel.
- Periodically receives “useful authors information” updates — rounds and authors that are still relevant for block dissemination.

3. **AuthorityService ↔ ConnectionKnowledge**
- When preparing or receiving block bundles`AuthorityService` asks a specific `ConnectionKnowledge` for **additional parts** (headers/shards/useful authors for shards/headers) to include.
- After receiving a bundle from some peer, `AuthorityService` sends an update back (via `UsefulAuthors` messages) indicating which peers should provide additional useful data. Those updates are forwarded both:
  - locally to the respected `ConnectionKnowledge`, and
  - globally via `CordialKnowledge` (for shards as `f+1` shards are needed for reconstruction).

4. **Eviction**
- When old DAG rounds are pruned, `DagState` notifies `CordialKnowledge` using`EvictBelow` message.
- `CordialKnowledge` updates metrics and notifies all connections to prune their local maps.


This refactor eliminates direct writes to `DagState` from multiple async contexts.  
All DAG updates now flow through the **Core Thread** via message passing, reducing contention.


One existing test was updated and two new tested were added:
1. `authority_service::tests::test_handle_subscribe_block_bundles_request` was updated to check that the headers and shards are pushed in the bundles as expected according the CordialKnowledge logic
2. `cordial_knowledge::tests::test_cordial_knowledge_bundle_with_byzantine` was added to check that the headers will be pushed to the peer in case a Byzantine node does not disseminate blocks properly.
3. `cordial_knowledge::tests::test_connection_knowledge_take_additional_parts` was added to check that the headers are taken to the bundle only once (evicted upon taking) and useful authors for shards and headers are calculated correctly using a constant `MAX_ROUND_GAP_FOR_USEFUL_PARTS`.

The change was successfully tested using a local network with some connections between peers being blocked.

## Links to any relevant issues

Fixes #8850 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

