### PR TITLE
upstream(iota): fix `iota move build --dump-bytecode-as-base64` to correctly take into account Move.lock addresses (#8931)

### DIFF
--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -53,6 +53,7 @@ use iota_types::{
     crypto::{IotaKeyPair, SignatureScheme},
 };
 use move_analyzer::analyzer;
+use move_core_types::account_address::AccountAddress;
 use move_package::BuildConfig;
 use rand::rngs::OsRng;
 use serde_json::json;
@@ -549,16 +550,38 @@ impl IotaCommand {
                         let rerooted_path = move_cli::base::reroot_path(package_path.as_deref())?;
                         let mut build_config =
                             resolve_lock_file_path(build_config, Some(&rerooted_path))?;
+
+                        let previous_id = if let Some(ref chain_id) = chain_id {
+                            iota_package_management::set_package_id(
+                                &rerooted_path,
+                                build_config.install_dir.clone(),
+                                chain_id,
+                                AccountAddress::ZERO,
+                            )?
+                        } else {
+                            None
+                        };
+
                         let protocol_config = read_api.get_protocol_config(None).await?;
                         build_config.implicit_dependencies =
                             implicit_deps_for_protocol_version(protocol_config.protocol_version)?;
                         let mut pkg = IotaBuildConfig {
-                            config: build_config,
+                            config: build_config.clone(),
                             run_bytecode_verifier: true,
                             print_diags_to_stderr: true,
-                            chain_id,
+                            chain_id: chain_id.clone(),
                         }
                         .build(&rerooted_path)?;
+
+                        // Restore original ID, then check result.
+                        if let (Some(chain_id), Some(previous_id)) = (chain_id, previous_id) {
+                            let _ = iota_package_management::set_package_id(
+                                &rerooted_path,
+                                build_config.install_dir.clone(),
+                                &chain_id,
+                                previous_id,
+                            )?;
+                        }
 
                         let with_unpublished_deps = build.with_unpublished_dependencies;
 


### PR DESCRIPTION
# Description of change

This PR fixes a bug where `iota move build --dump-bytecode-as-base64` uses a published address in the resolved table for the root package being built instead of 0x0, leading to inconsistencies when this interacts with automated feature management.

## Links to any relevant issues

Based on https://github.com/MystenLabs/sui/pull/22528
Cherry-picked from https://github.com/iotaledger/iota/pull/8931

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: `iota move build --dump-bytecode-as-base64` is now working correctly due to a bug in the logic when a Move.lock file existed with the published address.
- [ ] Rust SDK:
- [ ] REST API:
