### PR TITLE
fix(iota-core, transaction-checks): Harmonize check_transaction_input and check_transaction_input_with_given_gas 

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -976,8 +976,8 @@ impl AuthorityState {
                 &tx_receiving_objects,
                 &self.metrics.bytecode_verifier_metrics,
                 &self.config.verifier_signing_config,
-                is_gas_check_required,
                 authenticator_computation_cost,
+                is_gas_check_required,
             )?;
 
         check_coin_deny_list_v1_during_signing(

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -884,6 +884,7 @@ impl AuthorityState {
         let mut is_gas_check_required = true;
         let protocol_config = epoch_store.protocol_config();
         let reference_gas_price = epoch_store.reference_gas_price();
+        let mut authenticator_computation_cost = 0;
 
         let epoch = epoch_store.epoch();
 
@@ -956,12 +957,14 @@ impl AuthorityState {
                 tx_digest.to_owned(),
                 &mut None,
             );
-
-            if let Err(validation_error) = validation_result {
-                return Err(IotaError::MoveAuthenticatorExecutionFailure {
-                    error: validation_error.to_string(),
-                });
-            }
+            match validation_result {
+                Ok(gas_cost) => authenticator_computation_cost = gas_cost,
+                Err(validation_error) => {
+                    return Err(IotaError::MoveAuthenticatorExecutionFailure {
+                        error: validation_error.to_string(),
+                    });
+                }
+            };
         }
 
         let (_gas_status, tx_checked_input_objects) =
@@ -974,6 +977,7 @@ impl AuthorityState {
                 &self.metrics.bytecode_verifier_metrics,
                 &self.config.verifier_signing_config,
                 is_gas_check_required,
+                authenticator_computation_cost,
             )?;
 
         check_coin_deny_list_v1_during_signing(
@@ -1991,6 +1995,7 @@ impl AuthorityState {
         // Cheap validity checks for a transaction, including input size limits.
         transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
         let is_gas_check_required = true;
+        let authenticator_computation_cost = 0;
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 
@@ -2042,6 +2047,7 @@ impl AuthorityState {
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
                     is_gas_check_required,
+                    authenticator_computation_cost,
                 )?,
                 Some(gas_object_id),
             )
@@ -2056,6 +2062,7 @@ impl AuthorityState {
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
                     is_gas_check_required,
+                    authenticator_computation_cost,
                 )?,
                 None,
             )
@@ -2186,6 +2193,7 @@ impl AuthorityState {
         // Cheap validity checks for a transaction, including input size limits.
         transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
         let is_gas_check_required = true;
+        let authenticator_computation_cost = 0;
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 
@@ -2236,6 +2244,7 @@ impl AuthorityState {
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
                     is_gas_check_required,
+                    authenticator_computation_cost,
                 )?,
                 Some(gas_object_id),
             )
@@ -2250,6 +2259,7 @@ impl AuthorityState {
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
                     is_gas_check_required,
+                    authenticator_computation_cost,
                 )?,
                 None,
             )
@@ -2307,6 +2317,7 @@ impl AuthorityState {
     ) -> IotaResult<DevInspectResults> {
         let epoch_store = self.load_epoch_store_one_call_per_task();
         let is_gas_check_required = true;
+        let authenticator_computation_cost = 0;
         if !self.is_fullnode(&epoch_store) {
             return Err(IotaError::UnsupportedFeature {
                 error: "dev-inspect is only supported on fullnodes".to_string(),
@@ -2426,6 +2437,7 @@ impl AuthorityState {
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
                     is_gas_check_required,
+                    authenticator_computation_cost,
                 )?
             } else {
                 iota_transaction_checks::check_transaction_input(
@@ -2437,6 +2449,7 @@ impl AuthorityState {
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
                     is_gas_check_required,
+                    authenticator_computation_cost,
                 )?
             }
         };

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2046,8 +2046,8 @@ impl AuthorityState {
                     gas_object,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
-                    is_gas_check_required,
                     authenticator_computation_cost,
+                    is_gas_check_required,
                 )?,
                 Some(gas_object_id),
             )
@@ -2061,8 +2061,8 @@ impl AuthorityState {
                     &receiving_objects,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
-                    is_gas_check_required,
                     authenticator_computation_cost,
+                    is_gas_check_required,
                 )?,
                 None,
             )
@@ -2243,8 +2243,8 @@ impl AuthorityState {
                     gas_object,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
-                    is_gas_check_required,
                     authenticator_computation_cost,
+                    is_gas_check_required,
                 )?,
                 Some(gas_object_id),
             )
