### PR TITLE
feat: add `AuthContext` to the implicit aliases list

### DIFF
--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/immutable.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/immutable.move
@@ -10,7 +10,6 @@
 //# publish --sender A --dependencies simple_abstract_account
 module test::authenticate;
 
-use iota::auth_context::AuthContext;
 use simple_abstract_account::abstract_account::AbstractAccount;
 
 #[authenticator]

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/immutable.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/immutable.snap
@@ -13,20 +13,20 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-17:
+task 2, lines 10-16:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8694400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 19:
+task 3, line 18:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate" --create-function simple_abstract_account::abstract_account::create_immutable --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("ImmutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [140, 167, 82, 197, 75, 28, 56, 33, 131, 192, 33, 171, 135, 35, 247, 247, 168, 143, 47, 113, 147, 161, 114, 76, 250, 72, 36, 104, 26, 244, 105, 40, 84, 68, 14, 208, 67, 101, 113, 89, 203, 61, 49, 48, 19, 65, 107, 184, 162, 72, 58, 252, 136, 15, 27, 175, 192, 187, 125, 19, 252, 32, 102, 92, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101] }
 created: object(4,0), object(4,1), object(4,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6847600,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 21:
+task 4, line 20:
 //# view-object 4,2
 Owner: Immutable
 Version: 3
@@ -38,13 +38,13 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 23-25:
+task 5, lines 22-24:
 //# abstract --account object(4,2) --ptb-inputs 100 @A
 created: object(6,0)
 mutated: object(4,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 6, line 27:
+task 6, line 26:
 //# view-object 6,0
 Owner: Account Address ( A )
 Version: 4

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/immutable_rotate.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/immutable_rotate.move
@@ -10,7 +10,6 @@
 //# publish --sender A --dependencies simple_abstract_account
 module test::authenticate;
 
-use iota::auth_context::AuthContext;
 use simple_abstract_account::abstract_account::AbstractAccount;
 
 #[authenticator]

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/immutable_rotate.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/immutable_rotate.snap
@@ -13,20 +13,20 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-20:
+task 2, lines 10-19:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 10009200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 22:
+task 3, line 21:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate1" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [200, 63, 46, 120, 101, 108, 81, 229, 180, 74, 212, 106, 107, 173, 16, 224, 196, 5, 93, 135, 146, 196, 129, 211, 43, 185, 137, 13, 53, 41, 207, 70, 141, 109, 156, 140, 207, 99, 33, 246, 182, 180, 113, 222, 250, 13, 105, 110, 105, 207, 125, 40, 165, 1, 202, 227, 57, 14, 109, 54, 186, 140, 187, 218, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 13, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 49] }
 created: object(4,0), object(4,1), object(4,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6855200,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 24:
+task 4, line 23:
 //# view-object 4,2
 Owner: Shared( 3 )
 Version: 3
@@ -38,7 +38,7 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 26-27:
+task 5, lines 25-26:
 //# abstract --account immshared(4,2) --ptb-inputs object(4,2) object(3,1) "authenticate" "authenticate2"
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: fake(4,2), type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("AuthenticatorFunctionRefV1Rotated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [200, 63, 46, 120, 101, 108, 81, 229, 180, 74, 212, 106, 107, 173, 16, 224, 196, 5, 93, 135, 146, 196, 129, 211, 43, 185, 137, 13, 53, 41, 207, 70, 141, 109, 156, 140, 207, 99, 33, 246, 182, 180, 113, 222, 250, 13, 105, 110, 105, 207, 125, 40, 165, 1, 202, 227, 57, 14, 109, 54, 186, 140, 187, 218, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 13, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 49, 141, 109, 156, 140, 207, 99, 33, 246, 182, 180, 113, 222, 250, 13, 105, 110, 105, 207, 125, 40, 165, 1, 202, 227, 57, 14, 109, 54, 186, 140, 187, 218, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 13, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 50] }
 mutated: object(4,0), object(4,1), object(4,2)

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable.move
@@ -11,7 +11,6 @@
 module test::authenticate;
 
 use simple_abstract_account::abstract_account::AbstractAccount;
-use iota::auth_context::AuthContext;
 
 #[authenticator]
 public fun authenticate(_account: &AbstractAccount, _auth_ctx: &AuthContext, _ctx: &TxContext) {}

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable.snap
@@ -13,20 +13,20 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-17:
+task 2, lines 10-16:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8694400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 19:
+task 3, line 18:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [30, 14, 67, 118, 11, 92, 102, 11, 239, 78, 77, 214, 67, 10, 205, 181, 36, 33, 190, 149, 148, 225, 179, 198, 215, 89, 26, 58, 140, 199, 65, 139, 84, 68, 14, 208, 67, 101, 113, 89, 203, 61, 49, 48, 19, 65, 107, 184, 162, 72, 58, 252, 136, 15, 27, 175, 192, 187, 125, 19, 252, 32, 102, 92, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101] }
 created: object(4,0), object(4,1), object(4,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6847600,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 21:
+task 4, line 20:
 //# view-object 4,2
 Owner: Shared( 3 )
 Version: 3
@@ -38,6 +38,6 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 23-24:
+task 5, lines 22-23:
 //# abstract --account object(4,2) --ptb-inputs 100 @A
 Error: Error checking transaction input objects: Feature is not supported: MoveAuthenticator cannot authenticate mutable shared objects

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable_rotate.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable_rotate.move
@@ -10,7 +10,6 @@
 //# publish --sender A --dependencies simple_abstract_account
 module test::authenticate;
 
-use iota::auth_context::AuthContext;
 use simple_abstract_account::abstract_account::AbstractAccount;
 
 #[authenticator]

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable_rotate.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable_rotate.snap
@@ -13,20 +13,20 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-20:
+task 2, lines 10-19:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 10009200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 22:
+task 3, line 21:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate1" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [200, 63, 46, 120, 101, 108, 81, 229, 180, 74, 212, 106, 107, 173, 16, 224, 196, 5, 93, 135, 146, 196, 129, 211, 43, 185, 137, 13, 53, 41, 207, 70, 141, 109, 156, 140, 207, 99, 33, 246, 182, 180, 113, 222, 250, 13, 105, 110, 105, 207, 125, 40, 165, 1, 202, 227, 57, 14, 109, 54, 186, 140, 187, 218, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 13, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 49] }
 created: object(4,0), object(4,1), object(4,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6855200,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 24:
+task 4, line 23:
 //# view-object 4,2
 Owner: Shared( 3 )
 Version: 3
@@ -38,7 +38,7 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 26-27:
+task 5, lines 25-26:
 //# abstract --account immshared(4,2) --ptb-inputs object(4,2) object(3,1) "authenticate" "authenticate2"
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: fake(4,2), type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("AuthenticatorFunctionRefV1Rotated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [200, 63, 46, 120, 101, 108, 81, 229, 180, 74, 212, 106, 107, 173, 16, 224, 196, 5, 93, 135, 146, 196, 129, 211, 43, 185, 137, 13, 53, 41, 207, 70, 141, 109, 156, 140, 207, 99, 33, 246, 182, 180, 113, 222, 250, 13, 105, 110, 105, 207, 125, 40, 165, 1, 202, 227, 57, 14, 109, 54, 186, 140, 187, 218, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 13, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 49, 141, 109, 156, 140, 207, 99, 33, 246, 182, 180, 113, 222, 250, 13, 105, 110, 105, 207, 125, 40, 165, 1, 202, 227, 57, 14, 109, 54, 186, 140, 187, 218, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 13, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 50] }
 mutated: object(4,0), object(4,1), object(4,2)

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/receive_object.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/receive_object.move
@@ -9,7 +9,6 @@
 module test::authenticate;
 
 use iota::account;
-use iota::auth_context::AuthContext;
 use iota::authenticator_function;
 use iota::coin::Coin;
 use iota::iota::IOTA;

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/receive_object.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/receive_object.snap
@@ -6,20 +6,20 @@ processed 8 tasks
 init:
 A: object(0,0)
 
-task 1, lines 8-54:
+task 1, lines 8-53:
 //# publish --sender A
 created: object(1,0), object(1,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 12836400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, line 56:
+task 2, line 55:
 //# init-abstract-account --sender A --package-metadata object(1,1) --inputs "authenticate" "authenticate" --create-function test::authenticate::create --account-type test::authenticate::AbstractAccount
 events: Event { package_id: test, transaction_module: Identifier("authenticate"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: test, module: Identifier("authenticate"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [232, 227, 240, 64, 48, 205, 246, 78, 179, 193, 35, 90, 57, 244, 195, 181, 240, 17, 111, 161, 122, 23, 44, 255, 230, 87, 84, 96, 129, 206, 151, 139, 83, 100, 76, 185, 164, 42, 94, 219, 169, 104, 83, 91, 247, 167, 225, 224, 6, 244, 222, 137, 250, 19, 50, 35, 253, 139, 68, 238, 116, 203, 57, 192, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101] }
 created: object(2,0), object(2,1), object(2,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6786800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 3, line 58:
+task 3, line 57:
 //# view-object 2,2
 Owner: Shared( 3 )
 Version: 3
@@ -31,7 +31,7 @@ Contents: test::authenticate::AbstractAccount {
     },
 }
 
-task 5, lines 62-64:
+task 5, lines 61-63:
 //# programmable --sender A --inputs 2000000000 @a_account
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: TransferObjects([Result(0)], Input(1));
@@ -39,12 +39,12 @@ created: object(5,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 6, lines 66-67:
+task 6, lines 65-66:
 //# abstract --account immshared(2,2) --ptb-inputs object(2,2) receiving(5,0)
 Error: Transaction Effects Status: Move Runtime Abort. Location: iota::transfer::receive_impl (function index 12) at offset 0, Abort Code: 5
 Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: iota, name: Identifier("transfer") }, function: 12, instruction: 0, function_name: Some("receive_impl") }, 5) at command Some(0)
 
-task 7, line 69:
+task 7, line 68:
 //# view-object 5,0
 Owner: Account Address ( a_account )
 Version: 4

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/several_accounts.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/several_accounts.move
@@ -11,7 +11,6 @@
 module test::authenticate;
 
 use simple_abstract_account::abstract_account::AbstractAccount;
-use iota::auth_context::AuthContext;
 use std::ascii;
 
 #[authenticator]

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/several_accounts.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/several_accounts.snap
@@ -13,34 +13,34 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-25:
+task 2, lines 10-24:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9918000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 27:
+task 3, line 26:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate_hello_world" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [118, 148, 168, 179, 49, 8, 198, 92, 21, 125, 6, 180, 227, 97, 246, 20, 241, 88, 51, 186, 200, 202, 42, 84, 230, 84, 167, 107, 231, 146, 174, 230, 57, 11, 82, 234, 228, 162, 3, 155, 237, 197, 142, 43, 85, 213, 106, 74, 73, 1, 24, 171, 0, 12, 137, 124, 25, 149, 48, 40, 186, 221, 194, 209, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 24, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 95, 104, 101, 108, 108, 111, 95, 119, 111, 114, 108, 100] }
 created: object(4,0), object(4,1), object(4,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6938800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 29:
+task 4, line 28:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate_hello_world" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [41, 136, 66, 34, 41, 130, 234, 15, 148, 150, 15, 26, 136, 204, 199, 155, 93, 231, 53, 230, 100, 251, 0, 61, 41, 114, 85, 58, 233, 36, 247, 249, 57, 11, 82, 234, 228, 162, 3, 155, 237, 197, 142, 43, 85, 213, 106, 74, 73, 1, 24, 171, 0, 12, 137, 124, 25, 149, 48, 40, 186, 221, 194, 209, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 24, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 95, 104, 101, 108, 108, 111, 95, 119, 111, 114, 108, 100] }
 created: object(5,0), object(5,1), object(5,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6938800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 5, line 31:
+task 5, line 30:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate_hello_world" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [26, 63, 107, 222, 55, 154, 143, 69, 249, 81, 65, 162, 105, 249, 36, 212, 243, 210, 42, 166, 121, 72, 232, 248, 62, 58, 5, 119, 17, 117, 131, 75, 57, 11, 82, 234, 228, 162, 3, 155, 237, 197, 142, 43, 85, 213, 106, 74, 73, 1, 24, 171, 0, 12, 137, 124, 25, 149, 48, 40, 186, 221, 194, 209, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 24, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 95, 104, 101, 108, 108, 111, 95, 119, 111, 114, 108, 100] }
 created: object(6,0), object(6,1), object(6,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6938800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 6, line 33:
+task 6, line 32:
 //# view-object 4,1
 Owner: Object ID: ( fake(4,2) )
 Version: 3
@@ -104,7 +104,7 @@ Contents: iota::dynamic_field::Field<iota::account::AuthenticatorFunctionRefV1Ke
     },
 }
 
-task 7, line 35:
+task 7, line 34:
 //# view-object 4,2
 Owner: Shared( 3 )
 Version: 3
@@ -116,7 +116,7 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
     },
 }
 
-task 8, line 37:
+task 8, line 36:
 //# view-object 5,1
 Owner: Object ID: ( fake(5,2) )
 Version: 4
@@ -180,7 +180,7 @@ Contents: iota::dynamic_field::Field<iota::account::AuthenticatorFunctionRefV1Ke
     },
 }
 
-task 9, line 39:
+task 9, line 38:
 //# view-object 5,2
 Owner: Shared( 4 )
 Version: 4
@@ -192,7 +192,7 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
     },
 }
 
-task 10, line 41:
+task 10, line 40:
 //# view-object 6,1
 Owner: Object ID: ( fake(6,2) )
 Version: 5
@@ -256,7 +256,7 @@ Contents: iota::dynamic_field::Field<iota::account::AuthenticatorFunctionRefV1Ke
     },
 }
 
