### PR TITLE
feat(consensus): switch to blake3 hasher in starfish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.3.1",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13596,6 +13609,7 @@ dependencies = [
 name = "starfish-config"
 version = "0.1.0"
 dependencies = [
+ "blake3",
  "fastcrypto",
  "insta",
  "iota-network-stack",

--- a/crates/starfish/config/Cargo.toml
+++ b/crates/starfish/config/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 # external dependencies
+blake3 = "1.8.2"
 fastcrypto.workspace = true
 rand.workspace = true
 rs_merkle = "1.5.0"
@@ -19,7 +20,6 @@ serde.workspace = true
 # internal dependencies
 iota-network-stack.workspace = true
 shared-crypto.workspace = true
-blake3 = "1.8.2"
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/starfish/config/Cargo.toml
+++ b/crates/starfish/config/Cargo.toml
@@ -19,6 +19,7 @@ serde.workspace = true
 # internal dependencies
 iota-network-stack.workspace = true
 shared-crypto.workspace = true
+blake3 = "1.8.2"
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/starfish/config/src/crypto.rs
+++ b/crates/starfish/config/src/crypto.rs
@@ -17,9 +17,10 @@
 use fastcrypto::{
     bls12381, ed25519,
     error::FastCryptoError,
-    hash::{Blake2b256, HashFunction},
+    hash::{HashFunction},
     traits::{KeyPair as _, Signer as _, ToFromBytes as _, VerifyingKey as _},
 };
+use fastcrypto::hash::Digest;
 use rs_merkle::Hasher;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::INTENT_PREFIX_LENGTH;
@@ -169,9 +170,30 @@ impl AuthorityKeyPair {
     }
 }
 
-/// Defines algorithm and format of block and commit digests.
-// TODO: change Blake2b256 to Blake3 when starting optimizations
-pub type DefaultHashFunction = Blake2b256;
+
+
+
+#[derive(Default)]
+pub struct Blake3Hasher {
+    hasher: blake3::Hasher,
+}
+
+impl HashFunction<32> for Blake3Hasher {
+    fn update<Data: AsRef<[u8]>>(&mut self, data: Data) {
+        self.hasher.update(data.as_ref());
+    }
+
+    fn finalize(self) -> Digest<32> {
+        let mut out = [0u8; 32];
+        out.copy_from_slice(self.hasher.finalize().as_bytes());
+        Digest { digest: out }
+    }
+}
+
+/// Fast hash function (Blake3) for consensus-related operations.
+/// Since transactions are encoded, their serializations are increased by approximately
+/// three times, making Blake3’s higher throughput beneficial for overall performance.
+pub type DefaultHashFunction = Blake3Hasher;
 
 #[derive(Clone)]
 pub struct DefaultHashFunctionWrapper;

--- a/crates/starfish/config/src/crypto.rs
+++ b/crates/starfish/config/src/crypto.rs
@@ -17,10 +17,9 @@
 use fastcrypto::{
     bls12381, ed25519,
     error::FastCryptoError,
-    hash::{HashFunction},
+    hash::{Digest, HashFunction},
     traits::{KeyPair as _, Signer as _, ToFromBytes as _, VerifyingKey as _},
 };
-use fastcrypto::hash::Digest;
 use rs_merkle::Hasher;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::INTENT_PREFIX_LENGTH;
@@ -170,9 +169,6 @@ impl AuthorityKeyPair {
     }
 }
 
-
-
-
 #[derive(Default)]
 pub struct Blake3Hasher {
     hasher: blake3::Hasher,
@@ -191,8 +187,9 @@ impl HashFunction<32> for Blake3Hasher {
 }
 
 /// Fast hash function (Blake3) for consensus-related operations.
-/// Since transactions are encoded, their serializations are increased by approximately
-/// three times, making Blake3’s higher throughput beneficial for overall performance.
+/// Since transactions are encoded, their serializations are increased by
+/// approximately three times, making Blake3’s higher throughput beneficial for
+/// overall performance.
 pub type DefaultHashFunction = Blake3Hasher;
 
 #[derive(Clone)]


### PR DESCRIPTION
# Description of change

This PR switches Blake2b to Blake3 in Starfish consensus. Since Starfish encodes transactions, the transaction serialization is approximately 3 times larger than normal one. To improve the performance and reduce the CPU usage, we can rely on a faster hash function solely inside the Starfish consensus logic.

## Links to any relevant issues

Fixes #9003 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Switch to Blake3 hash for Starfish consensus
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
