### PR TITLE
feat(iota-protocol-config): enable committee selection from active validators for testnet

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -81,9 +81,9 @@ pub const MAX_PROTOCOL_VERSION: u64 = 14;
 //             Enable median-based commit timestamp calculation in consensus,
 //             and enforce checkpoint timestamp monotonicity for testnet.
 //             Enable batched block sync for mainnet.
-//             Enable selecting committee only from active validators that next
-//             epoch version and issued valid AuthorityCapabilities notification
-//             in testnet.
+//             Enable selecting committee only from active validators that
+//             support the next epoch's version and issued valid
+//             AuthorityCapabilities notification in testnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -2263,8 +2263,9 @@ impl ProtocolConfig {
                         // enforce checkpoint timestamp monotonicity for testnet.
                         cfg.feature_flags
                             .consensus_median_timestamp_with_checkpoint_enforcement = true;
-                        // Enable selecting committee only from active validators that next epoch
-                        // version and issued valid AuthorityCapabilities notification in testnet.
+                        // Enable selecting committee only from active validators that support the
+                        // next epoch's version and issued valid AuthorityCapabilities notification
+                        // in testnet.
                         cfg.feature_flags
                             .select_committee_supporting_next_epoch_version = true;
                     }

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -81,6 +81,9 @@ pub const MAX_PROTOCOL_VERSION: u64 = 14;
 //             Enable median-based commit timestamp calculation in consensus,
 //             and enforce checkpoint timestamp monotonicity for testnet.
 //             Enable batched block sync for mainnet.
+//             Enable selecting committee only from active validators that next
+//             epoch version and issued valid AuthorityCapabilities notification
+//             in testnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -2254,11 +2257,16 @@ impl ProtocolConfig {
                 14 => {
                     // Enable batched block sync for mainnet.
                     cfg.feature_flags.consensus_batched_block_sync = true;
+
                     if chain != Chain::Mainnet {
                         // Enable median-based commit timestamp calculation in consensus and
                         // enforce checkpoint timestamp monotonicity for testnet.
                         cfg.feature_flags
                             .consensus_median_timestamp_with_checkpoint_enforcement = true;
+                        // Enable selecting committee only from active validators that next epoch
+                        // version and issued valid AuthorityCapabilities notification in testnet.
+                        cfg.feature_flags
+                            .select_committee_supporting_next_epoch_version = true;
                     }
                     if chain != Chain::Testnet && chain != Chain::Mainnet {
                         // Switch consensus protocol to Starfish in devnet

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_14.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_14.snap
@@ -28,6 +28,7 @@ feature_flags:
   normalize_ptb_arguments: true
   select_committee_from_eligible_validators: true
   track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
   consensus_median_timestamp_with_checkpoint_enforcement: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048


### PR DESCRIPTION
# Description of change

enable committee selection from active validators for testnet

## Links to any relevant issues

Resolves #9008 

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: enable committee selection from validators who issued valid authority capabilities for testnet
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