-task 11, line 43:
+task 11, line 42:
 //# view-object 6,2
 Owner: Shared( 5 )
 Version: 5

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/sponsor.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/sponsor.move
@@ -11,7 +11,6 @@
 module test::authenticate;
 
 use simple_abstract_account::abstract_account::AbstractAccount;
-use iota::auth_context::AuthContext;
 
 #[authenticator]
 public fun authenticate(_account: &AbstractAccount, _auth_ctx: &AuthContext, _ctx: &TxContext) {}

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/sponsor.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/sponsor.snap
@@ -13,20 +13,20 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-17:
+task 2, lines 10-16:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8694400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 19:
+task 3, line 18:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [30, 14, 67, 118, 11, 92, 102, 11, 239, 78, 77, 214, 67, 10, 205, 181, 36, 33, 190, 149, 148, 225, 179, 198, 215, 89, 26, 58, 140, 199, 65, 139, 84, 68, 14, 208, 67, 101, 113, 89, 203, 61, 49, 48, 19, 65, 107, 184, 162, 72, 58, 252, 136, 15, 27, 175, 192, 187, 125, 19, 252, 32, 102, 92, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101] }
 created: object(4,0), object(4,1), object(4,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6847600,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 21:
+task 4, line 20:
 //# view-object 4,2
 Owner: Shared( 3 )
 Version: 3
@@ -38,14 +38,14 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 23-25:
+task 5, lines 22-24:
 //# abstract --account immshared(4,2) --sponsor A --ptb-inputs 100 @A
 created: object(6,0)
 mutated: object(0,0)
 unchanged_shared: object(4,2)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 6, line 27:
+task 6, line 26:
 //# view-object 6,0
 Owner: Account Address ( A )
 Version: 4

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.move
@@ -37,9 +37,8 @@ module test_coin::regulated_coin {
 
 //# publish --sender A --dependencies test_coin simple_abstract_account
 module test_account::authenticate {
-    use simple_abstract_account::abstract_account::AbstractAccount;
-    use iota::auth_context::AuthContext;
     use iota::coin::Coin;
+    use simple_abstract_account::abstract_account::AbstractAccount;
     use test_coin::regulated_coin::REGULATED_COIN;
 
     #[authenticator]

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.snap
@@ -34,44 +34,44 @@ created: object(4,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 4, lines 38-52:
+task 4, lines 38-51:
 //# publish --sender A --dependencies test_coin simple_abstract_account
 created: object(5,0), object(5,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9956000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 5, line 54:
+task 5, line 53:
 //# init-abstract-account --sender A --package-metadata object(5,1) --inputs "authenticate" "authenticate" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [97, 208, 61, 161, 153, 161, 199, 127, 242, 198, 62, 232, 193, 121, 0, 59, 13, 12, 194, 255, 43, 238, 0, 31, 119, 197, 233, 224, 17, 51, 136, 74, 38, 86, 158, 254, 253, 100, 248, 20, 27, 181, 51, 68, 83, 188, 180, 20, 161, 104, 106, 234, 127, 224, 137, 157, 192, 93, 128, 2, 176, 0, 186, 28, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101] }
 created: object(6,0), object(6,1), object(6,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6847600,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 7, lines 59-63:
+task 7, lines 58-62:
 //# abstract --account immshared(6,2) --auth-inputs immshared(1,0) --ptb-inputs 100 @A
 created: object(8,0)
 mutated: object(6,0)
 unchanged_shared: object(1,0), object(6,2)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 8, lines 64-66:
+task 8, lines 63-65:
 //# run iota::coin::deny_list_v1_add --args object(0x403) object(1,2) @account_addr --type-args test_coin::regulated_coin::REGULATED_COIN --sender C
 events: Event { package_id: iota, transaction_module: Identifier("coin"), sender: C, type_: StructTag { address: iota, module: Identifier("deny_list"), name: Identifier("PerTypeConfigCreated"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0, 96, 48, 55, 54, 98, 97, 56, 56, 97, 49, 55, 52, 50, 57, 52, 55, 55, 52, 49, 53, 57, 53, 101, 99, 99, 49, 97, 101, 97, 101, 48, 56, 55, 101, 101, 57, 98, 55, 100, 97, 57, 97, 52, 49, 48, 101, 100, 53, 48, 57, 54, 57, 48, 50, 57, 102, 52, 51, 98, 52, 99, 52, 100, 52, 99, 58, 58, 114, 101, 103, 117, 108, 97, 116, 101, 100, 95, 99, 111, 105, 110, 58, 58, 82, 69, 71, 85, 76, 65, 84, 69, 68, 95, 67, 79, 73, 78, 177, 51, 95, 88, 36, 152, 30, 217, 70, 230, 243, 77, 182, 89, 219, 50, 64, 135, 107, 20, 58, 237, 234, 43, 148, 26, 99, 12, 27, 232, 137, 159] }
 created: object(9,0), object(9,1), object(9,2)
 mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,1), object(1,2)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 12144800,  storage_rebate: 2758800, non_refundable_storage_fee: 0
 
-task 9, lines 67-71:
+task 9, lines 66-70:
 //# abstract --account immshared(6,2) --auth-inputs immshared(1,0) --ptb-inputs 100 @A
 Error: Error checking transaction input objects: Address object(6,2) is denied for coin object(1,5)::regulated_coin::REGULATED_COIN
 
-task 10, lines 72-74:
+task 10, lines 71-73:
 //# run iota::coin::deny_list_v1_remove --args object(0x403) object(1,2) @account_addr --type-args test_coin::regulated_coin::REGULATED_COIN --sender C
 mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,1), object(1,2)
 deleted: object(9,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4377600,  storage_rebate: 6832400, non_refundable_storage_fee: 0
 
-task 11, lines 75-77:
+task 11, lines 74-76:
 //# abstract --account immshared(6,2) --auth-inputs immshared(1,0) --ptb-inputs 100 @A
 created: object(12,0)
 mutated: object(6,0)

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519.move
@@ -11,7 +11,6 @@
 module test::authenticate;
 
 use abstract_account_with_pub_key::abstract_account::AbstractAccount;
-use iota::auth_context::AuthContext;
 use iota::ed25519;
 
 /// Ed25519 signature authenticator.

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519.snap
@@ -13,20 +13,20 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9348000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-35:
+task 2, lines 10-34:
 //# publish --sender A --dependencies abstract_account_with_pub_key
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9750800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 37:
+task 3, line 36:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate_ed25519" x"cc62332e34bb2d5cd69f60efbb2a36cb916c7eb458301ea36636c4dbb012bd88" --create-function abstract_account_with_pub_key::abstract_account::create --account-type abstract_account_with_pub_key::abstract_account::AbstractAccount
 events: Event { package_id: abstract_account_with_pub_key, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: abstract_account_with_pub_key, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [185, 125, 55, 136, 200, 189, 190, 33, 166, 246, 152, 6, 76, 13, 226, 173, 113, 223, 216, 130, 226, 87, 54, 49, 33, 124, 69, 63, 177, 171, 194, 143, 144, 180, 200, 71, 251, 28, 134, 82, 7, 83, 50, 144, 154, 218, 209, 61, 171, 254, 128, 113, 29, 181, 11, 95, 178, 107, 156, 94, 37, 150, 186, 118, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 20, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 95, 101, 100, 50, 53, 53, 49, 57] }
 created: object(4,0), object(4,1), object(4,2), object(4,3)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9006000,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 39:
+task 4, line 38:
 //# view-object 4,0
 Owner: Shared( 3 )
 Version: 3
@@ -38,14 +38,14 @@ Contents: abstract_account_with_pub_key::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 41-43:
+task 5, lines 40-42:
 //# abstract --account immshared(4,0) --auth-inputs x"cce72947906dbae4c166fc01fd096432784032be43db540909bc901dbc057992b4d655ca4f4355cf0868e1266baacf6919902969f063e74162f8f04bc4056105" x"315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3" --ptb-inputs 100 @A
 created: object(6,0)
 mutated: object(4,1)
 unchanged_shared: object(4,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 6, line 45:
+task 6, line 44:
 //# view-object 6,0
 Owner: Account Address ( A )
 Version: 4

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519_wrong_digest.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519_wrong_digest.move
@@ -11,7 +11,6 @@
 module test::authenticate;
 
 use abstract_account_with_pub_key::abstract_account::AbstractAccount;
-use iota::auth_context::AuthContext;
 use iota::ed25519;
 
 /// Ed25519 signature authenticator.

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519_wrong_digest.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519_wrong_digest.snap
@@ -13,20 +13,20 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9348000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-35:
+task 2, lines 10-34:
 //# publish --sender A --dependencies abstract_account_with_pub_key
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9750800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 37:
+task 3, line 36:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate_ed25519" x"cc62332e34bb2d5cd69f60efbb2a36cb916c7eb458301ea36636c4dbb012bd88" --create-function abstract_account_with_pub_key::abstract_account::create --account-type abstract_account_with_pub_key::abstract_account::AbstractAccount
 events: Event { package_id: abstract_account_with_pub_key, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: abstract_account_with_pub_key, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [185, 125, 55, 136, 200, 189, 190, 33, 166, 246, 152, 6, 76, 13, 226, 173, 113, 223, 216, 130, 226, 87, 54, 49, 33, 124, 69, 63, 177, 171, 194, 143, 144, 180, 200, 71, 251, 28, 134, 82, 7, 83, 50, 144, 154, 218, 209, 61, 171, 254, 128, 113, 29, 181, 11, 95, 178, 107, 156, 94, 37, 150, 186, 118, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 20, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 95, 101, 100, 50, 53, 53, 49, 57] }
 created: object(4,0), object(4,1), object(4,2), object(4,3)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9006000,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 39:
+task 4, line 38:
 //# view-object 4,0
 Owner: Shared( 3 )
 Version: 3
@@ -38,6 +38,6 @@ Contents: abstract_account_with_pub_key::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 41-43:
+task 5, lines 40-42:
 //# abstract --account immshared(4,0) --auth-inputs x"cce72947906dbae4c166fc01fd096432784032be43db540909bc901dbc057992b4d655ca4f4355cf0868e1266baacf6919902969f063e74162f8f04bc4056105" x"315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c10000edd3" --ptb-inputs 100 @A
 Error: Failed to execute the Move authenticator, reason: "ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: object(3,0), name: Identifier(\"authenticate\") }, function: 0, instruction: 8, function_name: Some(\"authenticate_ed25519\") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some(\"object(3,0)::authenticate::authenticate_ed25519 at offset 8\"), exec_state: None, location: Module(ModuleId { address: object(3,0), name: Identifier(\"authenticate\") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 8)] }), command: Some(0) } }".

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519_wrong_signature.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519_wrong_signature.move
@@ -11,7 +11,6 @@
 module test::authenticate;
 
 use abstract_account_with_pub_key::abstract_account::AbstractAccount;
-use iota::auth_context::AuthContext;
 use iota::ed25519;
 
 /// Ed25519 signature authenticator.

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519_wrong_signature.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519_wrong_signature.snap
@@ -13,20 +13,20 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9348000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-35:
+task 2, lines 10-34:
 //# publish --sender A --dependencies abstract_account_with_pub_key
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9750800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 37:
+task 3, line 36:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate_ed25519" x"cc62332e34bb2d5cd69f60efbb2a36cb916c7eb458301ea36636c4dbb012bd88" --create-function abstract_account_with_pub_key::abstract_account::create --account-type abstract_account_with_pub_key::abstract_account::AbstractAccount
 events: Event { package_id: abstract_account_with_pub_key, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: abstract_account_with_pub_key, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [185, 125, 55, 136, 200, 189, 190, 33, 166, 246, 152, 6, 76, 13, 226, 173, 113, 223, 216, 130, 226, 87, 54, 49, 33, 124, 69, 63, 177, 171, 194, 143, 144, 180, 200, 71, 251, 28, 134, 82, 7, 83, 50, 144, 154, 218, 209, 61, 171, 254, 128, 113, 29, 181, 11, 95, 178, 107, 156, 94, 37, 150, 186, 118, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 20, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 95, 101, 100, 50, 53, 53, 49, 57] }
 created: object(4,0), object(4,1), object(4,2), object(4,3)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9006000,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 39:
+task 4, line 38:
 //# view-object 4,0
 Owner: Shared( 3 )
 Version: 3
@@ -38,6 +38,6 @@ Contents: abstract_account_with_pub_key::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 41-43:
+task 5, lines 40-42:
 //# abstract --account immshared(4,0) --auth-inputs x"cce72947906dbae4c166fc01fd096432784032be43db540909bc901dbc057992b4d655ca4f4355cf0868e1266baacf6919902969f063e74162f8f04bc4052345" x"315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3" --ptb-inputs 100 @A
 Error: Failed to execute the Move authenticator, reason: "ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: object(3,0), name: Identifier(\"authenticate\") }, function: 0, instruction: 8, function_name: Some(\"authenticate_ed25519\") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some(\"object(3,0)::authenticate::authenticate_ed25519 at offset 8\"), exec_state: None, location: Module(ModuleId { address: object(3,0), name: Identifier(\"authenticate\") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 8)] }), command: Some(0) } }".

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/event.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/event.move
@@ -10,7 +10,6 @@
 //# publish --sender A --dependencies simple_abstract_account
 module test::authenticate;
 
-use iota::auth_context::AuthContext;
 use simple_abstract_account::abstract_account::AbstractAccount;
 use std::ascii;
 

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/event.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/event.snap
@@ -13,20 +13,20 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-30:
+task 2, lines 10-29:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 11126400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 32:
+task 3, line 31:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate_with_event" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [252, 65, 39, 227, 47, 171, 94, 164, 121, 113, 29, 40, 237, 48, 155, 155, 121, 130, 141, 93, 92, 234, 72, 25, 188, 249, 116, 25, 1, 69, 150, 69, 50, 109, 203, 176, 59, 12, 147, 246, 196, 99, 24, 21, 217, 27, 66, 243, 179, 139, 68, 64, 37, 94, 102, 235, 159, 132, 207, 215, 254, 58, 143, 238, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 23, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 95, 119, 105, 116, 104, 95, 101, 118, 101, 110, 116] }
 created: object(4,0), object(4,1), object(4,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6931200,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 34:
+task 4, line 33:
 //# view-object 4,2
 Owner: Shared( 3 )
 Version: 3
@@ -38,7 +38,7 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 36-38:
+task 5, lines 35-37:
 //# abstract --account immshared(4,2) --ptb-inputs 100 @A
 events: Event { package_id: test, transaction_module: Identifier("authenticate"), sender: fake(4,2), type_: StructTag { address: test, module: Identifier("authenticate"), name: Identifier("AuthenticationSuccessEvent"), type_params: [] }, contents: [38, 72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 32, 65, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 105, 111, 110, 32, 115, 117, 99, 99, 101, 101, 100, 101, 100, 46] }
 created: object(6,0)
@@ -46,7 +46,7 @@ mutated: object(4,0)
 unchanged_shared: object(4,2)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 6, line 40:
+task 6, line 39:
 //# view-object 6,0
 Owner: Account Address ( A )
 Version: 4

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/not_attached.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/not_attached.move
@@ -8,7 +8,6 @@
 //# publish --sender A
 module test::authenticate;
 
-use iota::auth_context::AuthContext;
 use iota::package_metadata::PackageMetadataV1;
 use std::ascii;
 

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/not_attached.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/not_attached.snap
@@ -6,19 +6,19 @@ processed 5 tasks
 init:
 A: object(0,0)
 
-task 1, lines 8-32:
+task 1, lines 8-31:
 //# publish --sender A
 created: object(1,0), object(1,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 10146000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, line 34:
+task 2, line 33:
 //# init-abstract-account --sender A --package-metadata object(1,1) --inputs "authenticate" "authenticate" --create-function test::authenticate::create --account-type test::authenticate::AbstractAccount
 created: object(2,0), object(2,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3351600,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 3, line 36:
+task 3, line 35:
 //# view-object 2,1
 Owner: Shared( 3 )
 Version: 3
@@ -30,6 +30,6 @@ Contents: test::authenticate::AbstractAccount {
     },
 }
 
-task 4, lines 38-40:
+task 4, lines 37-39:
 //# abstract --account immshared(2,1) --ptb-inputs 100 @A
 Error: Error checking transaction input objects: AuthenticatorFunctionRef 0x71f86ca5a45282a1ef19f91abe9c880ad9a9b34fffba716fa32a9eb37a77a508 not found for account object(2,1) with version SequenceNumber(3)

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/randomness.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/randomness.move
@@ -10,7 +10,6 @@
 //# publish --sender A --dependencies simple_abstract_account
 module test::authenticate;
 
-use iota::auth_context::AuthContext;
 use iota::random::Random;
 use simple_abstract_account::abstract_account::AbstractAccount;
 

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/randomness.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/randomness.snap
@@ -13,7 +13,7 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-23:
+task 2, lines 10-22:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/randomness_attack.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/randomness_attack.move
@@ -10,7 +10,6 @@
 //# publish --sender A --dependencies simple_abstract_account
 module test::randomness_attack;
 
-use iota::auth_context::AuthContext;
 use iota::random::Random;
 use simple_abstract_account::abstract_account::AbstractAccount;
 

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/randomness_attack.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/randomness_attack.snap
@@ -13,20 +13,20 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-25:
+task 2, lines 10-24:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9424000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 27:
+task 3, line 26:
 //# init-abstract-account --sender A --package-metadata object(3,0) --inputs "randomness_attack" "authenticate_random" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [225, 24, 72, 218, 173, 229, 21, 128, 137, 239, 139, 216, 88, 144, 136, 148, 162, 26, 254, 91, 7, 187, 186, 36, 45, 249, 106, 109, 74, 133, 185, 134, 156, 37, 67, 160, 27, 23, 244, 200, 83, 2, 207, 60, 121, 247, 186, 6, 46, 144, 90, 182, 79, 173, 234, 236, 19, 14, 81, 157, 13, 43, 133, 91, 17, 114, 97, 110, 100, 111, 109, 110, 101, 115, 115, 95, 97, 116, 116, 97, 99, 107, 19, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 95, 114, 97, 110, 100, 111, 109] }
 created: object(4,0), object(4,1), object(4,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6938800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 29:
+task 4, line 28:
 //# view-object 4,2
 Owner: Shared( 3 )
 Version: 3
@@ -38,7 +38,7 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 31-32:
+task 5, lines 30-31:
 //# abstract --account immshared(4,2) --auth-inputs immshared(8) --ptb-inputs immshared(8)
 mutated: object(4,0)
 unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000008, object(4,2)

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/receiving.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/receiving.move
@@ -10,10 +10,9 @@
 //# publish --sender A --dependencies simple_abstract_account
 module test::authenticate;
 
-use simple_abstract_account::abstract_account::AbstractAccount;
-use iota::auth_context::AuthContext;
 use iota::coin::Coin;
 use iota::iota::IOTA;
+use simple_abstract_account::abstract_account::AbstractAccount;
 
 #[authenticator]
 public fun authenticate_receive_coin(

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/receiving.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/receiving.snap
@@ -13,7 +13,7 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-24:
+task 2, lines 10-23:
 //# publish --sender A --dependencies simple_abstract_account
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function parameter type: iota::transfer::Receiving<iota::coin::Coin<iota::iota::IOTA>>. Receiving objects are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/several_authenticators.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/several_authenticators.move
@@ -11,7 +11,6 @@
 module test::authenticate;
 
 use simple_abstract_account::abstract_account::AbstractAccount;
-use iota::auth_context::AuthContext;
 use std::ascii;
 
 #[authenticator]

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/several_authenticators.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/several_authenticators.snap
@@ -13,20 +13,20 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-35:
+task 2, lines 10-34:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 11544400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 37:
+task 3, line 36:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate_hello_world" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [174, 140, 72, 241, 4, 211, 74, 48, 36, 225, 68, 2, 234, 205, 163, 169, 109, 118, 162, 54, 41, 24, 58, 4, 26, 158, 97, 213, 8, 124, 125, 8, 158, 7, 134, 111, 90, 76, 115, 190, 4, 136, 218, 158, 2, 75, 255, 210, 82, 137, 45, 52, 91, 32, 177, 197, 15, 117, 86, 207, 175, 253, 92, 202, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 24, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 95, 104, 101, 108, 108, 111, 95, 119, 111, 114, 108, 100] }
 created: object(4,0), object(4,1), object(4,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6938800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 39:
+task 4, line 38:
 //# view-object 4,2
 Owner: Shared( 3 )
 Version: 3
@@ -38,14 +38,14 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 41-43:
+task 5, lines 40-42:
 //# abstract --account immshared(4,2) --auth-inputs "HelloWorld" --ptb-inputs 100 @A
 created: object(6,0)
 mutated: object(4,0)
 unchanged_shared: object(4,2)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 6, line 45:
+task 6, line 44:
 //# view-object 6,0
 Owner: Account Address ( A )
 Version: 4

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/simple.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/simple.move
@@ -11,7 +11,6 @@
 module test::authenticate;
 
 use simple_abstract_account::abstract_account::AbstractAccount;
-use iota::auth_context::AuthContext;
 use std::ascii;
 
 #[authenticator]

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/simple.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/simple.snap
@@ -13,20 +13,20 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-25:
+task 2, lines 10-24:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9918000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 27:
+task 3, line 26:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate_hello_world" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [118, 148, 168, 179, 49, 8, 198, 92, 21, 125, 6, 180, 227, 97, 246, 20, 241, 88, 51, 186, 200, 202, 42, 84, 230, 84, 167, 107, 231, 146, 174, 230, 57, 11, 82, 234, 228, 162, 3, 155, 237, 197, 142, 43, 85, 213, 106, 74, 73, 1, 24, 171, 0, 12, 137, 124, 25, 149, 48, 40, 186, 221, 194, 209, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 24, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 95, 104, 101, 108, 108, 111, 95, 119, 111, 114, 108, 100] }
 created: object(4,0), object(4,1), object(4,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6938800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 29:
+task 4, line 28:
 //# view-object 4,2
 Owner: Shared( 3 )
 Version: 3
@@ -38,14 +38,14 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 31-33:
+task 5, lines 30-32:
 //# abstract --account immshared(4,2) --auth-inputs "HelloWorld" --ptb-inputs 100 @A
 created: object(6,0)
 mutated: object(4,0)
 unchanged_shared: object(4,2)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 6, line 35:
+task 6, line 34:
 //# view-object 6,0
 Owner: Account Address ( A )
 Version: 4

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/simple_fail.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/simple_fail.move
@@ -11,7 +11,6 @@
 module test::authenticate;
 
 use simple_abstract_account::abstract_account::AbstractAccount;
-use iota::auth_context::AuthContext;
 use std::ascii;
 
 #[authenticator]

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/simple_fail.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/simple_fail.snap
@@ -13,20 +13,20 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-25:
+task 2, lines 10-24:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9918000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 27:
+task 3, line 26:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate_hello_world" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [118, 148, 168, 179, 49, 8, 198, 92, 21, 125, 6, 180, 227, 97, 246, 20, 241, 88, 51, 186, 200, 202, 42, 84, 230, 84, 167, 107, 231, 146, 174, 230, 57, 11, 82, 234, 228, 162, 3, 155, 237, 197, 142, 43, 85, 213, 106, 74, 73, 1, 24, 171, 0, 12, 137, 124, 25, 149, 48, 40, 186, 221, 194, 209, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 24, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 95, 104, 101, 108, 108, 111, 95, 119, 111, 114, 108, 100] }
 created: object(4,0), object(4,1), object(4,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6938800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 29:
+task 4, line 28:
 //# view-object 4,2
 Owner: Shared( 3 )
 Version: 3
@@ -38,6 +38,6 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 31-32:
+task 5, lines 30-31:
 //# abstract --account immshared(4,2) --auth-inputs "test" --ptb-inputs 100 @A
 Error: Failed to execute the Move authenticator, reason: "ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: object(3,0), name: Identifier(\"authenticate\") }, function: 0, instruction: 7, function_name: Some(\"authenticate_hello_world\") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some(\"object(3,0)::authenticate::authenticate_hello_world at offset 7\"), exec_state: None, location: Module(ModuleId { address: object(3,0), name: Identifier(\"authenticate\") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 7)] }), command: Some(0) } }".

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/without_attribute.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/without_attribute.move
@@ -11,7 +11,6 @@
 module test::authenticate;
 
 use simple_abstract_account::abstract_account::AbstractAccount;
-use iota::auth_context::AuthContext;
 use std::ascii;
 
 public fun authenticate_hello_world(

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/without_attribute.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/without_attribute.snap
@@ -13,12 +13,12 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-24:
+task 2, lines 10-23:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6429600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 26:
+task 3, line 25:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate_hello_world" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 Error: INVALID TEST. Unknown object, object(3,1)

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/wrong_type.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/wrong_type.move
@@ -10,8 +10,6 @@
 //# publish --sender A --dependencies simple_abstract_account
 module test::authenticate;
 
-use iota::auth_context::AuthContext;
-
 public struct AbstractAccount2 has key {
     id: UID,
 }

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/wrong_type.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/wrong_type.snap
@@ -13,13 +13,13 @@ created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-20:
+task 2, lines 10-18:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8975600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 22:
+task 3, line 20:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
 Error: Transaction Effects Status: Move Runtime Abort. Location: iota::authenticator_function::create_auth_function_ref_v1 (function index 0) at offset 15, Abort Code: 13835058261440593921
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: iota, name: Identifier("authenticator_function") }, function: 0, instruction: 15, function_name: Some("create_auth_function_ref_v1") }, 13835058261440593921), source: Some(VMError { major_status: ABORTED, sub_status: Some(13835058261440593921), message: Some("iota::authenticator_function::create_auth_function_ref_v1 at offset 15"), exec_state: None, location: Module(ModuleId { address: iota, name: Identifier("authenticator_function") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 15)] }), command: Some(0) } }

--- a/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context.move
+++ b/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context.move
@@ -7,8 +7,6 @@
 
 module Test::M;
 
-use iota::auth_context::AuthContext;
-
 public fun authenticate(_: &AuthContext, _: &TxContext) {}
 
 public fun authenticate_with_mut_auth_context(_: &mut AuthContext, _: &TxContext) {}

--- a/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context.snap
+++ b/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context.snap
@@ -3,33 +3,33 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 7 tasks
 
-task 1, lines 6-22:
+task 1, lines 6-20:
 //# publish
 created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5920400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 23-25:
+task 2, lines 21-23:
 //# run Test::M::authenticate
 Error: Transaction Effects Status: MOVE VM INVARIANT VIOLATION.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMInvariantViolation, source: Some("`iota::auth_context::AuthContext` can't be used as a parameter in this execution mode"), command: Some(0) } }
 
-task 3, lines 26-28:
+task 3, lines 24-26:
 //# run Test::M::authenticate_with_mut_auth_context
 Error: Transaction Effects Status: Arity mismatch for Move function. The number of arguments does not match the number of parameters
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ArityMismatch, source: Some("Expected 2 arguments calling function 'authenticate_with_mut_auth_context', but found 1"), command: Some(0) } }
 
-task 4, lines 29-31:
+task 4, lines 27-29:
 //# run Test::M::authenticate_with_auth_context_value
 Error: Transaction Effects Status: Arity mismatch for Move function. The number of arguments does not match the number of parameters
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ArityMismatch, source: Some("Expected 2 arguments calling function 'authenticate_with_auth_context_value', but found 1"), command: Some(0) } }
 
-task 5, lines 32-34:
+task 5, lines 30-32:
 //# run Test::M::authenticate_with_miss_placed_auth_context
 Error: Transaction Effects Status: Arity mismatch for Move function. The number of arguments does not match the number of parameters
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ArityMismatch, source: Some("Expected 3 arguments calling function 'authenticate_with_miss_placed_auth_context', but found 1"), command: Some(0) } }
 
-task 6, line 35:
+task 6, line 33:
 //# run Test::M::authenticate_with_only_auth_context
 Error: Transaction Effects Status: Arity mismatch for Move function. The number of arguments does not match the number of parameters
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ArityMismatch, source: Some("Expected 1 argument calling function 'authenticate_with_only_auth_context', but found 0"), command: Some(0) } }

--- a/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context_disabled.move
+++ b/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context_disabled.move
@@ -7,8 +7,6 @@
 
 module Test::M;
 
-use iota::auth_context::AuthContext;
-
 public fun authenticate(_: &AuthContext, _: &TxContext) {}
 
 // using `iota::auth_context::AuthContext` is not allowed by the protocol config

--- a/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context_disabled.snap
+++ b/crates/iota-adapter-transactional-tests/tests/iota/move_call_args_auth_context_disabled.snap
@@ -3,13 +3,13 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 3 tasks
 
-task 1, lines 6-14:
+task 1, lines 6-12:
 //# publish
 created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4202800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, line 15:
+task 2, line 13:
 //# run Test::M::authenticate
 Error: Transaction Effects Status: MOVE VM INVARIANT VIOLATION.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMInvariantViolation, source: Some("`iota::auth_context::AuthContext` can't be used as a parameter if the `move_authentication` feature is disabled"), command: Some(0) } }

--- a/crates/iota-adapter-transactional-tests/tests/programmable/private_account_functions.move
+++ b/crates/iota-adapter-transactional-tests/tests/programmable/private_account_functions.move
@@ -8,8 +8,6 @@
 //# publish
 module test::account;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key { id: UID }
 
 public fun create(ctx: &mut TxContext): Account { Account { id: object::new(ctx) } }

--- a/crates/iota-adapter-transactional-tests/tests/programmable/private_account_functions.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable/private_account_functions.snap
@@ -6,13 +6,13 @@ processed 5 tasks
 init:
 A: object(0,0)
 
-task 1, lines 8-18:
+task 1, lines 8-16:
 //# publish
 created: object(1,0), object(1,1)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8466400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 20-23:
+task 2, lines 18-21:
 //# programmable --inputs object(1,1) "account" "authenticate"
 //> 0: test::account::create();
 //> 1: iota::authenticator_function::create_auth_function_ref_v1<test::account::Account>(Input(0), Input(1), Input(2));
@@ -20,7 +20,7 @@ task 2, lines 20-23:
 Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot directly call iota::account::create_account_v1."), command: Some(2) } }
 
-task 3, lines 25-28:
+task 3, lines 23-26:
 //# programmable --inputs object(1,1) "account" "authenticate"
 //> 0: test::account::create();
 //> 1: iota::authenticator_function::create_auth_function_ref_v1<test::account::Account>(Input(0), Input(1), Input(2));
@@ -28,7 +28,7 @@ task 3, lines 25-28:
 Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot directly call iota::account::create_immutable_account_v1."), command: Some(2) } }
 
-task 4, lines 30-33:
+task 4, lines 28-31:
 //# programmable --inputs object(1,1) "account" "authenticate"
 //> 0: test::account::create();
 //> 1: iota::authenticator_function::create_auth_function_ref_v1<test::account::Account>(Input(0), Input(1), Input(2));

