### PR TITLE
fix(iota-core, transaction-checks): Avoid gas coins double check 

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -931,7 +931,9 @@ impl AuthorityState {
                     tx_data,
                     is_gas_check_required,
                 )?;
-            //
+
+            // After checking the `MoveAuthenticator` inputs, gas check is not required
+            // in order to avoid gas double-checking.
             is_gas_check_required = false;
             let (kind, signer, _) = tx_data.execution_parts();
 
@@ -2183,7 +2185,7 @@ impl AuthorityState {
     ) -> IotaResult<SimulateTransactionResult> {
         // Cheap validity checks for a transaction, including input size limits.
         transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
-
+        let is_gas_check_required = true;
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 
@@ -2233,7 +2235,7 @@ impl AuthorityState {
                     gas_object,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
-                    true,
+                    is_gas_check_required,
                 )?,
                 Some(gas_object_id),
             )
@@ -2247,7 +2249,7 @@ impl AuthorityState {
                     &receiving_objects,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
-                    true,
+                    is_gas_check_required,
                 )?,
                 None,
             )

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -881,7 +881,7 @@ impl AuthorityState {
     ) -> IotaResult<VerifiedSignedTransaction> {
         // Ensure that validator cannot reconfigure while we are signing the tx
         let _execution_lock = self.execution_lock_for_signing();
-
+        let mut is_gas_check_required = true;
         let protocol_config = epoch_store.protocol_config();
         let reference_gas_price = epoch_store.reference_gas_price();
 
@@ -929,8 +929,10 @@ impl AuthorityState {
                     protocol_config,
                     reference_gas_price,
                     tx_data,
+                    is_gas_check_required,
                 )?;
-
+            //
+            is_gas_check_required = false;
             let (kind, signer, _) = tx_data.execution_parts();
 
             // Execute the Move authenticator.
@@ -960,8 +962,6 @@ impl AuthorityState {
             }
         }
 
