### PR TITLE
fix(starfish): prevent integer overflow in get_useful_shards_authors

### DIFF
--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1470,7 +1470,11 @@ impl DagState {
     ) -> BTreeSet<AuthorityIndex> {
         let mut useful_shard_authors = BTreeSet::new();
         for (i, round) in last_useful_round.iter().enumerate() {
-            if block_round - round <= MAX_ROUND_GAP_FOR_USEFUL_SHARDS as u32 {
+            // Check that block_round >= round to avoid underflow. This can happen if we've
+            // received a block from a more recent round than the block we are about to
+            // send, especially during startup when we're sending older blocks.
+            if block_round >= round && block_round - round <= MAX_ROUND_GAP_FOR_USEFUL_SHARDS as u32
+            {
                 useful_shard_authors.insert(AuthorityIndex::from(i as u8));
             }
         }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1473,7 +1473,8 @@ impl DagState {
             // Check that block_round >= round to avoid underflow. This can happen if we've
             // received a block from a more recent round than the block we are about to
             // send, especially during startup when we're sending older blocks.
-            if block_round >= round && block_round - round <= MAX_ROUND_GAP_FOR_USEFUL_SHARDS as u32
+            if block_round >= *round
+                && block_round - round <= MAX_ROUND_GAP_FOR_USEFUL_SHARDS as u32
             {
                 useful_shard_authors.insert(AuthorityIndex::from(i as u8));
             }


### PR DESCRIPTION
# Description of change

This PR fixes an integer overflow panic in `get_useful_shards_authors` that was causing test failures in CI.

### Problem

The function performs an unchecked subtraction `block_round - round` which panics when `round > block_round`. This can occur during startup when we've received blocks from more recent rounds while processing older blocks to send.

### Solution

Added a guard condition to check `block_round >= round` before the subtraction, ensuring we only consider shards from rounds that are not in the future relative to the block being processed.

## Links to any relevant issues

Fixes #8947  

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
