### PR TITLE
fix(iota-move): Add implicit dependencies to all iota move commands

### DIFF
--- a/crates/iota-move/src/lib.rs
+++ b/crates/iota-move/src/lib.rs
@@ -5,7 +5,8 @@
 use std::path::Path;
 
 use clap::Parser;
-use iota_move_build::{IotaPackageHooks, set_iota_flavor};
+use iota_move_build::{IotaPackageHooks, implicit_deps, set_iota_flavor};
+use iota_package_management::system_package_versions::latest_system_packages;
 use move_cli::base::test::UnitTestResult;
 use move_package::BuildConfig;
 
@@ -43,6 +44,9 @@ pub fn execute_move_command(
     if let Some(err_msg) = set_iota_flavor(&mut build_config) {
         anyhow::bail!(err_msg);
     }
+
+    build_config.implicit_dependencies = implicit_deps(latest_system_packages());
+
     move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
     match command {
         Command::Build(c) => c.execute(package_path, build_config),

--- a/crates/iota/tests/shell_tests/iota_move_new_tests/new_then_disassemble.sh
+++ b/crates/iota/tests/shell_tests/iota_move_new_tests/new_then_disassemble.sh
@@ -1,0 +1,20 @@
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# tests that iota move new followed by iota move disassemble succeeds
+
+
+iota move new example
+cat > example/sources/example.move <<EOF
+module example::example;
+
+public fun foo(_ctx: &mut TxContext) {}
+EOF
+cd example
+
+echo "=== Build ===" | tee /dev/stderr
+iota move build
+
+echo "=== Disassemble ===" | tee /dev/stderr
+iota move disassemble build/example/bytecode_modules/example.mv

--- a/crates/iota/tests/snapshots/shell_tests__iota_move_new_tests__new_then_disassemble.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__iota_move_new_tests__new_then_disassemble.sh.snap
@@ -1,0 +1,52 @@
+---
+source: crates/iota/tests/shell_tests.rs
+description: tests/shell_tests/iota_move_new_tests/new_then_disassemble.sh
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# tests that iota move new followed by iota move disassemble succeeds
+
+
+iota move new example
+cat > example/sources/example.move <<EOF
+module example::example;
+
+public fun foo(_ctx: &mut TxContext) {}
+EOF
+cd example
+
+echo "=== Build ===" | tee /dev/stderr
+iota move build
+
+echo "=== Disassemble ===" | tee /dev/stderr
+iota move disassemble build/example/bytecode_modules/example.mv
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+=== Build ===
+=== Disassemble ===
+// Move bytecode v6
+module 0.example {
+use 0000000000000000000000000000000000000000000000000000000000000002::tx_context;
+
+public foo(_ctx#0#0: &mut TxContext) {
+B0:
+	0: Ret
+}
+
+}
+
+
+----- stderr -----
+=== Build ===
+INCLUDING DEPENDENCY Bridge
+INCLUDING DEPENDENCY IotaSystem
+INCLUDING DEPENDENCY IOTA
+INCLUDING DEPENDENCY MoveStdlib
+BUILDING example
+=== Disassemble ===

--- a/crates/iota/tests/snapshots/shell_tests__iota_move_new_tests__new_then_disassemble.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__iota_move_new_tests__new_then_disassemble.sh.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/iota/tests/shell_tests.rs
-description: tests/shell_tests/iota_move_new_tests/new_then_disassemble.sh
 ---
 ----- script -----
 # Copyright (c) Mysten Labs, Inc.
@@ -44,9 +43,9 @@ B0:
 
 ----- stderr -----
 === Build ===
-INCLUDING DEPENDENCY Bridge
 INCLUDING DEPENDENCY IotaSystem
-INCLUDING DEPENDENCY IOTA
+INCLUDING DEPENDENCY Stardust
+INCLUDING DEPENDENCY Iota
 INCLUDING DEPENDENCY MoveStdlib
 BUILDING example
 === Disassemble ===


### PR DESCRIPTION
# Description of change

Previously, implicit deps were only added in `iota move build` and `iota move test` commands; this caused `iota move disassemble` to fail for packages that used implicit deps, for example.

Now we set the implicit deps in all `iota move` commands.

According to the [changes](https://github.com/MystenLabs/sui/commit/ed74da42011996fc372b980b82c16398658e44f6#diff-dc80150cd79e3c77dff2215d18ffa2d9f0e4c32a85248f132cc867559b1d04ff).

## Links to any relevant issues

Fixes #8333 .

## How the change has been tested

Run iota-move tests

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Add implicit dependencies to all iota move commands
- [ ] Rust SDK:
- [ ] REST API:
