### PR TITLE
feat(consensus): Update protocol feature flags for mysticeti features

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -79,7 +79,7 @@ pub const MAX_PROTOCOL_VERSION: u64 = 14;
 //             non-committee validators in the devnet.
 // Version 14: Switches the consensus protocol to Starfish in devnet.
 //             Enable median-based commit timestamp calculation in consensus,
-//             and enforce checkpoint timestamp monotonicity for devnet.
+//             and enforce checkpoint timestamp monotonicity for testnet.
 //             Enable batched block sync for mainnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -2256,7 +2256,7 @@ impl ProtocolConfig {
                     cfg.feature_flags.consensus_batched_block_sync = true;
                     if chain != Chain::Mainnet {
                         // Enable median-based commit timestamp calculation in consensus and
-                        // enforce checkpoint timestamp monotonicity for devnet.
+                        // enforce checkpoint timestamp monotonicity for testnet.
                         cfg.feature_flags
                             .consensus_median_timestamp_with_checkpoint_enforcement = true;
                     }

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -78,9 +78,9 @@ pub const MAX_PROTOCOL_VERSION: u64 = 14;
 //             Enable processing and tracking AuthorityCapabilitiesV1 from
 //             non-committee validators in the devnet.
 // Version 14: Switches the consensus protocol to Starfish in devnet.
-//             Enable median-based commit timestamp calculation in consensus in
-//             devnet.
-//             Enforce checkpoint timestamps are non-decreasing for devnet.
+//             Enable median-based commit timestamp calculation in consensus,
+//             and checkpoint timestamps are non-decreasing for devnet.
+//             Enable batched block sync for mainnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -2252,13 +2252,17 @@ impl ProtocolConfig {
                     }
                 }
                 14 => {
-                    if chain != Chain::Testnet && chain != Chain::Mainnet {
-                        // Switch consensus protocol to Starfish in devnet
-                        cfg.feature_flags.consensus_choice = ConsensusChoice::Starfish;
+                    // Enable batched block sync for mainnet.
+                    cfg.feature_flags.consensus_batched_block_sync = true;
+                    if chain != Chain::Mainnet {
                         // Enable median-based commit timestamp calculation in consensus and
                         // enforce checkpoint timestamp monotonicity for devnet.
                         cfg.feature_flags
                             .consensus_median_timestamp_with_checkpoint_enforcement = true;
+                    }
+                    if chain != Chain::Testnet && chain != Chain::Mainnet {
+                        // Switch consensus protocol to Starfish in devnet
+                        cfg.feature_flags.consensus_choice = ConsensusChoice::Starfish;
                     }
                 }
                 // Use this template when making changes:

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -79,7 +79,7 @@ pub const MAX_PROTOCOL_VERSION: u64 = 14;
 //             non-committee validators in the devnet.
 // Version 14: Switches the consensus protocol to Starfish in devnet.
 //             Enable median-based commit timestamp calculation in consensus,
-//             and checkpoint timestamps are non-decreasing for devnet.
+//             and enforce checkpoint timestamp monotonicity for devnet.
 //             Enable batched block sync for mainnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_14.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_14.snap
@@ -19,6 +19,7 @@ feature_flags:
   consensus_round_prober_probe_accepted_rounds: true
   consensus_zstd_compression: true
   congestion_control_min_free_execution_slot: true
+  consensus_batched_block_sync: true
   congestion_control_gas_price_feedback_mechanism: true
   validate_identifier_inputs: true
   minimize_child_object_mutations: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_14.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_14.snap
@@ -28,6 +28,7 @@ feature_flags:
   normalize_ptb_arguments: true
   select_committee_from_eligible_validators: true
   track_non_committee_eligible_validators: true
+  consensus_median_timestamp_with_checkpoint_enforcement: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000


### PR DESCRIPTION
# Description of change

Update protocol feature flags for Mysticeti features:
* Enable median-based commit timestamp calculation in consensus, and checkpoint timestamps are non-decreasing for devnet.
* Enable batched block sync for mainnet.

## Links to any relevant issues

Resolves #8977

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Enable median-based commit timestamp calculation in consensus, and checkpoint timestamps are non-decreasing for devnet. Enable batched block sync for mainnet.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
