### PR TITLE
feat(gRPC): add improved transaction filter

### DIFF
--- a/crates/iota-core/src/event_filter.rs
+++ b/crates/iota-core/src/event_filter.rs
@@ -1,0 +1,129 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_json_rpc_types::{Filter, IotaEvent};
+use iota_metrics::monitored_scope;
+use iota_types::{
+    base_types::{IotaAddress, ObjectID, TransactionDigest},
+    error::IotaResult,
+};
+use move_core_types::{identifier::Identifier, language_storage::StructTag};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum GrpcEventFilter {
+    // Logical AND of several filters.
+    All(Vec<GrpcEventFilter>),
+    // Logical OR of several filters.
+    Any(Vec<GrpcEventFilter>),
+    // Logical NOT of a filter.
+    Not(Box<GrpcEventFilter>),
+
+    /// Return events emitted by the given transaction.
+    /// TODO: do we need that filter for streaming?
+    Transaction(
+        /// digest of the transaction, as base-64 encoded string
+        TransactionDigest,
+    ),
+
+    /// Query by sender address.
+    /// TODO: Is the same as the transaction's sender address. Do we need both?
+    Sender(IotaAddress),
+
+    /// Return events emitted in a specified Move package.
+    MovePackage(ObjectID),
+
+    /// Return events emitted in a specified Move module.
+    /// If the event is defined in Module A but emitted in a tx with Module B,
+    /// query `MoveModule` by module B returns the event.
+    /// Query `MoveEventModule` by module A returns the event too.
+    MoveModule {
+        /// the Move package ID
+        package: ObjectID,
+        /// the module name
+        module: Identifier,
+    },
+    /// Return events with the given Move module name where the event struct is
+    /// defined. If the event is defined in Module A but emitted in a tx
+    /// with Module B, query `MoveEventModule` by module A returns the
+    /// event. Query `MoveModule` by module B returns the event too.
+    MoveEventModule {
+        /// the Move package ID
+        package: ObjectID,
+        /// the module name
+        module: Identifier,
+    },
+    /// Return events with the given Move event struct name (struct tag).
+    /// For example, if the event is defined in `0xabcd::MyModule`, and named
+    /// `Foo`, then the struct tag is `0xabcd::MyModule::Foo`.
+    MoveEventType(StructTag),
+    /// Return events whose JSON representation contains the given field path
+    /// with the specified value. The path should be a JSON pointer as
+    /// defined in RFC 6901.
+    MoveEventField {
+        path: String,
+        value: Value,
+    },
+
+    /// Return events emitted in [start_time, end_time] interval
+    TimeRange {
+        /// left endpoint of time interval, milliseconds since epoch, inclusive
+        start_time: u64,
+        /// right endpoint of time interval, milliseconds since epoch, exclusive
+        end_time: u64,
+    },
+}
+
+impl GrpcEventFilter {
+    fn try_matches(&self, item: &IotaEvent) -> IotaResult<bool> {
+        Ok(match self {
+            GrpcEventFilter::All(filters) => filters.iter().all(|f| f.matches(item)),
+            GrpcEventFilter::Any(filters) => filters.iter().any(|f| f.matches(item)),
+            GrpcEventFilter::Not(filter) => !filter.matches(item),
+
+            GrpcEventFilter::Transaction(digest) => &item.id.tx_digest == digest,
+
+            GrpcEventFilter::Sender(sender) => &item.sender == sender,
+
+            GrpcEventFilter::MovePackage(object_id) => &item.package_id == object_id,
+
+            GrpcEventFilter::MoveModule { package, module } => {
+                &item.transaction_module == module && &item.package_id == package
+            }
+            GrpcEventFilter::MoveEventType(event_type) => &item.type_ == event_type,
+            GrpcEventFilter::MoveEventModule { package, module } => {
+                &item.type_.module == module && &ObjectID::from(item.type_.address) == package
+            }
+            GrpcEventFilter::MoveEventField { path, value } => {
+                matches!(item.parsed_json.pointer(path), Some(v) if v == value)
+            }
+
+            GrpcEventFilter::TimeRange {
+                start_time,
+                end_time,
+            } => {
+                if let Some(timestamp) = &item.timestamp_ms {
+                    start_time <= timestamp && end_time > timestamp
+                } else {
+                    false
+                }
+            }
+        })
+    }
+
+    pub fn and(self, other_filter: GrpcEventFilter) -> Self {
+        Self::All(vec![self, other_filter])
+    }
+    pub fn or(self, other_filter: GrpcEventFilter) -> Self {
+        Self::Any(vec![self, other_filter])
+    }
+}
+
+impl Filter<IotaEvent> for GrpcEventFilter {
+    fn matches(&self, item: &IotaEvent) -> bool {
+        let _scope = monitored_scope("GrpcEventFilter::matches");
+        self.try_matches(item).unwrap_or_default()
+    }
+}

