### PR TITLE
feat: bump iota to v1.9.2-rc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,7 +1835,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "const-str",
  "git-version",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "iota"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5440,7 +5440,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-simulator",
  "iota-source-validation",
  "iota-swarm",
@@ -5513,7 +5513,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "arrow-array 53.1.0",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5665,7 +5665,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5726,7 +5726,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-move-build",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -5748,7 +5748,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5794,7 +5794,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5897,7 +5897,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5952,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5985,7 +5985,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6019,7 +6019,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6048,7 +6048,7 @@ dependencies = [
  "iota-protocol-config",
  "iota-rest-api",
  "iota-rust-sdk",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-simulator",
  "iota-storage",
  "iota-swarm",
@@ -6079,7 +6079,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "serde_yaml",
 ]
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6134,7 +6134,7 @@ dependencies = [
  "iota-keys",
  "iota-metrics",
  "iota-network-stack",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-types",
  "parking_lot 0.12.3",
  "prometheus",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6196,7 +6196,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6217,7 +6217,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6267,7 +6267,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6285,7 +6285,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6298,7 +6298,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6337,7 +6337,7 @@ dependencies = [
  "iota-network-stack",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-types",
@@ -6370,7 +6370,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6383,14 +6383,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "axum 0.8.4",
 ]
 
 [[package]]
 name = "iota-grpc-api"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6415,7 +6415,7 @@ dependencies = [
 
 [[package]]
 name = "iota-grpc-types"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "iota-types",
  "serde",
@@ -6423,7 +6423,7 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "axum 0.8.4",
  "bytes",
@@ -6444,7 +6444,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6509,7 +6509,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6525,7 +6525,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6544,7 +6544,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6599,7 +6599,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6618,7 +6618,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6637,7 +6637,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6656,7 +6656,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6689,7 +6689,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "bip32",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "iota-kvstore"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6728,7 +6728,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6749,7 +6749,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger-signer"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6757,7 +6757,7 @@ dependencies = [
  "bip32",
  "clap",
  "iota-ledger",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "shared-crypto",
  "thiserror 1.0.64",
  "tokio",
@@ -6766,7 +6766,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6780,7 +6780,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-types",
  "move-core-types",
  "object_store 0.10.2",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -6809,7 +6809,7 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6821,7 +6821,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "backoff",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6867,7 +6867,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6927,7 +6927,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "bin-version",
  "clap",
@@ -6960,7 +6960,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6972,7 +6972,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -7011,7 +7011,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anemo",
  "bcs",
@@ -7039,7 +7039,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7092,7 +7092,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7116,7 +7116,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7128,7 +7128,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7144,13 +7144,13 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -7160,7 +7160,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7181,7 +7181,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -7191,7 +7191,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "clap",
  "insta",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7215,7 +7215,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7230,7 +7230,7 @@ dependencies = [
  "hex",
  "hyper 1.4.1",
  "iota-metrics",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-tls",
  "iota-types",
  "itertools 0.13.0",
@@ -7258,7 +7258,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7274,7 +7274,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-transaction-checks",
  "iota-types",
  "jsonrpsee",
@@ -7303,7 +7303,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7332,7 +7332,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-kv"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7359,7 +7359,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7376,7 +7376,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-swarm-config",
  "iota-types",
  "move-core-types",
@@ -7400,7 +7400,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7410,7 +7410,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-types",
  "itertools 0.13.0",
  "serde",
@@ -7485,7 +7485,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7524,7 +7524,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7546,7 +7546,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7580,7 +7580,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7607,7 +7607,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "colored",
@@ -7617,7 +7617,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -7639,7 +7639,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7654,7 +7654,7 @@ dependencies = [
  "iota-move",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-source-validation",
  "move-core-types",
  "move-package",
@@ -7675,7 +7675,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7726,7 +7726,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "bcs",
  "clap",
@@ -7754,7 +7754,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "futures",
@@ -7782,7 +7782,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -7810,7 +7810,7 @@ dependencies = [
 
 [[package]]
 name = "iota-synthetic-ingestion"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7827,12 +7827,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -7840,7 +7840,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7862,7 +7862,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -7884,7 +7884,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -7907,7 +7907,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7923,7 +7923,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -7936,7 +7936,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7981,7 +7981,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8056,7 +8056,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8084,7 +8084,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11374,7 +11374,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13168,7 +13168,7 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "bcs",
  "eyre",
@@ -13293,7 +13293,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14037,7 +14037,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -14124,7 +14124,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -14143,7 +14143,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.9.1-rc",
+ "iota-sdk 1.9.2-rc",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -14960,7 +14960,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -15032,7 +15032,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "bcs",
  "bincode",
@@ -15061,7 +15061,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -15071,7 +15071,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "serde",
  "thiserror 1.0.64",
@@ -15079,7 +15079,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "1.9.1-rc"
+version = "1.9.2-rc"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -114,12 +114,12 @@ task 15, lines 64-69:
 //# run-graphql --show-usage --show-headers --show-service-version
 Headers: {
     "content-type": "application/graphql-response+json",
-    "x-iota-rpc-version": "1.9.1-testing-no-sha",
+    "x-iota-rpc-version": "1.9.2-testing-no-sha",
     "vary": "origin, access-control-request-method, access-control-request-headers",
     "access-control-allow-origin": "*",
     "content-length": "157",
 }
-Service version: 1.9.1-testing-no-sha
+Service version: 1.9.2-testing-no-sha
 Response: {
   "data": {
     "checkpoint": {

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "1.9.1-rc"
+    "version": "1.9.2-rc"
   },
   "methods": [
     {


### PR DESCRIPTION
Bump iota to `v1.9.2-rc` for CLI and indexer write API fixes.
