### PR TITLE
fix(bcs): work around turbopack bug that breaks uleb128 in next@16

### DIFF
--- a/.changeset/uleb128-next16.md
+++ b/.changeset/uleb128-next16.md
@@ -1,0 +1,5 @@
+---
+'@iota/bcs': patch
+---
+
+Work around bug in turbopack thatbreaks uleb128 encoding in next@16

--- a/sdk/bcs/src/uleb.ts
+++ b/sdk/bcs/src/uleb.ts
@@ -14,7 +14,8 @@ export function ulebEncode(num: number): number[] {
 
     while (num > 0) {
         arr[len] = num & 0x7f;
-        if ((num >>= 7)) {
+        num >>= 7;
+        if (num >= 0) {
             arr[len] |= 0x80;
         }
         len += 1;


### PR DESCRIPTION
# Description of change

Following the approach from https://github.com/MystenLabs/ts-sdks/pull/639

## Links to any relevant issues

related issue: 
https://github.com/MystenLabs/ts-sdks/issues/635
https://github.com/vercel/next.js/issues/85474

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

