### PR TITLE
feat(iota-core): update neural network model server from congestion tracker module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ iota.log.*
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+congestion_audit.jsonl
 
 # misc
 *.key

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5861,7 +5861,6 @@ dependencies = [
  "num_cpus",
  "object_store 0.10.2",
  "once_cell",
- "ordered-float 5.1.0",
  "parking_lot 0.12.3",
  "pprof",
  "pretty_assertions",
@@ -10387,17 +10386,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
- "serde",
-]
-
-[[package]]
 name = "ouroboros"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11690,7 +11678,6 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "serde",
 ]
 
 [[package]]
@@ -11749,7 +11736,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
- "serde",
 ]
 
 [[package]]
@@ -14308,7 +14294,7 @@ checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "ordered-float 2.10.1",
+ "ordered-float",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5861,6 +5861,7 @@ dependencies = [
  "num_cpus",
  "object_store 0.10.2",
  "once_cell",
+ "ordered-float 5.1.0",
  "parking_lot 0.12.3",
  "pprof",
  "pretty_assertions",
@@ -10386,6 +10387,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
 name = "ouroboros"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11678,6 +11690,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -11736,6 +11749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+ "serde",
 ]
 
 [[package]]
@@ -14294,7 +14308,7 @@ checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "ordered-float",
+ "ordered-float 2.10.1",
 ]
 
 [[package]]

--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -57,6 +57,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tokio-stream.workspace = true
 tracing.workspace = true
 twox-hash = "1.6"
+ordered-float = { version = "5.0", features = ["serde"] }
 
 # internal dependencies
 consensus-config.workspace = true

--- a/crates/iota-core/src/congestion_tracker.rs
+++ b/crates/iota-core/src/congestion_tracker.rs
@@ -163,8 +163,6 @@ impl CongestionTracker {
         let mut stats: HashMap<ObjectID, ObjectCheckpointStats> = HashMap::new();
         let mut raw_txs: Vec<RawTxItem> =
             Vec::with_capacity(congestion_txs_data.len() + clearing_txs_data.len());
-        let mut per_obj_min_clearing: HashMap<ObjectID, u64> = HashMap::new();
-        let mut per_obj_max_congestion: HashMap<ObjectID, u64> = HashMap::new();
 
         for (is_congested, tx) in congestion_txs_data
             .iter()
@@ -195,34 +193,14 @@ impl CongestionTracker {
                 touched_objects: tx.objects.clone(),
             });
 
-            // per-object min clearing for clearing txs
-            if !is_congested {
-                for oid in &tx.objects {
-                    per_obj_min_clearing
-                        .entry(*oid)
-                        .and_modify(|m| *m = (*m).min(tx.gas_price))
-                        .or_insert(tx.gas_price);
-                }
-            } else {
-                // Track per-object max congestion (using feedback if present, otherwise gas price)
-                let cong_req = tx.gas_price_feedback.unwrap_or(tx.gas_price);
-                for oid in &tx.objects {
-                    per_obj_max_congestion
-                        .entry(*oid)
-                        .and_modify(|m| *m = (*m).max(cong_req))
-                        .or_insert(cong_req);
-                }
-            }
         }
 
-        // Build per-object required price in checkpoint:
-        // - prefer lowest clearing if present; otherwise use highest congestion observed.
+        // Build per-object required price in checkpoint using
+        // get_suggested_gas_price_for_objects()
         let mut per_obj_required_in_cp: HashMap<ObjectID, u64> = HashMap::new();
         for oid in &touched {
-            if let Some(c) = per_obj_min_clearing.get(oid) {
-                per_obj_required_in_cp.insert(*oid, *c);
-            } else if let Some(max_cong) = per_obj_max_congestion.get(oid) {
-                per_obj_required_in_cp.insert(*oid, *max_cong);
+            if let Some(price) = self.get_suggested_gas_price_for_objects(std::iter::once(*oid)) {
+                per_obj_required_in_cp.insert(*oid, price);
             }
         }
 

--- a/crates/iota-core/src/congestion_tracker.rs
+++ b/crates/iota-core/src/congestion_tracker.rs
@@ -324,39 +324,34 @@ impl CongestionTracker {
                 continue;
             }
 
-            // Compute the set of mutated shared objects for this transaction once,
-            // and only use those for congestion/clearing accounting and model input.
-            let mutated_objects: Vec<ObjectID> = effects
-                .input_shared_objects()
-                .into_iter()
-                .filter_map(|object| match object {
-                    InputSharedObject::Mutate((id, _, _)) => Some(id),
-                    _ => None,
-                })
-                .collect();
-
-            if let Some(CongestedObjects(_congested_objects)) =
+            if let Some(CongestedObjects(congested_objects)) =
                 effects.status().get_congested_objects()
             {
-                // Only consider transactions that actually mutate shared objects.
-                if !mutated_objects.is_empty() {
-                    congestion_txs_data.push(TxData {
-                        checkpoint: checkpoint.sequence_number,
-                        digest: *effects.transaction_digest(),
-                        objects: mutated_objects.clone(),
-                        gas_price,
-                        gas_price_feedback: Some(
-                            effects
-                                .status()
-                                .get_feedback_suggested_gas_price()
-                                .unwrap_or(self.reference_gas_price),
-                        ),
-                        sui_prediction: sui_prediction,
-                        ogd_prediction: ogd_prediction,
-                        cleread: false,
-                    });
-                }
+                congestion_txs_data.push(TxData {
+                    checkpoint: checkpoint.sequence_number,
+                    digest: *effects.transaction_digest(),
+                    objects: congested_objects.clone(),
+                    gas_price,
+                    gas_price_feedback: Some(
+                        effects
+                            .status()
+                            .get_feedback_suggested_gas_price()
+                            .unwrap_or(self.reference_gas_price),
+                    ),
+                    sui_prediction: sui_prediction,
+                    ogd_prediction: ogd_prediction,
+                    cleread: false,
+                });
             } else {
+                let mutated_objects: Vec<ObjectID> = effects
+                    .input_shared_objects()
+                    .into_iter()
+                    .filter_map(|object| match object {
+                        InputSharedObject::Mutate((id, _, _)) => Some(id),
+                        _ => None,
+                    })
+                    .collect();
+
                 // Only push to clearing_txs_data if there are mutated objects
                 if !mutated_objects.is_empty() {
                     clearing_txs_data.push(TxData {

--- a/crates/iota-core/src/congestion_tracker.rs
+++ b/crates/iota-core/src/congestion_tracker.rs
@@ -305,34 +305,39 @@ impl CongestionTracker {
                 continue;
             }
 
-            if let Some(CongestedObjects(congested_objects)) =
+            // Compute the set of mutated shared objects for this transaction once,
+            // and only use those for congestion/clearing accounting and model input.
+            let mutated_objects: Vec<ObjectID> = effects
+                .input_shared_objects()
+                .into_iter()
+                .filter_map(|object| match object {
+                    InputSharedObject::Mutate((id, _, _)) => Some(id),
+                    _ => None,
+                })
+                .collect();
+
+            if let Some(CongestedObjects(_congested_objects)) =
                 effects.status().get_congested_objects()
             {
-                congestion_txs_data.push(TxData {
-                    checkpoint: checkpoint.sequence_number,
-                    digest: *effects.transaction_digest(),
-                    objects: congested_objects.clone(),
-                    gas_price,
-                    gas_price_feedback: Some(
-                        effects
-                            .status()
-                            .get_feedback_suggested_gas_price()
-                            .unwrap_or(self.reference_gas_price),
-                    ),
-                    sui_prediction: sui_prediction,
-                    ogd_prediction: ogd_prediction,
-                    cleread: false,
-                });
+                // Only consider transactions that actually mutate shared objects.
+                if !mutated_objects.is_empty() {
+                    congestion_txs_data.push(TxData {
+                        checkpoint: checkpoint.sequence_number,
+                        digest: *effects.transaction_digest(),
+                        objects: mutated_objects.clone(),
+                        gas_price,
+                        gas_price_feedback: Some(
+                            effects
+                                .status()
+                                .get_feedback_suggested_gas_price()
+                                .unwrap_or(self.reference_gas_price),
+                        ),
+                        sui_prediction: sui_prediction,
+                        ogd_prediction: ogd_prediction,
+                        cleread: false,
+                    });
+                }
             } else {
-                let mutated_objects: Vec<ObjectID> = effects
-                    .input_shared_objects()
-                    .into_iter()
-                    .filter_map(|object| match object {
-                        InputSharedObject::Mutate((id, _, _)) => Some(id),
-                        _ => None,
-                    })
-                    .collect();
-
                 // Only push to clearing_txs_data if there are mutated objects
                 if !mutated_objects.is_empty() {
                     clearing_txs_data.push(TxData {

--- a/crates/iota-core/src/congestion_tracker.rs
+++ b/crates/iota-core/src/congestion_tracker.rs
@@ -164,6 +164,7 @@ impl CongestionTracker {
         let mut raw_txs: Vec<RawTxItem> =
             Vec::with_capacity(congestion_txs_data.len() + clearing_txs_data.len());
         let mut per_obj_min_clearing: HashMap<ObjectID, u64> = HashMap::new();
+        let mut per_obj_max_congestion: HashMap<ObjectID, u64> = HashMap::new();
 
         for (is_congested, tx) in congestion_txs_data
             .iter()
@@ -202,6 +203,26 @@ impl CongestionTracker {
                         .and_modify(|m| *m = (*m).min(tx.gas_price))
                         .or_insert(tx.gas_price);
                 }
+            } else {
+                // Track per-object max congestion (using feedback if present, otherwise gas price)
+                let cong_req = tx.gas_price_feedback.unwrap_or(tx.gas_price);
+                for oid in &tx.objects {
+                    per_obj_max_congestion
+                        .entry(*oid)
+                        .and_modify(|m| *m = (*m).max(cong_req))
+                        .or_insert(cong_req);
+                }
+            }
+        }
+
+        // Build per-object required price in checkpoint:
+        // - prefer lowest clearing if present; otherwise use highest congestion observed.
+        let mut per_obj_required_in_cp: HashMap<ObjectID, u64> = HashMap::new();
+        for oid in &touched {
+            if let Some(c) = per_obj_min_clearing.get(oid) {
+                per_obj_required_in_cp.insert(*oid, *c);
+            } else if let Some(max_cong) = per_obj_max_congestion.get(oid) {
+                per_obj_required_in_cp.insert(*oid, *max_cong);
             }
         }
 
@@ -239,7 +260,7 @@ impl CongestionTracker {
             checkpoint.timestamp_ms,
             self.reference_gas_price,
             &raw_txs,
-            &per_obj_min_clearing,
+            &per_obj_required_in_cp,
         ) {
             self.model_updater.post_train_tx(train_batch);
         }

--- a/crates/iota-core/src/congestion_tracker.rs
+++ b/crates/iota-core/src/congestion_tracker.rs
@@ -19,6 +19,10 @@ use iota_types::{
 };
 use moka::{ops::compute::Op, sync::Cache};
 use serde::Deserialize;
+use crate::model_updater::{
+    build_cp_update_batch, build_train_tx_batch, HttpModelUpdater, ObjectCheckpointStats,
+    ObjectSnapshot, RawTxItem, ModelUpdater,
+};
 use tracing::info;
 
 use crate::execution_cache::TransactionCacheRead;
@@ -139,9 +143,109 @@ pub struct CongestionTracker {
     reference_gas_price: u64,
     /// Key-value cache for storing congestion info of objects.
     object_congestion_info: Cache<ObjectID, CongestionInfo>,
+    /// HTTP client for posting model updates/training batches.
+    model_updater: HttpModelUpdater,
 }
 
 impl CongestionTracker {
+    /// Compose and send model update and training batches for the given checkpoint.
+    fn inform_model(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+        congestion_txs_data: &[TxData],
+        clearing_txs_data: &[TxData],
+    ) {
+        // 1) Build touched set
+        let mut touched: std::collections::HashSet<ObjectID> = std::collections::HashSet::new();
+        for tx in congestion_txs_data {
+            touched.extend(tx.objects.iter().cloned());
+        }
+        for tx in clearing_txs_data {
+            touched.extend(tx.objects.iter().cloned());
+        }
+
+        // 2) Build snapshots from current cache
+        let mut snapshots: HashMap<ObjectID, ObjectSnapshot> = HashMap::new();
+        for oid in &touched {
+            if let Some(info) = self.get_congestion_info(*oid) {
+                snapshots.insert(
+                    *oid,
+                    ObjectSnapshot {
+                        latest_congestion_time: Some(info.latest_congestion_time),
+                        highest_congestion_gas_price: info.highest_congestion_gas_price,
+                        latest_clearing_time: info.latest_clearing_time,
+                        lowest_clearing_gas_price: info.lowest_clearing_gas_price.unwrap_or(0),
+                        hotness: info.hotness,
+                    },
+                );
+            }
+        }
+
+        // 3) Build per-checkpoint stats
+        let mut stats: HashMap<ObjectID, ObjectCheckpointStats> = HashMap::new();
+        for tx in congestion_txs_data {
+            for oid in &tx.objects {
+                let entry = stats.entry(*oid).or_default();
+                entry.was_congested = true;
+                entry.congested_tx_count += 1;
+            }
+        }
+        for tx in clearing_txs_data {
+            for oid in &tx.objects {
+                let entry = stats.entry(*oid).or_default();
+                entry.was_cleared = true;
+                entry.clearing_tx_count += 1;
+            }
+        }
+
+        // 4) Post update batch
+        let update_batch = build_cp_update_batch(
+            checkpoint.timestamp_ms,
+            self.reference_gas_price,
+            touched.iter().cloned(),
+            &snapshots,
+            &stats,
+        );
+        self.model_updater.post_update(update_batch);
+
+        // 5) Build raw tx items and per-object min clearing for training
+        let mut raw_txs: Vec<RawTxItem> = Vec::with_capacity(
+            congestion_txs_data.len() + clearing_txs_data.len(),
+        );
+        let mut per_obj_min_clearing: HashMap<ObjectID, u64> = HashMap::new();
+        for tx in congestion_txs_data {
+            raw_txs.push(RawTxItem {
+                tx_digest: tx.digest.to_string(),
+                is_congested: true,
+                gas_price: tx.gas_price,
+                gas_price_feedback: tx.gas_price_feedback,
+                touched_objects: tx.objects.clone(),
+            });
+        }
+        for tx in clearing_txs_data {
+            raw_txs.push(RawTxItem {
+                tx_digest: tx.digest.to_string(),
+                is_congested: false,
+                gas_price: tx.gas_price,
+                gas_price_feedback: None,
+                touched_objects: tx.objects.clone(),
+            });
+            for oid in &tx.objects {
+                per_obj_min_clearing
+                    .entry(*oid)
+                    .and_modify(|m| *m = (*m).min(tx.gas_price))
+                    .or_insert(tx.gas_price);
+            }
+        }
+        if let Some(train_batch) = build_train_tx_batch(
+            checkpoint.timestamp_ms,
+            self.reference_gas_price,
+            &raw_txs,
+            &per_obj_min_clearing,
+        ) {
+            self.model_updater.post_train_tx(train_batch);
+        }
+    }
     /// Create a new `CongestionTracker`. The cache capacity will be
     /// set to `CONGESTION_TRACKER_CACHE_CAPACITY`, which is `10_000`.
     pub fn new(reference_gas_price: u64) -> Self {
@@ -157,6 +261,7 @@ impl CongestionTracker {
         Self {
             reference_gas_price,
             object_congestion_info: Cache::new(CONGESTION_TRACKER_CACHE_CAPACITY),
+            model_updater: HttpModelUpdater::default(),
         }
     }
 
@@ -291,6 +396,9 @@ impl CongestionTracker {
                 tx.cleread,
             );
         }
+
+        // Inform model right before dumping hotness CSV
+        self.inform_model(checkpoint, &congestion_txs_data, &clearing_txs_data);
 
         if !self.get_all_hotness().is_empty() {
             info!(
@@ -1257,6 +1365,7 @@ mod tests {
             "obj1 should be removed from cache"
         );
         let hotness = tracker.get_hotness_for_object(&obj2).unwrap_or(0.0);
+        println!("hotness for obj2: {}", hotness);
         assert!(
             hotness == 1.25 * HOTNESS_ADJUSTMENT_FACTOR,
             "hotness for obj2 should be 1.25"

--- a/crates/iota-core/src/congestion_tracker.rs
+++ b/crates/iota-core/src/congestion_tracker.rs
@@ -155,16 +155,57 @@ impl CongestionTracker {
         congestion_txs_data: &[TxData],
         clearing_txs_data: &[TxData],
     ) {
-        // 1) Build touched set
+        // Single pass over both congested and clearing txs to build:
+        // - touched set
+        // - per-checkpoint stats (counts + flags)
+        // - raw training items and per-object min clearing map
         let mut touched: std::collections::HashSet<ObjectID> = std::collections::HashSet::new();
-        for tx in congestion_txs_data {
+        let mut stats: HashMap<ObjectID, ObjectCheckpointStats> = HashMap::new();
+        let mut raw_txs: Vec<RawTxItem> =
+            Vec::with_capacity(congestion_txs_data.len() + clearing_txs_data.len());
+        let mut per_obj_min_clearing: HashMap<ObjectID, u64> = HashMap::new();
+
+        for (is_congested, tx) in congestion_txs_data
+            .iter()
+            .map(|t| (true, t))
+            .chain(clearing_txs_data.iter().map(|t| (false, t)))
+        {
+            // touched set
             touched.extend(tx.objects.iter().cloned());
-        }
-        for tx in clearing_txs_data {
-            touched.extend(tx.objects.iter().cloned());
+
+            // stats per object
+            for oid in &tx.objects {
+                let entry = stats.entry(*oid).or_default();
+                if is_congested {
+                    entry.was_congested = true;
+                    entry.congested_tx_count += 1;
+                } else {
+                    entry.was_cleared = true;
+                    entry.clearing_tx_count += 1;
+                }
+            }
+
+            // raw training items
+            raw_txs.push(RawTxItem {
+                tx_digest: tx.digest.to_string(),
+                is_congested,
+                gas_price: tx.gas_price,
+                gas_price_feedback: if is_congested { tx.gas_price_feedback } else { None },
+                touched_objects: tx.objects.clone(),
+            });
+
+            // per-object min clearing for clearing txs
+            if !is_congested {
+                for oid in &tx.objects {
+                    per_obj_min_clearing
+                        .entry(*oid)
+                        .and_modify(|m| *m = (*m).min(tx.gas_price))
+                        .or_insert(tx.gas_price);
+                }
+            }
         }
 
-        // 2) Build snapshots from current cache
+        // Build snapshots from current cache using the touched set
         let mut snapshots: HashMap<ObjectID, ObjectSnapshot> = HashMap::new();
         for oid in &touched {
             if let Some(info) = self.get_congestion_info(*oid) {
@@ -174,31 +215,16 @@ impl CongestionTracker {
                         latest_congestion_time: Some(info.latest_congestion_time),
                         highest_congestion_gas_price: info.highest_congestion_gas_price,
                         latest_clearing_time: info.latest_clearing_time,
-                        lowest_clearing_gas_price: info.lowest_clearing_gas_price.unwrap_or(0),
+                        lowest_clearing_gas_price: info
+                            .lowest_clearing_gas_price
+                            .unwrap_or(self.reference_gas_price),
                         hotness: info.hotness,
                     },
                 );
             }
         }
 
-        // 3) Build per-checkpoint stats
-        let mut stats: HashMap<ObjectID, ObjectCheckpointStats> = HashMap::new();
-        for tx in congestion_txs_data {
-            for oid in &tx.objects {
-                let entry = stats.entry(*oid).or_default();
-                entry.was_congested = true;
-                entry.congested_tx_count += 1;
-            }
-        }
-        for tx in clearing_txs_data {
-            for oid in &tx.objects {
-                let entry = stats.entry(*oid).or_default();
-                entry.was_cleared = true;
-                entry.clearing_tx_count += 1;
-            }
-        }
-
-        // 4) Post update batch
+        // Post update batch
         let update_batch = build_cp_update_batch(
             checkpoint.timestamp_ms,
             self.reference_gas_price,
@@ -208,35 +234,7 @@ impl CongestionTracker {
         );
         self.model_updater.post_update(update_batch);
 
-        // 5) Build raw tx items and per-object min clearing for training
-        let mut raw_txs: Vec<RawTxItem> = Vec::with_capacity(
-            congestion_txs_data.len() + clearing_txs_data.len(),
-        );
-        let mut per_obj_min_clearing: HashMap<ObjectID, u64> = HashMap::new();
-        for tx in congestion_txs_data {
-            raw_txs.push(RawTxItem {
-                tx_digest: tx.digest.to_string(),
-                is_congested: true,
-                gas_price: tx.gas_price,
-                gas_price_feedback: tx.gas_price_feedback,
-                touched_objects: tx.objects.clone(),
-            });
-        }
-        for tx in clearing_txs_data {
-            raw_txs.push(RawTxItem {
-                tx_digest: tx.digest.to_string(),
-                is_congested: false,
-                gas_price: tx.gas_price,
-                gas_price_feedback: None,
-                touched_objects: tx.objects.clone(),
-            });
-            for oid in &tx.objects {
-                per_obj_min_clearing
-                    .entry(*oid)
-                    .and_modify(|m| *m = (*m).min(tx.gas_price))
-                    .or_insert(tx.gas_price);
-            }
-        }
+        // Post train batch (if any)
         if let Some(train_batch) = build_train_tx_batch(
             checkpoint.timestamp_ms,
             self.reference_gas_price,

--- a/crates/iota-core/src/lib.rs
+++ b/crates/iota-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod authority_client;
 pub mod authority_server;
 pub mod checkpoints;
 pub mod congestion_tracker;
+pub mod model_updater;
 pub mod connection_monitor;
 pub mod consensus_adapter;
 pub mod consensus_handler;

--- a/crates/iota-core/src/model_updater.rs
+++ b/crates/iota-core/src/model_updater.rs
@@ -1,0 +1,483 @@
+// model_updater.rs
+// Extracted model posting / training logic for congestion tracking.
+// This file intentionally does not modify any existing code paths yet.
+// It defines a trait-based API and HTTP implementation to be wired in later.
+
+use serde::Serialize;
+use std::{
+    collections::HashMap,
+    fs::{File, OpenOptions},
+    io::Write,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+use iota_types::base_types::ObjectID;
+
+/// Default base URL for the predictor service.
+pub const DEFAULT_PREDICTOR_BASE_URL: &str = "http://predictor:9666";
+/// Default JSONL audit log path (created/appended in current working dir).
+pub const AUDIT_LOG_PATH: &str = "congestion_audit.jsonl";
+/// Minimum reference gas price used in required-price lower bound.
+pub const MIN_REFERENCE_GAS_PRICE: u64 = 1000;
+
+/// Rows describing per-object state used by the predictor's /update endpoint.
+/// Note: This mirrors the shape currently produced inside CongestionTracker.
+#[derive(Debug, Clone, Serialize)]
+pub struct CpUpdateRow {
+    pub checkpoint_ms: u64,
+    pub reference_gas_price: u64,
+    pub object_id: String,
+
+    // CongestionInfo snapshot (post-update if present)
+    pub latest_congestion_time: Option<u64>,
+    pub highest_congestion_gas_price: u64,
+    pub latest_clearing_time: Option<u64>,
+    pub lowest_clearing_gas_price: u64,
+    pub hotness: f64,
+
+    // Per-checkpoint flags & counts for the object
+    pub was_touched_in_cp: bool,
+    pub was_congested_in_cp: bool,
+    pub was_cleared_in_cp: bool,
+    pub congested_tx_count_in_cp: u32,
+    pub clearing_tx_count_in_cp: u32,
+
+    // Convenience normalized helpers
+    pub hotness_over_ref: f64,
+    pub highest_congestion_over_ref: f64,
+    pub lowest_clearing_over_ref: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CpUpdateBatch {
+    pub checkpoint_ms: u64,
+    pub rows: Vec<CpUpdateRow>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TrainTxItem {
+    pub checkpoint_ms: u64,
+    pub reference_gas_price: u64,
+    pub required_price_in_cp: u64,
+    pub object_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TrainTxBatch {
+    pub items: Vec<TrainTxItem>,
+}
+
+/// Snapshot of per-object state needed to compose update rows.
+#[derive(Debug, Clone)]
+pub struct ObjectSnapshot {
+    pub latest_congestion_time: Option<u64>,
+    pub highest_congestion_gas_price: u64,
+    pub latest_clearing_time: Option<u64>,
+    pub lowest_clearing_gas_price: u64,
+    pub hotness: f64,
+}
+
+/// Per-checkpoint object stats derived from txs in this checkpoint.
+#[derive(Debug, Clone, Default)]
+pub struct ObjectCheckpointStats {
+    pub was_congested: bool,
+    pub was_cleared: bool,
+    pub congested_tx_count: u32,
+    pub clearing_tx_count: u32,
+}
+
+/// Build a CpUpdateBatch from touched object ids, snapshots and per-checkpoint stats.
+pub fn build_cp_update_batch(
+    checkpoint_ms: u64,
+    reference_gas_price: u64,
+    touched: impl IntoIterator<Item = ObjectID>,
+    snapshots: &HashMap<ObjectID, ObjectSnapshot>,
+    stats: &HashMap<ObjectID, ObjectCheckpointStats>,
+) -> CpUpdateBatch {
+    let mut rows = Vec::new();
+    for oid in touched {
+        if let Some(s) = snapshots.get(&oid) {
+            let st = stats.get(&oid).cloned().unwrap_or_default();
+            let hot = s.hotness;
+            let highest_cong = s.highest_congestion_gas_price;
+            let lowest_clear = s.lowest_clearing_gas_price;
+            rows.push(CpUpdateRow {
+                checkpoint_ms,
+                reference_gas_price,
+                object_id: oid.to_string(),
+
+                latest_congestion_time: s.latest_congestion_time,
+                highest_congestion_gas_price: highest_cong,
+                latest_clearing_time: s.latest_clearing_time,
+                lowest_clearing_gas_price: lowest_clear,
+                hotness: hot,
+
+                was_touched_in_cp: true,
+                was_congested_in_cp: st.was_congested,
+                was_cleared_in_cp: st.was_cleared,
+                congested_tx_count_in_cp: st.congested_tx_count,
+                clearing_tx_count_in_cp: st.clearing_tx_count,
+
+                hotness_over_ref: hot / reference_gas_price as f64,
+                highest_congestion_over_ref: if highest_cong > 0 {
+                    highest_cong as f64 / reference_gas_price as f64
+                } else {
+                    0.0
+                },
+                lowest_clearing_over_ref: if lowest_clear > 0 {
+                    lowest_clear as f64 / reference_gas_price as f64
+                } else {
+                    0.0
+                },
+            });
+        } else {
+            let st = stats.get(&oid).cloned().unwrap_or_default();
+            rows.push(CpUpdateRow {
+                checkpoint_ms,
+                reference_gas_price,
+                object_id: oid.to_string(),
+
+                latest_congestion_time: None,
+                highest_congestion_gas_price: 0,
+                latest_clearing_time: None,
+                lowest_clearing_gas_price: 0,
+                hotness: 0.0,
+
+                was_touched_in_cp: true,
+                was_congested_in_cp: st.was_congested,
+                was_cleared_in_cp: st.was_cleared,
+                congested_tx_count_in_cp: st.congested_tx_count,
+                clearing_tx_count_in_cp: st.clearing_tx_count,
+
+                hotness_over_ref: 0.0,
+                highest_congestion_over_ref: 0.0,
+                lowest_clearing_over_ref: 0.0,
+            });
+        }
+    }
+    CpUpdateBatch { checkpoint_ms, rows }
+}
+
+/// Build a TrainTxBatch from raw txs and per-object min clearing prices for this checkpoint.
+pub fn build_train_tx_batch(
+    checkpoint_ms: u64,
+    reference_gas_price: u64,
+    raw_txs: &[RawTxItem],
+    per_object_min_clearing_in_cp: &HashMap<ObjectID, u64>,
+) -> Option<TrainTxBatch> {
+    let mut items = Vec::new();
+    for tx in raw_txs {
+        let oids: Vec<String> = tx.touched_objects.iter().map(|o| o.to_string()).collect();
+        if oids.is_empty() {
+            continue;
+        }
+
+        let required = if tx.is_congested {
+            tx.gas_price_feedback
+                .unwrap_or(tx.gas_price)
+                .max(MIN_REFERENCE_GAS_PRICE)
+        } else {
+            let mut req = MIN_REFERENCE_GAS_PRICE;
+            for oid in &tx.touched_objects {
+                if let Some(min_clear) = per_object_min_clearing_in_cp.get(oid) {
+                    if *min_clear > MIN_REFERENCE_GAS_PRICE {
+                        req = req.max(*min_clear);
+                    }
+                }
+            }
+            req
+        };
+
+        items.push(TrainTxItem {
+            checkpoint_ms,
+            reference_gas_price,
+            required_price_in_cp: required,
+            object_ids: oids,
+        });
+    }
+    if items.is_empty() { None } else { Some(TrainTxBatch { items }) }
+}
+
+/// Trait abstraction for sending model-related updates.
+///
+/// Implementations should be resilient: never panic on send errors and prefer
+/// logging/metrics over propagating failures.
+pub trait ModelUpdater: Send + Sync {
+    /// Post a batch of per-object updates to the predictor. Should send even if empty.
+    fn post_update(&self, batch: CpUpdateBatch);
+
+    /// Post a batch of tx-level training items to the predictor.
+    fn post_train_tx(&self, batch: TrainTxBatch);
+}
+
+/// No-op implementation useful for tests or when disabled by config.
+pub struct NoopModelUpdater;
+
+impl ModelUpdater for NoopModelUpdater {
+    fn post_update(&self, batch: CpUpdateBatch) {
+        println!(
+            "[congestion/noop] skip POST /update (rows={})",
+            batch.rows.len()
+        );
+    }
+
+    fn post_train_tx(&self, batch: TrainTxBatch) {
+        println!(
+            "[congestion/noop] skip POST /train_tx (items={})",
+            batch.items.len()
+        );
+    }
+}
+
+/// HTTP implementation using reqwest, with async-or-blocking fallback depending
+/// on the presence of a Tokio runtime.
+pub struct HttpModelUpdater {
+    base_url: String,
+}
+
+impl HttpModelUpdater {
+    pub fn new<S: Into<String>>(base_url: S) -> Self {
+        Self {
+            base_url: base_url.into(),
+        }
+    }
+
+    fn update_url(&self) -> String {
+        format!("{}/update", self.base_url.trim_end_matches('/'))
+    }
+
+    fn train_tx_url(&self) -> String {
+        format!("{}/train_tx", self.base_url.trim_end_matches('/'))
+    }
+}
+
+impl Default for HttpModelUpdater {
+    fn default() -> Self {
+        Self::new(DEFAULT_PREDICTOR_BASE_URL)
+    }
+}
+
+impl ModelUpdater for HttpModelUpdater {
+    fn post_update(&self, batch: CpUpdateBatch) {
+        let url = self.update_url();
+        let rows = batch.rows.len();
+
+        if let Ok(_h) = tokio::runtime::Handle::try_current() {
+            // Prefer async if a runtime exists.
+            tokio::spawn(async move {
+                let client = reqwest::Client::new();
+                match client.post(&url).json(&batch).send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        println!("[congestion] POST /update ok (rows={rows})");
+                    }
+                    Ok(resp) => {
+                        println!(
+                            "[congestion] POST /update failed: status={} (rows={rows})",
+                            resp.status()
+                        );
+                    }
+                    Err(e) => {
+                        println!("[congestion] POST /update error: {e} (rows={rows})");
+                    }
+                }
+            });
+        } else {
+            // Fallback to a blocking client on a background thread.
+            std::thread::spawn(move || {
+                let client = reqwest::blocking::Client::new();
+                match client.post(&url).json(&batch).send() {
+                    Ok(resp) if resp.status().is_success() => {
+                        println!("[congestion/blocking] POST /update ok (rows={rows})");
+                    }
+                    Ok(resp) => {
+                        println!(
+                            "[congestion/blocking] POST /update failed: status={} (rows={rows})",
+                            resp.status()
+                        );
+                    }
+                    Err(e) => {
+                        println!("[congestion/blocking] POST /update error: {e} (rows={rows})");
+                    }
+                }
+            });
+        }
+    }
+
+    fn post_train_tx(&self, batch: TrainTxBatch) {
+        let url = self.train_tx_url();
+        let items = batch.items.len();
+
+        if let Ok(_h) = tokio::runtime::Handle::try_current() {
+            tokio::spawn(async move {
+                let client = reqwest::Client::new();
+                match client.post(&url).json(&batch).send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        println!("[congestion] POST /train_tx ok (items={items})");
+                    }
+                    Ok(resp) => {
+                        println!(
+                            "[congestion] POST /train_tx failed: status={} (items={items})",
+                            resp.status()
+                        );
+                    }
+                    Err(e) => {
+                        println!("[congestion] POST /train_tx error: {e} (items={items})");
+                    }
+                }
+            });
+        } else {
+            std::thread::spawn(move || {
+                let client = reqwest::blocking::Client::new();
+                match client.post(&url).json(&batch).send() {
+                    Ok(resp) if resp.status().is_success() => {
+                        println!(
+                            "[congestion/blocking] POST /train_tx ok (items={items})"
+                        );
+                    }
+                    Ok(resp) => {
+                        println!(
+                            "[congestion/blocking] POST /train_tx failed: status={} (items={items})",
+                            resp.status()
+                        );
+                    }
+                    Err(e) => {
+                        println!(
+                            "[congestion/blocking] POST /train_tx error: {e} (items={items})"
+                        );
+                    }
+                }
+            });
+        }
+    }
+}
+
+// -------------------------------
+// Audit JSONL support
+// -------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TxAuditRow {
+    pub checkpoint_id: u64,
+    pub reference_gas_price: u64,
+    pub tx_digest: String,
+    pub is_congested: bool,
+    pub gas_price: u64,
+    pub gas_price_feedback: Option<u64>,
+    pub touched_objects: Vec<String>,
+    pub required_price_in_cp: u64,
+    pub overpay: u64,
+}
+
+/// Raw tx representation used to derive audit rows.
+#[derive(Debug, Clone)]
+pub struct RawTxItem {
+    pub tx_digest: String,
+    pub is_congested: bool,
+    pub gas_price: u64,
+    pub gas_price_feedback: Option<u64>,
+    pub touched_objects: Vec<ObjectID>,
+}
+
+/// Helper for stable default of the object-id to skip in audit.
+pub fn default_skip_audit_object_id() -> ObjectID {
+    ObjectID::from_single_byte(0x6)
+}
+
+/// Build audit rows based on raw tx records and per-object min clearing price in the checkpoint.
+pub fn build_tx_audit_rows(
+    raw_txs: &[RawTxItem],
+    per_object_min_clearing_in_cp: &HashMap<ObjectID, u64>,
+    reference_gas_price: u64,
+    checkpoint_id: u64,
+    skip_object: Option<ObjectID>,
+) -> Vec<TxAuditRow> {
+    let mut out = Vec::with_capacity(raw_txs.len());
+    for tx in raw_txs {
+        if let Some(skip) = skip_object {
+            if tx.touched_objects.len() == 1 && tx.touched_objects[0] == skip {
+                continue;
+            }
+        }
+
+        // required price: congested -> feedback (or gas price) ;
+        // non-congested -> max per-object min clearing price observed in CP.
+        let required = if tx.is_congested {
+            tx.gas_price_feedback
+                .unwrap_or(tx.gas_price)
+                .max(MIN_REFERENCE_GAS_PRICE)
+        } else {
+            let mut req = MIN_REFERENCE_GAS_PRICE;
+            for oid in &tx.touched_objects {
+                if let Some(min_clear) = per_object_min_clearing_in_cp.get(oid) {
+                    if *min_clear > MIN_REFERENCE_GAS_PRICE {
+                        req = req.max(*min_clear);
+                    }
+                }
+            }
+            req
+        };
+
+        let overpay = tx.gas_price.saturating_sub(required);
+        out.push(TxAuditRow {
+            checkpoint_id,
+            reference_gas_price,
+            tx_digest: tx.tx_digest.clone(),
+            is_congested: tx.is_congested,
+            gas_price: tx.gas_price,
+            gas_price_feedback: tx.gas_price_feedback,
+            touched_objects: tx
+                .touched_objects
+                .iter()
+                .map(|o| o.to_string())
+                .collect(),
+            required_price_in_cp: required,
+            overpay,
+        });
+    }
+    out
+}
+
+/// Lightweight JSONL writer with an internal mutex; safe to share.
+pub struct AuditLogger {
+    writer: Option<Arc<Mutex<File>>>,
+}
+
+impl AuditLogger {
+    /// Opens (or creates) a JSONL file at `path` for append.
+    pub fn new_with_path(path: PathBuf) -> Self {
+        let writer = match OpenOptions::new().create(true).append(true).open(&path) {
+            Ok(f) => Some(Arc::new(Mutex::new(f))),
+            Err(e) => {
+                eprintln!("[congestion/audit] failed to open {:?}: {e}", path);
+                None
+            }
+        };
+        Self { writer }
+    }
+
+    /// Opens (or creates) the default audit file `AUDIT_LOG_PATH` for append.
+    pub fn new_default() -> Self {
+        Self::new_with_path(PathBuf::from(AUDIT_LOG_PATH))
+    }
+
+    /// Writes each row as a serialized JSON line; logs errors and continues.
+    pub fn write_rows(&self, rows: &[TxAuditRow]) {
+        if let Some(w) = &self.writer {
+            let mut guard = w.lock().unwrap();
+            for row in rows {
+                match serde_json::to_string(row) {
+                    Ok(line) => {
+                        if let Err(e) = writeln!(guard, "{}", line) {
+                            eprintln!("[congestion/audit] write error: {e}");
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("[congestion/audit] serialize error: {e}");
+                    }
+                }
+            }
+            let _ = guard.flush();
+        }
+    }
+}

--- a/crates/iota-core/src/model_updater.rs
+++ b/crates/iota-core/src/model_updater.rs
@@ -1,7 +1,4 @@
-// model_updater.rs
-// Extracted model posting / training logic for congestion tracking.
-// This file intentionally does not modify any existing code paths yet.
-// It defines a trait-based API and HTTP implementation to be wired in later.
+// model posting / training logic for congestion tracking.
 
 use serde::Serialize;
 use std::{

--- a/crates/iota-core/src/model_updater.rs
+++ b/crates/iota-core/src/model_updater.rs
@@ -11,7 +11,7 @@ use std::{
 use iota_types::base_types::ObjectID;
 
 /// Default base URL for the predictor service.
-pub const DEFAULT_PREDICTOR_BASE_URL: &str = "http://predictor:9666";
+pub const DEFAULT_PREDICTOR_BASE_URL: &str = "http://predictor:9666"; // docker-compose private network only; without compose use http://0.0.0.0:9666
 /// Default JSONL audit log path (created/appended in current working dir).
 pub const AUDIT_LOG_PATH: &str = "congestion_audit.jsonl";
 /// Minimum reference gas price used in required-price lower bound.

--- a/crates/iota-core/src/model_updater.rs
+++ b/crates/iota-core/src/model_updater.rs
@@ -160,7 +160,7 @@ pub fn build_train_tx_batch(
     checkpoint_ms: u64,
     reference_gas_price: u64,
     raw_txs: &[RawTxItem],
-    per_object_min_clearing_in_cp: &HashMap<ObjectID, u64>,
+    per_object_required_in_cp: &HashMap<ObjectID, u64>,
 ) -> Option<TrainTxBatch> {
     let mut items = Vec::new();
     for tx in raw_txs {
@@ -174,12 +174,13 @@ pub fn build_train_tx_batch(
                 .unwrap_or(tx.gas_price)
                 .max(MIN_REFERENCE_GAS_PRICE)
         } else {
+            // For non-congested txs, use the per-object required price in this checkpoint
+            // (lowest clearing if present, otherwise highest congestion for that object),
+            // falling back to MIN_REFERENCE_GAS_PRICE if absent.
             let mut req = MIN_REFERENCE_GAS_PRICE;
             for oid in &tx.touched_objects {
-                if let Some(min_clear) = per_object_min_clearing_in_cp.get(oid) {
-                    if *min_clear > MIN_REFERENCE_GAS_PRICE {
-                        req = req.max(*min_clear);
-                    }
+                if let Some(val) = per_object_required_in_cp.get(oid) {
+                    req = req.max(*val);
                 }
             }
             req

--- a/dev-tools/iota-private-network/docker-compose.yaml
+++ b/dev-tools/iota-private-network/docker-compose.yaml
@@ -264,16 +264,20 @@ services:
     networks:
       iota-network:
         ipv4_address: 10.0.0.35
+    working_dir: /opt/iota/logs
     volumes:
       - ./data/fullnode-1:/opt/iota/db:rw
       - ./configs/fullnodes/fullnode.yaml:/opt/iota/config/fullnode.yaml:ro
       - ./configs/genesis/genesis.blob:/opt/iota/config/genesis.blob:ro
       - ./results:/iota/crates/iota-core/src/results
+      - ./logs/fullnode-1:/opt/iota/logs:rw
     expose:
       - "9000"
     ports:
       - "127.0.0.1:9000:9000/tcp"
       - "127.0.0.1:9184:9184/tcp"
+    depends_on:
+      - predictor
 
   fullnode-2:
     <<: *common-fullnode
@@ -282,13 +286,17 @@ services:
     networks:
       iota-network:
         ipv4_address: 10.0.0.36
+    working_dir: /opt/iota/logs
     volumes:
       - ./data/fullnode-2:/opt/iota/db:rw
       - ./configs/fullnodes/backup.yaml:/opt/iota/config/fullnode.yaml:ro
       - ./configs/genesis/genesis.blob:/opt/iota/config/genesis.blob:ro
+      - ./logs/fullnode-2:/opt/iota/logs:rw
     ports:
       - "127.0.0.1:9001:9000/tcp"
       - "127.0.0.1:9185:9184/tcp"
+    depends_on:
+      - predictor
 
   fullnode-3:
     <<: *common-fullnode
@@ -297,13 +305,17 @@ services:
     networks:
       iota-network:
         ipv4_address: 10.0.0.37
+    working_dir: /opt/iota/logs
     volumes:
       - ./data/fullnode-3:/opt/iota/db:rw
       - ./configs/fullnodes/fullnode.yaml:/opt/iota/config/fullnode.yaml:ro
       - ./configs/genesis/genesis.blob:/opt/iota/config/genesis.blob:ro
+      - ./logs/fullnode-3:/opt/iota/logs:rw
     ports:
       - "127.0.0.1:9002:9000/tcp"
       - "127.0.0.1:9186:9184/tcp"
+    depends_on:
+      - predictor
 
   fullnode-4:
     <<: *common-fullnode
@@ -312,13 +324,33 @@ services:
     networks:
       iota-network:
         ipv4_address: 10.0.0.38
+    working_dir: /opt/iota/logs
     volumes:
       - ./data/fullnode-4:/opt/iota/db:rw
       - ./configs/fullnodes/fullnode.yaml:/opt/iota/config/fullnode.yaml:ro
       - ./configs/genesis/genesis.blob:/opt/iota/config/genesis.blob:ro
+      - ./logs/fullnode-4:/opt/iota/logs:rw
     ports:
       - "127.0.0.1:9003:9000/tcp"
       - "127.0.0.1:9187:9184/tcp"
+    depends_on:
+      - predictor
+
+  predictor:
+    image: iota-predictor:latest
+    container_name: predictor
+    hostname: predictor
+    networks:
+      iota-network:
+        ipv4_address: 10.0.0.44
+    ports:
+      - "127.0.0.1:9666:9666/tcp"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9666/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
 
   indexer-1:
     image: iotaledger/iota-indexer


### PR DESCRIPTION
# Description of change

This PR adds update to the neural network third party server via a function `inform_model`. `inform_model` is called at the end of `process_checkpoint_effects`.
Any logic regarding the update itself is placed in `model_updater.rs`, that is not to clutter congestion_tracker with un-related logic

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
