### PR TITLE
feat(core): Skip destroying monitoring instance in destroy command

### DIFF
--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -175,7 +175,10 @@ pub enum TestbedAction {
     Stop,
 
     /// Destroy the testbed and terminate all instances.
-    Destroy,
+    Destroy {
+        #[arg(long, default_value = "")]
+        keep_monitor_instance: Option<String>,
+    },
 }
 
 #[derive(Parser)]
@@ -255,8 +258,10 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
             TestbedAction::Stop => testbed.stop().await.wrap_err("Failed to stop testbed")?,
 
             // Destroy the testbed and terminal all instances.
-            TestbedAction::Destroy => testbed
-                .destroy()
+            TestbedAction::Destroy {
+                keep_monitor_instance: monitor_ip,
+            } => testbed
+                .destroy(monitor_ip)
                 .await
                 .wrap_err("Failed to destroy testbed")?,
         },

--- a/crates/iota-aws-orchestrator/src/testbed.rs
+++ b/crates/iota-aws-orchestrator/src/testbed.rs
@@ -153,12 +153,21 @@ impl<C: ServerProviderClient> Testbed<C> {
     }
 
     /// Destroy all instances of the testbed.
-    pub async fn destroy(&mut self) -> TestbedResult<()> {
+    pub async fn destroy(&mut self, monitor_ip: Option<String>) -> TestbedResult<()> {
         display::action("Destroying testbed");
 
-        try_join_all(
+        let instances_to_delete: Vec<_> = if let Some(ip) = monitor_ip {
             self.instances
                 .drain(..)
+                .filter(|instance| instance.main_ip.to_string() != ip)
+                .collect()
+        } else {
+            self.instances.drain(..).collect()
+        };
+
+        try_join_all(
+            instances_to_delete
+                .into_iter()
                 .map(|instance| self.client.delete_instance(instance)),
         )
         .await?;
@@ -287,7 +296,7 @@ mod test {
         let client = TestClient::new(settings.clone());
         let mut testbed = Testbed::new(settings, client).await.unwrap();
 
-        testbed.destroy().await.unwrap();
+        testbed.destroy(None).await.unwrap();
 
         assert_eq!(testbed.instances.len(), 0);
     }


### PR DESCRIPTION
# Description of change

This PR provides an option to skip destroying the monitoring instance, allowing us to continue checking the data on Grafana without other instances running.

Example usage: 
```
cargo run --bin iota-aws-orchestrator -- testbed destroy --keep-monitor-instance "176.34.93.112"
```

## Links to any relevant issues

Part of #8846

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
