### PR TITLE
feat: add the address check in MoveAuthenticator, allow only one(sender) MoveAuthenticator

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -912,7 +912,7 @@ impl AuthorityState {
             epoch,
         )?;
 
-        if let Some(move_authenticator) = transaction.move_authenticator() {
+        if let Some(move_authenticator) = transaction.sender_move_authenticator() {
             // It is supposed that `Move authentication` availability is checked in
             // `SenderSignedData::validity_check`.
 
@@ -1348,7 +1348,7 @@ impl AuthorityState {
             .execution_load_input_objects_latency
             .start_timer();
 
-        let objects = if let Some(move_authenticator) = certificate.move_authenticator() {
+        let objects = if let Some(move_authenticator) = certificate.sender_move_authenticator() {
             // It is supposed that `Move authentication` availability is checked in
             // `SenderSignedData::validity_check`.
 
@@ -1779,7 +1779,7 @@ impl AuthorityState {
         let (kind, signer, gas) = tx_data.execution_parts();
 
         let authenticator_computation_cost = if let Some(move_authenticator) =
-            certificate.move_authenticator()
+            certificate.sender_move_authenticator()
         {
             // It is supposed that `Move authentication` availability is checked in
             // `SenderSignedData::validity_check`.

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -18,7 +18,7 @@ use crate::{
     committee::EpochId,
     crypto::{SignatureScheme, default_hash},
     digests::{MoveAuthenticatorDigest, ObjectDigest, ZKLoginInputsDigest},
-    error::{IotaResult, UserInputError},
+    error::{IotaError, IotaResult, UserInputError},
     signature::{AuthenticatorTrait, VerifyParams},
     signature_verification::VerifiedDigestCache,
     transaction::{CallArg, InputObjectKind, ObjectArg, SharedInputObject},
@@ -157,13 +157,19 @@ impl AuthenticatorTrait for MoveAuthenticator {
     fn verify_claims<T>(
         &self,
         _value: &IntentMessage<T>,
-        _author: IotaAddress,
+        author: IotaAddress,
         _aux_verify_data: &VerifyParams,
         _zklogin_inputs_cache: Arc<VerifiedDigestCache<ZKLoginInputsDigest>>,
     ) -> IotaResult
     where
         T: Serialize,
     {
+        if author != self.address()? {
+            return Err(IotaError::InvalidSignature {
+                error: "Invalid author".to_string(),
+            });
+        };
+
         Ok(())
     }
 }

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2439,8 +2439,9 @@ impl SenderSignedData {
                 .into());
             }
 
-            // The following restrictions are temporary added until we implement
-            // MoveAuthenticator support for sponsors.
+            // TODO(https://github.com/iotaledger/iota/issues/8966): The following
+            // restrictions are temporary added until we implement MoveAuthenticator support
+            // for sponsors.
 
             if authenticators_num > 1 {
                 return Err(UserInputError::Unsupported(

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2428,13 +2428,34 @@ impl SenderSignedData {
             }
         );
 
-        // Check the `MoveAuthenticator` transactions limitations.
-        if self.move_authenticator().is_some() && !tx_data.kind().is_programmable_transaction() {
-            return Err(UserInputError::Unsupported(
-                "SenderSignedData with MoveAuthenticator must be a programmable transaction"
-                    .to_string(),
-            )
-            .into());
+        // Check the `MoveAuthenticator` limitations.
+        let authenticators_num = self.move_authenticators().len();
+        if authenticators_num > 0 {
+            if !tx_data.kind().is_programmable_transaction() {
+                return Err(UserInputError::Unsupported(
+                    "SenderSignedData with MoveAuthenticator must be a programmable transaction"
+                        .to_string(),
+                )
+                .into());
+            }
+
+            // The following restrictions are temporary added until we implement
+            // MoveAuthenticator support for sponsors.
+
+            if authenticators_num > 1 {
+                return Err(UserInputError::Unsupported(
+                    "SenderSignedData with more than one MoveAuthenticator is not supported"
+                        .to_string(),
+                )
+                .into());
+            }
+
+            if self.sender_move_authenticator().is_none() {
+                return Err(UserInputError::Unsupported(
+                    "SenderSignedData can have MoveAuthenticator only for the sender".to_string(),
+                )
+                .into());
+            }
         }
 
         // Checks to see if the transaction has expired
@@ -2467,19 +2488,28 @@ impl SenderSignedData {
         Ok(tx_size)
     }
 
-    // TODO: A temporary created function. Needs to be replaced with a proper check.
-    pub fn move_authenticator(&self) -> Option<&MoveAuthenticator> {
-        let signatures = self.tx_signatures();
+    pub fn move_authenticators(&self) -> Vec<&MoveAuthenticator> {
+        self.tx_signatures()
+            .iter()
+            .filter_map(|sig| {
+                if let GenericSignature::MoveAuthenticator(move_authenticator) = sig {
+                    Some(move_authenticator)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 
-        if signatures.len() == 1 {
-            if let GenericSignature::MoveAuthenticator(move_authenticator) = &signatures[0] {
-                Some(move_authenticator)
-            } else {
-                None
-            }
-        } else {
-            None
-        }
+    pub fn sender_move_authenticator(&self) -> Option<&MoveAuthenticator> {
+        let sender = self.intent_message().value.sender();
+
+        self.move_authenticators()
+            .into_iter()
+            .find(|a| match a.address() {
+                Ok(addr) => addr == sender,
+                Err(_) => false,
+            })
     }
 }
 
@@ -2512,7 +2542,7 @@ impl<S> Envelope<SenderSignedData, S> {
     pub fn shared_input_objects(&self) -> impl Iterator<Item = SharedInputObject> + '_ {
         // Add the Move authenticator shared objects if any.
         let authenticator_shared_objects =
-            if let Some(move_authenticator) = self.move_authenticator() {
+            if let Some(move_authenticator) = self.sender_move_authenticator() {
                 move_authenticator
                     .shared_objects()
                     .into_iter()


### PR DESCRIPTION
# Description of change

1. Improved `MoveAuthenticator:: verify_claims` implementation by checking the author address.
2. Check a transaction's authenticator amount; allow only one authenticator(sender) until we implement sponsor support.

## Links to any relevant issues

fixes #8747 

