### PR TITLE
feat(node): ignore private/unroutable addresses in discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5134,9 +5134,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -7040,6 +7040,7 @@ dependencies = [
  "http-body 1.0.1",
  "hyper-rustls 0.27.3",
  "hyper-util",
+ "idna",
  "iota-http",
  "multiaddr",
  "once_cell",

--- a/crates/iota-config/src/p2p.rs
+++ b/crates/iota-config/src/p2p.rs
@@ -374,6 +374,11 @@ pub struct DiscoveryConfig {
     /// If unspecified, this will default to `300` seconds (5 minutes).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cooldown_cleanup_interval_sec: Option<u64>,
+
+    /// Whether to allow private IP and local DNS addresses (e.g., 192.168.0.1,
+    /// localhost, .local) when verifying peer addresses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allow_private_addresses: Option<bool>,
 }
 
 impl DiscoveryConfig {
@@ -458,6 +463,12 @@ impl DiscoveryConfig {
         self.address_verification_failure_cooldown_sec
             .unwrap_or(600)
             > 0
+    }
+
+    /// Whether to allow private IP and local DNS addresses (e.g., 192.168.0.1,
+    /// localhost, .local) when verifying peer addresses.
+    pub fn allow_private_addresses(&self) -> bool {
+        self.allow_private_addresses.unwrap_or(false)
     }
 }
 

--- a/crates/iota-network-stack/Cargo.toml
+++ b/crates/iota-network-stack/Cargo.toml
@@ -18,6 +18,7 @@ http.workspace = true
 http-body.workspace = true
 hyper-rustls.workspace = true
 hyper-util.workspace = true
+idna = "1.1.0"
 multiaddr = "0.17.0"
 once_cell.workspace = true
 pin-project-lite = "0.2.13"

--- a/crates/iota-network-stack/src/multiaddr.rs
+++ b/crates/iota-network-stack/src/multiaddr.rs
@@ -219,19 +219,28 @@ impl Multiaddr {
         new
     }
 
-    /// Checks if the multiaddr contains a private/unroutable IP address.
-    /// Returns true if the address should is private or unroutable.
-    pub fn is_private_or_unroutable(&self) -> bool {
+    /// Checks if the multiaddr contains a private/unroutable IP address or
+    /// invalid DNS. Returns true if the address should is private or
+    /// unroutable.
+    pub fn is_private_or_unroutable(&self, allow_private_addresses: bool) -> bool {
         let Some(protocol) = self.0.iter().next() else {
             return true; // Empty address is not routable
         };
 
         match protocol {
-            multiaddr::Protocol::Ip4(addr) => is_ipv4_private_or_unroutable(addr),
+            multiaddr::Protocol::Ip4(addr) => {
+                is_ipv4_private_or_unroutable(addr, allow_private_addresses)
+            }
             multiaddr::Protocol::Ip6(addr) => is_ipv6_private_or_unroutable(addr),
-            multiaddr::Protocol::Dns(_) => false,
-            multiaddr::Protocol::Dns4(_) => false,
-            multiaddr::Protocol::Dns6(_) => false,
+            multiaddr::Protocol::Dns(hostname) => {
+                !is_valid_fqdn(hostname.as_ref(), allow_private_addresses)
+            }
+            multiaddr::Protocol::Dns4(hostname) => {
+                !is_valid_fqdn(hostname.as_ref(), allow_private_addresses)
+            }
+            multiaddr::Protocol::Dns6(hostname) => {
+                !is_valid_fqdn(hostname.as_ref(), allow_private_addresses)
+            }
             _ => true, // Other protocol types are not supported
         }
     }
@@ -239,7 +248,7 @@ impl Multiaddr {
     /// Checks if the multiaddr is suitable for public announcement for anemo.
     /// This includes checking for private/unroutable addresses and valid
     /// format.
-    pub fn is_valid_public_anemo_address(&self) -> bool {
+    pub fn is_valid_public_anemo_address(&self, allow_private_addresses: bool) -> bool {
         // Check if address is empty
         if self.is_empty() {
             return false;
@@ -251,7 +260,7 @@ impl Multiaddr {
         }
 
         // Check if it's a private or unroutable address
-        if self.is_private_or_unroutable() {
+        if self.is_private_or_unroutable(allow_private_addresses) {
             return false;
         }
 
@@ -426,11 +435,14 @@ pub(crate) fn parse_ip6(address: &Multiaddr) -> Result<(SocketAddr, &'static str
 
 /// Checks if an IPv4 address is private, reserved, or otherwise unroutable on
 /// the public internet.
-fn is_ipv4_private_or_unroutable(addr: Ipv4Addr) -> bool {
+fn is_ipv4_private_or_unroutable(addr: Ipv4Addr, allow_private_addresses: bool) -> bool {
+    if !allow_private_addresses && addr.is_private() {
+        // RFC 1918 - Private Networks (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+        return true;
+    }
+
     // RFC 1122 - "This" Network (0.0.0.0/8) and Unspecified (0.0.0.0/32)
     addr.is_unspecified() ||
-    // RFC 1918 - Private Networks (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
-    addr.is_private() ||
     // RFC 1122 - Loopback (127.0.0.0/8)
     addr.is_loopback() ||
     // RFC 3927 - Link-Local (169.254.0.0/16)
@@ -486,7 +498,98 @@ fn is_ipv6_private_or_unroutable(addr: Ipv6Addr) -> bool {
     // RFC 4862 - Link-Local (fe80::/10)
     (addr.segments()[0] & 0xffc0) == 0xfe80 ||
     // RFC 4291 - IPv4-mapped IPv6 addresses (::ffff:0:0/96) - check embedded IPv4
-    addr.to_ipv4_mapped().is_some_and(is_ipv4_private_or_unroutable)
+    addr.to_ipv4_mapped().is_some_and(|addr| is_ipv4_private_or_unroutable(addr, false))
+}
+
+/// Checks if a hostname is a valid FQDN (Fully Qualified Domain Name).
+/// Returns true if the hostname is valid for DNS resolution.
+/// This implements RFC-compliant hostname validation with IDNA support for
+/// Unicode domains.
+fn is_valid_fqdn(hostname: &str, allow_localhost_dns: bool) -> bool {
+    if hostname.ends_with('.') {
+        // we do not allow hostnames with dot at the end
+        return false;
+    }
+
+    // Basic length check
+    if hostname.is_empty() || hostname.len() > 253 {
+        return false;
+    }
+
+    let hostname_lower = hostname.to_lowercase();
+    if !allow_localhost_dns {
+        // Reject localhost and local domain variants
+        if hostname_lower == "localhost" || hostname_lower.ends_with(".local") {
+            return false;
+        }
+    } else if hostname_lower == "localhost" {
+        // Skip further checks for exact "localhost"
+        return true;
+    }
+
+    // Try to convert to ASCII using IDNA (handles Unicode domains)
+    let ascii_hostname = match idna::domain_to_ascii(hostname) {
+        Ok(ascii) => ascii,
+        Err(_) => return false, // Invalid Unicode domain
+    };
+
+    // Split into labels
+    let labels: Vec<&str> = ascii_hostname.split('.').collect();
+
+    // Must have at least 2 labels (hostname.tld) for public use
+    if labels.len() < 2 {
+        return false;
+    }
+
+    // Validate each label using ASCII rules (after IDNA conversion)
+    for label in &labels {
+        if !is_valid_dns_label(label) {
+            return false;
+        }
+    }
+
+    // Basic TLD validation: last label should be valid DNS label and >= 2 chars
+    // After IDNA conversion, TLDs can be punycode (xn--...) so we use general DNS
+    // label validation
+    let tld = *labels.last().unwrap();
+    if tld.len() < 2 {
+        return false;
+    }
+
+    // For TLD, we allow punycode (xn--) or pure alphabetic
+    let is_valid_tld = if tld.starts_with("xn--") {
+        // Punycode TLD - already validated as DNS label above
+        true
+    } else {
+        // Regular TLD - should be alphabetic only
+        tld.chars().all(|c| c.is_ascii_alphabetic())
+    };
+
+    if !is_valid_tld {
+        return false;
+    }
+
+    true
+}
+
+/// Validates a single DNS label according to RFC 1035
+fn is_valid_dns_label(label: &str) -> bool {
+    // Label length: 1-63 characters (RFC 1035)
+    if label.is_empty() || label.len() > 63 {
+        return false;
+    }
+
+    let bytes = label.as_bytes();
+
+    // Must start and end with alphanumeric character (no hyphens at boundaries)
+    if !bytes[0].is_ascii_alphanumeric() || !bytes[bytes.len() - 1].is_ascii_alphanumeric() {
+        return false;
+    }
+
+    // Can only contain alphanumeric characters and hyphens
+    bytes
+        .iter()
+        .all(|&b| b.is_ascii_alphanumeric() || b == b'-')
 }
 
 #[cfg(test)]
@@ -725,7 +828,7 @@ mod test {
 
         for (multiaddr, description, should_be_filtered) in test_cases {
             let addr = Multiaddr(multiaddr);
-            let is_filtered = addr.is_private_or_unroutable();
+            let is_filtered = addr.is_private_or_unroutable(false);
             assert_eq!(
                 is_filtered, should_be_filtered,
                 "Failed for {description}: expected {should_be_filtered} but got {is_filtered}",
@@ -808,7 +911,7 @@ mod test {
 
         for (multiaddr, description, should_be_filtered) in test_cases {
             let addr = Multiaddr(multiaddr);
-            let is_filtered = addr.is_private_or_unroutable();
+            let is_filtered = addr.is_private_or_unroutable(false);
             assert_eq!(
                 is_filtered, should_be_filtered,
                 "Failed for {description}: expected {should_be_filtered} but got {is_filtered}",
@@ -839,7 +942,7 @@ mod test {
 
         for (multiaddr, description, should_be_private) in test_cases {
             let addr = Multiaddr(multiaddr);
-            let is_private = addr.is_private_or_unroutable();
+            let is_private = addr.is_private_or_unroutable(false);
             assert_eq!(
                 is_private, should_be_private,
                 "Failed for {description}: expected {should_be_private} but got {is_private}",
@@ -880,10 +983,173 @@ mod test {
 
         for (multiaddr, description, should_be_valid) in test_cases {
             let addr = Multiaddr(multiaddr);
-            let is_valid = addr.is_valid_public_anemo_address();
+            let is_valid = addr.is_valid_public_anemo_address(false);
             assert_eq!(
                 is_valid, should_be_valid,
                 "Failed for {description}: expected {should_be_valid} but got {is_valid}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_valid_fqdn() {
+        use super::is_valid_fqdn;
+
+        // Valid FQDNs - domains with proper structure
+        let valid_cases = vec![
+            "example.com",
+            "subdomain.example.com",
+            "iota.org",
+            "api.iota.org",
+            "test123.example-domain.org",
+            "google.com",
+            "github.com",
+            "example.co", // Two-letter TLD
+            "test.example.net",
+            "api-v1.service.io",
+            "very-long-subdomain-name-that-is-still-valid.example.org",
+            // Unicode domains (IDNA)
+            "café.com",         // Unicode characters
+            "москва.рф",        // Cyrillic
+            "τεστ.gr",          // Greek
+            "测试.中国",        // Chinese
+            "xn--nxasmq6b.com", // Already punycode-encoded domain
+        ];
+
+        for fqdn in valid_cases {
+            assert!(
+                is_valid_fqdn(fqdn, false),
+                "Expected '{fqdn}' to be a valid FQDN",
+            );
+        }
+
+        // Invalid FQDNs
+        let long_domain = "a".repeat(254);
+        let long_label = "a".repeat(64);
+        let long_label_domain = format!("{long_label}.com");
+        let invalid_cases = vec![
+            "",                 // Empty string
+            "localhost",        // Localhost should be rejected
+            "test.local",       // .local domain
+            "hostname",         // Single label (no TLD)
+            "a.b",              // Single char TLD
+            "example.1",        // Numeric TLD
+            "example.c1",       // Alphanumeric TLD
+            ".",                // Just a dot
+            ".example.com",     // Leading dot
+            "example.com.",     // Trailing dot (absolute FQDN)
+            "-example.com",     // Label starting with hyphen
+            "example-.com",     // Label ending with hyphen
+            "exam_ple.com",     // Underscore not allowed
+            "exam ple.com",     // Space not allowed
+            &long_domain,       // Domain name too long (254 chars)
+            &long_label_domain, // Label too long (64 chars)
+            "example..com",     // Double dot
+            "192.168.1.1",      // IP address (should use IP protocols)
+            "2001:db8::1",      // IPv6 address (should use IP protocols)
+            "example.com-",     // Trailing hyphen in TLD
+            "example.",         // Empty TLD
+            // Invalid Unicode domains
+            "invalid\u{200D}.com", // Zero-width joiner (invalid in domain)
+            "test\u{0000}.com",    // Null character (invalid)
+        ];
+
+        for fqdn in invalid_cases {
+            assert!(
+                !is_valid_fqdn(fqdn, false),
+                "Expected '{fqdn}' to be an invalid FQDN"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_valid_dns_label() {
+        use super::is_valid_dns_label;
+
+        // Valid DNS labels
+        let max_length_label = "a".repeat(63);
+        let valid_cases = vec![
+            "a",
+            "ab",
+            "example",
+            "test123",
+            "api-v1",
+            "sub-domain",
+            "a1b2c3",
+            "123",             // All numeric is valid per RFC 1035
+            &max_length_label, // Max length (63 chars)
+        ];
+
+        for label in valid_cases {
+            assert!(
+                is_valid_dns_label(label),
+                "Expected '{label}' to be a valid DNS label"
+            );
+        }
+
+        // Invalid DNS labels
+        let too_long_label = "a".repeat(64);
+        let invalid_cases = vec![
+            "",              // Empty
+            "-example",      // Starts with hyphen
+            "example-",      // Ends with hyphen
+            "ex_ample",      // Contains underscore
+            "ex ample",      // Contains space
+            "ex.ample",      // Contains dot
+            &too_long_label, // Too long (64 chars)
+        ];
+
+        for label in invalid_cases {
+            assert!(
+                !is_valid_dns_label(label),
+                "Expected '{label}' to be an invalid DNS label"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dns_validation_in_multiaddr() {
+        // Test that DNS validation is properly integrated into multiaddr validation
+
+        // Valid DNS addresses should not be filtered
+        let valid_dns_cases = vec![
+            multiaddr!(Dns("example.com"), Udp(10500u16)),
+            multiaddr!(Dns("iota.org"), Udp(10500u16)),
+            multiaddr!(Dns("api.example.com"), Udp(10500u16)),
+            // Unicode domains
+            multiaddr!(Dns("café.com"), Udp(10500u16)),
+            multiaddr!(Dns("москва.рф"), Udp(10500u16)),
+        ];
+
+        for addr in valid_dns_cases {
+            let multiaddr = Multiaddr(addr);
+            assert!(
+                !multiaddr.is_private_or_unroutable(false),
+                "Valid DNS address {multiaddr} should not be filtered as private/unroutable"
+            );
+            assert!(
+                multiaddr.is_valid_public_anemo_address(false),
+                "Valid DNS address {multiaddr} should be valid for public announcement"
+            );
+        }
+
+        // Invalid DNS addresses should be filtered
+        let invalid_dns_cases = vec![
+            multiaddr!(Dns("localhost"), Udp(10500u16)),
+            multiaddr!(Dns("hostname.local"), Udp(10500u16)),
+            multiaddr!(Dns("hostname"), Udp(10500u16)), // Single label
+            multiaddr!(Dns(""), Udp(10500u16)),         // Empty
+        ];
+
+        for addr in invalid_dns_cases {
+            let multiaddr = Multiaddr(addr);
+            assert!(
+                multiaddr.is_private_or_unroutable(false),
+                "Invalid DNS address {multiaddr} should be filtered as private/unroutable"
+            );
+            assert!(
+                !multiaddr.is_valid_public_anemo_address(false),
+                "Invalid DNS address {multiaddr} should not be valid for public announcement"
             );
         }
     }

--- a/crates/iota-network-stack/src/multiaddr.rs
+++ b/crates/iota-network-stack/src/multiaddr.rs
@@ -218,6 +218,45 @@ impl Multiaddr {
 
         new
     }
+
+    /// Checks if the multiaddr contains a private/unroutable IP address.
+    /// Returns true if the address should is private or unroutable.
+    pub fn is_private_or_unroutable(&self) -> bool {
+        let Some(protocol) = self.0.iter().next() else {
+            return true; // Empty address is not routable
+        };
+
+        match protocol {
+            multiaddr::Protocol::Ip4(addr) => is_ipv4_private_or_unroutable(addr),
+            multiaddr::Protocol::Ip6(addr) => is_ipv6_private_or_unroutable(addr),
+            multiaddr::Protocol::Dns(_) => false,
+            multiaddr::Protocol::Dns4(_) => false,
+            multiaddr::Protocol::Dns6(_) => false,
+            _ => true, // Other protocol types are not supported
+        }
+    }
+
+    /// Checks if the multiaddr is suitable for public announcement for anemo.
+    /// This includes checking for private/unroutable addresses and valid
+    /// format.
+    pub fn is_valid_public_anemo_address(&self) -> bool {
+        // Check if address is empty
+        if self.is_empty() {
+            return false;
+        }
+
+        // Check if it can be converted to anemo address (format validation)
+        if self.to_anemo_address().is_err() {
+            return false;
+        }
+
+        // Check if it's a private or unroutable address
+        if self.is_private_or_unroutable() {
+            return false;
+        }
+
+        true
+    }
 }
 
 impl std::fmt::Display for Multiaddr {
@@ -385,6 +424,71 @@ pub(crate) fn parse_ip6(address: &Multiaddr) -> Result<(SocketAddr, &'static str
     Ok((socket_addr, http_or_https))
 }
 
+/// Checks if an IPv4 address is private, reserved, or otherwise unroutable on
+/// the public internet.
+fn is_ipv4_private_or_unroutable(addr: Ipv4Addr) -> bool {
+    // RFC 1122 - "This" Network (0.0.0.0/8) and Unspecified (0.0.0.0/32)
+    addr.is_unspecified() ||
+    // RFC 1918 - Private Networks (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+    addr.is_private() ||
+    // RFC 1122 - Loopback (127.0.0.0/8)
+    addr.is_loopback() ||
+    // RFC 3927 - Link-Local (169.254.0.0/16)
+    addr.is_link_local() ||
+    // RFC 1112 / RFC 3171 - Multicast (224.0.0.0/4)
+    addr.is_multicast() ||
+    // RFC 6598 - Shared Address Space / Carrier-Grade NAT (100.64.0.0/10)
+    (addr.octets()[0] == 100 && (addr.octets()[1] & 0b11000000) == 64) ||
+    // RFC 6890 - IETF Protocol Assignments (192.0.0.0/24)
+    (addr.octets()[0] == 192 && addr.octets()[1] == 0 && addr.octets()[2] == 0) ||
+    // RFC 5737 - Documentation/TEST-NET addresses (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24)
+    (addr.octets()[0] == 192 && addr.octets()[1] == 0 && addr.octets()[2] == 2) ||
+    (addr.octets()[0] == 198 && addr.octets()[1] == 51 && addr.octets()[2] == 100) ||
+    (addr.octets()[0] == 203 && addr.octets()[1] == 0 && addr.octets()[2] == 113) ||
+    // RFC 7535 - AS112-v4 (192.31.196.0/24)
+    (addr.octets()[0] == 192 && addr.octets()[1] == 31 && addr.octets()[2] == 196) ||
+    // RFC 7450 - Automatic Multicast Tunneling (192.52.193.0/24)
+    (addr.octets()[0] == 192 && addr.octets()[1] == 52 && addr.octets()[2] == 193) ||
+    // RFC 3068 - 6to4 Relay Anycast (192.88.99.0/24)
+    (addr.octets()[0] == 192 && addr.octets()[1] == 88 && addr.octets()[2] == 99) ||
+    // RFC 2544 - Network Interconnect Device Benchmark Testing (198.18.0.0/15)
+    (addr.octets()[0] == 198 && (addr.octets()[1] & 0b11111110) == 18) ||
+    // RFC 1112 - Reserved for Future Use (240.0.0.0/4)
+    (addr.octets()[0] >= 240)
+}
+
+/// Checks if an IPv6 address is private, reserved, or otherwise unroutable on
+/// the public internet.
+fn is_ipv6_private_or_unroutable(addr: Ipv6Addr) -> bool {
+    // RFC 4291 - Unspecified Address (::/128)
+    addr.is_unspecified() ||
+    // RFC 4291 - Loopback Address (::1/128)
+    addr.is_loopback() ||
+    // RFC 4291 - Multicast (ff00::/8)
+    addr.is_multicast() ||
+    // RFC 6666 - Discard-Only Address Block (100::/64)
+    (addr.segments()[0] == 0x0100 && addr.segments()[1] == 0 &&
+     addr.segments()[2] == 0 && addr.segments()[3] == 0) ||
+    // RFC 4380 - Teredo (2001::/32)
+    (addr.segments()[0] == 0x2001 && addr.segments()[1] == 0x0000) ||
+    // RFC 5180 - Benchmarking (2001:2::/48)
+    (addr.segments()[0] == 0x2001 && addr.segments()[1] == 0x0002) ||
+    // RFC 4843 - ORCHID (2001:10::/28)
+    (addr.segments()[0] == 0x2001 && (addr.segments()[1] & 0xfff0) == 0x0010) ||
+    // RFC 3849 - Documentation (2001:db8::/32)
+    (addr.segments()[0] == 0x2001 && addr.segments()[1] == 0x0db8) ||
+    // RFC 3056 - 6to4 (2002::/16)
+    addr.segments()[0] == 0x2002 ||
+    // RFC 4193 - Unique Local Addresses (fc00::/7)
+    (addr.segments()[0] & 0xfe00) == 0xfc00 ||
+    // RFC 3513 - Site-Local (deprecated, fec0::/10)
+    (addr.segments()[0] & 0xffc0) == 0xfec0 ||
+    // RFC 4862 - Link-Local (fe80::/10)
+    (addr.segments()[0] & 0xffc0) == 0xfe80 ||
+    // RFC 4291 - IPv4-mapped IPv6 addresses (::ffff:0:0/96) - check embedded IPv4
+    addr.to_ipv4_mapped().is_some_and(is_ipv4_private_or_unroutable)
+}
+
 #[cfg(test)]
 mod test {
     use multiaddr::multiaddr;
@@ -509,5 +613,278 @@ mod test {
             Multiaddr(multiaddr!(Dns("iota.iota"), Tcp(10501u16))).with_localhost_ip();
         assert_eq!(Some("127.0.0.1".to_string()), multi_addr_dns.hostname());
         assert_eq!(Some(10501u16), multi_addr_dns.port());
+    }
+
+    #[test]
+    fn test_is_private_or_unroutable_ipv4() {
+        // Test cases: (multiaddr, description, should_be_filtered)
+        let test_cases = vec![
+            // Private addresses (RFC 1918)
+            (
+                multiaddr!(Ip4([10, 0, 0, 1]), Udp(10500u16)),
+                "RFC 1918 private - 10.0.0.0/8",
+                true,
+            ),
+            (
+                multiaddr!(Ip4([172, 16, 0, 1]), Udp(10500u16)),
+                "RFC 1918 private - 172.16.0.0/12",
+                true,
+            ),
+            (
+                multiaddr!(Ip4([192, 168, 1, 1]), Udp(10500u16)),
+                "RFC 1918 private - 192.168.0.0/16",
+                true,
+            ),
+            // Loopback (RFC 1122)
+            (
+                multiaddr!(Ip4([127, 0, 0, 1]), Udp(10500u16)),
+                "RFC 1122 loopback",
+                true,
+            ),
+            // Link-local (RFC 3927)
+            (
+                multiaddr!(Ip4([169, 254, 1, 1]), Udp(10500u16)),
+                "RFC 3927 link-local",
+                true,
+            ),
+            // Unspecified (RFC 1122)
+            (
+                multiaddr!(Ip4([0, 0, 0, 0]), Udp(10500u16)),
+                "RFC 1122 unspecified",
+                true,
+            ),
+            // Multicast (RFC 3171)
+            (
+                multiaddr!(Ip4([224, 0, 0, 1]), Udp(10500u16)),
+                "RFC 3171 multicast",
+                true,
+            ),
+            // Carrier-grade NAT (RFC 6598)
+            (
+                multiaddr!(Ip4([100, 64, 0, 1]), Udp(10500u16)),
+                "RFC 6598 carrier-grade NAT",
+                true,
+            ),
+            // IETF Protocol Assignments (RFC 6890)
+            (
+                multiaddr!(Ip4([192, 0, 0, 1]), Udp(10500u16)),
+                "RFC 6890 IETF Protocol Assignments - 192.0.0.0/24",
+                true,
+            ),
+            // AS112-v4 (RFC 7535)
+            (
+                multiaddr!(Ip4([192, 31, 196, 1]), Udp(10500u16)),
+                "RFC 7535 AS112-v4 - 192.31.196.0/24",
+                true,
+            ),
+            // Automatic Multicast Tunneling (RFC 7450)
+            (
+                multiaddr!(Ip4([192, 52, 193, 1]), Udp(10500u16)),
+                "RFC 7450 Automatic Multicast Tunneling - 192.52.193.0/24",
+                true,
+            ),
+            // Documentation addresses (RFC 5737)
+            (
+                multiaddr!(Ip4([192, 0, 2, 1]), Udp(10500u16)),
+                "RFC 5737 documentation - 192.0.2.0/24",
+                true,
+            ),
+            (
+                multiaddr!(Ip4([198, 51, 100, 1]), Udp(10500u16)),
+                "RFC 5737 documentation - 198.51.100.0/24",
+                true,
+            ),
+            (
+                multiaddr!(Ip4([203, 0, 113, 1]), Udp(10500u16)),
+                "RFC 5737 documentation - 203.0.113.0/24",
+                true,
+            ),
+            // Benchmarking (RFC 2544)
+            (
+                multiaddr!(Ip4([198, 18, 0, 1]), Udp(10500u16)),
+                "RFC 2544 benchmarking - 198.18.0.0/15",
+                true,
+            ),
+            // Public addresses should not be filtered
+            (
+                multiaddr!(Ip4([8, 8, 8, 8]), Udp(10500u16)),
+                "Google DNS - should not be filtered",
+                false,
+            ),
+            (
+                multiaddr!(Ip4([1, 1, 1, 1]), Udp(10500u16)),
+                "Cloudflare DNS - should not be filtered",
+                false,
+            ),
+            (
+                multiaddr!(Ip4([208, 67, 222, 222]), Udp(10500u16)),
+                "OpenDNS - should not be filtered",
+                false,
+            ),
+        ];
+
+        for (multiaddr, description, should_be_filtered) in test_cases {
+            let addr = Multiaddr(multiaddr);
+            let is_filtered = addr.is_private_or_unroutable();
+            assert_eq!(
+                is_filtered, should_be_filtered,
+                "Failed for {description}: expected {should_be_filtered} but got {is_filtered}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_private_or_unroutable_ipv6() {
+        // Test cases: (multiaddr, description, should_be_filtered)
+        let test_cases = vec![
+            // Loopback (RFC 4291)
+            (
+                multiaddr!(Ip6([0, 0, 0, 0, 0, 0, 0, 1]), Udp(10500u16)),
+                "RFC 4291 loopback",
+                true,
+            ),
+            // Unspecified (RFC 4291)
+            (
+                multiaddr!(Ip6([0, 0, 0, 0, 0, 0, 0, 0]), Udp(10500u16)),
+                "RFC 4291 unspecified",
+                true,
+            ),
+            // Discard-Only Address Block (RFC 6666)
+            (
+                multiaddr!(Ip6([0x0100, 0, 0, 0, 0, 0, 0, 1]), Udp(10500u16)),
+                "RFC 6666 discard-only - 100::/64",
+                true,
+            ),
+            // Unique local addresses (RFC 4193) - fc00::/7
+            (
+                multiaddr!(Ip6([0xfc00, 0, 0, 0, 0, 0, 0, 1]), Udp(10500u16)),
+                "RFC 4193 unique local - fc00::/7",
+                true,
+            ),
+            (
+                multiaddr!(Ip6([0xfd00, 0, 0, 0, 0, 0, 0, 1]), Udp(10500u16)),
+                "RFC 4193 unique local - fd00::/7",
+                true,
+            ),
+            // Link-local addresses (RFC 4862) - fe80::/10
+            (
+                multiaddr!(Ip6([0xfe80, 0, 0, 0, 0, 0, 0, 1]), Udp(10500u16)),
+                "RFC 4862 link-local",
+                true,
+            ),
+            // Benchmarking (RFC 5180) - 2001:2::/48
+            (
+                multiaddr!(Ip6([0x2001, 0x0002, 0, 0, 0, 0, 0, 1]), Udp(10500u16)),
+                "RFC 5180 benchmarking - 2001:2::/48",
+                true,
+            ),
+            // Documentation addresses (RFC 3849) - 2001:db8::/32
+            (
+                multiaddr!(Ip6([0x2001, 0x0db8, 0, 0, 0, 0, 0, 1]), Udp(10500u16)),
+                "RFC 3849 documentation",
+                true,
+            ),
+            // Multicast addresses
+            (
+                multiaddr!(Ip6([0xff02, 0, 0, 0, 0, 0, 0, 1]), Udp(10500u16)),
+                "IPv6 multicast",
+                true,
+            ),
+            // Public addresses should not be filtered
+            (
+                multiaddr!(
+                    Ip6([0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x68]),
+                    Udp(10500u16)
+                ),
+                "Google DNS IPv6 - should not be filtered",
+                false,
+            ),
+            (
+                multiaddr!(Ip6([0x2606, 0x4700, 0x10, 0, 0, 0, 0, 0x68]), Udp(10500u16)),
+                "Cloudflare DNS IPv6 - should not be filtered",
+                false,
+            ),
+        ];
+
+        for (multiaddr, description, should_be_filtered) in test_cases {
+            let addr = Multiaddr(multiaddr);
+            let is_filtered = addr.is_private_or_unroutable();
+            assert_eq!(
+                is_filtered, should_be_filtered,
+                "Failed for {description}: expected {should_be_filtered} but got {is_filtered}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_private_or_unroutable_dns() {
+        // Test cases: (multiaddr, description, should_be_private)
+        let test_cases = vec![
+            (
+                multiaddr!(Dns("iota.org"), Udp(10500u16)),
+                "DNS addresses should be allowed for public discovery",
+                false,
+            ),
+            (
+                multiaddr!(Dns4("iota.org"), Udp(10500u16)),
+                "DNS4 addresses should be allowed for public discovery",
+                false,
+            ),
+            (
+                multiaddr!(Dns6("iota.org"), Udp(10500u16)),
+                "DNS6 addresses should be allowed for public discovery",
+                false,
+            ),
+        ];
+
+        for (multiaddr, description, should_be_private) in test_cases {
+            let addr = Multiaddr(multiaddr);
+            let is_private = addr.is_private_or_unroutable();
+            assert_eq!(
+                is_private, should_be_private,
+                "Failed for {description}: expected {should_be_private} but got {is_private}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_valid_for_public_announcement() {
+        // Test cases: (multiaddr, description, should_be_valid)
+        let test_cases = vec![
+            (
+                multiaddr!(Ip4([192, 168, 1, 1]), Udp(10500u16)),
+                "Private IPv4 address should be invalid",
+                false,
+            ),
+            (
+                multiaddr!(Ip4([127, 0, 0, 1]), Udp(10500u16)),
+                "Loopback IPv4 address should be invalid",
+                false,
+            ),
+            (
+                multiaddr!(Ip4([8, 8, 8, 8]), Udp(10500u16)),
+                "Valid public IPv4 address should be valid",
+                true,
+            ),
+            (
+                multiaddr!(Dns("example.com"), Udp(10500u16)),
+                "Valid DNS address should be valid",
+                true,
+            ),
+            (
+                multiaddr!(Ip4([8, 8, 8, 8]), Tcp(10500u16)),
+                "TCP instead of UDP should be invalid for anemo",
+                false,
+            ),
+        ];
+
+        for (multiaddr, description, should_be_valid) in test_cases {
+            let addr = Multiaddr(multiaddr);
+            let is_valid = addr.is_valid_public_anemo_address();
+            assert_eq!(
+                is_valid, should_be_valid,
+                "Failed for {description}: expected {should_be_valid} but got {is_valid}",
+            );
+        }
     }
 }

--- a/crates/iota-network/src/discovery/mod.rs
+++ b/crates/iota-network/src/discovery/mod.rs
@@ -205,9 +205,21 @@ impl DiscoveryEventLoop {
             .config
             .external_address
             .clone()
-            .and_then(|addr| addr.to_anemo_address().ok().map(|_| addr))
+            .and_then(|addr| {
+                // Validate that our external address is suitable for public announcement
+                if addr.is_valid_public_anemo_address() {
+                    addr.to_anemo_address().ok().map(|_| addr)
+                } else {
+                    info!(
+                        "External address {} is not suitable for public announcement (invalid/private/unroutable)",
+                        addr
+                    );
+                    None
+                }
+            })
             .into_iter()
             .collect();
+
         let our_info = NodeInfo {
             peer_id: self.network.peer_id(),
             addresses: address,
@@ -855,12 +867,17 @@ fn verify_peer_infos(
             continue;
         }
 
-        // Verify that all addresses provided are valid anemo addresses
+        // Verify that all addresses provided are valid anemo addresses and not
+        // private/unroutable
         if !peer_info
             .addresses
             .iter()
-            .all(|addr| addr.len() < MAX_ADDRESS_LENGTH && addr.to_anemo_address().is_ok())
+            .all(|addr| addr.len() < MAX_ADDRESS_LENGTH && addr.is_valid_public_anemo_address())
         {
+            debug!(
+                "Rejecting peer {} due to invalid, private, or unroutable addresses: {:?}",
+                peer_info.peer_id, peer_info.addresses
+            );
             continue;
         }
 
@@ -875,7 +892,7 @@ fn verify_peer_infos(
         };
         let msg = bcs::to_bytes(peer_info.data()).expect("BCS serialization should not fail");
         if let Err(e) = public_key.verify(&msg, peer_info.auth_sig()) {
-            info!(
+            debug!(
                 "Discovery failed to verify signature for NodeInfo for peer {:?}: {e:?}",
                 peer_info.peer_id
             );
@@ -956,7 +973,7 @@ async fn verify_addresses_of_peers(
 
     for (verified_peer_info, verified_addresses) in address_verification_results {
         if verified_addresses.is_empty() {
-            info!(
+            debug!(
                 "Rejecting peer {} ({}) due to failed address verification for all addresses",
                 verified_peer_info.peer_id,
                 verified_peer_info

--- a/crates/iota-network/src/discovery/mod.rs
+++ b/crates/iota-network/src/discovery/mod.rs
@@ -207,7 +207,7 @@ impl DiscoveryEventLoop {
             .clone()
             .and_then(|addr| {
                 // Validate that our external address is suitable for public announcement
-                if addr.is_valid_public_anemo_address() {
+                if addr.is_valid_public_anemo_address(self.discovery_config.allow_private_addresses()) {
                     addr.to_anemo_address().ok().map(|_| addr)
                 } else {
                     info!(
@@ -869,11 +869,10 @@ fn verify_peer_infos(
 
         // Verify that all addresses provided are valid anemo addresses and not
         // private/unroutable
-        if !peer_info
-            .addresses
-            .iter()
-            .all(|addr| addr.len() < MAX_ADDRESS_LENGTH && addr.is_valid_public_anemo_address())
-        {
+        if !peer_info.addresses.iter().all(|addr| {
+            addr.len() < MAX_ADDRESS_LENGTH
+                && addr.is_valid_public_anemo_address(config.allow_private_addresses())
+        }) {
             debug!(
                 "Rejecting peer {} due to invalid, private, or unroutable addresses: {:?}",
                 peer_info.peer_id, peer_info.addresses

--- a/crates/iota-network/src/discovery/tests.rs
+++ b/crates/iota-network/src/discovery/tests.rs
@@ -137,6 +137,16 @@ fn start_network(
     (event_loop, handle, state)
 }
 
+fn start_network_without_external_address(
+    discovery: UnstartedDiscovery,
+    network: Network,
+    keypair: NetworkKeyPair,
+) -> (DiscoveryEventLoop, Handle, Arc<RwLock<State>>) {
+    let (event_loop, handle) = discovery.build(network.clone(), keypair);
+    let state = event_loop.state.clone();
+    (event_loop, handle, state)
+}
+
 fn create_test_channel() -> (
     watch::Sender<TrustedPeerChangeEvent>,
     watch::Receiver<TrustedPeerChangeEvent>,
@@ -1487,7 +1497,11 @@ async fn test_address_verification_cooldown_and_cleanup() -> Result<()> {
     // Step 1: Add peer with unreachable address, check that it's in cooldown
     let peer_info_other = NodeInfo {
         peer_id: peer_id_other,
-        addresses: vec!["/ip4/192.0.2.1/udp/12345".parse().unwrap()], // Unreachable address
+        addresses: vec![
+            "/dns/unreachable-test-peer.invalid/udp/12345"
+                .parse()
+                .unwrap(),
+        ], // Invalid domain, safe for testing
         timestamp_ms: now_unix(),
         access_type: AccessType::Public,
     };
@@ -1795,6 +1809,278 @@ async fn test_peer_deduplication() -> Result<()> {
         3,
         "Mixed duplicates and unique peers should result in 3 unique entries"
     );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_private_address_filtering() -> Result<()> {
+    // Test that private and unroutable addresses are filtered out during peer
+    // discovery
+
+    // Create a test network and state
+    let (discovery, _server, network, key) = set_up_network(P2pConfig::default(), None);
+
+    // Set up the nodes's own info to avoid unwrap panics
+    let signed_peer_info = NodeInfo {
+        peer_id: network.peer_id(),
+        addresses: Vec::new(),
+        timestamp_ms: now_unix(),
+        access_type: AccessType::Public,
+    }
+    .sign(&key);
+
+    let (_event_loop, _handle, state) = start_network(discovery, network.clone(), key);
+    state.write().unwrap().our_info = Some(signed_peer_info);
+
+    // Define test cases with various private/unroutable addresses that should be
+    // filtered
+    let filtered_addresses = vec![
+        // IPv4 private networks (RFC 1918)
+        "/ip4/192.168.1.100/udp/12345",
+        "/ip4/10.0.0.1/udp/12345",
+        "/ip4/172.16.0.1/udp/12345",
+        // IPv4 loopback
+        "/ip4/127.0.0.1/udp/12345",
+        // IPv4 link-local (RFC 3927)
+        "/ip4/169.254.1.1/udp/12345",
+        // IPv4 multicast
+        "/ip4/224.0.0.1/udp/12345",
+        // IPv4 carrier-grade NAT (RFC 6598)
+        "/ip4/100.64.0.1/udp/12345",
+        // IPv4 documentation addresses (RFC 5737)
+        "/ip4/192.0.2.1/udp/12345",
+        "/ip4/198.51.100.1/udp/12345",
+        "/ip4/203.0.113.1/udp/12345",
+        // IPv6 loopback
+        "/ip6/::1/udp/12345",
+        // IPv6 unique local addresses (RFC 4193)
+        "/ip6/fc00::1/udp/12345",
+        "/ip6/fd00::1/udp/12345",
+        // IPv6 link-local (RFC 4862)
+        "/ip6/fe80::1/udp/12345",
+        // IPv6 documentation (RFC 3849)
+        "/ip6/2001:db8::1/udp/12345",
+        // IPv6 multicast
+        "/ip6/ff02::1/udp/12345",
+    ];
+
+    // Test public addresses that should NOT be filtered (but may fail verification
+    // due to unreachability)
+    let public_addresses = [
+        // Valid public IPv4 addresses using invalid domains for testing
+        "/dns/nonexistent-test-domain-for-iota.invalid/udp/12345",
+        "/dns/test-peer-unreachable.invalid/udp/12345",
+    ];
+
+    let mut filtered_peer_infos = Vec::new();
+    let mut filtered_peer_ids = Vec::new();
+
+    // Create peers with private/unroutable addresses (should be filtered)
+    for (i, address_str) in filtered_addresses.iter().enumerate() {
+        let key = NetworkKeyPair::generate(&mut rand::thread_rng());
+        let peer_id = anemo::PeerId(key.public().0.to_bytes());
+
+        let peer_info = NodeInfo {
+            peer_id,
+            addresses: vec![address_str.parse().unwrap()],
+            timestamp_ms: now_unix() + i as u64,
+            access_type: AccessType::Public,
+        };
+        let signed_peer_info = peer_info.sign(&key);
+
+        filtered_peer_infos.push(signed_peer_info);
+        filtered_peer_ids.push(peer_id);
+    }
+
+    let mut public_peer_infos = Vec::new();
+    let mut public_peer_ids = Vec::new();
+
+    // Create peers with public addresses (should reach verification)
+    for (i, address_str) in public_addresses.iter().enumerate() {
+        let key = NetworkKeyPair::generate(&mut rand::thread_rng());
+        let peer_id = anemo::PeerId(key.public().0.to_bytes());
+
+        let peer_info = NodeInfo {
+            peer_id,
+            addresses: vec![address_str.parse().unwrap()],
+            timestamp_ms: now_unix() + 1000 + i as u64,
+            access_type: AccessType::Public,
+        };
+        let signed_peer_info = peer_info.sign(&key);
+
+        public_peer_infos.push(signed_peer_info);
+        public_peer_ids.push(peer_id);
+    }
+
+    // Combine all peer infos and update
+    let mut all_peer_infos = filtered_peer_infos;
+    all_peer_infos.extend(public_peer_infos);
+
+    update_peers_for_test(&network, state.clone(), all_peer_infos).await;
+
+    let state_guard = state.read().unwrap();
+
+    // Verify that all private/unroutable address peers are filtered out before
+    // verification
+    for (i, peer_id) in filtered_peer_ids.iter().enumerate() {
+        assert!(
+            !state_guard.known_peers.contains_key(peer_id),
+            "Peer {} with private/unroutable address {} should be filtered out",
+            i,
+            filtered_addresses[i]
+        );
+        assert!(
+            !state_guard
+                .address_verification_cooldown
+                .contains_key(peer_id),
+            "Peer {} with private/unroutable address {} should not even reach verification cooldown",
+            i,
+            filtered_addresses[i]
+        );
+    }
+
+    // Verify that public address peers reach verification (even if they fail due to
+    // unreachability) They either get added to known_peers or added to
+    // verification cooldown
+    for (i, peer_id) in public_peer_ids.iter().enumerate() {
+        let public_peer_processed = state_guard.known_peers.contains_key(peer_id)
+            || state_guard
+                .address_verification_cooldown
+                .contains_key(peer_id);
+        assert!(
+            public_peer_processed,
+            "Peer {} with public address {} should at least reach verification step",
+            i, public_addresses[i]
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_construct_our_info_address_filtering() -> Result<()> {
+    // Test that private addresses are filtered out and valid public addresses are
+    // included during our own info construction
+
+    // Test cases: (address, should_be_included, description)
+    let test_addresses = vec![
+        // Private/unroutable addresses - should be filtered out
+        (
+            "/ip4/192.168.1.100/udp/12345",
+            false,
+            "IPv4 private network (RFC 1918)",
+        ),
+        (
+            "/ip4/10.0.0.1/udp/12345",
+            false,
+            "IPv4 private network (RFC 1918)",
+        ),
+        (
+            "/ip4/172.16.0.1/udp/12345",
+            false,
+            "IPv4 private network (RFC 1918)",
+        ),
+        ("/ip4/127.0.0.1/udp/12345", false, "IPv4 loopback"),
+        (
+            "/ip4/169.254.1.1/udp/12345",
+            false,
+            "IPv4 link-local (RFC 3927)",
+        ),
+        ("/ip4/224.0.0.1/udp/12345", false, "IPv4 multicast"),
+        (
+            "/ip4/100.64.0.1/udp/12345",
+            false,
+            "IPv4 carrier-grade NAT (RFC 6598)",
+        ),
+        ("/ip6/::1/udp/12345", false, "IPv6 loopback"),
+        (
+            "/ip6/fc00::1/udp/12345",
+            false,
+            "IPv6 unique local (RFC 4193)",
+        ),
+        (
+            "/ip6/fe80::1/udp/12345",
+            false,
+            "IPv6 link-local (RFC 4862)",
+        ),
+        (
+            "/ip6/2001:db8::1/udp/12345",
+            false,
+            "IPv6 documentation (RFC 3849)",
+        ),
+        // Unsupported address formats - should be filtered out
+        (
+            "/dns4/iota.org/udp/12345",
+            false,
+            "DNS4 hostname (unsupported by anemo)",
+        ),
+        (
+            "/dns6/iota.org/udp/12345",
+            false,
+            "DNS6 hostname (unsupported by anemo)",
+        ),
+        // Valid public addresses - should be included
+        ("/ip4/8.8.8.8/udp/12345", true, "Google DNS IPv4"),
+        ("/ip4/1.1.1.1/udp/12345", true, "Cloudflare DNS IPv4"),
+        (
+            "/ip6/2001:4860:4860::8888/udp/12345",
+            true,
+            "Google DNS IPv6",
+        ),
+        (
+            "/ip6/2606:4700:4700::1111/udp/12345",
+            true,
+            "Cloudflare DNS IPv6",
+        ),
+        ("/dns/example.com/udp/12345", true, "DNS hostname"),
+    ];
+
+    for (address_str, should_be_included, description) in test_addresses {
+        // Create a config with the test external address
+        let config = P2pConfig {
+            external_address: Some(address_str.parse().unwrap()),
+            ..Default::default()
+        };
+
+        let (discovery, _server, network, key) = set_up_network(config, None);
+        let (event_loop, _handle, state) =
+            start_network_without_external_address(discovery, network.clone(), key);
+
+        // Start the event loop which will call construct_our_info
+        tokio::spawn(event_loop.start());
+
+        // Give it a moment to initialize
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let state_guard = state.read().unwrap();
+        let our_info = state_guard.our_info.as_ref().unwrap();
+
+        if should_be_included {
+            // Valid public addresses should be included
+            assert!(
+                !our_info.addresses.is_empty(),
+                "Valid public address {address_str} ({description}) should be included in our own info"
+            );
+
+            // Verify the address is actually included
+            let address_found = our_info
+                .addresses
+                .iter()
+                .any(|addr| addr.to_string() == address_str);
+            assert!(
+                address_found,
+                "Valid public address {address_str} ({description}) should be found in our addresses: {:?}",
+                our_info.addresses
+            );
+        } else {
+            // Private/unroutable addresses should be filtered out
+            assert!(
+                our_info.addresses.is_empty(),
+                "Private/unroutable address {address_str} ({description}) should be filtered out from our own info",
+            );
+        }
+    }
 
     Ok(())
 }

--- a/crates/iota-network/src/discovery/tests.rs
+++ b/crates/iota-network/src/discovery/tests.rs
@@ -20,6 +20,18 @@ use crate::utils::{
 // Helper functions for common test patterns //
 ///////////////////////////////////////////////
 
+fn default_discovery_config_with_private_addresses_allowed() -> DiscoveryConfig {
+    DiscoveryConfig {
+        allow_private_addresses: Some(true),
+        ..Default::default()
+    }
+}
+
+fn default_p2p_config_with_private_addresses_allowed() -> P2pConfig {
+    P2pConfig::default()
+        .set_discovery_config(default_discovery_config_with_private_addresses_allowed())
+}
+
 fn assert_peers(
     self_name: &str,
     network: &Network,
@@ -269,8 +281,12 @@ async fn update_peers_for_test(
     network: &Network,
     state: Arc<RwLock<State>>,
     peers: Vec<SignedNodeInfo>,
+    allow_private_addresses: bool,
 ) {
-    let config = DiscoveryConfig::default();
+    let config = DiscoveryConfig {
+        allow_private_addresses: Some(allow_private_addresses),
+        ..Default::default()
+    };
     update_known_peers(
         network,
         state,
@@ -288,7 +304,7 @@ async fn update_peers_for_test(
 
 #[tokio::test]
 async fn get_known_peers() -> Result<()> {
-    let config = P2pConfig::default();
+    let config = default_p2p_config_with_private_addresses_allowed();
 
     let (discovery, server, network, key) = set_up_network(config, None);
     let key_for_signing = key.copy();
@@ -357,7 +373,7 @@ async fn get_known_peers() -> Result<()> {
 
 #[tokio::test]
 async fn make_connection_to_seed_peer() -> Result<()> {
-    let mut config = P2pConfig::default();
+    let mut config = default_p2p_config_with_private_addresses_allowed();
 
     let (discovery_1, _server_1, network_1, key_1) = set_up_network(config.clone(), None);
     let (_event_loop_1, _handle_1, _state_1) = start_network(discovery_1, network_1.clone(), key_1);
@@ -390,7 +406,7 @@ async fn make_connection_to_seed_peer() -> Result<()> {
 
 #[tokio::test]
 async fn make_connection_to_seed_peer_with_peer_id() -> Result<()> {
-    let mut config = P2pConfig::default();
+    let mut config = default_p2p_config_with_private_addresses_allowed();
 
     let (discovery_1, _server_1, network_1, key_1) = set_up_network(config.clone(), None);
     let (_event_loop_1, _handle_1, _state_1) = start_network(discovery_1, network_1.clone(), key_1);
@@ -423,7 +439,7 @@ async fn make_connection_to_seed_peer_with_peer_id() -> Result<()> {
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn three_nodes_can_connect_via_discovery() -> Result<()> {
-    let mut config = P2pConfig::default();
+    let mut config = default_p2p_config_with_private_addresses_allowed();
 
     // Setup the peer that will be the seed for the other two
     let (discovery_1, _server_1, network_1, key_1) = set_up_network(config.clone(), None);
@@ -615,6 +631,7 @@ async fn test_access_types() {
     let default_discovery_config = DiscoveryConfig {
         target_concurrent_connections: Some(100),
         interval_period_ms: Some(1000),
+        allow_private_addresses: Some(true), // Allow localhost for testing
         ..Default::default()
     };
     let default_p2p_config = P2pConfig {
@@ -625,6 +642,7 @@ async fn test_access_types() {
         target_concurrent_connections: Some(100),
         interval_period_ms: Some(1000),
         access_type: Some(AccessType::Private),
+        allow_private_addresses: Some(true), // Allow localhost for testing
         ..Default::default()
     };
 
@@ -645,7 +663,8 @@ async fn test_access_types() {
     let (mut discovery_3, _server_3, network_3, key_3) = set_up_network(config.clone(), None);
 
     // Node 4, private, allowlist: Node 3, 5, and 6
-    let (mut discovery_4, _server_4, network_4, key_4) = set_up_network(P2pConfig::default(), None);
+    let (mut discovery_4, _server_4, network_4, key_4) =
+        set_up_network(default_p2p_config_with_private_addresses_allowed(), None);
 
     // Node 5, private, allowlisted: Node 3 and Node 4
     let (discovery_5, _server_5, network_5, key_5) = {
@@ -961,7 +980,7 @@ async fn test_access_types() {
 #[tokio::test]
 async fn test_handle_trusted_peer_change_event() -> Result<()> {
     fn mock_multiaddr(port: u16) -> Multiaddr {
-        format!("/dns/mockhost/udp/{port}").parse().unwrap()
+        format!("/dns/mock.local/udp/{port}").parse().unwrap()
     }
 
     // Create mock peers, good enough for the test
@@ -993,6 +1012,7 @@ async fn test_handle_trusted_peer_change_event() -> Result<()> {
             peer_id: peers[1].peer_id,
             address: Some(mock_multiaddr(1)),
         }],
+        allow_private_addresses: Some(true), // Allow localhost for testing
         ..Default::default()
     };
     let mut config = P2pConfig::default().set_discovery_config(discovery_config);
@@ -1245,7 +1265,7 @@ async fn test_address_spoofing_prevention() -> Result<()> {
     let mut attack_peers = vec![signed_peer_info_legitimate];
     attack_peers.extend(malicious_peers.clone());
 
-    update_peers_for_test(&network_victim, state_victim.clone(), attack_peers).await;
+    update_peers_for_test(&network_victim, state_victim.clone(), attack_peers, true).await;
 
     // Verify that address deduplication and verification work together correctly
     let known_peers = state_victim.read().unwrap().known_peers.clone();
@@ -1284,7 +1304,7 @@ async fn test_address_conflict_resolution_with_existing_peers() -> Result<()> {
     // Test that address conflicts between new peers and existing entries are
     // resolved correctly
 
-    let config = P2pConfig::default();
+    let config = default_p2p_config_with_private_addresses_allowed();
 
     let start_timestamp_ms = now_unix();
     let timestamp_peer_1 = start_timestamp_ms + 100;
@@ -1333,6 +1353,7 @@ async fn test_address_conflict_resolution_with_existing_peers() -> Result<()> {
         &network_victim,
         state_victim.clone(),
         vec![signed_peer_info_1],
+        true,
     )
     .await;
 
@@ -1383,6 +1404,7 @@ async fn test_address_conflict_resolution_with_existing_peers() -> Result<()> {
         &network_victim,
         state_victim.clone(),
         vec![signed_peer_info_2],
+        true,
     )
     .await;
 
@@ -1441,6 +1463,7 @@ async fn test_address_conflict_resolution_with_existing_peers() -> Result<()> {
         &network_victim,
         state_victim.clone(),
         vec![signed_peer_info_3],
+        true,
     )
     .await;
 
@@ -1507,7 +1530,7 @@ async fn test_address_verification_cooldown_and_cleanup() -> Result<()> {
     };
     let signed_peer_info_other = peer_info_other.sign(&key_other);
 
-    update_peers_for_test(&network, state.clone(), vec![signed_peer_info_other]).await;
+    update_peers_for_test(&network, state.clone(), vec![signed_peer_info_other], true).await;
 
     // Verify peer is in cooldown after failed verification
     assert_peer_in_known_peers(
@@ -1536,6 +1559,7 @@ async fn test_address_verification_cooldown_and_cleanup() -> Result<()> {
         &network,
         state.clone(),
         vec![signed_peer_info_valid_other.clone()],
+        true,
     )
     .await;
 
@@ -1560,7 +1584,13 @@ async fn test_address_verification_cooldown_and_cleanup() -> Result<()> {
     // seconds) Add a bit extra to ensure the cleanup runs
     tokio::time::sleep(Duration::from_secs(500)).await;
 
-    update_peers_for_test(&network, state.clone(), vec![signed_peer_info_valid_other]).await;
+    update_peers_for_test(
+        &network,
+        state.clone(),
+        vec![signed_peer_info_valid_other],
+        true,
+    )
+    .await;
 
     // Verify peer is processed normally after cooldown expires
     assert_peer_in_known_peers(
@@ -1917,7 +1947,7 @@ async fn test_private_address_filtering() -> Result<()> {
     let mut all_peer_infos = filtered_peer_infos;
     all_peer_infos.extend(public_peer_infos);
 
-    update_peers_for_test(&network, state.clone(), all_peer_infos).await;
+    update_peers_for_test(&network, state.clone(), all_peer_infos, false).await;
 
     let state_guard = state.read().unwrap();
 
@@ -2019,6 +2049,22 @@ async fn test_construct_our_info_address_filtering() -> Result<()> {
             "/dns6/iota.org/udp/12345",
             false,
             "DNS6 hostname (unsupported by anemo)",
+        ),
+        // Invalid DNS addresses - should be filtered out
+        (
+            "/dns/localhost/udp/12345",
+            false,
+            "localhost hostname (invalid FQDN)",
+        ),
+        (
+            "/dns/test.local/udp/12345",
+            false,
+            ".local domain (invalid FQDN)",
+        ),
+        (
+            "/dns/hostname/udp/12345",
+            false,
+            "single label hostname (invalid FQDN)",
         ),
         // Valid public addresses - should be included
         ("/ip4/8.8.8.8/udp/12345", true, "Google DNS IPv4"),


### PR DESCRIPTION
# Description of change

This PR adds a filter for private/unroutable addresses in the node discovery.

## Links to any relevant issues

#8897

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Added filters for private/unroutable addresses in the node discovery
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
