### PR TITLE
refactor(consensus): make aws-orchestrator instance specs configurable per role

### DIFF
--- a/crates/iota-aws-orchestrator/README.md
+++ b/crates/iota-aws-orchestrator/README.md
@@ -78,7 +78,7 @@ If you're working with a private GitHub repository, you can include a [private a
 The `iota-aws-orchestrator` binary provides various functionalities for creating, starting, stopping, and destroying instances. You can use the following command to boot 2 node and 2 dedicated client instances per region (if the settings file specifies 10 regions, as shown in the example above, a total of 20 instances will be created):
 
 ```bash
-cargo run --bin iota-aws-orchestrator -- testbed deploy --instances 2 --dedicated-clietns 2
+cargo run --bin iota-aws-orchestrator -- testbed deploy --instances 2 --dedicated-clients 2
 ```
 
 ### Note:

--- a/crates/iota-aws-orchestrator/README.md
+++ b/crates/iota-aws-orchestrator/README.md
@@ -126,7 +126,7 @@ cargo run --bin iota-aws-orchestrator -- testbed destroy
 
 ### Note:
 
-Use the `--leave-monitoring` command to skip destruction of the metrics instance.
+Use the `--keep-monitoring` command to skip destruction of the metrics instance.
 
 that will terminate all the deployed EC2 instances. Keep in mind that AWS is not immediately deleting the terminated instances - this could take a few hours - so in case you want to immediately deploy a new testbed it would be advised
 to use a different `testbed_id` in the `settings.json` to avoid any later conflicts (see the FAQ section for more information).

--- a/crates/iota-aws-orchestrator/README.md
+++ b/crates/iota-aws-orchestrator/README.md
@@ -50,7 +50,9 @@ Create a file called `settings.json` that contains all the configuration paramet
     "ap-southeast-1",
     "ap-southeast-2"
   ],
-  "specs": "m5d.8xlarge",
+  "node_specs": "m5d.8xlarge",
+  "client_specs": "m5d.2xlarge",
+  "metrics_specs": "m5d.4xlarge",
   "repository": {
     "url": "https://github.com/iotaledger/iota.git",
     "commit": "main"
@@ -73,11 +75,16 @@ If you're working with a private GitHub repository, you can include a [private a
 
 ## Step 3. Create a testbed
 
-The `iota-aws-orchestrator` binary provides various functionalities for creating, starting, stopping, and destroying instances. You can use the following command to boot 2 instances per region (if the settings file specifies 10 regions, as shown in the example above, a total of 20 instances will be created):
+The `iota-aws-orchestrator` binary provides various functionalities for creating, starting, stopping, and destroying instances. You can use the following command to boot 2 node and 2 dedicated client instances per region (if the settings file specifies 10 regions, as shown in the example above, a total of 20 instances will be created):
 
 ```bash
-cargo run --bin iota-aws-orchestrator -- testbed deploy --instances 2
+cargo run --bin iota-aws-orchestrator -- testbed deploy --instances 2 --dedicated-clietns 2
 ```
+
+### Note:
+
+- Use the `--skip-monitoring` command to skip deployment of a dedicated metrics instance.
+- Use the `--dedicated-clietns N` command to deploy dedicated client machines `N` per region.
 
 To check the current status of the testbed instances, use the following command:
 
@@ -98,6 +105,11 @@ Running benchmarks involves installing the specified version of the codebase on 
 cargo run --bin iota-aws-orchestrator -- benchmark --committee 10 fixed-load --loads 200 --duration 180
 ```
 
+### Note
+
+- Use the `--skip-monitoring` command to skip the use of a metrics instance.
+- Use the `--dedicated-clietns N` command to use dedicated load generator machines `N` in total.
+
 In a network of 10 validators, each with a corresponding load generator, each load generator submits a fixed load of 20 tx/s. Performance measurements are collected by regularly scraping the Prometheus metrics exposed by the load generators. The `iota-aws-orchestrator` binary provides additional commands to run a specific number of load generators on separate machines.
 
 ## Step 5. Monitoring
@@ -111,6 +123,10 @@ After you have found yourself that you don't need the deployed testbed anymore y
 ```
 cargo run --bin iota-aws-orchestrator -- testbed destroy
 ```
+
+### Note:
+
+Use the `--leave-monitoring` command to skip destruction of the metrics instance.
 
 that will terminate all the deployed EC2 instances. Keep in mind that AWS is not immediately deleting the terminated instances - this could take a few hours - so in case you want to immediately deploy a new testbed it would be advised
 to use a different `testbed_id` in the `settings.json` to avoid any later conflicts (see the FAQ section for more information).
@@ -141,8 +157,7 @@ In the common case to successfully run a benchmark we need to have enough instan
 
 for example when running the command `cargo run --bin iota-aws-orchestrator -- benchmark --committee 4 fixed-load --loads 500 --duration 500`, we'll need the following amount of instances available:
 
-- `4 instances` to run the validators (since we set `--committee 4`)
-- `1 instance` to run the grafana dashboard (by default only 1 is needed)
+- `4 node instances` to run the validators (since we set `--committee 4`)
+- `1 instance` to run the grafana dashboard (by default only 1 is needed), 0 if `--skip-monitoring` command is used
+- 'N of client instances' where N is the number passed by the `--dedicated-clients N` command
 - no additional instances to run the benchmarking clients, as those will be co-deployed on the validator nodes
-
-so in total we must have deployed a testbed of at least `5 instances`. If we attempt to run with fewer, then the above error will be thrown.

--- a/crates/iota-aws-orchestrator/README.md
+++ b/crates/iota-aws-orchestrator/README.md
@@ -108,7 +108,7 @@ cargo run --bin iota-aws-orchestrator -- benchmark --committee 10 fixed-load --l
 ### Note
 
 - Use the `--skip-monitoring` command to skip the use of a metrics instance.
-- Use the `--dedicated-clietns N` command to use dedicated load generator machines `N` in total.
+- Use the `--dedicated-clients N` command to use dedicated load generator machines `N` in total.
 
 In a network of 10 validators, each with a corresponding load generator, each load generator submits a fixed load of 20 tx/s. Performance measurements are collected by regularly scraping the Prometheus metrics exposed by the load generators. The `iota-aws-orchestrator` binary provides additional commands to run a specific number of load generators on separate machines.
 

--- a/crates/iota-aws-orchestrator/assets/settings-template.json
+++ b/crates/iota-aws-orchestrator/assets/settings-template.json
@@ -4,7 +4,9 @@
     "token_file": "/Users/${USER}/.aws/credentials",
     "ssh_private_key_file": "/Users/${USER}/.ssh/aws",
     "regions": ["us-east-1", "us-west-2", "ca-central-1", "eu-central-1", "ap-northeast-1", "eu-west-1", "eu-west-2", "eu-north-1", "ap-south-1", "ap-southeast-1", "ap-southeast-2"],
-    "specs": "m5d.8xlarge",
+    "node_specs": "m5d.8xlarge",
+    "client_specs": "m5d.2xlarge",
+    "metrics_specs": "m5d.8xlarge",
     "repository": {
         "url": "https://github.com/iotaledger/iota.git",
         "commit": "main"

--- a/crates/iota-aws-orchestrator/src/client/aws.rs
+++ b/crates/iota-aws-orchestrator/src/client/aws.rs
@@ -19,7 +19,7 @@ use aws_sdk_ec2::{
 use aws_smithy_runtime_api::client::{behavior_version::BehaviorVersion, result::SdkError};
 use serde::Serialize;
 
-use super::{Instance, ServerProviderClient};
+use super::{Instance, InstanceRole, ServerProviderClient};
 use crate::{
     error::{CloudProviderError, CloudProviderResult},
     settings::Settings,
@@ -95,7 +95,13 @@ impl AwsClient {
         }
         Ok(())
     }
-
+    fn get_tag_value(instance: &aws_sdk_ec2::types::Instance, key: &str) -> Option<String> {
+        instance
+            .tags()
+            .iter()
+            .find(|tag| tag.key().is_some_and(|k| k == key))
+            .and_then(|tag| tag.value().map(|v| v.to_string()))
+    }
     /// Convert an AWS instance into an orchestrator instance (used in the rest
     /// of the codebase).
     fn make_instance(
@@ -103,6 +109,10 @@ impl AwsClient {
         region: String,
         aws_instance: &aws_sdk_ec2::types::Instance,
     ) -> Instance {
+        let role: InstanceRole = Self::get_tag_value(aws_instance, "Role")
+            .expect("AWS instance should have a role")
+            .as_str()
+            .into();
         Instance {
             id: aws_instance
                 .instance_id()
@@ -134,6 +144,7 @@ impl AwsClient {
                     .name()
                     .expect("AWS status should have a name")
             ),
+            role,
         }
     }
 
@@ -242,7 +253,7 @@ impl AwsClient {
         // Request storage details for the instance type specified in the settings.
         let request = client
             .describe_instance_types()
-            .instance_types(self.settings.specs.as_str().into());
+            .instance_types(self.settings.node_specs.as_str().into());
 
         // Send the request.
         let response = request.send().await?;
@@ -263,16 +274,59 @@ impl AwsClient {
 impl ServerProviderClient for AwsClient {
     const USERNAME: &'static str = "ubuntu";
 
-    async fn list_instances(&self) -> CloudProviderResult<Vec<Instance>> {
-        let filter = Filter::builder()
+    async fn list_instances(&self, role: InstanceRole) -> CloudProviderResult<Vec<Instance>> {
+        let filter_name = Filter::builder()
             .name("tag:Name")
             .values(self.settings.testbed_id.clone())
+            .build();
+        let filter_role = Filter::builder()
+            .name("tag:Role")
+            .values(role.to_string())
+            .build();
+        let filter_state = Filter::builder()
+            .name("instance-state-name")
+            .values("pending")
+            .values("running")
+            .values("stopping")
+            .values("stopped")
             .build();
 
         let mut instances = Vec::new();
         for (region, client) in &self.clients {
-            let request = client.describe_instances().filters(filter.clone());
-            for reservation in request.send().await?.reservations() {
+            let request = client.describe_instances().set_filters(Some(vec![
+                filter_name.clone(),
+                filter_role.clone(),
+                filter_state.clone(),
+            ]));
+            let response = request.send().await?;
+            for reservation in response.reservations() {
+                for instance in reservation.instances() {
+                    instances.push(self.make_instance(region.clone(), instance));
+                }
+            }
+        }
+
+        Ok(instances)
+    }
+
+    async fn list_instances_by_region_and_ids(
+        &self,
+        regions_and_ids: Vec<(String, String)>,
+    ) -> CloudProviderResult<Vec<Instance>> {
+        let mut instances = Vec::new();
+        let ids_by_region: HashMap<String, Vec<String>> =
+            regions_and_ids
+                .into_iter()
+                .fold(HashMap::new(), |mut acc, (k, v)| {
+                    acc.entry(k).or_default().push(v);
+                    acc
+                });
+        for (region, client) in &self.clients {
+            let request = client
+                .describe_instances()
+                .set_instance_ids(ids_by_region.get(region).cloned());
+            let response = request.send().await?;
+            for reservation in response.reservations() {
                 for instance in reservation.instances() {
                     instances.push(self.make_instance(region.clone(), instance));
                 }
@@ -328,7 +382,11 @@ impl ServerProviderClient for AwsClient {
         Ok(())
     }
 
-    async fn create_instance<S>(&self, region: S) -> CloudProviderResult<Instance>
+    async fn create_instance<S>(
+        &self,
+        region: S,
+        role: InstanceRole,
+    ) -> CloudProviderResult<Instance>
     where
         S: Into<String> + Serialize + Send,
     {
@@ -350,6 +408,7 @@ impl ServerProviderClient for AwsClient {
         let tags = TagSpecification::builder()
             .resource_type(ResourceType::Instance)
             .tags(Tag::builder().key("Name").value(testbed_id).build())
+            .tags(Tag::builder().key("Role").value(role.to_string()).build())
             .build();
 
         let storage = BlockDeviceMapping::builder()
@@ -362,11 +421,15 @@ impl ServerProviderClient for AwsClient {
                     .build(),
             )
             .build();
-
+        let instance_type = match role {
+            InstanceRole::Node => &self.settings.node_specs,
+            InstanceRole::Metrics => &self.settings.metrics_specs,
+            InstanceRole::Client => &self.settings.client_specs,
+        };
         let request = client
             .run_instances()
             .image_id(image_id)
-            .instance_type(self.settings.specs.as_str().into())
+            .instance_type(instance_type.as_str().into())
             .key_name(testbed_id)
             .min_count(1)
             .max_count(1)
@@ -416,5 +479,11 @@ impl ServerProviderClient for AwsClient {
         } else {
             Ok(Vec::new())
         }
+    }
+    #[cfg(test)]
+    fn instances(&self) -> Vec<Instance> {
+        // Only used under testing by the TestClient, unreachable cause no test
+        // should use AwsClient.
+        unreachable!()
     }
 }

--- a/crates/iota-aws-orchestrator/src/client/aws.rs
+++ b/crates/iota-aws-orchestrator/src/client/aws.rs
@@ -274,7 +274,10 @@ impl AwsClient {
 impl ServerProviderClient for AwsClient {
     const USERNAME: &'static str = "ubuntu";
 
-    async fn list_instances(&self, role: InstanceRole) -> CloudProviderResult<Vec<Instance>> {
+    async fn list_instances_by_role(
+        &self,
+        role: InstanceRole,
+    ) -> CloudProviderResult<Vec<Instance>> {
         let filter_name = Filter::builder()
             .name("tag:Name")
             .values(self.settings.testbed_id.clone())

--- a/crates/iota-aws-orchestrator/src/client/mod.rs
+++ b/crates/iota-aws-orchestrator/src/client/mod.rs
@@ -13,6 +13,29 @@ use super::error::CloudProviderResult;
 
 pub mod aws;
 
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq, Hash)]
+pub enum InstanceRole {
+    Node,
+    Client,
+    Metrics,
+}
+
+impl Display for InstanceRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl From<&str> for InstanceRole {
+    fn from(role: &str) -> Self {
+        match role {
+            "Node" => InstanceRole::Node,
+            "Client" => InstanceRole::Client,
+            "Metrics" => InstanceRole::Metrics,
+            _ => unreachable!(),
+        }
+    }
+}
 /// Represents a cloud provider instance.
 #[derive(Debug, Deserialize, Clone, Eq, PartialEq, Hash)]
 pub struct Instance {
@@ -30,6 +53,8 @@ pub struct Instance {
     pub specs: String,
     /// The current status of the instance.
     pub status: String,
+    // The role of the instance. "Node" | "Client" | "Metrics"
+    pub role: InstanceRole,
 }
 
 impl Instance {
@@ -41,6 +66,11 @@ impl Instance {
     /// Return whether the instance is inactive and not ready for use.
     pub fn is_inactive(&self) -> bool {
         !self.is_active()
+    }
+
+    // Return whether the instance is able to be started
+    pub fn is_stopped(&self) -> bool {
+        self.status.to_lowercase() == "stopped"
     }
 
     /// Return whether the instance is terminated and in the process of being
@@ -64,6 +94,7 @@ impl Instance {
             tags: Default::default(),
             specs: Default::default(),
             status: Default::default(),
+            role: InstanceRole::Node,
         }
     }
 }
@@ -74,7 +105,12 @@ pub trait ServerProviderClient: Display {
     const USERNAME: &'static str;
 
     /// List all existing instances (regardless of their status).
-    async fn list_instances(&self) -> CloudProviderResult<Vec<Instance>>;
+    async fn list_instances(&self, role: InstanceRole) -> CloudProviderResult<Vec<Instance>>;
+
+    async fn list_instances_by_region_and_ids(
+        &self,
+        ids: Vec<(String, String)>,
+    ) -> CloudProviderResult<Vec<Instance>>;
 
     /// Start the specified instances.
     async fn start_instances<'a, I>(&self, instances: I) -> CloudProviderResult<()>
@@ -88,7 +124,11 @@ pub trait ServerProviderClient: Display {
         I: Iterator<Item = &'a Instance> + Send;
 
     /// Create an instance in a specific region.
-    async fn create_instance<S>(&self, region: S) -> CloudProviderResult<Instance>
+    async fn create_instance<S>(
+        &self,
+        region: S,
+        role: InstanceRole,
+    ) -> CloudProviderResult<Instance>
     where
         S: Into<String> + Serialize + Send;
 
@@ -101,6 +141,9 @@ pub trait ServerProviderClient: Display {
 
     /// Return provider-specific commands to setup the instance.
     async fn instance_setup_commands(&self) -> CloudProviderResult<Vec<String>>;
+
+    #[cfg(test)]
+    fn instances(&self) -> Vec<Instance>;
 }
 
 #[cfg(test)]
@@ -109,7 +152,7 @@ pub mod test_client {
 
     use serde::Serialize;
 
-    use super::{Instance, ServerProviderClient};
+    use super::{Instance, InstanceRole, ServerProviderClient};
     use crate::{error::CloudProviderResult, settings::Settings};
 
     pub struct TestClient {
@@ -136,9 +179,21 @@ pub mod test_client {
     impl ServerProviderClient for TestClient {
         const USERNAME: &'static str = "root";
 
-        async fn list_instances(&self) -> CloudProviderResult<Vec<Instance>> {
+        async fn list_instances(&self, _role: InstanceRole) -> CloudProviderResult<Vec<Instance>> {
             let guard = self.instances.lock().unwrap();
             Ok(guard.clone())
+        }
+        async fn list_instances_by_region_and_ids(
+            &self,
+            regions_and_ids: Vec<(String, String)>,
+        ) -> CloudProviderResult<Vec<Instance>> {
+            let guard = self.instances.lock().unwrap();
+            let instances_by_ids = guard
+                .iter()
+                .filter(|x| regions_and_ids.contains(&(x.region.clone(), x.id.clone())))
+                .cloned()
+                .collect::<Vec<_>>();
+            Ok(instances_by_ids)
         }
 
         async fn start_instances<'a, I>(&self, instances: I) -> CloudProviderResult<()>
@@ -165,7 +220,11 @@ pub mod test_client {
             Ok(())
         }
 
-        async fn create_instance<S>(&self, region: S) -> CloudProviderResult<Instance>
+        async fn create_instance<S>(
+            &self,
+            region: S,
+            role: InstanceRole,
+        ) -> CloudProviderResult<Instance>
         where
             S: Into<String> + Serialize + Send,
         {
@@ -177,8 +236,9 @@ pub mod test_client {
                 main_ip: format!("0.0.0.{id}").parse().unwrap(),
                 private_ip: format!("0.0.0.{id}").parse().unwrap(),
                 tags: Vec::new(),
-                specs: self.settings.specs.clone(),
+                specs: self.settings.node_specs.clone(),
                 status: "running".into(),
+                role,
             };
             guard.push(instance.clone());
             Ok(instance)
@@ -196,6 +256,9 @@ pub mod test_client {
 
         async fn instance_setup_commands(&self) -> CloudProviderResult<Vec<String>> {
             Ok(Vec::new())
+        }
+        fn instances(&self) -> Vec<Instance> {
+            self.instances.lock().unwrap().clone()
         }
     }
 }

--- a/crates/iota-aws-orchestrator/src/client/mod.rs
+++ b/crates/iota-aws-orchestrator/src/client/mod.rs
@@ -104,8 +104,12 @@ pub trait ServerProviderClient: Display {
     /// The username used to connect to the instances.
     const USERNAME: &'static str;
 
-    /// List all existing instances (regardless of their status).
-    async fn list_instances(&self, role: InstanceRole) -> CloudProviderResult<Vec<Instance>>;
+    /// List all existing instances (regardless of their status) filtered by
+    /// role.
+    async fn list_instances_by_role(
+        &self,
+        role: InstanceRole,
+    ) -> CloudProviderResult<Vec<Instance>>;
 
     async fn list_instances_by_region_and_ids(
         &self,
@@ -179,7 +183,10 @@ pub mod test_client {
     impl ServerProviderClient for TestClient {
         const USERNAME: &'static str = "root";
 
-        async fn list_instances(&self, _role: InstanceRole) -> CloudProviderResult<Vec<Instance>> {
+        async fn list_instances_by_role(
+            &self,
+            _role: InstanceRole,
+        ) -> CloudProviderResult<Vec<Instance>> {
             let guard = self.instances.lock().unwrap();
             Ok(guard.clone())
         }

--- a/crates/iota-aws-orchestrator/src/error.rs
+++ b/crates/iota-aws-orchestrator/src/error.rs
@@ -106,6 +106,12 @@ pub enum TestbedError {
     #[error("Not enough instances: missing {0} instances")]
     InsufficientCapacity(usize),
 
+    #[error("Metrics instance is missing")]
+    MetricsServerMissing(),
+
+    #[error("Not enough dedicated client instances: missing {0} instances")]
+    InsufficientDedicatedClientCapacity(usize),
+
     #[error(transparent)]
     Monitor(#[from] MonitorError),
 }

--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -156,6 +156,14 @@ pub enum TestbedAction {
         #[arg(long)]
         instances: usize,
 
+        // Skips deployment of a Metrics instance
+        #[arg(long, action, default_value = "false", global = true)]
+        skip_monitoring: bool,
+
+        /// The number of instances running exclusively load generators.
+        #[arg(long, value_name = "INT", default_value = "0", global = true)]
+        dedicated_clients: usize,
+
         /// The region where to deploy the instances. If this parameter is not
         /// specified, the command deploys the specified number of
         /// instances in all regions listed in the setting file.
@@ -169,13 +177,29 @@ pub enum TestbedAction {
         /// Number of instances to deploy.
         #[arg(long, default_value = "200")]
         instances: usize,
+
+        // Skips deployment of a Metrics instance
+        #[arg(long, action, default_value = "false", global = true)]
+        skip_monitoring: bool,
+
+        /// The number of instances running exclusively load generators.
+        #[arg(long, value_name = "INT", default_value = "0", global = true)]
+        dedicated_clients: usize,
     },
 
     /// Stop an existing testbed (without destroying the instances).
-    Stop,
+    Stop {
+        /// Leaves the monitoring instance running
+        #[arg(long, action, default_value = "false", global = true)]
+        leave_monitoring: bool,
+    },
 
     /// Destroy the testbed and terminate all instances.
-    Destroy,
+    Destroy {
+        /// Leaves the monitoring instance running
+        #[arg(long, action, default_value = "false", global = true)]
+        leave_monitoring: bool,
+    },
 }
 
 #[derive(Parser)]
@@ -240,23 +264,35 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
             TestbedAction::Status => testbed.status(),
 
             // Deploy the specified number of instances on the testbed.
-            TestbedAction::Deploy { instances, region } => testbed
-                .deploy(instances, region)
+            TestbedAction::Deploy {
+                instances,
+                dedicated_clients,
+                skip_monitoring,
+                region,
+            } => testbed
+                .deploy(instances, region, skip_monitoring, dedicated_clients)
                 .await
                 .wrap_err("Failed to deploy testbed")?,
 
             // Start the specified number of instances on an existing testbed.
-            TestbedAction::Start { instances } => testbed
-                .start(instances)
+            TestbedAction::Start {
+                instances,
+                skip_monitoring,
+                dedicated_clients,
+            } => testbed
+                .start(instances, dedicated_clients, skip_monitoring)
                 .await
                 .wrap_err("Failed to start testbed")?,
 
             // Stop an existing testbed.
-            TestbedAction::Stop => testbed.stop().await.wrap_err("Failed to stop testbed")?,
+            TestbedAction::Stop { leave_monitoring } => testbed
+                .stop(leave_monitoring)
+                .await
+                .wrap_err("Failed to stop testbed")?,
 
             // Destroy the testbed and terminal all instances.
-            TestbedAction::Destroy => testbed
-                .destroy()
+            TestbedAction::Destroy { leave_monitoring } => testbed
+                .destroy(leave_monitoring)
                 .await
                 .wrap_err("Failed to destroy testbed")?,
         },
@@ -287,7 +323,9 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
                 .with_timeout(timeout)
                 .with_retries(retries);
 
-            let instances = testbed.instances();
+            let node_instances = testbed.node_instances();
+            let client_instances = testbed.client_instances();
+            let metrics_instance = testbed.metrics_instance();
 
             let setup_commands = testbed
                 .setup_commands()
@@ -328,7 +366,9 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
 
             Orchestrator::new(
                 settings,
-                instances,
+                node_instances,
+                client_instances,
+                metrics_instance,
                 setup_commands,
                 protocol_commands,
                 ssh_manager,

--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -189,16 +189,16 @@ pub enum TestbedAction {
 
     /// Stop an existing testbed (without destroying the instances).
     Stop {
-        /// Leaves the monitoring instance running
+        /// Keeps the monitoring instance running
         #[arg(long, action, default_value = "false", global = true)]
-        leave_monitoring: bool,
+        keep_monitoring: bool,
     },
 
     /// Destroy the testbed and terminate all instances.
     Destroy {
-        /// Leaves the monitoring instance running
+        /// Keeps the monitoring instance running
         #[arg(long, action, default_value = "false", global = true)]
-        leave_monitoring: bool,
+        keep_monitoring: bool,
     },
 }
 
@@ -285,14 +285,14 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
                 .wrap_err("Failed to start testbed")?,
 
             // Stop an existing testbed.
-            TestbedAction::Stop { leave_monitoring } => testbed
-                .stop(leave_monitoring)
+            TestbedAction::Stop { keep_monitoring } => testbed
+                .stop(keep_monitoring)
                 .await
                 .wrap_err("Failed to stop testbed")?,
 
             // Destroy the testbed and terminal all instances.
-            TestbedAction::Destroy { leave_monitoring } => testbed
-                .destroy(leave_monitoring)
+            TestbedAction::Destroy { keep_monitoring } => testbed
+                .destroy(keep_monitoring)
                 .await
                 .wrap_err("Failed to destroy testbed")?,
         },

--- a/crates/iota-aws-orchestrator/src/measurement.rs
+++ b/crates/iota-aws-orchestrator/src/measurement.rs
@@ -182,7 +182,7 @@ impl<T: BenchmarkType> MeasurementsCollection<T> {
     /// Create a new (empty) collection of measurements.
     pub fn new(settings: &Settings, parameters: BenchmarkParameters<T>) -> Self {
         Self {
-            machine_specs: settings.specs.clone(),
+            machine_specs: settings.node_specs.clone(),
             commit: settings.repository.commit.clone(),
             parameters,
             scrapers: HashMap::new(),

--- a/crates/iota-aws-orchestrator/src/monitor.rs
+++ b/crates/iota-aws-orchestrator/src/monitor.rs
@@ -93,6 +93,7 @@ impl Prometheus {
     /// The commands to install prometheus.
     pub fn install_commands() -> Vec<&'static str> {
         vec![
+            "sudo apt-get update",
             "sudo apt-get -y install prometheus",
             "sudo chmod 777 -R /var/lib/prometheus/ /etc/prometheus/",
         ]
@@ -115,9 +116,12 @@ impl Prometheus {
         let mut config = vec![Self::global_configuration()];
 
         // Add configurations to scrape the clients.
+        let mut client_ips = vec![];
         let clients_metrics_path = protocol.clients_metrics_path(clients, parameters);
         for (i, (_, clients_metrics_path)) in clients_metrics_path.into_iter().enumerate() {
             let id = format!("client-{i}");
+            let node_ip = clients_metrics_path.split(":").next().unwrap().to_string();
+            client_ips.push(node_ip);
             let scrape_config = Self::scrape_configuration(&id, &clients_metrics_path);
             config.push(scrape_config);
         }
@@ -131,10 +135,19 @@ impl Prometheus {
             let scrape_config = Self::scrape_configuration(&id, &nodes_metrics_path);
             config.push(scrape_config);
         }
+
+        // Add client prometheus exporter to the config only if dedicated clients are
+        // used
+        if !node_ips.contains(client_ips.first().unwrap()) {
+            let prometheus_client_exporter_config =
+                Self::node_exporter_configuration("prometheus_exporter_clients", client_ips, 9100);
+            config.push(prometheus_client_exporter_config);
+        }
         // Add configuration to scrape prometheus exporter metrics
         let prometheus_exporter_config =
             Self::node_exporter_configuration("prometheus_exporter", node_ips, 9100);
         config.push(prometheus_exporter_config);
+
         // Make the command to configure and restart prometheus.
         [
             &format!(

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -14,13 +14,13 @@ use tokio::time::{self, Instant};
 
 use crate::{
     benchmark::{BenchmarkParameters, BenchmarkParametersGenerator, BenchmarkType},
-    client::Instance,
+    client::{Instance, InstanceRole},
     display, ensure,
     error::{TestbedError, TestbedResult},
     faults::CrashRecoverySchedule,
     logs::LogsAnalyzer,
     measurement::{Measurement, MeasurementsCollection},
-    monitor::Monitor,
+    monitor::{Monitor, Prometheus},
     protocol::{ProtocolCommands, ProtocolMetrics},
     settings::Settings,
     ssh::{CommandContext, CommandStatus, SshConnectionManager},
@@ -30,9 +30,12 @@ use crate::{
 pub struct Orchestrator<P, T> {
     /// The testbed's settings.
     settings: Settings,
-    /// The state of the testbed (reflecting accurately the state of the
-    /// machines).
-    instances: Vec<Instance>,
+    /// Node instances
+    node_instances: Vec<Instance>,
+    // Dedicated Client instances
+    client_instances: Option<Vec<Instance>>,
+    // Dedicated Metrics instance
+    metrics_instance: Option<Instance>,
     /// The type of the benchmark parameters.
     benchmark_type: PhantomData<T>,
     /// Provider-specific commands to install on the instance.
@@ -70,14 +73,18 @@ impl<P, T> Orchestrator<P, T> {
     /// Make a new orchestrator.
     pub fn new(
         settings: Settings,
-        instances: Vec<Instance>,
+        node_instances: Vec<Instance>,
+        client_instances: Option<Vec<Instance>>,
+        metrics_instance: Option<Instance>,
         instance_setup_commands: Vec<String>,
         protocol_commands: P,
         ssh_manager: SshConnectionManager,
     ) -> Self {
         Self {
             settings,
-            instances,
+            node_instances,
+            client_instances,
+            metrics_instance,
             benchmark_type: PhantomData,
             instance_setup_commands,
             protocol_commands,
@@ -134,6 +141,18 @@ impl<P, T> Orchestrator<P, T> {
         self
     }
 
+    /// Returns all the instances combined
+    pub fn instances(&self) -> Vec<Instance> {
+        let mut instances = self.node_instances.clone();
+        if let Some(client_instances) = &self.client_instances {
+            instances.extend(client_instances.clone());
+        }
+        if let Some(metrics_instance) = &self.metrics_instance {
+            instances.push(metrics_instance.clone());
+        }
+        instances
+    }
+
     /// Select on which instances of the testbed to run the benchmarks. This
     /// function returns two vector of instances; the first contains the
     /// instances on which to run the load generators and the second
@@ -143,36 +162,63 @@ impl<P, T> Orchestrator<P, T> {
         parameters: &BenchmarkParameters<T>,
     ) -> TestbedResult<(Vec<Instance>, Vec<Instance>, Option<Instance>)> {
         // Ensure there are enough active instances.
-        let available_instances: Vec<_> = self.instances.iter().filter(|x| x.is_active()).collect();
-        let minimum_instances = if self.skip_monitoring {
-            parameters.nodes + self.dedicated_clients
-        } else {
-            parameters.nodes + self.dedicated_clients + 1
-        };
+        let available_nodes: Vec<_> = self
+            .node_instances
+            .iter()
+            .filter(|x| x.is_active())
+            .collect();
         ensure!(
-            available_instances.len() >= minimum_instances,
-            TestbedError::InsufficientCapacity(minimum_instances - available_instances.len())
+            available_nodes.len() >= parameters.nodes,
+            TestbedError::InsufficientCapacity(parameters.nodes - available_nodes.len())
         );
+        let mut available_metrics_node = None;
+        if !self.skip_monitoring {
+            ensure!(
+                self.metrics_instance
+                    .as_ref()
+                    .is_some_and(|m| m.is_active()),
+                TestbedError::MetricsServerMissing()
+            );
+            available_metrics_node = self.metrics_instance.clone();
+        }
+        let mut available_dedicated_client_nodes = vec![];
+        if self.dedicated_clients > 0 {
+            ensure!(
+                self.client_instances.as_ref().is_some_and(|m| m
+                    .iter()
+                    .filter(|x| {
+                        if x.is_active() {
+                            available_dedicated_client_nodes.push(*x);
+                            true
+                        } else {
+                            false
+                        }
+                    })
+                    .count()
+                    >= self.dedicated_clients),
+                TestbedError::InsufficientDedicatedClientCapacity(
+                    self.dedicated_clients - available_dedicated_client_nodes.len()
+                )
+            );
+        }
 
-        // Sort the instances by region.
-        let mut instances_by_regions = HashMap::new();
-        for instance in available_instances {
-            instances_by_regions
+        // Sort the node instances by region.
+        let mut node_instances_by_regions = HashMap::new();
+        for instance in available_nodes {
+            node_instances_by_regions
                 .entry(&instance.region)
                 .or_insert_with(VecDeque::new)
                 .push_back(instance);
         }
 
-        // Select the instance to host the monitoring stack.
-        let mut monitoring_instance = None;
-        if !self.skip_monitoring {
-            for region in &self.settings.regions {
-                if let Some(regional_instances) = instances_by_regions.get_mut(region) {
-                    if let Some(instance) = regional_instances.pop_front() {
-                        monitoring_instance = Some(instance.clone());
-                    }
-                    break;
-                }
+        // Sort dedicated client instances by region.
+        let mut client_instances_by_regions = HashMap::new();
+        if self.dedicated_clients > 0 {
+            for instance in available_dedicated_client_nodes {
+                client_instances_by_regions
+                    .entry(&instance.region)
+                    .or_insert_with(VecDeque::new)
+                    .push_back(instance);
             }
         }
 
@@ -182,7 +228,7 @@ impl<P, T> Orchestrator<P, T> {
             if client_instances.len() == self.dedicated_clients {
                 break;
             }
-            if let Some(regional_instances) = instances_by_regions.get_mut(region) {
+            if let Some(regional_instances) = client_instances_by_regions.get_mut(region) {
                 if let Some(instance) = regional_instances.pop_front() {
                     client_instances.push(instance.clone());
                 }
@@ -195,7 +241,7 @@ impl<P, T> Orchestrator<P, T> {
             if nodes_instances.len() == parameters.nodes {
                 break;
             }
-            if let Some(regional_instances) = instances_by_regions.get_mut(region) {
+            if let Some(regional_instances) = node_instances_by_regions.get_mut(region) {
                 if let Some(instance) = regional_instances.pop_front() {
                     nodes_instances.push(instance.clone());
                 }
@@ -208,7 +254,7 @@ impl<P, T> Orchestrator<P, T> {
             client_instances.clone_from(&nodes_instances);
         }
 
-        Ok((client_instances, nodes_instances, monitoring_instance))
+        Ok((client_instances, nodes_instances, available_metrics_node))
     }
 }
 
@@ -280,16 +326,33 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
 
         let command = [
             &basic_commands[..],
-            &Monitor::dependencies()[..],
+            &Prometheus::install_commands(),
             &cloud_provider_specific_dependencies[..],
             &protocol_dependencies[..],
         ]
         .concat()
         .join(" && ");
 
-        let active = self.instances.iter().filter(|x| x.is_active()).cloned();
         let context = CommandContext::default();
-        self.ssh_manager.execute(active, command, context).await?;
+        let without_metrics = self
+            .instances()
+            .iter()
+            .filter(|i| i.role != InstanceRole::Metrics)
+            .cloned()
+            .collect::<Vec<_>>();
+        self.ssh_manager
+            .execute(without_metrics, command, context.clone())
+            .await?;
+        if !self.skip_monitoring {
+            let metrics_instance = self
+                .metrics_instance
+                .clone()
+                .expect("No metrics instance available");
+            let monitor_command = Monitor::dependencies().join(" && ");
+            self.ssh_manager
+                .execute(vec![metrics_instance], monitor_command, context)
+                .await?;
+        }
 
         display::done();
         Ok(())
@@ -325,30 +388,35 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         // to avoid keeping alive many ssh connections for too long.
         let commit = &self.settings.repository.commit;
         let command = [
-            "git fetch -f",
-            &format!("(git checkout -b {commit} {commit} || git checkout -f {commit})"),
-            "(git pull -f || true)",
-            "source $HOME/.cargo/env",
-            "cargo build --release",
+            &format!("git fetch origin {commit} --force"),
+            &format!("(git reset --hard origin/{commit} || git checkout --force {commit})"),
+            "git clean -fd -e target",
+            "source \"$HOME/.cargo/env\"",
+            "cargo build --release --bin iota --bin iota-node --bin stress",
         ]
         .join(" && ");
 
         display::action(format!("update command: {command}"));
-
-        let active = self.instances.iter().filter(|x| x.is_active()).cloned();
 
         let id = "update";
         let repo_name = self.settings.repository_name();
         let context = CommandContext::new()
             .run_background(id.into())
             .with_execute_from_path(repo_name.into());
+        let without_metrics = self
+            .instances()
+            .iter()
+            .filter(|i| i.role != InstanceRole::Metrics)
+            .cloned()
+            .collect::<Vec<_>>();
+
         self.ssh_manager
-            .execute(active.clone(), command, context)
+            .execute(without_metrics.clone(), command, context)
             .await?;
 
         // Wait until the command finished running.
         self.ssh_manager
-            .wait_for_command(active, id, CommandStatus::Terminated)
+            .wait_for_command(without_metrics, id, CommandStatus::Terminated)
             .await?;
 
         display::done();
@@ -392,7 +460,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         let command = command.join(" ; ");
 
         // Execute the deletion on all machines.
-        let active = self.instances.iter().filter(|x| x.is_active()).cloned();
+        let active = self.instances().into_iter().filter(|x| x.is_active());
         let context = CommandContext::default();
         self.ssh_manager.execute(active, command, context).await?;
 

--- a/crates/iota-aws-orchestrator/src/settings.rs
+++ b/crates/iota-aws-orchestrator/src/settings.rs
@@ -13,7 +13,7 @@ use reqwest::Url;
 use serde::{Deserialize, Deserializer, de::Error};
 
 use crate::{
-    client::Instance,
+    client::{Instance, InstanceRole},
     error::{SettingsError, SettingsResult},
 };
 
@@ -64,12 +64,19 @@ pub struct Settings {
     /// specified. the public key defaults the same path as the private key
     /// with an added extension 'pub'.
     pub ssh_public_key_file: Option<PathBuf>,
-    /// The list of cloud provider regions to deploy the testbed.
+    /// The list of cloud provider regions to deploy on the testbed. If the
+    /// metrics server is used, it will be located in the first region in
+    /// the list.
     pub regions: Vec<String>,
-    /// The specs of the instances to deploy. Those are dependent on the cloud
-    /// provider, e.g., specifying 't3.medium' creates instances with 2 vCPU
-    /// and 4GBo of ram on AWS.
-    pub specs: String,
+    /// The specs of the instances to deploy for nodes. Those are dependent
+    /// on the cloud provider, e.g., specifying 't3.medium' creates
+    /// instances with 2 vCPU and 4GB of ram on AWS.
+    pub node_specs: String,
+    /// The list of cloud provider regions to deploy for clients on the
+    /// testbed.
+    pub client_specs: String,
+    /// Region to deploy the metrics instance.
+    pub metrics_specs: String,
     /// The details of the git reposit to deploy.
     pub repository: Repository,
     /// The working directory on the remote instance (containing all
@@ -164,9 +171,26 @@ impl Settings {
     /// Check whether the input instance matches the criteria described in the
     /// settings.
     pub fn filter_instances(&self, instance: &Instance) -> bool {
-        self.regions.contains(&instance.region)
-            && instance.specs.to_lowercase().replace('.', "")
-                == self.specs.to_lowercase().replace('.', "")
+        match &instance.role {
+            InstanceRole::Node => {
+                self.regions.contains(&instance.region)
+                    && instance.specs.to_lowercase().replace('.', "")
+                        == self.node_specs.to_lowercase().replace('.', "")
+            }
+            InstanceRole::Client => {
+                self.regions.contains(&instance.region)
+                    && instance.specs.to_lowercase().replace('.', "")
+                        == self.client_specs.to_lowercase().replace('.', "")
+            }
+            InstanceRole::Metrics => {
+                self.regions
+                    .first()
+                    .expect("At least one region must be present")
+                    == &instance.region
+                    && instance.specs.to_lowercase().replace('.', "")
+                        == self.metrics_specs.to_lowercase().replace('.', "")
+            }
+        }
     }
 
     /// The number of regions specified in the settings.
@@ -192,7 +216,9 @@ impl Settings {
             ssh_private_key_file: "/path/to/private/key/file".into(),
             ssh_public_key_file: Some(path),
             regions: vec!["London".into(), "New York".into()],
-            specs: "small".into(),
+            node_specs: "small".into(),
+            client_specs: "small".into(),
+            metrics_specs: "small".into(),
             repository: Repository {
                 url: Url::parse("https://example.net/author/repo").unwrap(),
                 commit: "main".into(),

--- a/crates/iota-aws-orchestrator/src/ssh.rs
+++ b/crates/iota-aws-orchestrator/src/ssh.rs
@@ -209,9 +209,35 @@ impl SshConnectionManager {
                 let context = context.clone();
 
                 tokio::spawn(async move {
-                    let connection = ssh_manager.connect(instance.ssh_address()).await?;
-                    // SshConnection::execute is a blocking call, needs to go to blocking pool
-                    connection.execute(context.apply(command)).await
+                    let command_str = command.into();
+                    let mut consecutive_errors = 0;
+                    loop {
+                        match ssh_manager.connect(instance.ssh_address()).await {
+                            Ok(connection) => {
+                                // success resets the error streak
+                                consecutive_errors = 0;
+                                match connection.execute(context.apply(command_str.clone())).await {
+                                    Ok(output) => {
+                                        return Ok(output);
+                                    }
+                                    Err(err) => {
+                                        consecutive_errors += 1;
+                                        if consecutive_errors >= 5 {
+                                            return Err(err);
+                                        }
+                                    }
+                                }
+                            }
+                            Err(err) => {
+                                consecutive_errors += 1;
+                                if consecutive_errors >= 5 {
+                                    return Err(err);
+                                }
+                            }
+                        }
+
+                        sleep(Duration::from_secs(5)).await;
+                    }
                 })
             })
             .collect::<Vec<_>>()
@@ -227,21 +253,33 @@ impl SshConnectionManager {
     where
         I: IntoIterator<Item = Instance> + Clone,
     {
+        let mut consecutive_errors = 0;
         loop {
             sleep(Self::RETRY_DELAY).await;
 
-            let result = self
+            match self
                 .execute(
                     instances.clone(),
                     "(tmux ls || true)",
                     CommandContext::default(),
                 )
-                .await?;
-            if result
-                .iter()
-                .all(|(stdout, _)| CommandStatus::status(command_id, stdout) == status)
+                .await
             {
-                break;
+                Ok(result) => {
+                    consecutive_errors = 0;
+                    if result
+                        .iter()
+                        .all(|(stdout, _)| CommandStatus::status(command_id, stdout) == status)
+                    {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    consecutive_errors += 1;
+                    if consecutive_errors >= 5 {
+                        return Err(e);
+                    }
+                }
             }
         }
         Ok(())

--- a/crates/iota-aws-orchestrator/src/testbed.rs
+++ b/crates/iota-aws-orchestrator/src/testbed.rs
@@ -8,7 +8,7 @@ use futures::future::try_join_all;
 use prettytable::{Table, row};
 use tokio::time::{self, Instant};
 
-use super::client::Instance;
+use super::client::{Instance, InstanceRole};
 use crate::{
     client::ServerProviderClient,
     display,
@@ -23,9 +23,12 @@ pub struct Testbed<C> {
     settings: Settings,
     /// The client interfacing with the cloud provider.
     client: C,
-    /// The state of the testbed (reflecting accurately the state of the
-    /// machines).
-    instances: Vec<Instance>,
+    /// List of Node instances.
+    node_instances: Vec<Instance>,
+    /// List of dedicated Client instances.
+    client_instances: Option<Vec<Instance>>,
+    /// Dedicated Metrics Instance
+    metrics_instance: Option<Instance>,
 }
 
 impl<C: ServerProviderClient> Testbed<C> {
@@ -33,12 +36,20 @@ impl<C: ServerProviderClient> Testbed<C> {
     pub async fn new(settings: Settings, client: C) -> TestbedResult<Self> {
         let public_key = settings.load_ssh_public_key()?;
         client.register_ssh_public_key(public_key).await?;
-        let instances = client.list_instances().await?;
+        let node_instances = client.list_instances(InstanceRole::Node).await?;
+        let client_instances = client.list_instances(InstanceRole::Client).await?;
+        let metrics_instance = client.list_instances(InstanceRole::Metrics).await?;
 
         Ok(Self {
             settings,
             client,
-            instances,
+            node_instances,
+            client_instances: if client_instances.is_empty() {
+                None
+            } else {
+                Some(client_instances)
+            },
+            metrics_instance: metrics_instance.into_iter().next(),
         })
     }
 
@@ -49,11 +60,26 @@ impl<C: ServerProviderClient> Testbed<C> {
 
     /// Return the list of instances of the testbed.
     pub fn instances(&self) -> Vec<Instance> {
-        self.instances
-            .iter()
-            .filter(|x| self.settings.filter_instances(x))
-            .cloned()
-            .collect()
+        let mut instances = self.node_instances.clone();
+        if let Some(instance) = self.metrics_instance.clone() {
+            instances.push(instance);
+        }
+        if let Some(client_instances) = &self.client_instances {
+            instances.extend(client_instances.clone());
+        }
+        instances
+    }
+    /// Return the list of Node instances of the testbed.
+    pub fn node_instances(&self) -> Vec<Instance> {
+        self.node_instances.clone()
+    }
+    /// Return the list of Client instances of the testbed.
+    pub fn client_instances(&self) -> Option<Vec<Instance>> {
+        self.client_instances.clone()
+    }
+    /// Return the Metrics Instance of the testbed.
+    pub fn metrics_instance(&self) -> Option<Instance> {
+        self.metrics_instance.clone()
     }
 
     /// Return the list of provider-specific instance setup commands.
@@ -66,8 +92,8 @@ impl<C: ServerProviderClient> Testbed<C> {
 
     /// Print the current status of the testbed.
     pub fn status(&self) {
-        let filtered = self
-            .instances
+        let instances = self.instances();
+        let filtered = instances
             .iter()
             .filter(|instance| self.settings.filter_instances(instance));
         let sorted: Vec<(_, Vec<_>)> = self
@@ -100,7 +126,8 @@ impl<C: ServerProviderClient> Testbed<C> {
                 let private_key_file = self.settings.ssh_private_key_file.display();
                 let username = C::USERNAME;
                 let ip = instance.main_ip;
-                let connect = format!("ssh -i {private_key_file} {username}@{ip}");
+                let role = instance.role.to_string();
+                let connect = format!("[{role:<7}] ssh -i {private_key_file} {username}@{ip}");
                 if !instance.is_terminated() {
                     if instance.is_active() {
                         table.add_row(row![bFg->format!("{j}"), connect]);
@@ -127,39 +154,104 @@ impl<C: ServerProviderClient> Testbed<C> {
     /// Populate the testbed by creating the specified amount of instances per
     /// region. The total number of instances created is thus the specified
     /// amount x the number of regions.
-    pub async fn deploy(&mut self, quantity: usize, region: Option<String>) -> TestbedResult<()> {
+    pub async fn deploy(
+        &mut self,
+        quantity: usize,
+        region: Option<String>,
+        skip_monitoring: bool,
+        dedicated_clients: usize,
+    ) -> TestbedResult<()> {
         display::action(format!("Deploying instances ({quantity} per region)"));
 
-        let instances = match region {
+        let mut instances = vec![];
+
+        if !skip_monitoring {
+            let metrics_region = match &region {
+                Some(region) => region.clone(),
+                None => self
+                    .settings
+                    .regions
+                    .first()
+                    .expect("At least one region must be present")
+                    .clone(),
+            };
+            let metrics_instance = self
+                .client
+                .create_instance(metrics_region, InstanceRole::Metrics)
+                .await?;
+            instances.push(metrics_instance);
+        }
+
+        let node_instances = match &region {
             Some(x) => {
-                try_join_all((0..quantity).map(|_| self.client.create_instance(x.clone()))).await?
+                try_join_all(
+                    (0..quantity)
+                        .map(|_| self.client.create_instance(x.clone(), InstanceRole::Node)),
+                )
+                .await?
             }
             None => {
                 try_join_all(self.settings.regions.iter().flat_map(|region| {
-                    (0..quantity).map(|_| self.client.create_instance(region.clone()))
+                    (0..quantity).map(|_| {
+                        self.client
+                            .create_instance(region.clone(), InstanceRole::Node)
+                    })
+                }))
+                .await?
+            }
+        };
+        instances.extend(node_instances);
+
+        let client_instances = match (&region, dedicated_clients) {
+            (_, 0) => vec![],
+            (Some(x), _) => {
+                try_join_all(
+                    (0..quantity)
+                        .map(|_| self.client.create_instance(x.clone(), InstanceRole::Client)),
+                )
+                .await?
+            }
+            (None, dedicated_clients) => {
+                try_join_all(self.settings.regions.iter().flat_map(|region| {
+                    (0..dedicated_clients).map(|_| {
+                        self.client
+                            .create_instance(region.clone(), InstanceRole::Client)
+                    })
                 }))
                 .await?
             }
         };
 
+        instances.extend(client_instances);
+
         // Wait until the instances are booted.
         if cfg!(not(test)) {
             self.wait_until_reachable(instances.iter()).await?;
         }
-        self.instances = self.client.list_instances().await?;
+        let node_instances = self.client.list_instances(InstanceRole::Node).await?;
+        let client_instances = self.client.list_instances(InstanceRole::Client).await?;
+        let metrics_instance = self.client.list_instances(InstanceRole::Metrics).await?;
+        self.node_instances = node_instances;
+        self.client_instances = if client_instances.is_empty() {
+            None
+        } else {
+            Some(client_instances)
+        };
+        self.metrics_instance = metrics_instance.into_iter().next();
 
         display::done();
         Ok(())
     }
 
     /// Destroy all instances of the testbed.
-    pub async fn destroy(&mut self) -> TestbedResult<()> {
+    pub async fn destroy(&mut self, leave_monitoring: bool) -> TestbedResult<()> {
         display::action("Destroying testbed");
 
         try_join_all(
-            self.instances
-                .drain(..)
-                .map(|instance| self.client.delete_instance(instance)),
+            self.instances()
+                .iter()
+                .filter(|i| !(leave_monitoring && i.role == InstanceRole::Metrics))
+                .map(|instance| self.client.delete_instance(instance.clone())),
         )
         .await?;
 
@@ -169,22 +261,67 @@ impl<C: ServerProviderClient> Testbed<C> {
 
     /// Start the specified number of instances in each region. Returns an error
     /// if there are not enough available instances.
-    pub async fn start(&mut self, quantity: usize) -> TestbedResult<()> {
+    pub async fn start(
+        &mut self,
+        quantity: usize,
+        dedicated_clients: usize,
+        skip_monitoring: bool,
+    ) -> TestbedResult<()> {
         display::action("Booting instances");
 
         // Gather available instances.
         let mut available = Vec::new();
+
         for region in &self.settings.regions {
+            #[cfg(not(test))]
             available.extend(
-                self.instances
+                self.node_instances
                     .iter()
                     .filter(|x| {
-                        x.is_inactive() && &x.region == region && self.settings.filter_instances(x)
+                        x.is_stopped() && &x.region == region && self.settings.filter_instances(x)
                     })
                     .take(quantity)
                     .cloned()
                     .collect::<Vec<_>>(),
             );
+            #[cfg(test)]
+            available.extend(
+                self.client
+                    .instances()
+                    .iter()
+                    .filter(|i| i.role == InstanceRole::Node)
+                    .filter(|x| {
+                        x.is_stopped() && &x.region == region && self.settings.filter_instances(x)
+                    })
+                    .take(quantity)
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            );
+        }
+        if !skip_monitoring {
+            if let Some(metrics_instance) = &self.metrics_instance {
+                if metrics_instance.is_inactive() {
+                    available.push(metrics_instance.clone());
+                }
+            }
+        }
+        if dedicated_clients > 0 {
+            for region in &self.settings.regions {
+                available.extend(
+                    self.client_instances
+                        .clone()
+                        .unwrap()
+                        .iter()
+                        .filter(|x| {
+                            x.is_inactive()
+                                && &x.region == region
+                                && self.settings.filter_instances(x)
+                        })
+                        .take(dedicated_clients)
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                );
+            }
         }
 
         // Start instances.
@@ -194,26 +331,43 @@ impl<C: ServerProviderClient> Testbed<C> {
         if cfg!(not(test)) {
             self.wait_until_reachable(available.iter()).await?;
         }
-        self.instances = self.client.list_instances().await?;
+        let node_instances = self.client.list_instances(InstanceRole::Node).await?;
+        let client_instances = self.client.list_instances(InstanceRole::Client).await?;
+        let metrics_instance = self.client.list_instances(InstanceRole::Metrics).await?;
+        self.node_instances = node_instances;
+        self.client_instances = if client_instances.is_empty() {
+            None
+        } else {
+            Some(client_instances)
+        };
+        self.metrics_instance = metrics_instance.into_iter().next();
 
         display::done();
         Ok(())
     }
 
     /// Stop all instances of the testbed.
-    pub async fn stop(&mut self) -> TestbedResult<()> {
+    pub async fn stop(&mut self, leave_monitoring: bool) -> TestbedResult<()> {
         display::action("Stopping instances");
 
         // Stop all instances.
         self.client
-            .stop_instances(self.instances.iter().filter(|i| i.is_active()))
+            .stop_instances(self.instances().iter().filter(|i| {
+                i.is_active() && !(i.role == InstanceRole::Metrics && leave_monitoring)
+            }))
             .await?;
 
         // Wait until the instances are stopped.
         loop {
-            let instances = self.client.list_instances().await?;
+            let mut instances = self.client.list_instances(InstanceRole::Node).await?;
+            let client_instances = self.client.list_instances(InstanceRole::Client).await?;
+            instances.extend(client_instances);
+            if !leave_monitoring {
+                let metrics_instance = self.client.list_instances(InstanceRole::Metrics).await?;
+                instances.extend(metrics_instance);
+            }
+
             if instances.iter().all(|x| x.is_inactive()) {
-                self.instances = instances;
                 break;
             }
         }
@@ -227,8 +381,9 @@ impl<C: ServerProviderClient> Testbed<C> {
     where
         I: Iterator<Item = &'a Instance> + Clone,
     {
-        let instances_ids: Vec<_> = instances.map(|x| x.id.clone()).collect();
-
+        let instance_region_and_ids = instances
+            .map(|x| (x.region.clone(), x.id.clone()))
+            .collect::<Vec<_>>();
         let mut interval = time::interval(Duration::from_secs(5));
         interval.tick().await; // The first tick returns immediately.
 
@@ -237,21 +392,21 @@ impl<C: ServerProviderClient> Testbed<C> {
             let now = interval.tick().await;
             let elapsed = now.duration_since(start).as_secs_f64().ceil() as u64;
             display::status(format!("{elapsed}s"));
+            let instances = self
+                .client
+                .list_instances_by_region_and_ids(instance_region_and_ids.clone())
+                .await?;
 
-            let instances = self.client.list_instances().await?;
-            let futures = instances
-                .iter()
-                .filter(|x| instances_ids.contains(&x.id))
-                .map(|instance| {
-                    let private_key_file = self.settings.ssh_private_key_file.clone();
-                    SshConnection::new(
-                        instance.ssh_address(),
-                        C::USERNAME,
-                        private_key_file,
-                        None,
-                        None,
-                    )
-                });
+            let futures = instances.iter().map(|instance| {
+                let private_key_file = self.settings.ssh_private_key_file.clone();
+                SshConnection::new(
+                    instance.ssh_address(),
+                    C::USERNAME,
+                    private_key_file,
+                    None,
+                    None,
+                )
+            });
             if try_join_all(futures).await.is_ok() {
                 break;
             }
@@ -262,7 +417,11 @@ impl<C: ServerProviderClient> Testbed<C> {
 
 #[cfg(test)]
 mod test {
-    use crate::{client::test_client::TestClient, settings::Settings, testbed::Testbed};
+    use crate::{
+        client::{InstanceRole, ServerProviderClient, test_client::TestClient},
+        settings::Settings,
+        testbed::Testbed,
+    };
 
     #[tokio::test]
     async fn deploy() {
@@ -270,13 +429,13 @@ mod test {
         let client = TestClient::new(settings.clone());
         let mut testbed = Testbed::new(settings, client).await.unwrap();
 
-        testbed.deploy(5, None).await.unwrap();
+        testbed.deploy(5, None, true, 0).await.unwrap();
 
         assert_eq!(
-            testbed.instances.len(),
+            testbed.node_instances.len(),
             5 * testbed.settings.number_of_regions()
         );
-        for (i, instance) in testbed.instances.iter().enumerate() {
+        for (i, instance) in testbed.node_instances.iter().enumerate() {
             assert_eq!(i.to_string(), instance.id);
         }
     }
@@ -287,9 +446,9 @@ mod test {
         let client = TestClient::new(settings.clone());
         let mut testbed = Testbed::new(settings, client).await.unwrap();
 
-        testbed.destroy().await.unwrap();
+        testbed.destroy(false).await.unwrap();
 
-        assert_eq!(testbed.instances.len(), 0);
+        assert_eq!(testbed.node_instances.len(), 0);
     }
 
     #[tokio::test]
@@ -297,23 +456,27 @@ mod test {
         let settings = Settings::new_for_test();
         let client = TestClient::new(settings.clone());
         let mut testbed = Testbed::new(settings, client).await.unwrap();
-        testbed.deploy(5, None).await.unwrap();
-        testbed.stop().await.unwrap();
+        testbed.deploy(5, None, true, 0).await.unwrap();
+        testbed.stop(false).await.unwrap();
 
-        let result = testbed.start(2).await;
+        let result = testbed.start(2, 0, false).await;
 
         assert!(result.is_ok());
         for region in &testbed.settings.regions {
             let active = testbed
-                .instances
+                .client
+                .instances()
                 .iter()
+                .filter(|i| i.role == InstanceRole::Node)
                 .filter(|x| x.is_active() && &x.region == region)
                 .count();
             assert_eq!(active, 2);
 
             let inactive = testbed
-                .instances
+                .client
+                .instances()
                 .iter()
+                .filter(|i| i.role == InstanceRole::Node)
                 .filter(|x| x.is_inactive() && &x.region == region)
                 .count();
             assert_eq!(inactive, 3);
@@ -325,11 +488,11 @@ mod test {
         let settings = Settings::new_for_test();
         let client = TestClient::new(settings.clone());
         let mut testbed = Testbed::new(settings, client).await.unwrap();
-        testbed.deploy(5, None).await.unwrap();
-        testbed.start(2).await.unwrap();
+        testbed.deploy(5, None, true, 0).await.unwrap();
+        testbed.start(2, 0, false).await.unwrap();
 
-        testbed.stop().await.unwrap();
+        testbed.stop(false).await.unwrap();
 
-        assert!(testbed.instances.iter().all(|x| x.is_inactive()))
+        assert!(testbed.client.instances().iter().all(|x| x.is_inactive()))
     }
 }

--- a/crates/iota-aws-orchestrator/src/testbed.rs
+++ b/crates/iota-aws-orchestrator/src/testbed.rs
@@ -92,8 +92,8 @@ impl<C: ServerProviderClient> Testbed<C> {
 
     /// Print the current status of the testbed.
     pub fn status(&self) {
-        let instances = self.instances();
-        let filtered = instances
+        let filtered = self
+            .instances()
             .iter()
             .filter(|instance| self.settings.filter_instances(instance));
         let sorted: Vec<(_, Vec<_>)> = self

--- a/crates/iota-aws-orchestrator/src/testbed.rs
+++ b/crates/iota-aws-orchestrator/src/testbed.rs
@@ -36,9 +36,9 @@ impl<C: ServerProviderClient> Testbed<C> {
     pub async fn new(settings: Settings, client: C) -> TestbedResult<Self> {
         let public_key = settings.load_ssh_public_key()?;
         client.register_ssh_public_key(public_key).await?;
-        let node_instances = client.list_instances(InstanceRole::Node).await?;
-        let client_instances = client.list_instances(InstanceRole::Client).await?;
-        let metrics_instance = client.list_instances(InstanceRole::Metrics).await?;
+        let node_instances = client.list_instances_by_role(InstanceRole::Node).await?;
+        let client_instances = client.list_instances_by_role(InstanceRole::Client).await?;
+        let metrics_instance = client.list_instances_by_role(InstanceRole::Metrics).await?;
 
         Ok(Self {
             settings,
@@ -94,7 +94,7 @@ impl<C: ServerProviderClient> Testbed<C> {
     pub fn status(&self) {
         let filtered = self
             .instances()
-            .iter()
+            .into_iter()
             .filter(|instance| self.settings.filter_instances(instance));
         let sorted: Vec<(_, Vec<_>)> = self
             .settings
@@ -206,7 +206,7 @@ impl<C: ServerProviderClient> Testbed<C> {
             (_, 0) => vec![],
             (Some(x), _) => {
                 try_join_all(
-                    (0..quantity)
+                    (0..dedicated_clients)
                         .map(|_| self.client.create_instance(x.clone(), InstanceRole::Client)),
                 )
                 .await?
@@ -228,9 +228,18 @@ impl<C: ServerProviderClient> Testbed<C> {
         if cfg!(not(test)) {
             self.wait_until_reachable(instances.iter()).await?;
         }
-        let node_instances = self.client.list_instances(InstanceRole::Node).await?;
-        let client_instances = self.client.list_instances(InstanceRole::Client).await?;
-        let metrics_instance = self.client.list_instances(InstanceRole::Metrics).await?;
+        let node_instances = self
+            .client
+            .list_instances_by_role(InstanceRole::Node)
+            .await?;
+        let client_instances = self
+            .client
+            .list_instances_by_role(InstanceRole::Client)
+            .await?;
+        let metrics_instance = self
+            .client
+            .list_instances_by_role(InstanceRole::Metrics)
+            .await?;
         self.node_instances = node_instances;
         self.client_instances = if client_instances.is_empty() {
             None
@@ -244,13 +253,13 @@ impl<C: ServerProviderClient> Testbed<C> {
     }
 
     /// Destroy all instances of the testbed.
-    pub async fn destroy(&mut self, leave_monitoring: bool) -> TestbedResult<()> {
+    pub async fn destroy(&mut self, keep_monitoring: bool) -> TestbedResult<()> {
         display::action("Destroying testbed");
 
         try_join_all(
             self.instances()
                 .iter()
-                .filter(|i| !(leave_monitoring && i.role == InstanceRole::Metrics))
+                .filter(|i| !(keep_monitoring && i.role == InstanceRole::Metrics))
                 .map(|instance| self.client.delete_instance(instance.clone())),
         )
         .await?;
@@ -331,9 +340,18 @@ impl<C: ServerProviderClient> Testbed<C> {
         if cfg!(not(test)) {
             self.wait_until_reachable(available.iter()).await?;
         }
-        let node_instances = self.client.list_instances(InstanceRole::Node).await?;
-        let client_instances = self.client.list_instances(InstanceRole::Client).await?;
-        let metrics_instance = self.client.list_instances(InstanceRole::Metrics).await?;
+        let node_instances = self
+            .client
+            .list_instances_by_role(InstanceRole::Node)
+            .await?;
+        let client_instances = self
+            .client
+            .list_instances_by_role(InstanceRole::Client)
+            .await?;
+        let metrics_instance = self
+            .client
+            .list_instances_by_role(InstanceRole::Metrics)
+            .await?;
         self.node_instances = node_instances;
         self.client_instances = if client_instances.is_empty() {
             None
@@ -347,23 +365,34 @@ impl<C: ServerProviderClient> Testbed<C> {
     }
 
     /// Stop all instances of the testbed.
-    pub async fn stop(&mut self, leave_monitoring: bool) -> TestbedResult<()> {
+    pub async fn stop(&mut self, keep_monitoring: bool) -> TestbedResult<()> {
         display::action("Stopping instances");
 
         // Stop all instances.
         self.client
-            .stop_instances(self.instances().iter().filter(|i| {
-                i.is_active() && !(i.role == InstanceRole::Metrics && leave_monitoring)
-            }))
+            .stop_instances(
+                self.instances().iter().filter(|i| {
+                    i.is_active() && !(i.role == InstanceRole::Metrics && keep_monitoring)
+                }),
+            )
             .await?;
 
         // Wait until the instances are stopped.
         loop {
-            let mut instances = self.client.list_instances(InstanceRole::Node).await?;
-            let client_instances = self.client.list_instances(InstanceRole::Client).await?;
+            let mut instances = self
+                .client
+                .list_instances_by_role(InstanceRole::Node)
+                .await?;
+            let client_instances = self
+                .client
+                .list_instances_by_role(InstanceRole::Client)
+                .await?;
             instances.extend(client_instances);
-            if !leave_monitoring {
-                let metrics_instance = self.client.list_instances(InstanceRole::Metrics).await?;
+            if !keep_monitoring {
+                let metrics_instance = self
+                    .client
+                    .list_instances_by_role(InstanceRole::Metrics)
+                    .await?;
                 instances.extend(metrics_instance);
             }
 

--- a/crates/iota-aws-orchestrator/src/testbed.rs
+++ b/crates/iota-aws-orchestrator/src/testbed.rs
@@ -60,12 +60,12 @@ impl<C: ServerProviderClient> Testbed<C> {
 
     /// Return the list of instances of the testbed.
     pub fn instances(&self) -> Vec<Instance> {
-        let mut instances = self.node_instances.clone();
-        if let Some(instance) = self.metrics_instance.clone() {
+        let mut instances = self.node_instances();
+        if let Some(instance) = self.metrics_instance() {
             instances.push(instance);
         }
-        if let Some(client_instances) = &self.client_instances {
-            instances.extend(client_instances.clone());
+        if let Some(client_instances) = self.client_instances() {
+            instances.extend(client_instances);
         }
         instances
     }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -285,7 +285,7 @@ impl DisseminationWorker {
     /// structs in batches. It waits for
     /// TIME_TO_BATCH_CONNECTION_KNOWLEDGE_MSGS, then drain the channel of
     /// messages and disseminate them. With this approach, one acquire locks
-    /// in a predicted way while loosing some reactiveness. Instead of
+    /// in a predicted way while losing some reactiveness. Instead of
     /// potentially 10000 write locks, it could be up to 1 sec /
     /// TIME_TO_BATCH_CONNECTION_KNOWLEDGE_MSGS
     async fn run(mut self) {


### PR DESCRIPTION
# Description of change

Refactor of the `iota-aws-orchestrator` that allows for separate configuration of instance specifications based on their role.
- added `node_specs`, `client_specs` and `metrics_specs` to the settings configuration.
- added `--dedicated-clients N` argument to the `testbed deploy` command, used to deploy `N` dedicated clients per region.
- added `--skip-monitoring` argument to the `testbed deploy` command, used to skip deployment of a dedicated monitoring instance.
- added `--leave-monitoring` argument to the `testbed stop` and `testbed destroy` commands, used to prevent stoppage/destruction of the monitoring instance. 

## Links to any relevant issues

fixes #8975.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
