### PR TITLE
fix(starfish): prevent resending processed commits during DAG recovery

### DIFF
--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -29,16 +29,16 @@ use tracing::{debug, info, instrument, trace_span, warn};
 
 use crate::{
     authority::{
-        AuthorityMetrics, AuthorityState,
         authority_per_epoch_store::{
             AuthorityPerEpochStore, ConsensusStats, ConsensusStatsAPI, ExecutionIndices,
             ExecutionIndicesWithStats,
-        },
-        backpressure::{BackpressureManager, BackpressureSubscriber},
+        }, backpressure::{BackpressureManager, BackpressureSubscriber},
         epoch_start_configuration::EpochStartConfigTrait,
+        AuthorityMetrics,
+        AuthorityState,
     },
     checkpoints::{CheckpointService, CheckpointServiceNotify},
-    consensus_types::{AuthorityIndex, consensus_output_api::ConsensusOutputAPI},
+    consensus_types::{consensus_output_api::ConsensusOutputAPI, AuthorityIndex},
     execution_cache::{ObjectCacheRead, TransactionCacheRead},
     scoring_decision::update_low_scoring_authorities,
     transaction_manager::TransactionManager,
@@ -208,7 +208,10 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         // TODO: Is this check necessary? For now mysticeti will not
         // return more than one leader per round so we are not in danger of
         // ignoring any commits.
-        assert!(round >= last_committed_round);
+        assert!(
+            round >= last_committed_round,
+            "Consensus output round {round} is less than last committed round {last_committed_round}"
+        );
         if last_committed_round == round {
             // we can receive the same commit twice after restart
             // It is critical that the writes done by this function are atomic - otherwise
@@ -853,7 +856,7 @@ mod tests {
     use futures::pin_mut;
     use iota_protocol_config::{Chain, ConsensusTransactionOrdering};
     use iota_types::{
-        base_types::{AuthorityName, IotaAddress, random_object_ref},
+        base_types::{random_object_ref, AuthorityName, IotaAddress},
         committee::Committee,
         messages_consensus::{
             AuthorityCapabilitiesV1, ConsensusTransaction, ConsensusTransactionKind,

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -29,16 +29,16 @@ use tracing::{debug, info, instrument, trace_span, warn};
 
 use crate::{
     authority::{
+        AuthorityMetrics, AuthorityState,
         authority_per_epoch_store::{
             AuthorityPerEpochStore, ConsensusStats, ConsensusStatsAPI, ExecutionIndices,
             ExecutionIndicesWithStats,
-        }, backpressure::{BackpressureManager, BackpressureSubscriber},
+        },
+        backpressure::{BackpressureManager, BackpressureSubscriber},
         epoch_start_configuration::EpochStartConfigTrait,
-        AuthorityMetrics,
-        AuthorityState,
     },
     checkpoints::{CheckpointService, CheckpointServiceNotify},
-    consensus_types::{consensus_output_api::ConsensusOutputAPI, AuthorityIndex},
+    consensus_types::{AuthorityIndex, consensus_output_api::ConsensusOutputAPI},
     execution_cache::{ObjectCacheRead, TransactionCacheRead},
     scoring_decision::update_low_scoring_authorities,
     transaction_manager::TransactionManager,
@@ -856,7 +856,7 @@ mod tests {
     use futures::pin_mut;
     use iota_protocol_config::{Chain, ConsensusTransactionOrdering};
     use iota_types::{
-        base_types::{random_object_ref, AuthorityName, IotaAddress},
+        base_types::{AuthorityName, IotaAddress, random_object_ref},
         committee::Committee,
         messages_consensus::{
             AuthorityCapabilitiesV1, ConsensusTransaction, ConsensusTransactionKind,

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -57,6 +57,9 @@ pub(crate) struct CommitObserver {
     dag_state: Arc<RwLock<DagState>>,
 
     leader_schedule: Arc<LeaderSchedule>,
+    /// Tracks the last commit index sent through the channel.
+    /// Used to prevent resending already sent commits.
+    last_sent_commit_index: CommitIndex,
 }
 
 impl CommitObserver {
@@ -67,6 +70,7 @@ impl CommitObserver {
         store: Arc<dyn Store>,
         leader_schedule: Arc<LeaderSchedule>,
     ) -> Self {
+        let last_processed_commit_index = commit_consumer.last_processed_commit_index;
         let mut observer = Self {
             commit_interpreter: Linearizer::new(
                 context.clone(),
@@ -79,9 +83,10 @@ impl CommitObserver {
             store,
             dag_state,
             leader_schedule,
+            last_sent_commit_index: last_processed_commit_index,
         };
 
-        observer.recover_and_send_commits(commit_consumer.last_processed_commit_index);
+        observer.recover_and_send_commits(last_processed_commit_index);
         observer
     }
 
@@ -118,17 +123,34 @@ impl CommitObserver {
         let (solid_sub_dags, missing_transactions) =
             self.commit_solidifier.try_commit(&pending_sub_dags);
 
-        tracing::trace!("Missing committed data {missing_transactions:#?}");
+        tracing::trace!("Missing committed transactions {missing_transactions:#?}");
 
-        // Retrieve the transaction acknowledgment authors for the missing transactions.
-        // This will be used by the transactions synchronizer to fetch the missing
-        // transactions from the authorities that acknowledged them.
+        // Retrieve the transaction acknowledgment authors for the missing
+        // transactions. This will be used by the transaction synchronizer to
+        // fetch the missing transactions from the authorities that acknowledged
+        // them.
         let missing_transaction_acknowledgers = self
             .commit_interpreter
             .get_transaction_ack_authors(missing_transactions);
 
         let mut sent_sub_dags = Vec::with_capacity(solid_sub_dags.len());
         for solid_sub_dag in solid_sub_dags.iter() {
+            // Skip commits that have already been sent
+            if solid_sub_dag.commit_ref.index <= self.last_sent_commit_index {
+                debug!(
+                    "Skipping already sent commit (index: {} <= last sent: {})",
+                    solid_sub_dag.commit_ref.index, self.last_sent_commit_index
+                );
+                continue;
+            }
+
+            // Ensure commits are sent in order - if we're skipping indices, something is
+            // wrong
+            assert_eq!(
+                solid_sub_dag.commit_ref.index,
+                self.last_sent_commit_index + 1,
+            );
+
             // Failures in sender.send() are assumed to be permanent
             if let Err(err) = self.sender.send(solid_sub_dag.clone()) {
                 tracing::error!(
@@ -136,11 +158,12 @@ impl CommitObserver {
                 );
                 return Err(ConsensusError::Shutdown);
             }
-            tracing::debug!(
-                "Sending to execution commit {} leader {}",
-                solid_sub_dag.commit_ref,
-                solid_sub_dag.leader
+            info!(
+                "Sending commit to execution (index: {}, leader {})",
+                solid_sub_dag.commit_ref, solid_sub_dag.leader
             );
+
+            self.last_sent_commit_index = solid_sub_dag.commit_ref.index;
             sent_sub_dags.push(solid_sub_dag);
         }
         self.report_metrics(&pending_sub_dags, &solid_sub_dags);
@@ -169,7 +192,7 @@ impl CommitObserver {
             .expect("Reading the last commit should not fail");
 
         // Value used to recover transactions_ack_tracker in the linearizer.
-        let mut recovery_lower_bound = last_processed_commit_index + 1;
+        let mut recovery_lower_bound: CommitIndex = last_processed_commit_index + 1;
         if let Some(last_commit) = &last_commit {
             let last_commit_index = last_commit.index();
 
@@ -185,12 +208,6 @@ impl CommitObserver {
                 .min(commit_index_to_recover_acks)
                 .max(1);
             assert!(last_commit_index >= last_processed_commit_index);
-            if last_commit_index == last_processed_commit_index {
-                debug!(
-                    "Nothing to recover for commit observer as commit index {last_commit_index} = \
-                    {last_processed_commit_index} last processed index"
-                );
-            }
         };
 
         // Retrieve all the commits from the recover lower bound until the end.
@@ -200,7 +217,7 @@ impl CommitObserver {
             .expect("Scanning commits should not fail");
 
         info!(
-            "Recovering commit observer after last processed index {last_processed_commit_index} and \
+            "Recovering commit observer state after last processed index {last_processed_commit_index} and \
             recovery lower bound {recovery_lower_bound} with last commit {} and {} recovery commits",
             last_commit.map(|c| c.index()).unwrap_or_default(),
             recovery_commits.len()
@@ -210,12 +227,11 @@ impl CommitObserver {
         // commits and resend all the committed sub-dags to the consensus output channel
         // for all the commits above the last processed index.
         let mut next_commit_index_to_recover = recovery_lower_bound;
-        let mut last_sent_commit_index = last_processed_commit_index;
         let num_recovery_commits = recovery_commits.len();
 
         for (index, commit) in recovery_commits.into_iter().enumerate() {
             let commit_index = commit.index();
-            // Commit index must be continuous during recovert.
+            // Commit index must be continuous during recovery.
             assert_eq!(commit_index, next_commit_index_to_recover);
             if index == 0 {
                 self.commit_solidifier
@@ -253,14 +269,17 @@ impl CommitObserver {
             }
             // Put all the pending sub-dags into the commit solidifier to make sure that
             // they are tracked there. The commit will be sent to IOTA here if all the
-            // transactions are available, or will be kept in the buffer and sent later when
+            // transactions are available or will be kept in the buffer and sent later when
             // the transactions become available.
             let (solid_sub_dags, _missing) = self.commit_solidifier.try_commit(&[pending_sub_dag]);
             // Only submit unprocessed commits to IOTA
             for solid_sub_dag in solid_sub_dags {
                 if solid_sub_dag.commit_ref.index > last_processed_commit_index {
                     // Commit index must be continuous during recovery.
-                    assert_eq!(solid_sub_dag.commit_ref.index, last_sent_commit_index + 1);
+                    assert_eq!(
+                        solid_sub_dag.commit_ref.index,
+                        self.last_sent_commit_index + 1
+                    );
                     info!(
                         "Sending solid commit {} during recovery",
                         solid_sub_dag.commit_ref.index
@@ -271,7 +290,13 @@ impl CommitObserver {
                         )
                     });
 
-                    last_sent_commit_index += 1;
+                    self.last_sent_commit_index += 1;
+                } else {
+                    debug!(
+                        "Not sending solid commit as commit index {} <= \
+                    {last_processed_commit_index} last processed index",
+                        solid_sub_dag.commit_ref.index
+                    );
                 }
             }
 
@@ -305,7 +330,7 @@ impl CommitObserver {
         // First report block_header-related metrics for pending subdags
         for commit in pending_sub_dags {
             debug!(
-                "Consensus pending subdag {} with leader {} has {} blocks",
+                "Pending subdag {} with leader {} has {} blocks",
                 commit.commit_ref,
                 commit.leader,
                 commit.blocks.len()
@@ -339,8 +364,8 @@ impl CommitObserver {
 
         // Now report transaction-related metrics for committed subdags
         for commit in committed_sub_dags {
-            info!(
-                "Consensus available subdag {} with leader {} has transactions from {} blocks",
+            debug!(
+                "Committed subdag {} with leader {} has transactions from {} blocks",
                 commit.commit_ref,
                 commit.leader,
                 commit.transactions.len()
@@ -442,7 +467,7 @@ mod tests {
         // Check commits are returned by CommitObserver::handle_commit is accurate
         let mut expected_stored_refs: Vec<BlockRef> = vec![];
         for (idx, subdag) in commits.iter().enumerate() {
-            tracing::info!("{subdag:?}");
+            info!("{subdag:?}");
             assert_eq!(subdag.leader, leaders[idx].reference());
             let expected_ts = if idx == 0 {
                 leaders[idx].timestamp_ms()
@@ -538,7 +563,7 @@ mod tests {
             .map(Option::unwrap)
             .collect::<Vec<_>>();
 
-        // Commit first batch of leaders (2) and "receive" the subdags as the
+        // Commit the first batch of leaders (2) and "receive" the subdags as the
         // consumer of the consensus output channel.
         let expected_last_processed_index: usize = 2;
         let (mut created_commits, _missing_transactions_refs) = observer
@@ -554,7 +579,7 @@ mod tests {
         // Check commits sent over consensus output channel is accurate
         let mut processed_subdag_index = 0;
         while let Ok(subdag) = receiver.try_recv() {
-            tracing::info!("Processed subdag with index {}", subdag.commit_ref.index);
+            info!("Processed subdag with index {}", subdag.commit_ref.index);
             assert_eq!(subdag.base, created_commits[processed_subdag_index].base);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
             processed_subdag_index = subdag.commit_ref.index as usize;
@@ -591,7 +616,7 @@ mod tests {
 
         let expected_last_sent_index = num_rounds as usize;
         while let Ok(subdag) = receiver.try_recv() {
-            tracing::info!("{subdag} was sent but not processed by consumer");
+            info!("{subdag} was sent but not processed by consumer");
             assert_eq!(subdag.base, created_commits[processed_subdag_index].base);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
             processed_subdag_index = subdag.commit_ref.index as usize;
@@ -623,7 +648,7 @@ mod tests {
         // from last processed index of 2 and finishing at last sent index of 3.
         processed_subdag_index = expected_last_processed_index;
         while let Ok(subdag) = receiver.try_recv() {
-            tracing::info!("Processed {subdag} on resubmission");
+            info!("Processed {subdag} on resubmission");
             assert_eq!(subdag.base, created_commits[processed_subdag_index].base);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
             processed_subdag_index = subdag.commit_ref.index as usize;
@@ -685,7 +710,7 @@ mod tests {
         // Check commits sent over consensus output channel is accurate
         let mut processed_subdag_index = 0;
         while let Ok(subdag) = receiver.try_recv() {
-            tracing::info!("Processed subdag with index {}", subdag.commit_ref.index);
+            info!("Processed subdag with index {}", subdag.commit_ref.index);
             assert_eq!(subdag.base, created_commits[processed_subdag_index].base);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
             processed_subdag_index = subdag.commit_ref.index as usize;

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -246,7 +246,7 @@ impl Core {
 
         info!(
             "Core recovery completed with last proposed block {:?}",
-            last_proposed_block
+            last_proposed_block.map(|b| b.verified_block_header)
         );
 
         self

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -398,8 +398,7 @@ impl DagState {
             .max()
             .expect("There should be at least one last committed round");
         debug!(
-            "Last solid commit has leader at round {}; last pending commit has leader at round {}",
-            last_solid_commit_leader_round, max_commit_round
+            "Last solid commit has leader at round {last_solid_commit_leader_round}; last commit has leader at round {max_commit_round}",
         );
         self.last_solid_commit_leader_round = Some(last_solid_commit_leader_round);
         let gap = (*max_commit_round).saturating_sub(last_solid_commit_leader_round);

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -9,7 +9,7 @@ use std::{
 use parking_lot::RwLock;
 use tracing::debug;
 
-use crate::{BlockRef, CommittedSubDag, commit::PendingSubDag, dag_state::DagState};
+use crate::{BlockRef, CommitIndex, CommittedSubDag, commit::PendingSubDag, dag_state::DagState};
 
 /// The `DataManager` is responsible for managing and handling
 /// the commit process for newly committed sub-dags. It ensures that sub-dags
@@ -32,7 +32,7 @@ pub(crate) struct DataManager {
     // Buffer for pending subdags, keyed by commit_ref.index for order
     pending_subdags: BTreeMap<u32, PendingSubDag>,
     // The highest committed commit_ref.index
-    last_committed_index: u32,
+    last_committed_index: CommitIndex,
 }
 
 impl DataManager {
@@ -54,7 +54,7 @@ impl DataManager {
         }
     }
 
-    pub(crate) fn set_last_committed_index(&mut self, index: u32) {
+    pub(crate) fn set_last_committed_index(&mut self, index: CommitIndex) {
         self.last_committed_index = index;
     }
 


### PR DESCRIPTION
# Description of change

This PR fixes a bug that caused Starfish `simtests` to fail during nightly runs. The issue was related to resending already processed commits during DAG recovery when some commits become unsolid because not all transactions have been flushed before the node restart. The changes improve the commit observer to ensure proper state management and prevent sending commits with indices that have been processed by the node before.

## Links to any relevant issues

Fixes #8844 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes