### PR TITLE
feat(consensus): Implement bandwidth metrics for Starfish and Mysticeti

### DIFF
--- a/consensus/core/src/network/metrics_layer.rs
+++ b/consensus/core/src/network/metrics_layer.rs
@@ -72,6 +72,7 @@ impl MetricsCallbackMaker {
             timer,
             route,
             excessive_message_size: self.excessive_message_size,
+            response_body_size: None,
         }
     }
 }
@@ -83,12 +84,34 @@ pub(crate) struct MetricsResponseCallback {
     timer: HistogramTimer,
     route: String,
     excessive_message_size: usize,
+    /// If Some, response size has already been observed (exact size was known
+    /// from headers). If None, response size should be tracked via body
+    /// chunks.
+    response_body_size: Option<usize>,
 }
 
 impl MetricsResponseCallback {
-    // Update response metrics.
-    pub(crate) fn on_response(&mut self, response: &dyn SizedResponse) {
-        let response_size = response.size();
+    /// Track response metrics from HTTP response parts.
+    /// Handles both size tracking and error tracking.
+    pub(crate) fn on_response(&mut self, response: &dyn SizedResponse, headers: &http::HeaderMap) {
+        let mut response_size = response.size();
+
+        // Try to get exact body size from Content-Length header
+        // This is calculated outside of response.size() to properly handle
+        // streaming/chunked responses later to avoid calculating the same bytes twice -
+        // once from the header value and when parsing the response body chunks.
+        let body_size = headers
+            .get(http::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<usize>().ok());
+
+        if let Some(body_size) = body_size {
+            // Exact size is known, update response size
+            response_size += body_size;
+
+            // Mark as already observed
+            self.response_body_size = Some(body_size);
+        }
         if response_size > 0 {
             self.metrics
                 .response_size
@@ -115,6 +138,16 @@ impl MetricsResponseCallback {
             .errors
             .with_label_values(&[self.route.as_str(), "unknown"])
             .inc();
+    }
+
+    pub(crate) fn on_chunk(&mut self, chunk_size: usize) {
+        // Only track chunks if the exact size wasn't known from headers
+        if self.response_body_size.is_none() && chunk_size > 0 {
+            self.metrics
+                .response_size
+                .with_label_values(&[&self.route])
+                .observe(chunk_size as f64);
+        }
     }
 }
 

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -985,10 +985,29 @@ struct PeerInfo {
 
 // Adapt MetricsCallbackMaker and MetricsResponseCallback to http.
 
+/// Calculate approximate size of HTTP headers.
+/// Note: This is an approximation of uncompressed size. Actual wire size will
+/// be smaller due to HTTP/2 HPACK compression.
+fn calculate_header_size(headers: &http::HeaderMap) -> usize {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            // +4 bytes for ": " and "\r\n" separator in HTTP/1.1 format
+            name.as_str().len() + value.len() + 4
+        })
+        .sum()
+}
+
 impl SizedRequest for http::request::Parts {
     fn size(&self) -> usize {
-        // TODO: implement this.
-        0
+        let header_size = calculate_header_size(&self.headers);
+        let body_size = self
+            .headers
+            .get(http::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(0);
+        header_size + body_size
     }
 
     fn route(&self) -> String {
@@ -1002,8 +1021,9 @@ impl SizedRequest for http::request::Parts {
 
 impl SizedResponse for http::response::Parts {
     fn size(&self) -> usize {
-        // TODO: implement this.
-        0
+        // Return header size only. Body size is tracked separately via
+        // ResponseHandler::on_body_chunk callback to support streaming responses.
+        calculate_header_size(&self.headers)
     }
 
     fn error_type(&self) -> Option<String> {
@@ -1025,11 +1045,19 @@ impl MakeCallbackHandler for MetricsCallbackMaker {
 
 impl ResponseHandler for MetricsResponseCallback {
     fn on_response(&mut self, response: &http::response::Parts) {
-        MetricsResponseCallback::on_response(self, response)
+        MetricsResponseCallback::on_response(self, response, &response.headers)
     }
 
     fn on_error<E>(&mut self, err: &E) {
         MetricsResponseCallback::on_error(self, err)
+    }
+
+    fn on_body_chunk<B>(&mut self, chunk: &B)
+    where
+        B: bytes::Buf,
+    {
+        let chunk_size = chunk.chunk().len();
+        self.on_chunk(chunk_size);
     }
 }
 

--- a/crates/starfish/core/src/network/metrics_layer.rs
+++ b/crates/starfish/core/src/network/metrics_layer.rs
@@ -72,6 +72,7 @@ impl MetricsCallbackMaker {
             timer,
             route,
             excessive_message_size: self.excessive_message_size,
+            response_body_size: None,
         }
     }
 }
@@ -83,13 +84,34 @@ pub(crate) struct MetricsResponseCallback {
     timer: HistogramTimer,
     route: String,
     excessive_message_size: usize,
+    /// If Some, response size has already been observed (exact size was known
+    /// from headers). If None, response size should be tracked via body
+    /// chunks.
+    response_body_size: Option<usize>,
 }
 
 impl MetricsResponseCallback {
-    // Update response metrics.
-    // Update response metrics.
-    pub(crate) fn on_response(&mut self, response: &dyn SizedResponse) {
-        let response_size = response.size();
+    /// Track response metrics from HTTP response parts.
+    /// Handles both size tracking and error tracking.
+    pub(crate) fn on_response(&mut self, response: &dyn SizedResponse, headers: &http::HeaderMap) {
+        let mut response_size = response.size();
+
+        // Try to get exact body size from Content-Length header
+        // This is calculated outside of response.size() to properly handle
+        // streaming/chunked responses later to avoid calculating the same bytes twice -
+        // once from the header value and when parsing the response body chunks.
+        let body_size = headers
+            .get(http::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<usize>().ok());
+
+        if let Some(body_size) = body_size {
+            // Exact size is known, update response size
+            response_size += body_size;
+
+            // Mark as already observed
+            self.response_body_size = Some(body_size);
+        }
         if response_size > 0 {
             self.metrics
                 .response_size
@@ -116,6 +138,16 @@ impl MetricsResponseCallback {
             .errors
             .with_label_values(&[self.route.as_str(), "unknown"])
             .inc();
+    }
+
+    pub(crate) fn on_chunk(&mut self, chunk_size: usize) {
+        // Only track chunks if the exact size wasn't known from headers
+        if self.response_body_size.is_none() && chunk_size > 0 {
+            self.metrics
+                .response_size
+                .with_label_values(&[&self.route])
+                .observe(chunk_size as f64);
+        }
     }
 }
 

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -1059,10 +1059,29 @@ struct PeerInfo {
 
 // Adapt MetricsCallbackMaker and MetricsResponseCallback to http.
 
+/// Calculate approximate size of HTTP headers.
+/// Note: This is an approximation of uncompressed size. Actual wire size will
+/// be smaller due to HTTP/2 HPACK compression.
+fn calculate_header_size(headers: &http::HeaderMap) -> usize {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            // +4 bytes for ": " and "\r\n" separator in HTTP/1.1 format
+            name.as_str().len() + value.len() + 4
+        })
+        .sum()
+}
+
 impl SizedRequest for http::request::Parts {
     fn size(&self) -> usize {
-        // TODO: implement this.
-        0
+        let header_size = calculate_header_size(&self.headers);
+        let body_size = self
+            .headers
+            .get(http::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(0);
+        header_size + body_size
     }
 
     fn route(&self) -> String {
@@ -1076,8 +1095,9 @@ impl SizedRequest for http::request::Parts {
 
 impl SizedResponse for http::response::Parts {
     fn size(&self) -> usize {
-        // TODO: implement this.
-        0
+        // Return header size only. Body size is tracked separately via
+        // ResponseHandler::on_body_chunk callback to support streaming responses.
+        calculate_header_size(&self.headers)
     }
 
     fn error_type(&self) -> Option<String> {
@@ -1099,11 +1119,19 @@ impl MakeCallbackHandler for MetricsCallbackMaker {
 
 impl ResponseHandler for MetricsResponseCallback {
     fn on_response(&mut self, response: &http::response::Parts) {
-        MetricsResponseCallback::on_response(self, response)
+        MetricsResponseCallback::on_response(self, response, &response.headers)
     }
 
     fn on_error<E>(&mut self, err: &E) {
         MetricsResponseCallback::on_error(self, err)
+    }
+
+    fn on_body_chunk<B>(&mut self, chunk: &B)
+    where
+        B: bytes::Buf,
+    {
+        let chunk_size = chunk.chunk().len();
+        self.on_chunk(chunk_size);
     }
 }
 


### PR DESCRIPTION
# Description of change

Add missing implementation of gRPC request/response size metrics for Mysticeti and Starfish. 

## Links to any relevant issues

Resolves #8088 

## How the change has been tested

Local network with Grafana

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
