### PR TITLE
fix(iota-core): refine capability notification early exit condition

### DIFF
--- a/crates/iota-core/src/authority_aggregator.rs
+++ b/crates/iota-core/src/authority_aggregator.rs
@@ -12,12 +12,12 @@ use std::{
     time::Duration,
 };
 
-use futures::{StreamExt, future::BoxFuture, stream::FuturesUnordered};
-use iota_authority_aggregation::{AsyncResult, ReduceOutput, quorum_map_then_reduce_with_timeout};
+use futures::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
+use iota_authority_aggregation::{quorum_map_then_reduce_with_timeout, AsyncResult, ReduceOutput};
 use iota_config::genesis::Genesis;
-use iota_metrics::{GaugeGuard, MonitorCancellation, monitored_future, spawn_monitored_task};
+use iota_metrics::{monitored_future, spawn_monitored_task, GaugeGuard, MonitorCancellation};
 use iota_network::{
-    DEFAULT_CONNECT_TIMEOUT_SEC, DEFAULT_REQUEST_TIMEOUT_SEC, default_iota_network_config,
+    default_iota_network_config, DEFAULT_CONNECT_TIMEOUT_SEC, DEFAULT_REQUEST_TIMEOUT_SEC,
 };
 use iota_network_stack::config::Config;
 use iota_swarm_config::network_config::NetworkConfig;
