### PR TITLE
fix(release-notes): try to get PR number from commit message before Github API

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -152,6 +152,7 @@ vercel.json @iotaledger/tooling
 /scripts/generate_files/ @muXxer
 /scripts/tooling/ @iotaledger/tooling
 /scripts/utils/ @muXxer
+/scripts/release_notes/ @dev-tools
 
 # Other
 /kiosk/ @iotaledger/vm-language

--- a/scripts/release_notes/release_notes.py
+++ b/scripts/release_notes/release_notes.py
@@ -185,7 +185,14 @@ def extract_notes(commit_or_pr, seen, is_pr):
         pr = commit_or_pr
         notes = extract_notes_from_pr(pr)
     else:
-        pr, notes = extract_notes_from_commit(commit_or_pr)
+        # Try to get the PR number from the commit message or fallback to the
+        # one returned from the Github API
+        match = RE_PR.match(git("show", "-s", "--format=%B", commit_or_pr))
+        if match:
+            pr = match.group(1)
+            notes = extract_notes_from_pr(pr)
+        else:
+            pr, notes = extract_notes_from_commit(commit_or_pr)
 
     result = {}
 


### PR DESCRIPTION
# Description of change


There was an issue where the release notes would not pick up individual commits of non-squashed feature branches.
This fix first tries to get a PR number from the commit message, otherwise fallback to the Github API.

Taking ownership of this script as it's very finicky and at this point my team has the most expertise of it.

Tested locally.