--- a/crates/iota-core/src/event_filter.rs
+++ b/crates/iota-core/src/event_filter.rs
@@ -5,7 +5,7 @@
 use iota_json_rpc_types::{Filter, IotaEvent};
 use iota_metrics::monitored_scope;
 use iota_types::{
-    base_types::{IotaAddress, ObjectID, TransactionDigest},
+    base_types::{IotaAddress, ObjectID},
     error::IotaResult,
 };
 use move_core_types::{identifier::Identifier, language_storage::StructTag};
@@ -21,58 +21,42 @@ pub enum GrpcEventFilter {
     // Logical NOT of a filter.
     Not(Box<GrpcEventFilter>),
 
-    /// Return events emitted by the given transaction.
-    /// TODO: do we need that filter for streaming?
-    Transaction(
-        /// digest of the transaction, as base-64 encoded string
-        TransactionDigest,
-    ),
-
-    /// Query by sender address.
-    /// TODO: Is the same as the transaction's sender address. Do we need both?
+    /// Filter by sender address.
     Sender(IotaAddress),
 
-    /// Return events emitted in a specified Move package.
-    MovePackage(ObjectID),
-
-    /// Return events emitted in a specified Move module.
-    /// If the event is defined in Module A but emitted in a tx with Module B,
-    /// query `MoveModule` by module B returns the event.
-    /// Query `MoveEventModule` by module A returns the event too.
-    MoveModule {
+    /// Return events emitted in a specified Move package + module (optional).
+    /// If the event is defined in PackageA::ModuleA but emitted in a tx with
+    /// PackageB::ModuleB, filtering `MovePackageAndModule` by PackageB::ModuleB
+    /// returns the event. Filtering `MoveEventPackageAndModule` by
+    /// PackageA::ModuleA returns the event too.
+    MovePackageAndModule {
         /// the Move package ID
         package: ObjectID,
-        /// the module name
-        module: Identifier,
+        /// the module name (optional)
+        module: Option<Identifier>,
     },
-    /// Return events with the given Move module name where the event struct is
-    /// defined. If the event is defined in Module A but emitted in a tx
-    /// with Module B, query `MoveEventModule` by module A returns the
-    /// event. Query `MoveModule` by module B returns the event too.
-    MoveEventModule {
+    /// Return events with the given Move package + module (optional) where the
+    /// event struct is defined. If the event is defined in
+    /// PackageA::ModuleA but emitted in a tx with PackageB::ModuleB, filtering
+    /// `MoveEventPackageAndModule` by PackageA::ModuleA returns the
+    /// event. Filtering `MovePackageAndModule` by PackageB::ModuleB returns the
+    /// event too.
+    MoveEventPackageAndModule {
         /// the Move package ID
         package: ObjectID,
-        /// the module name
-        module: Identifier,
+        /// the module name (optional)
+        module: Option<Identifier>,
     },
     /// Return events with the given Move event struct name (struct tag).
     /// For example, if the event is defined in `0xabcd::MyModule`, and named
     /// `Foo`, then the struct tag is `0xabcd::MyModule::Foo`.
     MoveEventType(StructTag),
     /// Return events whose JSON representation contains the given field path
-    /// with the specified value. The path should be a JSON pointer as
-    /// defined in RFC 6901.
+    /// with the specified value (optional). The path should be a JSON pointer
+    /// as defined in RFC 6901.
     MoveEventField {
         path: String,
-        value: Value,
-    },
-
-    /// Return events emitted in [start_time, end_time] interval
-    TimeRange {
-        /// left endpoint of time interval, milliseconds since epoch, inclusive
-        start_time: u64,
-        /// right endpoint of time interval, milliseconds since epoch, exclusive
-        end_time: u64,
+        value: Option<Value>,
     },
 }
 
@@ -83,31 +67,25 @@ impl GrpcEventFilter {
             GrpcEventFilter::Any(filters) => filters.iter().any(|f| f.matches(item)),
             GrpcEventFilter::Not(filter) => !filter.matches(item),
 
-            GrpcEventFilter::Transaction(digest) => &item.id.tx_digest == digest,
-
             GrpcEventFilter::Sender(sender) => &item.sender == sender,
 
-            GrpcEventFilter::MovePackage(object_id) => &item.package_id == object_id,
-
-            GrpcEventFilter::MoveModule { package, module } => {
-                &item.transaction_module == module && &item.package_id == package
+            GrpcEventFilter::MovePackageAndModule { package, module } => {
+                &item.package_id == package
+                    && (module.is_none()
+                        || matches!(module,  Some(m2) if m2 == &item.transaction_module))
+            }
+            GrpcEventFilter::MoveEventPackageAndModule { package, module } => {
+                &ObjectID::from(item.type_.address) == package
+                    && (module.is_none() || matches!(module,  Some(m2) if m2 == &item.type_.module))
             }
             GrpcEventFilter::MoveEventType(event_type) => &item.type_ == event_type,
-            GrpcEventFilter::MoveEventModule { package, module } => {
-                &item.type_.module == module && &ObjectID::from(item.type_.address) == package
-            }
             GrpcEventFilter::MoveEventField { path, value } => {
-                matches!(item.parsed_json.pointer(path), Some(v) if v == value)
-            }
-
-            GrpcEventFilter::TimeRange {
-                start_time,
-                end_time,
-            } => {
-                if let Some(timestamp) = &item.timestamp_ms {
-                    start_time <= timestamp && end_time > timestamp
+                let json_ptr_value = item.parsed_json.pointer(path);
+                if value.is_none() {
+                    // If no value is specified, just check for the existence of the field.
+                    json_ptr_value.is_some()
                 } else {
-                    false
+                    matches!(json_ptr_value, Some(v) if v == value.as_ref().unwrap())
                 }
             }
         })

--- a/crates/iota-core/src/lib.rs
+++ b/crates/iota-core/src/lib.rs
@@ -19,6 +19,7 @@ pub(crate) mod consensus_types;
 pub mod consensus_validator;
 pub mod db_checkpoint_handler;
 pub mod epoch;
+pub mod event_filter;
 pub mod execution_cache;
 mod execution_driver;
 mod fallback_fetch;

--- a/crates/iota-core/src/lib.rs
+++ b/crates/iota-core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod streamer;
 pub mod subscription_handler;
 pub mod test_utils;
 pub mod traffic_controller;
+pub mod transaction_filter;
 mod transaction_input_loader;
 mod transaction_manager;
 pub mod transaction_orchestrator;

--- a/crates/iota-core/src/subscription_handler.rs
+++ b/crates/iota-core/src/subscription_handler.rs
@@ -16,7 +16,10 @@ use prometheus::{
 use tokio_stream::Stream;
 use tracing::{error, instrument, trace};
 
-use crate::streamer::Streamer;
+use crate::{
+    streamer::Streamer,
+    transaction_filter::{GrpcTransactionFilter, TransactionDataWithEffectsAndEvents},
+};
 
 #[cfg(test)]
 #[path = "unit_tests/subscription_handler_tests.rs"]
@@ -70,6 +73,11 @@ pub struct SubscriptionHandler {
     event_streamer: Streamer<IotaEvent, IotaEvent, EventFilter>,
     transaction_streamer:
         Streamer<EffectsWithInput, IotaTransactionBlockEffects, TransactionFilter>,
+    grpc_transaction_streamer: Streamer<
+        TransactionDataWithEffectsAndEvents,
+        IotaTransactionBlockEffects,
+        GrpcTransactionFilter,
+    >,
 }
 
 impl SubscriptionHandler {
@@ -77,7 +85,16 @@ impl SubscriptionHandler {
         let metrics = Arc::new(SubscriptionMetrics::new(registry));
         Self {
             event_streamer: Streamer::spawn(EVENT_DISPATCH_BUFFER_SIZE, metrics.clone(), "event"),
-            transaction_streamer: Streamer::spawn(EVENT_DISPATCH_BUFFER_SIZE, metrics, "tx"),
+            transaction_streamer: Streamer::spawn(
+                EVENT_DISPATCH_BUFFER_SIZE,
+                metrics.clone(),
+                "tx",
+            ),
+            grpc_transaction_streamer: Streamer::spawn(
+                EVENT_DISPATCH_BUFFER_SIZE,
+                metrics,
+                "grpc_tx",
+            ),
         }
     }
 }
@@ -95,6 +112,17 @@ impl SubscriptionHandler {
             tx_digest =? effects.transaction_digest(),
             "Processing tx/event subscription"
         );
+
+        if let Err(e) =
+            self.grpc_transaction_streamer
+                .try_send(TransactionDataWithEffectsAndEvents {
+                    tx_data: input.clone(),
+                    effects: effects.clone(),
+                    events: events.clone(),
+                })
+        {
+            error!(error =? e, "Failed to send transaction to grpc dispatch");
+        }
 
         if let Err(e) = self.transaction_streamer.try_send(EffectsWithInput {
             input: input.clone(),
@@ -122,5 +150,12 @@ impl SubscriptionHandler {
         filter: TransactionFilter,
     ) -> impl Stream<Item = IotaTransactionBlockEffects> {
         self.transaction_streamer.subscribe(filter)
+    }
+
+    pub fn subscribe_grpc_transactions(
+        &self,
+        filter: GrpcTransactionFilter,
+    ) -> impl Stream<Item = IotaTransactionBlockEffects> {
+        self.grpc_transaction_streamer.subscribe(filter)
     }
 }

--- a/crates/iota-core/src/transaction_filter.rs
+++ b/crates/iota-core/src/transaction_filter.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_json_rpc_types::{
-    EventFilter, Filter, IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI,
+    Filter, IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI,
     IotaTransactionBlockEvents, IotaTransactionKind, OwnedObjectRef,
 };
 use iota_metrics::monitored_scope;
@@ -13,6 +13,8 @@ use iota_types::{
     transaction::{TransactionData, TransactionDataAPI},
 };
 use serde::{Deserialize, Serialize};
+
+use crate::event_filter::GrpcEventFilter;
 
 #[derive(Clone)]
 pub struct TransactionDataWithEffectsAndEvents {
@@ -52,6 +54,8 @@ pub enum GrpcTransactionFilter {
     /// Query transactions that wrapped or deleted the specified object.
     /// Includes transactions that either created and immediately wrapped
     /// the object or unwrapped and immediately deleted it.
+    /// TODO: @infra: do we need that now that we have the AffectedObject
+    /// filter?
     WrappedOrDeletedObject(ObjectID),
     /// Query for transactions that touch this object.
     AffectedObject(ObjectID),
@@ -64,7 +68,7 @@ pub enum GrpcTransactionFilter {
     },
 
     /// Query transactions that contain events matching the given event filter.
-    Events(EventFilter),
+    Events(GrpcEventFilter),
 }
 
 impl Filter<TransactionDataWithEffectsAndEvents> for GrpcTransactionFilter {

--- a/crates/iota-core/src/transaction_filter.rs
+++ b/crates/iota-core/src/transaction_filter.rs
@@ -1,0 +1,138 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_json_rpc_types::{
+    EventFilter, Filter, IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI,
+    IotaTransactionBlockEvents, IotaTransactionKind, OwnedObjectRef,
+};
+use iota_metrics::monitored_scope;
+use iota_types::{
+    base_types::{IotaAddress, ObjectID},
+    object::Owner,
+    transaction::{TransactionData, TransactionDataAPI},
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone)]
+pub struct TransactionDataWithEffectsAndEvents {
+    pub tx_data: TransactionData,
+    pub effects: IotaTransactionBlockEffects,
+    pub events: IotaTransactionBlockEvents,
+}
+
+impl From<TransactionDataWithEffectsAndEvents> for IotaTransactionBlockEffects {
+    fn from(e: TransactionDataWithEffectsAndEvents) -> Self {
+        e.effects
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum GrpcTransactionFilter {
+    // Logical AND of several filters.
+    All(Vec<GrpcTransactionFilter>),
+    // Logical OR of several filters.
+    Any(Vec<GrpcTransactionFilter>),
+    // Logical NOT of a filter.
+    Not(Box<GrpcTransactionFilter>),
+
+    /// Query transactions of any given kind in the input.
+    TransactionKind(Vec<IotaTransactionKind>),
+
+    /// Query by sender address.
+    FromAddress(IotaAddress),
+    /// Query by recipient address.
+    ToAddress(IotaAddress),
+
+    /// Query by input object.
+    InputObject(ObjectID),
+    /// Query by changed object, including created, mutated and unwrapped
+    /// objects.
+    ChangedObject(ObjectID),
+    /// Query transactions that wrapped or deleted the specified object.
+    /// Includes transactions that either created and immediately wrapped
+    /// the object or unwrapped and immediately deleted it.
+    WrappedOrDeletedObject(ObjectID),
+    /// Query for transactions that touch this object.
+    AffectedObject(ObjectID),
+
+    /// Query by move function.
+    MoveFunction {
+        package: ObjectID,
+        module: Option<String>,
+        function: Option<String>,
+    },
+
+    /// Query transactions that contain events matching the given event filter.
+    Events(EventFilter),
+}
+
+impl Filter<TransactionDataWithEffectsAndEvents> for GrpcTransactionFilter {
+    fn matches(&self, item: &TransactionDataWithEffectsAndEvents) -> bool {
+        let _scope = monitored_scope("GrpcTransactionFilter::matches");
+        match self {
+            GrpcTransactionFilter::All(filters) => filters.iter().all(|f| f.matches(item)),
+            GrpcTransactionFilter::Any(filters) => filters.iter().any(|f| f.matches(item)),
+            GrpcTransactionFilter::Not(filter) => !filter.matches(item),
+
+            GrpcTransactionFilter::TransactionKind(kinds) => kinds
+                .iter()
+                .any(|kind| kind == &IotaTransactionKind::from(item.tx_data.kind())),
+
+            GrpcTransactionFilter::FromAddress(a) => &item.tx_data.sender() == a,
+            GrpcTransactionFilter::ToAddress(a) => {
+                let mutated: &[OwnedObjectRef] = item.effects.mutated();
+                mutated.iter().chain(item.effects.unwrapped().iter()).any(|oref: &OwnedObjectRef| {
+                    matches!(oref.owner, Owner::AddressOwner(owner) if owner == *a)
+                })
+            }
+
+            GrpcTransactionFilter::InputObject(o) => {
+                let Ok(input_objects) = item.tx_data.input_objects() else {
+                    return false;
+                };
+                input_objects.iter().any(|object| object.object_id() == *o)
+            }
+            GrpcTransactionFilter::ChangedObject(o) => item
+                .effects
+                .mutated()
+                .iter()
+                .any(|oref: &OwnedObjectRef| &oref.reference.object_id == o),
+            GrpcTransactionFilter::WrappedOrDeletedObject(o) => item
+                .effects
+                .wrapped()
+                .iter()
+                .chain(item.effects.deleted().iter())
+                .chain(item.effects.unwrapped_then_deleted().iter())
+                .any(|oref| &oref.object_id == o),
+            GrpcTransactionFilter::AffectedObject(o) => item
+                .effects
+                .created()
+                .iter()
+                .chain(item.effects.mutated().iter())
+                .chain(item.effects.unwrapped().iter())
+                .map(|oref: &OwnedObjectRef| &oref.reference)
+                .chain(item.effects.shared_objects().iter())
+                .chain(item.effects.deleted().iter())
+                .chain(item.effects.unwrapped_then_deleted().iter())
+                .chain(item.effects.wrapped().iter())
+                .any(|oref| &oref.object_id == o),
+
+            GrpcTransactionFilter::MoveFunction {
+                package,
+                module,
+                function,
+            } => item.tx_data.move_calls().into_iter().any(|(p, m, f)| {
+                p == package
+                    && (module.is_none() || matches!(module,  Some(m2) if m2 == &m.to_string()))
+                    && (function.is_none() || matches!(function, Some(f2) if f2 == &f.to_string()))
+            }),
+
+            GrpcTransactionFilter::Events(event_filter) => item
+                .events
+                .data
+                .iter()
+                .any(|event| event_filter.matches(event)),
+        }
+    }
+}

--- a/crates/iota-core/src/transaction_filter.rs
+++ b/crates/iota-core/src/transaction_filter.rs
@@ -38,36 +38,40 @@ pub enum GrpcTransactionFilter {
     // Logical NOT of a filter.
     Not(Box<GrpcTransactionFilter>),
 
-    /// Query transactions of any given kind in the input.
+    /// Filter transactions of any given kind in the input.
     TransactionKind(Vec<IotaTransactionKind>),
 
-    /// Query by sender address.
-    FromAddress(IotaAddress),
-    /// Query by recipient address.
-    ToAddress(IotaAddress),
+    /// Filter by sender address.
+    Sender(IotaAddress),
+    /// Filter by recipient address. The recipient is determined by
+    /// checking the owners of mutated and unwrapped objects.
+    Receiver(IotaAddress),
 
-    /// Query by input object.
+    /// Filter by input object.
     InputObject(ObjectID),
-    /// Query by changed object, including created, mutated and unwrapped
+    /// Filter by changed object, including created, mutated and unwrapped
     /// objects.
     ChangedObject(ObjectID),
-    /// Query transactions that wrapped or deleted the specified object.
+    /// Filter transactions that wrapped or deleted the specified object.
     /// Includes transactions that either created and immediately wrapped
     /// the object or unwrapped and immediately deleted it.
     /// TODO: @infra: do we need that now that we have the AffectedObject
     /// filter?
     WrappedOrDeletedObject(ObjectID),
-    /// Query for transactions that touch this object.
+    /// Filter for transactions that touch this object.
     AffectedObject(ObjectID),
 
-    /// Query by move function.
-    MoveFunction {
+    /// Filter by move package, module (optional) and function (optional).
+    MoveCall {
+        /// the Move package ID
         package: ObjectID,
+        /// the module name
         module: Option<String>,
+        /// the function name
         function: Option<String>,
     },
 
-    /// Query transactions that contain events matching the given event filter.
+    /// Filter transactions that contain events matching the given event filter.
     Events(GrpcEventFilter),
 }
 
@@ -83,8 +87,8 @@ impl Filter<TransactionDataWithEffectsAndEvents> for GrpcTransactionFilter {
                 .iter()
                 .any(|kind| kind == &IotaTransactionKind::from(item.tx_data.kind())),
 
-            GrpcTransactionFilter::FromAddress(a) => &item.tx_data.sender() == a,
-            GrpcTransactionFilter::ToAddress(a) => {
+            GrpcTransactionFilter::Sender(a) => &item.tx_data.sender() == a,
+            GrpcTransactionFilter::Receiver(a) => {
                 let mutated: &[OwnedObjectRef] = item.effects.mutated();
                 mutated.iter().chain(item.effects.unwrapped().iter()).any(|oref: &OwnedObjectRef| {
                     matches!(oref.owner, Owner::AddressOwner(owner) if owner == *a)
@@ -122,7 +126,7 @@ impl Filter<TransactionDataWithEffectsAndEvents> for GrpcTransactionFilter {
                 .chain(item.effects.wrapped().iter())
                 .any(|oref| &oref.object_id == o),
 
-            GrpcTransactionFilter::MoveFunction {
+            GrpcTransactionFilter::MoveCall {
                 package,
                 module,
                 function,


### PR DESCRIPTION
# Description of change

This PR adds a new transaction filter and a new event filter for gRPC (not used yet by the API).
It combines the two existing json-rpc filters into one, but also adds the possibility to filter for transactions that match a certain event filter. Also, the possibility to chain the filters was added (`Any`, `All`, `Or`, `And`) similar to the event filters.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes