### PR TITLE
feat: use internal ip addresses in `iota-aws-orchestrator`

### DIFF
--- a/crates/iota-aws-orchestrator/src/benchmark.rs
+++ b/crates/iota-aws-orchestrator/src/benchmark.rs
@@ -43,6 +43,13 @@ pub struct BenchmarkParameters<T> {
     pub load: usize,
     /// The duration of the benchmark.
     pub duration: Duration,
+    /// Flag indicating whether nodes should advertise their internal or public
+    /// IP address for inter-node communication. When running the simulation
+    /// in multiple regions, nodes need to use their public IPs to correctly
+    /// communicate, however when a simulation is running in a single VPC,
+    /// they should use their internal IPs to avoid paying for data sent between
+    /// the nodes.
+    pub use_internal_ip_address: bool,
 }
 
 impl<T: BenchmarkType> Default for BenchmarkParameters<T> {
@@ -53,6 +60,7 @@ impl<T: BenchmarkType> Default for BenchmarkParameters<T> {
             faults: FaultsType::default(),
             load: 500,
             duration: Duration::from_secs(60),
+            use_internal_ip_address: true,
         }
     }
 }
@@ -61,8 +69,8 @@ impl<T: BenchmarkType> Debug for BenchmarkParameters<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{:?}-{:?}-{}-{}",
-            self.benchmark_type, self.faults, self.nodes, self.load
+            "{:?}-{:?}-{}-{}-{}",
+            self.benchmark_type, self.faults, self.nodes, self.load, self.use_internal_ip_address,
         )
     }
 }
@@ -71,8 +79,8 @@ impl<T> Display for BenchmarkParameters<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{} nodes ({}) - {} tx/s",
-            self.nodes, self.faults, self.load
+            "{} nodes ({}) - {} tx/s (use internal IPs: {})",
+            self.nodes, self.faults, self.load, self.use_internal_ip_address
         )
     }
 }
@@ -85,6 +93,7 @@ impl<T> BenchmarkParameters<T> {
         faults: FaultsType,
         load: usize,
         duration: Duration,
+        use_internal_ip_address: bool,
     ) -> Self {
         Self {
             benchmark_type,
@@ -92,6 +101,7 @@ impl<T> BenchmarkParameters<T> {
             faults,
             load,
             duration,
+            use_internal_ip_address,
         }
     }
 }
@@ -133,6 +143,9 @@ pub struct BenchmarkParametersGenerator<T> {
     upper_bound_result: Option<MeasurementsCollection<T>>,
     /// The current number of iterations.
     iterations: usize,
+    /// Flag indicating whether nodes should advertise their internal or public
+    /// IP address for inter-node communication.
+    use_internal_ip_address: bool,
 }
 
 impl<T: BenchmarkType> Iterator for BenchmarkParametersGenerator<T> {
@@ -147,6 +160,7 @@ impl<T: BenchmarkType> Iterator for BenchmarkParametersGenerator<T> {
                 self.faults.clone(),
                 load,
                 self.duration,
+                self.use_internal_ip_address,
             )
         })
     }
@@ -157,7 +171,7 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
     const DEFAULT_DURATION: Duration = Duration::from_secs(180);
 
     /// make a new generator.
-    pub fn new(nodes: usize, mut load_type: LoadType) -> Self {
+    pub fn new(nodes: usize, mut load_type: LoadType, use_internal_ip_address: bool) -> Self {
         let next_load = match &mut load_type {
             LoadType::Fixed(loads) => {
                 if loads.is_empty() {
@@ -178,6 +192,7 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
             lower_bound_result: None,
             upper_bound_result: None,
             iterations: 0,
+            use_internal_ip_address,
         }
     }
 
@@ -312,7 +327,8 @@ pub mod test {
             starting_load: 100,
             max_iterations: 10,
         };
-        let mut generator = BenchmarkParametersGenerator::<TestBenchmarkType>::new(nodes, load);
+        let mut generator =
+            BenchmarkParametersGenerator::<TestBenchmarkType>::new(nodes, load, true);
         let parameters = generator.next().unwrap();
 
         let collection = MeasurementsCollection::new(&settings, parameters);
@@ -338,7 +354,8 @@ pub mod test {
             starting_load: 100,
             max_iterations: 10,
         };
-        let mut generator = BenchmarkParametersGenerator::<TestBenchmarkType>::new(nodes, load);
+        let mut generator =
+            BenchmarkParametersGenerator::<TestBenchmarkType>::new(nodes, load, true);
         let first_parameters = generator.next().unwrap();
 
         // Register a first result (zero latency). This sets the lower bound.
@@ -377,7 +394,8 @@ pub mod test {
             starting_load: 100,
             max_iterations: 0,
         };
-        let mut generator = BenchmarkParametersGenerator::<TestBenchmarkType>::new(nodes, load);
+        let mut generator =
+            BenchmarkParametersGenerator::<TestBenchmarkType>::new(nodes, load, true);
         let parameters = generator.next().unwrap();
 
         let collection = MeasurementsCollection::new(&settings, parameters);

--- a/crates/iota-aws-orchestrator/src/client/aws.rs
+++ b/crates/iota-aws-orchestrator/src/client/aws.rs
@@ -113,6 +113,11 @@ impl AwsClient {
                 .unwrap_or("0.0.0.0") // Stopped instances do not have an ip address.
                 .parse()
                 .expect("AWS instance should have a valid ip"),
+            private_ip: aws_instance
+                .private_ip_address()
+                .unwrap_or("0.0.0.0") // Stopped instances do not have an ip address.
+                .parse()
+                .expect("AWS instance should have a valid ip"),
             tags: vec![self.settings.testbed_id.clone()],
             specs: format!(
                 "{:?}",

--- a/crates/iota-aws-orchestrator/src/client/mod.rs
+++ b/crates/iota-aws-orchestrator/src/client/mod.rs
@@ -22,6 +22,8 @@ pub struct Instance {
     pub region: String,
     /// The public ip address of the instance (accessible from anywhere).
     pub main_ip: Ipv4Addr,
+    /// The public ip address of the instance (accessible from the same VPC).
+    pub private_ip: Ipv4Addr,
     /// The list of tags associated with the instance.
     pub tags: Vec<String>,
     /// The specs of the instance.
@@ -57,7 +59,8 @@ impl Instance {
         Self {
             id,
             region: Default::default(),
-            main_ip: Ipv4Addr::new(127, 0, 0, 1),
+            main_ip: Ipv4Addr::LOCALHOST,
+            private_ip: Ipv4Addr::LOCALHOST,
             tags: Default::default(),
             specs: Default::default(),
             status: Default::default(),
@@ -172,6 +175,7 @@ pub mod test_client {
                 id: id.to_string(),
                 region: region.into(),
                 main_ip: format!("0.0.0.{id}").parse().unwrap(),
+                private_ip: format!("0.0.0.{id}").parse().unwrap(),
                 tags: Vec::new(),
                 specs: self.settings.specs.clone(),
                 status: "running".into(),

--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -125,6 +125,15 @@ pub enum Operation {
         /// The load to submit to the system.
         #[command(subcommand)]
         load_type: Load,
+
+        /// Flag indicating whether nodes should advertise their internal or
+        /// public IP address for inter-node communication. When running
+        /// the simulation in multiple regions, nodes need to use their public
+        /// IPs to correctly communicate, however when a simulation is
+        /// running in a single VPC, they should use their internal IPs to avoid
+        /// paying for data sent between the nodes.
+        #[clap(long, action, default_value_t = false, global = true)]
+        use_internal_ip_addresses: bool,
     },
 
     /// Print a summary of the specified measurements collection.
@@ -269,6 +278,7 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
             timeout,
             retries,
             load_type,
+            use_internal_ip_addresses,
         } => {
             // Create a new orchestrator to instruct the testbed.
             let username = testbed.username();
@@ -310,10 +320,11 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
                 }
             };
 
-            let generator = BenchmarkParametersGenerator::new(committee, load)
-                .with_benchmark_type(benchmark_type)
-                .with_custom_duration(duration)
-                .with_faults(fault_type);
+            let generator =
+                BenchmarkParametersGenerator::new(committee, load, use_internal_ip_addresses)
+                    .with_benchmark_type(benchmark_type)
+                    .with_custom_duration(duration)
+                    .with_faults(fault_type);
 
             Orchestrator::new(
                 settings,

--- a/crates/iota-aws-orchestrator/src/measurement.rs
+++ b/crates/iota-aws-orchestrator/src/measurement.rs
@@ -280,6 +280,9 @@ impl<T: BenchmarkType> MeasurementsCollection<T> {
         table.add_row(row![b->"Benchmark type:", self.parameters.benchmark_type]);
         table.add_row(row![bH2->""]);
         table.add_row(row![b->"Nodes:", self.parameters.nodes]);
+        table.add_row(
+            row![b->"Use internal IPs:", format!("{}", self.parameters.use_internal_ip_address)],
+        );
         table.add_row(row![b->"Faults:", self.parameters.faults]);
         table.add_row(row![b->"Load:", format!("{} tx/s", self.parameters.load)]);
         table.add_row(row![b->"Duration:", format!("{} s", duration.as_secs())]);

--- a/crates/iota-aws-orchestrator/src/monitor.rs
+++ b/crates/iota-aws-orchestrator/src/monitor.rs
@@ -5,6 +5,7 @@
 use std::{fs, net::SocketAddr, path::PathBuf};
 
 use crate::{
+    benchmark::{BenchmarkParameters, BenchmarkType},
     client::Instance,
     error::{MonitorError, MonitorResult},
     protocol::ProtocolMetrics,
@@ -43,13 +44,18 @@ impl Monitor {
     }
 
     /// Start a prometheus instance on each remote machine.
-    pub async fn start_prometheus<P: ProtocolMetrics>(
+    pub async fn start_prometheus<P: ProtocolMetrics, T: BenchmarkType>(
         &self,
         protocol_commands: &P,
+        parameters: &BenchmarkParameters<T>,
     ) -> MonitorResult<()> {
         let instance = std::iter::once(self.instance.clone());
-        let commands =
-            Prometheus::setup_commands(self.clients.clone(), self.nodes.clone(), protocol_commands);
+        let commands = Prometheus::setup_commands(
+            self.clients.clone(),
+            self.nodes.clone(),
+            protocol_commands,
+            parameters,
+        );
         self.ssh_manager
             .execute(instance, commands, CommandContext::default())
             .await?;
@@ -94,10 +100,16 @@ impl Prometheus {
 
     /// Generate the commands to update the prometheus configuration and restart
     /// prometheus.
-    pub fn setup_commands<I, P>(clients: I, nodes: I, protocol: &P) -> String
+    pub fn setup_commands<I, P, T>(
+        clients: I,
+        nodes: I,
+        protocol: &P,
+        parameters: &BenchmarkParameters<T>,
+    ) -> String
     where
         I: IntoIterator<Item = Instance>,
         P: ProtocolMetrics,
+        T: BenchmarkType,
     {
         // Generate the prometheus' global configuration.
         let mut config = vec![Self::global_configuration()];
@@ -111,7 +123,7 @@ impl Prometheus {
         }
 
         // Add configurations to scrape the nodes.
-        let nodes_metrics_path = protocol.nodes_metrics_path(nodes);
+        let nodes_metrics_path = protocol.nodes_metrics_path(nodes, parameters);
         for (i, (_, nodes_metrics_path)) in nodes_metrics_path.into_iter().enumerate() {
             let id = format!("node-{i}");
             let scrape_config = Self::scrape_configuration(&id, &nodes_metrics_path);

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -229,6 +229,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             .run_background("node".into())
             .with_log_file("~/node.log".into())
             .with_execute_from_path(repo.into());
+
         self.ssh_manager
             .execute_per_instance(targets, context)
             .await?;
@@ -236,7 +237,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         // Wait until all nodes are reachable.
         let commands = self
             .protocol_commands
-            .nodes_metrics_command(instances.clone());
+            .nodes_metrics_command(instances.clone(), parameters);
         self.ssh_manager.wait_for_success(commands).await;
 
         Ok(())
@@ -301,7 +302,9 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             display::action("Configuring monitoring instance");
 
             let monitor = Monitor::new(instance, clients, nodes, self.ssh_manager.clone());
-            monitor.start_prometheus(&self.protocol_commands).await?;
+            monitor
+                .start_prometheus(&self.protocol_commands, parameters)
+                .await?;
             monitor.start_grafana().await?;
 
             display::done();
@@ -329,6 +332,8 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             "cargo build --release",
         ]
         .join(" && ");
+
+        display::action(format!("update command: {command}"));
 
         let active = self.instances.iter().filter(|x| x.is_active()).cloned();
 
@@ -359,7 +364,10 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
 
         // Generate the genesis configuration file and the keystore allowing access to
         // gas objects.
-        let command = self.protocol_commands.genesis_command(nodes.iter());
+        let command = self
+            .protocol_commands
+            .genesis_command(nodes.iter(), parameters);
+        display::action(format!("Genesis command: {command}"));
         let repo_name = self.settings.repository_name();
         let context = CommandContext::new().with_execute_from_path(repo_name.into());
         let all = clients.into_iter().chain(nodes);
@@ -454,7 +462,11 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         // TODO: Remove this when consensus client latency metrics are available.
         // We will be getting latency metrics directly from consensus nodes instead from
         // the nw client
-        metrics_commands.append(&mut self.protocol_commands.nodes_metrics_command(nodes.clone()));
+        metrics_commands.append(
+            &mut self
+                .protocol_commands
+                .nodes_metrics_command(nodes.clone(), parameters),
+        );
 
         let mut aggregator = MeasurementsCollection::new(&self.settings, parameters.clone());
         let mut metrics_interval = time::interval(self.scrape_interval);

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -16,6 +16,7 @@ use super::{ProtocolCommands, ProtocolMetrics};
 use crate::{
     benchmark::{BenchmarkParameters, BenchmarkType},
     client::Instance,
+    display,
     settings::Settings,
 };
 
@@ -75,13 +76,23 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
         vec![authorities_db, consensus_db]
     }
 
-    fn genesis_command<'a, I>(&self, instances: I) -> String
+    fn genesis_command<'a, I>(
+        &self,
+        instances: I,
+        parameters: &BenchmarkParameters<IotaBenchmarkType>,
+    ) -> String
     where
         I: Iterator<Item = &'a Instance>,
     {
         let working_dir = self.working_dir.display();
         let ips = instances
-            .map(|x| x.main_ip.to_string())
+            .map(|x| {
+                match parameters.use_internal_ip_address {
+                    true => x.private_ip,
+                    false => x.main_ip,
+                }
+                .to_string()
+            })
             .collect::<Vec<_>>()
             .join(" ");
         let genesis = [
@@ -144,6 +155,8 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                 ]
                 .join(" ");
                 let command = ["source $HOME/.cargo/env", &run].join(" && ");
+
+                display::action(format!("\n Command ({i}): {command}"));
 
                 (instance, command)
             })
@@ -249,13 +262,27 @@ impl ProtocolMetrics for IotaProtocol {
     const LATENCY_SUM: &'static str = "latency_s_sum";
     const LATENCY_SQUARED_SUM: &'static str = "latency_squared_s";
 
-    fn nodes_metrics_path<I>(&self, instances: I) -> Vec<(Instance, String)>
+    fn nodes_metrics_path<I, T>(
+        &self,
+        instances: I,
+        parameters: &BenchmarkParameters<T>,
+    ) -> Vec<(Instance, String)>
     where
         I: IntoIterator<Item = Instance>,
+        T: BenchmarkType,
     {
         let (ips, instances): (Vec<_>, Vec<_>) = instances
             .into_iter()
-            .map(|x| (x.main_ip.to_string(), x))
+            .map(|x| {
+                (
+                    match parameters.use_internal_ip_address {
+                        true => x.private_ip,
+                        false => x.main_ip,
+                    }
+                    .to_string(),
+                    x,
+                )
+            })
             .unzip();
 
         GenesisConfig::new_for_benchmarks(&ips)

--- a/crates/iota-aws-orchestrator/src/protocol/mod.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/mod.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use crate::{
     benchmark::{BenchmarkParameters, BenchmarkType},
     client::Instance,
+    display,
 };
 
 pub mod iota;
@@ -23,7 +24,7 @@ pub trait ProtocolCommands<T: BenchmarkType> {
 
     /// The command to generate the genesis and all configuration files. This
     /// command is run on each remote machine.
-    fn genesis_command<'a, I>(&self, instances: I) -> String
+    fn genesis_command<'a, I>(&self, instances: I, parameters: &BenchmarkParameters<T>) -> String
     where
         I: Iterator<Item = &'a Instance>;
 
@@ -71,17 +72,32 @@ pub trait ProtocolMetrics {
     const LATENCY_SQUARED_SUM: &'static str;
 
     /// The network path where the nodes expose prometheus metrics.
-    fn nodes_metrics_path<I>(&self, instances: I) -> Vec<(Instance, String)>
-    where
-        I: IntoIterator<Item = Instance>;
-    /// The command to retrieve the metrics from the nodes.
-    fn nodes_metrics_command<I>(&self, instances: I) -> Vec<(Instance, String)>
+    fn nodes_metrics_path<I, T>(
+        &self,
+        instances: I,
+        parameters: &BenchmarkParameters<T>,
+    ) -> Vec<(Instance, String)>
     where
         I: IntoIterator<Item = Instance>,
+        T: BenchmarkType;
+    /// The command to retrieve the metrics from the nodes.
+    fn nodes_metrics_command<I, T>(
+        &self,
+        instances: I,
+        parameters: &BenchmarkParameters<T>,
+    ) -> Vec<(Instance, String)>
+    where
+        I: IntoIterator<Item = Instance>,
+        T: BenchmarkType,
     {
-        self.nodes_metrics_path(instances)
+        self.nodes_metrics_path(instances, parameters)
             .into_iter()
-            .map(|(instance, path)| (instance, format!("curl {path}")))
+            .map(|(instance, path)| {
+                (instance, {
+                    display::action(format!("\ncurl {path}"));
+                    format!("curl {path}")
+                })
+            })
             .collect()
     }
 
@@ -104,7 +120,10 @@ pub trait ProtocolMetrics {
 #[cfg(test)]
 pub mod test_protocol_metrics {
     use super::ProtocolMetrics;
-    use crate::client::Instance;
+    use crate::{
+        benchmark::{BenchmarkParameters, BenchmarkType},
+        client::Instance,
+    };
 
     pub struct TestProtocolMetrics;
 
@@ -115,9 +134,14 @@ pub mod test_protocol_metrics {
         const LATENCY_SUM: &'static str = "latency_s_sum";
         const LATENCY_SQUARED_SUM: &'static str = "latency_squared_s";
 
-        fn nodes_metrics_path<I>(&self, instances: I) -> Vec<(Instance, String)>
+        fn nodes_metrics_path<I, T>(
+            &self,
+            instances: I,
+            _parameters: &BenchmarkParameters<T>,
+        ) -> Vec<(Instance, String)>
         where
             I: IntoIterator<Item = Instance>,
+            T: BenchmarkType,
         {
             instances
                 .into_iter()


### PR DESCRIPTION
# Description of change

Modify `iota-aws-orchestrator` to support internal ip addresses for deployment inside of VPC.
- adds a `use_internal_ip_address` boolean parameter to the `BenchmarkParameters`.

## Links to any relevant issues

fixes #8898.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