-        // TODO: Gas coins should not be double-checked if `GenericSignature` is of type
-        // `MoveAuthenticator`.
         let (_gas_status, tx_checked_input_objects) =
             iota_transaction_checks::check_transaction_input(
                 protocol_config,
@@ -971,6 +971,7 @@ impl AuthorityState {
                 &tx_receiving_objects,
                 &self.metrics.bytecode_verifier_metrics,
                 &self.config.verifier_signing_config,
+                is_gas_check_required,
             )?;
 
         check_coin_deny_list_v1_during_signing(
@@ -1755,6 +1756,7 @@ impl AuthorityState {
     )> {
         let _scope = monitored_scope("Execution::prepare_certificate");
         let _metrics_guard = self.metrics.prepare_certificate_latency.start_timer();
+        let mut is_gas_check_required = true;
         let prepare_certificate_start_time = tokio::time::Instant::now();
 
         let protocol_config = epoch_store.protocol_config();
@@ -1815,7 +1817,12 @@ impl AuthorityState {
                     tx_data,
                     authenticator_input_objects,
                     &tx_input_objects,
+                    is_gas_check_required,
                 )?;
+
+            // After checking the `MoveAuthenticator` inputs, gas check is not required
+            // in order to avoid gas double-checking.
+            is_gas_check_required = false;
 
             // Execute the Move authenticator.
             let validation_result = epoch_store.executor().validate_transaction(
@@ -1852,15 +1859,13 @@ impl AuthorityState {
 
         // The cost of partially re-auditing a transaction before execution is
         // tolerated.
-        //
-        //  TODO: Gas coins should not be double-checked if `GenericSignature` is of
-        // type `MoveAuthenticator`.
         let (tx_gas_status, tx_input_objects) = iota_transaction_checks::check_certificate_input(
             certificate,
             tx_input_objects,
             protocol_config,
             reference_gas_price,
             authenticator_computation_cost,
+            is_gas_check_required,
         )?;
 
         let owned_object_refs = tx_input_objects.inner().filter_owned_objects();
@@ -1983,7 +1988,7 @@ impl AuthorityState {
     )> {
         // Cheap validity checks for a transaction, including input size limits.
         transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
-
+        let is_gas_check_required = true;
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 
@@ -2034,6 +2039,7 @@ impl AuthorityState {
                     gas_object,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
+                    is_gas_check_required,
                 )?,
                 Some(gas_object_id),
             )
@@ -2047,6 +2053,7 @@ impl AuthorityState {
                     &receiving_objects,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
+                    is_gas_check_required,
                 )?,
                 None,
             )
@@ -2226,6 +2233,7 @@ impl AuthorityState {
                     gas_object,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
+                    true,
                 )?,
                 Some(gas_object_id),
             )
@@ -2239,6 +2247,7 @@ impl AuthorityState {
                     &receiving_objects,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
+                    true,
                 )?,
                 None,
             )
@@ -2295,7 +2304,7 @@ impl AuthorityState {
         skip_checks: Option<bool>,
     ) -> IotaResult<DevInspectResults> {
         let epoch_store = self.load_epoch_store_one_call_per_task();
-
+        let is_gas_check_required = true;
         if !self.is_fullnode(&epoch_store) {
             return Err(IotaError::UnsupportedFeature {
                 error: "dev-inspect is only supported on fullnodes".to_string(),
@@ -2414,6 +2423,7 @@ impl AuthorityState {
                     dummy_gas_object,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
+                    is_gas_check_required,
                 )?
             } else {
                 iota_transaction_checks::check_transaction_input(
@@ -2424,6 +2434,7 @@ impl AuthorityState {
                     &receiving_objects,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
+                    is_gas_check_required,
                 )?
             }
         };
@@ -5500,6 +5511,7 @@ impl AuthorityState {
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
         transaction: &TransactionData,
+        is_gas_check_required: bool,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects, AuthenticatorInfoV1)> {
         let digest = transaction.digest();
         let signer = transaction.sender();
@@ -5602,6 +5614,7 @@ impl AuthorityState {
                 transaction.gas_price(),
                 authenticator_input_objects,
                 tx_input_objects,
+                is_gas_check_required,
             )?;
 
         Ok((gas_status, checked_input_objects, authenticator_info))
@@ -5614,6 +5627,7 @@ impl AuthorityState {
         transaction: &TransactionData,
         authenticator_input_objects: InputObjects,
         tx_input_objects: &InputObjects,
+        is_gas_check_required: bool,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         // The `MoveAuthenticator` receiving objects are checked on the signing step.
 
@@ -5630,6 +5644,7 @@ impl AuthorityState {
             transaction.gas_price(),
             authenticator_input_objects,
             tx_input_objects,
+            is_gas_check_required,
         )
     }
 

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -924,6 +924,7 @@ impl LocalExec {
             &protocol_config,
             reference_gas_price,
             authenticator_computation_cost,
+            true,
         )
         .unwrap();
         let (kind, signer, gas) = executable.transaction_data().execution_parts();

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -212,6 +212,7 @@ impl SingleValidator {
             self.epoch_store.protocol_config(),
             self.epoch_store.reference_gas_price(),
             authenticator_computation_cost,
+            true,
         )
         .unwrap();
         let (kind, signer, gas) = executable.transaction_data().execution_parts();

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -54,6 +54,7 @@ mod checked {
         reference_gas_price: u64,
         authenticator_computation_cost: u64,
         transaction: &TransactionData,
+        is_gas_check_required: bool,
     ) -> IotaResult<IotaGasStatus> {
         if transaction.is_system_tx() {
             Ok(IotaGasStatus::new_unmetered())
@@ -75,6 +76,7 @@ mod checked {
                 gas_budget_to_use,
                 gas_spent_for_authentication,
                 transaction.gas_price(),
+                is_gas_check_required,
             )
         }
     }
@@ -88,6 +90,7 @@ mod checked {
         receiving_objects: &ReceivingObjects,
         metrics: &Arc<BytecodeVerifierMetrics>,
         verifier_signing_config: &VerifierSigningConfig,
+        is_gas_check_required: bool,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         // `MoveAuthenticator`computation cost is not used here at the moment.
         let authenticator_computation_cost = 0;
@@ -99,6 +102,7 @@ mod checked {
             transaction,
             &input_objects,
             &[],
+            is_gas_check_required,
         )?;
         check_receiving_objects(&input_objects, receiving_objects)?;
         // Runs verifier, which could be expensive.
@@ -121,6 +125,7 @@ mod checked {
         gas_object: Object,
         metrics: &Arc<BytecodeVerifierMetrics>,
         verifier_signing_config: &VerifierSigningConfig,
+        is_gas_check_required: bool,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         let gas_object_ref = gas_object.compute_object_reference();
         input_objects.push(ObjectReadResult::new_from_gas_object(&gas_object));
@@ -135,6 +140,7 @@ mod checked {
             transaction,
             &input_objects,
             &[gas_object_ref],
+            is_gas_check_required,
         )?;
         check_receiving_objects(&input_objects, &receiving_objects)?;
         // Runs verifier, which could be expensive.
@@ -160,6 +166,7 @@ mod checked {
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
         authenticator_computation_cost: u64,
+        is_gas_check_required: bool,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         let transaction = cert.data().transaction_data();
         let gas_status = check_transaction_input_inner(
@@ -169,6 +176,7 @@ mod checked {
             transaction,
             &input_objects,
             &[],
+            is_gas_check_required,
         )?;
         // NB: We do not check receiving objects when executing. Only at signing time do
         // we check. NB: move verifier is only checked at signing time, not at
@@ -230,6 +238,7 @@ mod checked {
         gas_price: u64,
         authenticator_input_objects: InputObjects,
         tx_input_objects: &InputObjects,
+        is_gas_check_required: bool,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         // To be sure that we can cover the Move authenticator + transaction execution
         // gas cost.
@@ -247,6 +256,7 @@ mod checked {
             gas_budget_to_use,
             gas_spent_for_authentication,
             gas_price,
+            is_gas_check_required,
         )?;
 
         check_move_authenticator_objects(&authenticator_input_objects)?;
@@ -263,6 +273,7 @@ mod checked {
         input_objects: &InputObjects,
         // Overrides the gas objects in the transaction.
         gas_override: &[ObjectRef],
+        is_gas_check_required: bool,
     ) -> IotaResult<IotaGasStatus> {
         // Cheap validity checks that is ok to run multiple times during processing.
         let gas = if gas_override.is_empty() {
@@ -278,6 +289,7 @@ mod checked {
             reference_gas_price,
             authenticator_computation_cost,
             transaction,
+            is_gas_check_required,
         )?;
         check_objects(transaction, input_objects)?;
 
@@ -414,6 +426,7 @@ mod checked {
         gas_budget_to_use: u64,
         gas_spent_for_authentication: u64,
         gas_price: u64,
+        is_gas_check_required: bool,
     ) -> IotaResult<IotaGasStatus> {
         debug_assert!(
             gas_budget_to_use <= gas_budget_to_check,
@@ -428,18 +441,20 @@ mod checked {
             protocol_config,
         )?;
 
-        // Check the balance and coins consistency; Load all the gas coins.
-        let objects: BTreeMap<_, _> = objects.iter().map(|o| (o.id(), o)).collect();
-        let mut gas_objects = vec![];
-        for obj_ref in gas {
-            let obj = objects.get(&obj_ref.0);
-            let obj = *obj.ok_or(UserInputError::ObjectNotFound {
-                object_id: obj_ref.0,
-                version: Some(obj_ref.1),
-            })?;
-            gas_objects.push(obj);
+        if is_gas_check_required {
+            // Check the balance and coins consistency; Load all the gas coins.
+            let objects: BTreeMap<_, _> = objects.iter().map(|o| (o.id(), o)).collect();
+            let mut gas_objects = vec![];
+            for obj_ref in gas {
+                let obj = objects.get(&obj_ref.0);
+                let obj = *obj.ok_or(UserInputError::ObjectNotFound {
+                    object_id: obj_ref.0,
+                    version: Some(obj_ref.1),
+                })?;
+                gas_objects.push(obj);
+            }
+            gas_status.check_gas_balance(&gas_objects, gas_budget_to_check)?;
         }
-        gas_status.check_gas_balance(&gas_objects, gas_budget_to_check)?;
 
         Ok(gas_status)
     }

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -132,7 +132,7 @@ impl EpochState {
             &receiving_objects,
             &self.bytecode_verifier_metrics,
             verifier_signing_config,
-            true
+            true,
         )?;
 
         let transaction_data = transaction.data().transaction_data();

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -132,6 +132,7 @@ impl EpochState {
             &receiving_objects,
             &self.bytecode_verifier_metrics,
             verifier_signing_config,
+            true
         )?;
 
         let transaction_data = transaction.data().transaction_data();


### PR DESCRIPTION

[run-ci]

# Description of change

Avoid double gas checks during signing and execution stages in case of move authentication.

This PR introduces a boolean `is_gas_check_required` flag in the transaction-check flow to avoid double gas validation when a transaction has a `MoveAuthenticator`.

Previously, gas coins were validated twice during transaction signing:
- During `check_move_authenticator_input()` - where gas sufficiency is verified for both the authenticator and transaction execution.
- Again in `check_transaction_input()` or `check_certificate_input()` - performing the same checks a second time.

The main change is located in `iota-transaction-checks/lib.rs/check_gas`:
 
```
if is_gas_check_required {
    // Check the balance and coins consistency; Load all the gas coins.
    let objects: BTreeMap<_, _> = objects.iter().map(|o| (o.id(), o)).collect();
    let mut gas_objects = vec![];
    for obj_ref in gas {
        let obj = objects.get(&obj_ref.0);
        let obj = *obj.ok_or(UserInputError::ObjectNotFound {
            object_id: obj_ref.0,
            version: Some(obj_ref.1),
        })?;
        gas_objects.push(obj);
    }
    gas_status.check_gas_balance(&gas_objects, gas_budget_to_check)?;
}
```
        
## Links to any relevant issues

Fixes #8847 .

## How the change has been tested

Run tests for `iota-core`