### PR TITLE
chore: bump rust toolchain to 1.89

### DIFF
--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -404,8 +404,6 @@ impl Metrics {
                 .faulty_blocks_unprovable_by_authority
                 .with_label_values(&[hostname, source, error.name()])
                 .inc();
-        } else {
-            return;
         }
     }
 }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4944,7 +4944,7 @@ impl AuthorityState {
         // transactions through consensus.
         epoch_store.assign_shared_object_versions_idempotent(
             self.get_object_cache_reader().as_ref(),
-            &[executable_tx.clone()],
+            std::slice::from_ref(&executable_tx),
         )?;
 
         let input_objects =

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -328,7 +328,7 @@ mod tests {
             _ => panic!("expected shared object"),
         };
         let authority = TestAuthorityBuilder::new()
-            .with_starting_objects(&[shared_object.clone()])
+            .with_starting_objects(std::slice::from_ref(&shared_object))
             .build()
             .await;
         let certs = vec![
@@ -642,7 +642,7 @@ mod tests {
             _ => panic!("expected shared object"),
         };
         let authority = TestAuthorityBuilder::new()
-            .with_starting_objects(&[shared_object.clone()])
+            .with_starting_objects(std::slice::from_ref(&shared_object))
             .build()
             .await;
         let certs = vec![

--- a/crates/iota-core/src/traffic_controller/mod.rs
+++ b/crates/iota-core/src/traffic_controller/mod.rs
@@ -731,16 +731,11 @@ impl TrafficSim {
 
         let metrics = futures::future::join_all(tasks).await.into_iter().fold(
             TrafficSimMetrics::default(),
-            |acc, run_client_ret| {
-                if run_client_ret.is_err() {
-                    error!(
-                        "Error running traffic sim client: {:?}",
-                        run_client_ret.err()
-                    );
+            |acc, run_client_ret| match run_client_ret {
+                Ok(metrics) => acc + metrics,
+                Err(err) => {
+                    error!("Error running traffic sim client: {:?}", err);
                     acc
-                } else {
-                    let metrics = run_client_ret.unwrap();
-                    acc + metrics
                 }
             },
         );

--- a/crates/iota-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_manager_tests.rs
@@ -540,7 +540,7 @@ async fn transaction_manager_receiving_object_ready_notifications() {
 
     // Notify TM that the receiving object 0 is available.
     transaction_manager.objects_available(
-        get_input_keys(&[receiving_object_new0.clone()]),
+        get_input_keys(std::slice::from_ref(&receiving_object_new0)),
         &state.epoch_store_for_testing(),
     );
 
@@ -550,7 +550,7 @@ async fn transaction_manager_receiving_object_ready_notifications() {
 
     // Notify TM that the receiving object 0 is available.
     transaction_manager.objects_available(
-        get_input_keys(&[receiving_object_new1.clone()]),
+        get_input_keys(std::slice::from_ref(&receiving_object_new1)),
         &state.epoch_store_for_testing(),
     );
 
@@ -642,7 +642,7 @@ async fn transaction_manager_receiving_object_ready_notifications_multiple_of_sa
 
     // Notify TM that the receiving object 0 is available.
     transaction_manager.objects_available(
-        get_input_keys(&[receiving_object_new0.clone()]),
+        get_input_keys(std::slice::from_ref(&receiving_object_new0)),
         &state.epoch_store_for_testing(),
     );
 
@@ -664,7 +664,7 @@ async fn transaction_manager_receiving_object_ready_notifications_multiple_of_sa
 
     // Notify TM that the receiving object 0 is available.
     transaction_manager.objects_available(
-        get_input_keys(&[receiving_object_new1.clone()]),
+        get_input_keys(std::slice::from_ref(&receiving_object_new1)),
         &state.epoch_store_for_testing(),
     );
 

--- a/crates/iota-sdk/src/iota_client_config.rs
+++ b/crates/iota-sdk/src/iota_client_config.rs
@@ -19,9 +19,8 @@ use crate::{
     IotaClientBuilder,
 };
 
-/// Configuration for the IOTA client, containing a
-/// [`Keystore`](iota_keys::keystore::Keystore) and potentially multiple
-/// [`IotaEnv`]s.
+/// Configuration for the IOTA client, containing a [`Keystore`] and potentially
+/// multiple [`IotaEnv`]s.
 #[serde_as]
 #[derive(Serialize, Deserialize, Getters, MutGetters)]
 #[getset(get = "pub", get_mut = "pub")]

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -587,7 +587,7 @@ mod tests {
             .build();
 
         // The first attempt should fail due to a missing block
-        let (committed, missing) = manager.try_commit(&[subdag.clone()]);
+        let (committed, missing) = manager.try_commit(std::slice::from_ref(&subdag));
         assert!(committed.is_empty());
         assert_eq!(missing.len(), 1);
 
@@ -722,14 +722,14 @@ mod tests {
             .build();
 
         // First submit subdag2 (index 2)
-        let (committed, missing) = manager.try_commit(&[subdag2.clone()]);
+        let (committed, missing) = manager.try_commit(std::slice::from_ref(&subdag2));
         assert!(committed.is_empty());
         assert!(missing.is_empty());
         assert!(manager.pending_subdags.contains_key(&2));
         assert_eq!(manager.last_committed_index, 0);
 
         // Then submit subdag1 (index 1) - should commit both
-        let (committed, missing) = manager.try_commit(&[subdag1.clone()]);
+        let (committed, missing) = manager.try_commit(std::slice::from_ref(&subdag1));
         assert_eq!(committed.len(), 2);
         assert!(missing.is_empty());
         assert!(manager.pending_subdags.is_empty());
@@ -768,17 +768,17 @@ mod tests {
             .build();
 
         // Initial commit attempts
-        let (committed, missing) = manager.try_commit(&[subdag3.clone()]);
+        let (committed, missing) = manager.try_commit(std::slice::from_ref(&subdag3));
         assert!(committed.is_empty());
         assert_eq!(missing.len(), 1);
         assert_eq!(manager.pending_subdags.len(), 1);
 
-        let (committed, missing) = manager.try_commit(&[subdag2.clone()]);
+        let (committed, missing) = manager.try_commit(std::slice::from_ref(&subdag2));
         assert!(committed.is_empty());
         assert_eq!(missing.len(), 1);
         assert_eq!(manager.pending_subdags.len(), 2);
 
-        let (committed, missing) = manager.try_commit(&[subdag1.clone()]);
+        let (committed, missing) = manager.try_commit(std::slice::from_ref(&subdag1));
         assert!(missing.is_empty());
         assert_eq!(committed.len(), 1); // subdag1 can commit
         assert_eq!(committed[0].commit_ref, subdag1.commit_ref);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.88"
+channel = "1.89"


### PR DESCRIPTION
# Description of change

Bump rust toolchain to 1.89 and fix new clippy lints.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
