### PR TITLE
fix(ci): Fix split cluster check

### DIFF
--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -64,7 +64,7 @@ fi
 export IOTA_CONFIG_DIR="$WORKING_DIR/config"
 rm -rf "$IOTA_CONFIG_DIR"
 
-"$WORKING_DIR/iota-release" genesis --epoch-duration-ms 20000
+"$WORKING_DIR/iota-release" genesis --epoch-duration-ms 20000 --committee-size 4
 
 LOG_DIR="$WORKING_DIR/logs"
 

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -16,8 +16,8 @@
 # first arg is the released commit, defaults to `origin/mainnet`
 RELEASE_COMMIT=${1:-origin/mainnet}
 
-# second arg is the release candidate commit, defaults to origin/main
-RELEASE_CANDIDATE_COMMIT=${2:-origin/main}
+# second arg is the release candidate commit, defaults to origin/develop
+RELEASE_CANDIDATE_COMMIT=${2:-origin/develop}
 
 # Abort if git repo is dirty
 if ! git diff-index --quiet HEAD --; then
@@ -103,13 +103,23 @@ if ! grep -q "Node State has been reconfigured" "$LOG_DIR/fullnode.log"; then
 fi
 
 # ensure that the random beacon's DKG completes on both versions.
-# "random beacon: created" indicates that the random beacon is enabled and started.
-if grep -q "random beacon: created" "$LOG_DIR/node-0.log" && ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-0.log"; then
+# Both "random beacon: created" and "random beacon: DKG complete" must be present.
+if ! grep -q "random beacon: created" "$LOG_DIR/node-0.log"; then
+  echo "Could not find 'random beacon: created' in node-0"
+  exit 1
+fi
+
+if ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-0.log"; then
   echo "Could not find 'random beacon: DKG complete' in node-0"
   exit 1
 fi
 
-if grep -q "random beacon: created" "$LOG_DIR/node-2.log" && ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-2.log"; then
+if ! grep -q "random beacon: created" "$LOG_DIR/node-2.log"; then
+  echo "Could not find 'random beacon: created' in node-2"
+  exit 1
+fi
+
+if ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-2.log"; then
   echo "Could not find 'random beacon: DKG complete' in node-2"
   exit 1
 fi


### PR DESCRIPTION
# Description of change

`split-cluster-check.sh` was completely broken and didn't do what it was designed to do after updates to the `genesis` command as well as outdated DKG checks. We changed the genesis command to support 4 validators instead using the default value of 1. We additionally require all logs to be present, since DKG is always enabled on all networks. 

## How the change has been tested

Ran it locally to reproduce a problem that wasn't caught by the test before the fix.

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

