### PR TITLE
feat(consensus): introduce a reason to create a block and update the branch for min_block_delay

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -60,13 +60,6 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_sync_last_known_own_block_timeout")]
     pub sync_last_known_own_block_timeout: Duration,
 
-    /// Proposing new block is stopped when the propagation delay is greater
-    /// than this threshold. Propagation delay is the difference between the
-    /// round of the last proposed block and the highest round from this
-    /// authority that is received by all validators in a quorum.
-    #[serde(default = "Parameters::default_propagation_delay_stop_proposal_threshold")]
-    pub propagation_delay_stop_proposal_threshold: u32,
-
     /// The number of rounds of blocks to be kept in the Dag state cache per
     /// authority. The larger the number the more the blocks that will be
     /// kept in memory allowing minimising any potential disk access.
@@ -166,10 +159,6 @@ impl Parameters {
             Duration::from_secs(5)
         }
     }
-    pub(crate) fn default_propagation_delay_stop_proposal_threshold() -> u32 {
-        // Propagation delay is usually 0 round in production.
-        if cfg!(msim) { 2 } else { 5 }
-    }
 
     pub(crate) fn default_dag_state_cached_rounds() -> u32 {
         if cfg!(msim) {
@@ -223,8 +212,6 @@ impl Default for Parameters {
             max_transactions_per_fetch: Parameters::default_max_transactions_per_fetch(),
             sync_last_known_own_block_timeout:
                 Parameters::default_sync_last_known_own_block_timeout(),
-            propagation_delay_stop_proposal_threshold:
-                Parameters::default_propagation_delay_stop_proposal_threshold(),
             dag_state_cached_rounds: Parameters::default_dag_state_cached_rounds(),
             commit_sync_parallel_fetches: Parameters::default_commit_sync_parallel_fetches(),
             commit_sync_batch_size: Parameters::default_commit_sync_batch_size(),

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -28,8 +28,8 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_leader_timeout")]
     pub leader_timeout: Duration,
 
-    /// Minimum delay between own blocks. This avoids generating too many rounds when
-    /// latency is low. This is especially necessary for tests running
+    /// Minimum delay between own blocks. This avoids generating too many rounds
+    /// when latency is low. This is especially necessary for tests running
     /// locally. If setting a non-default value, it should be set low enough
     /// to avoid reducing round rate and increasing latency in realistic and
     /// distributed configurations.
@@ -115,7 +115,8 @@ impl Parameters {
             // Avoid excessive CPU, data and logs in tests.
             Duration::from_millis(250)
         } else {
-            // For production, use min delay between block being set to 50ms, reducing the block rate to 20 blocks/sec
+            // For production, use min delay between block being set to 50ms, reducing the
+            // block rate to 20 blocks/sec
             Duration::from_millis(50)
         }
     }

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -28,13 +28,13 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_leader_timeout")]
     pub leader_timeout: Duration,
 
-    /// Minimum delay between rounds, to avoid generating too many rounds when
+    /// Minimum delay between own blocks. This avoids generating too many rounds when
     /// latency is low. This is especially necessary for tests running
     /// locally. If setting a non-default value, it should be set low enough
     /// to avoid reducing round rate and increasing latency in realistic and
     /// distributed configurations.
-    #[serde(default = "Parameters::default_min_round_delay")]
-    pub min_round_delay: Duration,
+    #[serde(default = "Parameters::default_min_block_delay")]
+    pub min_block_delay: Duration,
 
     /// Maximum forward time drift (how far in future) allowed for received
     /// blocks.
@@ -104,8 +104,8 @@ impl Parameters {
         Duration::from_millis(250)
     }
 
-    pub(crate) fn default_min_round_delay() -> Duration {
-        if cfg!(msim) || std::env::var("__TEST_ONLY_CONSENSUS_USE_LONG_MIN_ROUND_DELAY").is_ok() {
+    pub(crate) fn default_min_block_delay() -> Duration {
+        if cfg!(msim) || std::env::var("__TEST_ONLY_CONSENSUS_USE_LONG_MIN_BLOCK_DELAY").is_ok() {
             // Checkpoint building and execution cannot keep up with high commit rate in
             // simtests, leading to long reconfiguration delays. This is because
             // simtest is single threaded, and spending too much time in
@@ -115,6 +115,7 @@ impl Parameters {
             // Avoid excessive CPU, data and logs in tests.
             Duration::from_millis(250)
         } else {
+            // For production, use min delay between block being set to 50ms, reducing the block rate to 20 blocks/sec
             Duration::from_millis(50)
         }
     }
@@ -203,7 +204,7 @@ impl Default for Parameters {
         Self {
             db_path: PathBuf::default(),
             leader_timeout: Parameters::default_leader_timeout(),
-            min_round_delay: Parameters::default_min_round_delay(),
+            min_block_delay: Parameters::default_min_block_delay(),
             max_forward_time_drift: Parameters::default_max_forward_time_drift(),
             max_headers_per_commit_sync_fetch:
                 Parameters::default_max_headers_per_commit_sync_fetch(),

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -5,7 +5,7 @@ expression: parameters
 leader_timeout:
   secs: 0
   nanos: 250000000
-min_round_delay:
+min_block_delay:
   secs: 0
   nanos: 50000000
 max_forward_time_drift:
@@ -17,7 +17,6 @@ max_transactions_per_fetch: 100
 sync_last_known_own_block_timeout:
   secs: 5
   nanos: 0
-propagation_delay_stop_proposal_threshold: 5
 dag_state_cached_rounds: 500
 commit_sync_parallel_fetches: 8
 commit_sync_batch_size: 100

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1256,6 +1256,7 @@ mod tests {
         transaction::TransactionConsumer,
         transactions_synchronizer::TransactionsSynchronizer,
     };
+    use crate::core::ReasonToCreateBlock;
 
     #[derive(Default)]
     struct FakeNetworkClient {}
@@ -2021,7 +2022,7 @@ mod tests {
         async fn new_block(
             &self,
             _round: Round,
-            _force: bool,
+            _reason: ReasonToCreateBlock,
         ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
             unimplemented!("Unimplemented")
         }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1239,7 +1239,7 @@ mod tests {
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
         cordial_knowledge::{ConnectionKnowledgeMessage, CordialKnowledge},
-        core::{Core, CoreSignals},
+        core::{Core, CoreSignals, ReasonToCreateBlock},
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
         dag_state::{DagState, TransactionSource},
         encoder::create_encoder,
@@ -1256,7 +1256,6 @@ mod tests {
         transaction::TransactionConsumer,
         transactions_synchronizer::TransactionsSynchronizer,
     };
-    use crate::core::ReasonToCreateBlock;
 
     #[derive(Default)]
     struct FakeNetworkClient {}

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1716,11 +1716,11 @@ mod test {
 
         // Try to propose again - with or without ignore leaders check, it will not
         // return any block
-        let (new_block_opt, missing_committed_txns) = core.try_propose(false).unwrap();
+        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::MinBlockDelayTimeout).unwrap();
         assert!(new_block_opt.is_none());
         assert!(missing_committed_txns.is_empty());
 
-        let (new_block_opt, missing_committed_txns) = core.try_propose(true).unwrap();
+        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
         assert!(new_block_opt.is_none());
         assert!(missing_committed_txns.is_empty());
         // Check no commits have been persisted to dag_state & store
@@ -1785,11 +1785,11 @@ mod test {
         assert_eq!(core.last_proposed_round(), 1);
         expected_ancestors.insert(core.last_proposed_block_header().reference());
         // attempt to create a block - none will be produced.
-        let (new_block_opt, missing_committed_txns) = core.try_propose(false).unwrap();
+        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::MinBlockDelayTimeout).unwrap();
         assert!(new_block_opt.is_none());
         assert!(missing_committed_txns.is_empty());
 
-        // Adding another block now forms a quorum for round 1, so block at round 2 will
+        // Adding another block now forms a quorum for round 1, so block at round 2 will be
         // proposed
         let block_3 = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 2).build());
         expected_ancestors.insert(block_3.reference());
@@ -1868,7 +1868,7 @@ mod test {
         );
 
         // Trying to explicitly propose a block will not produce anything
-        let (new_block_opt, missing_committed_txns) = core.try_propose(true).unwrap();
+        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
         assert!(new_block_opt.is_none());
         assert!(missing_committed_txns.is_empty());
 
@@ -1885,7 +1885,7 @@ mod test {
         assert!(missing_committed_txns.is_empty());
 
         // Try to propose - no block should be produced.
-        let (new_block_opt, missing_committed_txns) = core.try_propose(true).unwrap();
+        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
         assert!(new_block_opt.is_none());
         assert!(missing_committed_txns.is_empty());
 
@@ -1893,7 +1893,7 @@ mod test {
         // the network informed us that we do have proposed a block about.
         core.set_last_known_proposed_round(10);
 
-        let (new_block_opt, missing_committed_txns) = core.try_propose(true).expect("No error");
+        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::KnownLastBlock).expect("No error");
         assert!(missing_committed_txns.is_empty());
 
         let block = new_block_opt.unwrap();
@@ -1960,9 +1960,9 @@ mod test {
                 if let Some(r) = last_round_blocks.first().map(|b| b.round()) {
                     assert_eq!(round - 1, r);
                     if core_fixture.core.last_proposed_round() == r {
-                        // Force propose new block regardless of min round delay.
+                        // Force propose new block regardless of min block delay.
                         let (new_block_opt, missing_committed_txns) =
-                            core_fixture.core.try_propose(true).unwrap();
+                            core_fixture.core.try_propose(ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
                         assert!(missing_committed_txns.is_empty());
                         new_block_opt.unwrap_or_else(|| {
                             panic!("Block should have been proposed for round {round}")

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -116,6 +116,23 @@ pub(crate) struct Core {
     encoder: Box<dyn ShardEncoder + Send + Sync>,
 }
 
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+pub (crate) enum Reason {
+    MinTimeout,
+    AddBlock,
+    MaxTimeout,
+}
+
+impl Reason {
+    fn to_string(&self) -> &'static str {
+        match self {
+            Reason::MinTimeout => "MinTimeout",
+            Reason::AddBlock => "AddBlock",
+            Reason::MaxTimeout => "MaxTimeout",
+        }
+    }
+}
+
 impl Core {
     pub(crate) fn new(
         context: Arc<Context>,
@@ -219,7 +236,7 @@ impl Core {
         // refs can be ignored as the missing transactions will be fetched by the
         // periodic transactions' synchronizer.
         self.try_commit().unwrap();
-        let last_proposed_block = match self.try_propose(true).unwrap() {
+        let last_proposed_block = match self.try_propose(Reason::MaxTimeout).unwrap() {
             (Some(block), _) => Some(block),
             (None, _) => {
                 let last_proposed_block = self.dag_state.read().recover_last_own_block();
@@ -295,7 +312,7 @@ impl Core {
             let (_subdags, new_missing_committed_txns) = self.try_commit()?;
 
             // Try to propose now since there are new blocks accepted.
-            self.try_propose(false)?;
+            self.try_propose(Reason::AddBlock)?;
 
             // Now set up leader timeout if needed.
             // This needs to be called after try_commit() and try_propose(), which may
@@ -357,7 +374,7 @@ impl Core {
             let (_subdags, new_missing_committed_txns) = self.try_commit()?;
 
             // Try to propose now since there are new blocks accepted.
-            self.try_propose(false)?;
+            self.try_propose(Reason::AddBlock)?;
 
             // Now set up leader timeout if needed.
             // This needs to be called after try_commit() and try_propose(), which may
@@ -491,7 +508,7 @@ impl Core {
     pub(crate) fn new_block(
         &mut self,
         round: Round,
-        force: bool,
+        reason: Reason,
     ) -> ConsensusResult<(
         Option<VerifiedBlock>,
         BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
@@ -502,9 +519,9 @@ impl Core {
                 .metrics
                 .node_metrics
                 .leader_timeout_total
-                .with_label_values(&[&format!("{force}")])
+                .with_label_values(&[&reason.to_string()])
                 .inc();
-            let result = self.try_propose(force);
+            let result = self.try_propose(reason);
             // The threshold clock round may have advanced, so a signal needs to be sent.
             self.try_signal_new_round();
             return result;
@@ -517,7 +534,7 @@ impl Core {
     // ancestors and if the minimum round delay has passed.
     fn try_propose(
         &mut self,
-        force: bool,
+        reason: Reason,
     ) -> ConsensusResult<(
         Option<VerifiedBlock>,
         BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
@@ -525,7 +542,7 @@ impl Core {
         if !self.should_propose() {
             return Ok((None, BTreeMap::new()));
         }
-        if let Some(verified_block) = self.try_new_block(force) {
+        if let Some(verified_block) = self.try_new_block(reason) {
             self.signals.new_block(verified_block.clone())?;
 
             fail_point!("consensus-after-propose");
@@ -541,7 +558,7 @@ impl Core {
     /// already proposed for latest or earlier round, then no block is
     /// created and None is returned.
     #[instrument(level = "trace", skip_all)]
-    fn try_new_block(&mut self, force: bool) -> Option<VerifiedBlock> {
+    fn try_new_block(&mut self, reason: Reason) -> Option<VerifiedBlock> {
         let _s = self
             .context
             .metrics
@@ -566,7 +583,7 @@ impl Core {
         // Create a new block either because we want to "forcefully" propose a block due
         // to a leader timeout, or because we are actually ready to produce the
         // block (leader exists and min delay has passed).
-        if !force {
+        if reason != Reason::MaxTimeout {
             if !self.leaders_exist(quorum_round) {
                 return None;
             }
@@ -583,14 +600,14 @@ impl Core {
         }
 
         // Determine the ancestors to be included in proposal.
-        let ancestors = self.ancestors_to_propose(clock_round, !force);
+        let ancestors = self.ancestors_to_propose(clock_round, reason);
 
         // If we did not find enough good ancestors to propose, continue to wait before
         // proposing.
         if ancestors.is_empty() {
             assert!(
-                !force,
-                "Ancestors should have been returned if force is true!"
+                reason != Reason::MaxTimeout,
+                "Ancestors should have been returned if maximal timeout is expired!"
             );
             return None;
         }
@@ -782,7 +799,7 @@ impl Core {
             .metrics
             .node_metrics
             .proposed_blocks
-            .with_label_values(&[&force.to_string()])
+            .with_label_values(&[&reason.to_string()])
             .inc();
 
         Some(verified_block)
@@ -1028,13 +1045,13 @@ impl Core {
 
     /// Retrieves the next ancestors to propose to form a block at `clock_round`
     /// round. If force=false and the stake of available ancestors is not big
-    /// enough, then this function will wait. It force=true and stake is not
+    /// enough, then this function will return empty vector. It force=true and stake is not
     /// big enough then the function will panic, because it means that there is
     /// a bug somewhere
     fn ancestors_to_propose(
         &mut self,
         clock_round: Round,
-        force: bool,
+        reason: Reason,
     ) -> Vec<VerifiedBlockHeader> {
         let node_metrics = &self.context.metrics.node_metrics;
         let _s = node_metrics
@@ -1082,7 +1099,7 @@ impl Core {
             parent_round_quorum.add(ancestor.author(), &self.context.committee);
         }
 
-        if !force && !parent_round_quorum.reached_threshold(&self.context.committee) {
+        if reason != Reason::MaxTimeout && !parent_round_quorum.reached_threshold(&self.context.committee) {
             node_metrics.selection_wait.inc();
             debug!(
                 "Only found {} stake of ancestors to include for round {clock_round}, will wait for more.",

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -110,7 +110,7 @@ pub(crate) struct Core {
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 pub(crate) enum ReasonToCreateBlock {
-    MinRoundTimeout,
+    MinBlockDelayTimeout,
     AddBlock,
     AddBlockHeader,
     MaxLeaderTimeout,
@@ -122,7 +122,7 @@ pub(crate) enum ReasonToCreateBlock {
 impl ReasonToCreateBlock {
     fn label(&self) -> &'static str {
         match self {
-            ReasonToCreateBlock::MinRoundTimeout => "MinRoundTimeout",
+            ReasonToCreateBlock::MinBlockDelayTimeout => "MinBlockDelayTimeout",
             ReasonToCreateBlock::AddBlock => "AddBlock",
             ReasonToCreateBlock::MaxLeaderTimeout => "MaxLeaderTimeout",
             ReasonToCreateBlock::AddBlockHeader => "AddBlockHeader",
@@ -136,10 +136,10 @@ impl ReasonToCreateBlock {
     // existence of a leader in quorum round and min timeout
     fn is_forced(&self) -> bool {
         match self {
-            ReasonToCreateBlock::MinRoundTimeout => false,
+            ReasonToCreateBlock::MinBlockDelayTimeout => false,
             ReasonToCreateBlock::AddBlock => false,
             ReasonToCreateBlock::MaxLeaderTimeout => true,
-            ReasonToCreateBlock::AddBlockHeader => true,
+            ReasonToCreateBlock::AddBlockHeader => false,
             ReasonToCreateBlock::Recover => true,
             ReasonToCreateBlock::QuorumSubscribersExist => true,
             ReasonToCreateBlock::KnownLastBlock => true,
@@ -514,9 +514,8 @@ impl Core {
             .set(new_clock_round as i64);
     }
 
-    /// Creating a new block for the dictated round. This is used when a leader
-    /// timeout occurs, either when the min timeout expires or max. When
-    /// `force = true`, then any checks like previous round
+    /// Creating a new block for the dictated round. This is used when either
+    /// the min block delay timeout expires or max leader timeout expires. In the latter case, any checks like previous round
     /// leader existence will get skipped.
     pub(crate) fn new_block(
         &mut self,
@@ -531,7 +530,7 @@ impl Core {
             self.context
                 .metrics
                 .node_metrics
-                .leader_timeout_total
+                .timeout_expired_total
                 .with_label_values(&[&reason.label()])
                 .inc();
             let result = self.try_propose(reason);
@@ -606,7 +605,7 @@ impl Core {
                     .clock
                     .timestamp_utc_ms()
                     .saturating_sub(self.last_proposed_timestamp_ms()),
-            ) < self.context.parameters.min_round_delay
+            ) < self.context.parameters.min_block_delay
             {
                 return None;
             }
@@ -1779,7 +1778,7 @@ mod test {
         let verified_block = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 1).build());
         expected_ancestors.insert(verified_block.reference());
         // Wait for min round delay to allow blocks to be proposed.
-        sleep(context.parameters.min_round_delay).await;
+        sleep(context.parameters.min_block_delay).await;
         // add blocks to trigger proposal.
         _ = core.add_blocks(vec![verified_block]);
 
@@ -1795,7 +1794,7 @@ mod test {
         let block_3 = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 2).build());
         expected_ancestors.insert(block_3.reference());
         // Wait for min round delay to allow blocks to be proposed.
-        sleep(context.parameters.min_round_delay).await;
+        sleep(context.parameters.min_block_delay).await;
         // add blocks to trigger proposal.
         _ = core.add_blocks(vec![block_3]);
 
@@ -1990,7 +1989,7 @@ mod test {
                 .add_block_headers(last_round_blocks.clone())
                 .unwrap();
             let (new_block_opt, missing_committed_txns) =
-                core_fixture.core.try_propose(false).unwrap();
+                core_fixture.core.try_propose(ReasonToCreateBlock::AddBlockHeader).unwrap();
             assert!(new_block_opt.is_none());
             assert!(missing_committed_txns.is_empty());
         }
@@ -1998,7 +1997,7 @@ mod test {
         // Now try to create the blocks for round 4 via the leader timeout method which
         // should ignore any leader checks or min round delay.
         for core_fixture in cores.iter_mut() {
-            let (new_block, missing_committed_txns) = core_fixture.core.new_block(4, true).unwrap();
+            let (new_block, missing_committed_txns) = core_fixture.core.new_block(4, ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
             assert!(missing_committed_txns.is_empty());
             assert!(new_block.is_some());
 
@@ -2072,7 +2071,7 @@ mod test {
         );
 
         // There is no proposal even with forced proposing.
-        let (new_block_opt, missing_committed_txns) = core.try_propose(true).unwrap();
+        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
         assert!(new_block_opt.is_none());
         assert!(missing_committed_txns.is_empty());
 
@@ -2080,7 +2079,7 @@ mod test {
         core.set_quorum_subscribers_exists(true);
 
         // Proposing now would succeed.
-        let (new_block_opt, missing_committed_txns) = core.try_propose(true).unwrap();
+        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::QuorumSubscribersExist).unwrap();
         assert!(new_block_opt.is_some());
         assert!(missing_committed_txns.is_empty());
     }
@@ -2101,7 +2100,7 @@ mod test {
             let mut this_round_block_headers = Vec::new();
 
             // Wait for min round delay to allow blocks to be proposed.
-            sleep(default_params.min_round_delay).await;
+            sleep(default_params.min_block_delay).await;
 
             for core_fixture in &mut cores {
                 // add the blocks from last round
@@ -2320,7 +2319,7 @@ mod test {
         for round in 1..=33 {
             let mut this_round_block_headers = Vec::new();
             // Wait for min round delay to allow blocks to be proposed.
-            sleep(default_params.min_round_delay).await;
+            sleep(default_params.min_block_delay).await;
             for core_fixture in &mut cores {
                 // add the blocks from last round
                 // this will trigger a block creation for the round and a signal should be
@@ -2451,7 +2450,7 @@ mod test {
             let mut this_round_block_headers = Vec::new();
 
             // Wait for min round delay to allow blocks to be proposed.
-            sleep(default_params.min_round_delay).await;
+            sleep(default_params.min_block_delay).await;
 
             for core_fixture in &mut cores {
                 // add the blocks from last round
@@ -2557,7 +2556,7 @@ mod test {
                     .core
                     .add_block_headers(last_round_block_headers.clone())
                     .unwrap();
-                core_fixture.core.new_block(round, true).unwrap();
+                core_fixture.core.new_block(round, ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
 
                 let block_header = core_fixture.core.last_proposed_block_header();
                 assert_eq!(block_header.round(), round);
@@ -2577,7 +2576,7 @@ mod test {
         // referenced + the authority's block of round 0.
         let core_fixture = &mut cores[excluded_authority];
         // Wait for min round delay to allow blocks to be proposed.
-        sleep(default_params.min_round_delay).await;
+        sleep(default_params.min_block_delay).await;
         // add blocks to trigger proposal.
         core_fixture
             .core

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1032,7 +1032,6 @@ impl Core {
     /// Retrieves the next ancestors to propose to form a block at `clock_round`
     /// round.
     fn ancestors_to_propose(&mut self, clock_round: Round) -> Vec<VerifiedBlockHeader> {
-
         // Take the ancestors before the clock_round (excluded) for each authority.
         let all_ancestors = self
             .dag_state
@@ -1065,8 +1064,9 @@ impl Core {
 
         let mut parent_round_quorum = StakeAggregator::<QuorumThreshold>::new();
 
-        // Make a sanity check that the total stake of quorum clock round ancestors is above a quorum threshold.
-        // This must be guaranteed by a threshold clock component that advanced the round.
+        // Make a sanity check that the total stake of quorum clock round ancestors is
+        // above a quorum threshold. This must be guaranteed by a threshold
+        // clock component that advanced the round.
         for ancestor in included_ancestors
             .iter()
             .filter(|a| a.round() == quorum_round)

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -597,7 +597,7 @@ impl Core {
         // to a leader timeout, or because we are actually ready to produce the
         // block (leader exists and min delay has passed).
         if !reason.is_forced() {
-            if !self.leader_exist(quorum_round) {
+            if !self.leaders_exist(quorum_round) {
                 return None;
             }
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -597,7 +597,7 @@ impl Core {
         // to a leader timeout, or because we are actually ready to produce the
         // block (leader exists and min delay has passed).
         if !reason.is_forced() {
-            if !self.leaders_exist(quorum_round) {
+            if !self.leader_exist(quorum_round) {
                 return None;
             }
 
@@ -1032,13 +1032,8 @@ impl Core {
     /// Retrieves the next ancestors to propose to form a block at `clock_round`
     /// round.
     fn ancestors_to_propose(&mut self, clock_round: Round) -> Vec<VerifiedBlockHeader> {
-        let node_metrics = &self.context.metrics.node_metrics;
-        let _s = node_metrics
-            .scope_processing_time
-            .with_label_values(&["Core::ancestors_to_propose"])
-            .start_timer();
 
-        // Now take the ancestors before the clock_round (excluded) for each authority.
+        // Take the ancestors before the clock_round (excluded) for each authority.
         let all_ancestors = self
             .dag_state
             .read()
@@ -1070,7 +1065,8 @@ impl Core {
 
         let mut parent_round_quorum = StakeAggregator::<QuorumThreshold>::new();
 
-        // Check total stake of high scoring parent round ancestors
+        // Make a sanity check that the total stake of quorum clock round ancestors is above a quorum threshold.
+        // This must be guaranteed by a threshold clock component that advanced the round.
         for ancestor in included_ancestors
             .iter()
             .filter(|a| a.round() == quorum_round)
@@ -1086,10 +1082,7 @@ impl Core {
         included_ancestors
     }
 
-    /// Checks whether all the leaders of the round exist.
-    /// TODO: we can leverage some additional signal here in order to more
-    /// cleverly manipulate later the leader timeout Ex if we already have
-    /// one leader - the first in order - we might don't want to wait as much.
+    /// Checks whether the leaders of the round exist.
     fn leaders_exist(&self, round: Round) -> bool {
         let dag_state = self.dag_state.read();
         for leader in self.leaders(round) {

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -67,14 +67,6 @@ pub(crate) struct Core {
     /// there is not enough subscribers, because new proposed blocks will
     /// not be sufficiently propagated to the network.
     quorum_subscribers_exists: bool,
-    /// Estimated delay by round for propagating blocks to a quorum.
-    /// Because of the nature of TCP and block streaming, propagation delay is
-    /// expected to be 0 in most cases, even when the actual latency of
-    /// broadcasting blocks is high. When this value is higher than the
-    /// `propagation_delay_stop_proposal_threshold`, most likely this
-    /// validator cannot broadcast  blocks to the network at all. Core stops
-    /// proposing new blocks in this case.
-    propagation_delay: Round,
 
     /// Used to make commit decisions for leader blocks in the dag.
     committer: UniversalCommitter,
@@ -117,18 +109,38 @@ pub(crate) struct Core {
 }
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
-pub (crate) enum Reason {
-    MinTimeout,
+pub(crate) enum Reason {
+    MinRoundTimeout,
     AddBlock,
-    MaxTimeout,
+    AddBlockHeader,
+    MaxLeaderTimeout,
+    Recover,
+    QuorumSubscribersExist,
+    KnownLastBlock,
 }
 
 impl Reason {
     fn to_string(&self) -> &'static str {
         match self {
-            Reason::MinTimeout => "MinTimeout",
+            Reason::MinRoundTimeout => "MinRoundTimeout",
             Reason::AddBlock => "AddBlock",
-            Reason::MaxTimeout => "MaxTimeout",
+            Reason::MaxLeaderTimeout => "MaxLeaderTimeout",
+            Reason::AddBlockHeader => "AddBlockHeader",
+            Reason::Recover => "Recover",
+            Reason::QuorumSubscribersExist => "QuorumSubscribersExist",
+            Reason::KnownLastBlock => "KnownLastBlock",
+        }
+    }
+
+    fn is_forced(&self) -> bool {
+        match self {
+            Reason::MinRoundTimeout => false,
+            Reason::AddBlock => false,
+            Reason::MaxLeaderTimeout => true,
+            Reason::AddBlockHeader => true,
+            Reason::Recover => true,
+            Reason::QuorumSubscribersExist => true,
+            Reason::KnownLastBlock => true,
         }
     }
 }
@@ -193,7 +205,6 @@ impl Core {
             transaction_consumer,
             block_manager,
             quorum_subscribers_exists,
-            propagation_delay: 0,
             committer,
             commit_observer,
             signals,
@@ -236,7 +247,7 @@ impl Core {
         // refs can be ignored as the missing transactions will be fetched by the
         // periodic transactions' synchronizer.
         self.try_commit().unwrap();
-        let last_proposed_block = match self.try_propose(Reason::MaxTimeout).unwrap() {
+        let last_proposed_block = match self.try_propose(Reason::Recover).unwrap() {
             (Some(block), _) => Some(block),
             (None, _) => {
                 let last_proposed_block = self.dag_state.read().recover_last_own_block();
@@ -374,7 +385,7 @@ impl Core {
             let (_subdags, new_missing_committed_txns) = self.try_commit()?;
 
             // Try to propose now since there are new blocks accepted.
-            self.try_propose(Reason::AddBlock)?;
+            self.try_propose(Reason::AddBlockHeader)?;
 
             // Now set up leader timeout if needed.
             // This needs to be called after try_commit() and try_propose(), which may
@@ -583,7 +594,7 @@ impl Core {
         // Create a new block either because we want to "forcefully" propose a block due
         // to a leader timeout, or because we are actually ready to produce the
         // block (leader exists and min delay has passed).
-        if reason != Reason::MaxTimeout {
+        if !reason.is_forced() {
             if !self.leaders_exist(quorum_round) {
                 return None;
             }
@@ -599,18 +610,9 @@ impl Core {
             }
         }
 
-        // Determine the ancestors to be included in proposal.
-        let ancestors = self.ancestors_to_propose(clock_round, reason);
-
-        // If we did not find enough good ancestors to propose, continue to wait before
-        // proposing.
-        if ancestors.is_empty() {
-            assert!(
-                reason != Reason::MaxTimeout,
-                "Ancestors should have been returned if maximal timeout is expired!"
-            );
-            return None;
-        }
+        // Determine the ancestors to be included in proposal. A quorum of ancestor must
+        // exist due to a threshold clock
+        let ancestors = self.ancestors_to_propose(clock_round);
 
         // Update the last included ancestor block refs
         for ancestor in &ancestors {
@@ -1002,25 +1004,6 @@ impl Core {
             return false;
         }
 
-        if self.propagation_delay
-            > self
-                .context
-                .parameters
-                .propagation_delay_stop_proposal_threshold
-        {
-            debug!(
-                "Skip proposing for round {clock_round}, high propagation delay {} > {}.",
-                self.propagation_delay,
-                self.context
-                    .parameters
-                    .propagation_delay_stop_proposal_threshold
-            );
-            core_skipped_proposals
-                .with_label_values(&["high_propagation_delay"])
-                .inc();
-            return false;
-        }
-
         let Some(last_known_proposed_round) = self.last_known_proposed_round else {
             debug!(
                 "Skip proposing for round {clock_round}, last known proposed round has not been synced yet."
@@ -1044,15 +1027,8 @@ impl Core {
     }
 
     /// Retrieves the next ancestors to propose to form a block at `clock_round`
-    /// round. If force=false and the stake of available ancestors is not big
-    /// enough, then this function will return empty vector. It force=true and stake is not
-    /// big enough then the function will panic, because it means that there is
-    /// a bug somewhere
-    fn ancestors_to_propose(
-        &mut self,
-        clock_round: Round,
-        reason: Reason,
-    ) -> Vec<VerifiedBlockHeader> {
+    /// round.
+    fn ancestors_to_propose(&mut self, clock_round: Round) -> Vec<VerifiedBlockHeader> {
         let node_metrics = &self.context.metrics.node_metrics;
         let _s = node_metrics
             .scope_processing_time
@@ -1097,15 +1073,6 @@ impl Core {
             .filter(|a| a.round() == quorum_round)
         {
             parent_round_quorum.add(ancestor.author(), &self.context.committee);
-        }
-
-        if reason != Reason::MaxTimeout && !parent_round_quorum.reached_threshold(&self.context.committee) {
-            node_metrics.selection_wait.inc();
-            debug!(
-                "Only found {} stake of ancestors to include for round {clock_round}, will wait for more.",
-                parent_round_quorum.stake()
-            );
-            return vec![];
         }
 
         assert!(

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -658,21 +658,6 @@ impl Core {
                 .observe(clock_round.saturating_sub(ancestor.round()).into());
         }
 
-        // Record timestamp drift but don't enforce ancestor timestamp checks.
-        let now = self.context.clock.timestamp_utc_ms();
-        ancestors.iter().for_each(|block| {
-            if block.timestamp_ms() > now {
-                trace!("Ancestor block {block:?} has timestamp {}, greater than current timestamp {now}. Proposing for round {clock_round}.",  block.timestamp_ms());
-                let authority = &self.context.committee.authority(block.author()).hostname;
-                self.context
-                    .metrics
-                    .node_metrics
-                    .proposed_block_ancestors_timestamp_drift_ms
-                    .with_label_values(&[authority])
-                    .inc_by(block.timestamp_ms().saturating_sub(now));
-            }
-        });
-
         // Consume the next transactions to be included. Do not drop the guards yet as
         // this would acknowledge the inclusion of transactions. Just let this
         // be done in the end of the method.
@@ -726,6 +711,21 @@ impl Core {
             .dag_state
             .write()
             .take_commit_votes(MAX_COMMIT_VOTES_PER_BLOCK);
+
+        // Get current timestamp and record drift but don't enforce ancestor timestamp checks.
+        let now = self.context.clock.timestamp_utc_ms();
+        ancestors.iter().for_each(|block| {
+            if block.timestamp_ms() > now {
+                trace!("Ancestor block {block:?} has timestamp {}, greater than current timestamp {now}. Proposing for round {clock_round}.",  block.timestamp_ms());
+                let authority = &self.context.committee.authority(block.author()).hostname;
+                self.context
+                    .metrics
+                    .node_metrics
+                    .proposed_block_ancestors_timestamp_drift_ms
+                    .with_label_values(&[authority])
+                    .inc_by(block.timestamp_ms().saturating_sub(now));
+            }
+        });
 
         // Create the block and insert to storage.
         let block_header = BlockHeader::V1(BlockHeaderV1::new(

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -515,8 +515,9 @@ impl Core {
     }
 
     /// Creating a new block for the dictated round. This is used when either
-    /// the min block delay timeout expires or max leader timeout expires. In the latter case, any checks like previous round
-    /// leader existence will get skipped.
+    /// the min block delay timeout expires or max leader timeout expires. In
+    /// the latter case, any checks like previous round leader existence
+    /// will get skipped.
     pub(crate) fn new_block(
         &mut self,
         round: Round,
@@ -543,7 +544,7 @@ impl Core {
 
     // Attempts to create a new block, persist and propose it to all peers.
     // When force is true, ignore if leader from the last round exists among
-    // ancestors and if the minimum round delay has passed.
+    // ancestors and if the minimum block delay has passed.
     fn try_propose(
         &mut self,
         reason: ReasonToCreateBlock,
@@ -711,7 +712,8 @@ impl Core {
             .write()
             .take_commit_votes(MAX_COMMIT_VOTES_PER_BLOCK);
 
-        // Get current timestamp and record drift but don't enforce ancestor timestamp checks.
+        // Get current timestamp and record drift but don't enforce ancestor timestamp
+        // checks.
         let now = self.context.clock.timestamp_utc_ms();
         ancestors.iter().for_each(|block| {
             if block.timestamp_ms() > now {
@@ -1716,11 +1718,15 @@ mod test {
 
         // Try to propose again - with or without ignore leaders check, it will not
         // return any block
-        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::MinBlockDelayTimeout).unwrap();
+        let (new_block_opt, missing_committed_txns) = core
+            .try_propose(ReasonToCreateBlock::MinBlockDelayTimeout)
+            .unwrap();
         assert!(new_block_opt.is_none());
         assert!(missing_committed_txns.is_empty());
 
-        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
+        let (new_block_opt, missing_committed_txns) = core
+            .try_propose(ReasonToCreateBlock::MaxLeaderTimeout)
+            .unwrap();
         assert!(new_block_opt.is_none());
         assert!(missing_committed_txns.is_empty());
         // Check no commits have been persisted to dag_state & store
@@ -1777,7 +1783,7 @@ mod test {
         // Adding one block now will trigger the creation of new block for round 1
         let verified_block = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 1).build());
         expected_ancestors.insert(verified_block.reference());
-        // Wait for min round delay to allow blocks to be proposed.
+        // Wait for min block delay to allow blocks to be proposed.
         sleep(context.parameters.min_block_delay).await;
         // add blocks to trigger proposal.
         _ = core.add_blocks(vec![verified_block]);
@@ -1785,15 +1791,17 @@ mod test {
         assert_eq!(core.last_proposed_round(), 1);
         expected_ancestors.insert(core.last_proposed_block_header().reference());
         // attempt to create a block - none will be produced.
-        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::MinBlockDelayTimeout).unwrap();
+        let (new_block_opt, missing_committed_txns) = core
+            .try_propose(ReasonToCreateBlock::MinBlockDelayTimeout)
+            .unwrap();
         assert!(new_block_opt.is_none());
         assert!(missing_committed_txns.is_empty());
 
-        // Adding another block now forms a quorum for round 1, so block at round 2 will be
-        // proposed
+        // Adding another block now forms a quorum for round 1, so block at round 2 will
+        // be proposed
         let block_3 = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 2).build());
         expected_ancestors.insert(block_3.reference());
-        // Wait for min round delay to allow blocks to be proposed.
+        // Wait for min block delay to allow blocks to be proposed.
         sleep(context.parameters.min_block_delay).await;
         // add blocks to trigger proposal.
         _ = core.add_blocks(vec![block_3]);
@@ -1868,7 +1876,9 @@ mod test {
         );
 
         // Trying to explicitly propose a block will not produce anything
-        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
+        let (new_block_opt, missing_committed_txns) = core
+            .try_propose(ReasonToCreateBlock::MaxLeaderTimeout)
+            .unwrap();
         assert!(new_block_opt.is_none());
         assert!(missing_committed_txns.is_empty());
 
@@ -1885,7 +1895,9 @@ mod test {
         assert!(missing_committed_txns.is_empty());
 
         // Try to propose - no block should be produced.
-        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
+        let (new_block_opt, missing_committed_txns) = core
+            .try_propose(ReasonToCreateBlock::MaxLeaderTimeout)
+            .unwrap();
         assert!(new_block_opt.is_none());
         assert!(missing_committed_txns.is_empty());
 
@@ -1893,7 +1905,9 @@ mod test {
         // the network informed us that we do have proposed a block about.
         core.set_last_known_proposed_round(10);
 
-        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::KnownLastBlock).expect("No error");
+        let (new_block_opt, missing_committed_txns) = core
+            .try_propose(ReasonToCreateBlock::KnownLastBlock)
+            .expect("No error");
         assert!(missing_committed_txns.is_empty());
 
         let block = new_block_opt.unwrap();
@@ -1961,8 +1975,10 @@ mod test {
                     assert_eq!(round - 1, r);
                     if core_fixture.core.last_proposed_round() == r {
                         // Force propose new block regardless of min block delay.
-                        let (new_block_opt, missing_committed_txns) =
-                            core_fixture.core.try_propose(ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
+                        let (new_block_opt, missing_committed_txns) = core_fixture
+                            .core
+                            .try_propose(ReasonToCreateBlock::MaxLeaderTimeout)
+                            .unwrap();
                         assert!(missing_committed_txns.is_empty());
                         new_block_opt.unwrap_or_else(|| {
                             panic!("Block should have been proposed for round {round}")
@@ -1988,16 +2004,21 @@ mod test {
                 .core
                 .add_block_headers(last_round_blocks.clone())
                 .unwrap();
-            let (new_block_opt, missing_committed_txns) =
-                core_fixture.core.try_propose(ReasonToCreateBlock::AddBlockHeader).unwrap();
+            let (new_block_opt, missing_committed_txns) = core_fixture
+                .core
+                .try_propose(ReasonToCreateBlock::AddBlockHeader)
+                .unwrap();
             assert!(new_block_opt.is_none());
             assert!(missing_committed_txns.is_empty());
         }
 
         // Now try to create the blocks for round 4 via the leader timeout method which
-        // should ignore any leader checks or min round delay.
+        // should ignore any leader checks or min block delay.
         for core_fixture in cores.iter_mut() {
-            let (new_block, missing_committed_txns) = core_fixture.core.new_block(4, ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
+            let (new_block, missing_committed_txns) = core_fixture
+                .core
+                .new_block(4, ReasonToCreateBlock::MaxLeaderTimeout)
+                .unwrap();
             assert!(missing_committed_txns.is_empty());
             assert!(new_block.is_some());
 
@@ -2071,7 +2092,9 @@ mod test {
         );
 
         // There is no proposal even with forced proposing.
-        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
+        let (new_block_opt, missing_committed_txns) = core
+            .try_propose(ReasonToCreateBlock::MaxLeaderTimeout)
+            .unwrap();
         assert!(new_block_opt.is_none());
         assert!(missing_committed_txns.is_empty());
 
@@ -2079,7 +2102,9 @@ mod test {
         core.set_quorum_subscribers_exists(true);
 
         // Proposing now would succeed.
-        let (new_block_opt, missing_committed_txns) = core.try_propose(ReasonToCreateBlock::QuorumSubscribersExist).unwrap();
+        let (new_block_opt, missing_committed_txns) = core
+            .try_propose(ReasonToCreateBlock::QuorumSubscribersExist)
+            .unwrap();
         assert!(new_block_opt.is_some());
         assert!(missing_committed_txns.is_empty());
     }
@@ -2099,7 +2124,7 @@ mod test {
         for round in 1..=30 {
             let mut this_round_block_headers = Vec::new();
 
-            // Wait for min round delay to allow blocks to be proposed.
+            // Wait for min block delay to allow blocks to be proposed.
             sleep(default_params.min_block_delay).await;
 
             for core_fixture in &mut cores {
@@ -2318,7 +2343,7 @@ mod test {
         let mut last_round_block_headers = Vec::new();
         for round in 1..=33 {
             let mut this_round_block_headers = Vec::new();
-            // Wait for min round delay to allow blocks to be proposed.
+            // Wait for min block delay to allow blocks to be proposed.
             sleep(default_params.min_block_delay).await;
             for core_fixture in &mut cores {
                 // add the blocks from last round
@@ -2449,7 +2474,7 @@ mod test {
         for round in 1..=10 {
             let mut this_round_block_headers = Vec::new();
 
-            // Wait for min round delay to allow blocks to be proposed.
+            // Wait for min block delay to allow blocks to be proposed.
             sleep(default_params.min_block_delay).await;
 
             for core_fixture in &mut cores {
@@ -2556,7 +2581,10 @@ mod test {
                     .core
                     .add_block_headers(last_round_block_headers.clone())
                     .unwrap();
-                core_fixture.core.new_block(round, ReasonToCreateBlock::MaxLeaderTimeout).unwrap();
+                core_fixture
+                    .core
+                    .new_block(round, ReasonToCreateBlock::MaxLeaderTimeout)
+                    .unwrap();
 
                 let block_header = core_fixture.core.last_proposed_block_header();
                 assert_eq!(block_header.round(), round);
@@ -2570,12 +2598,12 @@ mod test {
         }
 
         // Now send all the produced blocks to core of authority 3. It should produce a
-        // new block. If no compression would be applied the we should expect
+        // new block. If no compression is applied then we should expect
         // all the previous blocks to be referenced from round 0..=10. However, since
         // compression is applied only the last round's (10) blocks should be
         // referenced + the authority's block of round 0.
         let core_fixture = &mut cores[excluded_authority];
-        // Wait for min round delay to allow blocks to be proposed.
+        // Wait for min block delay to allow blocks to be proposed.
         sleep(default_params.min_block_delay).await;
         // add blocks to trigger proposal.
         core_fixture

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -109,7 +109,7 @@ pub(crate) struct Core {
 }
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
-pub(crate) enum Reason {
+pub(crate) enum ReasonToCreateBlock {
     MinRoundTimeout,
     AddBlock,
     AddBlockHeader,
@@ -119,28 +119,30 @@ pub(crate) enum Reason {
     KnownLastBlock,
 }
 
-impl Reason {
-    fn to_string(&self) -> &'static str {
+impl ReasonToCreateBlock {
+    fn label(&self) -> &'static str {
         match self {
-            Reason::MinRoundTimeout => "MinRoundTimeout",
-            Reason::AddBlock => "AddBlock",
-            Reason::MaxLeaderTimeout => "MaxLeaderTimeout",
-            Reason::AddBlockHeader => "AddBlockHeader",
-            Reason::Recover => "Recover",
-            Reason::QuorumSubscribersExist => "QuorumSubscribersExist",
-            Reason::KnownLastBlock => "KnownLastBlock",
+            ReasonToCreateBlock::MinRoundTimeout => "MinRoundTimeout",
+            ReasonToCreateBlock::AddBlock => "AddBlock",
+            ReasonToCreateBlock::MaxLeaderTimeout => "MaxLeaderTimeout",
+            ReasonToCreateBlock::AddBlockHeader => "AddBlockHeader",
+            ReasonToCreateBlock::Recover => "Recover",
+            ReasonToCreateBlock::QuorumSubscribersExist => "QuorumSubscribersExist",
+            ReasonToCreateBlock::KnownLastBlock => "KnownLastBlock",
         }
     }
 
+    // Some reason are forcing block creation, bypassing several checks such as
+    // existence of a leader in quorum round and min timeout
     fn is_forced(&self) -> bool {
         match self {
-            Reason::MinRoundTimeout => false,
-            Reason::AddBlock => false,
-            Reason::MaxLeaderTimeout => true,
-            Reason::AddBlockHeader => true,
-            Reason::Recover => true,
-            Reason::QuorumSubscribersExist => true,
-            Reason::KnownLastBlock => true,
+            ReasonToCreateBlock::MinRoundTimeout => false,
+            ReasonToCreateBlock::AddBlock => false,
+            ReasonToCreateBlock::MaxLeaderTimeout => true,
+            ReasonToCreateBlock::AddBlockHeader => true,
+            ReasonToCreateBlock::Recover => true,
+            ReasonToCreateBlock::QuorumSubscribersExist => true,
+            ReasonToCreateBlock::KnownLastBlock => true,
         }
     }
 }
@@ -247,7 +249,7 @@ impl Core {
         // refs can be ignored as the missing transactions will be fetched by the
         // periodic transactions' synchronizer.
         self.try_commit().unwrap();
-        let last_proposed_block = match self.try_propose(Reason::Recover).unwrap() {
+        let last_proposed_block = match self.try_propose(ReasonToCreateBlock::Recover).unwrap() {
             (Some(block), _) => Some(block),
             (None, _) => {
                 let last_proposed_block = self.dag_state.read().recover_last_own_block();
@@ -323,7 +325,7 @@ impl Core {
             let (_subdags, new_missing_committed_txns) = self.try_commit()?;
 
             // Try to propose now since there are new blocks accepted.
-            self.try_propose(Reason::AddBlock)?;
+            self.try_propose(ReasonToCreateBlock::AddBlock)?;
 
             // Now set up leader timeout if needed.
             // This needs to be called after try_commit() and try_propose(), which may
@@ -385,7 +387,7 @@ impl Core {
             let (_subdags, new_missing_committed_txns) = self.try_commit()?;
 
             // Try to propose now since there are new blocks accepted.
-            self.try_propose(Reason::AddBlockHeader)?;
+            self.try_propose(ReasonToCreateBlock::AddBlockHeader)?;
 
             // Now set up leader timeout if needed.
             // This needs to be called after try_commit() and try_propose(), which may
@@ -519,7 +521,7 @@ impl Core {
     pub(crate) fn new_block(
         &mut self,
         round: Round,
-        reason: Reason,
+        reason: ReasonToCreateBlock,
     ) -> ConsensusResult<(
         Option<VerifiedBlock>,
         BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
@@ -530,7 +532,7 @@ impl Core {
                 .metrics
                 .node_metrics
                 .leader_timeout_total
-                .with_label_values(&[&reason.to_string()])
+                .with_label_values(&[&reason.label()])
                 .inc();
             let result = self.try_propose(reason);
             // The threshold clock round may have advanced, so a signal needs to be sent.
@@ -545,7 +547,7 @@ impl Core {
     // ancestors and if the minimum round delay has passed.
     fn try_propose(
         &mut self,
-        reason: Reason,
+        reason: ReasonToCreateBlock,
     ) -> ConsensusResult<(
         Option<VerifiedBlock>,
         BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
@@ -569,7 +571,7 @@ impl Core {
     /// already proposed for latest or earlier round, then no block is
     /// created and None is returned.
     #[instrument(level = "trace", skip_all)]
-    fn try_new_block(&mut self, reason: Reason) -> Option<VerifiedBlock> {
+    fn try_new_block(&mut self, reason: ReasonToCreateBlock) -> Option<VerifiedBlock> {
         let _s = self
             .context
             .metrics
@@ -801,7 +803,7 @@ impl Core {
             .metrics
             .node_metrics
             .proposed_blocks
-            .with_label_values(&[&reason.to_string()])
+            .with_label_values(&[&reason.label()])
             .inc();
 
         Some(verified_block)

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -143,7 +143,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
     async fn new_block(
         &self,
         round: Round,
-        force: ReasonToCreateBlock,
+        reason: ReasonToCreateBlock,
     ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError>;
 
     async fn get_missing_block_headers(
@@ -501,7 +501,7 @@ pub(crate) mod tests {
         block_headers: Mutex<Vec<VerifiedBlockHeader>>,
         missing_block_headers: parking_lot::Mutex<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>,
         last_known_proposed_round: Mutex<Vec<Round>>,
-        new_block_calls: Arc<Mutex<Vec<(Round, bool, Instant)>>>,
+        new_block_calls: Arc<Mutex<Vec<(Round, ReasonToCreateBlock, Instant)>>>,
         quorum_subscribers_exists: Mutex<bool>,
     }
 
@@ -536,7 +536,7 @@ pub(crate) mod tests {
             last_known_proposed_round.clone()
         }
 
-        pub(crate) async fn get_new_block_calls(&self) -> Vec<(Round, bool, Instant)> {
+        pub(crate) async fn get_new_block_calls(&self) -> Vec<(Round, ReasonToCreateBlock, Instant)> {
             let mut binding = self.new_block_calls.lock();
             let all_calls = binding.drain(0..);
             all_calls.into_iter().collect()
@@ -616,11 +616,11 @@ pub(crate) mod tests {
         async fn new_block(
             &self,
             round: Round,
-            force: bool,
+            reason: ReasonToCreateBlock,
         ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
             self.new_block_calls
                 .lock()
-                .push((round, force, Instant::now()));
+                .push((round, reason, Instant::now()));
             Ok(BTreeMap::new())
         }
 

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -32,6 +32,7 @@ use crate::{
     dag_state::{DagState, TransactionSource},
     error::{ConsensusError, ConsensusResult},
 };
+use crate::core::Reason;
 
 const CORE_THREAD_COMMANDS_CHANNEL_SIZE: usize = 2000;
 
@@ -68,7 +69,7 @@ enum CoreThreadCommand {
     NewBlock(
         Round,
         oneshot::Sender<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>,
-        bool,
+        Reason,
     ),
     /// Request missing blocks that need to be synced together with authorities
     /// that have these blocks.
@@ -143,7 +144,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
     async fn new_block(
         &self,
         round: Round,
-        force: bool,
+        force: Reason,
     ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError>;
 
     async fn get_missing_block_headers(
@@ -211,9 +212,9 @@ impl CoreThread {
                             let (missing_block_refs, missing_committed_txns) = self.core.add_certified_commits(commits)?;
                             sender.send((missing_block_refs, missing_committed_txns)).ok();
                         }
-                        CoreThreadCommand::NewBlock(round, sender, force) => {
+                        CoreThreadCommand::NewBlock(round, sender, reason) => {
                             let _scope = monitored_scope("CoreThread::loop::new_block");
-                            let (_new_block_opt, missing_committed_txns) = self.core.new_block(round, force)?;
+                            let (_new_block_opt, missing_committed_txns) = self.core.new_block(round, reason)?;
                             sender.send(missing_committed_txns).ok();
                         }
                         CoreThreadCommand::GetMissingBlocks(sender) => {
@@ -240,7 +241,7 @@ impl CoreThread {
                     let _scope = monitored_scope("CoreThread::loop::set_last_known_proposed_round");
                     let round = *self.rx_last_known_proposed_round.borrow();
                     self.core.set_last_known_proposed_round(round);
-                    self.core.new_block(round + 1, true)?;
+                    self.core.new_block(round + 1, Reason::MaxTimeout)?;
                 }
                 _ = self.rx_quorum_subscribers_exists.changed() => {
                     let _scope = monitored_scope("CoreThread::loop::set_quorum_subscribers_exists");
@@ -250,7 +251,7 @@ impl CoreThread {
                     if !should_propose_before && self.core.should_propose() {
                         // If core cannot propose before but can propose now, try to produce a new block to ensure liveness,
                         // because block proposal could have been skipped.
-                        self.core.new_block(Round::MAX, true)?;
+                        self.core.new_block(Round::MAX, Reason::MaxTimeout)?;
                     }
                 }
             }
@@ -439,10 +440,10 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
     async fn new_block(
         &self,
         round: Round,
-        force: bool,
+        reason: Reason,
     ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
         let (sender, receiver) = oneshot::channel();
-        self.send(CoreThreadCommand::NewBlock(round, sender, force))
+        self.send(CoreThreadCommand::NewBlock(round, sender, reason))
             .await;
         receiver.await.map_err(|e| Shutdown(e.to_string()))
     }

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -27,7 +27,7 @@ use crate::{
     block_header::{BlockRef, Round, VerifiedBlock, VerifiedOwnShard, VerifiedTransactions},
     commit::CertifiedCommits,
     context::Context,
-    core::{Core, Reason},
+    core::{Core, ReasonToCreateBlock},
     core_thread::CoreError::Shutdown,
     dag_state::{DagState, TransactionSource},
     error::{ConsensusError, ConsensusResult},
@@ -68,7 +68,7 @@ enum CoreThreadCommand {
     NewBlock(
         Round,
         oneshot::Sender<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>,
-        Reason,
+        ReasonToCreateBlock,
     ),
     /// Request missing blocks that need to be synced together with authorities
     /// that have these blocks.
@@ -143,7 +143,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
     async fn new_block(
         &self,
         round: Round,
-        force: Reason,
+        force: ReasonToCreateBlock,
     ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError>;
 
     async fn get_missing_block_headers(
@@ -240,7 +240,7 @@ impl CoreThread {
                     let _scope = monitored_scope("CoreThread::loop::set_last_known_proposed_round");
                     let round = *self.rx_last_known_proposed_round.borrow();
                     self.core.set_last_known_proposed_round(round);
-                    self.core.new_block(round + 1, Reason::KnownLastBlock)?;
+                    self.core.new_block(round + 1, ReasonToCreateBlock::KnownLastBlock)?;
                 }
                 _ = self.rx_quorum_subscribers_exists.changed() => {
                     let _scope = monitored_scope("CoreThread::loop::set_quorum_subscribers_exists");
@@ -250,7 +250,7 @@ impl CoreThread {
                     if !should_propose_before && self.core.should_propose() {
                         // If core cannot propose before but can propose now, try to produce a new block to ensure liveness,
                         // because block proposal could have been skipped.
-                        self.core.new_block(Round::MAX, Reason::QuorumSubscribersExist)?;
+                        self.core.new_block(Round::MAX, ReasonToCreateBlock::QuorumSubscribersExist)?;
                     }
                 }
             }
@@ -439,7 +439,7 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
     async fn new_block(
         &self,
         round: Round,
-        reason: Reason,
+        reason: ReasonToCreateBlock,
     ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
         let (sender, receiver) = oneshot::channel();
         self.send(CoreThreadCommand::NewBlock(round, sender, reason))

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -27,12 +27,11 @@ use crate::{
     block_header::{BlockRef, Round, VerifiedBlock, VerifiedOwnShard, VerifiedTransactions},
     commit::CertifiedCommits,
     context::Context,
-    core::Core,
+    core::{Core, Reason},
     core_thread::CoreError::Shutdown,
     dag_state::{DagState, TransactionSource},
     error::{ConsensusError, ConsensusResult},
 };
-use crate::core::Reason;
 
 const CORE_THREAD_COMMANDS_CHANNEL_SIZE: usize = 2000;
 
@@ -241,7 +240,7 @@ impl CoreThread {
                     let _scope = monitored_scope("CoreThread::loop::set_last_known_proposed_round");
                     let round = *self.rx_last_known_proposed_round.borrow();
                     self.core.set_last_known_proposed_round(round);
-                    self.core.new_block(round + 1, Reason::MaxTimeout)?;
+                    self.core.new_block(round + 1, Reason::KnownLastBlock)?;
                 }
                 _ = self.rx_quorum_subscribers_exists.changed() => {
                     let _scope = monitored_scope("CoreThread::loop::set_quorum_subscribers_exists");
@@ -251,7 +250,7 @@ impl CoreThread {
                     if !should_propose_before && self.core.should_propose() {
                         // If core cannot propose before but can propose now, try to produce a new block to ensure liveness,
                         // because block proposal could have been skipped.
-                        self.core.new_block(Round::MAX, Reason::MaxTimeout)?;
+                        self.core.new_block(Round::MAX, Reason::QuorumSubscribersExist)?;
                     }
                 }
             }

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -536,7 +536,9 @@ pub(crate) mod tests {
             last_known_proposed_round.clone()
         }
 
-        pub(crate) async fn get_new_block_calls(&self) -> Vec<(Round, ReasonToCreateBlock, Instant)> {
+        pub(crate) async fn get_new_block_calls(
+            &self,
+        ) -> Vec<(Round, ReasonToCreateBlock, Instant)> {
             let mut binding = self.new_block_calls.lock();
             let all_calls = binding.drain(0..);
             all_calls.into_iter().collect()

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -327,9 +327,9 @@ mod tests {
         let all_calls = dispatcher.get_new_block_calls().await;
         assert_eq!(all_calls.len(), 1);
 
-        let (round, force, timestamp) = all_calls[0];
+        let (round, reason, timestamp) = all_calls[0];
         assert_eq!(round, 10);
-        assert!(force);
+        assert_eq!(reason, ReasonToCreateBlock::MaxLeaderTimeout);
         assert!(
             leader_timeout <= timestamp - start,
             "Leader timeout setting {:?} should be less than actual time difference {:?}",

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -42,7 +42,7 @@ pub(crate) struct LeaderTimeoutTask<D: CoreThreadDispatcher> {
     new_round_receiver: watch::Receiver<Round>,
     new_block_receiver: broadcast::Receiver<VerifiedBlock>,
     leader_timeout: Duration,
-    min_round_delay: Duration,
+    min_block_delay: Duration,
     stop: Receiver<()>,
 }
 
@@ -63,7 +63,7 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
             new_block_receiver: signals_receivers.block_broadcast_receiver(),
             new_round_receiver: signals_receivers.new_round_receiver(),
             leader_timeout: context.parameters.leader_timeout,
-            min_round_delay: context.parameters.min_round_delay,
+            min_block_delay: context.parameters.min_block_delay,
         };
         let handle = tokio::spawn(async move { me.run().await });
 
@@ -79,18 +79,19 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
     /// block within the specified timeout, the task forces the creation of a
     /// new block, maintaining the continuity and robustness of the leader
     /// election process.
+    /// In addition, if min b
     async fn run(&mut self) {
         let new_round = &mut self.new_round_receiver;
         let new_block = &mut self.new_block_receiver.resubscribe();
         let mut quorum_round: Round = *new_round.borrow_and_update();
-        let mut last_own_round: Option<Round> = None;
-        let mut min_round_delay_timed_out = false;
+        let mut last_own_block_round: Option<Round> = None;
+        let mut min_block_delay_timed_out = false;
         let mut max_leader_round_timed_out = false;
         let timer_start = Instant::now();
-        let min_round_delay_timeout = sleep_until(timer_start + self.min_round_delay);
+        let min_block_delay_timeout = sleep_until(timer_start + self.min_block_delay);
         let max_leader_timeout = sleep_until(timer_start + self.leader_timeout);
 
-        tokio::pin!(min_round_delay_timeout);
+        tokio::pin!(min_block_delay_timeout);
         tokio::pin!(max_leader_timeout);
 
         loop {
@@ -99,9 +100,9 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                 // If we already timed out before then, the branch gets disabled so we don't attempt
                 // all the time to produce already produced blocks for that round.
 
-                () = &mut min_round_delay_timeout, if !min_round_delay_timed_out && last_own_round.is_some() => {
-                    let round_to_create_block: Round = last_own_round.expect("We should expect some last own round") + 1;
-                    match self.dispatcher.new_block(round_to_create_block, ReasonToCreateBlock::MinRoundTimeout).await {
+                () = &mut min_block_delay_timeout, if !min_block_delay_timed_out && last_own_block_round.is_some() => {
+                    let round_to_create_block: Round = last_own_block_round.expect("We should expect some last own round") + 1;
+                    match self.dispatcher.new_block(round_to_create_block, ReasonToCreateBlock::MinBlockDelayTimeout).await {
                         Ok(missing_committed_txns) => {
                             if !missing_committed_txns.is_empty() {
                                 debug!(
@@ -123,7 +124,7 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                             return;
                         }
                     }
-                    min_round_delay_timed_out = true;
+                    min_block_delay_timed_out = true;
                 },
                 // When the max leader timer expires then we attempt to trigger the creation of a new block. This
                 // call is made with `force = true` to bypass any checks that allow to propose immediately if block
@@ -171,14 +172,14 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                     .as_mut()
                     .reset(now + self.leader_timeout);
                 },
-                 // A new block was created ---
+                 // A new block was created. Set a timer in min_block_delay
                 Ok(block) = new_block.recv() => {
-                    last_own_round = Some(block.round());
+                    last_own_block_round = Some(block.round());
 
-                    min_round_delay_timed_out = false;
+                    min_block_delay_timed_out = false;
 
                     let now = Instant::now();
-                    min_round_delay_timeout.as_mut().reset(now + self.min_round_delay);
+                    min_block_delay_timeout.as_mut().reset(now + self.min_block_delay);
                 },
                 _ = &mut self.stop => {
                     debug!("Stop signal has been received, now shutting down");
@@ -212,6 +213,7 @@ mod tests {
         storage::mem_store::MemStore,
         transactions_synchronizer::TransactionsSynchronizer,
     };
+    use crate::core::ReasonToCreateBlock;
 
     #[derive(Default)]
     struct FakeNetworkClient {}
@@ -274,7 +276,7 @@ mod tests {
         let min_round_delay = Duration::from_millis(50);
         let parameters = Parameters {
             leader_timeout,
-            min_round_delay,
+            min_block_delay: min_round_delay,
             ..Default::default()
         };
         let context = Arc::new(context.with_parameters(parameters));
@@ -310,9 +312,9 @@ mod tests {
         let all_calls = dispatcher.get_new_block_calls().await;
         assert_eq!(all_calls.len(), 1);
 
-        let (round, force, timestamp) = all_calls[0];
+        let (round, reason, timestamp) = all_calls[0];
         assert_eq!(round, 10);
-        assert!(!force);
+        assert_eq!(reason, ReasonToCreateBlock::MinBlockDelayTimeout);
         assert!(
             min_round_delay <= timestamp - start,
             "Leader timeout min setting {:?} should be less than actual time difference {:?}",
@@ -347,14 +349,14 @@ mod tests {
         let (context, _signers) = Context::new_for_test(4);
         let dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let leader_timeout = Duration::from_millis(500);
-        let min_round_delay = Duration::from_millis(50);
+        let min_block_delay = Duration::from_millis(50);
         let parameters = Parameters {
             leader_timeout,
-            min_round_delay,
+            min_block_delay,
             ..Default::default()
         };
         let context = Arc::new(context.with_parameters(parameters));
-        let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
+        let block_verifier = Arc::new(NoopBlockVerifier {});
 
         let transactions_synchronizer = TransactionsSynchronizer::start(
             Arc::new(FakeNetworkClient::default()),
@@ -380,24 +382,24 @@ mod tests {
         );
 
         // now send some signals with some small delay between them, but not enough so
-        // every round manages to timeout and call the force new block method.
+        // every round manages to timeout and call the new block method.
         signals.new_round(13);
-        sleep(min_round_delay / 2).await;
+        sleep(min_block_delay / 2).await;
         signals.new_round(14);
-        sleep(min_round_delay / 2).await;
+        sleep(min_block_delay / 2).await;
         signals.new_round(15);
         sleep(2 * leader_timeout).await;
 
         // only the last one should be received
         let all_calls = dispatcher.get_new_block_calls().await;
-        let (round, force, timestamp) = all_calls[0];
+        let (round, reason, timestamp) = all_calls[0];
         assert_eq!(round, 15);
-        assert!(!force);
-        assert!(min_round_delay < timestamp - now);
+        assert_eq!(reason, ReasonToCreateBlock::MinBlockDelayTimeout);
+        assert!(min_block_delay < timestamp - now);
 
-        let (round, force, timestamp) = all_calls[1];
+        let (round, reason, timestamp) = all_calls[1];
         assert_eq!(round, 15);
-        assert!(force);
+        assert_eq!(reason, ReasonToCreateBlock::MaxLeaderTimeout);
         assert!(leader_timeout < timestamp - now);
     }
 }

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{sync::Arc, time::Duration};
-
+use crate::core::Reason;
 use tokio::{
     sync::{
         oneshot::{Receiver, Sender},
@@ -91,7 +91,7 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                 // all the time to produce already produced blocks for that round.
 
                 () = &mut min_leader_timeout, if !min_leader_round_timed_out => {
-                    match self.dispatcher.new_block(leader_round, false).await {
+                    match self.dispatcher.new_block(leader_round, Reason::MinTimeout).await {
                         Ok(missing_committed_txns) => {
                             if !missing_committed_txns.is_empty() {
                                 debug!(
@@ -122,7 +122,7 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                 // if the round has not advanced in the meantime. Otherwise, the max timeout will not get
                 // triggered at all.
                 () = &mut max_leader_timeout, if !max_leader_round_timed_out => {
-                    match self.dispatcher.new_block(leader_round, true).await {
+                    match self.dispatcher.new_block(leader_round, Reason::MaxTimeout).await {
                         Ok(missing_committed_txns) => {
                             if !missing_committed_txns.is_empty() {
                                 debug!(

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -81,9 +81,10 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
     /// election process.
     /// In addition, if min b
     async fn run(&mut self) {
-        let new_round = &mut self.new_round_receiver;
+        debug!("LeaderTimeoutTask is running");
+        let new_clock_round = &mut self.new_round_receiver;
         let new_block = &mut self.new_block_receiver.resubscribe();
-        let mut quorum_round: Round = *new_round.borrow_and_update();
+        let mut clock_round: Round = *new_clock_round.borrow_and_update();
         let mut last_own_block_round: Option<Round> = None;
         let mut min_block_delay_timed_out = false;
         let mut max_leader_round_timed_out = false;
@@ -95,14 +96,15 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
         tokio::pin!(max_leader_timeout);
 
         loop {
+            debug!("Loop is running");
             tokio::select! {
-                // When the min round delay timer expires, then we attempt to trigger the creation of a new block.
+                // When the min block delay timer expires, then we attempt to trigger the creation of a new block.
                 // If we already timed out before then, the branch gets disabled so we don't attempt
                 // all the time to produce already produced blocks for that round.
 
                 () = &mut min_block_delay_timeout, if !min_block_delay_timed_out && last_own_block_round.is_some() => {
-                    let round_to_create_block: Round = last_own_block_round.expect("We should expect some last own round") + 1;
-                    match self.dispatcher.new_block(round_to_create_block, ReasonToCreateBlock::MinBlockDelayTimeout).await {
+                    let next_round: Round = last_own_block_round.expect("We should expect some last own round") + 1;
+                    match self.dispatcher.new_block(next_round, ReasonToCreateBlock::MinBlockDelayTimeout).await {
                         Ok(missing_committed_txns) => {
                             if !missing_committed_txns.is_empty() {
                                 debug!(
@@ -127,13 +129,10 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                     min_block_delay_timed_out = true;
                 },
                 // When the max leader timer expires then we attempt to trigger the creation of a new block. This
-                // call is made with `force = true` to bypass any checks that allow to propose immediately if block
+                // call is made with reason MaxLeaderTimeout to bypass any checks that allow to propose immediately if block
                 // not already produced.
-                // Keep in mind that first the min timeout should get triggered and then the max timeout, only
-                // if the round has not advanced in the meantime. Otherwise, the max timeout will not get
-                // triggered at all.
                 () = &mut max_leader_timeout, if !max_leader_round_timed_out => {
-                    match self.dispatcher.new_block(quorum_round, ReasonToCreateBlock::MaxLeaderTimeout).await {
+                    match self.dispatcher.new_block(clock_round, ReasonToCreateBlock::MaxLeaderTimeout).await {
                         Ok(missing_committed_txns) => {
                             if !missing_committed_txns.is_empty() {
                                 debug!(
@@ -158,11 +157,11 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                     max_leader_round_timed_out = true;
                 }
 
-                // A threshold round has been advanced. Reset the leader timeout.
-                Ok(_) = new_round.changed() => {
-                    quorum_round = *new_round.borrow_and_update();
-                    debug!("New quorum round has been received {quorum_round}, resetting timer");
-                    let _span = tracing::trace_span!("new_consensus_round_received", round = ?quorum_round).entered();
+                // A clock round has been advanced. Reset the leader timeout.
+                Ok(_) = new_clock_round.changed() => {
+                    clock_round = *new_clock_round.borrow_and_update();
+                    debug!("New clock round has been received {clock_round}, resetting timer");
+                    let _span = tracing::trace_span!("new_consensus_round_received", round = ?clock_round).entered();
 
                     max_leader_round_timed_out = false;
 
@@ -174,6 +173,7 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                 },
                  // A new block was created. Set a timer in min_block_delay
                 Ok(block) = new_block.recv() => {
+                    debug!("New block {block:?} was created and seen in leader timeout task");
                     last_own_block_round = Some(block.round());
 
                     min_block_delay_timed_out = false;
@@ -200,20 +200,21 @@ mod tests {
     use tokio::time::{Instant, sleep};
 
     use crate::{
-        BlockRef, Round,
+        BlockRef, Round, TestBlockHeader,
+        block_header::VerifiedBlock,
         block_verifier::NoopBlockVerifier,
         commit::CommitRange,
         context::Context,
-        core::CoreSignals,
+        core::{CoreSignals, ReasonToCreateBlock},
         core_thread::tests::MockCoreThreadDispatcher,
         dag_state::DagState,
+        encoder::create_encoder,
         error::ConsensusResult,
         leader_timeout::LeaderTimeoutTask,
         network::{BlockBundleStream, NetworkClient},
         storage::mem_store::MemStore,
         transactions_synchronizer::TransactionsSynchronizer,
     };
-    use crate::core::ReasonToCreateBlock;
 
     #[derive(Default)]
     struct FakeNetworkClient {}
@@ -270,13 +271,14 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn basic_leader_timeout() {
+        telemetry_subscribers::init_for_testing();
         let (context, _signers) = Context::new_for_test(4);
         let dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let leader_timeout = Duration::from_millis(500);
-        let min_round_delay = Duration::from_millis(50);
+        let min_block_delay = Duration::from_millis(50);
         let parameters = Parameters {
             leader_timeout,
-            min_block_delay: min_round_delay,
+            min_block_delay,
             ..Default::default()
         };
         let context = Arc::new(context.with_parameters(parameters));
@@ -300,15 +302,36 @@ mod tests {
             dispatcher.clone(),
             transactions_synchronizer,
             &signal_receivers,
-            context,
+            context.clone(),
         );
 
-        // send a signal that a new round has been produced.
+        // send a signal that own block was created at round 8 to initialize the
+        // broadcaster
+        let mut encoder = create_encoder(&context);
+        let input_block = VerifiedBlock::new_for_test(
+            TestBlockHeader::new_with_commitment(8, 0, &context, &mut encoder).build(),
+        );
+        // send a signal that a new round has been advanced to initialize the watcher.
+        signals.new_round(9);
+
+        signals
+            .new_block(input_block)
+            .expect("We should expect correct sending a new block");
+        sleep(min_block_delay / 2).await;
+        // send a signal that own block was created at round 9, which will start min
+        // block delay timeout
+        let input_block = VerifiedBlock::new_for_test(
+            TestBlockHeader::new_with_commitment(9, 0, &context, &mut encoder).build(),
+        );
+        signals
+            .new_block(input_block)
+            .expect("We should expect correct sending a new block");
+        // send a signal that a new round has been advanced.
         signals.new_round(10);
 
-        // wait enough until the min round delay has passed and a new_block call is
+        // wait enough until the min block delay has passed and a new_block call is
         // triggered
-        sleep(2 * min_round_delay).await;
+        sleep(2 * min_block_delay).await;
         let all_calls = dispatcher.get_new_block_calls().await;
         assert_eq!(all_calls.len(), 1);
 
@@ -316,9 +339,9 @@ mod tests {
         assert_eq!(round, 10);
         assert_eq!(reason, ReasonToCreateBlock::MinBlockDelayTimeout);
         assert!(
-            min_round_delay <= timestamp - start,
+            min_block_delay <= timestamp - start,
             "Leader timeout min setting {:?} should be less than actual time difference {:?}",
-            min_round_delay,
+            min_block_delay,
             timestamp - start
         );
 
@@ -346,6 +369,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn multiple_leader_timeouts() {
+        telemetry_subscribers::init_for_testing();
         let (context, _signers) = Context::new_for_test(4);
         let dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let leader_timeout = Duration::from_millis(500);
@@ -378,16 +402,39 @@ mod tests {
             dispatcher.clone(),
             transactions_synchronizer,
             &signal_receivers,
-            context,
+            context.clone(),
         );
 
         // now send some signals with some small delay between them, but not enough so
-        // every round manages to timeout and call the new block method.
+        // it does not trigger a call of the new block method.
         signals.new_round(13);
+        // send a signal that own block was created at round 12
+        let mut encoder = create_encoder(&context);
+
+        let input_block = VerifiedBlock::new_for_test(
+            TestBlockHeader::new_with_commitment(12, 0, &context, &mut encoder).build(),
+        );
+        signals
+            .new_block(input_block)
+            .expect("We should expect correct sending a new block");
         sleep(min_block_delay / 2).await;
         signals.new_round(14);
+        let input_block = VerifiedBlock::new_for_test(
+            TestBlockHeader::new_with_commitment(13, 0, &context, &mut encoder).build(),
+        );
+        signals
+            .new_block(input_block)
+            .expect("We should expect correct sending a new block");
         sleep(min_block_delay / 2).await;
+
+        // Finally signal again and give enough time to trigger block creation
         signals.new_round(15);
+        let input_block = VerifiedBlock::new_for_test(
+            TestBlockHeader::new_with_commitment(14, 0, &context, &mut encoder).build(),
+        );
+        signals
+            .new_block(input_block)
+            .expect("We should expect correct sending a new block");
         sleep(2 * leader_timeout).await;
 
         // only the last one should be received

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -79,7 +79,8 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
     /// block within the specified timeout, the task forces the creation of a
     /// new block, maintaining the continuity and robustness of the leader
     /// election process.
-    /// In addition, if min b
+    /// In addition, if min block delay timeout is expired it attempts to
+    /// non-forcefully create a new block.
     async fn run(&mut self) {
         debug!("LeaderTimeoutTask is running");
         let new_clock_round = &mut self.new_round_receiver;

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{sync::Arc, time::Duration};
-use crate::core::Reason;
+
 use tokio::{
     sync::{
+        broadcast,
         oneshot::{Receiver, Sender},
         watch,
     },
@@ -15,8 +16,12 @@ use tokio::{
 use tracing::{debug, warn};
 
 use crate::{
-    block_header::Round, context::Context, core::CoreSignalsReceivers,
-    core_thread::CoreThreadDispatcher, transactions_synchronizer::TransactionsSynchronizerHandle,
+    BlockHeaderAPI,
+    block_header::{Round, VerifiedBlock},
+    context::Context,
+    core::{CoreSignalsReceivers, Reason},
+    core_thread::CoreThreadDispatcher,
+    transactions_synchronizer::TransactionsSynchronizerHandle,
 };
 
 pub(crate) struct LeaderTimeoutTaskHandle {
@@ -35,6 +40,7 @@ pub(crate) struct LeaderTimeoutTask<D: CoreThreadDispatcher> {
     dispatcher: Arc<D>,
     transactions_synchronizer: Arc<TransactionsSynchronizerHandle>,
     new_round_receiver: watch::Receiver<Round>,
+    new_block_receiver: broadcast::Receiver<VerifiedBlock>,
     leader_timeout: Duration,
     min_round_delay: Duration,
     stop: Receiver<()>,
@@ -54,6 +60,7 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
             dispatcher,
             transactions_synchronizer,
             stop,
+            new_block_receiver: signals_receivers.block_broadcast_receiver(),
             new_round_receiver: signals_receivers.new_round_receiver(),
             leader_timeout: context.parameters.leader_timeout,
             min_round_delay: context.parameters.min_round_delay,
@@ -74,24 +81,27 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
     /// election process.
     async fn run(&mut self) {
         let new_round = &mut self.new_round_receiver;
-        let mut leader_round: Round = *new_round.borrow_and_update();
-        let mut min_leader_round_timed_out = false;
+        let new_block = &mut self.new_block_receiver.resubscribe();
+        let mut quorum_round: Round = *new_round.borrow_and_update();
+        let mut last_own_round: Option<Round> = None;
+        let mut min_round_delay_timed_out = false;
         let mut max_leader_round_timed_out = false;
         let timer_start = Instant::now();
-        let min_leader_timeout = sleep_until(timer_start + self.min_round_delay);
+        let min_round_delay_timeout = sleep_until(timer_start + self.min_round_delay);
         let max_leader_timeout = sleep_until(timer_start + self.leader_timeout);
 
-        tokio::pin!(min_leader_timeout);
+        tokio::pin!(min_round_delay_timeout);
         tokio::pin!(max_leader_timeout);
 
         loop {
             tokio::select! {
-                // When the min leader timer expires, then we attempt to trigger the creation of a new block.
+                // When the min round delay timer expires, then we attempt to trigger the creation of a new block.
                 // If we already timed out before then, the branch gets disabled so we don't attempt
                 // all the time to produce already produced blocks for that round.
 
-                () = &mut min_leader_timeout, if !min_leader_round_timed_out => {
-                    match self.dispatcher.new_block(leader_round, Reason::MinTimeout).await {
+                () = &mut min_round_delay_timeout, if !min_round_delay_timed_out && last_own_round.is_some() => {
+                    let round_to_create_block: Round = last_own_round.expect("We should expect some last own round") + 1;
+                    match self.dispatcher.new_block(round_to_create_block, Reason::MinRoundTimeout).await {
                         Ok(missing_committed_txns) => {
                             if !missing_committed_txns.is_empty() {
                                 debug!(
@@ -113,7 +123,7 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                             return;
                         }
                     }
-                    min_leader_round_timed_out = true;
+                    min_round_delay_timed_out = true;
                 },
                 // When the max leader timer expires then we attempt to trigger the creation of a new block. This
                 // call is made with `force = true` to bypass any checks that allow to propose immediately if block
@@ -122,7 +132,7 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                 // if the round has not advanced in the meantime. Otherwise, the max timeout will not get
                 // triggered at all.
                 () = &mut max_leader_timeout, if !max_leader_round_timed_out => {
-                    match self.dispatcher.new_block(leader_round, Reason::MaxTimeout).await {
+                    match self.dispatcher.new_block(quorum_round, Reason::MaxLeaderTimeout).await {
                         Ok(missing_committed_txns) => {
                             if !missing_committed_txns.is_empty() {
                                 debug!(
@@ -147,22 +157,28 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                     max_leader_round_timed_out = true;
                 }
 
-                // A new round has been produced. Reset the leader timeout.
+                // A threshold round has been advanced. Reset the leader timeout.
                 Ok(_) = new_round.changed() => {
-                    leader_round = *new_round.borrow_and_update();
-                    debug!("New round has been received {leader_round}, resetting timer");
-                    let _span = tracing::trace_span!("new_consensus_round_received", round = ?leader_round).entered();
+                    quorum_round = *new_round.borrow_and_update();
+                    debug!("New quorum round has been received {quorum_round}, resetting timer");
+                    let _span = tracing::trace_span!("new_consensus_round_received", round = ?quorum_round).entered();
 
-                    min_leader_round_timed_out = false;
                     max_leader_round_timed_out = false;
 
                     let now = Instant::now();
-                    min_leader_timeout
-                    .as_mut()
-                    .reset(now + self.min_round_delay);
+
                     max_leader_timeout
                     .as_mut()
                     .reset(now + self.leader_timeout);
+                },
+                 // A new block was created ---
+                Ok(block) = new_block.recv() => {
+                    last_own_round = Some(block.round());
+
+                    min_round_delay_timed_out = false;
+
+                    let now = Instant::now();
+                    min_round_delay_timeout.as_mut().reset(now + self.min_round_delay);
                 },
                 _ = &mut self.stop => {
                     debug!("Stop signal has been received, now shutting down");

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -19,7 +19,7 @@ use crate::{
     BlockHeaderAPI,
     block_header::{Round, VerifiedBlock},
     context::Context,
-    core::{CoreSignalsReceivers, Reason},
+    core::{CoreSignalsReceivers, ReasonToCreateBlock},
     core_thread::CoreThreadDispatcher,
     transactions_synchronizer::TransactionsSynchronizerHandle,
 };
@@ -101,7 +101,7 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
 
                 () = &mut min_round_delay_timeout, if !min_round_delay_timed_out && last_own_round.is_some() => {
                     let round_to_create_block: Round = last_own_round.expect("We should expect some last own round") + 1;
-                    match self.dispatcher.new_block(round_to_create_block, Reason::MinRoundTimeout).await {
+                    match self.dispatcher.new_block(round_to_create_block, ReasonToCreateBlock::MinRoundTimeout).await {
                         Ok(missing_committed_txns) => {
                             if !missing_committed_txns.is_empty() {
                                 debug!(
@@ -132,7 +132,7 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                 // if the round has not advanced in the meantime. Otherwise, the max timeout will not get
                 // triggered at all.
                 () = &mut max_leader_timeout, if !max_leader_round_timed_out => {
-                    match self.dispatcher.new_block(quorum_round, Reason::MaxLeaderTimeout).await {
+                    match self.dispatcher.new_block(quorum_round, ReasonToCreateBlock::MaxLeaderTimeout).await {
                         Ok(missing_committed_txns) => {
                             if !missing_committed_txns.is_empty() {
                                 debug!(

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -174,7 +174,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) sync_last_known_own_block_retries: IntCounter,
     pub(crate) commit_round_advancement_interval: Histogram,
     pub(crate) last_decided_leader_round: IntGauge,
-    pub(crate) leader_timeout_total: IntCounterVec,
+    pub(crate) timeout_expired_total: IntCounterVec,
     pub(crate) missing_blocks_total: IntCounter,
     pub(crate) missing_blocks_after_fetch_total: IntCounter,
     pub(crate) num_of_bad_nodes: IntGauge,
@@ -247,8 +247,8 @@ impl NodeMetrics {
             ).unwrap(),
             proposed_blocks: register_int_counter_vec_with_registry!(
                 "proposed_blocks",
-                "Total number of proposed blocks. If force is true then this block has been created forcefully via a leader timeout event.",
-                &["force"],
+                "Total number of proposed blocks. The reason gives a hint what triggered block creation",
+                &["reason"],
                 registry,
             ).unwrap(),
             proposed_block_size: register_histogram_with_registry!(
@@ -669,9 +669,9 @@ impl NodeMetrics {
                 "The last round where a commit decision was made.",
                 registry,
             ).unwrap(),
-            leader_timeout_total: register_int_counter_vec_with_registry!(
+            timeout_expired_total: register_int_counter_vec_with_registry!(
                 "leader_timeout_total",
-                "Total number of leader timeouts, either when the min round time has passed, or max leader timeout",
+                "Total number of timeouts, either when the min block delay time has passed, or max leader timeout",
                 &["timeout_type"],
                 registry,
             ).unwrap(),

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -175,7 +175,6 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_round_advancement_interval: Histogram,
     pub(crate) last_decided_leader_round: IntGauge,
     pub(crate) leader_timeout_total: IntCounterVec,
-    pub(crate) selection_wait: IntCounter,
     pub(crate) missing_blocks_total: IntCounter,
     pub(crate) missing_blocks_after_fetch_total: IntCounter,
     pub(crate) num_of_bad_nodes: IntGauge,
@@ -674,11 +673,6 @@ impl NodeMetrics {
                 "leader_timeout_total",
                 "Total number of leader timeouts, either when the min round time has passed, or max leader timeout",
                 &["timeout_type"],
-                registry,
-            ).unwrap(),
-            selection_wait: register_int_counter_with_registry!(
-                "selection_wait",
-                "Number of times we waited for ancestor selection.",
                 registry,
             ).unwrap(),
             missing_blocks_total: register_int_counter_with_registry!(

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -129,7 +129,7 @@ impl NetworkClient for TonicClient {
                 }
             });
         let rate_limited_stream =
-            tokio_stream::StreamExt::throttle(stream, self.context.parameters.min_round_delay / 2)
+            tokio_stream::StreamExt::throttle(stream, self.context.parameters.min_block_delay / 2)
                 .boxed();
         Ok(rate_limited_stream)
     }
@@ -532,7 +532,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
                 })
             });
         let rate_limited_stream =
-            tokio_stream::StreamExt::throttle(stream, self.context.parameters.min_round_delay / 2)
+            tokio_stream::StreamExt::throttle(stream, self.context.parameters.min_block_delay / 2)
                 .boxed();
         Ok(Response::new(rate_limited_stream))
     }

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -653,6 +653,7 @@ mod tests {
         },
         commit::CertifiedCommits,
         context::Context,
+        core::ReasonToCreateBlock,
         core_thread::{CoreError, CoreThreadDispatcher},
         dag_state::{DagState, TransactionSource},
         encoder::create_encoder,
@@ -661,7 +662,6 @@ mod tests {
         },
         storage::mem_store::MemStore,
     };
-    use crate::core::ReasonToCreateBlock;
 
     #[derive(Default)]
     struct MockCoreThreadDispatcher {

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -661,6 +661,7 @@ mod tests {
         },
         storage::mem_store::MemStore,
     };
+    use crate::core::ReasonToCreateBlock;
 
     #[derive(Default)]
     struct MockCoreThreadDispatcher {
@@ -741,7 +742,7 @@ mod tests {
         async fn new_block(
             &self,
             _round: Round,
-            _force: bool,
+            _reason: ReasonToCreateBlock,
         ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -1418,6 +1418,7 @@ mod tests {
         commit::{CertifiedCommits, CommitRange, CommitVote, TrustedCommit},
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
+        core::ReasonToCreateBlock,
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
         dag_state::{DagState, TransactionSource},
         error::{ConsensusError, ConsensusResult},
@@ -1429,7 +1430,6 @@ mod tests {
         },
         transactions_synchronizer::TransactionsSynchronizer,
     };
-    use crate::core::ReasonToCreateBlock;
 
     type FetchRequestKey = (Vec<BlockRef>, AuthorityIndex);
     type FetchRequestHeadersResponse = (Vec<VerifiedBlockHeader>, Option<Duration>);

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -1429,6 +1429,7 @@ mod tests {
         },
         transactions_synchronizer::TransactionsSynchronizer,
     };
+    use crate::core::ReasonToCreateBlock;
 
     type FetchRequestKey = (Vec<BlockRef>, AuthorityIndex);
     type FetchRequestHeadersResponse = (Vec<VerifiedBlockHeader>, Option<Duration>);
@@ -2411,7 +2412,7 @@ mod tests {
         async fn new_block(
             &self,
             _round: Round,
-            _force: bool,
+            _reason: ReasonToCreateBlock,
         ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
             Ok(BTreeMap::new())
         }

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1073,12 +1073,12 @@ mod tests {
         block_verifier::NoopBlockVerifier,
         commit::{CertifiedCommits, CommitRange},
         context::Context,
+        core::ReasonToCreateBlock,
         core_thread::CoreError,
         dag_state::DagState,
         network::{BlockBundleStream, NetworkClient, SerializedTransactions},
         storage::mem_store::MemStore,
     };
-    use crate::core::ReasonToCreateBlock;
 
     #[tokio::test]
     async fn successful_live_syncing() {

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1078,6 +1078,7 @@ mod tests {
         network::{BlockBundleStream, NetworkClient, SerializedTransactions},
         storage::mem_store::MemStore,
     };
+    use crate::core::ReasonToCreateBlock;
 
     #[tokio::test]
     async fn successful_live_syncing() {
@@ -2106,7 +2107,7 @@ mod tests {
         async fn new_block(
             &self,
             _round: Round,
-            _force: bool,
+            _reason: ReasonToCreateBlock,
         ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
             unimplemented!()
         }


### PR DESCRIPTION
# Description of change

The logic to create blocks was inherited from Mysticeti, but it was misleading, especially the way we trigger block creation with min block delay timeout. It didn't allow for reproducible tests. Previously, the delay of 50ms was triggered from the moment we have advanced the round. Now we non-forcefully attempt to create a new block in the 50ms delay after the creation of the previous block.

In addition, we introduce reasons for block creation such as 
```
pub(crate) enum ReasonToCreateBlock {
    MinBlockDelayTimeout,
    AddBlock,
    AddBlockHeader,
    MaxLeaderTimeout,
    Recover,
    QuorumSubscribersExist,
    KnownLastBlock,
}
```
Some of the reasons, like `MaxLeaderTimeout` bypass additional checks for min delay and existence of a leader in the previous round. Some of the reasons, like `MinBlockDelayTimeout` attempts to create a block while checking all the conditions.

During testing the change in the local deployment, we observe very stable result for latency, BPS, etc.

## Links to any relevant issues

Fixes #9042 and #9031

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: A validator in Starfish attempts to create a next block after a delay of 50ms from the previous block creation.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
