### PR TITLE
upstream(indexer): align watermarks table schema in live indexer to alt indexer

### DIFF
--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -416,7 +416,7 @@ impl ExecutorCluster {
                     .get_latest_object_snapshot_watermark()
                     .await
                     .unwrap()
-                    .map(|watermark| watermark.cp)
+                    .map(|watermark| watermark.checkpoint_hi_inclusive)
                     .unwrap_or_default();
             }
         })

--- a/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/up.sql
@@ -1,29 +1,34 @@
-CREATE TABLE watermarks
+CREATE TABLE IF NOT EXISTS watermarks
 (
-    -- The table governed by this watermark, i.e `epochs`, `checkpoints`, `transactions`.
-    entity                      TEXT          NOT NULL,
-    -- Inclusive upper epoch bound for this entity's data. Committer updates this field. Pruner uses
-    -- this to determine if pruning is necessary based on the retention policy.
+    -- The pipeline governed by this watermark, i.e `epochs`, `checkpoints`,
+    -- `transactions`.
+    pipeline                    TEXT          PRIMARY KEY,
+    -- Inclusive upper epoch bound for this entity's data. Committer updates
+    -- this field. Pruner uses this to determine if pruning is necessary based
+    -- on the retention policy.
     epoch_hi_inclusive          BIGINT        NOT NULL,
-    -- Inclusive lower epoch bound for this entity's data. Pruner updates this field when the epoch range exceeds the retention policy.
-    epoch_lo                    BIGINT        NOT NULL,
-    -- Inclusive upper checkpoint bound for this entity's data. Committer updates this field. All
-    -- data of this entity in the checkpoint must be persisted before advancing this watermark. The
-    -- committer refers to this on disaster recovery to resume writing.
+    -- Inclusive upper checkpoint bound for this entity's data. Committer
+    -- updates this field. All data of this entity in the checkpoint must be
+    -- persisted before advancing this watermark. The committer refers to this
+    -- on disaster recovery to resume writing.
     checkpoint_hi_inclusive     BIGINT        NOT NULL,
-    -- Inclusive upper transaction sequence number bound for this entity's data. Committer updates
-    -- this field.
-    tx_hi_inclusive             BIGINT        NOT NULL,
-    -- Inclusive low watermark that the pruner advances. Corresponds to the epoch id, checkpoint
-    -- sequence number, or tx sequence number depending on the entity. Data before this watermark is
-    -- considered pruned by a reader. The underlying data may still exist in the db instance.
+    -- Exclusive upper transaction sequence number bound for this entity's
+    -- data. Committer updates this field.
+    tx_hi                       BIGINT        NOT NULL,
+    -- Inclusive lower epoch bound for this entity's data. Pruner updates this
+    -- field when the epoch range exceeds the retention policy.
+    epoch_lo                    BIGINT        NOT NULL,
+    -- Inclusive low watermark that the pruner advances. Corresponds to the
+    -- epoch id, checkpoint sequence number, or tx sequence number depending on
+    -- the entity. Data before this watermark is considered pruned by a reader.
+    -- The underlying data may still exist in the db instance.
     reader_lo                   BIGINT        NOT NULL,
-    -- Updated using the database's current timestamp when the pruner sees that some data needs to
-    -- be dropped. The pruner uses this column to determine whether to prune or wait long enough
-    -- that all in-flight reads complete or timeout before it acts on an updated watermark.
+    -- Updated using the database's current timestamp when the pruner sees that
+    -- some data needs to be dropped. The pruner uses this column to determine
+    -- whether to prune or wait long enough that all in-flight reads complete
+    -- or timeout before it acts on an updated watermark.
     timestamp_ms                BIGINT        NOT NULL,
-    -- Column used by the pruner to track its true progress. Data at and below this watermark can
-    -- be immediately pruned.
-    pruner_hi_inclusive         BIGINT,
-    PRIMARY KEY (entity)
+    -- Column used by the pruner to track its true progress. Data below this
+    -- watermark can be immediately pruned.
+    pruner_hi                   BIGINT        NOT NULL
 );

--- a/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/up.sql
@@ -1,8 +1,7 @@
 CREATE TABLE IF NOT EXISTS watermarks
 (
-    -- The pipeline governed by this watermark, i.e `epochs`, `checkpoints`,
-    -- `transactions`.
-    pipeline                    TEXT          PRIMARY KEY,
+    -- The table governed by this watermark, i.e `epochs`, `checkpoints`, `transactions`.
+    entity                      TEXT          PRIMARY KEY,
     -- Inclusive upper epoch bound for this entity's data. Committer updates
     -- this field. Pruner uses this to determine if pruning is necessary based
     -- on the retention policy.

--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -153,14 +153,21 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
 }
 
 /// The indexer writer operates on checkpoint data, which contains information
-/// on the current epoch, checkpoint, and transaction. These three numbers form
-/// the watermark upper bound for each committed table.The reader and pruner are
-/// responsible for determining which of the three units will be used for a
-/// particular table.
+/// on the current epoch, checkpoint, and transaction.
+///
+/// These three numbers form the watermark upper bound for each committed table.
+/// The reader and pruner are responsible for determining which of the three
+/// units will be used for a particular table.
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub struct CommitterWatermark {
+    /// Highest epoch written for given table. Doesn't mean that data for the
+    /// whole epoch is persisted as it stil may be in progress.
     pub epoch_hi_inclusive: u64,
+    /// Highest checkpoint for which all data is already written for given
+    /// table.
     pub checkpoint_hi_inclusive: u64,
+    /// Exclusive upper transaction sequence number bound for this table's
+    /// data.
     pub tx_hi: u64,
 }
 impl From<&IndexedCheckpoint> for CommitterWatermark {

--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -85,7 +85,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
         let mut next_cp_to_process = self
             .get_watermark_hi()
             .await?
-            .map(|watermark| watermark.cp.saturating_add(1))
+            .map(|watermark| watermark.checkpoint_hi_inclusive.saturating_add(1))
             .unwrap_or_default();
 
         loop {
@@ -108,7 +108,8 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
                             return Ok(());
                         }
                         for (watermark, data) in tuple_chunk {
-                            unprocessed.insert(watermark.cp, (watermark, data));
+                            unprocessed
+                                .insert(watermark.checkpoint_hi_inclusive, (watermark, data));
                         }
                     }
                     Some(None) => break, // Stream has ended
@@ -158,28 +159,25 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
 /// particular table.
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub struct CommitterWatermark {
-    pub epoch: u64,
-    pub cp: u64,
-    pub tx: u64,
+    pub epoch_hi_inclusive: u64,
+    pub checkpoint_hi_inclusive: u64,
+    pub tx_hi: u64,
 }
 impl From<&IndexedCheckpoint> for CommitterWatermark {
     fn from(checkpoint: &IndexedCheckpoint) -> Self {
         Self {
-            epoch: checkpoint.epoch,
-            cp: checkpoint.sequence_number,
-            tx: checkpoint.network_total_transactions.saturating_sub(1),
+            epoch_hi_inclusive: checkpoint.epoch,
+            checkpoint_hi_inclusive: checkpoint.sequence_number,
+            tx_hi: checkpoint.network_total_transactions,
         }
     }
 }
 impl From<&CheckpointData> for CommitterWatermark {
     fn from(checkpoint: &CheckpointData) -> Self {
         Self {
-            epoch: checkpoint.checkpoint_summary.epoch,
-            cp: checkpoint.checkpoint_summary.sequence_number,
-            tx: checkpoint
-                .checkpoint_summary
-                .network_total_transactions
-                .saturating_sub(1),
+            epoch_hi_inclusive: checkpoint.checkpoint_summary.epoch,
+            checkpoint_hi_inclusive: checkpoint.checkpoint_summary.sequence_number,
+            tx_hi: checkpoint.checkpoint_summary.network_total_transactions,
         }
     }
 }

--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
 use iota_rest_api::CheckpointData;
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -33,7 +34,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
     async fn persist(&self, batch: Vec<T>) -> IndexerResult<()>;
 
     /// Reads high watermark of the table DB.
-    async fn get_watermark_hi(&self) -> IndexerResult<Option<CommitterWatermark>>;
+    async fn get_watermark_hi(&self) -> IndexerResult<Option<CheckpointSequenceNumber>>;
 
     /// Sets high watermark of the table DB, also update metrics.
     async fn set_watermark_hi(&self, watermark_hi: CommitterWatermark) -> IndexerResult<()>;
