### PR TITLE
fix(graphql-rpc): read also checkpointed transactions after execution

### DIFF
--- a/crates/iota-graphql-rpc/src/mutation.rs
+++ b/crates/iota-graphql-rpc/src/mutation.rs
@@ -5,9 +5,9 @@ use async_graphql::*;
 use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
 use fastcrypto::encoding::Base64;
 use iota_indexer::{
-    models::transactions::OptimisticTransaction,
+    models::transactions::{OptimisticTransaction, StoredTransaction},
     optimistic_indexing::OptimisticTransactionExecutor,
-    schema::{optimistic_transactions, tx_global_order},
+    schema::{optimistic_transactions, transactions, tx_digests, tx_global_order},
 };
 use iota_json_rpc_types::IotaTransactionBlockResponseOptions;
 
@@ -15,11 +15,31 @@ use crate::{
     data::{Db, DbConnection, QueryExecutor},
     error::Error,
     types::{
-        execution_result::ExecutionResult,
-        transaction_block_effects::{TransactionBlockEffects, TransactionBlockEffectsKind},
+        execution_result::ExecutionResult, transaction_block::TransactionBlock,
+        transaction_block_effects::TransactionBlockEffects,
     },
 };
 pub struct Mutation;
+
+/// Query checkpointed transaction by digest from the database
+async fn query_checkpointed_transaction_by_digest(
+    db: &Db,
+    digest_bytes: Vec<u8>,
+) -> Result<StoredTransaction, Error> {
+    db.execute_repeatable(move |conn| {
+        conn.first(move || {
+            transactions::table
+                .inner_join(
+                    tx_digests::table
+                        .on(transactions::tx_sequence_number.eq(tx_digests::tx_sequence_number)),
+                )
+                .filter(tx_digests::tx_digest.eq(digest_bytes.clone()))
+                .select(StoredTransaction::as_select())
+        })
+    })
+    .await
+    .map_err(|e| Error::Internal(format!("Unable to query checkpointed transaction: {e}")))
+}
 
 /// Query optimistic transaction by digest from the database
 async fn query_optimistic_transaction_by_digest(
@@ -120,7 +140,22 @@ impl Mutation {
         let digest_bytes = tx_digest.inner().to_vec();
 
         let db: &Db = ctx.data_unchecked();
-        let optimistic_tx = query_optimistic_transaction_by_digest(db, digest_bytes).await?;
+        let query_optimistic_tx = query_optimistic_transaction_by_digest(db, digest_bytes.clone());
+        let query_checkpointed_tx = query_checkpointed_transaction_by_digest(db, digest_bytes);
+        tokio::pin!(query_optimistic_tx, query_checkpointed_tx);
+
+        let effects: Result<TransactionBlockEffects, _> = tokio::select! {
+                checkpointed_tx = &mut query_checkpointed_tx => match checkpointed_tx {
+                    Ok(checkpointed_tx) => TransactionBlock::try_from(checkpointed_tx)?.try_into(),
+                    _ => query_optimistic_tx.await?.try_into()
+                },
+                optimistic_tx = &mut query_optimistic_tx => {
+                    match optimistic_tx {
+                        Ok(optimistic_tx) => optimistic_tx.try_into(),
+                        _ => TransactionBlock::try_from(query_checkpointed_tx.await?)?.try_into(),
+                    }
+                }
+        };
 
         Ok(ExecutionResult {
             errors: if result.errors.is_empty() {
@@ -128,17 +163,9 @@ impl Mutation {
             } else {
                 Some(result.errors)
             },
-            effects: TransactionBlockEffects {
-                kind: TransactionBlockEffectsKind::try_from(optimistic_tx)
-                    .map_err(|e| {
-                        Error::Internal(format!(
-                            "Unable to create TransactionBlockEffectsKind: {e}"
-                        ))
-                    })
-                    .extend()?,
-                // set to u64::MAX, as the executed transaction has not been indexed yet
-                checkpoint_viewed_at: u64::MAX,
-            },
+            effects: effects
+                .map_err(|_| Error::Internal("Transaction not indexed after execution".into()))
+                .extend()?,
         })
     }
 }

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -610,7 +610,7 @@ impl TryFrom<StoredTransaction> for TransactionBlock {
 
     fn try_from(stored_tx: StoredTransaction) -> Result<Self, Error> {
         let checkpoint_viewed_at = stored_tx.checkpoint_sequence_number as u64;
-        let inner = TransactionBlockInner::try_from(stored_tx.clone())?;
+        let inner = TransactionBlockInner::try_from(stored_tx)?;
 
         Ok(TransactionBlock {
             inner,

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -605,6 +605,20 @@ impl TryFrom<StoredTransaction> for TransactionBlockInner {
     }
 }
 
+impl TryFrom<StoredTransaction> for TransactionBlock {
+    type Error = Error;
+
+    fn try_from(stored_tx: StoredTransaction) -> Result<Self, Error> {
+        let checkpoint_viewed_at = stored_tx.checkpoint_sequence_number as u64;
+        let inner = TransactionBlockInner::try_from(stored_tx.clone())?;
+
+        Ok(TransactionBlock {
+            inner,
+            checkpoint_viewed_at,
+        })
+    }
+}
+
 impl TryFrom<OptimisticTransaction> for TransactionBlockInner {
     type Error = Error;
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -637,12 +637,24 @@ impl TryFrom<OptimisticTransaction> for TransactionBlockEffectsKind {
     }
 }
 
-impl TryFrom<TransactionBlock> for TransactionBlockEffects {
+impl TryFrom<OptimisticTransaction> for TransactionBlockEffects {
+    type Error = Error;
+
+    fn try_from(tx: OptimisticTransaction) -> Result<Self, Error> {
+        // set to u64::MAX, as the executed transaction has not been indexed yet
+        let checkpoint_viewed_at = u64::MAX;
+        Ok(Self {
+            kind: tx.try_into()?,
+            checkpoint_viewed_at,
+        })
+    }
+}
+
+impl TryFrom<TransactionBlock> for TransactionBlockEffectsKind {
     type Error = Error;
 
     fn try_from(block: TransactionBlock) -> Result<Self, Error> {
-        let checkpoint_viewed_at = block.checkpoint_viewed_at;
-        let kind = match block.inner {
+        match block.inner {
             TransactionBlockInner::Checkpointed { stored_tx, .. } => {
                 bcs::from_bytes(&stored_tx.raw_effects)
                     .map(|native| TransactionBlockEffectsKind::Checkpointed {
@@ -666,10 +678,17 @@ impl TryFrom<TransactionBlock> for TransactionBlockEffects {
                 native: effects,
                 events,
             }),
-        }?;
+        }
+    }
+}
 
+impl TryFrom<TransactionBlock> for TransactionBlockEffects {
+    type Error = Error;
+
+    fn try_from(block: TransactionBlock) -> Result<Self, Error> {
+        let checkpoint_viewed_at = block.checkpoint_viewed_at;
         Ok(Self {
-            kind,
+            kind: block.try_into()?,
             checkpoint_viewed_at,
         })
     }


### PR DESCRIPTION
# Description of change

Fixes `mutation.executeTransactionBlock` which could fail while trying to construct the transaction response. The reason being that it was expecting that the transaction would be indexed through the optimistic path, which is not necessarily true.

## How the change has been tested

Describe the tests that you ran to verify your changes.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)

### Release Notes

- [x] GraphQL: Fixes `mutation.executeTransactionBlock` which could fail if the transaction executed was indexed through the checkpoint path.

