### PR TITLE
feat: force push the `object_to_authenticate` as first parameter of the authenticator move call

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -918,17 +918,21 @@ impl AuthorityState {
         // account object are also checked and must be provided.
         // It is also checked if there is enough gas to execute the transaction and its
         // authenticators.
-        let (gas_status, tx_checked_input_objects, auth_checked_input_objects, authenticator_info) =
-            self.check_transaction_inputs_for_signing(
-                protocol_config,
-                reference_gas_price,
-                tx_data,
-                tx_input_objects,
-                &tx_receiving_objects,
-                move_authenticator,
-                auth_input_objects,
-                account_object,
-            )?;
+        let (
+            gas_status,
+            tx_checked_input_objects,
+            auth_checked_input_objects_union,
+            authenticator_info,
+        ) = self.check_transaction_inputs_for_signing(
+            protocol_config,
+            reference_gas_price,
+            tx_data,
+            tx_input_objects,
+            &tx_receiving_objects,
+            move_authenticator,
+            auth_input_objects,
+            account_object,
+        )?;
 
         check_coin_deny_list_v1_during_signing(
             tx_data.sender(),
@@ -941,7 +945,7 @@ impl AuthorityState {
             // It is supposed that `MoveAuthenticator` availability is checked in
             // `SenderSignedData::validity_check`.
 
-            let auth_checked_input_objects = auth_checked_input_objects
+            let auth_checked_input_objects_union = auth_checked_input_objects_union
                 .expect("MoveAuthenticator input objects must be provided");
             let authenticator_info =
                 authenticator_info.expect("AuthenticatorInfoV1 object must be provided");
@@ -961,7 +965,7 @@ impl AuthorityState {
                 gas_status,
                 move_authenticator.to_owned(),
                 authenticator_info,
-                auth_checked_input_objects,
+                auth_checked_input_objects_union,
                 kind,
                 signer,
                 transaction.digest().to_owned(),
@@ -1730,7 +1734,7 @@ impl AuthorityState {
             // that the account object is loaded.
             let account_object = account_object.expect("Account object must be provided");
 
-            let authenticator_info = self.check_move_account(
+            let (checked_account_object, authenticator_info) = self.check_move_account(
                 auth_account_object_id,
                 auth_account_object_seq_number,
                 auth_account_object_digest,
@@ -1754,6 +1758,7 @@ impl AuthorityState {
             ) = iota_transaction_checks::check_certificate_and_move_authenticator_input(
                 certificate,
                 tx_input_objects,
+                checked_account_object,
                 move_authenticator_input_objects,
                 authenticator_gas_budget,
                 protocol_config,
@@ -5329,24 +5334,24 @@ impl AuthorityState {
         auth_account_object_id: ObjectID,
         auth_account_object_seq_number: Option<SequenceNumber>,
         auth_account_object_digest: Option<ObjectDigest>,
-        account_object: ObjectReadResult,
+        account_object_read_result: ObjectReadResult,
         signer: &IotaAddress,
-    ) -> IotaResult<AuthenticatorInfoV1> {
-        let account_object = match account_object.object {
+    ) -> IotaResult<(CheckedInputObjects, AuthenticatorInfoV1)> {
+        let account_object = match &account_object_read_result.object {
             ObjectReadResultKind::Object(object) => Ok(object),
             ObjectReadResultKind::DeletedSharedObject(version, digest) => {
                 Err(UserInputError::AccountObjectDeleted {
-                    account_id: account_object.id(),
-                    account_version: version,
-                    transaction_digest: digest,
+                    account_id: account_object_read_result.id(),
+                    account_version: version.to_owned(),
+                    transaction_digest: digest.to_owned(),
                 })
             }
             // It is impossible to check the account object because it is used in a canceled
             // transaction and is not loaded.
             ObjectReadResultKind::CancelledTransactionSharedObject(version) => {
                 Err(UserInputError::AccountObjectInCanceledTransaction {
-                    account_id: account_object.id(),
-                    account_version: version,
+                    account_id: account_object_read_result.id(),
+                    account_version: version.to_owned(),
                 })
             }
         }?;
@@ -5430,7 +5435,12 @@ impl AuthorityState {
                     }
                 })?;
 
-            Ok(field.value)
+            let checked_account_object =
+                CheckedInputObjects::new_with_checked_transaction_inputs(InputObjects::from(vec![
+                    account_object_read_result,
+                ]));
+
+            Ok((checked_account_object, field.value))
         } else {
             Err(UserInputError::MoveAuthenticatorNotFound {
                 authenticator_info_id: authenticator_info_field_id,
@@ -5486,7 +5496,7 @@ impl AuthorityState {
         Option<CheckedInputObjects>,
         Option<AuthenticatorInfoV1>,
     )> {
-        let (auth_checked_input_objects, authenticator_info, authenticator_gas_budget) =
+        let (auth_checked_input_objects_union, authenticator_info, authenticator_gas_budget) =
             if let Some(move_authenticator) = move_authenticator {
                 let auth_input_objects =
                     auth_input_objects.expect("MoveAuthenticator input objects must be provided");
@@ -5500,7 +5510,7 @@ impl AuthorityState {
                 ) = move_authenticator.object_to_authenticate_components()?;
 
                 // Make sure the sender is a Move account.
-                let authenticator_info = self.check_move_account(
+                let (checked_account_object, authenticator_info) = self.check_move_account(
                     auth_account_object_id,
                     auth_account_object_seq_number,
                     auth_account_object_digest,
@@ -5509,15 +5519,18 @@ impl AuthorityState {
                 )?;
 
                 // Check the MoveAuthenticator input objects.
-                let auth_checked_input_objects =
-                    iota_transaction_checks::check_move_authenticator_input(auth_input_objects)?;
+                let auth_checked_input_objects_union =
+                    iota_transaction_checks::check_move_authenticator_input_for_signing(
+                        checked_account_object,
+                        auth_input_objects,
+                    )?;
 
                 // `max_auth_gas` is used here as a Move authenticator gas budget until it is
                 // not a part of the transaction data.
                 let authenticator_gas_budget = protocol_config.max_auth_gas();
 
                 (
-                    Some(auth_checked_input_objects),
+                    Some(auth_checked_input_objects_union),
                     Some(authenticator_info),
                     authenticator_gas_budget,
                 )
@@ -5541,7 +5554,7 @@ impl AuthorityState {
         Ok((
             gas_status,
             tx_checked_input_objects,
-            auth_checked_input_objects,
+            auth_checked_input_objects_union,
             authenticator_info,
         ))
     }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1353,7 +1353,7 @@ impl AuthorityState {
             // `SenderSignedData::validity_check`.
 
             // Load the account object.
-            let account_object = self.input_loader.read_objects_for_execution(
+            let account_object_inputs = self.input_loader.read_objects_for_execution(
                 epoch_store,
                 // This key is used for resolving transaction shared object versions.
                 // It is supposed that the authenticator shared inputs are also can be
@@ -1365,16 +1365,16 @@ impl AuthorityState {
             )?;
 
             debug_assert!(
-                account_object.len() <= 1,
+                account_object_inputs.len() <= 1,
                 "Only one account object must be loaded or none if the `object_to_authenticate` type is not supported"
             );
 
-            let account_object = account_object.iter().next().cloned();
+            let account_object = account_object_inputs.iter().next().cloned();
 
             // Load the `MoveAuthenticator` input objects.
             let input_object_kinds = move_authenticator.input_objects();
 
-            let input_objects = self.input_loader.read_objects_for_execution(
+            let mut input_objects = self.input_loader.read_objects_for_execution(
                 epoch_store,
                 // This key is used for resolving transaction shared object versions.
                 // It is supposed that the authenticator shared inputs are also can be
@@ -1384,6 +1384,10 @@ impl AuthorityState {
                 &input_object_kinds,
                 epoch_store.epoch(),
             )?;
+
+            // We push the account object to the authenticator input objects
+            // to make it available during execution.
+            input_objects.extend_no_duplicates(account_object_inputs);
 
             (account_object, Some(input_objects))
         } else {
@@ -5511,7 +5515,7 @@ impl AuthorityState {
             move_authenticator.object_to_authenticate_components()?;
 
         // Load the account object.
-        let (account_object, object_to_authenticate_receiving) =
+        let (account_object_inputs, object_to_authenticate_receiving) =
             self.input_loader.read_objects_for_signing(
                 Some(&digest),
                 &move_authenticator.object_to_authenticate().input_objects(),
@@ -5531,13 +5535,13 @@ impl AuthorityState {
         );
 
         debug_assert!(
-            account_object.len() == 1,
+            account_object_inputs.len() == 1,
             "Only one account object must be loaded"
         );
 
         // Since the `object_to_authenticate` components are provided, it is supposed
         // that the account object is loaded.
-        let account_object = account_object
+        let account_object = account_object_inputs
             .iter()
             .next()
             .cloned()
@@ -5567,7 +5571,7 @@ impl AuthorityState {
         // `tx_digest_for_caching` parameter is not used, but we need to be careful
         // with caching because we call `read_objects_for_signing` several times with
         // different inputs but the same transaction digest.
-        let (authenticator_input_objects, authenticator_receiving_objects) =
+        let (mut authenticator_input_objects, authenticator_receiving_objects) =
             self.input_loader.read_objects_for_signing(
                 Some(&digest),
                 &authenticator_input_object_kinds,
@@ -5587,6 +5591,10 @@ impl AuthorityState {
         );
 
         // Check the inputs.
+
+        // We push the account object to the authenticator input objects
+        // to make it available during execution.
+        authenticator_input_objects.extend_no_duplicates(account_object_inputs);
 
         // `max_auth_gas` is used here as a Move authenticator gas budget until it is
         // not a part of the transaction data.

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -97,11 +97,7 @@ async fn test_abstract_account_creation_and_issue_tx() -> Result<(), anyhow::Err
             .collect();
     let signature_call_arg = CallArg::Pure(bcs::to_bytes(&hex_encoded_signature)?);
     let signatures = vec![GenericSignature::MoveAuthenticator(
-        MoveAuthenticator::new_for_testing(
-            vec![self_call_arg.clone(), signature_call_arg],
-            vec![],
-            self_call_arg,
-        ),
+        MoveAuthenticator::new_for_testing(vec![signature_call_arg], vec![], self_call_arg),
     )];
 
     // Create the TX envelope and execute it
@@ -158,7 +154,7 @@ async fn test_abstract_account_issues_sponsored_tx() -> Result<(), anyhow::Error
         mutable: false,
     });
     let aa_signature = GenericSignature::MoveAuthenticator(MoveAuthenticator::new_for_testing(
-        vec![self_call_arg.clone()],
+        vec![],
         vec![],
         self_call_arg,
     ));

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -207,14 +207,21 @@ mod checked {
     /// A common function to check the `MoveAuthenticator` inputs for signing.
     ///
     /// Checks that the authenticator inputs meet the requirements and returns
-    /// the checked authenticator input objects.
+    /// the union of the checked authenticator input objects and the account
+    /// object.
     #[instrument(level = "trace", skip_all)]
-    pub fn check_move_authenticator_input(
+    pub fn check_move_authenticator_input_for_signing(
+        account_object: CheckedInputObjects,
         authenticator_input_objects: InputObjects,
     ) -> IotaResult<CheckedInputObjects> {
         check_move_authenticator_objects(&authenticator_input_objects)?;
 
-        Ok(authenticator_input_objects.into_checked())
+        let auth_input_objects_union = checked_input_objects_union(
+            authenticator_input_objects.into_checked(),
+            &account_object,
+        )?;
+
+        Ok(auth_input_objects_union)
     }
 
     /// A function to check the `MoveAuthenticator` inputs for execution and
@@ -232,6 +239,7 @@ mod checked {
     pub fn check_certificate_and_move_authenticator_input(
         cert: &VerifiedExecutableTransaction,
         tx_input_objects: InputObjects,
+        account_object: CheckedInputObjects,
         authenticator_input_objects: InputObjects,
         authenticator_gas_budget: u64,
         protocol_config: &ProtocolConfig,
@@ -257,6 +265,8 @@ mod checked {
             tx_input_objects.into_checked(),
             &authenticator_input_objects,
         )?;
+        let input_objects_union =
+            checked_input_objects_union(input_objects_union, &account_object)?;
 
         Ok((gas_status, authenticator_input_objects, input_objects_union))
     }

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2931,13 +2931,13 @@ impl InputObjectKind {
 /// The result of reading an object for execution. Because shared objects may be
 /// deleted, one possible result of reading a shared object is that
 /// ObjectReadResultKind::Deleted is returned.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ObjectReadResult {
     pub input_object_kind: InputObjectKind,
     pub object: ObjectReadResultKind,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum ObjectReadResultKind {
     Object(Object),
     // The version of the object that the transaction intended to read, and the digest of the tx
@@ -3328,6 +3328,15 @@ impl InputObjects {
 
     pub fn push(&mut self, object: ObjectReadResult) {
         self.objects.push(object);
+    }
+
+    pub fn extend_no_duplicates(&mut self, other: Self) {
+        let new_objects: Vec<_> = other
+            .objects
+            .into_iter()
+            .filter(|x| !self.objects.contains(x))
+            .collect();
+        self.objects.extend(new_objects);
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &ObjectReadResult> {

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -3016,7 +3016,7 @@ impl InputObjectKind {
 /// The result of reading an object for execution. Because shared objects may be
 /// deleted, one possible result of reading a shared object is that
 /// ObjectReadResultKind::Deleted is returned.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct ObjectReadResult {
     pub input_object_kind: InputObjectKind,
     pub object: ObjectReadResultKind,
@@ -3413,15 +3413,6 @@ impl InputObjects {
 
     pub fn push(&mut self, object: ObjectReadResult) {
         self.objects.push(object);
-    }
-
-    pub fn extend_no_duplicates(&mut self, other: Self) {
-        let new_objects: Vec<_> = other
-            .objects
-            .into_iter()
-            .filter(|x| !self.objects.contains(x))
-            .collect();
-        self.objects.extend(new_objects);
     }
 
     // If it contains then it returns the ObjectReadResult

--- a/docs/examples/rust/aa/iotaccount.rs
+++ b/docs/examples/rust/aa/iotaccount.rs
@@ -97,11 +97,7 @@ async fn main() -> Result<(), anyhow::Error> {
     });
     let signature_call_arg = CallArg::Pure(bcs::to_bytes(&hex_encoded_signature)?);
     let signatures = vec![GenericSignature::MoveAuthenticator(
-        MoveAuthenticator::new_for_testing(
-            vec![self_call_arg.clone(), signature_call_arg],
-            vec![],
-            self_call_arg,
-        ),
+        MoveAuthenticator::new_for_testing(vec![signature_call_arg], vec![], self_call_arg),
     )];
 
     let transaction_response = iota_client

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -1653,18 +1653,26 @@ mod checked {
     /// Construct a PTB with a single move call. This calls the authenticator
     /// function found in `AuthenticatorInfo`. The inputs for the function are
     /// found in `MoveAuthenticator`.
+    /// `MoveAuthenticator::object_to_authenticate` is added as the first
+    /// argument to the created PTB, followed by all arguments in
+    /// `MoveAuthenticator::call_args`.
     fn setup_authenticator_move_call(
         authenticator: MoveAuthenticator,
         authenticator_info: AuthenticatorInfoV1,
     ) -> Result<ProgrammableTransaction, ExecutionError> {
         let mut builder = ProgrammableTransactionBuilder::new();
 
+        let mut args = vec![authenticator.object_to_authenticate().to_owned()];
+        args.extend(authenticator.call_args().to_owned());
+
         let res = builder.move_call(
             authenticator_info.package,
-            Identifier::new(authenticator_info.module.clone()).unwrap(),
-            Identifier::new(authenticator_info.function.clone()).unwrap(),
+            Identifier::new(authenticator_info.module.clone())
+                .expect("`AuthenticatorInfoV1::module` is expected to be a valid `Identifier`"),
+            Identifier::new(authenticator_info.function.clone())
+                .expect("`AuthenticatorInfoV1::function` is expected to be a valid `Identifier`"),
             authenticator.type_arguments().to_owned(),
-            authenticator.call_args().to_owned(),
+            args,
         );
 
         assert_invariant!(


### PR DESCRIPTION
[run-ci]

# Description of change

`object_to_authenticate` is pushed as a Move authenticator call as the first parameter.

## Links to any relevant issues

fixes #8902 
