### PR TITLE
feat(verifier): reject authenticate functions having a Receiving ref

### DIFF
--- a/crates/iota-e2e-tests/tests/abstract_account/authenticate/sources/receiving.move
+++ b/crates/iota-e2e-tests/tests/abstract_account/authenticate/sources/receiving.move
@@ -1,0 +1,99 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module authenticate::receiving;
+
+use iota::auth_context::AuthContext;
+use iota::transfer::Receiving;
+
+// Receiving
+
+public struct Object has key, store {
+    id: iota::object::UID,
+}
+
+// FAIL
+public fun immutable_ref(
+    _to_receive: &Receiving<Object>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+// FAIL
+#[allow(lint(share_owned))]
+public fun by_value(
+    to_receive: Receiving<Object>,
+    parent: &mut Object,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {
+    let object = transfer::public_receive(&mut parent.id, to_receive);
+    transfer::public_share_object(object);
+}
+
+// FAIL
+public fun by_mutable_ref(
+    _to_receive: &mut Receiving<Object>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+// Receiving and vector
+
+// FAIL
+public fun vector_immutable_ref(
+    _objects: &vector<Receiving<Object>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+// FAIL
+public fun vector_mutable_ref(
+    _objects: &mut vector<Receiving<Object>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+// FAIL
+#[allow(lint(share_owned))]
+public fun vector_by_value(
+    to_receive: vector<Receiving<Object>>,
+    parent: &mut Object,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {
+    to_receive.do!(|to_receive| {
+        let object = transfer::public_receive(&mut parent.id, to_receive);
+        transfer::public_share_object(object);
+    });
+}
+
+// Receiving and option
+
+// FAIL
+public fun option_immutable_ref(
+    _objects: &Option<Receiving<Object>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+// FAIL
+public fun option_mutable_ref(
+    _objects: &mut Option<Receiving<Object>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}
+
+// FAIL
+#[allow(lint(share_owned))]
+public fun option_by_value(
+    to_receive: Option<Receiving<Object>>,
+    parent: &mut Object,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {
+    to_receive.do!(|to_receive| {
+        let object = transfer::public_receive(&mut parent.id, to_receive);
+        transfer::public_share_object(object);
+    });
+}

--- a/crates/iota-e2e-tests/tests/abstract_account/authenticate/sources/receiving.move
+++ b/crates/iota-e2e-tests/tests/abstract_account/authenticate/sources/receiving.move
@@ -5,6 +5,7 @@ module authenticate::receiving;
 
 use iota::auth_context::AuthContext;
 use iota::transfer::Receiving;
+use iota::vec_map::VecMap;
 
 // Receiving
 
@@ -97,3 +98,12 @@ public fun option_by_value(
         transfer::public_share_object(object);
     });
 }
+
+// Receiving and datatype instantiation
+
+// FAIL
+public fun datatype_inst_immutable_ref(
+    _to_receive: &VecMap<u8, Receiving<Object>>,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {}

--- a/crates/iota-e2e-tests/tests/authenticate_verifier_tests.rs
+++ b/crates/iota-e2e-tests/tests/authenticate_verifier_tests.rs
@@ -115,7 +115,7 @@ macro_rules! gen_simtest_expect_fail {
         async fn $function_name() {
             let env = TestEnvironment::new().await;
             let (effects, _) = env
-                .create_auth_info_using("signature", "at_least_two_args")
+                .create_auth_info_using(stringify!($module_name), stringify!($function_name))
                 .await
                 .unwrap();
             assert!(effects.status().is_err());
@@ -162,6 +162,20 @@ fail::{
     template_object_mutable_reference,
     templated_object_by_value,
     templated_object_mutable_ref
+});
+
+tests_in_module!(
+receiving;
+fail::{
+    immutable_ref,
+    by_value,
+    by_mutable_ref,
+    vector_immutable_ref,
+    vector_by_value,
+    vector_by_mutable_ref,
+    option_immutable_ref,
+    option_by_value,
+    option_by_mutable_ref
 });
 
 tests_in_module!(

--- a/crates/iota-e2e-tests/tests/authenticate_verifier_tests.rs
+++ b/crates/iota-e2e-tests/tests/authenticate_verifier_tests.rs
@@ -175,7 +175,8 @@ fail::{
     vector_by_mutable_ref,
     option_immutable_ref,
     option_by_value,
-    option_by_mutable_ref
+    option_by_mutable_ref,
+    datatype_inst_immutable_ref
 });
 
 tests_in_module!(

--- a/iota-execution/latest/iota-verifier/src/account_auth_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/account_auth_verifier.rs
@@ -257,7 +257,10 @@ fn verify_immutable_reference(
                     "Invalid immutable reference. A datatype instantiation must NOT be a receiving struct, offending argument: {param:?}"
                 ))
             } else {
-                verify_immutable_reference(module, &type_args[0])
+                for type_arg in type_args.iter() {
+                    verify_immutable_reference(module, type_arg)?
+                }
+                Ok(())
             }
         }
         Signer => Err(format!(

--- a/iota-execution/latest/iota-verifier/src/account_auth_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/account_auth_verifier.rs
@@ -17,6 +17,7 @@ use iota_types::{
     },
     error::ExecutionError,
     id::RESOLVED_IOTA_ID,
+    transfer::RESOLVED_RECEIVING_STRUCT,
 };
 use move_binary_format::{
     CompiledModule,
@@ -234,9 +235,47 @@ fn verify_pure_input_type(
     }
 }
 
+/// Verify that the parameter type when it is an immutable reference.
+/// An immutable reference is valid for an authenticate function in any case
+/// except for the `iota::transfer::Receiving` struct
+fn verify_immutable_reference(
+    module: &CompiledModule,
+    param: &SignatureToken,
+) -> Result<(), String> {
+    use SignatureToken::*;
+
+    match param {
+        U8 | U16 | U32 | U64 | U128 | U256 | Bool | Address | Datatype(_) | TypeParameter(_) => {
+            Ok(())
+        }
+        Vector(inner) => verify_immutable_reference(module, inner),
+        DatatypeInstantiation(datatype_instance) => {
+            let (idx, type_args) = &**datatype_instance;
+            let resolved_struct = resolve_struct(module, *idx);
+            if resolved_struct == RESOLVED_RECEIVING_STRUCT {
+                Err(format!(
+                    "Invalid immutable reference. A datatype instantiation must NOT be a receiving struct, offending argument: {param:?}"
+                ))
+            } else {
+                verify_immutable_reference(module, &type_args[0])
+            }
+        }
+        Signer => Err(format!(
+            "Invalid immutable reference. Signer cannot be immutably referenced, offending argument: {param:?}"
+        )),
+        Reference(_) => Err(format!(
+            "Invalid immutable reference. Reference cannot be immutably referenced, offending argument: {param:?}"
+        )),
+        MutableReference(_) => Err(format!(
+            "Invalid immutable reference. MutableReference cannot be immutably referenced, offending argument: {param:?}"
+        )),
+    }
+}
+
 /// Verify that the parameter type is a valid type for an `authenticate`
 /// function The parameter type can be:
-/// - an immutable reference
+/// - an immutable reference to anything but a receiving object (see
+///   [verify_immutable_reference])
 /// - a pure input type (see [verify_pure_input_type])
 fn verify_authenticate_param_type(
     module: &CompiledModule,
@@ -246,10 +285,7 @@ fn verify_authenticate_param_type(
     use SignatureToken::*;
 
     match param {
-        Reference(_) => Ok(()),
-        // This mutable reference could be allowed to enable a smother authenticate() function
-        // composition, but its usage must be checked before being enabled:
-        // MutableReference(inner) => verify_pure_input_type(module, function_type_args, inner),
+        Reference(ref_param) => verify_immutable_reference(module, ref_param),
         _ => verify_pure_input_type(module, function_type_args, param),
     }
 }


### PR DESCRIPTION
# Description of change

Changes the verifier check for the authenticate function in order to reject any Receiving parameter.

## Links to any relevant issues

Fixes #9104 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
