### PR TITLE
feat(release-notes): always add protocol section

### DIFF
--- a/scripts/release_notes/release_notes.py
+++ b/scripts/release_notes/release_notes.py
@@ -316,7 +316,8 @@ def do_generate(from_, to):
     root = git("rev-parse", "--show-toplevel")
     os.chdir(root)
 
-    protocol_version = extract_protocol_version(to) or "XX"
+    protocol_version_from = extract_protocol_version(from_) or "XX"
+    protocol_version_to = extract_protocol_version(to) or "XX"
 
     commits = git(
         "log",
@@ -340,18 +341,22 @@ def do_generate(from_, to):
     # Print the impact areas we know about first
     for impacted in NOTE_ORDER:
         notes = results.pop(impacted, None)
-        if not notes:
+        if not notes and impacted != "Protocol":
             continue
 
         print(f"## {impacted}")
 
         if impacted == "Protocol":
-            print(f"#### IOTA Protocol Version in this release: `{protocol_version}`")
+            if protocol_version_from == protocol_version_to:
+                print(f"\n#### This release does not introduce a new protocol version and still runs `{protocol_version_to}`")
+            else:
+                print(f"\n#### This release introduces protocol version `{protocol_version_to}`")
         print()
 
-        for pr, note in reversed(notes):
-            print_changelog(pr, note)
-            print()
+        if notes:
+            for pr, note in reversed(notes):
+                print_changelog(pr, note)
+                print()
 
     # Print any remaining impact areas
     for impacted, notes in results.items():

--- a/scripts/release_notes/release_notes.py
+++ b/scripts/release_notes/release_notes.py
@@ -348,7 +348,7 @@ def do_generate(from_, to):
 
         if impacted == "Protocol":
             if protocol_version_from == protocol_version_to:
-                print(f"\n#### This release does not introduce a new protocol version and still runs `{protocol_version_to}`")
+                print(f"\n#### This release does not introduce a new protocol version (current version: `{protocol_version_to}`)")
             else:
                 print(f"\n#### This release introduces protocol version `{protocol_version_to}`")
         print()


### PR DESCRIPTION
# Description of change

- Always add a Protocol section in the release notes, whether there are changes or not
- Explicits whether the release introduces a new protocol version or not

Examples:

Without any protocol changes
```
## Protocol

#### This release does not introduce a new protocol version and still runs `12`

## Nodes (Validators and Full nodes)

https://github.com/iotaledger/iota/pull/7511: add experimental "internal" gRPC API

https://github.com/iotaledger/iota/pull/7746: Add subscription to events including filtering in gRPC

https://github.com/iotaledger/iota/pull/8370: add experimental "internal" gRPC API, including subscription to events with filtering

## JSON-RPC

https://github.com/iotaledger/iota/pull/8647: Fix a bug in `queryTransactionBlocks` which causes that some results for `TransactionFilter::MoveFunction` are not returned.

## CLI

https://github.com/iotaledger/iota/pull/8620: Use the provided `--sender` if there is one, rather than always inferring it, for iota client call, publish, upgrade, and serialized-tx-kind.

## Internal gRPC API

https://github.com/iotaledger/iota/pull/8370: add gRPC streaming for checkpoint data and checkpoint summary, and use a trait to access the storage layer

## gRPC API

https://github.com/iotaledger/iota/pull/8019: use a trait to access the storage layer

## internal gRPC API

https://github.com/iotaledger/iota/pull/7511: add gRPC streaming for checkpoint data and checkpoint summary
```

With a new protocol version
```
## Protocol

#### This release introduces protocol version `14`

https://github.com/iotaledger/iota/pull/8896: - Switch consensus protocol to `Starfish` on Devnet

https://github.com/iotaledger/iota/pull/8756: Dropping the timestamp monotonicity block ancestor checks and performing stake-based calculation of the commit's timestamp by using the leader's strong ancestors timestamps median. Those changes are enabled only on the devnet.

https://github.com/iotaledger/iota/pull/8757: Force checkpoint timestamp to be non decreasing. This is only enabled on the devnet.

https://github.com/iotaledger/iota/pull/8987: Enable median-based commit timestamp calculation in consensus, and checkpoint timestamps are non-decreasing for devnet. Enable batched block sync for mainnet.

https://github.com/iotaledger/iota/pull/9004: Switch to Blake3 hash for Starfish consensus

https://github.com/iotaledger/iota/pull/9010: enable committee selection from validators who issued valid authority capabilities for testnet

## Nodes (Validators and Full nodes)

https://github.com/iotaledger/iota/pull/8894: Replace local execution with "wait for checkpoint" execution

https://github.com/iotaledger/iota/pull/8537: Improved accuracy in the computation of object hotness and gas price prediction.

https://github.com/iotaledger/iota/pull/8997: Added filters for private/unroutable addresses in the node discovery

## JSON-RPC

https://github.com/iotaledger/iota/pull/8857: Added PtbInput to support referencing results in
unsafe_batchTransaction

https://github.com/iotaledger/iota/pull/8969: Adds support for move view function calls through a new `iota_view` RPC method. :warning: Calls to the `iota_view` endpoint are only supported on  `devnet` , as the feature is still in alpha.

## GraphQL

https://github.com/iotaledger/iota/pull/8645: Transaction effects are now available immediately after execution via `Query.transactionBlock`.
    Note that other queries relying on the chain’s indexed state (such as address-level balance updates) may still show a delay until the transaction is checkpointed.
    To verify checkpoint inclusion, query `Query.transactionBlock` and check the `effects.checkpoint` field — it will be `null` until the transaction has been checkpointed.

https://github.com/iotaledger/iota/pull/8935: Fixes `mutation.executeTransactionBlock` which could fail if the transaction executed was indexed through the checkpoint path.

https://github.com/iotaledger/iota/pull/8969: Introducing a new `moveViewCall` query path to call move-view functions. :rotating_light:  The server now requires that the fullnode JSON-RPC url is specified in the configuration, to be able to run `mutation.executeTransactionBlock`, `query.{moveViewCall,dryRunTransactionBlock}`. :warning:  Usage of the `Query.moveViewCall` are only supported on `devnet`, as the feature is still in alpha.

## CLI

https://github.com/iotaledger/iota/pull/8931: `iota move build --dump-bytecode-as-base64` is now working correctly due to a bug in the logic when a Move.lock file existed with the published address.

## Rust SDK

https://github.com/iotaledger/iota/pull/8857: Added `single_move_call_with_ptb_inputs()` to support
referencing results of previous commands

https://github.com/iotaledger/iota/pull/8969: Added move_view_call_tx_kind and single_move_view_call to the TransactionBuilder
```

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/8463

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
