### PR TITLE
fix(ci): build move analyzer with implicit dependencies

### DIFF
--- a/.github/workflows/_move_ide.yml
+++ b/.github/workflows/_move_ide.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build move-analyzer
         run: |
-          cargo build --bin move-analyzer
+          cargo build -p iota-move-lsp --bin move-analyzer
           mkdir -p ~/.iota/bin
           cp ./target/debug/move-analyzer* ~/.iota/bin
 

--- a/.github/workflows/release_move_ide.yml
+++ b/.github/workflows/release_move_ide.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Cargo build for ${{ matrix.os }} platform
         shell: bash
         run: |
-          [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build --bin move-analyzer --release
+          [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build -p iota-move-lsp --bin move-analyzer --release
 
       # Filenames need to match external-crates/move/crates/move-analyzer/editors/code/scripts/create_from_local.sh
       - name: Rename binaries for ${{ matrix.os }}


### PR DESCRIPTION
# Description of change

Make the CI build the move analyzer with implicit dependencies. This can be done using the `iota-move-lsp` package.

## Links to any relevant issues

Fixes #8603 