@@ -2258,8 +2258,8 @@ impl AuthorityState {
                     &receiving_objects,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
-                    is_gas_check_required,
                     authenticator_computation_cost,
+                    is_gas_check_required,
                 )?,
                 None,
             )
@@ -2436,8 +2436,8 @@ impl AuthorityState {
                     dummy_gas_object,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
-                    is_gas_check_required,
                     authenticator_computation_cost,
+                    is_gas_check_required,
                 )?
             } else {
                 iota_transaction_checks::check_transaction_input(
@@ -2448,8 +2448,8 @@ impl AuthorityState {
                     &receiving_objects,
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
-                    is_gas_check_required,
                     authenticator_computation_cost,
+                    is_gas_check_required,
                 )?
             }
         };

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -90,8 +90,8 @@ mod checked {
         receiving_objects: &ReceivingObjects,
         metrics: &Arc<BytecodeVerifierMetrics>,
         verifier_signing_config: &VerifierSigningConfig,
-        is_gas_check_required: bool,
         authenticator_computation_cost: u64,
+        is_gas_check_required: bool,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         let gas_status = check_transaction_input_inner(
             protocol_config,
@@ -123,8 +123,8 @@ mod checked {
         gas_object: Object,
         metrics: &Arc<BytecodeVerifierMetrics>,
         verifier_signing_config: &VerifierSigningConfig,
-        is_gas_check_required: bool,
         authenticator_computation_cost: u64,
+        is_gas_check_required: bool,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         let gas_object_ref = gas_object.compute_object_reference();
         input_objects.push(ObjectReadResult::new_from_gas_object(&gas_object));

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -91,10 +91,8 @@ mod checked {
         metrics: &Arc<BytecodeVerifierMetrics>,
         verifier_signing_config: &VerifierSigningConfig,
         is_gas_check_required: bool,
+        authenticator_computation_cost: u64,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
-        // `MoveAuthenticator`computation cost is not used here at the moment.
-        let authenticator_computation_cost = 0;
-
         let gas_status = check_transaction_input_inner(
             protocol_config,
             reference_gas_price,
@@ -126,12 +124,10 @@ mod checked {
         metrics: &Arc<BytecodeVerifierMetrics>,
         verifier_signing_config: &VerifierSigningConfig,
         is_gas_check_required: bool,
+        authenticator_computation_cost: u64,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         let gas_object_ref = gas_object.compute_object_reference();
         input_objects.push(ObjectReadResult::new_from_gas_object(&gas_object));
-
-        // `MoveAuthenticator`computation cost is not used here at the moment.
-        let authenticator_computation_cost = 0;
 
         let gas_status = check_transaction_input_inner(
             protocol_config,

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -132,8 +132,8 @@ impl EpochState {
             &receiving_objects,
             &self.bytecode_verifier_metrics,
             verifier_signing_config,
-            true,
             0, // authenticator_computation_cost as we don't charge for it without authenticator
+            true,
         )?;
 
         let transaction_data = transaction.data().transaction_data();

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -133,6 +133,7 @@ impl EpochState {
             &self.bytecode_verifier_metrics,
             verifier_signing_config,
             true,
+            0, // authenticator_computation_cost as we don't charge for it without authenticator
         )?;
 
         let transaction_data = transaction.data().transaction_data();


### PR DESCRIPTION
[run-ci]

# Description of change

This PR introduces an explicit `authenticator_computation_cost` parameter in `check_transaction_input` and `check_transaction_input_with_given_gas` functions to represent the gas cost computation by the execution of a `MoveAuthenticator` validation.
Previously, comments in the code indicated that “MoveAuthenticator computation cost is not used here at the moment”. This PR resolves that limitation by properly propagating and using the authenticator gas computation cost value.

## Links to any relevant issues

Fixes #8848 .

## How the change has been tested

Run tests for iota-core