--- a/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/abstract_account_keyed.move
+++ b/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/abstract_account_keyed.move
@@ -5,7 +5,6 @@ module abstract_account::abstract_account_keyed;
 
 use abstract_account::abstract_account::{Self, AbstractAccount};
 use abstract_account::basic_keyed_aa;
-use iota::auth_context::AuthContext;
 use iota::authenticator_function::AuthenticatorFunctionRefV1;
 
 // === Errors ===

--- a/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/basic_keyed_aa.move
+++ b/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/basic_keyed_aa.move
@@ -3,7 +3,6 @@
 
 module abstract_account::basic_keyed_aa;
 
-use iota::auth_context::AuthContext;
 use iota::ecdsa_k1;
 use iota::ecdsa_r1;
 use iota::ed25519;

--- a/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/delayed_abstract_account_keyed.move
+++ b/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/delayed_abstract_account_keyed.move
@@ -5,7 +5,6 @@ module abstract_account::delayed_abstract_account_keyed;
 
 use abstract_account::basic_keyed_aa;
 use abstract_account::delayed_abstract_account::{Self, DelayedAbstractAccount};
-use iota::auth_context::AuthContext;
 use iota::authenticator_function::AuthenticatorFunctionRefV1;
 
 // === Errors ===

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -1454,7 +1454,6 @@ Doesn't support simulator mode.
 module test::authenticate;
 
 use simple_abstract_account::abstract_account::AbstractAccount;
-use iota::auth_context::AuthContext;
 use std::ascii;
 
 #[authenticator]
@@ -1513,21 +1512,22 @@ task 1, line 8:
 Output for 'crates/iota-adapter-transactional-tests/data/account_abstraction/simple_abstract_account.move':
 created: object(2,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 7584800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 10-25:
+task 2, lines 10-24:
 //# publish --sender A --dependencies simple_abstract_account
 created: object(3,0), object(3,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9918000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 27:
+task 3, line 26:
 //# init-abstract-account --sender A --package-metadata object(3,1) --inputs "authenticate" "authenticate_hello_world" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
+events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [118, 148, 168, 179, 49, 8, 198, 92, 21, 125, 6, 180, 227, 97, 246, 20, 241, 88, 51, 186, 200, 202, 42, 84, 230, 84, 167, 107, 231, 146, 174, 230, 57, 11, 82, 234, 228, 162, 3, 155, 237, 197, 142, 43, 85, 213, 106, 74, 73, 1, 24, 171, 0, 12, 137, 124, 25, 149, 48, 40, 186, 221, 194, 209, 12, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 24, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 95, 104, 101, 108, 108, 111, 95, 119, 111, 114, 108, 100] }
 created: object(4,0), object(4,1), object(4,2)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6718400,  storage_rebate: 980400, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6938800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 4, line 29:
+task 4, line 28:
 //# view-object 4,2
 Owner: Shared( 3 )
 Version: 3
@@ -1539,14 +1539,14 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
     },
 }
 
-task 5, lines 31-33:
+task 5, lines 30-32:
 //# abstract --account immshared(4,2) --auth-inputs "HelloWorld" --ptb-inputs 100 @A
 created: object(6,0)
 mutated: object(4,0)
 unchanged_shared: object(4,2)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 6, line 35:
+task 6, line 34:
 //# view-object 6,0
 Owner: Account Address ( A )
 Version: 4

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-18:
+task 0, lines 4-16:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: _::account::Account. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/concrete.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/concrete.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 public struct Wrapped has store {
     cd: u8,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/concrete.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/concrete.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-21:
+task 0, lines 4-19:
 //# publish
 created: object(1,0), object(1,1)
 mutated: object(0,0)

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/concrete_multiple.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/concrete_multiple.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 public struct Wrapped has store {
     cd: u8,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/concrete_multiple.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/concrete_multiple.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-30:
+task 0, lines 4-28:
 //# publish
 created: object(1,0), object(1,1)
 mutated: object(0,0)

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-15:
+task 0, lines 4-13:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &mut _::account::Account. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/option_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/option_by_value.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
 use std::option::Option;
 
 public struct Account has key {

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/option_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/option_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-28:
+task 0, lines 4-27:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: std::option::Option<_::account::Account>. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/option_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/option_immutable_ref.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
 use std::option::Option;
 
 public struct Account has key {

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/option_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/option_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-19:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &std::option::Option<_::account::Account>. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/option_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/option_mutable_ref.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
 use std::option::Option;
 
 public struct Account has key {

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/option_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/option_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-19:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &mut std::option::Option<_::account::Account>. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/primitive.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/primitive.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 // FAIL
 #[authenticator]
 public fun primitive(_account: u64, _actx: &AuthContext, _ctx: &TxContext) {}

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/primitive.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/primitive.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-11:
+task 0, lines 4-9:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: u64. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/receiving.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/receiving.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::receiving;
 
-use iota::auth_context::AuthContext;
 use iota::transfer::Receiving;
 
 public struct Account has key {

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/receiving.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/receiving.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-16:
+task 0, lines 4-15:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &iota::transfer::Receiving<_::receiving::Account>. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/string.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/string.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
 use std::string::String;
 
 // FAIL

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/string.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/string.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-12:
+task 0, lines 4-11:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: std::string::String. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/template_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/template_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 public struct Wrapper<T> has key {
     id: UID,
     wrapped: vector<T>,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/template_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/template_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-23:
+task 0, lines 4-21:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: T0. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/template_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/template_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 // FAIL
 #[authenticator]
 public fun template_immutable_ref<T: key>(_account: &T, _actx: &AuthContext, _ctx: &TxContext) {}

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/template_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/template_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-11:
+task 0, lines 4-9:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &T0. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/template_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/template_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 // FAIL
 #[authenticator]
 public fun template_mutable_ref<T: key>(_account: &mut T, _actx: &AuthContext, _ctx: &TxContext) {}

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/template_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/template_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-11:
+task 0, lines 4-9:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &mut T0. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/templated_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/templated_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 #[allow(unused_field)]
 public struct Account<T: store> has key, store {
     id: UID,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/templated_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/templated_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-29:
+task 0, lines 4-27:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: _::account::Account<T0>. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/templated_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/templated_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 #[allow(unused_field)]
 public struct Account<T: store> has key {
     id: UID,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/templated_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/templated_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-21:
+task 0, lines 4-19:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &_::account::Account<T0>. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/templated_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/templated_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 #[allow(unused_field)]
 public struct Account<T: store> has key {
     id: UID,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/templated_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/templated_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-21:
+task 0, lines 4-19:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &mut _::account::Account<T0>. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/vector_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/vector_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/vector_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/vector_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-27:
+task 0, lines 4-25:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: vector<_::account::Account>. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/vector_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/vector_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/vector_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/vector_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-19:
+task 0, lines 4-17:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &vector<_::account::Account>. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/vector_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/vector_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::account;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/vector_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/account/vector_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-19:
+task 0, lines 4-17:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &mut vector<_::account::Account>. Valid types for the first parameter are immutable references to an object type (with no generics)."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::object;
 
-use iota::auth_context::AuthContext;
-
 // Test account struct
 public struct Account has key {
     id: UID,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-23:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: _::object::Object. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::object;
 
-use iota::auth_context::AuthContext;
-
 // Test account struct
 public struct Account has key {
     id: UID,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-27:
+task 0, lines 4-25:
 //# publish
 created: object(1,0), object(1,1)
 mutated: object(0,0)

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::object;
 
-use iota::auth_context::AuthContext;
-
 // Test account struct
 public struct Account has key {
     id: UID,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-27:
+task 0, lines 4-25:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut _::object::Object. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::object;
 
-use iota::auth_context::AuthContext;
-
 // Test account struct
 public struct Account has key {
     id: UID,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-38:
+task 0, lines 4-36:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: _::object::Object<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_copy_drop_store_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_copy_drop_store_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::object;
 
-use iota::auth_context::AuthContext;
-
 // Test account struct
 public struct Account has key {
     id: UID,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_copy_drop_store_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_copy_drop_store_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-31:
+task 0, lines 4-29:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: _::object::ObjectPrimitive<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_copy_drop_store_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_copy_drop_store_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::object;
 
-use iota::auth_context::AuthContext;
-
 // Test account struct
 public struct Account has key {
     id: UID,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_copy_drop_store_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_copy_drop_store_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-28:
+task 0, lines 4-26:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut _::object::ObjectPrimitive<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::object;
 
-use iota::auth_context::AuthContext;
-
 // Test account struct
 public struct Account has key {
     id: UID,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-56:
+task 0, lines 4-54:
 //# publish
 created: object(1,0), object(1,1)
 mutated: object(0,0)

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_key_store_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_key_store_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::object;
 
-use iota::auth_context::AuthContext;
-
 // Test account struct
 public struct Account has key {
     id: UID,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_key_store_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_key_store_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-38:
+task 0, lines 4-36:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: _::object::ObjectObject<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_key_store_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_key_store_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::object;
 
-use iota::auth_context::AuthContext;
-
 // Test account struct
 public struct Account has key {
     id: UID,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_key_store_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_key_store_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-28:
+task 0, lines 4-26:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut _::object::ObjectObject<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::object;
 
-use iota::auth_context::AuthContext;
-
 // Test account struct
 public struct Account has key {
     id: UID,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/template_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-28:
+task 0, lines 4-26:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut _::object::Object<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-22:
+task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: std::option::Option<_::option::NonObject>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-22:
+task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<_::option::NonObject>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-22:
+task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<_::option::NonObject>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-28:
+task 0, lines 4-26:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: std::option::Option<_::option::Object>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-24:
+task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<_::option::Object>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-24:
+task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<_::option::Object>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 created: object(1,0), object(1,1)
 mutated: object(0,0)

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_immutable_reference.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_immutable_reference.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_immutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_immutable_reference.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<u8>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_mutable_reference.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_mutable_reference.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_mutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_mutable_reference.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<u8>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Wrapped has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-39:
+task 0, lines 4-37:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: std::option::Option<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<T0>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-24:
+task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: std::option::Option<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_immutable_reference.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_immutable_reference.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_immutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_immutable_reference.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<T0>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_mutable_reference.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_mutable_reference.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_mutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_mutable_reference.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-23:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: std::option::Option<_::option::NonObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-23:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<_::option::NonObjectTemplated<T0>>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-23:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<_::option::NonObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-30:
+task 0, lines 4-28:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: std::option::Option<_::option::ObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-23:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<_::option::ObjectTemplated<T0>>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::option;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-23:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<_::option::ObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/by_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/by_mutable_ref.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::receiving;
 
-use iota::auth_context::AuthContext;
 use iota::transfer::Receiving;
 
 public struct Account has key {

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/by_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/by_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-24:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function parameter type: &mut iota::transfer::Receiving<_::receiving::Object>. Receiving objects are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/by_value.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::receiving;
 
-use iota::auth_context::AuthContext;
 use iota::transfer::Receiving;
 
 public struct Account has key {

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-30:
+task 0, lines 4-29:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function parameter type: iota::transfer::Receiving<_::receiving::Object>. Receiving objects are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/datatype_inst_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/datatype_inst_immutable_ref.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::receiving;
 
-use iota::auth_context::AuthContext;
 use iota::transfer::Receiving;
 use iota::vec_map::VecMap;
 

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/datatype_inst_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/datatype_inst_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-28:
+task 0, lines 4-27:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &iota::vec_map::VecMap<u8, iota::transfer::Receiving<_::receiving::Object>>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/immutable_ref.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::receiving;
 
-use iota::auth_context::AuthContext;
 use iota::transfer::Receiving;
 
 public struct Account has key {

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-24:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function parameter type: &iota::transfer::Receiving<_::receiving::Object>. Receiving objects are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_by_value.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::receiving;
 
-use iota::auth_context::AuthContext;
 use iota::transfer::Receiving;
 
 public struct Account has key {

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-26:
+task 0, lines 4-25:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: std::option::Option<iota::transfer::Receiving<_::receiving::Object>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_immutable_ref.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::receiving;
 
-use iota::auth_context::AuthContext;
 use iota::transfer::Receiving;
 
 public struct Account has key {

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-27:
+task 0, lines 4-26:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<iota::transfer::Receiving<_::receiving::Object>>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_mutable_ref.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::receiving;
 
-use iota::auth_context::AuthContext;
 use iota::transfer::Receiving;
 
 public struct Account has key {

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-27:
+task 0, lines 4-26:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<iota::transfer::Receiving<_::receiving::Object>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_by_value.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::receiving;
 
-use iota::auth_context::AuthContext;
 use iota::transfer::Receiving;
 
 public struct Account has key {

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-26:
+task 0, lines 4-25:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: vector<iota::transfer::Receiving<_::receiving::Object>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_immutable_ref.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::receiving;
 
-use iota::auth_context::AuthContext;
 use iota::transfer::Receiving;
 
 public struct Account has key {

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-27:
+task 0, lines 4-26:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<iota::transfer::Receiving<_::receiving::Object>>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_mutable_ref.move
@@ -4,7 +4,6 @@
 //# publish
 module 0x0::receiving;
 
-use iota::auth_context::AuthContext;
 use iota::transfer::Receiving;
 
 public struct Account has key {

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-24:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<iota::transfer::Receiving<_::receiving::Object>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/arg_mutable_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/arg_mutable_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::signature;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/arg_mutable_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/arg_mutable_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 created: object(1,0), object(1,1)
 mutated: object(0,0)

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/arg_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/arg_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::signature;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/arg_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/arg_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-15:
+task 0, lines 4-13:
 //# publish
 created: object(1,0), object(1,1)
 mutated: object(0,0)

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_cant_be_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_cant_be_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::signature;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_cant_be_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_cant_be_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-19:
+task 0, lines 4-17:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'auth_context_cant_be_mutable_ref' can only receive 'AuthContext' as immutable reference"), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_cant_be_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_cant_be_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::signature;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_cant_be_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_cant_be_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-15:
+task 0, lines 4-13:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'auth_context_cant_be_value' can only receive 'AuthContext' as immutable reference"), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_isnt_struct.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_isnt_struct.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::signature;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_isnt_struct.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_isnt_struct.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-15:
+task 0, lines 4-13:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'auth_context_isnt_struct' can only receive 'AuthContext' as immutable reference"), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/minimally_viable_auth_function.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/minimally_viable_auth_function.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::signature;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/minimally_viable_auth_function.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/minimally_viable_auth_function.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-19:
+task 0, lines 4-17:
 //# publish
 created: object(1,0), object(1,1)
 mutated: object(0,0)

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/tx_context_cant_be_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/tx_context_cant_be_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::signature;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/tx_context_cant_be_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/tx_context_cant_be_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-19:
+task 0, lines 4-17:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'tx_context_cant_be_mutable_ref' can only receive 'TxContext' as immutable reference"), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/tx_context_isnt_struct.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/tx_context_isnt_struct.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::signature;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/tx_context_isnt_struct.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/tx_context_isnt_struct.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-15:
+task 0, lines 4-13:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'tx_context_isnt_struct' can only receive 'TxContext' as immutable reference"), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/with_signer.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/with_signer.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::signature;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/with_signer.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/with_signer.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-15:
+task 0, lines 4-13:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: signer. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/without_account.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/without_account.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::signature;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/without_account.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/without_account.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-15:
+task 0, lines 4-13:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'without_account' must require at least: a reference to an account object type, &AuthContext and &TxContext arguments."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/without_auth_context.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/without_auth_context.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::signature;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/without_auth_context.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/without_auth_context.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-15:
+task 0, lines 4-13:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'without_auth_context' must require at least: a reference to an account object type, &AuthContext and &TxContext arguments."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/without_tx_context.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/without_tx_context.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::signature;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/without_tx_context.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/without_tx_context.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-15:
+task 0, lines 4-13:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'without_tx_context' must require at least: a reference to an account object type, &AuthContext and &TxContext arguments."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::template;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-22:
+task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: T0. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::template;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 created: object(1,0), object(1,1)
 mutated: object(0,0)

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::template;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut T0. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/primitive.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/primitive.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::template;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/primitive.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/primitive.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 created: object(1,0), object(1,1)
 mutated: object(0,0)

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::template;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-23:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: _::template::NonObjectTemplated<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::template;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-23:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &_::template::NonObjectTemplated<T0>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::template;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-23:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut _::template::NonObjectTemplated<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::template;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-28:
+task 0, lines 4-26:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: _::template::ObjectTemplated<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::template;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-23:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &_::template::ObjectTemplated<T0>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::template;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-25:
+task 0, lines 4-23:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut _::template::ObjectTemplated<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-22:
+task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: vector<_::vector::NonObject>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-22:
+task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<_::vector::NonObject>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-22:
+task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<_::vector::NonObject>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-26:
+task 0, lines 4-24:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: vector<_::vector::Object>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-24:
+task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<_::vector::Object>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-24:
+task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<_::vector::Object>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 created: object(1,0), object(1,1)
 mutated: object(0,0)

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_immutable_reference.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_immutable_reference.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_immutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_immutable_reference.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<u8>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_mutable_reference.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_mutable_reference.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_mutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_mutable_reference.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<u8>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Wrapped has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-39:
+task 0, lines 4-37:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: vector<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<T0>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-22:
+task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: vector<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_immutable_reference.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_immutable_reference.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_immutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_immutable_reference.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<T0>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_mutable_reference.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_mutable_reference.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_mutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_mutable_reference.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-20:
+task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-24:
+task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: vector<_::vector::NonObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-24:
+task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<_::vector::NonObjectTemplated<T0>>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-24:
+task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<_::vector::NonObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_by_value.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_by_value.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_by_value.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-29:
+task 0, lines 4-27:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: vector<_::vector::ObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_immutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_immutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_immutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-24:
+task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<_::vector::ObjectTemplated<T0>>. Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_mutable_ref.move
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_mutable_ref.move
@@ -4,8 +4,6 @@
 //# publish
 module 0x0::vector;
 
-use iota::auth_context::AuthContext;
-
 public struct Account has key {
     id: UID,
 }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_mutable_ref.snap
@@ -3,7 +3,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 1 task
 
-task 0, lines 4-24:
+task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<_::vector::ObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/examples/move/dynamic_multisig_account/sources/dynamic_multisig_account.move
+++ b/examples/move/dynamic_multisig_account/sources/dynamic_multisig_account.move
@@ -6,7 +6,6 @@ module dynamic_multisig_account::dynamic_multisig_account;
 use dynamic_multisig_account::members::{Self, Members};
 use dynamic_multisig_account::transactions::{Self, Transactions};
 use iota::account;
-use iota::auth_context::AuthContext;
 use iota::authenticator_function::AuthenticatorFunctionRefV1;
 use iota::dynamic_field;
 

--- a/examples/move/dynamic_multisig_account/tests/dynamic_multisig_account_tests.move
+++ b/examples/move/dynamic_multisig_account/tests/dynamic_multisig_account_tests.move
@@ -7,7 +7,6 @@ module dynamic_multisig_account::dynamic_multisig_account_tests;
 use dynamic_multisig_account::dynamic_multisig_account::{Self, DynamicMultisigAccount};
 use dynamic_multisig_account::members;
 use dynamic_multisig_account::transactions;
-use iota::auth_context::{Self, AuthContext};
 use iota::authenticator_function::{Self, AuthenticatorFunctionRefV1};
 use iota::test_scenario::{Self, Scenario};
 use iota::test_utils::{assert_eq, assert_ref_eq};

--- a/examples/move/function_keys/sources/function_keys.move
+++ b/examples/move/function_keys/sources/function_keys.move
@@ -30,7 +30,6 @@ use function_keys::fk_store::{
     disallow,
     is_allowed
 };
-use iota::auth_context::AuthContext;
 use iota::authenticator_function::AuthenticatorFunctionRefV1;
 use iota::ed25519;
 use iota::hex::decode;

--- a/examples/move/function_keys/tests/function_keys_tests.move
+++ b/examples/move/function_keys/tests/function_keys_tests.move
@@ -18,7 +18,6 @@ module function_keys::function_keys_scenario_tests;
 
 use function_keys::fk_store::{Self as store, make_func_key};
 use function_keys::function_keys;
-use iota::auth_context::{Self as acx, AuthContext};
 use iota::authenticator_function::{Self, AuthenticatorFunctionRefV1};
 use iota::hex;
 use iota::ptb_command::{Self, Command};
@@ -571,7 +570,7 @@ fun create_tx_context_for_testing(sender: address, digest: vector<u8>): TxContex
 
 /// Build an AuthContext for tests.
 fun create_auth_context_with_commands_for_testing(cmds: vector<Command>): AuthContext {
-    acx::new_with_tx_inputs(vector::empty(), vector::empty(), cmds)
+    auth_context::new_with_tx_inputs(vector::empty(), vector::empty(), cmds)
 }
 
 fun public_key_for_testing(): vector<u8> { b"42" }

--- a/examples/move/iotaccount/sources/keyed_iotaccount.move
+++ b/examples/move/iotaccount/sources/keyed_iotaccount.move
@@ -3,7 +3,6 @@
 
 module iotaccount::keyed_iotaccount;
 
-use iota::auth_context::AuthContext;
 use iota::authenticator_function::AuthenticatorFunctionRefV1;
 use iota::ecdsa_k1;
 use iota::ecdsa_r1;

--- a/examples/move/iotaccount/tests/keyed_iotaccount_tests.move
+++ b/examples/move/iotaccount/tests/keyed_iotaccount_tests.move
@@ -4,7 +4,6 @@
 #[test_only]
 module iotaccount::keyed_iotaccount_tests;
 
-use iota::auth_context::{Self, AuthContext};
 use iota::authenticator_function;
 use iota::ecdsa_k1;
 use iota::hex;

--- a/examples/move/spending_limit/sources/account.move
+++ b/examples/move/spending_limit/sources/account.move
@@ -5,7 +5,7 @@ module spending_limit::account;
 
 use generic_keyed_authentication::owner_public_key;
 use iota::account;
-use iota::auth_context::{AuthContext, tx_commands, tx_inputs};
+use iota::auth_context::{tx_commands, tx_inputs};
 use iota::authenticator_function::AuthenticatorFunctionRefV1;
 use iota::balance::{Self, Balance};
 use iota::bcs;

--- a/examples/move/spending_limit/tests/account_tests.move
+++ b/examples/move/spending_limit/tests/account_tests.move
@@ -5,7 +5,6 @@
 module spending_limit::account_tests;
 
 use generic_keyed_authentication::owner_public_key;
-use iota::auth_context::{Self, AuthContext};
 use iota::authenticator_function::AuthenticatorFunctionRefV1;
 use iota::coin;
 use iota::hex;

--- a/examples/move/time_locked/sources/account.move
+++ b/examples/move/time_locked/sources/account.move
@@ -5,7 +5,6 @@ module time_locked::account;
 
 use generic_keyed_authentication::owner_public_key;
 use iota::account;
-use iota::auth_context::AuthContext;
 use iota::authenticator_function::AuthenticatorFunctionRefV1;
 use iota::clock::Clock;
 use iotaccount::iotaccount;

--- a/examples/move/time_locked/tests/account_tests.move
+++ b/examples/move/time_locked/tests/account_tests.move
@@ -5,7 +5,6 @@
 module time_locked::account_tests;
 
 use generic_keyed_authentication::owner_public_key;
-use iota::auth_context::{Self, AuthContext};
 use iota::authenticator_function::{Self, AuthenticatorFunctionRefV1};
 use iota::clock;
 use iota::hex;

--- a/external-crates/move/crates/move-compiler/src/expansion/name_validation.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/name_validation.rs
@@ -28,10 +28,12 @@ pub const IMPLICIT_STD_MEMBERS: &[(Symbol, Symbol, ModuleMemberKind)] = &[(
 // use iota::object::{Self, ID, UID};
 // use iota::transfer;
 // use iota::tx_context::{Self, TxContext};
+// use iota::auth_context::{Self, AuthContext};
 pub const IMPLICIT_IOTA_MODULES: &[Symbol] = &[
     symbol!("object"),
     symbol!("transfer"),
     symbol!("tx_context"),
+    symbol!("auth_context"),
 ];
 pub const IMPLICIT_IOTA_MEMBERS: &[(Symbol, Symbol, ModuleMemberKind)] = &[
     (symbol!("object"), symbol!("ID"), ModuleMemberKind::Struct),
@@ -39,6 +41,11 @@ pub const IMPLICIT_IOTA_MEMBERS: &[(Symbol, Symbol, ModuleMemberKind)] = &[
     (
         symbol!("tx_context"),
         symbol!("TxContext"),
+        ModuleMemberKind::Struct,
+    ),
+    (
+        symbol!("auth_context"),
+        symbol!("AuthContext"),
         ModuleMemberKind::Struct,
     ),
 ];

--- a/external-crates/move/crates/move-compiler/tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move
+++ b/external-crates/move/crates/move-compiler/tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move
@@ -6,9 +6,13 @@ module iota::transfer {}
 module iota::tx_context {
     public struct TxContext()
 }
+module iota::auth_context {
+    public struct AuthContext()
+}
 
 module a::m {
     use iota::object::{Self, ID, UID};
     use iota::transfer;
     use iota::tx_context::{Self, TxContext};
+    use iota::auth_context::{Self, AuthContext};
 }

--- a/external-crates/move/crates/move-compiler/tests/iota_mode/move_2024/expansion/unnecessary_alias_default.snap
+++ b/external-crates/move/crates/move-compiler/tests/iota_mode/move_2024/expansion/unnecessary_alias_default.snap
@@ -6,97 +6,129 @@ info:
   lint: false
 ---
 warning[W02021]: duplicate alias
-   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:11:24
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:14:24
    │
-11 │     use iota::object::{Self, ID, UID};
+14 │     use iota::object::{Self, ID, UID};
    │                        ^^^^ Unnecessary alias 'object' for module 'iota::object'. This alias is provided by default
    │
    = This warning can be suppressed with '#[allow(duplicate_alias)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09001]: unused alias
-   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:11:24
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:14:24
    │
-11 │     use iota::object::{Self, ID, UID};
+14 │     use iota::object::{Self, ID, UID};
    │                        ^^^^ Unused 'use' of alias 'object'. Consider removing it
    │
    = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W02021]: duplicate alias
-   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:11:30
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:14:30
    │
-11 │     use iota::object::{Self, ID, UID};
+14 │     use iota::object::{Self, ID, UID};
    │                              ^^ Unnecessary alias 'ID' for module member 'iota::object::ID'. This alias is provided by default
    │
    = This warning can be suppressed with '#[allow(duplicate_alias)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09001]: unused alias
-   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:11:30
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:14:30
    │
-11 │     use iota::object::{Self, ID, UID};
+14 │     use iota::object::{Self, ID, UID};
    │                              ^^ Unused 'use' of alias 'ID'. Consider removing it
    │
    = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W02021]: duplicate alias
-   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:11:34
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:14:34
    │
-11 │     use iota::object::{Self, ID, UID};
+14 │     use iota::object::{Self, ID, UID};
    │                                  ^^^ Unnecessary alias 'UID' for module member 'iota::object::UID'. This alias is provided by default
    │
    = This warning can be suppressed with '#[allow(duplicate_alias)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09001]: unused alias
-   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:11:34
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:14:34
    │
-11 │     use iota::object::{Self, ID, UID};
+14 │     use iota::object::{Self, ID, UID};
    │                                  ^^^ Unused 'use' of alias 'UID'. Consider removing it
    │
    = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W02021]: duplicate alias
-   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:12:15
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:15:15
    │
-12 │     use iota::transfer;
+15 │     use iota::transfer;
    │               ^^^^^^^^ Unnecessary alias 'transfer' for module 'iota::transfer'. This alias is provided by default
    │
    = This warning can be suppressed with '#[allow(duplicate_alias)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09001]: unused alias
-   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:12:15
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:15:15
    │
-12 │     use iota::transfer;
+15 │     use iota::transfer;
    │               ^^^^^^^^ Unused 'use' of alias 'transfer'. Consider removing it
    │
    = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W02021]: duplicate alias
-   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:13:28
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:16:28
    │
-13 │     use iota::tx_context::{Self, TxContext};
+16 │     use iota::tx_context::{Self, TxContext};
    │                            ^^^^ Unnecessary alias 'tx_context' for module 'iota::tx_context'. This alias is provided by default
    │
    = This warning can be suppressed with '#[allow(duplicate_alias)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09001]: unused alias
-   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:13:28
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:16:28
    │
-13 │     use iota::tx_context::{Self, TxContext};
+16 │     use iota::tx_context::{Self, TxContext};
    │                            ^^^^ Unused 'use' of alias 'tx_context'. Consider removing it
    │
    = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W02021]: duplicate alias
-   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:13:34
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:16:34
    │
-13 │     use iota::tx_context::{Self, TxContext};
+16 │     use iota::tx_context::{Self, TxContext};
    │                                  ^^^^^^^^^ Unnecessary alias 'TxContext' for module member 'iota::tx_context::TxContext'. This alias is provided by default
    │
    = This warning can be suppressed with '#[allow(duplicate_alias)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09001]: unused alias
-   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:13:34
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:16:34
    │
-13 │     use iota::tx_context::{Self, TxContext};
+16 │     use iota::tx_context::{Self, TxContext};
    │                                  ^^^^^^^^^ Unused 'use' of alias 'TxContext'. Consider removing it
+   │
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W02021]: duplicate alias
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:17:30
+   │
+17 │     use iota::auth_context::{Self, AuthContext};
+   │                              ^^^^ Unnecessary alias 'auth_context' for module 'iota::auth_context'. This alias is provided by default
+   │
+   = This warning can be suppressed with '#[allow(duplicate_alias)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W09001]: unused alias
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:17:30
+   │
+17 │     use iota::auth_context::{Self, AuthContext};
+   │                              ^^^^ Unused 'use' of alias 'auth_context'. Consider removing it
+   │
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W02021]: duplicate alias
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:17:36
+   │
+17 │     use iota::auth_context::{Self, AuthContext};
+   │                                    ^^^^^^^^^^^ Unnecessary alias 'AuthContext' for module member 'iota::auth_context::AuthContext'. This alias is provided by default
+   │
+   = This warning can be suppressed with '#[allow(duplicate_alias)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W09001]: unused alias
+   ┌─ tests/iota_mode/move_2024/expansion/unnecessary_alias_default.move:17:36
+   │
+17 │     use iota::auth_context::{Self, AuthContext};
+   │                                    ^^^^^^^^^^^ Unused 'use' of alias 'AuthContext'. Consider removing it
    │
    = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-symbol-pool/src/lib.rs
+++ b/external-crates/move/crates/move-symbol-pool/src/lib.rs
@@ -71,6 +71,8 @@ static_symbols!(
     "Clock",
     "tx_context",
     "TxContext",
+    "auth_context",
+    "AuthContext",
     "ID",
     "IOTA",
     "authenticator_state",


### PR DESCRIPTION
# Description of change

The `auth_context` module and the `AuthContext` struct are added to the implicit aliases list.

## Links to any relevant issues

fixes #8907

