### PR TITLE
feat(iota-core,starfish): add configurable Starfish consensus parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5789,6 +5789,7 @@ dependencies = [
  "reqwest 0.12.7",
  "serde",
  "serde_yaml",
+ "starfish-config",
  "tracing",
 ]
 

--- a/crates/iota-config/Cargo.toml
+++ b/crates/iota-config/Cargo.toml
@@ -35,3 +35,4 @@ iota-names.workspace = true
 iota-rest-api.workspace = true
 iota-types.workspace = true
 move-vm-config.workspace = true
+starfish-config.workspace = true

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -30,6 +30,7 @@ use iota_types::{
 use once_cell::sync::OnceCell;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
+use starfish_config::Parameters as StarfishParameters;
 use tracing::info;
 
 use crate::{
@@ -775,7 +776,12 @@ pub struct ConsensusConfig {
     /// estimates.
     pub submit_delay_step_override_millis: Option<u64>,
 
+    /// Parameters for Mysticeti consensus
     pub parameters: Option<ConsensusParameters>,
+
+    /// Parameters for Starfish consensus
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub starfish_parameters: Option<StarfishParameters>,
 }
 
 impl ConsensusConfig {

--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -93,7 +93,7 @@ impl ConsensusManagerTrait for StarfishManager {
     /// Starts the Starfish consensus manager for the current epoch.
     async fn start(
         &self,
-        _config: &NodeConfig,
+        config: &NodeConfig,
         epoch_store: Arc<AuthorityPerEpochStore>,
         consensus_handler_initializer: ConsensusHandlerInitializer,
         tx_validator: IotaTxValidator,
@@ -114,12 +114,16 @@ impl ConsensusManagerTrait for StarfishManager {
             return;
         };
 
-        // TODO: https://github.com/iotaledger/iota/issues/8353
-        // We might need to get consensus parameters from the node config in the future
-        // and use them for creating parameters.
+        let consensus_config = config
+            .consensus_config()
+            .expect("consensus_config should exist");
+
         let parameters = Parameters {
             db_path: self.get_store_path(epoch),
-            ..Default::default()
+            ..consensus_config
+                .starfish_parameters
+                .clone()
+                .unwrap_or_default()
         };
 
         let own_protocol_key = self.protocol_keypair.public();

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -156,6 +156,7 @@ impl ValidatorConfigBuilder {
             max_submit_position: self.max_submit_position,
             submit_delay_step_override_millis: self.submit_delay_step_override_millis,
             parameters: Default::default(),
+            starfish_parameters: Default::default(),
         };
 
         let p2p_config = P2pConfig {

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -151,7 +151,7 @@ impl Parameters {
         }
     }
 
-    // Maximum number of block headers to fetch per periodic or live sync request.
+    // Maximum number of transactions to fetch per request.
     pub(crate) fn default_max_transactions_per_fetch() -> usize {
         if cfg!(msim) { 10 } else { 100 }
     }


### PR DESCRIPTION
# Description of change

This PR adds support for configurable Starfish consensus parameters through the node configuration, similar to the existing Mysticeti implementation.

The changes allow operators to configure Starfish-specific parameters (e.g., max headers per fetch, transaction limits, bundle sizes) via the node config instead of using hardcoded defaults.

## Links to any relevant issues

Resolves #8353

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes