### PR TITLE
feat(authority): support failing validation effects commit post-consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6059,6 +6059,7 @@ dependencies = [
  "iota-types",
  "jsonrpsee",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-package",
  "p256",

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1837,7 +1837,7 @@ impl AuthorityState {
             reference_gas_price,
             move_authentication_result
                 .as_ref()
-                .map(|(authentication_cost, _, _)| *authentication_cost)
+                .map(|(computation_cost, _, _)| *computation_cost)
                 .unwrap_or(0),
         )?;
 
@@ -1870,8 +1870,9 @@ impl AuthorityState {
                     )
                 }
                 Some((_, Err(move_authentication_error), authentication_checked_input_objects)) => {
-                    let (store, gas_status, effects, error) =
-                        epoch_store.executor().invalid_transaction_to_effects(
+                    let (store, gas_status, effects, error) = epoch_store
+                        .executor()
+                        .produce_effects_for_invalid_authentication(
                             backing_store,
                             protocol_config,
                             self.metrics.limits_metrics.clone(),

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1809,7 +1809,7 @@ impl AuthorityState {
                 // `max_auth_gas` is used here as a Move authenticator gas budget until it is
                 // not a part of the transaction data.
                 let authenticator_gas_budget = protocol_config.max_auth_gas();
-                let (gas_status, authentication_checked_input_objects, tx_checked_input_objects) =
+                let (gas_status, authenticator_checked_input_objects, authenticator_and_tx_checked_input_objects) =
                     iota_transaction_checks::check_certificate_and_move_authenticator_input(
                         certificate,
                         tx_input_objects.clone(), 
@@ -1819,7 +1819,7 @@ impl AuthorityState {
                         reference_gas_price,
                     )?;
 
-                let owned_object_refs = tx_checked_input_objects.inner().filter_owned_objects();
+                let owned_object_refs = authenticator_and_tx_checked_input_objects.inner().filter_owned_objects();
                 self.check_owned_locks(&owned_object_refs)?;
 
                 epoch_store
@@ -1838,11 +1838,11 @@ impl AuthorityState {
                         gas,
                         move_authenticator.to_owned(),
                         authenticator_info,
-                        authentication_checked_input_objects,
+                        authenticator_checked_input_objects,
+                        authenticator_and_tx_checked_input_objects,
                         kind,
                         signer,
                         tx_digest,
-                        tx_checked_input_objects,
                         &mut None,
                     )
             } else {

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1746,7 +1746,7 @@ impl AuthorityState {
         certificate: &VerifiedExecutableTransaction,
         tx_input_objects: InputObjects,
         account_object: Option<ObjectReadResult>,
-        authenticator_input_objects: Option<InputObjects>,
+        move_authenticator_input_objects: Option<InputObjects>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<(
         InnerTemporaryStore,
@@ -1778,68 +1778,51 @@ impl AuthorityState {
 
         let (kind, signer, gas) = tx_data.execution_parts();
 
-        let (authenticator_computation_cost, validation_result, authenticator_input_objects) =
+        // Check if the sender needs to be authenticated in Move and, if so, execute the
+        // authentication.
+        let move_authentication_result =
             if let Some(move_authenticator) = certificate.move_authenticator() {
-                // It is supposed that `Move authentication` availability is checked in
-                // `SenderSignedData::validity_check`.
-
-                // Check basic `object_to_authenticate` preconditions and get its components.
+                // Check the `MoveAuthenticator` input objects.
                 let (
-                    auth_account_object_id,
-                    auth_account_object_seq_number,
-                    auth_account_object_digest,
-                ) = move_authenticator.object_to_authenticate_components()?;
-
-                // Since the `object_to_authenticate` components are provided, it is supposed
-                // that the account object is loaded.
-                let account_object = account_object.expect("Account object must be provided");
-
-                let authenticator_info = self.check_move_account(
-                    auth_account_object_id,
-                    auth_account_object_seq_number,
-                    auth_account_object_digest,
+                    authentication_gas_status,
+                    authentication_checked_input_objects,
+                    authenticator_info,
+                ) = self.check_move_authenticator_inputs_for_executing(
+                    move_authenticator,
+                    move_authenticator_input_objects,
                     account_object,
-                    &signer,
+                    protocol_config,
+                    reference_gas_price,
+                    tx_data,
+                    &tx_input_objects,
+                    signer,
                 )?;
 
-                let authenticator_input_objects = authenticator_input_objects.expect(
-                "In case of a `MoveAuthenticator` signature, the authenticator input objects must be provided",
-            );
-
-                // Check the `MoveAuthenticator` input objects.
-                let (authenticator_gas_status, authenticator_input_objects) =
-                    Self::check_move_authenticator_inputs_for_executing(
-                        protocol_config,
-                        reference_gas_price,
-                        tx_data,
-                        authenticator_input_objects,
-                        &tx_input_objects,
-                    )?;
-
-                // Execute the Move authenticator.
-                let (authenticator_computation_cost, validation_result) =
+                // Execute the Move authentication.
+                let (authentication_computation_cost, authentication_result) =
                     epoch_store.executor().validate_transaction(
                         backing_store,
                         protocol_config,
                         self.metrics.limits_metrics.clone(),
                         &epoch_id,
                         epoch_start_timestamp,
-                        authenticator_gas_status,
+                        authentication_gas_status,
                         move_authenticator.to_owned(),
                         authenticator_info,
-                        authenticator_input_objects.clone(),
+                        authentication_checked_input_objects.clone(),
                         kind.clone(),
                         signer,
                         tx_digest,
                         &mut None,
                     );
-                (
-                    authenticator_computation_cost,
-                    validation_result,
-                    Some(authenticator_input_objects),
-                )
+
+                Some((
+                    authentication_computation_cost,
+                    authentication_result,
+                    authentication_checked_input_objects,
+                ))
             } else {
-                (0, Ok(()), None)
+                None
             };
 
         // The cost of partially re-auditing a transaction before execution is
@@ -1852,60 +1835,64 @@ impl AuthorityState {
             tx_input_objects,
             protocol_config,
             reference_gas_price,
-            authenticator_computation_cost,
+            move_authentication_result
+                .as_ref()
+                .map(|(authentication_cost, _, _)| *authentication_cost)
+                .unwrap_or(0),
         )?;
 
         let owned_object_refs = tx_input_objects.inner().filter_owned_objects();
         self.check_owned_locks(&owned_object_refs)?;
 
         #[cfg_attr(not(any(msim, fail_points)), expect(unused_mut))]
-        let (inner_temp_store, _, mut effects, execution_error_opt) = match validation_result {
-            Ok(_) => epoch_store.executor().execute_transaction_to_effects(
-                backing_store,
-                protocol_config,
-                self.metrics.limits_metrics.clone(),
-                // TODO: would be nice to pass the whole NodeConfig here, but it creates a
-                // cyclic dependency w/ iota-adapter
-                self.config
-                    .expensive_safety_check_config
-                    .enable_deep_per_tx_iota_conservation_check(),
-                self.config.certificate_deny_config.certificate_deny_set(),
-                &epoch_id,
-                epoch_start_timestamp,
-                tx_input_objects,
-                gas,
-                tx_gas_status,
-                kind,
-                signer,
-                tx_digest,
-                &mut None,
-            ),
-            Err(validation_error) => {
-                let authenticator_input_objects = authenticator_input_objects
-                    .expect("Inputs must be present if validation failed");
-                let (inner_temp_store, gas_status, mut effects, execution_error) =
-                    epoch_store.executor().invalid_transaction_to_effects(
+        let (inner_temp_store, _, mut effects, execution_error_opt) =
+            match move_authentication_result {
+                None | Some((_, Ok(()), _)) => {
+                    epoch_store.executor().execute_transaction_to_effects(
                         backing_store,
                         protocol_config,
                         self.metrics.limits_metrics.clone(),
+                        // TODO: would be nice to pass the whole NodeConfig here, but it creates a
+                        // cyclic dependency w/ iota-adapter
                         self.config
                             .expensive_safety_check_config
                             .enable_deep_per_tx_iota_conservation_check(),
                         self.config.certificate_deny_config.certificate_deny_set(),
                         &epoch_id,
                         epoch_start_timestamp,
-                        tx_gas_status,
-                        gas,
-                        validation_error,
-                        authenticator_input_objects,
                         tx_input_objects,
+                        gas,
+                        tx_gas_status,
                         kind,
                         signer,
                         tx_digest,
-                    );
-                (inner_temp_store, gas_status, effects, Err(execution_error))
-            }
-        };
+                        &mut None,
+                    )
+                }
+                Some((_, Err(move_authentication_error), authentication_checked_input_objects)) => {
+                    let (store, gas_status, effects, error) =
+                        epoch_store.executor().invalid_transaction_to_effects(
+                            backing_store,
+                            protocol_config,
+                            self.metrics.limits_metrics.clone(),
+                            self.config
+                                .expensive_safety_check_config
+                                .enable_deep_per_tx_iota_conservation_check(),
+                            self.config.certificate_deny_config.certificate_deny_set(),
+                            &epoch_id,
+                            epoch_start_timestamp,
+                            tx_gas_status,
+                            gas,
+                            move_authentication_error,
+                            authentication_checked_input_objects,
+                            tx_input_objects,
+                            kind,
+                            signer,
+                            tx_digest,
+                        );
+                    (store, gas_status, effects, Err(error))
+                }
+            };
 
         fail_point_if!("cp_execution_nondeterminism", || {
             #[cfg(msim)]
@@ -5627,28 +5614,61 @@ impl AuthorityState {
 
     /// Checks the `MoveAuthenticator` inputs for executing.
     fn check_move_authenticator_inputs_for_executing(
+        &self,
+        move_authenticator: &MoveAuthenticator,
+        move_authenticator_input_objects: Option<InputObjects>,
+        object_to_authenticate: Option<ObjectReadResult>,
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
-        transaction: &TransactionData,
-        authenticator_input_objects: InputObjects,
+        tx_data: &TransactionData,
         tx_input_objects: &InputObjects,
-    ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
-        // The `MoveAuthenticator` receiving objects are checked on the signing step.
+        tx_signer: IotaAddress,
+    ) -> IotaResult<(IotaGasStatus, CheckedInputObjects, AuthenticatorInfoV1)> {
+        // It is supposed that `Move authentication` availability is checked in
+        // `SenderSignedData::validity_check`.
 
+        // Check basic `object_to_authenticate` preconditions and get its components.
+        let (auth_account_object_id, auth_account_object_seq_number, auth_account_object_digest) =
+            move_authenticator.object_to_authenticate_components()?;
+
+        // Since the `object_to_authenticate` components are provided, it is supposed
+        // that the account object is loaded.
+        let account_object = object_to_authenticate.expect("Account object must be provided");
+
+        let authenticator_info = self.check_move_account(
+            auth_account_object_id,
+            auth_account_object_seq_number,
+            auth_account_object_digest,
+            account_object,
+            &tx_signer,
+        )?;
+
+        let move_authenticator_input_objects = move_authenticator_input_objects.expect(
+                "In case of a `MoveAuthenticator` signature, the authenticator input objects must be provided",
+            );
+
+        // Check the `MoveAuthenticator` input objects.
+        // The `MoveAuthenticator` receiving objects are checked on the signing step.
         // `max_auth_gas` is used here as a Move authenticator gas budget until it is
         // not a part of the transaction data.
         let authenticator_gas_budget = protocol_config.max_auth_gas();
+        let (authentication_gas_status, authentication_checked_input_objects) =
+            iota_transaction_checks::check_move_authenticator_input(
+                protocol_config,
+                reference_gas_price,
+                tx_data.gas(),
+                authenticator_gas_budget,
+                tx_data.gas_budget(),
+                tx_data.gas_price(),
+                move_authenticator_input_objects,
+                tx_input_objects,
+            )?;
 
-        iota_transaction_checks::check_move_authenticator_input(
-            protocol_config,
-            reference_gas_price,
-            transaction.gas(),
-            authenticator_gas_budget,
-            transaction.gas_budget(),
-            transaction.gas_price(),
-            authenticator_input_objects,
-            tx_input_objects,
-        )
+        Ok((
+            authentication_gas_status,
+            authentication_checked_input_objects,
+            authenticator_info,
+        ))
     }
 
     #[cfg(test)]

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1778,42 +1778,49 @@ impl AuthorityState {
 
         let (kind, signer, gas) = tx_data.execution_parts();
 
-        // The cost of partially re-auditing a transaction before execution is
-        // tolerated.
-        //
-        //  TODO: Gas coins should not be double-checked if `GenericSignature` is of
-        // type `MoveAuthenticator`.
-        let (tx_gas_status, tx_checked_input_objects) =
-            iota_transaction_checks::check_certificate_input(
-                certificate,
-                tx_input_objects.clone(), // TODO: avoid clone
-                protocol_config,
-                reference_gas_price,
-            )?;
-
-        let owned_object_refs = tx_checked_input_objects.inner().filter_owned_objects();
-        self.check_owned_locks(&owned_object_refs)?;
-
         #[cfg_attr(not(any(msim, fail_points)), expect(unused_mut))]
         let (inner_temp_store, _, mut effects, execution_error_opt) =
-        // Check if the sender needs to be authenticated in Move and, if so, execute the
-        // authentication.        
+            // Check if the sender needs to be authenticated in Move and, if so, execute the
+            // authentication.        
             if let Some(move_authenticator) = certificate.move_authenticator() {
-                // Check the `MoveAuthenticator` input objects.
-                let (
-                    authentication_gas_status,
-                    authentication_checked_input_objects,
-                    authenticator_info,
-                ) = self.check_move_authenticator_inputs_for_executing(
-                    move_authenticator,
-                    move_authenticator_input_objects,
+
+                // Check basic `object_to_authenticate` preconditions and get its components.
+                let (auth_account_object_id, auth_account_object_seq_number, auth_account_object_digest) =
+                    move_authenticator.object_to_authenticate_components()?;
+
+                // Since the `object_to_authenticate` components are provided, it is supposed
+                // that the account object is loaded.
+                let account_object = account_object.expect("Account object must be provided");
+
+                let authenticator_info = self.check_move_account(
+                    auth_account_object_id,
+                    auth_account_object_seq_number,
+                    auth_account_object_digest,
                     account_object,
-                    protocol_config,
-                    reference_gas_price,
-                    tx_data,
-                    &tx_input_objects,
-                    signer,
+                    &signer,
                 )?;
+
+                let move_authenticator_input_objects = move_authenticator_input_objects.expect(
+                    "In case of a `MoveAuthenticator` signature, the authenticator input objects must be provided",
+                );
+
+                // Check the `MoveAuthenticator` input objects.
+                // The `MoveAuthenticator` receiving objects are checked on the signing step.
+                // `max_auth_gas` is used here as a Move authenticator gas budget until it is
+                // not a part of the transaction data.
+                let authenticator_gas_budget = protocol_config.max_auth_gas();
+                let (gas_status, authentication_checked_input_objects, tx_checked_input_objects) =
+                    iota_transaction_checks::check_certificate_and_move_authenticator_input(
+                        certificate,
+                        tx_input_objects.clone(), 
+                        move_authenticator_input_objects,
+                        authenticator_gas_budget,
+                        protocol_config,
+                        reference_gas_price,
+                    )?;
+
+                let owned_object_refs = tx_checked_input_objects.inner().filter_owned_objects();
+                self.check_owned_locks(&owned_object_refs)?;
 
                 epoch_store
                     .executor()
@@ -1827,8 +1834,7 @@ impl AuthorityState {
                         self.config.certificate_deny_config.certificate_deny_set(),
                         &epoch_id,
                         epoch_start_timestamp,
-                        authentication_gas_status,
-                        tx_gas_status,
+                        gas_status,
                         gas,
                         move_authenticator.to_owned(),
                         authenticator_info,
@@ -1841,6 +1847,19 @@ impl AuthorityState {
                     )
             } else {
                 // No Move authentication required, proceed to execute the transaction directly.
+
+                // The cost of partially re-auditing a transaction before execution is
+                // tolerated.
+                let (tx_gas_status, tx_checked_input_objects) =
+                    iota_transaction_checks::check_certificate_input(
+                        certificate,
+                        tx_input_objects,
+                        protocol_config,
+                        reference_gas_price,
+                    )?;
+
+                let owned_object_refs = tx_checked_input_objects.inner().filter_owned_objects();
+                self.check_owned_locks(&owned_object_refs)?;
                 epoch_store.executor().execute_transaction_to_effects(
                         backing_store,
                         protocol_config,
@@ -5579,65 +5598,6 @@ impl AuthorityState {
             )?;
 
         Ok((gas_status, checked_input_objects, authenticator_info))
-    }
-
-    /// Checks the `MoveAuthenticator` inputs for executing.
-    fn check_move_authenticator_inputs_for_executing(
-        &self,
-        move_authenticator: &MoveAuthenticator,
-        move_authenticator_input_objects: Option<InputObjects>,
-        object_to_authenticate: Option<ObjectReadResult>,
-        protocol_config: &ProtocolConfig,
-        reference_gas_price: u64,
-        tx_data: &TransactionData,
-        tx_input_objects: &InputObjects,
-        tx_signer: IotaAddress,
-    ) -> IotaResult<(IotaGasStatus, CheckedInputObjects, AuthenticatorInfoV1)> {
-        // It is supposed that `MoveAuthenticator` availability is checked in
-        // `SenderSignedData::validity_check`.
-
-        // Check basic `object_to_authenticate` preconditions and get its components.
-        let (auth_account_object_id, auth_account_object_seq_number, auth_account_object_digest) =
-            move_authenticator.object_to_authenticate_components()?;
-
-        // Since the `object_to_authenticate` components are provided, it is supposed
-        // that the account object is loaded.
-        let account_object = object_to_authenticate.expect("Account object must be provided");
-
-        let authenticator_info = self.check_move_account(
-            auth_account_object_id,
-            auth_account_object_seq_number,
-            auth_account_object_digest,
-            account_object,
-            &tx_signer,
-        )?;
-
-        let move_authenticator_input_objects = move_authenticator_input_objects.expect(
-                "In case of a `MoveAuthenticator` signature, the authenticator input objects must be provided",
-            );
-
-        // Check the `MoveAuthenticator` input objects.
-        // The `MoveAuthenticator` receiving objects are checked on the signing step.
-        // `max_auth_gas` is used here as a Move authenticator gas budget until it is
-        // not a part of the transaction data.
-        let authenticator_gas_budget = protocol_config.max_auth_gas();
-        let (authentication_gas_status, authentication_checked_input_objects) =
-            iota_transaction_checks::check_move_authenticator_input(
-                protocol_config,
-                reference_gas_price,
-                tx_data.gas(),
-                authenticator_gas_budget,
-                tx_data.gas_budget(),
-                tx_data.gas_price(),
-                move_authenticator_input_objects,
-                tx_input_objects,
-            )?;
-
-        Ok((
-            authentication_gas_status,
-            authentication_checked_input_objects,
-            authenticator_info,
-        ))
     }
 
     #[cfg(test)]

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -934,7 +934,7 @@ impl AuthorityState {
             let (kind, signer, _) = tx_data.execution_parts();
 
             // Execute the Move authenticator.
-            let validation_result = epoch_store.executor().validate_transaction(
+            let (_, validation_result) = epoch_store.executor().validate_transaction(
                 self.get_backing_store().as_ref(),
                 protocol_config,
                 self.metrics.limits_metrics.clone(),
@@ -1778,77 +1778,69 @@ impl AuthorityState {
 
         let (kind, signer, gas) = tx_data.execution_parts();
 
-        let authenticator_computation_cost = if let Some(move_authenticator) =
-            certificate.move_authenticator()
-        {
-            // It is supposed that `Move authentication` availability is checked in
-            // `SenderSignedData::validity_check`.
+        let (authenticator_computation_cost, validation_result, authenticator_input_objects) =
+            if let Some(move_authenticator) = certificate.move_authenticator() {
+                // It is supposed that `Move authentication` availability is checked in
+                // `SenderSignedData::validity_check`.
 
-            // Check basic `object_to_authenticate` preconditions and get its components.
-            let (
-                auth_account_object_id,
-                auth_account_object_seq_number,
-                auth_account_object_digest,
-            ) = move_authenticator.object_to_authenticate_components()?;
+                // Check basic `object_to_authenticate` preconditions and get its components.
+                let (
+                    auth_account_object_id,
+                    auth_account_object_seq_number,
+                    auth_account_object_digest,
+                ) = move_authenticator.object_to_authenticate_components()?;
 
-            // Since the `object_to_authenticate` components are provided, it is supposed
-            // that the account object is loaded.
-            let account_object = account_object.expect("Account object must be provided");
+                // Since the `object_to_authenticate` components are provided, it is supposed
+                // that the account object is loaded.
+                let account_object = account_object.expect("Account object must be provided");
 
-            let authenticator_info = self.check_move_account(
-                auth_account_object_id,
-                auth_account_object_seq_number,
-                auth_account_object_digest,
-                account_object,
-                &signer,
-            )?;
+                let authenticator_info = self.check_move_account(
+                    auth_account_object_id,
+                    auth_account_object_seq_number,
+                    auth_account_object_digest,
+                    account_object,
+                    &signer,
+                )?;
 
-            let authenticator_input_objects = authenticator_input_objects.expect(
+                let authenticator_input_objects = authenticator_input_objects.expect(
                 "In case of a `MoveAuthenticator` signature, the authenticator input objects must be provided",
             );
 
-            // Check the `MoveAuthenticator` input objects.
-            let (authenticator_gas_status, authenticator_input_objects) =
-                Self::check_move_authenticator_inputs_for_executing(
-                    protocol_config,
-                    reference_gas_price,
-                    tx_data,
-                    authenticator_input_objects,
-                    &tx_input_objects,
-                )?;
+                // Check the `MoveAuthenticator` input objects.
+                let (authenticator_gas_status, authenticator_input_objects) =
+                    Self::check_move_authenticator_inputs_for_executing(
+                        protocol_config,
+                        reference_gas_price,
+                        tx_data,
+                        authenticator_input_objects,
+                        &tx_input_objects,
+                    )?;
 
-            // Execute the Move authenticator.
-            let validation_result = epoch_store.executor().validate_transaction(
-                backing_store,
-                protocol_config,
-                self.metrics.limits_metrics.clone(),
-                &epoch_id,
-                epoch_start_timestamp,
-                authenticator_gas_status,
-                move_authenticator.to_owned(),
-                authenticator_info,
-                authenticator_input_objects,
-                kind.clone(),
-                signer,
-                tx_digest,
-                &mut None,
-            );
-
-            match validation_result {
-                Ok(authenticator_computation_cost) => authenticator_computation_cost,
-                Err(validation_error) => {
-                    // If an error occurs during execution, the storage, effects, and the execution
-                    // error itself are returned so that the gas can be charged.
-                    // I case of validation we do not support this, so the only available option
-                    // here is to return an error.
-                    return Err(IotaError::MoveAuthenticatorExecutionFailure {
-                        error: validation_error.to_string(),
-                    });
-                }
-            }
-        } else {
-            0
-        };
+                // Execute the Move authenticator.
+                let (authenticator_computation_cost, validation_result) =
+                    epoch_store.executor().validate_transaction(
+                        backing_store,
+                        protocol_config,
+                        self.metrics.limits_metrics.clone(),
+                        &epoch_id,
+                        epoch_start_timestamp,
+                        authenticator_gas_status,
+                        move_authenticator.to_owned(),
+                        authenticator_info,
+                        authenticator_input_objects.clone(),
+                        kind.clone(),
+                        signer,
+                        tx_digest,
+                        &mut None,
+                    );
+                (
+                    authenticator_computation_cost,
+                    validation_result,
+                    Some(authenticator_input_objects),
+                )
+            } else {
+                (0, Ok(()), None)
+            };
 
         // The cost of partially re-auditing a transaction before execution is
         // tolerated.
@@ -1867,8 +1859,8 @@ impl AuthorityState {
         self.check_owned_locks(&owned_object_refs)?;
 
         #[cfg_attr(not(any(msim, fail_points)), expect(unused_mut))]
-        let (inner_temp_store, _, mut effects, execution_error_opt) =
-            epoch_store.executor().execute_transaction_to_effects(
+        let (inner_temp_store, _, mut effects, execution_error_opt) = match validation_result {
+            Ok(_) => epoch_store.executor().execute_transaction_to_effects(
                 backing_store,
                 protocol_config,
                 self.metrics.limits_metrics.clone(),
@@ -1887,7 +1879,33 @@ impl AuthorityState {
                 signer,
                 tx_digest,
                 &mut None,
-            );
+            ),
+            Err(validation_error) => {
+                let authenticator_input_objects = authenticator_input_objects
+                    .expect("Inputs must be present if validation failed");
+                let (inner_temp_store, gas_status, mut effects, execution_error) =
+                    epoch_store.executor().invalid_transaction_to_effects(
+                        backing_store,
+                        protocol_config,
+                        self.metrics.limits_metrics.clone(),
+                        self.config
+                            .expensive_safety_check_config
+                            .enable_deep_per_tx_iota_conservation_check(),
+                        self.config.certificate_deny_config.certificate_deny_set(),
+                        &epoch_id,
+                        epoch_start_timestamp,
+                        tx_gas_status,
+                        gas,
+                        validation_error,
+                        authenticator_input_objects,
+                        tx_input_objects,
+                        kind,
+                        signer,
+                        tx_digest,
+                    );
+                (inner_temp_store, gas_status, effects, Err(execution_error))
+            }
+        };
 
         fail_point_if!("cp_execution_nondeterminism", || {
             #[cfg(msim)]

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -934,7 +934,7 @@ impl AuthorityState {
             let (kind, signer, _) = tx_data.execution_parts();
 
             // Execute the Move authenticator.
-            let (_, validation_result) = epoch_store.executor().validate_transaction(
+            let (_, validation_result) = epoch_store.executor().authenticate_transaction(
                 self.get_backing_store().as_ref(),
                 protocol_config,
                 self.metrics.limits_metrics.clone(),

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -934,7 +934,7 @@ impl AuthorityState {
             let (kind, signer, _) = tx_data.execution_parts();
 
             // Execute the Move authenticator.
-            let (_, validation_result) = epoch_store.executor().authenticate_transaction(
+            let validation_result = epoch_store.executor().authenticate_transaction(
                 self.get_backing_store().as_ref(),
                 protocol_config,
                 self.metrics.limits_metrics.clone(),

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1778,9 +1778,26 @@ impl AuthorityState {
 
         let (kind, signer, gas) = tx_data.execution_parts();
 
+        // The cost of partially re-auditing a transaction before execution is
+        // tolerated.
+        //
+        //  TODO: Gas coins should not be double-checked if `GenericSignature` is of
+        // type `MoveAuthenticator`.
+        let (tx_gas_status, tx_checked_input_objects) =
+            iota_transaction_checks::check_certificate_input(
+                certificate,
+                tx_input_objects.clone(), // TODO: avoid clone
+                protocol_config,
+                reference_gas_price,
+            )?;
+
+        let owned_object_refs = tx_checked_input_objects.inner().filter_owned_objects();
+        self.check_owned_locks(&owned_object_refs)?;
+
+        #[cfg_attr(not(any(msim, fail_points)), expect(unused_mut))]
+        let (inner_temp_store, _, mut effects, execution_error_opt) =
         // Check if the sender needs to be authenticated in Move and, if so, execute the
-        // authentication.
-        let move_authentication_result =
+        // authentication.        
             if let Some(move_authenticator) = certificate.move_authenticator() {
                 // Check the `MoveAuthenticator` input objects.
                 let (
@@ -1798,57 +1815,33 @@ impl AuthorityState {
                     signer,
                 )?;
 
-                // Execute the Move authentication.
-                let (authentication_computation_cost, authentication_result) =
-                    epoch_store.executor().validate_transaction(
+                epoch_store
+                    .executor()
+                    .authenticate_then_execute_transaction_to_effects(
                         backing_store,
                         protocol_config,
                         self.metrics.limits_metrics.clone(),
+                        self.config
+                            .expensive_safety_check_config
+                            .enable_deep_per_tx_iota_conservation_check(),
+                        self.config.certificate_deny_config.certificate_deny_set(),
                         &epoch_id,
                         epoch_start_timestamp,
                         authentication_gas_status,
+                        tx_gas_status,
+                        gas,
                         move_authenticator.to_owned(),
                         authenticator_info,
-                        authentication_checked_input_objects.clone(),
-                        kind.clone(),
+                        authentication_checked_input_objects,
+                        kind,
                         signer,
                         tx_digest,
+                        tx_checked_input_objects,
                         &mut None,
-                    );
-
-                Some((
-                    authentication_computation_cost,
-                    authentication_result,
-                    authentication_checked_input_objects,
-                ))
+                    )
             } else {
-                None
-            };
-
-        // The cost of partially re-auditing a transaction before execution is
-        // tolerated.
-        //
-        //  TODO: Gas coins should not be double-checked if `GenericSignature` is of
-        // type `MoveAuthenticator`.
-        let (tx_gas_status, tx_input_objects) = iota_transaction_checks::check_certificate_input(
-            certificate,
-            tx_input_objects,
-            protocol_config,
-            reference_gas_price,
-            move_authentication_result
-                .as_ref()
-                .map(|(computation_cost, _, _)| *computation_cost)
-                .unwrap_or(0),
-        )?;
-
-        let owned_object_refs = tx_input_objects.inner().filter_owned_objects();
-        self.check_owned_locks(&owned_object_refs)?;
-
-        #[cfg_attr(not(any(msim, fail_points)), expect(unused_mut))]
-        let (inner_temp_store, _, mut effects, execution_error_opt) =
-            match move_authentication_result {
-                None | Some((_, Ok(()), _)) => {
-                    epoch_store.executor().execute_transaction_to_effects(
+                // No Move authentication required, proceed to execute the transaction directly.
+                epoch_store.executor().execute_transaction_to_effects(
                         backing_store,
                         protocol_config,
                         self.metrics.limits_metrics.clone(),
@@ -1860,7 +1853,7 @@ impl AuthorityState {
                         self.config.certificate_deny_config.certificate_deny_set(),
                         &epoch_id,
                         epoch_start_timestamp,
-                        tx_input_objects,
+                        tx_checked_input_objects,
                         gas,
                         tx_gas_status,
                         kind,
@@ -1868,31 +1861,6 @@ impl AuthorityState {
                         tx_digest,
                         &mut None,
                     )
-                }
-                Some((_, Err(move_authentication_error), authentication_checked_input_objects)) => {
-                    let (store, gas_status, effects, error) = epoch_store
-                        .executor()
-                        .produce_effects_for_invalid_authentication(
-                            backing_store,
-                            protocol_config,
-                            self.metrics.limits_metrics.clone(),
-                            self.config
-                                .expensive_safety_check_config
-                                .enable_deep_per_tx_iota_conservation_check(),
-                            self.config.certificate_deny_config.certificate_deny_set(),
-                            &epoch_id,
-                            epoch_start_timestamp,
-                            tx_gas_status,
-                            gas,
-                            move_authentication_error,
-                            authentication_checked_input_objects,
-                            tx_input_objects,
-                            kind,
-                            signer,
-                            tx_digest,
-                        );
-                    (store, gas_status, effects, Err(error))
-                }
             };
 
         fail_point_if!("cp_execution_nondeterminism", || {

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -913,7 +913,7 @@ impl AuthorityState {
         )?;
 
         if let Some(move_authenticator) = transaction.move_authenticator() {
-            // It is supposed that `Move authentication` availability is checked in
+            // It is supposed that `MoveAuthenticator` availability is checked in
             // `SenderSignedData::validity_check`.
 
             // Check the `MoveAuthenticator` input objects.
@@ -1349,7 +1349,7 @@ impl AuthorityState {
             .start_timer();
 
         let objects = if let Some(move_authenticator) = certificate.move_authenticator() {
-            // It is supposed that `Move authentication` availability is checked in
+            // It is supposed that `MoveAuthenticator` availability is checked in
             // `SenderSignedData::validity_check`.
 
             // Load the account object.
@@ -5625,7 +5625,7 @@ impl AuthorityState {
         tx_input_objects: &InputObjects,
         tx_signer: IotaAddress,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects, AuthenticatorInfoV1)> {
-        // It is supposed that `Move authentication` availability is checked in
+        // It is supposed that `MoveAuthenticator` availability is checked in
         // `SenderSignedData::validity_check`.
 
         // Check basic `object_to_authenticate` preconditions and get its components.

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1812,7 +1812,7 @@ impl AuthorityState {
                 let (gas_status, authenticator_checked_input_objects, authenticator_and_tx_checked_input_objects) =
                     iota_transaction_checks::check_certificate_and_move_authenticator_input(
                         certificate,
-                        tx_input_objects.clone(), 
+                        tx_input_objects, 
                         move_authenticator_input_objects,
                         authenticator_gas_budget,
                         protocol_config,

--- a/crates/iota-e2e-tests/Cargo.toml
+++ b/crates/iota-e2e-tests/Cargo.toml
@@ -64,6 +64,7 @@ iota-test-transaction-builder.workspace = true
 iota-tool.workspace = true
 iota-types.workspace = true
 move-binary-format.workspace = true
+move-command-line-common.workspace = true
 move-core-types.workspace = true
 move-package.workspace = true
 shared-crypto.workspace = true

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -40,6 +40,7 @@ use iota_types::{
         TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE, Transaction, TransactionData,
     },
 };
+use move_command_line_common::error_bitset::ErrorBitset;
 use move_core_types::ident_str;
 use shared_crypto::intent::Intent;
 use test_cluster::{TestCluster, TestClusterBuilder};
@@ -243,7 +244,7 @@ async fn test_abstract_account_post_consensus_failure() -> Result<(), anyhow::Er
 
     assert!(summary.status.is_err(), "Expected the TX execution to fail");
     assert!(
-        summary.gas_used.gas_used() > 0
+        summary.gas_used.gas_used() == 3401600
             && summary.mutated_object_count == 2
             && summary.created_object_count == 0
             && summary.unwrapped_object_count == 0
@@ -255,8 +256,10 @@ async fn test_abstract_account_post_consensus_failure() -> Result<(), anyhow::Er
     assert!(
         matches!(
             summary.status.unwrap_err().0,
-            ExecutionFailureStatus::MoveAbort(MoveLocation { module, function_name, .. }, _)
-            if module.name() == ident_str!("basic_keyed_aa") && function_name == Some("authenticate_ed25519".to_string())
+            ExecutionFailureStatus::MoveAbort(MoveLocation { module, function_name, .. }, abort_code)
+            if module.name() == ident_str!("basic_keyed_aa")
+            && function_name == Some("authenticate_ed25519".to_string())
+            && ErrorBitset::from_u64(abort_code).unwrap().error_code() == Some(0)
         ),
         "Expected failure to be a Move abort in basic_keyed_aa::authenticate_ed25519",
     );

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -27,7 +27,6 @@ use iota_types::{
     IOTA_FRAMEWORK_ADDRESS, TypeTag,
     base_types::{IotaAddress, ObjectID, ObjectRef},
     crypto::{PublicKey, SignatureScheme},
-    effects::TransactionEffectsAPI,
     execution_status::{ExecutionFailureStatus, MoveLocation},
     messages_grpc::HandleCertificateRequestV1,
     move_authenticator::MoveAuthenticator,
@@ -240,12 +239,22 @@ async fn test_abstract_account_post_consensus_failure() -> Result<(), anyhow::Er
         )
         .await
         .unwrap();
-    let status = effects_cert.status().clone();
+    let summary = effects_cert.summary_for_debug();
 
-    assert!(status.is_err(), "Expected the TX execution to fail");
+    assert!(summary.status.is_err(), "Expected the TX execution to fail");
+    assert!(
+        summary.gas_used.gas_used() > 0
+            && summary.mutated_object_count == 2
+            && summary.created_object_count == 0
+            && summary.unwrapped_object_count == 0
+            && summary.deleted_object_count == 0
+            && summary.wrapped_object_count == 0,
+        "Expected gas to be used in the failed transaction and that only the gas object was mutated and the TX input object was bumped in version",
+    );
+
     assert!(
         matches!(
-            status.unwrap_err().0,
+            summary.status.unwrap_err().0,
             ExecutionFailureStatus::MoveAbort(MoveLocation { module, function_name, .. }, _)
             if module.name() == ident_str!("basic_keyed_aa") && function_name == Some("authenticate_ed25519".to_string())
         ),

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -12,6 +12,7 @@
 //! inspired by the `examples/move/iotaccount` implementation. This is needed in
 //! order to not depend on an external folder and to enable easier changes to
 //! the Move code.
+use std::net::SocketAddr;
 
 use fastcrypto::{
     ed25519::Ed25519Signature,
@@ -25,9 +26,14 @@ use iota_test_transaction_builder::publish_package;
 use iota_types::{
     IOTA_FRAMEWORK_ADDRESS, TypeTag,
     base_types::{IotaAddress, ObjectID, ObjectRef},
+    crypto::{PublicKey, SignatureScheme},
+    effects::TransactionEffectsAPI,
+    execution_status::{ExecutionFailureStatus, MoveLocation},
+    messages_grpc::HandleCertificateRequestV1,
     move_authenticator::MoveAuthenticator,
     object::Owner,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
+    quorum_driver_types::QuorumDriverResponse,
     signature::GenericSignature,
     storage::WriteKind,
     transaction::{
@@ -46,6 +52,8 @@ const AA_AUTHENTICATE_MODULE_NAME: &str = "basic_keyed_aa";
 const AA_AUTHENTICATE_FN_NAME_ED25519: &str = "authenticate_ed25519";
 const AA_AUTHENTICATE_FN_NAME_FREE_ACCESS: &str = "authenticate_free_access";
 
+/// Test the creation of an Abstract Account and the issuance of a simple
+/// transaction from it using the Move-based Ed25519 signature authenticator.
 #[sim_test]
 async fn test_abstract_account_creation_and_issue_tx() -> Result<(), anyhow::Error> {
     telemetry_subscribers::init_for_testing();
@@ -57,8 +65,7 @@ async fn test_abstract_account_creation_and_issue_tx() -> Result<(), anyhow::Err
         .await?;
     let aa_ref = test_env.aa_ref.unwrap();
 
-    // Retrieve the keystore
-    let keystore = test_env.test_cluster.wallet.config().keystore();
+    // Retrieve the sender
     let aa_sender = aa_ref.0.into();
 
     // Request faucet coins for the AbstractAccount
@@ -69,7 +76,7 @@ async fn test_abstract_account_creation_and_issue_tx() -> Result<(), anyhow::Err
         .await;
 
     // Create a simple transaction from the IOTA account
-    let pt = test_env.abstract_account_simple_tx()?;
+    let pt = test_env.craft_aa_simple_ptb()?;
     let tx_data = test_env
         .craft_tx_from_pt(
             pt, aa_gas, aa_sender, None, // No sponsor
@@ -77,32 +84,8 @@ async fn test_abstract_account_creation_and_issue_tx() -> Result<(), anyhow::Err
         .await?;
     let tx_digest = tx_data.digest().into_inner();
 
-    // Create the MoveAuthenticator for the Ed25519 signature authenticator:
-    // public fun authenticate_ed25519(
-    //    self: &AbstractAccount,
-    //    signature: vector<u8>,
-    //    _: &AuthContext,
-    //    ctx: &TxContext,
-    let self_call_arg = CallArg::Object(ObjectArg::SharedObject {
-        id: aa_ref.0,
-        initial_shared_version: aa_ref.1,
-        mutable: false,
-    });
-    // Sign the tx data with the owner key
-    let hex_encoded_signature: String =
-        Hex::encode(keystore.sign_hashed(&test_env.owner.unwrap(), &tx_digest)?)
-            .chars()
-            .skip(2) // flag prefix length
-            .take(Ed25519Signature::LENGTH * 2)
-            .collect();
-    let signature_call_arg = CallArg::Pure(bcs::to_bytes(&hex_encoded_signature)?);
-    let signatures = vec![GenericSignature::MoveAuthenticator(
-        MoveAuthenticator::new_for_testing(
-            vec![self_call_arg.clone(), signature_call_arg],
-            vec![],
-            self_call_arg,
-        ),
-    )];
+    // Create the MoveAuthenticator for the Ed25519 signature authenticator
+    let signatures = vec![test_env.create_move_authenticator_for_ed25519(&tx_digest)?];
 
     // Create the TX envelope and execute it
     let aa_simple_tx = Transaction::from_generic_sig_data(tx_data, signatures);
@@ -111,6 +94,9 @@ async fn test_abstract_account_creation_and_issue_tx() -> Result<(), anyhow::Err
         .await
 }
 
+/// Test the issuance of a sponsored transaction from an Abstract Account
+/// using the free access authenticator. The sponsor is a regular IOTA account
+/// that provides gas for the transaction.
 #[sim_test]
 async fn test_abstract_account_issues_sponsored_tx() -> Result<(), anyhow::Error> {
     telemetry_subscribers::init_for_testing();
@@ -134,7 +120,7 @@ async fn test_abstract_account_issues_sponsored_tx() -> Result<(), anyhow::Error
         .await;
 
     // Create a simple transaction from the IOTA account
-    let pt = test_env.abstract_account_simple_tx()?;
+    let pt = test_env.craft_aa_simple_ptb()?;
     let aa_sender = aa_ref.0.into();
     let tx_data = test_env
         .craft_tx_from_pt(pt, sponsor_gas, aa_sender, Some(sponsor))
@@ -146,22 +132,8 @@ async fn test_abstract_account_issues_sponsored_tx() -> Result<(), anyhow::Error
         &tx_data,
         Intent::iota_transaction(),
     )?);
-
-    // Create the MoveAuthenticator for the free access authenticator:
-    // public fun authenticate_free_access(
-    //    self: &AbstractAccount,
-    //    _: &AuthContext,
-    //    ctx: &TxContext,
-    let self_call_arg = CallArg::Object(ObjectArg::SharedObject {
-        id: aa_ref.0,
-        initial_shared_version: aa_ref.1,
-        mutable: false,
-    });
-    let aa_signature = GenericSignature::MoveAuthenticator(MoveAuthenticator::new_for_testing(
-        vec![self_call_arg.clone()],
-        vec![],
-        self_call_arg,
-    ));
+    // AA signature
+    let aa_signature = test_env.create_move_authenticator_for_free_access()?;
 
     // Create the TX envelope and execute it
     let aa_sponsored_tx =
@@ -171,6 +143,119 @@ async fn test_abstract_account_issues_sponsored_tx() -> Result<(), anyhow::Error
         .await
 }
 
+/// Test in 3 steps the failure of an Abstract Account transaction
+/// post-consensus:
+/// 1) Create a TX certificate signed by the validators where the authentication
+///    is successful
+/// 2) Tamper with the AA shared object state by creating a second TX altering
+///    the state by changing the public key that allows the authentication to
+///    pass
+/// 3) Submit the original certificate which should now fail during
+///    post-consensus, even though validators originally run the authenticate
+///    and it passed
+#[sim_test]
+async fn test_abstract_account_post_consensus_failure() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+    let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
+
+    // Build a test environment and create an abstract account
+    let mut test_env = TestEnvironment::new().await;
+    test_env
+        .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519)
+        .await?;
+    let aa_ref = test_env.aa_ref.unwrap();
+    let rgp = test_env.test_cluster.get_reference_gas_price().await;
+
+    // Retrieve the keystore and setup an account for rotating owner key
+    let keystore = test_env.test_cluster.wallet.config_mut().keystore_mut();
+    let new_aa_owner = keystore
+        .generate_and_add_new_key(SignatureScheme::ED25519, None, None, None)
+        .expect("ED25519 key generation should not fail")
+        .0;
+    assert!(new_aa_owner != test_env.owner.unwrap());
+    let new_aa_owner_pk = test_env
+        .test_cluster
+        .wallet
+        .config()
+        .keystore()
+        .get_key(&new_aa_owner)?
+        .public();
+    let aa_sender = aa_ref.0.into();
+
+    // Step 1: create an AA TX and ask the validators to sign it
+    // Create a simple transaction from the IOTA account
+    let aa_gas = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
+        .await;
+    let pt = test_env.craft_aa_simple_ptb()?;
+    let tx_data = test_env
+        .craft_tx_from_pt(
+            pt, aa_gas, aa_sender, None, // No sponsor
+        )
+        .await?;
+    let tx_digest = tx_data.digest().into_inner();
+    // Create the MoveAuthenticator for the Ed25519 signature authenticator
+    let signatures = vec![test_env.create_move_authenticator_for_ed25519(&tx_digest)?];
+    // Create the TX envelope and send it for validators signing
+    let aa_simple_tx = Transaction::from_generic_sig_data(tx_data, signatures);
+    let cert = test_env
+        .test_cluster
+        .create_certificate(aa_simple_tx, Some(client_ip))
+        .await
+        .unwrap();
+
+    // Step 2: tamper with the certificate to make it invalid post-consensus; this
+    // means creating a second transaction altering the AA shared object state
+    let aa_gas2 = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
+        .await;
+    let pt2 = test_env.craft_aa_rotate_owner_key_ptb(&new_aa_owner_pk)?;
+    let tx_data2 = test_env
+        .craft_tx_from_pt(
+            pt2, aa_gas2, aa_sender, None, // No sponsor
+        )
+        .await?;
+    let tx_digest2 = tx_data2.digest().into_inner();
+    // Create the MoveAuthenticator for the Ed25519 signature authenticator
+    let signatures2 = vec![test_env.create_move_authenticator_for_ed25519(&tx_digest2)?];
+    // Create the TX envelope and send it for validators signing
+    let aa_rotate_tx = Transaction::from_generic_sig_data(tx_data2, signatures2);
+    // Should succeed
+    test_env
+        .execute_and_check_tx_correctness(aa_rotate_tx)
+        .await?;
+    // Update the test environment with the new owner (this is just for
+    // completeness, not needed for this test)
+    test_env.owner = Some(new_aa_owner);
+
+    // Step 3: submit the original certificate which should now fail
+    let QuorumDriverResponse { effects_cert, .. } = test_env
+        .test_cluster
+        .authority_aggregator()
+        .process_certificate(
+            HandleCertificateRequestV1::new(cert).with_events(),
+            Some(client_ip),
+        )
+        .await
+        .unwrap();
+    let status = effects_cert.status().clone();
+
+    assert!(status.is_err(), "Expected the TX execution to fail");
+    assert!(
+        matches!(
+            status.unwrap_err().0,
+            ExecutionFailureStatus::MoveAbort(MoveLocation { module, function_name, .. }, _)
+            if module.name() == ident_str!("basic_keyed_aa") && function_name == Some("authenticate_ed25519".to_string())
+        ),
+        "Expected failure to be a Move abort in basic_keyed_aa::authenticate_ed25519",
+    );
+
+    Ok(())
+}
+
+/// Test environment for Abstract Account tests
 struct TestEnvironment {
     test_cluster: TestCluster,
     owner: Option<IotaAddress>,
@@ -298,7 +383,67 @@ impl TestEnvironment {
             .expect("Expected a shared object in the transaction response"))
     }
 
-    fn abstract_account_simple_tx(&self) -> anyhow::Result<ProgrammableTransaction> {
+    // Create the MoveAuthenticator for the Ed25519 signature authenticator:
+    // public fun authenticate_ed25519(
+    //    self: &AbstractAccount,
+    //    signature: vector<u8>,
+    //    _: &AuthContext,
+    //    ctx: &TxContext,
+    fn create_move_authenticator_for_ed25519(
+        &self,
+        tx_digest: &[u8; 32],
+    ) -> anyhow::Result<GenericSignature> {
+        let (Some(owner), Some(aa_ref)) = (self.owner, self.aa_ref) else {
+            anyhow::bail!("Abstract account not created yet");
+        };
+        let self_call_arg = CallArg::Object(ObjectArg::SharedObject {
+            id: aa_ref.0,
+            initial_shared_version: aa_ref.1,
+            mutable: false,
+        });
+        // Sign the tx data with the owner key
+        let hex_encoded_signature: String = Hex::encode(
+            self.test_cluster
+                .wallet
+                .config()
+                .keystore()
+                .sign_hashed(&owner, tx_digest)?,
+        )
+        .chars()
+        .skip(2) // flag prefix length
+        .take(Ed25519Signature::LENGTH * 2)
+        .collect();
+        let signature_call_arg = CallArg::Pure(bcs::to_bytes(&hex_encoded_signature)?);
+        Ok(GenericSignature::MoveAuthenticator(
+            MoveAuthenticator::new_for_testing(
+                vec![self_call_arg.clone(), signature_call_arg],
+                vec![],
+                self_call_arg,
+            ),
+        ))
+    }
+
+    // Create the MoveAuthenticator for the free access authenticator:
+    // public fun authenticate_free_access(
+    //    self: &AbstractAccount,
+    //    _: &AuthContext,
+    //    ctx: &TxContext,
+    fn create_move_authenticator_for_free_access(&self) -> anyhow::Result<GenericSignature> {
+        let Some(aa_ref) = self.aa_ref else {
+            anyhow::bail!("Abstract account not created yet");
+        };
+
+        let self_call_arg = CallArg::Object(ObjectArg::SharedObject {
+            id: aa_ref.0,
+            initial_shared_version: aa_ref.1,
+            mutable: false,
+        });
+        Ok(GenericSignature::MoveAuthenticator(
+            MoveAuthenticator::new_for_testing(vec![self_call_arg.clone()], vec![], self_call_arg),
+        ))
+    }
+
+    fn craft_aa_simple_ptb(&self) -> anyhow::Result<ProgrammableTransaction> {
         let (Some(aa_ref), Some(aa_package_id)) = (self.aa_ref, self.aa_package_id) else {
             anyhow::bail!("Abstract account not created yet");
         };
@@ -321,6 +466,56 @@ impl TestEnvironment {
             vec![TypeTag::U8, TypeTag::U8],
             arguments,
         );
+        Ok(builder.finish())
+    }
+
+    fn craft_aa_rotate_owner_key_ptb(
+        &mut self,
+        new_aa_owner_pk: &PublicKey,
+    ) -> anyhow::Result<ProgrammableTransaction> {
+        let (Some(aa_ref), Some(aa_package_id), Some(authenticate_fn_name)) =
+            (self.aa_ref, self.aa_package_id, &self.authenticate_fn_name)
+        else {
+            anyhow::bail!("Abstract account not created yet");
+        };
+        assert!(
+            authenticate_fn_name == AA_AUTHENTICATE_FN_NAME_ED25519,
+            "Key rotation is only supported for Ed25519 authentication"
+        );
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+
+        // create auth info
+        let arguments = vec![
+            builder.pure(aa_package_id)?,
+            builder.pure(AA_AUTHENTICATE_MODULE_NAME)?,
+            builder.pure(authenticate_fn_name)?,
+        ];
+        if let Argument::Result(authenticator_info_v1) = builder.programmable_move_call(
+            IOTA_FRAMEWORK_ADDRESS.into(),
+            ident_str!("account").to_owned(),
+            ident_str!("create_auth_info_v1").to_owned(),
+            vec![],
+            arguments,
+        ) {
+            // rotate the key in the abstract account.
+            let arguments = vec![
+                builder.obj(ObjectArg::SharedObject {
+                    id: aa_ref.0,
+                    initial_shared_version: aa_ref.1,
+                    mutable: true,
+                })?,
+                builder.pure(new_aa_owner_pk.as_ref())?,
+                Argument::Result(authenticator_info_v1),
+            ];
+            builder.programmable_move_call(
+                aa_package_id,
+                ident_str!(AA_CREATE_MODULE_NAME).to_owned(),
+                ident_str!("rotate_public_key").to_owned(),
+                vec![],
+                arguments,
+            );
+        }
         Ok(builder.finish())
     }
 

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -916,14 +916,11 @@ impl LocalExec {
             VerifiedTransaction::new_unchecked(transaction),
             executed_epoch,
         );
-        // `MoveAuthenticator` is not supported here.
-        let authenticator_computation_cost = 0;
         let (gas_status, input_objects) = iota_transaction_checks::check_certificate_input(
             &executable,
             input_objects,
             &protocol_config,
             reference_gas_price,
-            authenticator_computation_cost,
         )
         .unwrap();
         let (kind, signer, gas) = executable.transaction_data().execution_parts();

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -204,14 +204,11 @@ impl SingleValidator {
         let executable = VerifiedExecutableTransaction::new_from_certificate(
             VerifiedCertificate::new_unchecked(transaction),
         );
-        // `MoveAuthenticator` is not supported here.
-        let authenticator_computation_cost = 0;
         let (gas_status, input_objects) = iota_transaction_checks::check_certificate_input(
             &executable,
             objects,
             self.epoch_store.protocol_config(),
             self.epoch_store.reference_gas_price(),
-            authenticator_computation_cost,
         )
         .unwrap();
         let (kind, signer, gas) = executable.transaction_data().execution_parts();

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -249,7 +249,7 @@ mod checked {
     #[instrument(level = "trace", skip_all)]
     pub fn check_certificate_and_move_authenticator_input(
         cert: &VerifiedExecutableTransaction,
-        mut tx_input_objects: InputObjects,
+        tx_input_objects: InputObjects,
         authenticator_input_objects: InputObjects,
         authenticator_gas_budget: u64,
         protocol_config: &ProtocolConfig,
@@ -269,13 +269,14 @@ mod checked {
             authenticator_gas_budget,
         )?;
 
-        check_and_extend_input_objects(&mut tx_input_objects, &authenticator_input_objects)?;
-
-        Ok((
-            gas_status,
-            authenticator_input_objects.into_checked(),
+        // Create checked a union of input objects
+        let authenticator_input_objects = authenticator_input_objects.into_checked();
+        let input_objects_union = checked_input_objects_union(
             tx_input_objects.into_checked(),
-        ))
+            &authenticator_input_objects,
+        )?;
+
+        Ok((gas_status, authenticator_input_objects, input_objects_union))
     }
 
     // Common checks performed for transactions and certificates.
@@ -782,66 +783,63 @@ mod checked {
         Ok(())
     }
 
-    fn check_and_extend_input_objects(
-        input_objects: &mut InputObjects,
-        additional_objects: &InputObjects,
-    ) -> IotaResult<()> {
-        for additional_object in additional_objects.iter() {
-            if let Some(existing_object) = input_objects.find_object_id_mut(additional_object.id())
-            {
+    fn checked_input_objects_union(
+        base_set: CheckedInputObjects,
+        other_set: &CheckedInputObjects,
+    ) -> IotaResult<CheckedInputObjects> {
+        let mut base_set = base_set.into_inner();
+        for other_object in other_set.inner().iter() {
+            if let Some(base_object) = base_set.find_object_id_mut(other_object.id()) {
                 // This is an invariant
                 assert_eq!(
-                    existing_object.object, additional_object.object,
+                    base_object.object, other_object.object,
                     "The object read result for input objects with the same id must be equal"
                 );
 
                 // In the case of an alive object, check that the object kind matches exactly,
-                // or that if it is a shared object only the mutability changes
-                if let ObjectReadResultKind::Object(_) = &additional_object.object {
-                    match existing_object.input_object_kind {
+                // or that, if it is a shared object, only the mutability changes
+                if let ObjectReadResultKind::Object(_) = &other_object.object {
+                    match base_object.input_object_kind {
                         // If immutable or owned object or package, the kinds must match exactly
                         InputObjectKind::ImmOrOwnedMoveObject(_)
                         | InputObjectKind::MovePackage(_) => {
                             // This is an invariant
                             assert_eq!(
-                                existing_object.input_object_kind,
-                                additional_object.input_object_kind,
+                                base_object.input_object_kind, other_object.input_object_kind,
                                 "The object kind for input objects with the same id must be equal"
                             );
                         }
                         // else, if shared object, only mutability can differ
                         InputObjectKind::SharedMoveObject {
                             id: input_id,
-                            initial_shared_version: input_initial_shared_version,
-                            mutable: input_mutable,
+                            initial_shared_version: base_initial_shared_version,
+                            mutable: base_is_mutable,
                             ..
                         } => {
-                            match additional_object.input_object_kind {
+                            match other_object.input_object_kind {
                                 InputObjectKind::ImmOrOwnedMoveObject(_)
                                 | InputObjectKind::MovePackage(_) => {
-                                    // The object owner for input objects with the same id must be
-                                    // equal
+                                    // The object owner for objects with the same id must be equal
                                     fp_bail!(UserInputError::NotSharedObject.into())
                                 }
                                 InputObjectKind::SharedMoveObject {
                                     id: additional_id,
-                                    initial_shared_version: additional_initial_shared_version,
-                                    mutable: additional_mutable,
+                                    initial_shared_version: other_initial_shared_version,
+                                    mutable: other_is_mutable,
                                 } => {
                                     fp_ensure!(
                                         input_id == additional_id
-                                            && input_initial_shared_version
-                                                == additional_initial_shared_version,
+                                            && base_initial_shared_version
+                                                == other_initial_shared_version,
                                         UserInputError::SharedObjectStartingVersionMismatch.into()
                                     );
-                                    // if additional_mutable is true and
-                                    // input_mutable is false, then swap
-                                    if additional_mutable && !input_mutable {
-                                        existing_object.input_object_kind =
+                                    // if other_is_mutable is true and base_is_mutable is false,
+                                    // then swap
+                                    if other_is_mutable && !base_is_mutable {
+                                        base_object.input_object_kind =
                                             InputObjectKind::SharedMoveObject {
                                                 id: input_id,
-                                                initial_shared_version:
-                                                    input_initial_shared_version,
+                                                initial_shared_version: base_initial_shared_version,
                                                 mutable: true,
                                             };
                                     }
@@ -851,10 +849,10 @@ mod checked {
                     };
                 }
             } else {
-                input_objects.push(additional_object.clone());
+                base_set.push(other_object.clone());
             }
         }
-        Ok(())
+        Ok(base_set.into_checked())
     }
 
     /// Check package verification timeout

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -208,6 +208,7 @@ mod checked {
     /// Checks that there is enough gas to pay for the authenticator and
     /// transaction execution in the transaction inputs. And that the
     /// authenticator inputs meet the requirements.
+    /// It returns the gas status and the checked authenticator input objects.
     #[instrument(level = "trace", skip_all)]
     pub fn check_move_authenticator_input(
         protocol_config: &ProtocolConfig,
@@ -246,6 +247,9 @@ mod checked {
     /// Checks that there is enough gas to pay for the authenticator and
     /// transaction execution in the transaction inputs. And that the
     /// authenticator inputs meet the requirements.
+    /// It returns the gas status, the checked authenticator input objects, and
+    /// the union of the checked authenticator input objects and transaction
+    /// input objects.
     #[instrument(level = "trace", skip_all)]
     pub fn check_certificate_and_move_authenticator_input(
         cert: &VerifiedExecutableTransaction,

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -53,6 +53,7 @@ mod checked {
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
         transaction: &TransactionData,
+        authentication_gas_budget: u64,
     ) -> IotaResult<IotaGasStatus> {
         if transaction.is_system_tx() {
             Ok(IotaGasStatus::new_unmetered())
@@ -61,16 +62,14 @@ mod checked {
 
             // To be sure that we can cover the Move authenticator + transaction execution
             // gas cost.
-            let gas_budget_to_check = transaction_gas_budget;
-            let gas_budget_to_use = transaction_gas_budget;
+            let gas_budget = transaction_gas_budget + authentication_gas_budget;
 
             check_gas(
                 objects,
                 protocol_config,
                 reference_gas_price,
                 gas,
-                gas_budget_to_check,
-                gas_budget_to_use,
+                gas_budget,
                 transaction.gas_price(),
             )
         }
@@ -92,6 +91,7 @@ mod checked {
             transaction,
             &input_objects,
             &[],
+            0, // authentication_gas_budget
         )?;
         check_receiving_objects(&input_objects, receiving_objects)?;
         // Runs verifier, which could be expensive.
@@ -124,6 +124,7 @@ mod checked {
             transaction,
             &input_objects,
             &[gas_object_ref],
+            0, // authentication_gas_budget
         )?;
         check_receiving_objects(&input_objects, &receiving_objects)?;
         // Runs verifier, which could be expensive.
@@ -149,17 +150,13 @@ mod checked {
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
-        let transaction = cert.data().transaction_data();
-        let gas_status = check_transaction_input_inner(
+        let gas_status = check_certificate_input_inner(
+            cert,
+            &input_objects,
             protocol_config,
             reference_gas_price,
-            transaction,
-            &input_objects,
-            &[],
+            0, // authentication_gas_budget
         )?;
-        // NB: We do not check receiving objects when executing. Only at signing time do
-        // we check. NB: move verifier is only checked at signing time, not at
-        // execution.
 
         Ok((gas_status, input_objects.into_checked()))
     }
@@ -201,8 +198,7 @@ mod checked {
         Ok(input_objects.into_checked())
     }
 
-    /// A common function to check the `MoveAuthenticator` inputs for signing
-    /// and execution.
+    /// A common function to check the `MoveAuthenticator` inputs for signing.
     ///
     /// Checks that there is enough gas to pay for the authenticator and
     /// transaction execution in the transaction inputs. And that the
@@ -220,8 +216,7 @@ mod checked {
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         // To be sure that we can cover the Move authenticator + transaction execution
         // gas cost.
-        let gas_budget_to_check = authenticator_gas_budget + transaction_gas_budget;
-        let gas_budget_to_use = authenticator_gas_budget;
+        let gas_budget = authenticator_gas_budget + transaction_gas_budget;
 
         let gas_status = check_gas(
             // Only the transaction input objects are used for gas checks.
@@ -229,14 +224,70 @@ mod checked {
             protocol_config,
             reference_gas_price,
             gas,
-            gas_budget_to_check,
-            gas_budget_to_use,
+            gas_budget,
             gas_price,
         )?;
 
         check_move_authenticator_objects(&authenticator_input_objects)?;
 
         Ok((gas_status, authenticator_input_objects.into_checked()))
+    }
+
+    /// A function to check the `MoveAuthenticator` inputs for execution and
+    /// then for certificate execution.
+    /// To be used instead of check_certificate_input when there is a Move
+    /// authenticator present.
+    ///
+    /// Checks that there is enough gas to pay for the authenticator and
+    /// transaction execution in the transaction inputs. And that the
+    /// authenticator inputs meet the requirements.
+    #[instrument(level = "trace", skip_all)]
+    pub fn check_certificate_and_move_authenticator_input(
+        cert: &VerifiedExecutableTransaction,
+        tx_input_objects: InputObjects,
+        authenticator_input_objects: InputObjects,
+        authenticator_gas_budget: u64,
+        protocol_config: &ProtocolConfig,
+        reference_gas_price: u64,
+    ) -> IotaResult<(IotaGasStatus, CheckedInputObjects, CheckedInputObjects)> {
+        // Check Move authenticator inputs first
+        check_move_authenticator_objects(&authenticator_input_objects)?;
+
+        // Check certificate inputs next
+        let gas_status = check_certificate_input_inner(
+            cert,
+            &tx_input_objects,
+            protocol_config,
+            reference_gas_price,
+            authenticator_gas_budget,
+        )?;
+
+        Ok((
+            gas_status,
+            authenticator_input_objects.into_checked(),
+            tx_input_objects.into_checked(),
+        ))
+    }
+
+    fn check_certificate_input_inner(
+        cert: &VerifiedExecutableTransaction,
+        input_objects: &InputObjects,
+        protocol_config: &ProtocolConfig,
+        reference_gas_price: u64,
+        authentication_gas_budget: u64,
+    ) -> IotaResult<IotaGasStatus> {
+        let transaction = cert.data().transaction_data();
+        Ok(check_transaction_input_inner(
+            protocol_config,
+            reference_gas_price,
+            transaction,
+            input_objects,
+            &[],
+            authentication_gas_budget,
+        )?)
+        // NB: We do not check receiving objects when executing. Only at signing
+        // time do we check. NB: move verifier is only checked at
+        // signing time, not at execution.
     }
 
     // Common checks performed for transactions and certificates.
@@ -247,6 +298,7 @@ mod checked {
         input_objects: &InputObjects,
         // Overrides the gas objects in the transaction.
         gas_override: &[ObjectRef],
+        authentication_gas_budget: u64,
     ) -> IotaResult<IotaGasStatus> {
         // Cheap validity checks that is ok to run multiple times during processing.
         let gas = if gas_override.is_empty() {
@@ -261,6 +313,7 @@ mod checked {
             protocol_config,
             reference_gas_price,
             transaction,
+            authentication_gas_budget,
         )?;
         check_objects(transaction, input_objects)?;
 
@@ -393,23 +446,14 @@ mod checked {
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
         gas: &[ObjectRef],
-        gas_budget_to_check: u64,
-        gas_budget_to_use: u64,
+        gas_budget: u64,
         gas_price: u64,
     ) -> IotaResult<IotaGasStatus> {
-        debug_assert!(
-            gas_budget_to_use <= gas_budget_to_check,
-            "It is expected that the gas budget {gas_budget_to_use:?} is used for execution less or equal to the gas budget {gas_budget_to_check:?} is used to check the gas coins balance"
-        );
+        let gas_status =
+            IotaGasStatus::new(gas_budget, gas_price, reference_gas_price, protocol_config)?;
 
-        let gas_status = IotaGasStatus::new(
-            gas_budget_to_use,
-            gas_price,
-            reference_gas_price,
-            protocol_config,
-        )?;
-
-        // Check the balance and coins consistency; Load all the gas coins.
+        // check balance and coins consistency
+        // load all gas coins
         let objects: BTreeMap<_, _> = objects.iter().map(|o| (o.id(), o)).collect();
         let mut gas_objects = vec![];
         for obj_ref in gas {
@@ -420,8 +464,7 @@ mod checked {
             })?;
             gas_objects.push(obj);
         }
-        gas_status.check_gas_balance(&gas_objects, gas_budget_to_check)?;
-
+        gas_status.check_gas_balance(&gas_objects, gas_budget)?;
         Ok(gas_status)
     }
 

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -47,12 +47,11 @@ mod checked {
     // Called on both signing and execution.
     // On success the gas part of the transaction (gas data and gas coins)
     // is verified and good to go
-    pub fn get_gas_status(
+    fn get_gas_status(
         objects: &InputObjects,
         gas: &[ObjectRef],
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
-        authenticator_computation_cost: u64,
         transaction: &TransactionData,
     ) -> IotaResult<IotaGasStatus> {
         if transaction.is_system_tx() {
@@ -62,9 +61,8 @@ mod checked {
 
             // To be sure that we can cover the Move authenticator + transaction execution
             // gas cost.
-            let gas_budget_to_check = authenticator_computation_cost + transaction_gas_budget;
+            let gas_budget_to_check = transaction_gas_budget;
             let gas_budget_to_use = transaction_gas_budget;
-            let gas_spent_for_authentication = authenticator_computation_cost;
 
             check_gas(
                 objects,
@@ -73,7 +71,6 @@ mod checked {
                 gas,
                 gas_budget_to_check,
                 gas_budget_to_use,
-                gas_spent_for_authentication,
                 transaction.gas_price(),
             )
         }
@@ -89,13 +86,9 @@ mod checked {
         metrics: &Arc<BytecodeVerifierMetrics>,
         verifier_signing_config: &VerifierSigningConfig,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
-        // `MoveAuthenticator`computation cost is not used here at the moment.
-        let authenticator_computation_cost = 0;
-
         let gas_status = check_transaction_input_inner(
             protocol_config,
             reference_gas_price,
-            authenticator_computation_cost,
             transaction,
             &input_objects,
             &[],
@@ -125,13 +118,9 @@ mod checked {
         let gas_object_ref = gas_object.compute_object_reference();
         input_objects.push(ObjectReadResult::new_from_gas_object(&gas_object));
 
-        // `MoveAuthenticator`computation cost is not used here at the moment.
-        let authenticator_computation_cost = 0;
-
         let gas_status = check_transaction_input_inner(
             protocol_config,
             reference_gas_price,
-            authenticator_computation_cost,
             transaction,
             &input_objects,
             &[gas_object_ref],
@@ -159,13 +148,11 @@ mod checked {
         input_objects: InputObjects,
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
-        authenticator_computation_cost: u64,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         let transaction = cert.data().transaction_data();
         let gas_status = check_transaction_input_inner(
             protocol_config,
             reference_gas_price,
-            authenticator_computation_cost,
             transaction,
             &input_objects,
             &[],
@@ -235,7 +222,6 @@ mod checked {
         // gas cost.
         let gas_budget_to_check = authenticator_gas_budget + transaction_gas_budget;
         let gas_budget_to_use = authenticator_gas_budget;
-        let gas_spent_for_authentication = 0;
 
         let gas_status = check_gas(
             // Only the transaction input objects are used for gas checks.
@@ -245,7 +231,6 @@ mod checked {
             gas,
             gas_budget_to_check,
             gas_budget_to_use,
-            gas_spent_for_authentication,
             gas_price,
         )?;
 
@@ -258,7 +243,6 @@ mod checked {
     fn check_transaction_input_inner(
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
-        authenticator_computation_cost: u64,
         transaction: &TransactionData,
         input_objects: &InputObjects,
         // Overrides the gas objects in the transaction.
@@ -276,7 +260,6 @@ mod checked {
             gas,
             protocol_config,
             reference_gas_price,
-            authenticator_computation_cost,
             transaction,
         )?;
         check_objects(transaction, input_objects)?;
@@ -412,7 +395,6 @@ mod checked {
         gas: &[ObjectRef],
         gas_budget_to_check: u64,
         gas_budget_to_use: u64,
-        gas_spent_for_authentication: u64,
         gas_price: u64,
     ) -> IotaResult<IotaGasStatus> {
         debug_assert!(
@@ -420,9 +402,8 @@ mod checked {
             "It is expected that the gas budget {gas_budget_to_use:?} is used for execution less or equal to the gas budget {gas_budget_to_check:?} is used to check the gas coins balance"
         );
 
-        let gas_status = IotaGasStatus::new_with_gas_spent_for_authentication(
+        let gas_status = IotaGasStatus::new(
             gas_budget_to_use,
-            gas_spent_for_authentication,
             gas_price,
             reference_gas_price,
             protocol_config,

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -783,6 +783,12 @@ mod checked {
         Ok(())
     }
 
+    /// Create a union of two CheckedInputObjects, ensuring consistency
+    /// for objects that appear in both sets. The base_set is consumed and
+    /// returned with the union. The other_set is borrowed.
+    /// In the case of shared objects, the mutability can differ, but the
+    /// initial shared version must match. For other object kinds, they must
+    /// match exactly.
     fn checked_input_objects_union(
         base_set: CheckedInputObjects,
         other_set: &CheckedInputObjects,

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -91,7 +91,7 @@ mod checked {
             transaction,
             &input_objects,
             &[],
-            0, // authentication_gas_budget
+            0,
         )?;
         check_receiving_objects(&input_objects, receiving_objects)?;
         // Runs verifier, which could be expensive.
@@ -124,7 +124,7 @@ mod checked {
             transaction,
             &input_objects,
             &[gas_object_ref],
-            0, // authentication_gas_budget
+            0,
         )?;
         check_receiving_objects(&input_objects, &receiving_objects)?;
         // Runs verifier, which could be expensive.
@@ -150,13 +150,18 @@ mod checked {
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
-        let gas_status = check_certificate_input_inner(
-            cert,
-            &input_objects,
+        let transaction = cert.data().transaction_data();
+        let gas_status = check_transaction_input_inner(
             protocol_config,
             reference_gas_price,
-            0, // authentication_gas_budget
+            transaction,
+            &input_objects,
+            &[],
+            0,
         )?;
+        // NB: We do not check receiving objects when executing. Only at signing
+        // time do we check. NB: move verifier is only checked at
+        // signing time, not at execution.
 
         Ok((gas_status, input_objects.into_checked()))
     }
@@ -244,7 +249,7 @@ mod checked {
     #[instrument(level = "trace", skip_all)]
     pub fn check_certificate_and_move_authenticator_input(
         cert: &VerifiedExecutableTransaction,
-        tx_input_objects: InputObjects,
+        mut tx_input_objects: InputObjects,
         authenticator_input_objects: InputObjects,
         authenticator_gas_budget: u64,
         protocol_config: &ProtocolConfig,
@@ -254,40 +259,23 @@ mod checked {
         check_move_authenticator_objects(&authenticator_input_objects)?;
 
         // Check certificate inputs next
-        let gas_status = check_certificate_input_inner(
-            cert,
-            &tx_input_objects,
+        let transaction = cert.data().transaction_data();
+        let gas_status = check_transaction_input_inner(
             protocol_config,
             reference_gas_price,
+            transaction,
+            &tx_input_objects,
+            &[],
             authenticator_gas_budget,
         )?;
+
+        check_and_extend_input_objects(&mut tx_input_objects, &authenticator_input_objects)?;
 
         Ok((
             gas_status,
             authenticator_input_objects.into_checked(),
             tx_input_objects.into_checked(),
         ))
-    }
-
-    fn check_certificate_input_inner(
-        cert: &VerifiedExecutableTransaction,
-        input_objects: &InputObjects,
-        protocol_config: &ProtocolConfig,
-        reference_gas_price: u64,
-        authentication_gas_budget: u64,
-    ) -> IotaResult<IotaGasStatus> {
-        let transaction = cert.data().transaction_data();
-        Ok(check_transaction_input_inner(
-            protocol_config,
-            reference_gas_price,
-            transaction,
-            input_objects,
-            &[],
-            authentication_gas_budget,
-        )?)
-        // NB: We do not check receiving objects when executing. Only at signing
-        // time do we check. NB: move verifier is only checked at
-        // signing time, not at execution.
     }
 
     // Common checks performed for transactions and certificates.
@@ -791,6 +779,81 @@ mod checked {
                 }
             }
         };
+        Ok(())
+    }
+
+    fn check_and_extend_input_objects(
+        input_objects: &mut InputObjects,
+        additional_objects: &InputObjects,
+    ) -> IotaResult<()> {
+        for additional_object in additional_objects.iter() {
+            if let Some(existing_object) = input_objects.find_object_id_mut(additional_object.id())
+            {
+                // This is an invariant
+                assert_eq!(
+                    existing_object.object, additional_object.object,
+                    "The object read result for input objects with the same id must be equal"
+                );
+
+                // In the case of an alive object, check that the object kind matches exactly,
+                // or that if it is a shared object only the mutability changes
+                if let ObjectReadResultKind::Object(_) = &additional_object.object {
+                    match existing_object.input_object_kind {
+                        // If immutable or owned object or package, the kinds must match exactly
+                        InputObjectKind::ImmOrOwnedMoveObject(_)
+                        | InputObjectKind::MovePackage(_) => {
+                            // This is an invariant
+                            assert_eq!(
+                                existing_object.input_object_kind,
+                                additional_object.input_object_kind,
+                                "The object kind for input objects with the same id must be equal"
+                            );
+                        }
+                        // else, if shared object, only mutability can differ
+                        InputObjectKind::SharedMoveObject {
+                            id: input_id,
+                            initial_shared_version: input_initial_shared_version,
+                            mutable: input_mutable,
+                            ..
+                        } => {
+                            match additional_object.input_object_kind {
+                                InputObjectKind::ImmOrOwnedMoveObject(_)
+                                | InputObjectKind::MovePackage(_) => {
+                                    // The object owner for input objects with the same id must be
+                                    // equal
+                                    fp_bail!(UserInputError::NotSharedObject.into())
+                                }
+                                InputObjectKind::SharedMoveObject {
+                                    id: additional_id,
+                                    initial_shared_version: additional_initial_shared_version,
+                                    mutable: additional_mutable,
+                                } => {
+                                    fp_ensure!(
+                                        input_id == additional_id
+                                            && input_initial_shared_version
+                                                == additional_initial_shared_version,
+                                        UserInputError::SharedObjectStartingVersionMismatch.into()
+                                    );
+                                    // if additional_mutable is true and
+                                    // input_mutable is false, then swap
+                                    if additional_mutable && !input_mutable {
+                                        existing_object.input_object_kind =
+                                            InputObjectKind::SharedMoveObject {
+                                                id: input_id,
+                                                initial_shared_version:
+                                                    input_initial_shared_version,
+                                                mutable: true,
+                                            };
+                                    }
+                                }
+                            }
+                        }
+                    };
+                }
+            } else {
+                input_objects.push(additional_object.clone());
+            }
+        }
         Ok(())
     }
 

--- a/crates/iota-types/src/execution.rs
+++ b/crates/iota-types/src/execution.rs
@@ -33,7 +33,7 @@ pub type DeletedSharedObjectInfo = (ObjectID, SequenceNumber, bool, TransactionD
 /// inputs.
 pub type DeletedSharedObjects = Vec<DeletedSharedObjectInfo>;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum SharedInput {
     Existing(ObjectRef),
     Deleted(DeletedSharedObjectInfo),

--- a/crates/iota-types/src/execution.rs
+++ b/crates/iota-types/src/execution.rs
@@ -33,7 +33,7 @@ pub type DeletedSharedObjectInfo = (ObjectID, SequenceNumber, bool, TransactionD
 /// inputs.
 pub type DeletedSharedObjects = Vec<DeletedSharedObjectInfo>;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SharedInput {
     Existing(ObjectRef),
     Deleted(DeletedSharedObjectInfo),

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -38,7 +38,6 @@ pub mod checked {
         fn storage_rebate(&self) -> u64;
         fn unmetered_storage_rebate(&self) -> u64;
         fn gas_used(&self) -> u64;
-        fn gas_used_for_authentication(&self) -> u64;
         fn reset_storage_cost_and_rebate(&mut self);
         fn charge_storage_read(&mut self, size: usize) -> Result<(), ExecutionError>;
         fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError>;
@@ -68,43 +67,8 @@ pub mod checked {
         ) -> IotaResult<Self> {
             Self::check_gas_preconditions(gas_price, reference_gas_price, config)?;
 
-            // `IotaGasStatus` is created with zero `gas_spent_for_authentication` value.
-            let gas_spent_for_authentication = 0;
-
             Ok(Self::V1(IotaGasStatusV1::new_with_budget(
                 gas_budget,
-                gas_spent_for_authentication,
-                gas_price,
-                reference_gas_price,
-                config,
-            )))
-        }
-
-        pub fn new_with_gas_spent_for_authentication(
-            gas_budget: u64,
-            gas_spent_for_authentication: u64,
-            gas_price: u64,
-            reference_gas_price: u64,
-            config: &ProtocolConfig,
-        ) -> IotaResult<Self> {
-            Self::check_gas_preconditions(gas_price, reference_gas_price, config)?;
-
-            let computation_budget =
-                crate::gas_model::gas_v1::computation_budget(gas_budget, gas_price, config);
-
-            if computation_budget < gas_spent_for_authentication {
-                return Err(
-                    UserInputError::ComputationBudgetLessThenGasSpentForAuthentication {
-                        computation_budget,
-                        gas_spent_for_authentication,
-                    }
-                    .into(),
-                );
-            }
-
-            Ok(Self::V1(IotaGasStatusV1::new_with_budget(
-                gas_budget,
-                gas_spent_for_authentication,
                 gas_price,
                 reference_gas_price,
                 config,

--- a/crates/iota-types/src/gas_model/gas_v1.rs
+++ b/crates/iota-types/src/gas_model/gas_v1.rs
@@ -252,7 +252,6 @@ mod checked {
 
         pub(crate) fn new_with_budget(
             gas_budget: u64,
-            gas_spent_for_authentication: u64,
             gas_price: u64,
             reference_gas_price: u64,
             config: &ProtocolConfig,
@@ -265,7 +264,6 @@ mod checked {
                 GasStatus::new(
                     iota_cost_table.execution_cost_table.clone(),
                     computation_budget,
-                    gas_spent_for_authentication,
                     gas_price,
                     config.gas_model_version(),
                 ),
@@ -460,10 +458,6 @@ mod checked {
 
         fn gas_used(&self) -> u64 {
             self.gas_status.gas_used_pre_gas_price()
-        }
-
-        fn gas_used_for_authentication(&self) -> u64 {
-            self.gas_status.gas_spent_for_authentication_pre_gas_price()
         }
 
         fn reset_storage_cost_and_rebate(&mut self) {

--- a/crates/iota-types/src/gas_model/tables.rs
+++ b/crates/iota-types/src/gas_model/tables.rs
@@ -10,7 +10,6 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_profiler::GasProfiler;
-use move_vm_test_utils::gas_schedule::GasUnit;
 use once_cell::sync::Lazy;
 
 use crate::gas_model::units_types::{CostTable, Gas, GasCost};
@@ -51,7 +50,6 @@ pub struct GasStatus {
     pub gas_left: InternalGas,
     gas_price: u64,
     initial_budget: InternalGas,
-    gas_spent_for_authentication: InternalGas,
     pub charge: bool,
 
     // The current height of the operand stack, and the maximal height that it has reached.
@@ -81,28 +79,10 @@ impl GasStatus {
     /// Charge for every operation and fail when there is no more gas to pay for
     /// operations. This is the instantiation that must be used when
     /// executing a user script.
-    pub fn new(
-        cost_table: CostTable,
-        budget: u64,
-        gas_spent_for_authentication: u64,
-        gas_price: u64,
-        gas_model_version: u64,
-    ) -> Self {
+    pub fn new(cost_table: CostTable, budget: u64, gas_price: u64, gas_model_version: u64) -> Self {
         assert!(gas_price > 0, "gas price cannot be 0");
-        assert!(
-            budget >= gas_spent_for_authentication,
-            "`budget` cannot be less than `gas_spent_for_authentication`"
-        );
-
-        let initial_budget = Self::to_internal_units(budget / gas_price);
-        let gas_left = Self::to_internal_units((budget - gas_spent_for_authentication) / gas_price);
-        let gas_spent_for_authentication =
-            Self::to_internal_units(gas_spent_for_authentication / gas_price);
-
-        assert!(
-            (gas_spent_for_authentication + gas_left) == initial_budget,
-            "`initial_budget` must be equal to `gas_spent_for_authentication` + `gas_left`"
-        );
+        let budget_in_unit = budget / gas_price;
+        let gas_left = Self::to_internal_units(budget_in_unit);
 
         let (stack_height_current_tier_mult, stack_height_next_tier_start) =
             cost_table.stack_height_tier(0);
@@ -114,8 +94,7 @@ impl GasStatus {
             gas_model_version,
             gas_left,
             gas_price,
-            initial_budget,
-            gas_spent_for_authentication,
+            initial_budget: gas_left,
             cost_table,
             charge: true,
             stack_height_high_water_mark: 0,
@@ -144,7 +123,6 @@ impl GasStatus {
             gas_left: InternalGas::new(0),
             gas_price: 1,
             initial_budget: InternalGas::new(0),
-            gas_spent_for_authentication: InternalGas::new(0),
             cost_table: ZERO_COST_SCHEDULE.clone(),
             charge: false,
             stack_height_high_water_mark: 0,
@@ -337,15 +315,6 @@ impl GasStatus {
             None => InternalGas::to_unit_round_down(self.initial_budget),
         };
         u64::from(gas)
-    }
-
-    // The amount of gas spent for authentication, it does not include the
-    // multiplication for the gas price
-    pub fn gas_spent_for_authentication_pre_gas_price(&self) -> u64 {
-        u64::from(
-            self.gas_spent_for_authentication
-                .to_unit_round_down::<GasUnit>(),
-        )
     }
 
     // Charge the number of bytes with the cost per byte value

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2900,13 +2900,13 @@ impl InputObjectKind {
 /// The result of reading an object for execution. Because shared objects may be
 /// deleted, one possible result of reading a shared object is that
 /// ObjectReadResultKind::Deleted is returned.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ObjectReadResult {
     pub input_object_kind: InputObjectKind,
     pub object: ObjectReadResultKind,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum ObjectReadResultKind {
     Object(Object),
     // The version of the object that the transaction intended to read, and the digest of the tx
@@ -3086,6 +3086,7 @@ impl std::fmt::Debug for InputObjects {
 
 // An InputObjects new-type that has been verified by iota-transaction-checks,
 // and can be safely passed to execution.
+#[derive(Clone)]
 pub struct CheckedInputObjects(InputObjects);
 
 // DO NOT CALL outside of iota-transaction-checks, genesis, or replay.
@@ -3297,6 +3298,10 @@ impl InputObjects {
 
     pub fn push(&mut self, object: ObjectReadResult) {
         self.objects.push(object);
+    }
+
+    pub fn extend(&mut self, other: Self) {
+        self.objects.extend(other.objects);
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &ObjectReadResult> {

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -3110,6 +3110,10 @@ impl CheckedInputObjects {
         Self(input_objects)
     }
 
+    pub fn extend_no_duplicates(&mut self, other: Self) {
+        self.0.extend_no_duplicates(other.0);
+    }
+
     pub fn inner(&self) -> &InputObjects {
         &self.0
     }
@@ -3300,8 +3304,13 @@ impl InputObjects {
         self.objects.push(object);
     }
 
-    pub fn extend(&mut self, other: Self) {
-        self.objects.extend(other.objects);
+    pub fn extend_no_duplicates(&mut self, other: Self) {
+        let new_objects: Vec<_> = other
+            .objects
+            .into_iter()
+            .filter(|x| !self.objects.contains(x))
+            .collect();
+        self.objects.extend(new_objects);
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &ObjectReadResult> {

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -3086,7 +3086,6 @@ impl std::fmt::Debug for InputObjects {
 
 // An InputObjects new-type that has been verified by iota-transaction-checks,
 // and can be safely passed to execution.
-#[derive(Clone)]
 pub struct CheckedInputObjects(InputObjects);
 
 // DO NOT CALL outside of iota-transaction-checks, genesis, or replay.

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -3110,10 +3110,6 @@ impl CheckedInputObjects {
         Self(input_objects)
     }
 
-    pub fn extend_no_duplicates(&mut self, other: Self) {
-        self.0.extend_no_duplicates(other.0);
-    }
-
     pub fn inner(&self) -> &InputObjects {
         &self.0
     }
@@ -3191,17 +3187,6 @@ impl InputObjects {
         );
 
         owned_objects
-    }
-
-    pub fn shared_objects_set(&self) -> HashSet<SharedInput> {
-        self.objects
-            .iter()
-            .filter(|obj| obj.is_shared_object())
-            .map(|obj| {
-                obj.to_shared_input()
-                    .expect("already filtered for shared objects")
-            })
-            .collect()
     }
 
     pub fn filter_shared_objects(&self) -> Vec<SharedInput> {
@@ -3315,13 +3300,9 @@ impl InputObjects {
         self.objects.push(object);
     }
 
-    pub fn extend_no_duplicates(&mut self, other: Self) {
-        let new_objects: Vec<_> = other
-            .objects
-            .into_iter()
-            .filter(|x| !self.objects.contains(x))
-            .collect();
-        self.objects.extend(new_objects);
+    // If it contains then it returns the ObjectReadResult
+    pub fn find_object_id_mut(&mut self, object_id: ObjectID) -> Option<&mut ObjectReadResult> {
+        self.objects.iter_mut().find(|o| o.id() == object_id)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &ObjectReadResult> {

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -3193,6 +3193,17 @@ impl InputObjects {
         owned_objects
     }
 
+    pub fn shared_objects_set(&self) -> HashSet<SharedInput> {
+        self.objects
+            .iter()
+            .filter(|obj| obj.is_shared_object())
+            .map(|obj| {
+                obj.to_shared_input()
+                    .expect("already filtered for shared objects")
+            })
+            .collect()
+    }
+
     pub fn filter_shared_objects(&self) -> Vec<SharedInput> {
         self.objects
             .iter()

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2900,7 +2900,7 @@ impl InputObjectKind {
 /// The result of reading an object for execution. Because shared objects may be
 /// deleted, one possible result of reading a shared object is that
 /// ObjectReadResultKind::Deleted is returned.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct ObjectReadResult {
     pub input_object_kind: InputObjectKind,
     pub object: ObjectReadResultKind,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -257,7 +257,7 @@ mod checked {
     /// happens since we cannot charge it separately in the current
     /// implementation.
     #[instrument(name = "tx_validate", level = "debug", skip_all)]
-    pub fn validate_transaction(
+    pub fn validate_transaction<Mode: ExecutionMode>(
         store: &dyn BackingStore,
         // Configuration
         protocol_config: &ProtocolConfig,
@@ -281,7 +281,7 @@ mod checked {
         move_vm: &Arc<MoveVM>,
     ) -> (
         u64, // gas computation cost
-        Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
+        Result<Mode::ExecutionResults, ExecutionError>,
     ) {
         // Check the preconditions.
         debug_assert!(
@@ -352,20 +352,19 @@ mod checked {
             setup_authenticator_move_call(authenticator, authenticator_info).unwrap(); //TODO
 
         // Execute the authenticator transaction.
-        let (computation_gas_cost, execution_result) =
-            execute_authenticator_move_call::<execution_mode::Validation>(
-                &mut temporary_store,
-                authenticator_move_call,
-                gas_charger,
-                &mut tx_ctx,
-                move_vm,
-                protocol_config,
-                metrics,
-                false,
-                contains_deleted_input,
-                cancelled_objects,
-                trace_builder_opt,
-            );
+        let (computation_gas_cost, execution_result) = execute_authenticator_move_call::<Mode>(
+            &mut temporary_store,
+            authenticator_move_call,
+            gas_charger,
+            &mut tx_ctx,
+            move_vm,
+            protocol_config,
+            metrics,
+            false,
+            contains_deleted_input,
+            cancelled_objects,
+            trace_builder_opt,
+        );
 
         // Check the execution result.
         let status = if let Err(error) = &execution_result {

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -7,10 +7,7 @@ pub use checked::*;
 #[iota_macros::with_checked_arithmetic]
 mod checked {
 
-    use std::{
-        collections::{BTreeSet, HashSet},
-        sync::Arc,
-    };
+    use std::{collections::HashSet, sync::Arc};
 
     use iota_move_natives::all_natives;
     use iota_protocol_config::{LimitThresholdCrossed, ProtocolConfig, check_limit_by_meter};
@@ -109,12 +106,9 @@ mod checked {
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
         let input_objects = input_objects.into_inner();
-        let shared_object_refs = input_objects.filter_shared_objects();
-        let mut transaction_dependencies = input_objects.transaction_dependencies();
-
         let receiving_objects = transaction_kind.receiving_objects();
 
-        let mut temporary_store = TemporaryStore::new(
+        let temporary_store = TemporaryStore::new(
             store,
             input_objects.clone(),
             receiving_objects,
@@ -123,7 +117,7 @@ mod checked {
             *epoch_id,
         );
 
-        let mut gas_charger =
+        let gas_charger =
             GasCharger::new(transaction_digest, gas_coins, gas_status, protocol_config);
 
         let mut tx_ctx = TxContext::new_from_components(
@@ -133,40 +127,22 @@ mod checked {
             epoch_timestamp_ms,
         );
 
-        let (status, gas_cost_summary, execution_result) =
-            execute_transaction_to_effects_inner::<Mode>(
-                &mut temporary_store,
-                &mut gas_charger,
-                &mut tx_ctx,
-                transaction_kind,
-                transaction_signer,
-                transaction_digest,
-                &input_objects,
-                &mut transaction_dependencies,
-                move_vm,
-                protocol_config,
-                metrics,
-                enable_expensive_checks,
-                certificate_deny_set,
-                trace_builder_opt,
-                None,
-            );
-
-        let (inner, effects) = temporary_store.into_effects(
-            shared_object_refs,
-            &transaction_digest,
-            transaction_dependencies,
-            gas_cost_summary,
-            status,
-            &mut gas_charger,
-            *epoch_id,
-        );
-
-        (
-            inner,
-            gas_charger.into_gas_status(),
-            effects,
-            execution_result,
+        execute_transaction_to_effects_inner::<Mode>(
+            temporary_store,
+            gas_charger,
+            &mut tx_ctx,
+            transaction_kind,
+            transaction_signer,
+            transaction_digest,
+            &input_objects,
+            move_vm,
+            epoch_id,
+            protocol_config,
+            metrics,
+            enable_expensive_checks,
+            certificate_deny_set,
+            trace_builder_opt,
+            None,
         )
     }
 
@@ -174,15 +150,15 @@ mod checked {
     /// effects. It handles gas charging and execution logic.
     #[instrument(name = "tx_execute_to_effects_inner", level = "debug", skip_all)]
     fn execute_transaction_to_effects_inner<Mode: ExecutionMode>(
-        temporary_store: &mut TemporaryStore,
-        gas_charger: &mut GasCharger,
+        mut temporary_store: TemporaryStore,
+        mut gas_charger: GasCharger,
         tx_ctx: &mut TxContext,
         transaction_kind: TransactionKind,
         transaction_signer: IotaAddress,
         transaction_digest: TransactionDigest,
         input_objects: &InputObjects,
-        transaction_dependencies: &mut BTreeSet<TransactionDigest>,
         move_vm: &Arc<MoveVM>,
+        epoch_id: &EpochId,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         enable_expensive_checks: bool,
@@ -192,8 +168,9 @@ mod checked {
             Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
         >,
     ) -> (
-        ExecutionStatus,
-        GasCostSummary,
+        InnerTemporaryStore,
+        IotaGasStatus,
+        TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
         let mutable_inputs = if enable_expensive_checks {
@@ -201,6 +178,8 @@ mod checked {
         } else {
             HashSet::new()
         };
+        let shared_object_refs = input_objects.filter_shared_objects();
+        let mut transaction_dependencies = input_objects.transaction_dependencies();
         let contains_deleted_input = input_objects.contains_deleted_objects();
         let cancelled_objects = input_objects.get_cancelled_objects();
 
@@ -208,9 +187,9 @@ mod checked {
         let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
 
         let (gas_cost_summary, execution_result) = execute_transaction::<Mode>(
-            temporary_store,
+            &mut temporary_store,
             transaction_kind,
-            gas_charger,
+            &mut gas_charger,
             tx_ctx,
             move_vm,
             protocol_config,
@@ -249,14 +228,29 @@ mod checked {
             temporary_store
                 .check_ownership_invariants(
                     &transaction_signer,
-                    gas_charger,
+                    &mut gas_charger,
                     &mutable_inputs,
                     is_epoch_change,
                 )
                 .unwrap()
         }; // else, in dev inspect mode and anything goes--don't check
 
-        (status, gas_cost_summary, execution_result)
+        let (inner, effects) = temporary_store.into_effects(
+            shared_object_refs,
+            &transaction_digest,
+            transaction_dependencies,
+            gas_cost_summary,
+            status,
+            &mut gas_charger,
+            *epoch_id,
+        );
+
+        (
+            inner,
+            gas_charger.into_gas_status(),
+            effects,
+            execution_result,
+        )
     }
 
     /// This function produces transaction effects for a transaction that
@@ -311,6 +305,24 @@ mod checked {
         // It does not alter the state and produces no effects other than possible
         // errors.
 
+        // Keep track of the authenticator input objects for later use.
+        let authenticator_input_objects = authenticator_input_objects.into_inner();
+
+        let mut input_objects = transaction_input_objects.into_inner();
+        input_objects.extend_no_duplicates(authenticator_input_objects.clone());
+        // Receiving objects can only come from the transaction inputs
+        let transaction_receiving_objects = transaction_kind.receiving_objects();
+
+        // Prepare the temporary store for the authentication execution.
+        let mut temporary_store = TemporaryStore::new(
+            store,
+            input_objects.clone(),
+            transaction_receiving_objects,
+            transaction_digest,
+            protocol_config,
+            *epoch_id,
+        );
+
         // Prepare the gas charger for both authentication and transaction execution.
         let mut gas_charger =
             GasCharger::new(transaction_digest, gas_coins, gas_status, protocol_config);
@@ -324,29 +336,21 @@ mod checked {
             epoch_timestamp_ms,
         );
 
-        // Keep track of the authenticator input objects for later use.
-        let authenticator_input_objects = authenticator_input_objects.into_inner();
-        let authenticator_shared_objects = authenticator_input_objects.shared_objects_set();
-        let authenticator_transaction_dependencies =
-            authenticator_input_objects.transaction_dependencies();
-
         // Run the authentication.
-        let (authentication_inner_store, authentication_execution_result) =
-            authenticate_transaction_inner(
-                store,
-                protocol_config,
-                metrics.clone(),
-                epoch_id,
-                &mut gas_charger,
-                authenticator,
-                authenticator_info,
-                authenticator_input_objects,
-                transaction_kind.clone(),
-                transaction_digest,
-                &mut tx_ctx,
-                trace_builder_opt,
-                move_vm,
-            );
+        let authentication_execution_result = authenticate_transaction_inner(
+            &mut temporary_store,
+            protocol_config,
+            metrics.clone(),
+            &mut gas_charger,
+            authenticator,
+            authenticator_info,
+            &authenticator_input_objects,
+            transaction_kind.clone(),
+            transaction_digest,
+            &mut tx_ctx,
+            trace_builder_opt,
+            move_vm,
+        );
 
         // At this stage we have the gas status, with gas charged for reading the
         // authenticator inputs and for the computation, and a result which is either
@@ -355,79 +359,22 @@ mod checked {
         // We can now start the creation of the transaction effects, either for an
         // authentication failure or for a normal execution of the transaction.
 
-        // Input objects for the transaction execution do not include the authenticator
-        // inputs.
-        let transaction_input_objects = transaction_input_objects.into_inner();
-        // Receiving objects can only come from the transaction inputs
-        let transaction_receiving_objects = transaction_kind.receiving_objects();
-
-        // Shared inputs are merged from both the transaction and authenticator inputs.
-        let shared_object_refs = transaction_input_objects
-            .shared_objects_set()
-            .union(&authenticator_shared_objects)
-            .cloned()
-            .collect();
-        // Transaction dependencies are merged from both the transaction and
-        // authenticator inputs.
-        let mut transaction_dependencies: BTreeSet<_> = transaction_input_objects
-            .transaction_dependencies()
-            .union(&authenticator_transaction_dependencies)
-            .cloned()
-            .collect();
-
-        let mut transaction_temporary_store = TemporaryStore::new(
-            store,
-            transaction_input_objects.clone(),
-            transaction_receiving_objects,
+        execute_transaction_to_effects_inner::<Mode>(
+            temporary_store,
+            gas_charger,
+            &mut tx_ctx,
+            transaction_kind,
+            transaction_signer,
             transaction_digest,
+            &input_objects,
+            move_vm,
+            epoch_id,
             protocol_config,
-            *epoch_id,
-        );
-
-        let (status, gas_cost_summary, execution_result) =
-            execute_transaction_to_effects_inner::<Mode>(
-                &mut transaction_temporary_store,
-                &mut gas_charger,
-                &mut tx_ctx,
-                transaction_kind,
-                transaction_signer,
-                transaction_digest,
-                &transaction_input_objects,
-                &mut transaction_dependencies,
-                move_vm,
-                protocol_config,
-                metrics,
-                enable_expensive_checks,
-                certificate_deny_set,
-                trace_builder_opt,
-                Some(authentication_execution_result),
-            );
-
-        let (mut inner, effects) = transaction_temporary_store.into_effects(
-            shared_object_refs,
-            &transaction_digest,
-            transaction_dependencies,
-            gas_cost_summary,
-            status,
-            &mut gas_charger,
-            *epoch_id,
-        );
-
-        // TODO: lamport??
-        inner
-            .input_objects
-            .extend(authentication_inner_store.input_objects);
-        inner.loaded_runtime_objects.extend(
-            authentication_inner_store
-                .loaded_runtime_objects
-                .into_iter(),
-        );
-
-        (
-            inner,
-            gas_charger.into_gas_status(),
-            effects,
-            execution_result,
+            metrics,
+            enable_expensive_checks,
+            certificate_deny_set,
+            trace_builder_opt,
+            Some(authentication_execution_result),
         )
     }
 
@@ -466,6 +413,18 @@ mod checked {
         move_vm: &Arc<MoveVM>,
     ) -> Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>
     {
+        let input_objects = authenticator_input_objects.into_inner();
+
+        // Prepare the temporary store for the authentication execution.
+        let mut temporary_store = TemporaryStore::new(
+            store,
+            input_objects.clone(),
+            vec![],
+            transaction_digest,
+            protocol_config,
+            *epoch_id,
+        );
+
         // Prepare the gas charger for authentication execution.
         let mut gas_charger =
             GasCharger::new(transaction_digest, vec![], gas_status, protocol_config);
@@ -480,23 +439,20 @@ mod checked {
         );
 
         // Run the authentication.
-        let (_, authentication_execution_result) = authenticate_transaction_inner(
-            store,
+        authenticate_transaction_inner(
+            &mut temporary_store,
             protocol_config,
-            metrics,
-            epoch_id,
+            metrics.clone(),
             &mut gas_charger,
             authenticator,
             authenticator_info,
-            authenticator_input_objects.into_inner(),
-            transaction_kind,
+            &input_objects,
+            transaction_kind.clone(),
             transaction_digest,
             &mut tx_ctx,
             trace_builder_opt,
             move_vm,
-        );
-
-        authentication_execution_result
+        )
     }
 
     /// This function implements an abstracted IOTA account transaction
@@ -511,18 +467,16 @@ mod checked {
     /// used to check the computation cost.
     #[instrument(name = "tx_validate", level = "debug", skip_all)]
     pub fn authenticate_transaction_inner(
-        store: &dyn BackingStore,
+        temporary_store: &mut TemporaryStore<'_>,
         // Configuration
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
-        // Epoch
-        epoch_id: &EpochId,
         // Gas related
         gas_charger: &mut GasCharger,
         // Authenticator
         authenticator: MoveAuthenticator,
         authenticator_info: AuthenticatorInfoV1,
-        authenticator_input_objects: InputObjects,
+        authenticator_input_objects: &InputObjects,
         // Transaction
         transaction_kind: TransactionKind,
         transaction_digest: TransactionDigest,
@@ -531,10 +485,8 @@ mod checked {
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         // VM
         move_vm: &Arc<MoveVM>,
-    ) -> (
-        InnerTemporaryStore,
-        Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
-    ) {
+    ) -> Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>
+    {
         // Check the preconditions.
         debug_assert!(
             transaction_kind.is_programmable_transaction(),
@@ -557,16 +509,6 @@ mod checked {
         let contains_deleted_input = authenticator_input_objects.contains_deleted_objects();
         let cancelled_objects = authenticator_input_objects.get_cancelled_objects();
 
-        // Prepare the temporary store for the authentication execution.
-        let mut temporary_store = TemporaryStore::new(
-            store,
-            authenticator_input_objects,
-            vec![],
-            transaction_digest,
-            protocol_config,
-            *epoch_id,
-        );
-
         // Prepare the authentication context.
         let auth_ctx = {
             let TransactionKind::ProgrammableTransaction(ptb) = &transaction_kind else {
@@ -582,7 +524,7 @@ mod checked {
 
         // Execute the authentication.
         let authentication_execution_result = execute_authenticator_move_call(
-            &mut temporary_store,
+            temporary_store,
             authenticator,
             authenticator_info,
             gas_charger,
@@ -611,10 +553,7 @@ mod checked {
             authentication_execution_status
         );
 
-        (
-            temporary_store.into_inner(),
-            authentication_execution_result,
-        )
+        authentication_execution_result
     }
 
     /// Executes an authentication move call by processing the specified
@@ -649,34 +588,33 @@ mod checked {
             "At this point no gas charges must be applied yet"
         );
 
-        // Charge gas for reading the Move authenticator input objects from the storage.
+        // It must NOT charge gas for reading the Move authenticator input objects from
+        // the storage. It will be done later during the transaction execution.
         // Then execute the authentication.
-        gas_charger
-            .charge_input_objects(temporary_store)
-            .and_then(|()| {
-                run_inputs_checks(
-                    protocol_config,
-                    deny_cert,
-                    contains_deleted_input,
-                    cancelled_objects,
-                )?;
-                let authenticator_move_call =
-                    setup_authenticator_move_call(authenticator, authenticator_info)?;
-                programmable_transactions::execution::execute::<execution_mode::Validation>(
-                    protocol_config,
-                    metrics.clone(),
-                    move_vm,
-                    temporary_store,
-                    tx_ctx,
-                    gas_charger,
-                    authenticator_move_call,
-                    trace_builder_opt,
-                )
-                .and_then(|ok_result| {
-                    temporary_store.check_move_authenticator_results_consistency()?;
-                    Ok(ok_result)
-                })
+        run_inputs_checks(
+            protocol_config,
+            deny_cert,
+            contains_deleted_input,
+            cancelled_objects,
+        )
+        .and_then(|()| {
+            let authenticator_move_call =
+                setup_authenticator_move_call(authenticator, authenticator_info)?;
+            programmable_transactions::execution::execute::<execution_mode::Validation>(
+                protocol_config,
+                metrics.clone(),
+                move_vm,
+                temporary_store,
+                tx_ctx,
+                gas_charger,
+                authenticator_move_call,
+                trace_builder_opt,
+            )
+            .and_then(|ok_result| {
+                temporary_store.check_move_authenticator_results_consistency()?;
+                Ok(ok_result)
             })
+        })
     }
 
     /// Function dedicated to the execution of a GenesisTransaction.

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -246,7 +246,7 @@ mod checked {
                     is_epoch_change,
                 )
                 .unwrap()
-        }; // else, in dev inspect mode and anything goes--don't check
+        } // else, in dev inspect mode and anything goes--don't check
 
         let (inner, effects) = temporary_store.into_effects(
             shared_object_refs,
@@ -267,14 +267,18 @@ mod checked {
     }
 
     /// This function produces transaction effects for a transaction that
-    /// requires the Move authentication. It runs the Move authentication:
-    ///   - Then, if it fails it charges gas for the failed execution of the
+    /// requires the Move authentication.
+    /// It creates a temporary store, gas charger, and transaction context for
+    /// the authentication execution and then reuses these for the normal
+    /// transaction execution.
+    /// Running the Move authentication can have two outcomes:
+    ///   - If it fails, then it charges gas for the failed execution of the
     ///     authentication and produces transaction effects with the appropriate
     ///     error status.
     ///   - Else, if the authentication is successful, it continues with the
     ///     normal transaction execution.
-    /// It combines the input objects from both the failed authentication and
-    /// the original transaction and updates their sequence numbers.
+    /// It combines the input objects from both the authentication and
+    /// transaction.
     #[instrument(
         name = "tx_authenticate_then_execute_to_effects",
         level = "debug",
@@ -312,11 +316,9 @@ mod checked {
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
-        // Authenticate the transaction first. This means having read only inputs passed
-        // to an authenticate function. It charges gas for reading the input objects and
-        // then for the function instructions.
-        // It does not alter the state and produces no effects other than possible
-        // errors.
+        // Preparation
+        // It involves setting up the TemporaryStore, GasCharger, and TxContext, that
+        // will be common for both the authentication and transaction execution.
 
         // Input objects come from both authentication and transaction inputs
         let input_objects = authenticator_and_transaction_input_objects.into_inner();
@@ -337,7 +339,7 @@ mod checked {
         let contains_deleted_input = input_objects.contains_deleted_objects();
         let cancelled_objects = input_objects.get_cancelled_objects();
 
-        // Prepare the temporary store for the authentication execution.
+        // Prepare the temporary store.
         let mut temporary_store = TemporaryStore::new(
             store,
             input_objects,
@@ -347,12 +349,11 @@ mod checked {
             *epoch_id,
         );
 
-        // Prepare the gas charger for both authentication and transaction execution.
+        // Prepare the gas charger.
         let mut gas_charger =
             GasCharger::new(transaction_digest, gas_coins, gas_status, protocol_config);
 
-        // Prepare the transaction context for both authentication and transaction
-        // execution.
+        // Prepare the transaction context.
         let mut tx_ctx = TxContext::new_from_components(
             &transaction_signer,
             &transaction_digest,
@@ -360,7 +361,11 @@ mod checked {
             epoch_timestamp_ms,
         );
 
-        // Run the authentication.
+        // Authentication execution.
+        // It does not alter the state, if not for command execution gas charging, and
+        // produces no effects other than possible errors.
+
+        // Run the authentication execution.
         let authentication_execution_result = authenticate_transaction_inner(
             &mut temporary_store,
             protocol_config,
@@ -376,13 +381,13 @@ mod checked {
             move_vm,
         );
 
-        // At this stage we have the gas status, with gas charged for reading the
-        // authenticator inputs and for the computation, and a result which is either
-        // empty or an error.
-
+        // Transaction execution.
+        // At this stage we arrive with gas charged for the execution of the
+        // authenticate function and a result which is either empty or an error.
         // We can now start the creation of the transaction effects, either for an
         // authentication failure or for a normal execution of the transaction.
 
+        // Run the transaction execution and return the effects.
         execute_transaction_to_effects_inner::<Mode>(
             temporary_store,
             gas_charger,
@@ -406,16 +411,10 @@ mod checked {
         )
     }
 
-    /// This function implements an abstracted IOTA account transaction
-    /// validation. This validation checks that the authentication method used
-    /// for the account is valid. It prepares a `MoveAuthenticator` PTB with
-    /// a single move call for execution, then executes it through an inner
-    /// execution method. The `MoveAuthenticator` provides the inputs to use for
-    /// the authentication function found in `AuthenticatorInfo`, that is
-    /// retrieved from the abstracted IOTA account.
-    ///
-    /// Returns an error if it happens and the gas status that can be later
-    /// used to check the computation cost.
+    /// This function checks the authentication of a transaction without
+    /// returning effects. It executes an authenticate function using the
+    /// information of an authenticator. If the execution fails, it returns
+    /// an execution error; otherwise it returns an empty value.
     #[instrument(name = "tx_validate", level = "debug", skip_all)]
     pub fn authenticate_transaction(
         store: &dyn BackingStore,
@@ -483,16 +482,15 @@ mod checked {
         )
     }
 
-    /// This function implements an abstracted IOTA account transaction
-    /// validation. This validation checks that the authentication method used
-    /// for the account is valid. It prepares a `MoveAuthenticator` PTB with
-    /// a single move call for execution, then executes it through an inner
-    /// execution method. The `MoveAuthenticator` provides the inputs to use for
-    /// the authentication function found in `AuthenticatorInfo`, that is
-    /// retrieved from the abstracted IOTA account.
-    ///
-    /// Returns an error if it happens and the gas status that can be later
-    /// used to check the computation cost.
+    // This function implements the authentication execution. It checks that the
+    // authentication method used by the authenticator is valid. It prepares a
+    /// `MoveAuthenticator` PTB with a single move call for execution, then
+    /// executes it through an inner execution method. The
+    /// `MoveAuthenticator` provides the inputs to use for the
+    /// authentication function found in `AuthenticatorInfo`,
+    /// that is retrieved from an account.
+    /// If the execution fails, it returns an execution error; otherwise it
+    /// returns an empty value.
     #[instrument(name = "tx_validate", level = "debug", skip_all)]
     pub fn authenticate_transaction_inner(
         temporary_store: &mut TemporaryStore<'_>,
@@ -591,10 +589,9 @@ mod checked {
     /// consistency checks.
     ///
     /// Gas costs are managed through the `GasCharger` argument and charged only
-    /// for the authenticator move call execution.
+    /// for authentication move function execution.
     ///
-    /// Returns the move authenticator computation gas cost without bucketing
-    /// and the execution result.
+    /// Returns only the execution results.
     #[instrument(name = "auth_execute", level = "debug", skip_all)]
     fn execute_authenticator_move_call(
         temporary_store: &mut TemporaryStore<'_>,
@@ -718,7 +715,8 @@ mod checked {
     ) {
         gas_charger.smash_gas(temporary_store);
 
-        // At this point no charges have been applied yet
+        // At this point, either no charges have been applied yet or we have
+        // already a pre execution result to handle.
         debug_assert!(
             pre_execution_result_opt.is_some() || gas_charger.no_charges(),
             "No gas charges must be applied yet"
@@ -741,8 +739,8 @@ mod checked {
                 cancelled_objects,
             )?;
 
-            // If the authentication succeeded, proceed with the main execution loop
-            // else propagate the authentication error
+            // If the pre-execution succeeded, proceed with the main execution loop
+            // else propagate the pre-execution error
             let mut execution_result = pre_execution_result_opt.unwrap_or(Ok(())).and_then(|_| {
                 execution_loop::<Mode>(
                     temporary_store,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -448,19 +448,26 @@ mod checked {
         TransactionEffects,
         ExecutionError,
     ) {
+        // Merge input objects coming from the transaction together with
+        // those coming from the failed authenticator execution.
         let mut input_objects = transaction_input_objects.into_inner();
         input_objects.extend(invalid_authentication_input_objects.into_inner());
+
+        // Read objects and dependencies from both TX and authenticator.
         let mutable_inputs = if enable_expensive_checks {
             input_objects.mutable_inputs().keys().copied().collect()
         } else {
             HashSet::new()
         };
         let shared_object_refs = input_objects.filter_shared_objects();
-        let receiving_objects = transaction_kind.receiving_objects();
         let mut transaction_dependencies = input_objects.transaction_dependencies();
         let contains_deleted_input = input_objects.contains_deleted_objects();
         let cancelled_objects = input_objects.get_cancelled_objects();
 
+        // Read receiving objects only from the TX.
+        let receiving_objects = transaction_kind.receiving_objects();
+
+        // Prepare the needed environment for a normal transaction execution.
         let mut temporary_store = TemporaryStore::new(
             store,
             input_objects,
@@ -483,6 +490,8 @@ mod checked {
         let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
 
         let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
+
+        // Then, instead of executing the TX, charge gas for the failed authentication.
         let (gas_cost_summary, execution_error) = charge_gas_for_invalid_authentication::<Mode>(
             &mut temporary_store,
             transaction_kind,
@@ -498,6 +507,7 @@ mod checked {
             cancelled_objects,
         );
 
+        // Prepare the failure status.
         let (status, command) = execution_error.to_execution_status();
         let status = ExecutionStatus::new_failure(status, command);
 
@@ -517,6 +527,7 @@ mod checked {
         // dependencies
         transaction_dependencies.remove(&TransactionDigest::genesis_marker());
 
+        // Final checks
         if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
             temporary_store
                 .check_ownership_invariants(
@@ -528,6 +539,7 @@ mod checked {
                 .unwrap()
         } // else, in dev inspect mode and anything goes--don't check
 
+        // Produce the final effects.
         let (inner, effects) = temporary_store.into_effects(
             shared_object_refs,
             &transaction_digest,
@@ -801,9 +813,14 @@ mod checked {
             // Run the checks that must take precedence over the validation execution error.
             let pre_check: Result<(), ExecutionError> = (|| {
                 // We must charge object read here we must still ensure an effect is committed
-                // and all objects versions incremented
+                // and all objects versions incremented.
+                // This can fail only if not enough gas units are left.
                 gas_charger.charge_input_objects(temporary_store)?;
 
+                // This checks for denied certificates, deleted input objects,
+                // and cancelled objects due to congestion or
+                // randomness unavailability. If any of
+                // these conditions are met, it fails.
                 run_inputs_checks(
                     protocol_config,
                     deny_cert,
@@ -811,6 +828,11 @@ mod checked {
                     cancelled_objects,
                 )?;
 
+                // This checks a size limit based on the number of written_objects, number of
+                // modified_objects and number of input_objects. So, in this context, it should
+                // fail only if the number of input_objects is too large.
+                // TODO: adapt the limit to support the merge of TX and authenticator input
+                // objects.
                 check_meter_limit(
                     temporary_store,
                     gas_charger,
@@ -829,6 +851,7 @@ mod checked {
             }
         };
 
+        // Finally, charge gas for the invalid authentication execution.
         let cost_summary = gas_charger.charge_gas(temporary_store, &mut result);
 
         if let Err(e) = run_conservation_checks::<Mode>(
@@ -838,10 +861,9 @@ mod checked {
             move_vm,
             enable_expensive_checks,
             &cost_summary,
-            false,
+            false, // not genesis or epoch change tx
             advance_epoch_gas_summary,
         ) {
-            // FIXME: we cannot fail the transaction if this is an epoch change transaction.
             result = Err(e);
         }
 

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -347,24 +347,25 @@ mod checked {
         // execution.
         temporary_store.store_auth_context(auth_ctx);
 
-        // Setup a move authenticator transaction.
-        let authenticator_move_call =
-            setup_authenticator_move_call(authenticator, authenticator_info).unwrap(); //TODO
-
         // Execute the authenticator transaction.
-        let (computation_gas_cost, execution_result) = execute_authenticator_move_call::<Mode>(
-            &mut temporary_store,
-            authenticator_move_call,
-            gas_charger,
-            &mut tx_ctx,
-            move_vm,
-            protocol_config,
-            metrics,
-            false,
-            contains_deleted_input,
-            cancelled_objects,
-            trace_builder_opt,
-        );
+        let (computation_gas_cost, execution_result) =
+            match setup_authenticator_move_call(authenticator, authenticator_info) {
+                Ok(authenticator_move_call) => execute_authenticator_move_call::<Mode>(
+                    &mut temporary_store,
+                    authenticator_move_call,
+                    gas_charger,
+                    &mut tx_ctx,
+                    move_vm,
+                    protocol_config,
+                    metrics,
+                    false,
+                    contains_deleted_input,
+                    cancelled_objects,
+                    trace_builder_opt,
+                ),
+                // TODO: charge a minimum gas amount for failed setup?
+                Err(authenticator_setup_error) => (0, Err(authenticator_setup_error)),
+            };
 
         // Check the execution result.
         let status = if let Err(error) = &execution_result {

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -7,7 +7,10 @@ pub use checked::*;
 #[iota_macros::with_checked_arithmetic]
 mod checked {
 
-    use std::{collections::HashSet, sync::Arc};
+    use std::{
+        collections::{BTreeSet, HashSet},
+        sync::Arc,
+    };
 
     use iota_move_natives::all_natives;
     use iota_protocol_config::{LimitThresholdCrossed, ProtocolConfig, check_limit_by_meter};
@@ -34,7 +37,7 @@ mod checked {
         committee::EpochId,
         effects::TransactionEffects,
         error::{ExecutionError, ExecutionErrorKind},
-        execution::{ExecutionResults, ExecutionResultsV1, is_certificate_denied},
+        execution::{ExecutionResults, ExecutionResultsV1, SharedInput, is_certificate_denied},
         execution_config_utils::to_binary_config,
         execution_status::{CongestedObjects, ExecutionStatus},
         gas::{GasCostSummary, IotaGasStatus},
@@ -106,11 +109,20 @@ mod checked {
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
         let input_objects = input_objects.into_inner();
+        let mutable_inputs = if enable_expensive_checks {
+            input_objects.mutable_inputs().keys().copied().collect()
+        } else {
+            HashSet::new()
+        };
+        let shared_object_refs = input_objects.filter_shared_objects();
         let receiving_objects = transaction_kind.receiving_objects();
+        let transaction_dependencies = input_objects.transaction_dependencies();
+        let contains_deleted_input = input_objects.contains_deleted_objects();
+        let cancelled_objects = input_objects.get_cancelled_objects();
 
         let temporary_store = TemporaryStore::new(
             store,
-            input_objects.clone(),
+            input_objects,
             receiving_objects,
             transaction_digest,
             protocol_config,
@@ -131,10 +143,14 @@ mod checked {
             temporary_store,
             gas_charger,
             &mut tx_ctx,
+            &mutable_inputs,
+            shared_object_refs,
+            transaction_dependencies,
+            contains_deleted_input,
+            cancelled_objects,
             transaction_kind,
             transaction_signer,
             transaction_digest,
-            &input_objects,
             move_vm,
             epoch_id,
             protocol_config,
@@ -153,10 +169,14 @@ mod checked {
         mut temporary_store: TemporaryStore,
         mut gas_charger: GasCharger,
         tx_ctx: &mut TxContext,
+        mutable_inputs: &HashSet<ObjectID>,
+        shared_object_refs: Vec<SharedInput>,
+        mut transaction_dependencies: BTreeSet<TransactionDigest>,
+        contains_deleted_input: bool,
+        cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
         transaction_kind: TransactionKind,
         transaction_signer: IotaAddress,
         transaction_digest: TransactionDigest,
-        input_objects: &InputObjects,
         move_vm: &Arc<MoveVM>,
         epoch_id: &EpochId,
         protocol_config: &ProtocolConfig,
@@ -165,7 +185,10 @@ mod checked {
         certificate_deny_set: &HashSet<TransactionDigest>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         pre_execution_result_opt: Option<
-            Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
+            Result<
+                <execution_mode::Authentication as ExecutionMode>::ExecutionResults,
+                ExecutionError,
+            >,
         >,
     ) -> (
         InnerTemporaryStore,
@@ -173,16 +196,6 @@ mod checked {
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
-        let mutable_inputs = if enable_expensive_checks {
-            input_objects.mutable_inputs().keys().copied().collect()
-        } else {
-            HashSet::new()
-        };
-        let shared_object_refs = input_objects.filter_shared_objects();
-        let mut transaction_dependencies = input_objects.transaction_dependencies();
-        let contains_deleted_input = input_objects.contains_deleted_objects();
-        let cancelled_objects = input_objects.get_cancelled_objects();
-
         let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
         let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
 
@@ -229,7 +242,7 @@ mod checked {
                 .check_ownership_invariants(
                     &transaction_signer,
                     &mut gas_charger,
-                    &mutable_inputs,
+                    mutable_inputs,
                     is_epoch_change,
                 )
                 .unwrap()
@@ -305,15 +318,29 @@ mod checked {
         // It does not alter the state and produces no effects other than possible
         // errors.
 
-        // Input object come from both authentication and transaction inputs
+        // Input objects come from both authentication and transaction inputs
         let input_objects = authenticator_and_transaction_input_objects.into_inner();
+        // Mutable inputs come only from the transaction inputs
+        let mutable_inputs = if enable_expensive_checks {
+            input_objects.mutable_inputs().keys().copied().collect()
+        } else {
+            HashSet::new()
+        };
+        // Shared object refs come from both authentication and transaction inputs
+        let shared_object_refs = input_objects.filter_shared_objects();
         // Receiving objects can only come from the transaction inputs
         let transaction_receiving_objects = transaction_kind.receiving_objects();
+        // Transaction dependencies come from both authentication and transaction inputs
+        let transaction_dependencies = input_objects.transaction_dependencies();
+        // Deleted and cancelled objects come from both authentication and transaction
+        // inputs
+        let contains_deleted_input = input_objects.contains_deleted_objects();
+        let cancelled_objects = input_objects.get_cancelled_objects();
 
         // Prepare the temporary store for the authentication execution.
         let mut temporary_store = TemporaryStore::new(
             store,
-            input_objects.clone(),
+            input_objects,
             transaction_receiving_objects,
             transaction_digest,
             protocol_config,
@@ -360,10 +387,14 @@ mod checked {
             temporary_store,
             gas_charger,
             &mut tx_ctx,
+            &mutable_inputs,
+            shared_object_refs,
+            transaction_dependencies,
+            contains_deleted_input,
+            cancelled_objects,
             transaction_kind,
             transaction_signer,
             transaction_digest,
-            &input_objects,
             move_vm,
             epoch_id,
             protocol_config,
@@ -408,7 +439,7 @@ mod checked {
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         // VM
         move_vm: &Arc<MoveVM>,
-    ) -> Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>
+    ) -> Result<<execution_mode::Authentication as ExecutionMode>::ExecutionResults, ExecutionError>
     {
         let input_objects = authenticator_input_objects.into_inner();
 
@@ -482,7 +513,7 @@ mod checked {
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         // VM
         move_vm: &Arc<MoveVM>,
-    ) -> Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>
+    ) -> Result<<execution_mode::Authentication as ExecutionMode>::ExecutionResults, ExecutionError>
     {
         // Check the preconditions.
         debug_assert!(
@@ -578,7 +609,7 @@ mod checked {
         contains_deleted_input: bool,
         cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>
+    ) -> Result<<execution_mode::Authentication as ExecutionMode>::ExecutionResults, ExecutionError>
     {
         debug_assert!(
             gas_charger.no_charges(),
@@ -597,7 +628,7 @@ mod checked {
         .and_then(|()| {
             let authenticator_move_call =
                 setup_authenticator_move_call(authenticator, authenticator_info)?;
-            programmable_transactions::execution::execute::<execution_mode::Validation>(
+            programmable_transactions::execution::execute::<execution_mode::Authentication>(
                 protocol_config,
                 metrics.clone(),
                 move_vm,
@@ -676,7 +707,10 @@ mod checked {
         cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         pre_execution_result_opt: Option<
-            Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
+            Result<
+                <execution_mode::Authentication as ExecutionMode>::ExecutionResults,
+                ExecutionError,
+            >,
         >,
     ) -> (
         GasCostSummary,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -284,11 +284,11 @@ mod checked {
         authenticator: MoveAuthenticator,
         authenticator_info: AuthenticatorInfoV1,
         authenticator_input_objects: CheckedInputObjects,
+        authenticator_and_transaction_input_objects: CheckedInputObjects,
         // Transaction
         transaction_kind: TransactionKind,
         transaction_signer: IotaAddress,
         transaction_digest: TransactionDigest,
-        transaction_input_objects: CheckedInputObjects,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         // VM
@@ -305,11 +305,8 @@ mod checked {
         // It does not alter the state and produces no effects other than possible
         // errors.
 
-        // Keep track of the authenticator input objects for later use.
-        let authenticator_input_objects = authenticator_input_objects.into_inner();
-
-        let mut input_objects = transaction_input_objects.into_inner();
-        input_objects.extend_no_duplicates(authenticator_input_objects.clone());
+        // Input object come from both authentication and transaction inputs
+        let input_objects = authenticator_and_transaction_input_objects.into_inner();
         // Receiving objects can only come from the transaction inputs
         let transaction_receiving_objects = transaction_kind.receiving_objects();
 
@@ -344,7 +341,7 @@ mod checked {
             &mut gas_charger,
             authenticator,
             authenticator_info,
-            &authenticator_input_objects,
+            &authenticator_input_objects.into_inner(),
             transaction_kind.clone(),
             transaction_digest,
             &mut tx_ctx,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -412,9 +412,14 @@ mod checked {
         (computation_gas_cost, execution_result)
     }
 
-    ///
-    #[instrument(name = "tx_invalid_to_effects", level = "debug", skip_all)]
-    pub fn invalid_transaction_to_effects(
+    /// This function produces transaction effects for a transaction that failed
+    /// the Move authentication. It charges gas for the failed execution of the
+    /// authentication and produces transaction effects with the appropriate
+    /// error status. It combines the input objects from both the failed
+    /// authentication and the original transaction and updates their sequence
+    /// numbers.
+    #[instrument(name = "produce_effects_for_invalid_auth", level = "debug", skip_all)]
+    pub fn produce_effects_for_invalid_authentication<Mode: ExecutionMode>(
         store: &dyn BackingStore,
         // Configuration
         protocol_config: &ProtocolConfig,
@@ -427,14 +432,14 @@ mod checked {
         // Gas related
         gas_status: IotaGasStatus,
         gas_coins: Vec<ObjectRef>,
-        // Validation
-        validation_execution_error: ExecutionError,
-        validation_input_objects: CheckedInputObjects,
+        // Invalid Authentication
+        invalid_authentication_execution_error: ExecutionError,
+        invalid_authentication_input_objects: CheckedInputObjects,
         // Transaction
-        invalid_transaction_input_objects: CheckedInputObjects,
-        invalid_transaction_kind: TransactionKind,
-        invalid_transaction_signer: IotaAddress,
-        invalid_transaction_digest: TransactionDigest,
+        transaction_input_objects: CheckedInputObjects,
+        transaction_kind: TransactionKind,
+        transaction_signer: IotaAddress,
+        transaction_digest: TransactionDigest,
         // VM
         move_vm: &Arc<MoveVM>,
     ) -> (
@@ -443,15 +448,15 @@ mod checked {
         TransactionEffects,
         ExecutionError,
     ) {
-        let mut input_objects = invalid_transaction_input_objects.into_inner();
-        input_objects.extend(validation_input_objects.into_inner());
+        let mut input_objects = transaction_input_objects.into_inner();
+        input_objects.extend(invalid_authentication_input_objects.into_inner());
         let mutable_inputs = if enable_expensive_checks {
             input_objects.mutable_inputs().keys().copied().collect()
         } else {
             HashSet::new()
         };
         let shared_object_refs = input_objects.filter_shared_objects();
-        let receiving_objects = invalid_transaction_kind.receiving_objects();
+        let receiving_objects = transaction_kind.receiving_objects();
         let mut transaction_dependencies = input_objects.transaction_dependencies();
         let contains_deleted_input = input_objects.contains_deleted_objects();
         let cancelled_objects = input_objects.get_cancelled_objects();
@@ -460,32 +465,28 @@ mod checked {
             store,
             input_objects,
             receiving_objects,
-            invalid_transaction_digest,
+            transaction_digest,
             protocol_config,
             *epoch_id,
         );
 
-        let mut gas_charger = GasCharger::new(
-            invalid_transaction_digest,
-            gas_coins,
-            gas_status,
-            protocol_config,
-        );
+        let mut gas_charger =
+            GasCharger::new(transaction_digest, gas_coins, gas_status, protocol_config);
 
         let mut tx_ctx = TxContext::new_from_components(
-            &invalid_transaction_signer,
-            &invalid_transaction_digest,
+            &transaction_signer,
+            &transaction_digest,
             epoch_id,
             epoch_timestamp_ms,
         );
 
-        let is_epoch_change = invalid_transaction_kind.is_end_of_epoch_tx();
+        let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
 
-        let deny_cert = is_certificate_denied(&invalid_transaction_digest, certificate_deny_set);
-        let (gas_cost_summary, execution_error) = invalid_transaction(
+        let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
+        let (gas_cost_summary, execution_error) = charge_gas_for_invalid_authentication::<Mode>(
             &mut temporary_store,
-            invalid_transaction_kind,
-            validation_execution_error,
+            transaction_kind,
+            invalid_authentication_execution_error,
             &mut gas_charger,
             &mut tx_ctx,
             move_vm,
@@ -502,7 +503,7 @@ mod checked {
 
         #[skip_checked_arithmetic]
         trace!(
-            tx_digest = ?invalid_transaction_digest,
+            tx_digest = ?transaction_digest,
             computation_gas_cost = gas_cost_summary.computation_cost,
             computation_gas_cost_burned = gas_cost_summary.computation_cost_burned,
             storage_gas_cost = gas_cost_summary.storage_cost,
@@ -516,10 +517,10 @@ mod checked {
         // dependencies
         transaction_dependencies.remove(&TransactionDigest::genesis_marker());
 
-        if enable_expensive_checks && !execution_mode::Normal::allow_arbitrary_function_calls() {
+        if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
             temporary_store
                 .check_ownership_invariants(
-                    &invalid_transaction_signer,
+                    &transaction_signer,
                     &mut gas_charger,
                     &mutable_inputs,
                     is_epoch_change,
@@ -529,7 +530,7 @@ mod checked {
 
         let (inner, effects) = temporary_store.into_effects(
             shared_object_refs,
-            &invalid_transaction_digest,
+            &transaction_digest,
             transaction_dependencies,
             gas_cost_summary,
             status,
@@ -764,11 +765,18 @@ mod checked {
         (cost_summary, result)
     }
 
-    #[instrument(name = "tx_invalid", level = "debug", skip_all)]
-    fn invalid_transaction(
+    /// Runs checks that must be performed on the transaction inputs before
+    /// charging gas for the invalid authentication. These checks include
+    /// verifying if the transaction certificate is denied, if any input
+    /// objects have been deleted, and if any cancelled objects are present.
+    /// If any of these checks fail, an appropriate `ExecutionError` is
+    /// returned. Otherwise, the original authentication execution error is
+    /// returned. It also returns the gas cost summary for the charged gas.
+    #[instrument(name = "charge_gas_for_invalid_auth", level = "debug", skip_all)]
+    fn charge_gas_for_invalid_authentication<Mode: ExecutionMode>(
         temporary_store: &mut TemporaryStore<'_>,
         transaction_kind: TransactionKind,
-        validation_execution_error: ExecutionError,
+        invalid_authentication_execution_error: ExecutionError,
         gas_charger: &mut GasCharger,
         tx_ctx: &mut TxContext,
         move_vm: &Arc<MoveVM>,
@@ -814,16 +822,16 @@ mod checked {
             })();
 
             // If any of the pre-checks failed, that error has priority; otherwise use
-            // the provided validation_execution_error.
+            // the provided invalid_authentication_execution_error.
             match pre_check {
-                Ok(()) => Err(validation_execution_error),
+                Ok(()) => Err(invalid_authentication_execution_error),
                 Err(e) => Err(e),
             }
         };
 
         let cost_summary = gas_charger.charge_gas(temporary_store, &mut result);
 
-        if let Err(e) = run_conservation_checks::<execution_mode::Normal>(
+        if let Err(e) = run_conservation_checks::<Mode>(
             temporary_store,
             gas_charger,
             tx_ctx,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -71,6 +71,8 @@ mod checked {
         type_layout_resolver::TypeLayoutResolver,
     };
 
+    type MoveAuthenticationResult = (u64, Result<(), ExecutionError>);
+
     /// The main entry point to the adapter's transaction execution. It
     /// prepares a transaction for execution, then executes it through an
     /// inner execution method and finally produces an instance of
@@ -99,6 +101,7 @@ mod checked {
         enable_expensive_checks: bool,
         certificate_deny_set: &HashSet<TransactionDigest>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
+        move_authentication_result_opt: Option<MoveAuthenticationResult>,
     ) -> (
         InnerTemporaryStore,
         IotaGasStatus,
@@ -152,6 +155,7 @@ mod checked {
             contains_deleted_input,
             cancelled_objects,
             trace_builder_opt,
+            move_authentication_result_opt,
         );
 
         let status = if let Err(error) = &execution_result {
@@ -242,6 +246,95 @@ mod checked {
         )
     }
 
+    /// This function produces transaction effects for a transaction that
+    /// requires the Move authentication. It runs the Move authentication:
+    ///   - Then, if it fails it charges gas for the failed execution of the
+    ///     authentication and produces transaction effects with the appropriate
+    ///     error status.
+    ///   - Else, if the authentication is successful, it continues with the
+    ///     normal transaction execution.
+    /// It combines the input objects from both the failed authentication and
+    /// the original transaction and updates their sequence numbers.
+    #[instrument(
+        name = "tx_authenticate_then_execute_to_effects",
+        level = "debug",
+        skip_all
+    )]
+    pub fn authenticate_then_execute_transaction_to_effects<Mode: ExecutionMode>(
+        store: &dyn BackingStore,
+        // Configuration
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+        // Epoch
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        // Gas related
+        authenticator_gas_status: IotaGasStatus,
+        authenticated_transaction_gas_status: IotaGasStatus,
+        gas_coins: Vec<ObjectRef>,
+        // Authenticator
+        authenticator: MoveAuthenticator,
+        authenticator_info: AuthenticatorInfoV1,
+        authenticator_input_objects: CheckedInputObjects,
+        // Transaction
+        authenticated_transaction_kind: TransactionKind,
+        authenticated_transaction_signer: IotaAddress,
+        authenticated_transaction_digest: TransactionDigest,
+        authenticated_transaction_input_objects: CheckedInputObjects,
+        // Tracing
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+        // VM
+        move_vm: &Arc<MoveVM>,
+    ) -> (
+        InnerTemporaryStore,
+        IotaGasStatus,
+        TransactionEffects,
+        Result<Mode::ExecutionResults, ExecutionError>,
+    ) {
+        let move_authentication_result = validate_transaction(
+            store,
+            protocol_config,
+            metrics.clone(),
+            epoch_id,
+            epoch_timestamp_ms,
+            authenticator_gas_status,
+            authenticator,
+            authenticator_info,
+            authenticator_input_objects.clone(),
+            authenticated_transaction_kind.clone(),
+            authenticated_transaction_signer,
+            authenticated_transaction_digest,
+            trace_builder_opt,
+            move_vm,
+        );
+
+        // Merge input objects coming from the transaction together with
+        // those coming from the authenticator execution.
+        let mut input_objects = authenticated_transaction_input_objects;
+        input_objects.extend_no_duplicates(authenticator_input_objects);
+
+        execute_transaction_to_effects::<Mode>(
+            store,
+            input_objects,
+            gas_coins,
+            authenticated_transaction_gas_status,
+            authenticated_transaction_kind,
+            authenticated_transaction_signer,
+            authenticated_transaction_digest,
+            move_vm,
+            epoch_id,
+            epoch_timestamp_ms,
+            protocol_config,
+            metrics,
+            enable_expensive_checks,
+            certificate_deny_set,
+            trace_builder_opt,
+            Some(move_authentication_result),
+        )
+    }
+
     /// This function implements an abstracted IOTA account transaction
     /// validation. This validation checks that the authentication method used
     /// for the account is valid. It prepares a `MoveAuthenticator` PTB with
@@ -257,7 +350,7 @@ mod checked {
     /// happens since we cannot charge it separately in the current
     /// implementation.
     #[instrument(name = "tx_validate", level = "debug", skip_all)]
-    pub fn validate_transaction<Mode: ExecutionMode>(
+    pub fn validate_transaction(
         store: &dyn BackingStore,
         // Configuration
         protocol_config: &ProtocolConfig,
@@ -279,10 +372,7 @@ mod checked {
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         // VM
         move_vm: &Arc<MoveVM>,
-    ) -> (
-        u64, // gas computation cost
-        Result<Mode::ExecutionResults, ExecutionError>,
-    ) {
+    ) -> MoveAuthenticationResult {
         // Check the preconditions.
         debug_assert!(
             authenticated_transaction_kind.is_programmable_transaction(),
@@ -350,7 +440,7 @@ mod checked {
         // Execute the authenticator transaction.
         let (computation_gas_cost, execution_result) =
             match setup_authenticator_move_call(authenticator, authenticator_info) {
-                Ok(authenticator_move_call) => execute_authenticator_move_call::<Mode>(
+                Ok(authenticator_move_call) => execute_authenticator_move_call(
                     &mut temporary_store,
                     authenticator_move_call,
                     gas_charger,
@@ -412,152 +502,6 @@ mod checked {
         (computation_gas_cost, execution_result)
     }
 
-    /// This function produces transaction effects for a transaction that failed
-    /// the Move authentication. It charges gas for the failed execution of the
-    /// authentication and produces transaction effects with the appropriate
-    /// error status. It combines the input objects from both the failed
-    /// authentication and the original transaction and updates their sequence
-    /// numbers.
-    #[instrument(name = "produce_effects_for_invalid_auth", level = "debug", skip_all)]
-    pub fn produce_effects_for_invalid_authentication<Mode: ExecutionMode>(
-        store: &dyn BackingStore,
-        // Configuration
-        protocol_config: &ProtocolConfig,
-        metrics: Arc<LimitsMetrics>,
-        enable_expensive_checks: bool,
-        certificate_deny_set: &HashSet<TransactionDigest>,
-        // Epoch
-        epoch_id: &EpochId,
-        epoch_timestamp_ms: u64,
-        // Gas related
-        gas_status: IotaGasStatus,
-        gas_coins: Vec<ObjectRef>,
-        // Invalid Authentication
-        invalid_authentication_execution_error: ExecutionError,
-        invalid_authentication_input_objects: CheckedInputObjects,
-        // Transaction
-        transaction_input_objects: CheckedInputObjects,
-        transaction_kind: TransactionKind,
-        transaction_signer: IotaAddress,
-        transaction_digest: TransactionDigest,
-        // VM
-        move_vm: &Arc<MoveVM>,
-    ) -> (
-        InnerTemporaryStore,
-        IotaGasStatus,
-        TransactionEffects,
-        ExecutionError,
-    ) {
-        // Merge input objects coming from the transaction together with
-        // those coming from the failed authenticator execution.
-        let mut input_objects = transaction_input_objects.into_inner();
-        input_objects.extend(invalid_authentication_input_objects.into_inner());
-
-        // Read objects and dependencies from both TX and authenticator.
-        let mutable_inputs = if enable_expensive_checks {
-            input_objects.mutable_inputs().keys().copied().collect()
-        } else {
-            HashSet::new()
-        };
-        let shared_object_refs = input_objects.filter_shared_objects();
-        let mut transaction_dependencies = input_objects.transaction_dependencies();
-        let contains_deleted_input = input_objects.contains_deleted_objects();
-        let cancelled_objects = input_objects.get_cancelled_objects();
-
-        // Read receiving objects only from the TX.
-        let receiving_objects = transaction_kind.receiving_objects();
-
-        // Prepare the needed environment for a normal transaction execution.
-        let mut temporary_store = TemporaryStore::new(
-            store,
-            input_objects,
-            receiving_objects,
-            transaction_digest,
-            protocol_config,
-            *epoch_id,
-        );
-
-        let mut gas_charger =
-            GasCharger::new(transaction_digest, gas_coins, gas_status, protocol_config);
-
-        let mut tx_ctx = TxContext::new_from_components(
-            &transaction_signer,
-            &transaction_digest,
-            epoch_id,
-            epoch_timestamp_ms,
-        );
-
-        let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
-
-        let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
-
-        // Then, instead of executing the TX, charge gas for the failed authentication.
-        let (gas_cost_summary, execution_error) = charge_gas_for_invalid_authentication::<Mode>(
-            &mut temporary_store,
-            transaction_kind,
-            invalid_authentication_execution_error,
-            &mut gas_charger,
-            &mut tx_ctx,
-            move_vm,
-            protocol_config,
-            metrics,
-            enable_expensive_checks,
-            deny_cert,
-            contains_deleted_input,
-            cancelled_objects,
-        );
-
-        // Prepare the failure status.
-        let (status, command) = execution_error.to_execution_status();
-        let status = ExecutionStatus::new_failure(status, command);
-
-        #[skip_checked_arithmetic]
-        trace!(
-            tx_digest = ?transaction_digest,
-            computation_gas_cost = gas_cost_summary.computation_cost,
-            computation_gas_cost_burned = gas_cost_summary.computation_cost_burned,
-            storage_gas_cost = gas_cost_summary.storage_cost,
-            storage_gas_rebate = gas_cost_summary.storage_rebate,
-            "Finished execution of transaction with status {:?}",
-            status
-        );
-
-        // Genesis writes a special digest to indicate that an object was created during
-        // genesis and not written by any normal transaction - remove that from the
-        // dependencies
-        transaction_dependencies.remove(&TransactionDigest::genesis_marker());
-
-        // Final checks
-        if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
-            temporary_store
-                .check_ownership_invariants(
-                    &transaction_signer,
-                    &mut gas_charger,
-                    &mutable_inputs,
-                    is_epoch_change,
-                )
-                .unwrap()
-        } // else, in dev inspect mode and anything goes--don't check
-
-        // Produce the final effects.
-        let (inner, effects) = temporary_store.into_effects(
-            shared_object_refs,
-            &transaction_digest,
-            transaction_dependencies,
-            gas_cost_summary,
-            status,
-            &mut gas_charger,
-            *epoch_id,
-        );
-
-        (
-            inner,
-            gas_charger.into_gas_status(),
-            effects,
-            execution_error,
-        )
-    }
-
     /// Executes an authentication move call by processing the specified
     /// `ProgrammableTransaction`, running the main execution logic.
     /// Similarly to `execute_transaction`, this function handles certain error
@@ -570,7 +514,7 @@ mod checked {
     /// Returns the move authenticator computation gas cost without bucketing
     /// and the execution result.
     #[instrument(name = "auth_execute", level = "debug", skip_all)]
-    fn execute_authenticator_move_call<Mode: ExecutionMode>(
+    fn execute_authenticator_move_call(
         temporary_store: &mut TemporaryStore<'_>,
         authenticator_move_call: ProgrammableTransaction,
         mut gas_charger: GasCharger,
@@ -582,7 +526,7 @@ mod checked {
         contains_deleted_input: bool,
         cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (u64, Result<Mode::ExecutionResults, ExecutionError>) {
+    ) -> MoveAuthenticationResult {
         debug_assert!(
             gas_charger.no_charges(),
             "At this point no gas charges must be applied yet"
@@ -598,7 +542,7 @@ mod checked {
                     contains_deleted_input,
                     cancelled_objects,
                 )?;
-                programmable_transactions::execution::execute::<Mode>(
+                programmable_transactions::execution::execute::<execution_mode::Validation>(
                     protocol_config,
                     metrics.clone(),
                     move_vm,
@@ -618,7 +562,7 @@ mod checked {
         // rounding/bucketing.
         let gas_status = gas_charger.into_gas_status();
 
-        let authentication_computation_cost = gas_status.gas_used() * gas_status.gas_price();
+        let authentication_computation_cost = gas_status.gas_used();
 
         (authentication_computation_cost, result)
     }
@@ -684,6 +628,7 @@ mod checked {
         contains_deleted_input: bool,
         cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
+        move_authentication_result_opt: Option<MoveAuthenticationResult>,
     ) -> (
         GasCostSummary,
         Result<Mode::ExecutionResults, ExecutionError>,
@@ -713,16 +658,30 @@ mod checked {
                 cancelled_objects,
             )?;
 
-            let mut execution_result = execution_loop::<Mode>(
-                temporary_store,
-                transaction_kind,
-                tx_ctx,
-                move_vm,
-                gas_charger,
-                protocol_config,
-                metrics.clone(),
-                trace_builder_opt,
+            // If some authentication result is provided, charge its cost first
+            let authentication_result = move_authentication_result_opt.map_or(
+                Ok(()),
+                |(authentication_computation_cost, authentication_result)| {
+                    gas_charger
+                        .charge_authentication(authentication_computation_cost)
+                        .and(authentication_result)
+                },
             );
+
+            // Then if the authentication succeeded, proceed with the main execution loop
+            // else propagate the authentication error
+            let mut execution_result = authentication_result.and_then(|_| {
+                execution_loop::<Mode>(
+                    temporary_store,
+                    transaction_kind,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics.clone(),
+                    trace_builder_opt,
+                )
+            });
 
             let meter_check = check_meter_limit(
                 temporary_store,
@@ -775,99 +734,6 @@ mod checked {
         }
 
         (cost_summary, result)
-    }
-
-    /// Runs checks that must be performed on the transaction inputs before
-    /// charging gas for the invalid authentication. These checks include
-    /// verifying if the transaction certificate is denied, if any input
-    /// objects have been deleted, and if any cancelled objects are present.
-    /// If any of these checks fail, an appropriate `ExecutionError` is
-    /// returned. Otherwise, the original authentication execution error is
-    /// returned. It also returns the gas cost summary for the charged gas.
-    #[instrument(name = "charge_gas_for_invalid_auth", level = "debug", skip_all)]
-    fn charge_gas_for_invalid_authentication<Mode: ExecutionMode>(
-        temporary_store: &mut TemporaryStore<'_>,
-        transaction_kind: TransactionKind,
-        invalid_authentication_execution_error: ExecutionError,
-        gas_charger: &mut GasCharger,
-        tx_ctx: &mut TxContext,
-        move_vm: &Arc<MoveVM>,
-        protocol_config: &ProtocolConfig,
-        metrics: Arc<LimitsMetrics>,
-        enable_expensive_checks: bool,
-        deny_cert: bool,
-        contains_deleted_input: bool,
-        cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
-    ) -> (GasCostSummary, ExecutionError) {
-        gas_charger.smash_gas(temporary_store);
-
-        // At this point no charges have been applied yet
-        debug_assert!(
-            gas_charger.no_charges_for_execution(),
-            "No gas charges must be applied yet"
-        );
-
-        let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
-
-        let mut result: Result<(), ExecutionError> = {
-            // Run the checks that must take precedence over the validation execution error.
-            let pre_check: Result<(), ExecutionError> = (|| {
-                // We must charge object read here we must still ensure an effect is committed
-                // and all objects versions incremented.
-                // This can fail only if not enough gas units are left.
-                gas_charger.charge_input_objects(temporary_store)?;
-
-                // This checks for denied certificates, deleted input objects,
-                // and cancelled objects due to congestion or
-                // randomness unavailability. If any of
-                // these conditions are met, it fails.
-                run_inputs_checks(
-                    protocol_config,
-                    deny_cert,
-                    contains_deleted_input,
-                    cancelled_objects,
-                )?;
-
-                // This checks a size limit based on the number of written_objects, number of
-                // modified_objects and number of input_objects. So, in this context, it should
-                // fail only if the number of input_objects is too large.
-                // TODO: adapt the limit to support the merge of TX and authenticator input
-                // objects.
-                check_meter_limit(
-                    temporary_store,
-                    gas_charger,
-                    protocol_config,
-                    metrics.clone(),
-                )?;
-
-                Ok(())
-            })();
-
-            // If any of the pre-checks failed, that error has priority; otherwise use
-            // the provided invalid_authentication_execution_error.
-            match pre_check {
-                Ok(()) => Err(invalid_authentication_execution_error),
-                Err(e) => Err(e),
-            }
-        };
-
-        // Finally, charge gas for the invalid authentication execution.
-        let cost_summary = gas_charger.charge_gas(temporary_store, &mut result);
-
-        if let Err(e) = run_conservation_checks::<Mode>(
-            temporary_store,
-            gas_charger,
-            tx_ctx,
-            move_vm,
-            enable_expensive_checks,
-            &cost_summary,
-            false, // not genesis or epoch change tx
-            advance_epoch_gas_summary,
-        ) {
-            result = Err(e);
-        }
-
-        (cost_summary, result.err().unwrap())
     }
 
     /// Performs IOTA conservation checks during transaction execution, ensuring

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -7,7 +7,10 @@ pub use checked::*;
 #[iota_macros::with_checked_arithmetic]
 mod checked {
 
-    use std::{collections::HashSet, sync::Arc};
+    use std::{
+        collections::{BTreeSet, HashSet},
+        sync::Arc,
+    };
 
     use iota_move_natives::all_natives;
     use iota_protocol_config::{LimitThresholdCrossed, ProtocolConfig, check_limit_by_meter};
@@ -37,7 +40,7 @@ mod checked {
         execution::{ExecutionResults, ExecutionResultsV1, is_certificate_denied},
         execution_config_utils::to_binary_config,
         execution_status::{CongestedObjects, ExecutionStatus},
-        gas::{GasCostSummary, IotaGasStatus, IotaGasStatusAPI},
+        gas::{GasCostSummary, IotaGasStatus},
         gas_coin::GAS,
         inner_temporary_store::InnerTemporaryStore,
         iota_system_state::{
@@ -53,8 +56,8 @@ mod checked {
         transaction::{
             Argument, AuthenticatorStateExpire, AuthenticatorStateUpdateV1, CallArg, ChangeEpoch,
             ChangeEpochV2, ChangeEpochV3, CheckedInputObjects, Command, EndOfEpochTransactionKind,
-            GenesisTransaction, ObjectArg, ProgrammableTransaction, RandomnessStateUpdate,
-            TransactionKind,
+            GenesisTransaction, InputObjects, ObjectArg, ProgrammableTransaction,
+            RandomnessStateUpdate, TransactionKind,
         },
     };
     use move_binary_format::CompiledModule;
@@ -99,9 +102,6 @@ mod checked {
         enable_expensive_checks: bool,
         certificate_deny_set: &HashSet<TransactionDigest>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-        move_authentication_result_opt: Option<
-            Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
-        >,
     ) -> (
         InnerTemporaryStore,
         IotaGasStatus,
@@ -109,20 +109,14 @@ mod checked {
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
         let input_objects = input_objects.into_inner();
-        let mutable_inputs = if enable_expensive_checks {
-            input_objects.mutable_inputs().keys().copied().collect()
-        } else {
-            HashSet::new()
-        };
         let shared_object_refs = input_objects.filter_shared_objects();
-        let receiving_objects = transaction_kind.receiving_objects();
         let mut transaction_dependencies = input_objects.transaction_dependencies();
-        let contains_deleted_input = input_objects.contains_deleted_objects();
-        let cancelled_objects = input_objects.get_cancelled_objects();
+
+        let receiving_objects = transaction_kind.receiving_objects();
 
         let mut temporary_store = TemporaryStore::new(
             store,
-            input_objects,
+            input_objects.clone(),
             receiving_objects,
             transaction_digest,
             protocol_config,
@@ -139,14 +133,85 @@ mod checked {
             epoch_timestamp_ms,
         );
 
-        let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
+        let (status, gas_cost_summary, execution_result) =
+            execute_transaction_to_effects_inner::<Mode>(
+                &mut temporary_store,
+                &mut gas_charger,
+                &mut tx_ctx,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &input_objects,
+                &mut transaction_dependencies,
+                move_vm,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+                trace_builder_opt,
+                None,
+            );
 
-        let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
-        let (gas_cost_summary, execution_result) = execute_transaction::<Mode>(
-            &mut temporary_store,
-            transaction_kind,
+        let (inner, effects) = temporary_store.into_effects(
+            shared_object_refs,
+            &transaction_digest,
+            transaction_dependencies,
+            gas_cost_summary,
+            status,
             &mut gas_charger,
-            &mut tx_ctx,
+            *epoch_id,
+        );
+
+        (
+            inner,
+            gas_charger.into_gas_status(),
+            effects,
+            execution_result,
+        )
+    }
+
+    /// The main execution function that processes a transaction and produces
+    /// effects. It handles gas charging and execution logic.
+    #[instrument(name = "tx_execute_to_effects_inner", level = "debug", skip_all)]
+    fn execute_transaction_to_effects_inner<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore,
+        gas_charger: &mut GasCharger,
+        tx_ctx: &mut TxContext,
+        transaction_kind: TransactionKind,
+        transaction_signer: IotaAddress,
+        transaction_digest: TransactionDigest,
+        input_objects: &InputObjects,
+        transaction_dependencies: &mut BTreeSet<TransactionDigest>,
+        move_vm: &Arc<MoveVM>,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+        pre_execution_result_opt: Option<
+            Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
+        >,
+    ) -> (
+        ExecutionStatus,
+        GasCostSummary,
+        Result<Mode::ExecutionResults, ExecutionError>,
+    ) {
+        let mutable_inputs = if enable_expensive_checks {
+            input_objects.mutable_inputs().keys().copied().collect()
+        } else {
+            HashSet::new()
+        };
+        let contains_deleted_input = input_objects.contains_deleted_objects();
+        let cancelled_objects = input_objects.get_cancelled_objects();
+
+        let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
+        let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
+
+        let (gas_cost_summary, execution_result) = execute_transaction::<Mode>(
+            temporary_store,
+            transaction_kind,
+            gas_charger,
+            tx_ctx,
             move_vm,
             protocol_config,
             metrics,
@@ -155,48 +220,11 @@ mod checked {
             contains_deleted_input,
             cancelled_objects,
             trace_builder_opt,
-            move_authentication_result_opt,
+            pre_execution_result_opt,
         );
 
         let status = if let Err(error) = &execution_result {
-            // Elaborate errors in logs if they are unexpected or their status is terse.
-            use ExecutionErrorKind as K;
-            match error.kind() {
-                K::InvariantViolation | K::VMInvariantViolation => {
-                    #[skip_checked_arithmetic]
-                    tracing::error!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "INVARIANT VIOLATION! Source: {:?}",
-                        error.source(),
-                    );
-                }
-
-                K::IotaMoveVerificationError | K::VMVerificationOrDeserializationError => {
-                    #[skip_checked_arithmetic]
-                    tracing::debug!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "Verification Error. Source: {:?}",
-                        error.source(),
-                    );
-                }
-
-                K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
-                    #[skip_checked_arithmetic]
-                    tracing::debug!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "Publish/Upgrade Error. Source: {:?}",
-                        error.source(),
-                    )
-                }
-
-                _ => (),
-            };
-
-            let (status, command) = error.to_execution_status();
-            ExecutionStatus::new_failure(status, command)
+            elaborate_error_logs(error, transaction_digest)
         } else {
             ExecutionStatus::Success
         };
@@ -221,29 +249,14 @@ mod checked {
             temporary_store
                 .check_ownership_invariants(
                     &transaction_signer,
-                    &mut gas_charger,
+                    gas_charger,
                     &mutable_inputs,
                     is_epoch_change,
                 )
                 .unwrap()
-        } // else, in dev inspect mode and anything goes--don't check
+        }; // else, in dev inspect mode and anything goes--don't check
 
-        let (inner, effects) = temporary_store.into_effects(
-            shared_object_refs,
-            &transaction_digest,
-            transaction_dependencies,
-            gas_cost_summary,
-            status,
-            &mut gas_charger,
-            *epoch_id,
-        );
-
-        (
-            inner,
-            gas_charger.into_gas_status(),
-            effects,
-            execution_result,
-        )
+        (status, gas_cost_summary, execution_result)
     }
 
     /// This function produces transaction effects for a transaction that
@@ -278,10 +291,10 @@ mod checked {
         authenticator_info: AuthenticatorInfoV1,
         authenticator_input_objects: CheckedInputObjects,
         // Transaction
-        authenticated_transaction_kind: TransactionKind,
-        authenticated_transaction_signer: IotaAddress,
-        authenticated_transaction_digest: TransactionDigest,
-        authenticated_transaction_input_objects: CheckedInputObjects,
+        transaction_kind: TransactionKind,
+        transaction_signer: IotaAddress,
+        transaction_digest: TransactionDigest,
+        transaction_input_objects: CheckedInputObjects,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         // VM
@@ -297,46 +310,124 @@ mod checked {
         // then for the function instructions.
         // It does not alter the state and produces no effects other than possible
         // errors.
-        let (gas_status_post_authentication, authentication_result) = authenticate_transaction(
-            store,
-            protocol_config,
-            metrics.clone(),
+
+        // Prepare the gas charger for both authentication and transaction execution.
+        let mut gas_charger =
+            GasCharger::new(transaction_digest, gas_coins, gas_status, protocol_config);
+
+        // Prepare the transaction context for both authentication and transaction
+        // execution.
+        let mut tx_ctx = TxContext::new_from_components(
+            &transaction_signer,
+            &transaction_digest,
             epoch_id,
             epoch_timestamp_ms,
-            gas_status,
-            authenticator,
-            authenticator_info,
-            authenticator_input_objects.clone(),
-            authenticated_transaction_kind.clone(),
-            authenticated_transaction_signer,
-            authenticated_transaction_digest,
-            trace_builder_opt,
-            move_vm,
         );
 
+        // Keep track of the authenticator input objects for later use.
+        let authenticator_input_objects = authenticator_input_objects.into_inner();
+        let authenticator_shared_objects = authenticator_input_objects.shared_objects_set();
+        let authenticator_transaction_dependencies =
+            authenticator_input_objects.transaction_dependencies();
+
+        // Run the authentication.
+        let (authentication_inner_store, authentication_execution_result) =
+            authenticate_transaction_inner(
+                store,
+                protocol_config,
+                metrics.clone(),
+                epoch_id,
+                &mut gas_charger,
+                authenticator,
+                authenticator_info,
+                authenticator_input_objects,
+                transaction_kind.clone(),
+                transaction_digest,
+                &mut tx_ctx,
+                trace_builder_opt,
+                move_vm,
+            );
+
         // At this stage we have the gas status, with gas charged for reading the
-        // authenticator inputs and for the computation, and a result wich is either
+        // authenticator inputs and for the computation, and a result which is either
         // empty or an error.
 
         // We can now start the creation of the transaction effects, either for an
         // authentication failure or for a normal execution of the transaction.
-        execute_transaction_to_effects::<Mode>(
+
+        // Input objects for the transaction execution do not include the authenticator
+        // inputs.
+        let transaction_input_objects = transaction_input_objects.into_inner();
+        // Receiving objects can only come from the transaction inputs
+        let transaction_receiving_objects = transaction_kind.receiving_objects();
+
+        // Shared inputs are merged from both the transaction and authenticator inputs.
+        let shared_object_refs = transaction_input_objects
+            .shared_objects_set()
+            .union(&authenticator_shared_objects)
+            .cloned()
+            .collect();
+        // Transaction dependencies are merged from both the transaction and
+        // authenticator inputs.
+        let mut transaction_dependencies: BTreeSet<_> = transaction_input_objects
+            .transaction_dependencies()
+            .union(&authenticator_transaction_dependencies)
+            .cloned()
+            .collect();
+
+        let mut transaction_temporary_store = TemporaryStore::new(
             store,
-            authenticated_transaction_input_objects,
-            gas_coins,
-            gas_status_post_authentication,
-            authenticated_transaction_kind,
-            authenticated_transaction_signer,
-            authenticated_transaction_digest,
-            move_vm,
-            epoch_id,
-            epoch_timestamp_ms,
+            transaction_input_objects.clone(),
+            transaction_receiving_objects,
+            transaction_digest,
             protocol_config,
-            metrics,
-            enable_expensive_checks,
-            certificate_deny_set,
-            trace_builder_opt,
-            Some(authentication_result),
+            *epoch_id,
+        );
+
+        let (status, gas_cost_summary, execution_result) =
+            execute_transaction_to_effects_inner::<Mode>(
+                &mut transaction_temporary_store,
+                &mut gas_charger,
+                &mut tx_ctx,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &transaction_input_objects,
+                &mut transaction_dependencies,
+                move_vm,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+                trace_builder_opt,
+                Some(authentication_execution_result),
+            );
+
+        let (mut inner, effects) = transaction_temporary_store.into_effects(
+            shared_object_refs,
+            &transaction_digest,
+            transaction_dependencies,
+            gas_cost_summary,
+            status,
+            &mut gas_charger,
+            *epoch_id,
+        );
+
+        // TODO: lamport??
+        inner
+            .input_objects
+            .extend(authentication_inner_store.input_objects);
+        inner.loaded_runtime_objects.extend(
+            authentication_inner_store
+                .loaded_runtime_objects
+                .into_iter(),
+        );
+
+        (
+            inner,
+            gas_charger.into_gas_status(),
+            effects,
+            execution_result,
         )
     }
 
@@ -366,147 +457,164 @@ mod checked {
         authenticator_info: AuthenticatorInfoV1,
         authenticator_input_objects: CheckedInputObjects,
         // Transaction
-        authenticated_transaction_kind: TransactionKind,
-        authenticated_transaction_signer: IotaAddress,
-        authenticated_transaction_digest: TransactionDigest,
+        transaction_kind: TransactionKind,
+        transaction_signer: IotaAddress,
+        transaction_digest: TransactionDigest,
+        // Tracing
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+        // VM
+        move_vm: &Arc<MoveVM>,
+    ) -> Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>
+    {
+        // Prepare the gas charger for authentication execution.
+        let mut gas_charger =
+            GasCharger::new(transaction_digest, vec![], gas_status, protocol_config);
+
+        // Prepare the transaction context, equal for both authentication and
+        // transaction execution.
+        let mut tx_ctx = TxContext::new_from_components(
+            &transaction_signer,
+            &transaction_digest,
+            epoch_id,
+            epoch_timestamp_ms,
+        );
+
+        // Run the authentication.
+        let (_, authentication_execution_result) = authenticate_transaction_inner(
+            store,
+            protocol_config,
+            metrics,
+            epoch_id,
+            &mut gas_charger,
+            authenticator,
+            authenticator_info,
+            authenticator_input_objects.into_inner(),
+            transaction_kind,
+            transaction_digest,
+            &mut tx_ctx,
+            trace_builder_opt,
+            move_vm,
+        );
+
+        authentication_execution_result
+    }
+
+    /// This function implements an abstracted IOTA account transaction
+    /// validation. This validation checks that the authentication method used
+    /// for the account is valid. It prepares a `MoveAuthenticator` PTB with
+    /// a single move call for execution, then executes it through an inner
+    /// execution method. The `MoveAuthenticator` provides the inputs to use for
+    /// the authentication function found in `AuthenticatorInfo`, that is
+    /// retrieved from the abstracted IOTA account.
+    ///
+    /// Returns an error if it happens and the gas status that can be later
+    /// used to check the computation cost.
+    #[instrument(name = "tx_validate", level = "debug", skip_all)]
+    pub fn authenticate_transaction_inner(
+        store: &dyn BackingStore,
+        // Configuration
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        // Epoch
+        epoch_id: &EpochId,
+        // Gas related
+        gas_charger: &mut GasCharger,
+        // Authenticator
+        authenticator: MoveAuthenticator,
+        authenticator_info: AuthenticatorInfoV1,
+        authenticator_input_objects: InputObjects,
+        // Transaction
+        transaction_kind: TransactionKind,
+        transaction_digest: TransactionDigest,
+        tx_ctx: &mut TxContext,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         // VM
         move_vm: &Arc<MoveVM>,
     ) -> (
-        IotaGasStatus,
+        InnerTemporaryStore,
         Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
     ) {
         // Check the preconditions.
         debug_assert!(
-            authenticated_transaction_kind.is_programmable_transaction(),
+            transaction_kind.is_programmable_transaction(),
             "Only programmable transactions are allowed"
         );
-
-        // Prepare the move authenticator input objects.
-        let input_objects = authenticator_input_objects.into_inner();
-
-        let mutable_inputs = input_objects
-            .mutable_inputs()
-            .keys()
-            .copied()
-            .collect::<HashSet<_>>();
-        debug_assert!(mutable_inputs.is_empty(), "No mutable inputs are allowed");
-
-        let receiving_objects = authenticator.receiving_objects();
         debug_assert!(
-            receiving_objects.is_empty(),
+            authenticator_input_objects
+                .mutable_inputs()
+                .keys()
+                .copied()
+                .collect::<HashSet<_>>()
+                .is_empty(),
+            "No mutable inputs are allowed"
+        );
+        debug_assert!(
+            authenticator.receiving_objects().is_empty(),
             "No receiving inputs are allowed"
         );
-        let contains_deleted_input = input_objects.contains_deleted_objects();
-        let cancelled_objects = input_objects.get_cancelled_objects();
 
-        // Prepare an environment for the move authenticator transaction execution.
+        let contains_deleted_input = authenticator_input_objects.contains_deleted_objects();
+        let cancelled_objects = authenticator_input_objects.get_cancelled_objects();
+
+        // Prepare the temporary store for the authentication execution.
         let mut temporary_store = TemporaryStore::new(
             store,
-            input_objects,
-            receiving_objects,
-            authenticated_transaction_digest,
+            authenticator_input_objects,
+            vec![],
+            transaction_digest,
             protocol_config,
             *epoch_id,
         );
 
-        let gas_charger = GasCharger::new(
-            authenticated_transaction_digest,
-            // Gas objects are not used when verifying smart account transactions.
-            Vec::new(),
-            gas_status,
-            protocol_config,
-        );
-
-        // Prepare the authenticated transaction context.
-        let mut tx_ctx = TxContext::new_from_components(
-            &authenticated_transaction_signer,
-            &authenticated_transaction_digest,
-            epoch_id,
-            epoch_timestamp_ms,
-        );
-
-        // Prepare the authenticator context.
+        // Prepare the authentication context.
         let auth_ctx = {
-            let TransactionKind::ProgrammableTransaction(ptb) = authenticated_transaction_kind
-            else {
+            let TransactionKind::ProgrammableTransaction(ptb) = &transaction_kind else {
                 unreachable!("Only programmable transactions are allowed");
             };
-            AuthContext::new_from_components(authenticator.digest(), &ptb)
+            AuthContext::new_from_components(authenticator.digest(), ptb)
         };
 
-        // Store the authenticator context in the temporary store.
-        // It will be added to the authenticator's parameter list later, just before
+        // Store the authentication context in the temporary store.
+        // It will be added to the authentication's parameter list later, just before
         // execution.
         temporary_store.store_auth_context(auth_ctx);
 
-        // Execute the authenticator transaction.
-        let (gas_status, execution_result) =
-            match setup_authenticator_move_call(authenticator, authenticator_info) {
-                Ok(authenticator_move_call) => execute_authenticator_move_call(
-                    &mut temporary_store,
-                    authenticator_move_call,
-                    gas_charger,
-                    &mut tx_ctx,
-                    move_vm,
-                    protocol_config,
-                    metrics,
-                    false,
-                    contains_deleted_input,
-                    cancelled_objects,
-                    trace_builder_opt,
-                ),
-                // TODO: charge a minimum gas amount for failed setup?
-                Err(authenticator_setup_error) => (
-                    gas_charger.into_gas_status(),
-                    Err(authenticator_setup_error),
-                ),
-            };
+        // Execute the authentication.
+        let authentication_execution_result = execute_authenticator_move_call(
+            &mut temporary_store,
+            authenticator,
+            authenticator_info,
+            gas_charger,
+            tx_ctx,
+            move_vm,
+            protocol_config,
+            metrics.clone(),
+            false,
+            contains_deleted_input,
+            cancelled_objects,
+            trace_builder_opt,
+        );
 
-        // Check the execution result.
-        let status = if let Err(error) = &execution_result {
-            // Elaborate errors in logs if they are unexpected or their status is terse.
-            use ExecutionErrorKind as K;
-            match error.kind() {
-                K::InvariantViolation | K::VMInvariantViolation => {
-                    #[skip_checked_arithmetic]
-                    tracing::error!(
-                        kind = ?error.kind(),
-                        tx_digest = ?authenticated_transaction_digest,
-                        "INVARIANT VIOLATION in authenticator! Source: {:?}",
-                        error.source(),
-                    );
-                }
-
-                K::IotaMoveVerificationError | K::VMVerificationOrDeserializationError => {
-                    #[skip_checked_arithmetic]
-                    tracing::debug!(
-                        kind = ?error.kind(),
-                        tx_digest = ?authenticated_transaction_digest,
-                        "Authenticator Verification Error. Source: {:?}",
-                        error.source(),
-                    );
-                }
-
-                _ => (),
-            };
-
-            let (status, command) = error.to_execution_status();
-            ExecutionStatus::new_failure(status, command)
+        // Check the authentication result.
+        let authentication_execution_status = if let Err(error) = &authentication_execution_result {
+            elaborate_error_logs(error, transaction_digest)
         } else {
             ExecutionStatus::Success
         };
 
         #[skip_checked_arithmetic]
         trace!(
-            tx_digest = ?authenticated_transaction_digest,
-            computation_gas_cost = gas_status.gas_used(),
+            tx_digest = ?transaction_digest,
+            computation_gas_cost = gas_charger.summary().gas_used(),
             "Finished authenticator execution of transaction with status {:?}",
-            status
+            authentication_execution_status
         );
 
-        (gas_status, execution_result)
+        (
+            temporary_store.into_inner(),
+            authentication_execution_result,
+        )
     }
 
     /// Executes an authentication move call by processing the specified
@@ -523,8 +631,9 @@ mod checked {
     #[instrument(name = "auth_execute", level = "debug", skip_all)]
     fn execute_authenticator_move_call(
         temporary_store: &mut TemporaryStore<'_>,
-        authenticator_move_call: ProgrammableTransaction,
-        mut gas_charger: GasCharger,
+        authenticator: MoveAuthenticator,
+        authenticator_info: AuthenticatorInfoV1,
+        gas_charger: &mut GasCharger,
         tx_ctx: &mut TxContext,
         move_vm: &Arc<MoveVM>,
         protocol_config: &ProtocolConfig,
@@ -533,17 +642,16 @@ mod checked {
         contains_deleted_input: bool,
         cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        IotaGasStatus,
-        Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
-    ) {
+    ) -> Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>
+    {
         debug_assert!(
             gas_charger.no_charges(),
             "At this point no gas charges must be applied yet"
         );
 
         // Charge gas for reading the Move authenticator input objects from the storage.
-        let result = gas_charger
+        // Then execute the authentication.
+        gas_charger
             .charge_input_objects(temporary_store)
             .and_then(|()| {
                 run_inputs_checks(
@@ -552,13 +660,15 @@ mod checked {
                     contains_deleted_input,
                     cancelled_objects,
                 )?;
+                let authenticator_move_call =
+                    setup_authenticator_move_call(authenticator, authenticator_info)?;
                 programmable_transactions::execution::execute::<execution_mode::Validation>(
                     protocol_config,
                     metrics.clone(),
                     move_vm,
                     temporary_store,
                     tx_ctx,
-                    &mut gas_charger,
+                    gas_charger,
                     authenticator_move_call,
                     trace_builder_opt,
                 )
@@ -566,9 +676,7 @@ mod checked {
                     temporary_store.check_move_authenticator_results_consistency()?;
                     Ok(ok_result)
                 })
-            });
-
-        (gas_charger.into_gas_status(), result)
+            })
     }
 
     /// Function dedicated to the execution of a GenesisTransaction.
@@ -632,7 +740,7 @@ mod checked {
         contains_deleted_input: bool,
         cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-        move_authentication_result_opt: Option<
+        pre_execution_result_opt: Option<
             Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
         >,
     ) -> (
@@ -643,7 +751,7 @@ mod checked {
 
         // At this point no charges have been applied yet
         debug_assert!(
-            move_authentication_result_opt.is_some() || gas_charger.no_charges(),
+            pre_execution_result_opt.is_some() || gas_charger.no_charges(),
             "No gas charges must be applied yet"
         );
 
@@ -666,21 +774,18 @@ mod checked {
 
             // If the authentication succeeded, proceed with the main execution loop
             // else propagate the authentication error
-            let mut execution_result =
-                move_authentication_result_opt
-                    .unwrap_or(Ok(()))
-                    .and_then(|_| {
-                        execution_loop::<Mode>(
-                            temporary_store,
-                            transaction_kind,
-                            tx_ctx,
-                            move_vm,
-                            gas_charger,
-                            protocol_config,
-                            metrics.clone(),
-                            trace_builder_opt,
-                        )
-                    });
+            let mut execution_result = pre_execution_result_opt.unwrap_or(Ok(())).and_then(|_| {
+                execution_loop::<Mode>(
+                    temporary_store,
+                    transaction_kind,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics.clone(),
+                    trace_builder_opt,
+                )
+            });
 
             let meter_check = check_meter_limit(
                 temporary_store,
@@ -733,6 +838,51 @@ mod checked {
         }
 
         (cost_summary, result)
+    }
+
+    /// Elaborate errors in logs if they are unexpected or their status is
+    /// terse.
+    fn elaborate_error_logs(
+        execution_error: &ExecutionError,
+        transaction_digest: TransactionDigest,
+    ) -> ExecutionStatus {
+        use ExecutionErrorKind as K;
+        match execution_error.kind() {
+            K::InvariantViolation | K::VMInvariantViolation => {
+                #[skip_checked_arithmetic]
+                tracing::error!(
+                    kind = ?execution_error.kind(),
+                    tx_digest = ?transaction_digest,
+                    "INVARIANT VIOLATION! Source: {:?}",
+                    execution_error.source(),
+                );
+            }
+
+            K::IotaMoveVerificationError | K::VMVerificationOrDeserializationError => {
+                #[skip_checked_arithmetic]
+                tracing::debug!(
+                    kind = ?execution_error.kind(),
+                    tx_digest = ?transaction_digest,
+                    "Verification Error. Source: {:?}",
+                    execution_error.source(),
+                );
+            }
+
+            K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
+                #[skip_checked_arithmetic]
+                tracing::debug!(
+                    kind = ?execution_error.kind(),
+                    tx_digest = ?transaction_digest,
+                    "Publish/Upgrade Error. Source: {:?}",
+                    execution_error.source(),
+                )
+            }
+
+            _ => (),
+        };
+
+        let (status, command) = execution_error.to_execution_status();
+        ExecutionStatus::new_failure(status, command)
     }
 
     /// Performs IOTA conservation checks during transaction execution, ensuring

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -292,7 +292,7 @@ mod checked {
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
-        let (gas_status_post_authentication, authentication_result) = validate_transaction(
+        let (gas_status_post_authentication, authentication_result) = authenticate_transaction(
             store,
             protocol_config,
             metrics.clone(),
@@ -342,14 +342,10 @@ mod checked {
     /// the authentication function found in `AuthenticatorInfo`, that is
     /// retrieved from the abstracted IOTA account.
     ///
-    /// Returns an error if it happens or the move authenticator computation gas
-    /// cost without bucketing. It is different from the
-    /// `execute_transaction_to_effects` return type, because, in this case, we
-    /// do not need to return the gas value used for execution when an error
-    /// happens since we cannot charge it separately in the current
-    /// implementation.
+    /// Returns an error if it happens or and the gas status that can be later
+    /// used to check the computation cost.
     #[instrument(name = "tx_validate", level = "debug", skip_all)]
-    pub fn validate_transaction(
+    pub fn authenticate_transaction(
         store: &dyn BackingStore,
         // Configuration
         protocol_config: &ProtocolConfig,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -71,8 +71,6 @@ mod checked {
         type_layout_resolver::TypeLayoutResolver,
     };
 
-    type MoveAuthenticationResult = (u64, Result<(), ExecutionError>);
-
     /// The main entry point to the adapter's transaction execution. It
     /// prepares a transaction for execution, then executes it through an
     /// inner execution method and finally produces an instance of
@@ -101,7 +99,9 @@ mod checked {
         enable_expensive_checks: bool,
         certificate_deny_set: &HashSet<TransactionDigest>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-        move_authentication_result_opt: Option<MoveAuthenticationResult>,
+        move_authentication_result_opt: Option<
+            Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
+        >,
     ) -> (
         InnerTemporaryStore,
         IotaGasStatus,
@@ -271,8 +271,7 @@ mod checked {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         // Gas related
-        authenticator_gas_status: IotaGasStatus,
-        authenticated_transaction_gas_status: IotaGasStatus,
+        gas_status: IotaGasStatus,
         gas_coins: Vec<ObjectRef>,
         // Authenticator
         authenticator: MoveAuthenticator,
@@ -293,13 +292,13 @@ mod checked {
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
-        let move_authentication_result = validate_transaction(
+        let (gas_status_post_authentication, authentication_result) = validate_transaction(
             store,
             protocol_config,
             metrics.clone(),
             epoch_id,
             epoch_timestamp_ms,
-            authenticator_gas_status,
+            gas_status,
             authenticator,
             authenticator_info,
             authenticator_input_objects.clone(),
@@ -319,7 +318,7 @@ mod checked {
             store,
             input_objects,
             gas_coins,
-            authenticated_transaction_gas_status,
+            gas_status_post_authentication,
             authenticated_transaction_kind,
             authenticated_transaction_signer,
             authenticated_transaction_digest,
@@ -331,7 +330,7 @@ mod checked {
             enable_expensive_checks,
             certificate_deny_set,
             trace_builder_opt,
-            Some(move_authentication_result),
+            Some(authentication_result),
         )
     }
 
@@ -372,7 +371,10 @@ mod checked {
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         // VM
         move_vm: &Arc<MoveVM>,
-    ) -> MoveAuthenticationResult {
+    ) -> (
+        IotaGasStatus,
+        Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
+    ) {
         // Check the preconditions.
         debug_assert!(
             authenticated_transaction_kind.is_programmable_transaction(),
@@ -438,7 +440,7 @@ mod checked {
         temporary_store.store_auth_context(auth_ctx);
 
         // Execute the authenticator transaction.
-        let (computation_gas_cost, execution_result) =
+        let (gas_status, execution_result) =
             match setup_authenticator_move_call(authenticator, authenticator_info) {
                 Ok(authenticator_move_call) => execute_authenticator_move_call(
                     &mut temporary_store,
@@ -454,7 +456,10 @@ mod checked {
                     trace_builder_opt,
                 ),
                 // TODO: charge a minimum gas amount for failed setup?
-                Err(authenticator_setup_error) => (0, Err(authenticator_setup_error)),
+                Err(authenticator_setup_error) => (
+                    gas_charger.into_gas_status(),
+                    Err(authenticator_setup_error),
+                ),
             };
 
         // Check the execution result.
@@ -494,12 +499,12 @@ mod checked {
         #[skip_checked_arithmetic]
         trace!(
             tx_digest = ?authenticated_transaction_digest,
-            computation_gas_cost,
+            computation_gas_cost = gas_status.gas_used(),
             "Finished authenticator execution of transaction with status {:?}",
             status
         );
 
-        (computation_gas_cost, execution_result)
+        (gas_status, execution_result)
     }
 
     /// Executes an authentication move call by processing the specified
@@ -526,45 +531,42 @@ mod checked {
         contains_deleted_input: bool,
         cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> MoveAuthenticationResult {
+    ) -> (
+        IotaGasStatus,
+        Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
+    ) {
         debug_assert!(
             gas_charger.no_charges(),
             "At this point no gas charges must be applied yet"
         );
 
-        // Charge gas for reading the Move authenticator input objects from the storage.
-        let result = gas_charger
-            .charge_input_objects(temporary_store)
-            .and_then(|()| {
-                run_inputs_checks(
-                    protocol_config,
-                    deny_cert,
-                    contains_deleted_input,
-                    cancelled_objects,
-                )?;
-                programmable_transactions::execution::execute::<execution_mode::Validation>(
-                    protocol_config,
-                    metrics.clone(),
-                    move_vm,
-                    temporary_store,
-                    tx_ctx,
-                    &mut gas_charger,
-                    authenticator_move_call,
-                    trace_builder_opt,
-                )
-                .and_then(|ok_result| {
-                    temporary_store.check_move_authenticator_results_consistency()?;
-                    Ok(ok_result)
-                })
-            });
+        // Do NOT charge gas for reading the Move authenticator input objects from the
+        // storage. It will be charged later during the main transaction
+        // execution.
+        let result = run_inputs_checks(
+            protocol_config,
+            deny_cert,
+            contains_deleted_input,
+            cancelled_objects,
+        )
+        .and_then(|()| {
+            programmable_transactions::execution::execute::<execution_mode::Validation>(
+                protocol_config,
+                metrics.clone(),
+                move_vm,
+                temporary_store,
+                tx_ctx,
+                &mut gas_charger,
+                authenticator_move_call,
+                trace_builder_opt,
+            )
+            .and_then(|ok_result| {
+                temporary_store.check_move_authenticator_results_consistency()?;
+                Ok(ok_result)
+            })
+        });
 
-        // Compute the gas used for the authentication execution without
-        // rounding/bucketing.
-        let gas_status = gas_charger.into_gas_status();
-
-        let authentication_computation_cost = gas_status.gas_used();
-
-        (authentication_computation_cost, result)
+        (gas_charger.into_gas_status(), result)
     }
 
     /// Function dedicated to the execution of a GenesisTransaction.
@@ -628,7 +630,9 @@ mod checked {
         contains_deleted_input: bool,
         cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-        move_authentication_result_opt: Option<MoveAuthenticationResult>,
+        move_authentication_result_opt: Option<
+            Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
+        >,
     ) -> (
         GasCostSummary,
         Result<Mode::ExecutionResults, ExecutionError>,
@@ -637,7 +641,7 @@ mod checked {
 
         // At this point no charges have been applied yet
         debug_assert!(
-            gas_charger.no_charges_for_execution(),
+            move_authentication_result_opt.is_some() || gas_charger.no_charges_for_execution(),
             "No gas charges must be applied yet"
         );
 
@@ -658,30 +662,23 @@ mod checked {
                 cancelled_objects,
             )?;
 
-            // If some authentication result is provided, charge its cost first
-            let authentication_result = move_authentication_result_opt.map_or(
-                Ok(()),
-                |(authentication_computation_cost, authentication_result)| {
-                    gas_charger
-                        .charge_authentication(authentication_computation_cost)
-                        .and(authentication_result)
-                },
-            );
-
-            // Then if the authentication succeeded, proceed with the main execution loop
+            // If the authentication succeeded, proceed with the main execution loop
             // else propagate the authentication error
-            let mut execution_result = authentication_result.and_then(|_| {
-                execution_loop::<Mode>(
-                    temporary_store,
-                    transaction_kind,
-                    tx_ctx,
-                    move_vm,
-                    gas_charger,
-                    protocol_config,
-                    metrics.clone(),
-                    trace_builder_opt,
-                )
-            });
+            let mut execution_result =
+                move_authentication_result_opt
+                    .unwrap_or(Ok(()))
+                    .and_then(|_| {
+                        execution_loop::<Mode>(
+                            temporary_store,
+                            transaction_kind,
+                            tx_ctx,
+                            move_vm,
+                            gas_charger,
+                            protocol_config,
+                            metrics.clone(),
+                            trace_builder_opt,
+                        )
+                    });
 
             let meter_check = check_meter_limit(
                 temporary_store,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -64,7 +64,7 @@ mod checked {
 
     use crate::{
         adapter::new_move_vm,
-        execution_mode::{self, ExecutionMode, Validation},
+        execution_mode::{self, ExecutionMode},
         gas_charger::GasCharger,
         programmable_transactions,
         temporary_store::TemporaryStore,
@@ -279,7 +279,10 @@ mod checked {
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         // VM
         move_vm: &Arc<MoveVM>,
-    ) -> Result<u64, ExecutionError> {
+    ) -> (
+        u64, // gas computation cost
+        Result<<execution_mode::Validation as ExecutionMode>::ExecutionResults, ExecutionError>,
+    ) {
         // Check the preconditions.
         debug_assert!(
             authenticated_transaction_kind.is_programmable_transaction(),
@@ -346,22 +349,23 @@ mod checked {
 
         // Setup a move authenticator transaction.
         let authenticator_move_call =
-            setup_authenticator_move_call(authenticator, authenticator_info)?;
+            setup_authenticator_move_call(authenticator, authenticator_info).unwrap(); //TODO
 
         // Execute the authenticator transaction.
-        let (computation_gas_cost, execution_result) = execute_authenticator_move_call::<Validation>(
-            &mut temporary_store,
-            authenticator_move_call,
-            gas_charger,
-            &mut tx_ctx,
-            move_vm,
-            protocol_config,
-            metrics,
-            false,
-            contains_deleted_input,
-            cancelled_objects,
-            trace_builder_opt,
-        );
+        let (computation_gas_cost, execution_result) =
+            execute_authenticator_move_call::<execution_mode::Validation>(
+                &mut temporary_store,
+                authenticator_move_call,
+                gas_charger,
+                &mut tx_ctx,
+                move_vm,
+                protocol_config,
+                metrics,
+                false,
+                contains_deleted_input,
+                cancelled_objects,
+                trace_builder_opt,
+            );
 
         // Check the execution result.
         let status = if let Err(error) = &execution_result {
@@ -405,7 +409,140 @@ mod checked {
             status
         );
 
-        execution_result.map(|_| computation_gas_cost)
+        (computation_gas_cost, execution_result)
+    }
+
+    ///
+    #[instrument(name = "tx_invalid_to_effects", level = "debug", skip_all)]
+    pub fn invalid_transaction_to_effects(
+        store: &dyn BackingStore,
+        // Configuration
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+        // Epoch
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        // Gas related
+        gas_status: IotaGasStatus,
+        gas_coins: Vec<ObjectRef>,
+        // Validation
+        validation_execution_error: ExecutionError,
+        validation_input_objects: CheckedInputObjects,
+        // Transaction
+        invalid_transaction_input_objects: CheckedInputObjects,
+        invalid_transaction_kind: TransactionKind,
+        invalid_transaction_signer: IotaAddress,
+        invalid_transaction_digest: TransactionDigest,
+        // VM
+        move_vm: &Arc<MoveVM>,
+    ) -> (
+        InnerTemporaryStore,
+        IotaGasStatus,
+        TransactionEffects,
+        ExecutionError,
+    ) {
+        let mut input_objects = invalid_transaction_input_objects.into_inner();
+        input_objects.extend(validation_input_objects.into_inner());
+        let mutable_inputs = if enable_expensive_checks {
+            input_objects.mutable_inputs().keys().copied().collect()
+        } else {
+            HashSet::new()
+        };
+        let shared_object_refs = input_objects.filter_shared_objects();
+        let receiving_objects = invalid_transaction_kind.receiving_objects();
+        let mut transaction_dependencies = input_objects.transaction_dependencies();
+        let contains_deleted_input = input_objects.contains_deleted_objects();
+        let cancelled_objects = input_objects.get_cancelled_objects();
+
+        let mut temporary_store = TemporaryStore::new(
+            store,
+            input_objects,
+            receiving_objects,
+            invalid_transaction_digest,
+            protocol_config,
+            *epoch_id,
+        );
+
+        let mut gas_charger = GasCharger::new(
+            invalid_transaction_digest,
+            gas_coins,
+            gas_status,
+            protocol_config,
+        );
+
+        let mut tx_ctx = TxContext::new_from_components(
+            &invalid_transaction_signer,
+            &invalid_transaction_digest,
+            epoch_id,
+            epoch_timestamp_ms,
+        );
+
+        let is_epoch_change = invalid_transaction_kind.is_end_of_epoch_tx();
+
+        let deny_cert = is_certificate_denied(&invalid_transaction_digest, certificate_deny_set);
+        let (gas_cost_summary, execution_error) = invalid_transaction(
+            &mut temporary_store,
+            invalid_transaction_kind,
+            validation_execution_error,
+            &mut gas_charger,
+            &mut tx_ctx,
+            move_vm,
+            protocol_config,
+            metrics,
+            enable_expensive_checks,
+            deny_cert,
+            contains_deleted_input,
+            cancelled_objects,
+        );
+
+        let (status, command) = execution_error.to_execution_status();
+        let status = ExecutionStatus::new_failure(status, command);
+
+        #[skip_checked_arithmetic]
+        trace!(
+            tx_digest = ?invalid_transaction_digest,
+            computation_gas_cost = gas_cost_summary.computation_cost,
+            computation_gas_cost_burned = gas_cost_summary.computation_cost_burned,
+            storage_gas_cost = gas_cost_summary.storage_cost,
+            storage_gas_rebate = gas_cost_summary.storage_rebate,
+            "Finished execution of transaction with status {:?}",
+            status
+        );
+
+        // Genesis writes a special digest to indicate that an object was created during
+        // genesis and not written by any normal transaction - remove that from the
+        // dependencies
+        transaction_dependencies.remove(&TransactionDigest::genesis_marker());
+
+        if enable_expensive_checks && !execution_mode::Normal::allow_arbitrary_function_calls() {
+            temporary_store
+                .check_ownership_invariants(
+                    &invalid_transaction_signer,
+                    &mut gas_charger,
+                    &mutable_inputs,
+                    is_epoch_change,
+                )
+                .unwrap()
+        } // else, in dev inspect mode and anything goes--don't check
+
+        let (inner, effects) = temporary_store.into_effects(
+            shared_object_refs,
+            &invalid_transaction_digest,
+            transaction_dependencies,
+            gas_cost_summary,
+            status,
+            &mut gas_charger,
+            *epoch_id,
+        );
+
+        (
+            inner,
+            gas_charger.into_gas_status(),
+            effects,
+            execution_error,
+        )
     }
 
     /// Executes an authentication move call by processing the specified
@@ -625,6 +762,82 @@ mod checked {
         }
 
         (cost_summary, result)
+    }
+
+    #[instrument(name = "tx_invalid", level = "debug", skip_all)]
+    fn invalid_transaction(
+        temporary_store: &mut TemporaryStore<'_>,
+        transaction_kind: TransactionKind,
+        validation_execution_error: ExecutionError,
+        gas_charger: &mut GasCharger,
+        tx_ctx: &mut TxContext,
+        move_vm: &Arc<MoveVM>,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        deny_cert: bool,
+        contains_deleted_input: bool,
+        cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
+    ) -> (GasCostSummary, ExecutionError) {
+        gas_charger.smash_gas(temporary_store);
+
+        // At this point no charges have been applied yet
+        debug_assert!(
+            gas_charger.no_charges_for_execution(),
+            "No gas charges must be applied yet"
+        );
+
+        let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
+
+        let mut result: Result<(), ExecutionError> = {
+            // Run the checks that must take precedence over the validation execution error.
+            let pre_check: Result<(), ExecutionError> = (|| {
+                // We must charge object read here we must still ensure an effect is committed
+                // and all objects versions incremented
+                gas_charger.charge_input_objects(temporary_store)?;
+
+                run_inputs_checks(
+                    protocol_config,
+                    deny_cert,
+                    contains_deleted_input,
+                    cancelled_objects,
+                )?;
+
+                check_meter_limit(
+                    temporary_store,
+                    gas_charger,
+                    protocol_config,
+                    metrics.clone(),
+                )?;
+
+                Ok(())
+            })();
+
+            // If any of the pre-checks failed, that error has priority; otherwise use
+            // the provided validation_execution_error.
+            match pre_check {
+                Ok(()) => Err(validation_execution_error),
+                Err(e) => Err(e),
+            }
+        };
+
+        let cost_summary = gas_charger.charge_gas(temporary_store, &mut result);
+
+        if let Err(e) = run_conservation_checks::<execution_mode::Normal>(
+            temporary_store,
+            gas_charger,
+            tx_ctx,
+            move_vm,
+            enable_expensive_checks,
+            &cost_summary,
+            false,
+            advance_epoch_gas_summary,
+        ) {
+            // FIXME: we cannot fail the transaction if this is an epoch change transaction.
+            result = Err(e);
+        }
+
+        (cost_summary, result.err().unwrap())
     }
 
     /// Performs IOTA conservation checks during transaction execution, ensuring

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -292,6 +292,11 @@ mod checked {
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
+        // Authenticate the transaction first. This means having read only inputs passed
+        // to an authenticate function. It charges gas for reading the input objects and
+        // then for the function instructions.
+        // It does not alter the state and produces no effects other than possible
+        // errors.
         let (gas_status_post_authentication, authentication_result) = authenticate_transaction(
             store,
             protocol_config,
@@ -309,14 +314,15 @@ mod checked {
             move_vm,
         );
 
-        // Merge input objects coming from the transaction together with
-        // those coming from the authenticator execution.
-        let mut input_objects = authenticated_transaction_input_objects;
-        input_objects.extend_no_duplicates(authenticator_input_objects);
+        // At this stage we have the gas status, with gas charged for reading the
+        // authenticator inputs and for the computation, and a result wich is either
+        // empty or an error.
 
+        // We can now start the creation of the transaction effects, either for an
+        // authentication failure or for a normal execution of the transaction.
         execute_transaction_to_effects::<Mode>(
             store,
-            input_objects,
+            authenticated_transaction_input_objects,
             gas_coins,
             gas_status_post_authentication,
             authenticated_transaction_kind,
@@ -342,7 +348,7 @@ mod checked {
     /// the authentication function found in `AuthenticatorInfo`, that is
     /// retrieved from the abstracted IOTA account.
     ///
-    /// Returns an error if it happens or and the gas status that can be later
+    /// Returns an error if it happens and the gas status that can be later
     /// used to check the computation cost.
     #[instrument(name = "tx_validate", level = "debug", skip_all)]
     pub fn authenticate_transaction(
@@ -536,31 +542,31 @@ mod checked {
             "At this point no gas charges must be applied yet"
         );
 
-        // Do NOT charge gas for reading the Move authenticator input objects from the
-        // storage. It will be charged later during the main transaction
-        // execution.
-        let result = run_inputs_checks(
-            protocol_config,
-            deny_cert,
-            contains_deleted_input,
-            cancelled_objects,
-        )
-        .and_then(|()| {
-            programmable_transactions::execution::execute::<execution_mode::Validation>(
-                protocol_config,
-                metrics.clone(),
-                move_vm,
-                temporary_store,
-                tx_ctx,
-                &mut gas_charger,
-                authenticator_move_call,
-                trace_builder_opt,
-            )
-            .and_then(|ok_result| {
-                temporary_store.check_move_authenticator_results_consistency()?;
-                Ok(ok_result)
-            })
-        });
+        // Charge gas for reading the Move authenticator input objects from the storage.
+        let result = gas_charger
+            .charge_input_objects(temporary_store)
+            .and_then(|()| {
+                run_inputs_checks(
+                    protocol_config,
+                    deny_cert,
+                    contains_deleted_input,
+                    cancelled_objects,
+                )?;
+                programmable_transactions::execution::execute::<execution_mode::Validation>(
+                    protocol_config,
+                    metrics.clone(),
+                    move_vm,
+                    temporary_store,
+                    tx_ctx,
+                    &mut gas_charger,
+                    authenticator_move_call,
+                    trace_builder_opt,
+                )
+                .and_then(|ok_result| {
+                    temporary_store.check_move_authenticator_results_consistency()?;
+                    Ok(ok_result)
+                })
+            });
 
         (gas_charger.into_gas_status(), result)
     }
@@ -637,7 +643,7 @@ mod checked {
 
         // At this point no charges have been applied yet
         debug_assert!(
-            move_authentication_result_opt.is_some() || gas_charger.no_charges_for_execution(),
+            move_authentication_result_opt.is_some() || gas_charger.no_charges(),
             "No gas charges must be applied yet"
         );
 

--- a/iota-execution/latest/iota-adapter/src/execution_mode.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_mode.rs
@@ -215,9 +215,9 @@ impl ExecutionMode for System {
 }
 
 #[derive(Copy, Clone)]
-pub struct Validation;
+pub struct Authentication;
 
-impl ExecutionMode for Validation {
+impl ExecutionMode for Authentication {
     type ArgumentUpdates = ();
     type ExecutionResults = ();
 

--- a/iota-execution/latest/iota-adapter/src/gas_charger.rs
+++ b/iota-execution/latest/iota-adapter/src/gas_charger.rs
@@ -97,14 +97,6 @@ pub mod checked {
                 && self.gas_status.storage_gas_units() == 0
         }
 
-        pub fn no_charges_for_execution(&self) -> bool {
-            let gas_used_for_execution = self.gas_status.gas_used();
-
-            gas_used_for_execution == 0
-                && self.gas_status.storage_rebate() == 0
-                && self.gas_status.storage_gas_units() == 0
-        }
-
         pub fn is_unmetered(&self) -> bool {
             self.gas_status.is_unmetered()
         }

--- a/iota-execution/latest/iota-adapter/src/gas_charger.rs
+++ b/iota-execution/latest/iota-adapter/src/gas_charger.rs
@@ -13,13 +13,12 @@ pub mod checked {
         base_types::{ObjectID, ObjectRef},
         deny_list_v1::CONFIG_SETTING_DYNAMIC_FIELD_SIZE_FOR_GAS,
         digests::TransactionDigest,
-        error::{ExecutionError, ExecutionErrorKind},
+        error::ExecutionError,
         gas::{GasCostSummary, IotaGasStatus, deduct_gas},
         gas_model::tables::GasStatus,
         is_system_package,
         object::Data,
     };
-    use move_core_types::vm_status::StatusCode;
     use tracing::trace;
 
     use crate::{iota_types::gas::IotaGasStatusAPI, temporary_store::TemporaryStore};
@@ -267,17 +266,6 @@ pub mod checked {
             let cost_per_owner = bytes_read_per_owner * cost_per_byte;
             let owner_cost = cost_per_owner * (num_non_gas_coin_owners as usize);
             self.gas_status.charge_storage_read(owner_cost)
-        }
-
-        pub fn charge_authentication(&mut self, gas: u64) -> Result<(), ExecutionError> {
-            // TODO: do we need a dedicated function for this?
-            self.gas_status
-                .move_gas_status_mut()
-                .charge_bytes(gas as usize, 1)
-                .map_err(|e| {
-                    debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
-                    ExecutionErrorKind::InsufficientGas.into()
-                })
         }
 
         /// Resets any mutations, deletions, and events recorded in the store,

--- a/iota-execution/latest/iota-adapter/src/gas_charger.rs
+++ b/iota-execution/latest/iota-adapter/src/gas_charger.rs
@@ -13,12 +13,13 @@ pub mod checked {
         base_types::{ObjectID, ObjectRef},
         deny_list_v1::CONFIG_SETTING_DYNAMIC_FIELD_SIZE_FOR_GAS,
         digests::TransactionDigest,
-        error::ExecutionError,
+        error::{ExecutionError, ExecutionErrorKind},
         gas::{GasCostSummary, IotaGasStatus, deduct_gas},
         gas_model::tables::GasStatus,
         is_system_package,
         object::Data,
     };
+    use move_core_types::vm_status::StatusCode;
     use tracing::trace;
 
     use crate::{iota_types::gas::IotaGasStatusAPI, temporary_store::TemporaryStore};
@@ -98,8 +99,7 @@ pub mod checked {
         }
 
         pub fn no_charges_for_execution(&self) -> bool {
-            let gas_used_for_execution =
-                self.gas_status.gas_used() - self.gas_status.gas_used_for_authentication();
+            let gas_used_for_execution = self.gas_status.gas_used();
 
             gas_used_for_execution == 0
                 && self.gas_status.storage_rebate() == 0
@@ -267,6 +267,17 @@ pub mod checked {
             let cost_per_owner = bytes_read_per_owner * cost_per_byte;
             let owner_cost = cost_per_owner * (num_non_gas_coin_owners as usize);
             self.gas_status.charge_storage_read(owner_cost)
+        }
+
+        pub fn charge_authentication(&mut self, gas: u64) -> Result<(), ExecutionError> {
+            // TODO: do we need a dedicated function for this?
+            self.gas_status
+                .move_gas_status_mut()
+                .charge_bytes(gas as usize, 1)
+                .map_err(|e| {
+                    debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
+                    ExecutionErrorKind::InsufficientGas.into()
+                })
         }
 
         /// Resets any mutations, deletions, and events recorded in the store,

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -99,11 +99,11 @@ pub trait Executor {
         authenticator: MoveAuthenticator,
         authenticator_info: AuthenticatorInfoV1,
         authenticator_input_objects: CheckedInputObjects,
+        authenticator_and_transaction_input_objects: CheckedInputObjects,
         // Transaction
-        authenticated_transaction_kind: TransactionKind,
-        authenticated_transaction_signer: IotaAddress,
-        authenticated_transaction_digest: TransactionDigest,
-        authenticated_transaction_input_objects: CheckedInputObjects,
+        transaction_kind: TransactionKind,
+        transaction_signer: IotaAddress,
+        transaction_digest: TransactionDigest,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> (

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -134,7 +134,7 @@ pub trait Executor {
         authenticated_transaction_digest: TransactionDigest,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (IotaGasStatus, Result<(), ExecutionError>);
+    ) -> Result<(), ExecutionError>;
 
     fn update_genesis_state(
         &self,

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -102,7 +102,36 @@ pub trait Executor {
         authenticated_transaction_digest: TransactionDigest,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> Result<u64, ExecutionError>;
+    ) -> (u64, Result<(), ExecutionError>);
+
+    fn invalid_transaction_to_effects(
+        &self,
+        store: &dyn BackingStore,
+        // Configuration
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+        // Epoch
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        // Gas related
+        gas_status: IotaGasStatus,
+        gas_coins: Vec<ObjectRef>,
+        // Validation
+        validation_execution_error: ExecutionError,
+        validation_input_objects: CheckedInputObjects,
+        // Transaction
+        invalid_transaction_input_objects: CheckedInputObjects,
+        invalid_transaction_kind: TransactionKind,
+        invalid_transaction_signer: IotaAddress,
+        invalid_transaction_digest: TransactionDigest,
+    ) -> (
+        InnerTemporaryStore,
+        IotaGasStatus,
+        TransactionEffects,
+        ExecutionError,
+    );
 
     fn update_genesis_state(
         &self,

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -93,8 +93,7 @@ pub trait Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         // Gas related
-        authenticator_gas_status: IotaGasStatus,
-        authenticated_transaction_gas_status: IotaGasStatus,
+        gas_status: IotaGasStatus,
         gas_coins: Vec<ObjectRef>,
         // Authenticator
         authenticator: MoveAuthenticator,
@@ -135,7 +134,7 @@ pub trait Executor {
         authenticated_transaction_digest: TransactionDigest,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (u64, Result<(), ExecutionError>);
+    ) -> (IotaGasStatus, Result<(), ExecutionError>);
 
     fn update_genesis_state(
         &self,

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -113,7 +113,7 @@ pub trait Executor {
         Result<(), ExecutionError>,
     );
 
-    fn validate_transaction(
+    fn authenticate_transaction(
         &self,
         store: &dyn BackingStore,
         // Configuration

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -81,6 +81,39 @@ pub trait Executor {
         Result<Vec<ExecutionResult>, ExecutionError>,
     );
 
+    fn authenticate_then_execute_transaction_to_effects(
+        &self,
+        store: &dyn BackingStore,
+        // Configuration
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+        // Epoch
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        // Gas related
+        authenticator_gas_status: IotaGasStatus,
+        authenticated_transaction_gas_status: IotaGasStatus,
+        gas_coins: Vec<ObjectRef>,
+        // Authenticator
+        authenticator: MoveAuthenticator,
+        authenticator_info: AuthenticatorInfoV1,
+        authenticator_input_objects: CheckedInputObjects,
+        // Transaction
+        authenticated_transaction_kind: TransactionKind,
+        authenticated_transaction_signer: IotaAddress,
+        authenticated_transaction_digest: TransactionDigest,
+        authenticated_transaction_input_objects: CheckedInputObjects,
+        // Tracing
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+    ) -> (
+        InnerTemporaryStore,
+        IotaGasStatus,
+        TransactionEffects,
+        Result<(), ExecutionError>,
+    );
+
     fn validate_transaction(
         &self,
         store: &dyn BackingStore,
@@ -103,35 +136,6 @@ pub trait Executor {
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> (u64, Result<(), ExecutionError>);
-
-    fn produce_effects_for_invalid_authentication(
-        &self,
-        store: &dyn BackingStore,
-        // Configuration
-        protocol_config: &ProtocolConfig,
-        metrics: Arc<LimitsMetrics>,
-        enable_expensive_checks: bool,
-        certificate_deny_set: &HashSet<TransactionDigest>,
-        // Epoch
-        epoch_id: &EpochId,
-        epoch_timestamp_ms: u64,
-        // Gas related
-        gas_status: IotaGasStatus,
-        gas_coins: Vec<ObjectRef>,
-        // Invalid Authentication
-        invalid_authentication_execution_error: ExecutionError,
-        invalid_authentication_input_objects: CheckedInputObjects,
-        // Transaction
-        transaction_input_objects: CheckedInputObjects,
-        transaction_kind: TransactionKind,
-        transaction_signer: IotaAddress,
-        transaction_digest: TransactionDigest,
-    ) -> (
-        InnerTemporaryStore,
-        IotaGasStatus,
-        TransactionEffects,
-        ExecutionError,
-    );
 
     fn update_genesis_state(
         &self,

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -104,7 +104,7 @@ pub trait Executor {
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> (u64, Result<(), ExecutionError>);
 
-    fn invalid_transaction_to_effects(
+    fn produce_effects_for_invalid_authentication(
         &self,
         store: &dyn BackingStore,
         // Configuration
@@ -118,14 +118,14 @@ pub trait Executor {
         // Gas related
         gas_status: IotaGasStatus,
         gas_coins: Vec<ObjectRef>,
-        // Validation
-        validation_execution_error: ExecutionError,
-        validation_input_objects: CheckedInputObjects,
+        // Invalid Authentication
+        invalid_authentication_execution_error: ExecutionError,
+        invalid_authentication_input_objects: CheckedInputObjects,
         // Transaction
-        invalid_transaction_input_objects: CheckedInputObjects,
-        invalid_transaction_kind: TransactionKind,
-        invalid_transaction_signer: IotaAddress,
-        invalid_transaction_digest: TransactionDigest,
+        transaction_input_objects: CheckedInputObjects,
+        transaction_kind: TransactionKind,
+        transaction_signer: IotaAddress,
+        transaction_digest: TransactionDigest,
     ) -> (
         InnerTemporaryStore,
         IotaGasStatus,

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -7,7 +7,8 @@ use std::{collections::HashSet, path::PathBuf, sync::Arc};
 use iota_adapter_latest::{
     adapter::{new_move_vm, run_metered_move_bytecode_verifier},
     execution_engine::{
-        execute_genesis_state_update, execute_transaction_to_effects, validate_transaction,
+        execute_genesis_state_update, execute_transaction_to_effects,
+        invalid_transaction_to_effects, validate_transaction,
     },
     execution_mode,
     type_layout_resolver::TypeLayoutResolver,
@@ -190,7 +191,7 @@ impl executor::Executor for Executor {
         authenticated_transaction_digest: TransactionDigest,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> Result<u64, ExecutionError> {
+    ) -> (u64, Result<(), ExecutionError>) {
         validate_transaction(
             store,
             protocol_config,
@@ -205,6 +206,54 @@ impl executor::Executor for Executor {
             authenticated_transaction_signer,
             authenticated_transaction_digest,
             trace_builder_opt,
+            &self.0,
+        )
+    }
+
+    fn invalid_transaction_to_effects(
+        &self,
+        store: &dyn BackingStore,
+        // Configuration
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+        // Epoch
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        // Gas related
+        gas_status: IotaGasStatus,
+        gas_coins: Vec<ObjectRef>,
+        // Validation
+        validation_execution_error: ExecutionError,
+        validation_input_objects: CheckedInputObjects,
+        // Transaction
+        invalid_transaction_input_objects: CheckedInputObjects,
+        invalid_transaction_kind: TransactionKind,
+        invalid_transaction_signer: IotaAddress,
+        invalid_transaction_digest: TransactionDigest,
+    ) -> (
+        InnerTemporaryStore,
+        IotaGasStatus,
+        TransactionEffects,
+        ExecutionError,
+    ) {
+        invalid_transaction_to_effects(
+            store,
+            protocol_config,
+            metrics,
+            enable_expensive_checks,
+            certificate_deny_set,
+            epoch_id,
+            epoch_timestamp_ms,
+            gas_status,
+            gas_coins,
+            validation_execution_error,
+            validation_input_objects,
+            invalid_transaction_input_objects,
+            invalid_transaction_kind,
+            invalid_transaction_signer,
+            invalid_transaction_digest,
             &self.0,
         )
     }

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -7,8 +7,8 @@ use std::{collections::HashSet, path::PathBuf, sync::Arc};
 use iota_adapter_latest::{
     adapter::{new_move_vm, run_metered_move_bytecode_verifier},
     execution_engine::{
-        authenticate_then_execute_transaction_to_effects, execute_genesis_state_update,
-        execute_transaction_to_effects, validate_transaction,
+        authenticate_then_execute_transaction_to_effects, authenticate_transaction,
+        execute_genesis_state_update, execute_transaction_to_effects,
     },
     execution_mode,
     type_layout_resolver::TypeLayoutResolver,
@@ -226,7 +226,7 @@ impl executor::Executor for Executor {
         )
     }
 
-    fn validate_transaction(
+    fn authenticate_transaction(
         &self,
         store: &dyn BackingStore,
         // Configuration
@@ -248,7 +248,7 @@ impl executor::Executor for Executor {
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> (IotaGasStatus, Result<(), ExecutionError>) {
-        validate_transaction(
+        authenticate_transaction(
             store,
             protocol_config,
             metrics,

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -192,7 +192,7 @@ impl executor::Executor for Executor {
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> (u64, Result<(), ExecutionError>) {
-        validate_transaction(
+        validate_transaction::<execution_mode::Validation>(
             store,
             protocol_config,
             metrics,

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -185,8 +185,7 @@ impl executor::Executor for Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         // Gas related
-        authenticator_gas_status: IotaGasStatus,
-        authenticated_transaction_gas_status: IotaGasStatus,
+        gas_status: IotaGasStatus,
         gas_coins: Vec<ObjectRef>,
         // Authenticator
         authenticator: MoveAuthenticator,
@@ -213,8 +212,7 @@ impl executor::Executor for Executor {
             certificate_deny_set,
             epoch_id,
             epoch_timestamp_ms,
-            authenticator_gas_status,
-            authenticated_transaction_gas_status,
+            gas_status,
             gas_coins,
             authenticator,
             authenticator_info,
@@ -249,7 +247,7 @@ impl executor::Executor for Executor {
         authenticated_transaction_digest: TransactionDigest,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (u64, Result<(), ExecutionError>) {
+    ) -> (IotaGasStatus, Result<(), ExecutionError>) {
         validate_transaction(
             store,
             protocol_config,

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -188,11 +188,11 @@ impl executor::Executor for Executor {
         authenticator: MoveAuthenticator,
         authenticator_info: AuthenticatorInfoV1,
         authenticator_input_objects: CheckedInputObjects,
+        authenticator_and_transaction_input_objects: CheckedInputObjects,
         // Transaction
-        authenticated_transaction_kind: TransactionKind,
-        authenticated_transaction_signer: IotaAddress,
-        authenticated_transaction_digest: TransactionDigest,
-        authenticated_transaction_input_objects: CheckedInputObjects,
+        transaction_kind: TransactionKind,
+        transaction_signer: IotaAddress,
+        transaction_digest: TransactionDigest,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> (
@@ -214,10 +214,10 @@ impl executor::Executor for Executor {
             authenticator,
             authenticator_info,
             authenticator_input_objects,
-            authenticated_transaction_kind,
-            authenticated_transaction_signer,
-            authenticated_transaction_digest,
-            authenticated_transaction_input_objects,
+            authenticator_and_transaction_input_objects,
+            transaction_kind,
+            transaction_signer,
+            transaction_digest,
             trace_builder_opt,
             &self.0,
         )

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -106,7 +106,6 @@ impl executor::Executor for Executor {
             enable_expensive_checks,
             certificate_deny_set,
             trace_builder_opt,
-            None,
         )
     }
 
@@ -149,7 +148,6 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 certificate_deny_set,
                 &mut None,
-                None,
             )
         } else {
             execute_transaction_to_effects::<execution_mode::DevInspect<false>>(
@@ -168,7 +166,6 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 certificate_deny_set,
                 &mut None,
-                None,
             )
         }
     }
@@ -247,7 +244,7 @@ impl executor::Executor for Executor {
         authenticated_transaction_digest: TransactionDigest,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (IotaGasStatus, Result<(), ExecutionError>) {
+    ) -> Result<(), ExecutionError> {
         authenticate_transaction(
             store,
             protocol_config,

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -7,8 +7,8 @@ use std::{collections::HashSet, path::PathBuf, sync::Arc};
 use iota_adapter_latest::{
     adapter::{new_move_vm, run_metered_move_bytecode_verifier},
     execution_engine::{
-        execute_genesis_state_update, execute_transaction_to_effects,
-        produce_effects_for_invalid_authentication, validate_transaction,
+        authenticate_then_execute_transaction_to_effects, execute_genesis_state_update,
+        execute_transaction_to_effects, validate_transaction,
     },
     execution_mode,
     type_layout_resolver::TypeLayoutResolver,
@@ -106,6 +106,7 @@ impl executor::Executor for Executor {
             enable_expensive_checks,
             certificate_deny_set,
             trace_builder_opt,
+            None,
         )
     }
 
@@ -148,6 +149,7 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 certificate_deny_set,
                 &mut None,
+                None,
             )
         } else {
             execute_transaction_to_effects::<execution_mode::DevInspect<false>>(
@@ -166,8 +168,64 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 certificate_deny_set,
                 &mut None,
+                None,
             )
         }
+    }
+
+    fn authenticate_then_execute_transaction_to_effects(
+        &self,
+        store: &dyn BackingStore,
+        // Configuration
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+        // Epoch
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        // Gas related
+        authenticator_gas_status: IotaGasStatus,
+        authenticated_transaction_gas_status: IotaGasStatus,
+        gas_coins: Vec<ObjectRef>,
+        // Authenticator
+        authenticator: MoveAuthenticator,
+        authenticator_info: AuthenticatorInfoV1,
+        authenticator_input_objects: CheckedInputObjects,
+        // Transaction
+        authenticated_transaction_kind: TransactionKind,
+        authenticated_transaction_signer: IotaAddress,
+        authenticated_transaction_digest: TransactionDigest,
+        authenticated_transaction_input_objects: CheckedInputObjects,
+        // Tracing
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+    ) -> (
+        InnerTemporaryStore,
+        IotaGasStatus,
+        TransactionEffects,
+        Result<(), ExecutionError>,
+    ) {
+        authenticate_then_execute_transaction_to_effects::<execution_mode::Normal>(
+            store,
+            protocol_config,
+            metrics,
+            enable_expensive_checks,
+            certificate_deny_set,
+            epoch_id,
+            epoch_timestamp_ms,
+            authenticator_gas_status,
+            authenticated_transaction_gas_status,
+            gas_coins,
+            authenticator,
+            authenticator_info,
+            authenticator_input_objects,
+            authenticated_transaction_kind,
+            authenticated_transaction_signer,
+            authenticated_transaction_digest,
+            authenticated_transaction_input_objects,
+            trace_builder_opt,
+            &self.0,
+        )
     }
 
     fn validate_transaction(
@@ -192,7 +250,7 @@ impl executor::Executor for Executor {
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> (u64, Result<(), ExecutionError>) {
-        validate_transaction::<execution_mode::Validation>(
+        validate_transaction(
             store,
             protocol_config,
             metrics,
@@ -206,54 +264,6 @@ impl executor::Executor for Executor {
             authenticated_transaction_signer,
             authenticated_transaction_digest,
             trace_builder_opt,
-            &self.0,
-        )
-    }
-
-    fn produce_effects_for_invalid_authentication(
-        &self,
-        store: &dyn BackingStore,
-        // Configuration
-        protocol_config: &ProtocolConfig,
-        metrics: Arc<LimitsMetrics>,
-        enable_expensive_checks: bool,
-        certificate_deny_set: &HashSet<TransactionDigest>,
-        // Epoch
-        epoch_id: &EpochId,
-        epoch_timestamp_ms: u64,
-        // Gas related
-        gas_status: IotaGasStatus,
-        gas_coins: Vec<ObjectRef>,
-        // Invalid Authentication
-        invalid_authentication_execution_error: ExecutionError,
-        invalid_authentication_input_objects: CheckedInputObjects,
-        // Transaction
-        transaction_input_objects: CheckedInputObjects,
-        transaction_kind: TransactionKind,
-        transaction_signer: IotaAddress,
-        transaction_digest: TransactionDigest,
-    ) -> (
-        InnerTemporaryStore,
-        IotaGasStatus,
-        TransactionEffects,
-        ExecutionError,
-    ) {
-        produce_effects_for_invalid_authentication::<execution_mode::Normal>(
-            store,
-            protocol_config,
-            metrics,
-            enable_expensive_checks,
-            certificate_deny_set,
-            epoch_id,
-            epoch_timestamp_ms,
-            gas_status,
-            gas_coins,
-            invalid_authentication_execution_error,
-            invalid_authentication_input_objects,
-            transaction_input_objects,
-            transaction_kind,
-            transaction_signer,
-            transaction_digest,
             &self.0,
         )
     }

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -8,7 +8,7 @@ use iota_adapter_latest::{
     adapter::{new_move_vm, run_metered_move_bytecode_verifier},
     execution_engine::{
         execute_genesis_state_update, execute_transaction_to_effects,
-        invalid_transaction_to_effects, validate_transaction,
+        produce_effects_for_invalid_authentication, validate_transaction,
     },
     execution_mode,
     type_layout_resolver::TypeLayoutResolver,
@@ -210,7 +210,7 @@ impl executor::Executor for Executor {
         )
     }
 
-    fn invalid_transaction_to_effects(
+    fn produce_effects_for_invalid_authentication(
         &self,
         store: &dyn BackingStore,
         // Configuration
@@ -224,21 +224,21 @@ impl executor::Executor for Executor {
         // Gas related
         gas_status: IotaGasStatus,
         gas_coins: Vec<ObjectRef>,
-        // Validation
-        validation_execution_error: ExecutionError,
-        validation_input_objects: CheckedInputObjects,
+        // Invalid Authentication
+        invalid_authentication_execution_error: ExecutionError,
+        invalid_authentication_input_objects: CheckedInputObjects,
         // Transaction
-        invalid_transaction_input_objects: CheckedInputObjects,
-        invalid_transaction_kind: TransactionKind,
-        invalid_transaction_signer: IotaAddress,
-        invalid_transaction_digest: TransactionDigest,
+        transaction_input_objects: CheckedInputObjects,
+        transaction_kind: TransactionKind,
+        transaction_signer: IotaAddress,
+        transaction_digest: TransactionDigest,
     ) -> (
         InnerTemporaryStore,
         IotaGasStatus,
         TransactionEffects,
         ExecutionError,
     ) {
-        invalid_transaction_to_effects(
+        produce_effects_for_invalid_authentication::<execution_mode::Normal>(
             store,
             protocol_config,
             metrics,
@@ -248,12 +248,12 @@ impl executor::Executor for Executor {
             epoch_timestamp_ms,
             gas_status,
             gas_coins,
-            validation_execution_error,
-            validation_input_objects,
-            invalid_transaction_input_objects,
-            invalid_transaction_kind,
-            invalid_transaction_signer,
-            invalid_transaction_digest,
+            invalid_authentication_execution_error,
+            invalid_authentication_input_objects,
+            transaction_input_objects,
+            transaction_kind,
+            transaction_signer,
+            transaction_digest,
             &self.0,
         )
     }


### PR DESCRIPTION
# Description of change
This makes so that a move authentication passing pre-consensus (validators sign the TX) and failing post-consensus produces some effects (gas charging).

I think starting from `test_abstract_account_post_consensus_failure()` is a good way to understand the logic behind the change. 
Basically, what is needed, is to make it so that this can happen:
1) Create an AA TX and make the majority of validators to sign it; this means that the Move authentication based on the AA shared object state is CURRENTLY successful.
2) Then, tamper with the AA shared object state by altering the state of the AA shared object (e.g., create and send for execution a second TX  that changes a field of the AA shared object).
3) Finally, submit for execution the original certificate, i.e., the one obtained from the signature of the majority of validators. This PR changes the behavior at this step: 
    - before this PR, the TX execution simply didn't go through but just raised a Move authentication error within the iota-core;
    - whilst, after this PR, the Move authentication error is treated as execution error and thus producing effects; the result is that all input objects are considered when creating the transaction effects and the gas coin is reduced with the authentication computation gas cost execution.

This PR also merges input objects in the case of a successful execution.

In order to produce effects, the method `authenticate_then_execute_transaction_to_effects()` was added to the execution engine. This new method executes all the steps necessary to create the TransactionEffects after the authentication execution. This means that, after running `authenticate_transaction_inner()` and failing (as well as succeeding), the execution continues with `execute_transaction_to_effects_inner()` in order to finish the job, i.e., creating effects for a failing (or successful) transaction. 

## Links to any relevant issues

Fixes #8908 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