@@ -85,7 +86,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
         let mut next_cp_to_process = self
             .get_watermark_hi()
             .await?
-            .map(|watermark| watermark.checkpoint_hi_inclusive.saturating_add(1))
+            .map(|watermark| watermark.saturating_add(1))
             .unwrap_or_default();
 
         loop {
@@ -161,7 +162,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub struct CommitterWatermark {
     /// Highest epoch written for given table. Doesn't mean that data for the
-    /// whole epoch is persisted as it stil may be in progress.
+    /// whole epoch is persisted as it still may be in progress.
     pub epoch_hi_inclusive: u64,
     /// Highest checkpoint for which all data is already written for given
     /// table.

--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -264,21 +264,22 @@ impl PrimaryWriter {
             elapsed,
             "Checkpoint {}-{} committed with {} transactions.",
             first_checkpoint_seq,
-            committer_watermark.cp,
+            committer_watermark.checkpoint_hi_inclusive,
             tx_count,
         );
         self.metrics
             .latest_tx_checkpoint_sequence_number
-            .set(committer_watermark.cp as i64);
+            .set(committer_watermark.checkpoint_hi_inclusive as i64);
         self.metrics
             .total_tx_checkpoint_committed
             .inc_by(checkpoint_num as u64);
         self.metrics
             .total_transaction_committed
             .inc_by(tx_count as u64);
-        self.metrics
-            .transaction_per_checkpoint
-            .observe(tx_count as f64 / (committer_watermark.cp - first_checkpoint_seq + 1) as f64);
+        self.metrics.transaction_per_checkpoint.observe(
+            tx_count as f64
+                / (committer_watermark.checkpoint_hi_inclusive - first_checkpoint_seq + 1) as f64,
+        );
         // 1000.0 is not necessarily the batch size, it's to roughly map average tx
         // commit latency to [0.1, 1] seconds, which is well covered by
         // DB_COMMIT_LATENCY_SEC_BUCKETS.

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -48,11 +48,7 @@ impl SnapshotPipelineBuilder {
         cancel: CancellationToken,
     ) -> IndexerResult<SnapshotPipelineBuilder> {
         let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone(), lag_config);
-        let watermark = writer
-            .get_watermark_hi()
-            .await?
-            .map(|w| w.checkpoint_hi_inclusive)
-            .unwrap_or_default();
+        let watermark = writer.get_watermark_hi().await?.unwrap_or_default();
         Ok(SnapshotPipelineBuilder {
             writer,
             checkpoint_download_queue_size,

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -51,7 +51,7 @@ impl SnapshotPipelineBuilder {
         let watermark = writer
             .get_watermark_hi()
             .await?
-            .map(|w| w.cp)
+            .map(|w| w.checkpoint_hi_inclusive)
             .unwrap_or_default();
         Ok(SnapshotPipelineBuilder {
             writer,

--- a/crates/iota-indexer/src/ingestion/snapshot/persist.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/persist.rs
@@ -62,7 +62,7 @@ impl Writer<TransactionObjectChangesToCommit> for ObjectSnapshotWriter {
             .await?;
         self.metrics
             .latest_object_snapshot_sequence_number
-            .set(watermark.cp as i64);
+            .set(watermark.checkpoint_hi_inclusive as i64);
         Ok(())
     }
 

--- a/crates/iota-indexer/src/ingestion/snapshot/persist.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/persist.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 
 use crate::{
     config::SnapshotLagConfig,
@@ -52,8 +53,10 @@ impl Writer<TransactionObjectChangesToCommit> for ObjectSnapshotWriter {
         Ok(())
     }
 
-    async fn get_watermark_hi(&self) -> IndexerResult<Option<CommitterWatermark>> {
-        self.store.get_latest_object_snapshot_watermark().await
+    async fn get_watermark_hi(&self) -> IndexerResult<Option<CheckpointSequenceNumber>> {
+        self.store
+            .get_latest_object_snapshot_checkpoint_sequence_number()
+            .await
     }
 
     async fn set_watermark_hi(&self, watermark: CommitterWatermark) -> IndexerResult<()> {

--- a/crates/iota-indexer/src/models/watermarks.rs
+++ b/crates/iota-indexer/src/models/watermarks.rs
@@ -18,22 +18,22 @@ use crate::{
 pub struct StoredWatermark {
     /// The table governed by this watermark, i.e `epochs`, `checkpoints`,
     /// `transactions`.
-    pub entity: String,
+    pub pipeline: String,
     /// Inclusive upper epoch bound for this entity's data. Committer updates
     /// this field. Pruner uses this to determine if pruning is necessary
     /// based on the retention policy.
     pub epoch_hi_inclusive: i64,
-    /// Inclusive lower epoch bound for this entity's data. Pruner updates this
-    /// field when the epoch range exceeds the retention policy.
-    pub epoch_lo: i64,
     /// Inclusive upper checkpoint bound for this entity's data. Committer
     /// updates this field. All data of this entity in the checkpoint must
     /// be persisted before advancing this watermark. The committer refers
     /// to this on disaster recovery to resume writing.
     pub checkpoint_hi_inclusive: i64,
-    /// Inclusive upper transaction sequence number bound for this entity's
+    /// Exclusive upper transaction sequence number bound for this entity's
     /// data. Committer updates this field.
-    pub tx_hi_inclusive: i64,
+    pub tx_hi: i64,
+    /// Inclusive lower epoch bound for this entity's data. Pruner updates this
+    /// field when the epoch range exceeds the retention policy.
+    pub epoch_lo: i64,
     /// Inclusive low watermark that the pruner advances. Corresponds to the
     /// epoch id, checkpoint sequence number, or tx sequence number
     /// depending on the entity. Data before this watermark is considered
@@ -45,25 +45,25 @@ pub struct StoredWatermark {
     /// determine whether to prune or wait long enough that all in-flight
     /// reads complete or timeout before it acts on an updated watermark.
     pub timestamp_ms: i64,
-    /// Column used by the pruner to track its true progress. Data at and below
-    /// this watermark can be immediately pruned.
-    pub pruner_hi_inclusive: Option<i64>,
+    /// Column used by the pruner to track its true progress. Data below this
+    /// watermark can be immediately pruned.
+    pub pruner_hi: i64,
 }
 
 impl StoredWatermark {
     pub fn from_upper_bound_update(entity: &str, watermark: CommitterWatermark) -> Self {
         StoredWatermark {
-            entity: entity.to_string(),
-            epoch_hi_inclusive: watermark.epoch as i64,
-            checkpoint_hi_inclusive: watermark.cp as i64,
-            tx_hi_inclusive: watermark.tx as i64,
+            pipeline: entity.to_string(),
+            epoch_hi_inclusive: watermark.epoch_hi_inclusive as i64,
+            checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive as i64,
+            tx_hi: watermark.tx_hi as i64,
             ..StoredWatermark::default()
         }
     }
 
     pub fn from_lower_bound_update(entity: &str, epoch_lo: u64, reader_lo: u64) -> Self {
         StoredWatermark {
-            entity: entity.to_string(),
+            pipeline: entity.to_string(),
             epoch_lo: epoch_lo as i64,
             reader_lo: reader_lo as i64,
             ..StoredWatermark::default()
@@ -71,7 +71,7 @@ impl StoredWatermark {
     }
 
     pub fn entity(&self) -> Option<PrunableTable> {
-        PrunableTable::from_str(&self.entity).ok()
+        PrunableTable::from_str(&self.pipeline).ok()
     }
 
     /// Determine whether to set a new epoch lower bound based on the retention

--- a/crates/iota-indexer/src/models/watermarks.rs
+++ b/crates/iota-indexer/src/models/watermarks.rs
@@ -18,7 +18,7 @@ use crate::{
 pub struct StoredWatermark {
     /// The table governed by this watermark, i.e `epochs`, `checkpoints`,
     /// `transactions`.
-    pub pipeline: String,
+    pub entity: String,
     /// Inclusive upper epoch bound for this entity's data. Committer updates
     /// this field. Pruner uses this to determine if pruning is necessary
     /// based on the retention policy.
@@ -53,7 +53,7 @@ pub struct StoredWatermark {
 impl StoredWatermark {
     pub fn from_upper_bound_update(entity: &str, watermark: CommitterWatermark) -> Self {
         StoredWatermark {
-            pipeline: entity.to_string(),
+            entity: entity.to_string(),
             epoch_hi_inclusive: watermark.epoch_hi_inclusive as i64,
             checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive as i64,
             tx_hi: watermark.tx_hi as i64,
@@ -63,7 +63,7 @@ impl StoredWatermark {
 
     pub fn from_lower_bound_update(entity: &str, epoch_lo: u64, reader_lo: u64) -> Self {
         StoredWatermark {
-            pipeline: entity.to_string(),
+            entity: entity.to_string(),
             epoch_lo: epoch_lo as i64,
             reader_lo: reader_lo as i64,
             ..StoredWatermark::default()
@@ -71,7 +71,7 @@ impl StoredWatermark {
     }
 
     pub fn entity(&self) -> Option<PrunableTable> {
-        PrunableTable::from_str(&self.pipeline).ok()
+        PrunableTable::from_str(&self.entity).ok()
     }
 
     /// Determine whether to set a new epoch lower bound based on the retention

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -442,15 +442,15 @@ diesel::table! {
 }
 
 diesel::table! {
-    watermarks (entity) {
-        entity -> Text,
+    watermarks (pipeline) {
+        pipeline -> Text,
         epoch_hi_inclusive -> Int8,
-        epoch_lo -> Int8,
         checkpoint_hi_inclusive -> Int8,
-        tx_hi_inclusive -> Int8,
+        tx_hi -> Int8,
+        epoch_lo -> Int8,
         reader_lo -> Int8,
         timestamp_ms -> Int8,
-        pruner_hi_inclusive -> Nullable<Int8>,
+        pruner_hi -> Int8,
     }
 }
 

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -442,8 +442,8 @@ diesel::table! {
 }
 
 diesel::table! {
-    watermarks (pipeline) {
-        pipeline -> Text,
+    watermarks (entity) {
+        entity -> Text,
         epoch_hi_inclusive -> Int8,
         checkpoint_hi_inclusive -> Int8,
         tx_hi -> Int8,

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -38,6 +38,10 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         &self,
     ) -> Result<Option<CommitterWatermark>, IndexerError>;
 
+    async fn get_latest_object_snapshot_checkpoint_sequence_number(
+        &self,
+    ) -> Result<Option<u64>, IndexerError>;
+
     async fn get_chain_identifier(&self) -> Result<Option<Vec<u8>>, IndexerError>;
 
     fn persist_protocol_configs_and_feature_flags(

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -405,10 +405,10 @@ impl PgIndexerStore {
                 .select((
                     watermarks::epoch_hi_inclusive,
                     watermarks::checkpoint_hi_inclusive,
-                    watermarks::tx_hi_inclusive,
+                    watermarks::tx_hi,
                 ))
                 .filter(
-                    watermarks::entity
+                    watermarks::pipeline
                         .eq(ObjectsSnapshotHandlerTables::ObjectsSnapshot.to_string()),
                 )
                 .first::<(i64, i64, i64)>(conn)
@@ -416,9 +416,9 @@ impl PgIndexerStore {
                 .optional()
                 .map(|v| {
                     v.map(|(epoch, cp, tx)| CommitterWatermark {
-                        epoch: epoch as u64,
-                        cp: cp as u64,
-                        tx: tx as u64,
+                        epoch_hi_inclusive: epoch as u64,
+                        checkpoint_hi_inclusive: cp as u64,
+                        tx_hi: tx as u64,
                     })
                 })
         })
@@ -1590,13 +1590,13 @@ impl PgIndexerStore {
             |conn| {
                 diesel::insert_into(watermarks::table)
                     .values(&upper_bound_updates)
-                    .on_conflict(watermarks::entity)
+                    .on_conflict(watermarks::pipeline)
                     .do_update()
                     .set((
                         watermarks::epoch_hi_inclusive.eq(excluded(watermarks::epoch_hi_inclusive)),
                         watermarks::checkpoint_hi_inclusive
                             .eq(excluded(watermarks::checkpoint_hi_inclusive)),
-                        watermarks::tx_hi_inclusive.eq(excluded(watermarks::tx_hi_inclusive)),
+                        watermarks::tx_hi.eq(excluded(watermarks::tx_hi)),
                     ))
                     .execute(conn)
                     .map_err(IndexerError::from)
@@ -1671,7 +1671,7 @@ impl PgIndexerStore {
             |conn| {
                 diesel::insert_into(watermarks::table)
                     .values(&lower_bound_updates)
-                    .on_conflict(watermarks::entity)
+                    .on_conflict(watermarks::pipeline)
                     .do_update()
                     .set((
                         watermarks::reader_lo.eq(excluded(watermarks::reader_lo)),

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -20,6 +20,7 @@ use iota_protocol_config::ProtocolConfig;
 use iota_types::{
     base_types::ObjectID,
     digests::{ChainIdentifier, CheckpointDigest},
+    messages_checkpoint::CheckpointSequenceNumber,
 };
 use itertools::Itertools;
 use strum::IntoEnumIterator;
@@ -423,6 +424,18 @@ impl PgIndexerStore {
                 })
         })
         .context("Failed reading latest object snapshot watermark from PostgresDB")
+    }
+
+    fn get_latest_object_snapshot_checkpoint_sequence_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>, IndexerError> {
+        read_only_blocking!(&self.blocking_cp, |conn| {
+            objects_snapshot::table
+                .select(max(objects_snapshot::checkpoint_sequence_number))
+                .first::<Option<i64>>(conn)
+                .map(|v| v.map(|v| v as CheckpointSequenceNumber))
+        })
+        .context("Failed reading latest object snapshot checkpoint sequence number from PostgresDB")
     }
 
     fn persist_display_updates(
@@ -1796,6 +1809,15 @@ impl IndexerStore for PgIndexerStore {
     ) -> Result<Option<CommitterWatermark>, IndexerError> {
         self.execute_in_blocking_worker(|this| this.get_latest_object_snapshot_watermark())
             .await
+    }
+
+    async fn get_latest_object_snapshot_checkpoint_sequence_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>, IndexerError> {
+        self.execute_in_blocking_worker(|this| {
+            this.get_latest_object_snapshot_checkpoint_sequence_number()
+        })
+        .await
     }
 
     fn persist_objects_in_existing_transaction(

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -408,7 +408,7 @@ impl PgIndexerStore {
                     watermarks::tx_hi,
                 ))
                 .filter(
-                    watermarks::pipeline
+                    watermarks::entity
                         .eq(ObjectsSnapshotHandlerTables::ObjectsSnapshot.to_string()),
                 )
                 .first::<(i64, i64, i64)>(conn)
@@ -1590,7 +1590,7 @@ impl PgIndexerStore {
             |conn| {
                 diesel::insert_into(watermarks::table)
                     .values(&upper_bound_updates)
-                    .on_conflict(watermarks::pipeline)
+                    .on_conflict(watermarks::entity)
                     .do_update()
                     .set((
                         watermarks::epoch_hi_inclusive.eq(excluded(watermarks::epoch_hi_inclusive)),
@@ -1671,7 +1671,7 @@ impl PgIndexerStore {
             |conn| {
                 diesel::insert_into(watermarks::table)
                     .values(&lower_bound_updates)
-                    .on_conflict(watermarks::pipeline)
+                    .on_conflict(watermarks::entity)
                     .do_update()
                     .set((
                         watermarks::reader_lo.eq(excluded(watermarks::reader_lo)),

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -498,7 +498,7 @@ pub async fn wait_for_objects_snapshot(
                 .get_latest_object_snapshot_watermark()
                 .await
                 .unwrap()
-                .map(|watermark| watermark.cp);
+                .map(|watermark| watermark.checkpoint_hi_inclusive);
             cp_opt.is_none() || (cp_opt.unwrap() < checkpoint_sequence_number)
         } {
             tokio::time::sleep(Duration::from_millis(100)).await;


### PR DESCRIPTION
# Description of change

Original description:


> Since watermarks table isn't being written to yet, modify the db schema to match alt-indexer. The changes are to rename entity -> pipeline, tx_hi_inclusive -> tx_hi, and pruner_hi_inclusive -> pruner_hi and make it a non-null column. This works out nicely for graphql, since the transactions query implementations expect a half-open interval. Also simplifies pruner logic, since it can write the reader_lo as pruner_hi after delay, and table pruners will delete between [table_data, pruner_hi).


## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9122

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
