### PR TITLE
upstream(iota-graphql-rpc): Remove explicit cleanup_resources

### DIFF
--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -354,13 +354,6 @@ impl Cluster {
         wait_for_graphql_checkpoint_pruned(&self.graphql_client, checkpoint, base_timeout).await
     }
 
-    /// Sends a cancellation signal to the graphql and indexer services and
-    /// waits for them to shutdown.
-    pub async fn cleanup_resources(self) {
-        self.cancellation_token.cancel();
-        let _ = join!(self.graphql_server_join_handle, self.indexer_join_handle);
-    }
-
     /// Builds a transaction that transfers IOTA for testing.
     pub async fn build_transfer_iota_for_test(&self) -> TransactionData {
         let addresses = self.validator_fullnode_handle.wallet.get_addresses();

--- a/crates/iota-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/iota-graphql-rpc/tests/e2e_tests.rs
@@ -142,7 +142,6 @@ mod tests {
 
         let exp = format!("{{\"data\":{{\"chainIdentifier\":\"{chain_id_actual}\"}}}}");
         assert_eq!(&format!("{res}"), &exp);
-        cluster.cleanup_resources().await
     }
 
     #[tokio::test]
@@ -392,8 +391,6 @@ mod tests {
         })
         .await
         .unwrap();
-
-        cluster.cleanup_resources().await
     }
 
     #[tokio::test]
@@ -407,7 +404,6 @@ mod tests {
         assert!(
             !query_is_transaction_indexed_on_node(&cluster.graphql_client, digest.as_str()).await
         );
-        cluster.cleanup_resources().await
     }
 
     #[tokio::test]
@@ -540,8 +536,6 @@ mod tests {
             count, 1,
             "Transaction should be present in optimistic_transactions table"
         );
-
-        cluster.cleanup_resources().await
     }
 
     #[tokio::test]
@@ -664,7 +658,6 @@ mod tests {
         let binding = res.response_body().data.clone().into_json().unwrap();
         let res = binding.get("verifyZkloginSignature").unwrap();
         assert_eq!(res.get("success").unwrap(), false);
-        cluster.cleanup_resources().await
     }
 
     // TODO: add more test cases for transaction execution/dry run in transactional
@@ -753,7 +746,6 @@ mod tests {
         let indexed_on_node = tx.get("indexedOnNode").unwrap().as_bool().unwrap();
         assert!(!indexed_on_node);
         assert!(res.get("results").unwrap().is_array());
-        cluster.cleanup_resources().await
     }
 
     // Test dry run where the transaction kind is provided instead of the full
@@ -825,7 +817,6 @@ mod tests {
         // running the trasanction in which case the sender is null.
         assert!(sender_read.is_null());
         assert!(res.get("results").unwrap().is_array());
-        cluster.cleanup_resources().await
     }
 
     // Test that we can handle dry run with failures at execution stage too.
@@ -915,8 +906,6 @@ mod tests {
                 .unwrap()
                 .contains("UnusedValueWithoutDrop")
         );
-
-        cluster.cleanup_resources().await
     }
 
     #[tokio::test]
@@ -961,7 +950,6 @@ mod tests {
                 .unwrap()
                 .is_null()
         );
-        cluster.cleanup_resources().await
     }
 
     use iota_graphql_rpc::server::builder::tests::*;
@@ -976,7 +964,6 @@ mod tests {
             .wait_for_checkpoint_catchup(0, Duration::from_secs(10))
             .await;
         test_timeout_impl(&cluster).await;
-        cluster.cleanup_resources().await
     }
 
     #[tokio::test]
@@ -1024,6 +1011,5 @@ mod tests {
             .wait_for_checkpoint_catchup(0, Duration::from_secs(10))
             .await;
         test_health_check_impl().await;
-        cluster.cleanup_resources().await
     }
 }

--- a/crates/iota-json-rpc-api/src/write.rs
+++ b/crates/iota-json-rpc-api/src/write.rs
@@ -47,7 +47,7 @@ pub trait WriteApi {
     /// Calls a move view function.
     #[rustfmt::skip]
     #[method(name = "view")]
-     async fn view_function_call(
+    async fn view_function_call(
         &self,
         /// The fully qualified function name `<package_id>::<module_name>::<function_name>`. E.g.  `0x3::iota_system::get_total_iota_supply`.
         function_name: String,


### PR DESCRIPTION
# Description of change

This PR introduces an upstream path by removing explicit `cleanup_resources` method calls.

These were originally added to try and deal with a deadlock issue, which was due to an issue with inotify on macOS, fixed by 
#8582 
These calls are safe to remove (also note that if the test failed, they would never be hit, because the assert would cause a panic before they ran).

Plus fixes a cargo fmt error.

## Links to any relevant issues

fixes #8853 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

Ran multiple times the graphql tests
```sh
cargo nextest run -p iota-graphql-rpc --features pg_integration --no-fail-fast --test-threads 1
```

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch does not affect the normal operation of the indexer, thus no test where skipped.