### PR TITLE
refactor(iota-types): Add comments with warning to crucial enums

### DIFF
--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -90,6 +90,8 @@ pub enum ConsensusTransactionKey {
     NewJWKFetched(Box<(AuthorityName, JwkId, JWK)>),
     RandomnessDkgMessage(AuthorityName),
     RandomnessDkgConfirmation(AuthorityName),
+    // New entries should be added at the end to preserve serialization compatibility. DO NOT
+    // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
 
 impl Debug for ConsensusTransactionKey {
@@ -258,6 +260,8 @@ pub enum ConsensusTransactionKind {
     // of `RandomnessDkgMessages` have been received locally, to complete the key generation
     // process. Contents are a serialized `fastcrypto_tbls::dkg::Confirmation`.
     RandomnessDkgConfirmation(AuthorityName, Vec<u8>),
+    // New entries should be added at the end to preserve serialization compatibility. DO NOT
+    // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
 
 impl ConsensusTransactionKind {


### PR DESCRIPTION
# Description of change

Add warning comments about the ordering of existing and new enum values to avoid problems in the future if somebody puts a new value in wrong place (been there, done that).

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
