### PR TITLE
fix(move-vm-runtime): Fix issue in tracing dataloads

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
@@ -503,9 +503,8 @@ impl VMTracer<'_> {
         let function_type_info = FunctionTypeInfo::new(function, loader, ty_args, link_context)?;
 
         assert!(function_type_info.local_types.len() == function.local_count());
-        let start_trace_index = self.trace.current_trace_offset();
 
-        let call_args: Vec<_> = args
+        let call_args: Vec<(_, _)> = args
             .iter()
             .zip(function_type_info.local_types.iter().cloned())
             .map(|(value, tag_with_layout_info_opt)| {
@@ -515,9 +514,9 @@ impl VMTracer<'_> {
                     Some(ref_type) => {
                         let (id, trace_value) = self.emit_data_load(move_value, &ref_type);
                         self.loaded_data.insert(id, trace_value.clone());
-                        Some(trace_value)
+                        Some((trace_value, Some(id)))
                     }
-                    None => Some(TraceValue::RuntimeValue { value: move_value }),
+                    None => Some((TraceValue::RuntimeValue { value: move_value }, None)),
                 }
             })
             .collect::<Option<_>>()?;
@@ -533,9 +532,8 @@ impl VMTracer<'_> {
                     layout,
                     ref_type: ref_type
                         .map(|r_type| {
-                            let possible_location = start_trace_index + i;
-                            if self.loaded_data.contains_key(&possible_location) {
-                                let location = RuntimeLocation::Global(possible_location);
+                            if let Some(location) = call_args.get(i).and_then(|(_, id)| *id) {
+                                let location = RuntimeLocation::Global(location);
                                 ReferenceType::Filled {
                                     ref_type: r_type,
                                     location,
@@ -565,7 +563,10 @@ impl VMTracer<'_> {
             function.index(),
             function.name().to_string(),
             function.module_id().clone(),
-            call_args,
+            call_args
+                .into_iter()
+                .map(|(trace_value, _)| trace_value)
+                .collect(),
             function_type_info.ty_args,
             function_type_info
                 .return_types


### PR DESCRIPTION
# Description of change

Fixes an issue where references could flow into an initial frame, and
where there could be intervening values that are not references/data
loads.

According to the [changes](https://github.com/MystenLabs/sui/commit/4c197301cc57734b9827db748927060016dbda3a).

## Links to any relevant issues

Fixes #8339 .

