### PR TITLE
fix(consensus): private ip support in `iota-aws-orchestrator`

### DIFF
--- a/crates/iota-aws-orchestrator/src/monitor.rs
+++ b/crates/iota-aws-orchestrator/src/monitor.rs
@@ -115,7 +115,7 @@ impl Prometheus {
         let mut config = vec![Self::global_configuration()];
 
         // Add configurations to scrape the clients.
-        let clients_metrics_path = protocol.clients_metrics_path(clients);
+        let clients_metrics_path = protocol.clients_metrics_path(clients, parameters);
         for (i, (_, clients_metrics_path)) in clients_metrics_path.into_iter().enumerate() {
             let id = format!("client-{i}");
             let scrape_config = Self::scrape_configuration(&id, &clients_metrics_path);

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -436,7 +436,9 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             .await?;
 
         // Wait until all load generators are reachable.
-        let commands = self.protocol_commands.clients_metrics_command(clients);
+        let commands = self
+            .protocol_commands
+            .clients_metrics_command(clients, parameters);
         self.ssh_manager.wait_for_success(commands).await;
 
         display::done();
@@ -457,7 +459,9 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         let (clients, nodes, _) = self.select_instances(parameters)?;
 
         // Regularly scrape the client
-        let mut metrics_commands = self.protocol_commands.clients_metrics_command(clients);
+        let mut metrics_commands = self
+            .protocol_commands
+            .clients_metrics_command(clients, parameters);
 
         // TODO: Remove this when consensus client latency metrics are available.
         // We will be getting latency metrics directly from consensus nodes instead from

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -129,13 +129,13 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
     fn node_command<I>(
         &self,
         instances: I,
-        _parameters: &BenchmarkParameters<IotaBenchmarkType>,
+        parameters: &BenchmarkParameters<IotaBenchmarkType>,
     ) -> Vec<(Instance, String)>
     where
         I: IntoIterator<Item = Instance>,
     {
         let working_dir = self.working_dir.clone();
-        let network_addresses = Self::resolve_network_addresses(instances);
+        let network_addresses = Self::resolve_network_addresses(instances, parameters);
 
         network_addresses
             .into_iter()
@@ -240,9 +240,16 @@ impl IotaProtocol {
     /// It returns the Instance and the corresponding address.
     pub fn resolve_network_addresses(
         instances: impl IntoIterator<Item = Instance>,
+        parameters: &BenchmarkParameters<IotaBenchmarkType>,
     ) -> Vec<(Instance, Multiaddr)> {
         let instances: Vec<Instance> = instances.into_iter().collect();
-        let ips: Vec<_> = instances.iter().map(|x| x.main_ip.to_string()).collect();
+        let ips: Vec<_> = instances
+            .iter()
+            .map(|x| match parameters.use_internal_ip_address {
+                true => x.private_ip.to_string(),
+                false => x.main_ip.to_string(),
+            })
+            .collect();
         let genesis_config = GenesisConfig::new_for_benchmarks(&ips);
         let mut addresses = Vec::new();
         if let Some(validator_configs) = genesis_config.validator_config_info.as_ref() {
@@ -293,7 +300,10 @@ impl ProtocolMetrics for IotaProtocol {
             .map(|(config, instance)| {
                 let path = format!(
                     "{}:{}{}",
-                    instance.main_ip,
+                    match parameters.use_internal_ip_address {
+                        true => instance.private_ip,
+                        false => instance.main_ip,
+                    },
                     config.metrics_address.port(),
                     iota_metrics::METRICS_ROUTE
                 );
@@ -302,16 +312,24 @@ impl ProtocolMetrics for IotaProtocol {
             .collect()
     }
 
-    fn clients_metrics_path<I>(&self, instances: I) -> Vec<(Instance, String)>
+    fn clients_metrics_path<I, T>(
+        &self,
+        instances: I,
+        parameters: &BenchmarkParameters<T>,
+    ) -> Vec<(Instance, String)>
     where
         I: IntoIterator<Item = Instance>,
+        T: BenchmarkType,
     {
         instances
             .into_iter()
             .map(|instance| {
                 let path = format!(
                     "{}:{}{}",
-                    instance.main_ip,
+                    match parameters.use_internal_ip_address {
+                        true => instance.private_ip,
+                        false => instance.main_ip,
+                    },
                     Self::CLIENT_METRICS_PORT,
                     iota_metrics::METRICS_ROUTE
                 );

--- a/crates/iota-aws-orchestrator/src/protocol/mod.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/mod.rs
@@ -102,15 +102,25 @@ pub trait ProtocolMetrics {
     }
 
     /// The network path where the clients expose prometheus metrics.
-    fn clients_metrics_path<I>(&self, instances: I) -> Vec<(Instance, String)>
-    where
-        I: IntoIterator<Item = Instance>;
-    /// The command to retrieve the metrics from the clients.
-    fn clients_metrics_command<I>(&self, instances: I) -> Vec<(Instance, String)>
+    fn clients_metrics_path<I, T>(
+        &self,
+        instances: I,
+        parameters: &BenchmarkParameters<T>,
+    ) -> Vec<(Instance, String)>
     where
         I: IntoIterator<Item = Instance>,
+        T: BenchmarkType;
+    /// The command to retrieve the metrics from the clients.
+    fn clients_metrics_command<I, T>(
+        &self,
+        instances: I,
+        parameters: &BenchmarkParameters<T>,
+    ) -> Vec<(Instance, String)>
+    where
+        I: IntoIterator<Item = Instance>,
+        T: BenchmarkType,
     {
-        self.clients_metrics_path(instances)
+        self.clients_metrics_path(instances, parameters)
             .into_iter()
             .map(|(instance, path)| (instance, format!("curl {path}")))
             .collect()
@@ -150,9 +160,14 @@ pub mod test_protocol_metrics {
                 .collect()
         }
 
-        fn clients_metrics_path<I>(&self, instances: I) -> Vec<(Instance, String)>
+        fn clients_metrics_path<I, T>(
+            &self,
+            instances: I,
+            _parameters: &BenchmarkParameters<T>,
+        ) -> Vec<(Instance, String)>
         where
             I: IntoIterator<Item = Instance>,
+            T: BenchmarkType,
         {
             instances
                 .into_iter()


### PR DESCRIPTION
# Description of change

Fixed issues with running `iota-aws-orhestrator` inside of a VPC.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes