### PR TITLE
feat(iota-indexer-streaming): add prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6502,6 +6502,7 @@ dependencies = [
  "futures",
  "iota-indexer",
  "iota-types",
+ "prometheus",
  "serde",
  "serde_json",
  "thiserror 1.0.64",

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -490,7 +490,8 @@ impl ServerBuilder {
             None
         };
 
-        let graphql_streams = GraphQLStream::new(&config.connection.db_url, reader).await?;
+        let graphql_streams =
+            GraphQLStream::new(&config.connection.db_url, reader, &registry).await?;
 
         builder = builder
             .context_data(config.service.clone())

--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -6,8 +6,9 @@ use std::sync::Arc;
 use async_graphql::{Context, OutputType, SimpleObject, Subscription, Union};
 use futures::{Stream, StreamExt, TryStreamExt, future};
 use iota_indexer::indexer_reader::IndexerReader;
-use iota_indexer_streaming::memory::InMemory;
+use iota_indexer_streaming::{memory::InMemory, metrics::InMemoryStreamMetrics};
 use iota_json_rpc_types::Filter;
+use prometheus::Registry;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tracing::warn;
 
@@ -90,10 +91,19 @@ pub(crate) struct GraphQLStream {
 }
 
 impl GraphQLStream {
-    pub(crate) async fn new(db_url: &str, indexer_reader: IndexerReader) -> Result<Self, Error> {
-        let streamer = InMemory::new(db_url, Default::default(), indexer_reader)
-            .await
-            .map_err(|e| Error::Internal(format!("failed to connect to postgres: {e}")))?;
+    pub(crate) async fn new(
+        db_url: &str,
+        indexer_reader: IndexerReader,
+        registry: &Registry,
+    ) -> Result<Self, Error> {
+        let streamer = InMemory::new(
+            db_url,
+            Default::default(),
+            indexer_reader,
+            InMemoryStreamMetrics::new(registry),
+        )
+        .await
+        .map_err(|e| Error::Internal(format!("failed to connect to postgres: {e}")))?;
         Ok(Self {
             streamer: Arc::new(streamer),
         })

--- a/crates/iota-indexer-streaming/Cargo.toml
+++ b/crates/iota-indexer-streaming/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 # external dependencies
 async-trait.workspace = true
 futures.workspace = true
+prometheus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/iota-indexer-streaming/src/lib.rs
+++ b/crates/iota-indexer-streaming/src/lib.rs
@@ -6,3 +6,4 @@
 
 pub mod error;
 pub mod memory;
+pub mod metrics;

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -28,6 +28,7 @@ use iota_indexer::{
     },
 };
 use iota_types::event::Event;
+use prometheus::IntGauge;
 use serde::Deserialize;
 use tokio::sync::broadcast;
 use tokio_postgres::{
@@ -486,10 +487,10 @@ impl InMemory {
 struct SubscriberStream<T> {
     /// The inner stream implementation we want to wrap.
     inner: BroadcastStream<T>,
-    /// The prometheus label we want to record metrics.
-    label: &'static str,
-    /// The collection of available prometheus metrics we want to record.
-    metrics: Arc<InMemoryStreamMetrics>,
+    /// Tracks if the subscriber is active.
+    active_subscriber_number: IntGauge,
+    /// Tracks if the subscriber is lagging.
+    lagging_subscribers: IntGauge,
     /// Tracks if this subscriber is currently lagged.
     is_lagging: bool,
 }
@@ -500,15 +501,15 @@ impl<T> SubscriberStream<T> {
         label: &'static str,
         metrics: Arc<InMemoryStreamMetrics>,
     ) -> Self {
-        metrics
-            .active_subscriber_number
-            .with_label_values(&[label])
-            .inc();
+        let active_subscriber_number = metrics.active_subscriber_number.with_label_values(&[label]);
+        let lagging_subscribers = metrics.lagging_subscribers.with_label_values(&[label]);
+
+        active_subscriber_number.inc();
 
         Self {
             inner,
-            label,
-            metrics,
+            active_subscriber_number,
+            lagging_subscribers,
             is_lagging: false,
         }
     }
@@ -516,10 +517,7 @@ impl<T> SubscriberStream<T> {
 
 impl<T> Drop for SubscriberStream<T> {
     fn drop(&mut self) {
-        self.metrics
-            .active_subscriber_number
-            .with_label_values(&[self.label])
-            .dec();
+        self.active_subscriber_number.dec();
     }
 }
 
@@ -529,27 +527,18 @@ impl<T: Clone + Send + 'static> Stream for SubscriberStream<T> {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let poll = Pin::new(&mut self.inner).poll_next(cx);
 
-        match poll {
-            Poll::Ready(Some(Ok(_))) => {
-                if self.is_lagging {
-                    self.metrics
-                        .lagging_subscribers
-                        .with_label_values(&[self.label])
-                        .dec();
-                    self.is_lagging = false;
-                }
+        if let Poll::Ready(Some(Ok(_))) = poll {
+            if self.is_lagging {
+                self.lagging_subscribers.dec();
+                self.is_lagging = false;
             }
-            Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(_)))) => {
-                if !self.is_lagging {
-                    self.metrics
-                        .lagging_subscribers
-                        .with_label_values(&[self.label])
-                        .inc();
-                    self.is_lagging = true;
-                }
+        } else if let Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(_)))) = poll {
+            if !self.is_lagging {
+                self.lagging_subscribers.inc();
+                self.is_lagging = true;
             }
-            _ => {}
         }
+
         poll
     }
 }

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -502,6 +502,10 @@ struct SubscriberStream<T> {
 }
 
 impl<T> SubscriberStream<T> {
+    /// Represents the duration of the lag state of the subscriber, mostly to
+    /// help Prometheus scrape the metric.
+    const LAG_STATE: Duration = Duration::from_secs(1);
+
     pub fn new(
         inner: BroadcastStream<T>,
         label: &'static str,
@@ -520,11 +524,40 @@ impl<T> SubscriberStream<T> {
             lag_start: None,
         }
     }
+
+    /// Marks the subscriber as lagging.
+    fn mark_as_lagging(&mut self) {
+        if !self.is_lagging {
+            self.is_lagging = true;
+            self.lag_start = Some(Instant::now());
+            self.lagging_subscribers.inc();
+        }
+    }
+
+    /// Clears the lag flag if the subscriber has been lagging.
+    ///
+    /// It holds the lagging state for at least [`LAG_STATE`](Self::LAG_STATE)
+    /// second in order for Prometheus to scrape the metric.
+    fn clear_lagging(&mut self) {
+        if self.is_lagging
+            && self
+                .lag_start
+                .as_ref()
+                .is_some_and(|instant| instant.elapsed() >= Self::LAG_STATE)
+        {
+            self.lagging_subscribers.dec();
+            self.is_lagging = false;
+            self.lag_start = None;
+        }
+    }
 }
 
 impl<T> Drop for SubscriberStream<T> {
     fn drop(&mut self) {
         self.active_subscriber_number.dec();
+        if self.is_lagging {
+            self.lagging_subscribers.dec();
+        }
     }
 }
 impl<T: Clone + Send + 'static> Stream for SubscriberStream<T> {
@@ -532,25 +565,12 @@ impl<T: Clone + Send + 'static> Stream for SubscriberStream<T> {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // check if we should clear the lag flag (independent of message arrival)
-        if self.is_lagging
-            && self
-                .lag_start
-                .as_ref()
-                .is_some_and(|instant| instant.elapsed() >= Duration::from_secs(1))
-        {
-            self.lagging_subscribers.dec();
-            self.is_lagging = false;
-            self.lag_start = None;
-        }
+        self.clear_lagging();
 
         let poll = Pin::new(&mut self.inner).poll_next(cx);
 
         if let Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(_)))) = poll {
-            if !self.is_lagging {
-                self.lagging_subscribers.inc();
-                _ = self.lag_start.get_or_insert(Instant::now());
-                self.is_lagging = true;
-            }
+            self.mark_as_lagging();
         }
 
         poll

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -483,7 +483,7 @@ impl InMemory {
 ///
 /// Also the provides a way to track the lagging status of
 /// the subscriber.
-pub struct SubscriberStream<T> {
+struct SubscriberStream<T> {
     /// The inner stream implementation we want to wrap.
     inner: BroadcastStream<T>,
     /// The prometheus label we want to record metrics.

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -285,7 +285,10 @@ impl InMemory {
             .ready_chunks(config.notification_chunk_size.get());
 
         while let Some(messages) = stream.next().await {
-            let _timer = metrics.process_notification_batch_latency.start_timer();
+            // auto-records duration on drop (after each iteration).
+            let _record_processed_checkpoint_notifications =
+                metrics.process_notification_batch_latency.start_timer();
+
             if let Some((min_tx_sequence_number, max_tx_sequence_number)) =
                 Self::resolve_tx_bounds(&metrics, messages)?
             {
@@ -350,8 +353,9 @@ impl InMemory {
         transaction_tx: &broadcast::Sender<StoredTransaction>,
     ) -> IndexerStreamingResult<()> {
         // auto-records duration on drop (function return).
-        let _timer = metrics.process_transaction_batch_latency.start_timer();
-        let guard = metrics.query_tx_from_indexer_db_latency.start_timer();
+        let _record_function_execution_latency =
+            metrics.process_transaction_batch_latency.start_timer();
+        let db_query_timer = metrics.query_tx_from_indexer_db_latency.start_timer();
 
         let transactions: Vec<StoredTransaction> = indexer_reader
             .spawn_blocking(move |this| {
@@ -359,20 +363,20 @@ impl InMemory {
             })
             .await?;
 
-        let elapsed = guard.stop_and_record();
+        let elapsed = db_query_timer.stop_and_record();
         debug!(
             "transactions query took: {:?}, tx: {}",
             Duration::from_secs_f64(elapsed),
             transactions.len()
         );
 
-        let guard = metrics
+        let publish_data_to_subscribers_timer = metrics
             .broadcast_tx_and_ev_to_subscribers_latency
             .start_timer();
 
         Self::publish_tx_and_events(metrics, transactions, event_tx, transaction_tx).await?;
 
-        let elapsed = guard.stop_and_record();
+        let elapsed = publish_data_to_subscribers_timer.stop_and_record();
         debug!(
             "broadcast data took: {:?}",
             Duration::from_secs_f64(elapsed)
@@ -406,12 +410,12 @@ impl InMemory {
         // we sacrifice per-event/transaction granularity to avoid degrading
         // performance from frequent metric updates in a hot path.
         metrics
-            .channel_queue_size
+            .channel_pending_messages
             .with_label_values(&[METRICS_EVENT_LABEL])
             .set(event_tx.len() as i64);
 
         metrics
-            .channel_queue_size
+            .channel_pending_messages
             .with_label_values(&[METRICS_TRANSACTION_LABEL])
             .set(transaction_tx.len() as i64);
         Ok(())

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -16,7 +16,7 @@ use std::{
     str::FromStr,
     sync::Arc,
     task::{Context, Poll},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use futures::{Stream, StreamExt, TryFutureExt, stream};
@@ -497,6 +497,8 @@ struct SubscriberStream<T> {
     lagging_subscribers: IntGauge,
     /// Tracks if this subscriber is currently lagged.
     is_lagging: bool,
+    /// Timer to track lag duration.
+    lag_start: Option<Instant>,
 }
 
 impl<T> SubscriberStream<T> {
@@ -515,6 +517,7 @@ impl<T> SubscriberStream<T> {
             active_subscriber_number,
             lagging_subscribers,
             is_lagging: false,
+            lag_start: None,
         }
     }
 }
@@ -524,21 +527,28 @@ impl<T> Drop for SubscriberStream<T> {
         self.active_subscriber_number.dec();
     }
 }
-
 impl<T: Clone + Send + 'static> Stream for SubscriberStream<T> {
     type Item = Result<T, BroadcastStreamRecvError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // check if we should clear the lag flag (independent of message arrival)
+        if self.is_lagging
+            && self
+                .lag_start
+                .as_ref()
+                .is_some_and(|instant| instant.elapsed() >= Duration::from_secs(1))
+        {
+            self.lagging_subscribers.dec();
+            self.is_lagging = false;
+            self.lag_start = None;
+        }
+
         let poll = Pin::new(&mut self.inner).poll_next(cx);
 
-        if let Poll::Ready(Some(Ok(_))) = poll {
-            if self.is_lagging {
-                self.lagging_subscribers.dec();
-                self.is_lagging = false;
-            }
-        } else if let Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(_)))) = poll {
+        if let Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(_)))) = poll {
             if !self.is_lagging {
                 self.lagging_subscribers.inc();
+                _ = self.lag_start.get_or_insert(Instant::now());
                 self.is_lagging = true;
             }
         }

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -12,8 +12,11 @@
 use std::{
     fmt::Debug,
     num::{NonZeroI64, NonZeroUsize},
+    pin::Pin,
     str::FromStr,
-    time::Instant,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
 };
 
 use futures::{Stream, StreamExt, TryFutureExt, stream};
@@ -33,7 +36,10 @@ use tokio_postgres::{
 use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 use tracing::{debug, error};
 
-use crate::error::{IndexerStreamingError, IndexerStreamingResult};
+use crate::{
+    error::{IndexerStreamingError, IndexerStreamingResult},
+    metrics::{InMemoryStreamMetrics, METRICS_EVENT_LABEL, METRICS_TRANSACTION_LABEL},
+};
 
 /// Postgres NOTIFY channel name.
 const CHANNEL_NAME: &str = "checkpoint_committed";
@@ -139,6 +145,7 @@ impl Default for Config {
 pub struct InMemory {
     event_tx: broadcast::Sender<StoredEvent>,
     transaction_tx: broadcast::Sender<StoredTransaction>,
+    metrics: Arc<InMemoryStreamMetrics>,
     // to receive notifications from the database we must keep the client alive.
     _client: Client,
 }
@@ -154,7 +161,10 @@ impl InMemory {
         db_url: &str,
         config: Config,
         indexer_reader: IndexerReader,
+        metrics: impl Into<Arc<InMemoryStreamMetrics>>,
     ) -> IndexerStreamingResult<Self> {
+        let metrics = metrics.into();
+
         let (client, connection) = PostgresConfig::from_str(db_url)
             .map_err(|e| {
                 IndexerStreamingError::Postgres(format!("failed to parse Postgresdb url: {e}"))
@@ -169,6 +179,7 @@ impl InMemory {
         // communicate with the database.
         tokio::spawn({
             Self::process_checkpoint_notifications(
+                metrics.clone(),
                 config,
                 connection,
                 indexer_reader,
@@ -186,6 +197,7 @@ impl InMemory {
         Ok(Self {
             event_tx,
             transaction_tx,
+            metrics,
             _client: client,
         })
     }
@@ -217,7 +229,8 @@ impl InMemory {
     pub fn subscribe_events(
         &self,
     ) -> impl Stream<Item = Result<StoredEvent, BroadcastStreamRecvError>> {
-        BroadcastStream::new(self.event_tx.subscribe())
+        let stream = BroadcastStream::new(self.event_tx.subscribe());
+        SubscriberStream::new(stream, METRICS_EVENT_LABEL, self.metrics.clone())
     }
 
     /// Subscribe to a stream of [`StoredTransaction`].
@@ -246,7 +259,8 @@ impl InMemory {
     pub fn subscribe_transactions(
         &self,
     ) -> impl Stream<Item = Result<StoredTransaction, BroadcastStreamRecvError>> {
-        BroadcastStream::new(self.transaction_tx.subscribe())
+        let stream = BroadcastStream::new(self.transaction_tx.subscribe());
+        SubscriberStream::new(stream, METRICS_TRANSACTION_LABEL, self.metrics.clone())
     }
 
     /// Listens for database notifications and processes them.
@@ -258,6 +272,7 @@ impl InMemory {
     /// - fetches the transactions within the batch bounds and sends them to
     ///   subscribers alongside extracted events.
     async fn process_checkpoint_notifications(
+        metrics: Arc<InMemoryStreamMetrics>,
         config: Config,
         mut connection: Connection<Socket, NoTlsStream>,
         indexer_reader: IndexerReader,
@@ -269,9 +284,17 @@ impl InMemory {
             .ready_chunks(config.notification_chunk_size.get());
 
         while let Some(messages) = stream.next().await {
+            let _timer = metrics.process_notification_batch_latency.start_timer();
             if let Some((min_tx_sequence_number, max_tx_sequence_number)) =
-                Self::resolve_tx_bounds(messages)?
+                Self::resolve_tx_bounds(&metrics, messages)?
             {
+                metrics
+                    .notified_tx_seq_num_start_range
+                    .set(min_tx_sequence_number);
+                metrics
+                    .notified_tx_seq_num_end_range
+                    .set(max_tx_sequence_number);
+
                 let mut start = min_tx_sequence_number;
 
                 while start <= max_tx_sequence_number {
@@ -279,6 +302,7 @@ impl InMemory {
                         .min(max_tx_sequence_number);
 
                     Self::process_transaction_batch(
+                        &metrics,
                         start,
                         end,
                         &indexer_reader,
@@ -297,9 +321,10 @@ impl InMemory {
     /// Resolves the transaction sequence number bounds from the given messages
     /// batch.
     fn resolve_tx_bounds(
+        metrics: &InMemoryStreamMetrics,
         messages: Vec<Result<AsyncMessage, tokio_postgres::Error>>,
     ) -> IndexerStreamingResult<Option<(i64, i64)>> {
-        let mut filtered_messages = Self::filter_checkpoint_notifications(messages);
+        let mut filtered_messages = Self::filter_checkpoint_notifications(metrics, messages);
 
         let first = filtered_messages.next().transpose()?;
         let last = filtered_messages.last().transpose()?;
@@ -316,34 +341,54 @@ impl InMemory {
     /// publish them to subscribers alongside extracted events from every
     /// transaction.
     async fn process_transaction_batch(
+        metrics: &InMemoryStreamMetrics,
         start: i64,
         end: i64,
         indexer_reader: &IndexerReader,
         event_tx: &broadcast::Sender<StoredEvent>,
         transaction_tx: &broadcast::Sender<StoredTransaction>,
     ) -> IndexerStreamingResult<()> {
-        let instant = Instant::now();
+        // auto-records duration on drop (function return).
+        let _timer = metrics.process_transaction_batch_latency.start_timer();
+        let guard = metrics.query_tx_from_indexer_db_latency.start_timer();
+
         let transactions: Vec<StoredTransaction> = indexer_reader
             .spawn_blocking(move |this| {
                 this.multi_get_transactions_by_sequence_numbers_range(start, end)
             })
             .await?;
 
+        let elapsed = guard.stop_and_record();
         debug!(
             "transactions query took: {:?}, tx: {}",
-            instant.elapsed(),
+            Duration::from_secs_f64(elapsed),
             transactions.len()
         );
 
-        let instant = Instant::now();
-        Self::publish_tx_and_events(transactions, event_tx, transaction_tx).await?;
-        debug!("broadcast data took: {:?}", instant.elapsed());
+        let guard = metrics
+            .broadcast_tx_and_ev_to_subscribers_latency
+            .start_timer();
 
+        Self::publish_tx_and_events(metrics, transactions, event_tx, transaction_tx).await?;
+
+        let elapsed = guard.stop_and_record();
+        debug!(
+            "broadcast data took: {:?}",
+            Duration::from_secs_f64(elapsed)
+        );
+
+        metrics
+            .broadcasted_to_subscribers_tx_seq_num_start_range
+            .set(start);
+        metrics
+            .broadcasted_to_subscribers_tx_seq_num_end_range
+            .set(end);
         Ok(())
     }
 
     /// Publishes transactions and extracted events from them to subscribers.
     async fn publish_tx_and_events(
+        metrics: &InMemoryStreamMetrics,
         transactions: Vec<StoredTransaction>,
         event_tx: &broadcast::Sender<StoredEvent>,
         transaction_tx: &broadcast::Sender<StoredTransaction>,
@@ -356,19 +401,38 @@ impl InMemory {
             }
             _ = transaction_tx.send(tx);
         }
+
+        // we sacrifice per-event/transaction granularity to avoid degrading
+        // performance from frequent metric updates in a hot path.
+        metrics
+            .channel_queue_size
+            .with_label_values(&[METRICS_EVENT_LABEL])
+            .set(event_tx.len() as i64);
+
+        metrics
+            .channel_queue_size
+            .with_label_values(&[METRICS_TRANSACTION_LABEL])
+            .set(transaction_tx.len() as i64);
         Ok(())
     }
 
     /// Filters and parses database notifications into
     /// [`CheckpointCommitNotification`] from PostgreSQL messages.
-    fn filter_checkpoint_notifications(
+    fn filter_checkpoint_notifications<'a>(
+        metrics: &'a InMemoryStreamMetrics,
         messages: Vec<Result<AsyncMessage, tokio_postgres::Error>>,
-    ) -> impl Iterator<Item = IndexerStreamingResult<CheckpointCommitNotification>> {
+    ) -> impl Iterator<Item = IndexerStreamingResult<CheckpointCommitNotification>> + use<'a> {
         messages.into_iter().filter_map(|msg_result| {
             match msg_result {
                 Ok(AsyncMessage::Notification(n)) => {
                     match serde_json::from_str::<CheckpointCommitNotification>(n.payload()) {
-                        Ok(notification) => Some(Ok(notification)),
+                        Ok(notification) => {
+                            metrics
+                                .notified_checkpoint_sequence_number
+                                .set(notification.checkpoint_sequence_number);
+
+                            Some(Ok(notification))
+                        }
                         Err(_) => None,
                     }
                 }
@@ -407,5 +471,85 @@ impl InMemory {
             })
             .collect();
         Ok(stored)
+    }
+}
+
+/// A [`Stream`] wrapper that provides metrics capabilities for the
+/// [`BroadcastStream`].
+///
+/// It counts internally the total numbers of subscribers by incrementing the
+/// value every time the [`new`](Self::new) constructor is invoked and
+/// decrementing it when the stream is dropped.
+///
+/// Also the provides a way to track the lagging status of
+/// the subscriber.
+pub struct SubscriberStream<T> {
+    /// The inner stream implementation we want to wrap.
+    inner: BroadcastStream<T>,
+    /// The prometheus label we want to record metrics.
+    label: &'static str,
+    /// The collection of available prometheus metrics we want to record.
+    metrics: Arc<InMemoryStreamMetrics>,
+    /// Tracks if this subscriber is currently lagged.
+    is_lagging: bool,
+}
+
+impl<T> SubscriberStream<T> {
+    pub fn new(
+        inner: BroadcastStream<T>,
+        label: &'static str,
+        metrics: Arc<InMemoryStreamMetrics>,
+    ) -> Self {
+        metrics
+            .active_subscriber_number
+            .with_label_values(&[label])
+            .inc();
+
+        Self {
+            inner,
+            label,
+            metrics,
+            is_lagging: false,
+        }
+    }
+}
+
+impl<T> Drop for SubscriberStream<T> {
+    fn drop(&mut self) {
+        self.metrics
+            .active_subscriber_number
+            .with_label_values(&[self.label])
+            .dec();
+    }
+}
+
+impl<T: Clone + Send + 'static> Stream for SubscriberStream<T> {
+    type Item = Result<T, BroadcastStreamRecvError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let poll = Pin::new(&mut self.inner).poll_next(cx);
+
+        match poll {
+            Poll::Ready(Some(Ok(_))) => {
+                if self.is_lagging {
+                    self.metrics
+                        .lagging_subscribers
+                        .with_label_values(&[self.label])
+                        .dec();
+                    self.is_lagging = false;
+                }
+            }
+            Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(_)))) => {
+                if !self.is_lagging {
+                    self.metrics
+                        .lagging_subscribers
+                        .with_label_values(&[self.label])
+                        .inc();
+                    self.is_lagging = true;
+                }
+            }
+            _ => {}
+        }
+        poll
     }
 }

--- a/crates/iota-indexer-streaming/src/metrics.rs
+++ b/crates/iota-indexer-streaming/src/metrics.rs
@@ -1,0 +1,133 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Contains Prometheus metrics for the streaming components.
+
+use prometheus::{
+    Histogram, IntGauge, IntGaugeVec, Registry, register_histogram_with_registry,
+    register_int_gauge_vec_with_registry, register_int_gauge_with_registry,
+};
+
+/// Represents a Prometheus metric label to identify stream responsible for
+/// broadcasting events.
+pub const METRICS_EVENT_LABEL: &str = "events";
+/// Represents a Prometheus metric label to identify stream responsible for
+/// broadcasting transactions.
+pub const METRICS_TRANSACTION_LABEL: &str = "transactions";
+
+/// Holds all available Prometheus metrics for the
+/// [`InMemory`](crate::memory::InMemory) streamer implementation.
+pub struct InMemoryStreamMetrics {
+    /// Current number of active subscribers.
+    pub active_subscriber_number: IntGaugeVec,
+    /// Current number of lagging subscribers.
+    pub lagging_subscribers: IntGaugeVec,
+    /// Current notified checkpoint sequence number from the indexer.
+    pub notified_checkpoint_sequence_number: IntGauge,
+    /// Current notified transaction sequence number start range from the
+    /// indexer.
+    pub notified_tx_seq_num_start_range: IntGauge,
+    /// Current notified transaction sequence number end range from the indexer.
+    pub notified_tx_seq_num_end_range: IntGauge,
+    /// Current broadcasted transaction sequence number start range to
+    /// subscribers.
+    pub broadcasted_to_subscribers_tx_seq_num_start_range: IntGauge,
+    /// Current broadcasted transaction sequence number end range to
+    /// subscribers.
+    pub broadcasted_to_subscribers_tx_seq_num_end_range: IntGauge,
+    /// Latency of querying a range of transactions from the indexer database.
+    pub query_tx_from_indexer_db_latency: Histogram,
+    /// Latency of broadcasting transactions and events to subscribers.
+    pub broadcast_tx_and_ev_to_subscribers_latency: Histogram,
+    /// Current size of the broadcast channel queues.
+    pub channel_queue_size: IntGaugeVec,
+    /// Latency of processing a batch of transactions, from query to broadcast
+    /// to subscribers.
+    pub process_transaction_batch_latency: Histogram,
+    /// Latency of processing a batch of database notifications. It includes the
+    /// tx range bounds resolution, the time taken to query the database, and
+    /// broadcast them to subscribers.
+    pub process_notification_batch_latency: Histogram,
+}
+
+impl InMemoryStreamMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            active_subscriber_number: register_int_gauge_vec_with_registry!(
+                "active_subscriber_number",
+                "Current number of active subscribers",
+                &["type"],
+                registry,
+            )
+            .unwrap(),
+            lagging_subscribers: register_int_gauge_vec_with_registry!(
+                "lagging_subscribers",
+                "Current number of lagging subscribers",
+                &["type"],
+                registry,
+            )
+            .unwrap(),
+            notified_checkpoint_sequence_number: register_int_gauge_with_registry!(
+                "notified_checkpoint_sequence_number",
+                "Current notified checkpoint sequence number from the indexer",
+                registry,
+            )
+            .unwrap(),
+            notified_tx_seq_num_start_range: register_int_gauge_with_registry!(
+                "notified_tx_seq_num_start_range",
+                "Current notified transaction sequence number start range from the indexer",
+                registry,
+            )
+            .unwrap(),
+            notified_tx_seq_num_end_range: register_int_gauge_with_registry!(
+                "notified_tx_seq_num_end_range",
+                "Current notified transaction sequence number end range from the indexer",
+                registry,
+            )
+            .unwrap(),
+            broadcasted_to_subscribers_tx_seq_num_start_range: register_int_gauge_with_registry!(
+                "broadcasted_to_subscribers_tx_seq_num_start_range",
+                "Current broadcasted transaction sequence number start range to subscribers",
+                registry,
+            )
+            .unwrap(),
+            broadcasted_to_subscribers_tx_seq_num_end_range: register_int_gauge_with_registry!(
+                "broadcasted_to_subscribers_tx_seq_num_end_range",
+                "Current broadcasted transaction sequence number end range to subscribers",
+                registry,
+            )
+            .unwrap(),
+            query_tx_from_indexer_db_latency: register_histogram_with_registry!(
+                "query_tx_from_indexer_db_latency",
+                "Latency of querying a range of transactions from the indexer database",
+                registry,
+            )
+            .unwrap(),
+            broadcast_tx_and_ev_to_subscribers_latency: register_histogram_with_registry!(
+                "broadcast_tx_and_ev_to_subscribers_latency",
+                "Latency of broadcasting transactions and events to subscribers",
+                registry,
+            )
+            .unwrap(),
+            channel_queue_size: register_int_gauge_vec_with_registry!(
+                "channel_queue_size",
+                "Current size of the broadcast channel queue",
+                &["type"],
+                registry,
+            )
+            .unwrap(),
+            process_transaction_batch_latency: register_histogram_with_registry!(
+                "process_transaction_batch_latency",
+                "Latency of processing a batch of transactions, from query to broadcast to subscribers",
+                registry,
+            )
+            .unwrap(),
+            process_notification_batch_latency: register_histogram_with_registry!(
+                "process_notification_batch_latency",
+                "Latency of processing a batch of database notifications. It includes the tx range bounds resolution, the time taken to query the database, and broadcast them to subscribers",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}

--- a/crates/iota-indexer-streaming/src/metrics.rs
+++ b/crates/iota-indexer-streaming/src/metrics.rs
@@ -39,8 +39,8 @@ pub struct InMemoryStreamMetrics {
     pub query_tx_from_indexer_db_latency: Histogram,
     /// Latency of broadcasting transactions and events to subscribers.
     pub broadcast_tx_and_ev_to_subscribers_latency: Histogram,
-    /// Current size of the broadcast channel queues.
-    pub channel_queue_size: IntGaugeVec,
+    /// The number of messages not yet received by all active subscribers.
+    pub channel_pending_messages: IntGaugeVec,
     /// Latency of processing a batch of transactions, from query to broadcast
     /// to subscribers.
     pub process_transaction_batch_latency: Histogram,
@@ -109,9 +109,9 @@ impl InMemoryStreamMetrics {
                 registry,
             )
             .unwrap(),
-            channel_queue_size: register_int_gauge_vec_with_registry!(
-                "channel_queue_size",
-                "Current size of the broadcast channel queue",
+            channel_pending_messages: register_int_gauge_vec_with_registry!(
+                "channel_pending_messages",
+                "The number of messages not yet received by all active subscribers",
                 &["type"],
                 registry,
             )


### PR DESCRIPTION
# Description of change

This PR adds Prometheus metrics to the `iota-indexer-streaming`. It allows to monitor active subscribers, latency of internal process and to have a clear picture how it behaves under load.

## Links to any relevant issues

fixes #8711 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Used the `iota` cli, to quickly spin up a local network with a indexer & graphql server, since the latter uses the `iota-indexer-streming` we were able to see the metrics since it already exposes a Prometheus server.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch does not affect the indexer normal operations, thus no further tests were conducted. 

### Release Notes
- [x] Indexer: `iota-indexer-streaming` add Prometheus metrics.