@@ -32,8 +32,8 @@ use iota_types::{
     error::{IotaError, IotaResult, UserInputError},
     fp_ensure,
     iota_system_state::{
-        IotaSystemState, IotaSystemStateTrait,
-        epoch_start_iota_system_state::{EpochStartSystemState, EpochStartSystemStateTrait},
+        epoch_start_iota_system_state::{EpochStartSystemState, EpochStartSystemStateTrait}, IotaSystemState,
+        IotaSystemStateTrait,
     },
     message_envelope::Message,
     messages_grpc::{
@@ -47,18 +47,18 @@ use iota_types::{
     transaction::*,
 };
 use prometheus::{
-    Histogram, IntCounter, IntCounterVec, IntGauge, Registry, register_histogram_with_registry,
-    register_int_counter_vec_with_registry, register_int_counter_with_registry,
-    register_int_gauge_with_registry,
+    register_histogram_with_registry, register_int_counter_vec_with_registry, register_int_counter_with_registry, register_int_gauge_with_registry, Histogram, IntCounter,
+    IntCounterVec, IntGauge,
+    Registry,
 };
 use thiserror::Error;
 use tokio::time::{sleep, timeout};
-use tracing::{Instrument, debug, error, info, instrument, trace, trace_span, warn};
+use tracing::{debug, error, info, instrument, trace, trace_span, warn, Instrument};
 
 use crate::{
     authority_client::{
-        AuthorityAPI, NetworkAuthorityClient, make_authority_clients_with_timeout_config,
-        make_network_authority_clients_with_network_config,
+        make_authority_clients_with_timeout_config, make_network_authority_clients_with_network_config, AuthorityAPI,
+        NetworkAuthorityClient,
     },
     epoch::committee_store::CommitteeStore,
     safe_client::{SafeClient, SafeClientMetrics, SafeClientMetricsBase},
@@ -1946,7 +1946,7 @@ where
                             Self::record_rpc_error_maybe(self.metrics.clone(), &display_name, &err);
 
                             let (retryable, _categorized) = err.is_retryable();
-                            if  retryable { // TODO: make sure how timeouts are handled
+                            if  retryable {
                                 // Other retryable errors (timeouts, etc.)
                                 state.retryable_errors += weight;
                             } else {
@@ -1955,8 +1955,8 @@ where
                             }
                             state.errors.push((err, vec![name], weight));
 
-                            // Check if we have reached 2f+1 total errors (cannot reach validity threshold)
-                            if state.non_retryable_errors + state.retryable_errors >= quorum_threshold {
+                            // Check if we have reached 2f+1 non-retryable errors OR we have reached 2f+1 total errors, and there is still a chance to reach the validity threshold with retryable errors and good responses.
+                            if state.non_retryable_errors >= quorum_threshold || (state.non_retryable_errors + state.retryable_errors  >= quorum_threshold && state.good_responses + state.retryable_errors >= validity_threshold) {
                                 return ReduceOutput::Failed(state);
                             }
                         }
@@ -1990,6 +1990,10 @@ where
                 let grouped_errors = group_errors(state.errors);
 
                 // Determine an error type based on which condition was met
+                println!(
+                    "non_retryable_errors: {}, retryable_errors: {}, quorum_threshold: {}",
+                    state.non_retryable_errors, state.retryable_errors, quorum_threshold
+                );
                 if state.non_retryable_errors >= quorum_threshold {
                     Err(
                         AggregatorSendCapabilityNotificationError::NonRetryableNotification {

--- a/crates/iota-core/src/authority_aggregator.rs
+++ b/crates/iota-core/src/authority_aggregator.rs
@@ -12,12 +12,12 @@ use std::{
     time::Duration,
 };
 
-use futures::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
-use iota_authority_aggregation::{quorum_map_then_reduce_with_timeout, AsyncResult, ReduceOutput};
+use futures::{StreamExt, future::BoxFuture, stream::FuturesUnordered};
+use iota_authority_aggregation::{AsyncResult, ReduceOutput, quorum_map_then_reduce_with_timeout};
 use iota_config::genesis::Genesis;
-use iota_metrics::{monitored_future, spawn_monitored_task, GaugeGuard, MonitorCancellation};
+use iota_metrics::{GaugeGuard, MonitorCancellation, monitored_future, spawn_monitored_task};
 use iota_network::{
-    default_iota_network_config, DEFAULT_CONNECT_TIMEOUT_SEC, DEFAULT_REQUEST_TIMEOUT_SEC,
+    DEFAULT_CONNECT_TIMEOUT_SEC, DEFAULT_REQUEST_TIMEOUT_SEC, default_iota_network_config,
 };
 use iota_network_stack::config::Config;
 use iota_swarm_config::network_config::NetworkConfig;
@@ -32,8 +32,8 @@ use iota_types::{
     error::{IotaError, IotaResult, UserInputError},
     fp_ensure,
     iota_system_state::{
-        epoch_start_iota_system_state::{EpochStartSystemState, EpochStartSystemStateTrait}, IotaSystemState,
-        IotaSystemStateTrait,
+        IotaSystemState, IotaSystemStateTrait,
+        epoch_start_iota_system_state::{EpochStartSystemState, EpochStartSystemStateTrait},
     },
     message_envelope::Message,
     messages_grpc::{
@@ -47,18 +47,18 @@ use iota_types::{
     transaction::*,
 };
 use prometheus::{
-    register_histogram_with_registry, register_int_counter_vec_with_registry, register_int_counter_with_registry, register_int_gauge_with_registry, Histogram, IntCounter,
-    IntCounterVec, IntGauge,
-    Registry,
+    Histogram, IntCounter, IntCounterVec, IntGauge, Registry, register_histogram_with_registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+    register_int_gauge_with_registry,
 };
 use thiserror::Error;
 use tokio::time::{sleep, timeout};
-use tracing::{debug, error, info, instrument, trace, trace_span, warn, Instrument};
+use tracing::{Instrument, debug, error, info, instrument, trace, trace_span, warn};
 
 use crate::{
     authority_client::{
-        make_authority_clients_with_timeout_config, make_network_authority_clients_with_network_config, AuthorityAPI,
-        NetworkAuthorityClient,
+        AuthorityAPI, NetworkAuthorityClient, make_authority_clients_with_timeout_config,
+        make_network_authority_clients_with_network_config,
     },
     epoch::committee_store::CommitteeStore,
     safe_client::{SafeClient, SafeClientMetrics, SafeClientMetricsBase},

--- a/crates/iota-core/src/authority_aggregator.rs
+++ b/crates/iota-core/src/authority_aggregator.rs
@@ -1990,10 +1990,6 @@ where
                 let grouped_errors = group_errors(state.errors);
 
                 // Determine an error type based on which condition was met
-                println!(
-                    "non_retryable_errors: {}, retryable_errors: {}, quorum_threshold: {}",
-                    state.non_retryable_errors, state.retryable_errors, quorum_threshold
-                );
                 if state.non_retryable_errors >= quorum_threshold {
                     Err(
                         AggregatorSendCapabilityNotificationError::NonRetryableNotification {

--- a/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
@@ -3027,3 +3027,43 @@ async fn test_send_capability_notification_5_retryable_5_non_retryable_errors() 
     assert_eq!(agg.metrics.capability_notification_success.get(), 0);
     assert_eq!(agg.metrics.capability_notification_errors.get(), 1);
 }
+
+#[tokio::test]
+async fn test_send_capability_notification_3_success_7_non_retryable() {
+    // Test Case: Boundary scenario - 3 success, 7 non-retryable, 0 retryable
+    // 3 success (3000 weight) < validity threshold (3334)
+    // 7 non-retryable (7000 weight) >= quorum threshold (6667)
+    // Should fail with NonRetryableNotification since non-retryable errors alone
+    // meet the quorum threshold, and we cannot reach the validity threshold
+    let config = CapabilityNotificationConfig {
+        success_count: 3,
+        non_retryable_errors: CapabilityNotificationErrorType::create_non_retryable_errors(7),
+        retryable_errors: vec![],
+        timeout_delay_ms: None,
+    };
+
+    let (authorities, clients) =
+        create_capability_notification_mock_clients_with_errors(10, config);
+    let agg = get_genesis_agg(authorities, clients);
+    let request = create_test_capability_notification_request();
+
+    let result = agg.send_capability_notification_to_quorum(request).await;
+    assert!(
+        result.is_err(),
+        "Capability notification should fail when non-retryable errors meet quorum threshold"
+    );
+
+    // Should be non-retryable since non-retryable errors alone meet quorum
+    // threshold
+    match result.unwrap_err() {
+        AggregatorSendCapabilityNotificationError::NonRetryableNotification { .. } => {
+            // Expected - non-retryable errors meet quorum threshold, so we
+            // cannot reach validity threshold even if we retry
+        }
+        other => panic!("Expected NonRetryableNotification, got: {other:?}"),
+    }
+
+    // Verify metrics
+    assert_eq!(agg.metrics.capability_notification_success.get(), 0);
+    assert_eq!(agg.metrics.capability_notification_errors.get(), 1);
+}

--- a/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
@@ -2950,7 +2950,7 @@ async fn test_send_capability_notification_2_success_7_non_retryable_1_retryable
     // Test Case 4: Mixed scenario - 2 success, 7 non-retryable, 1 retryable
     // 2 success responses (below f+1 validity threshold of 3,334)
     // 7 non-retryable errors + 1 retryable error
-    // Should fail with RetryableNotification since there's a retryable error
+    // Should fail with NonRetryableNotification since the sum of retryable errors and success weights is below f+1 (3,334)
 
     let config = CapabilityNotificationConfig {
         success_count: 2,
@@ -2975,11 +2975,11 @@ async fn test_send_capability_notification_2_success_7_non_retryable_1_retryable
     // Assert specific error type - should be retryable since there's at least one
     // retryable error
     match result.unwrap_err() {
-        AggregatorSendCapabilityNotificationError::RetryableNotification { .. } => {
+        AggregatorSendCapabilityNotificationError::NonRetryableNotification { .. } => {
             // Expected retryable error type when there are retryable errors
             // present
         }
-        other => panic!("Expected RetryableNotification, got: {other:?}"),
+        other => panic!("Expected NonRetryableNotification, got: {other:?}"),
     }
 
     // Verify metrics

--- a/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
@@ -2950,7 +2950,8 @@ async fn test_send_capability_notification_2_success_7_non_retryable_1_retryable
     // Test Case 4: Mixed scenario - 2 success, 7 non-retryable, 1 retryable
     // 2 success responses (below f+1 validity threshold of 3,334)
     // 7 non-retryable errors + 1 retryable error
-    // Should fail with NonRetryableNotification since the sum of retryable errors and success weights is below f+1 (3,334)
+    // Should fail with NonRetryableNotification since the sum of retryable errors
+    // and success weights is below f+1 (3,334)
 
     let config = CapabilityNotificationConfig {
         success_count: 2,


### PR DESCRIPTION
# Description of change

This PR fixes the early exit condition in `send_capability_notification_to_quorum` to correctly determine whether an error should be retryable or non-retryable.

## Problem

The previous logic would exit early whenever total errors (retryable + non-retryable) reached the quorum threshold (2f+1), without properly verifying if the failure was actually recoverable. This caused premature exits that led to incorrect error classification.

For example, with 10 validators (total weight 10,000):
- Quorum threshold: 6,667 (2f+1)
- Validity threshold: 3,334 (f+1)

**Problematic scenario:** 2 success + 7 non-retryable + 1 retryable
- Old logic: exits early because total errors (7,000) >= quorum threshold (6,667)
- Error classification: returns `RetryableNotification` early because the received non-retryable errors (6,000) < quorum threshold (6,667)
- **Problem**: Even with perfect retries, success (2,000) + retryable (1,000) = 3,000 < validity threshold (3,334). We've only processed 6 non-retryable error responses and ignored 1 because of the early exit condition, which as a result returns a `RetryableNotification` response to the client. 
- This should be `NonRetryableNotification` since we cannot reach consensus despite having enough potential stake

## Solution

The refined condition now checks both criteria before early exit:
1. Whether non-retryable errors alone have reached quorum threshold (2f+1)
2. Whether total errors reached quorum threshold AND success + retryable errors can reach validity threshold (f+1)

This ensures correct error classification by only exiting early when we can definitively determine the appropriate error type.

## Links to any relevant issues

Fixes #8945  

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes