### PR TITLE
fix(move-package): removed scary external resolver output

### DIFF
--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -1504,8 +1504,6 @@ impl DependencyGraph {
 
         // Present the stderr from the resolver, whether the process succeeded or not.
         if !output.stderr.is_empty() {
-            let stderr_label = format!("{resolver} stderr:").red();
-            writeln!(progress_output, "{stderr_label}")?;
             progress_output.write_all(&output.stderr)?;
         }
 

--- a/external-crates/move/crates/move-package/tests/test_sources/external/Move@progress.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external/Move@progress.snap
@@ -2,7 +2,6 @@
 source: crates/move-package/tests/test_runner.rs
 ---
 RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/successful.sh
-../resolvers/successful.sh stderr:
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external
 Type:    dependencies

--- a/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move@progress.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move@progress.snap
@@ -2,13 +2,11 @@
 source: crates/move-package/tests/test_runner.rs
 ---
 RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/successful.sh
-../resolvers/successful.sh stderr:
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep
 Type:    dependencies
 Package: A
 RESOLVING DEV-DEPENDENCIES IN B FROM Root WITH ../resolvers/successful.sh
-../resolvers/successful.sh stderr:
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep
 Type:    dev-dependencies

--- a/external-crates/move/crates/move-package/tests/test_sources/external_failing/Move@progress.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_failing/Move@progress.snap
@@ -2,5 +2,4 @@
 source: crates/move-package/tests/test_runner.rs
 ---
 RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/failing.sh
-../resolvers/failing.sh stderr:
 Failed to resolve dependencies for A

--- a/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response/Move@progress.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response/Move@progress.snap
@@ -2,7 +2,6 @@
 source: crates/move-package/tests/test_runner.rs
 ---
 RESOLVING DEPENDENCIES IN Anything FROM Root WITH ../resolvers/successful_package_batch_response.sh
-../resolvers/successful_package_batch_response.sh stderr:
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response
 Type:    dependencies


### PR DESCRIPTION
# Description of change

Currently if an external resolver outputs anything it is marked as an error, this PR removes that line. The output from the resolver is still printed, and if the resolver exits with an error code, that is still reported as an error.

According to the [changes](https://github.com/MystenLabs/sui/commit/82d8d1430d42ecb5fc5a13b33d0df91d463f4813#diff-22ac6bae8b1621da7436f2fdb5cc822e817c81fa0e5f812f5d093912c22127df).

## Links to any relevant issues

Fixes #8332 .

## How the change has been tested

Run move-package tests.
