### PR TITLE
upstream(indexer): committers should read watermark hi directly from table

### DIFF
--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -33,7 +33,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
     async fn persist(&self, batch: Vec<T>) -> IndexerResult<()>;
 
     /// Reads high watermark of the table DB.
-    async fn get_watermark_hi(&self) -> IndexerResult<Option<CommitterWatermark>>;
+    async fn get_watermark_hi(&self) -> IndexerResult<Option<u64>>;
 
     /// Sets high watermark of the table DB, also update metrics.
     async fn set_watermark_hi(&self, watermark_hi: CommitterWatermark) -> IndexerResult<()>;
@@ -85,7 +85,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
         let mut next_cp_to_process = self
             .get_watermark_hi()
             .await?
-            .map(|watermark| watermark.checkpoint_hi_inclusive.saturating_add(1))
+            .map(|watermark| watermark.saturating_add(1))
             .unwrap_or_default();
 
         loop {

--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -162,7 +162,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub struct CommitterWatermark {
     /// Highest epoch written for given table. Doesn't mean that data for the
-    /// whole epoch is persisted as it stil may be in progress.
+    /// whole epoch is persisted as it still may be in progress.
     pub epoch_hi_inclusive: u64,
     /// Highest checkpoint for which all data is already written for given
     /// table.

--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
 use iota_rest_api::CheckpointData;
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -33,7 +34,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
     async fn persist(&self, batch: Vec<T>) -> IndexerResult<()>;
 
     /// Reads high watermark of the table DB.
-    async fn get_watermark_hi(&self) -> IndexerResult<Option<u64>>;
+    async fn get_watermark_hi(&self) -> IndexerResult<Option<CheckpointSequenceNumber>>;
 
     /// Sets high watermark of the table DB, also update metrics.
     async fn set_watermark_hi(&self, watermark_hi: CommitterWatermark) -> IndexerResult<()>;

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -48,11 +48,7 @@ impl SnapshotPipelineBuilder {
         cancel: CancellationToken,
     ) -> IndexerResult<SnapshotPipelineBuilder> {
         let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone(), lag_config);
-        let watermark = writer
-            .get_watermark_hi()
-            .await?
-            .map(|w| w.checkpoint_hi_inclusive)
-            .unwrap_or_default();
+        let watermark = writer.get_watermark_hi().await?.unwrap_or_default();
         Ok(SnapshotPipelineBuilder {
             writer,
             checkpoint_download_queue_size,

--- a/crates/iota-indexer/src/ingestion/snapshot/persist.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/persist.rs
@@ -52,8 +52,10 @@ impl Writer<TransactionObjectChangesToCommit> for ObjectSnapshotWriter {
         Ok(())
     }
 
-    async fn get_watermark_hi(&self) -> IndexerResult<Option<CommitterWatermark>> {
-        self.store.get_latest_object_snapshot_watermark().await
+    async fn get_watermark_hi(&self) -> IndexerResult<Option<u64>> {
+        self.store
+            .get_latest_object_snapshot_checkpoint_sequence_number()
+            .await
     }
 
     async fn set_watermark_hi(&self, watermark: CommitterWatermark) -> IndexerResult<()> {

--- a/crates/iota-indexer/src/ingestion/snapshot/persist.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/persist.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 
 use crate::{
     config::SnapshotLagConfig,
@@ -52,7 +53,7 @@ impl Writer<TransactionObjectChangesToCommit> for ObjectSnapshotWriter {
         Ok(())
     }
 
-    async fn get_watermark_hi(&self) -> IndexerResult<Option<u64>> {
+    async fn get_watermark_hi(&self) -> IndexerResult<Option<CheckpointSequenceNumber>> {
         self.store
             .get_latest_object_snapshot_checkpoint_sequence_number()
             .await

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -38,6 +38,10 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         &self,
     ) -> Result<Option<CommitterWatermark>, IndexerError>;
 
+    async fn get_latest_object_snapshot_checkpoint_sequence_number(
+        &self,
+    ) -> Result<Option<u64>, IndexerError>;
+
     async fn get_chain_identifier(&self) -> Result<Option<Vec<u8>>, IndexerError>;
 
     fn persist_protocol_configs_and_feature_flags(

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -425,6 +425,18 @@ impl PgIndexerStore {
         .context("Failed reading latest object snapshot watermark from PostgresDB")
     }
 
+    fn get_latest_object_snapshot_checkpoint_sequence_number(
+        &self,
+    ) -> Result<Option<u64>, IndexerError> {
+        read_only_blocking!(&self.blocking_cp, |conn| {
+            objects_snapshot::table
+                .select(max(objects_snapshot::checkpoint_sequence_number))
+                .first::<Option<i64>>(conn)
+                .map(|v| v.map(|v| v as u64))
+        })
+        .context("Failed reading latest object snapshot checkpoint sequence number from PostgresDB")
+    }
+
     fn persist_display_updates(
         &self,
         display_updates: BTreeMap<String, StoredDisplay>,
@@ -1796,6 +1808,15 @@ impl IndexerStore for PgIndexerStore {
     ) -> Result<Option<CommitterWatermark>, IndexerError> {
         self.execute_in_blocking_worker(|this| this.get_latest_object_snapshot_watermark())
             .await
+    }
+
+    async fn get_latest_object_snapshot_checkpoint_sequence_number(
+        &self,
+    ) -> Result<Option<u64>, IndexerError> {
+        self.execute_in_blocking_worker(|this| {
+            this.get_latest_object_snapshot_checkpoint_sequence_number()
+        })
+        .await
     }
 
     fn persist_objects_in_existing_transaction(

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -20,6 +20,7 @@ use iota_protocol_config::ProtocolConfig;
 use iota_types::{
     base_types::ObjectID,
     digests::{ChainIdentifier, CheckpointDigest},
+    messages_checkpoint::CheckpointSequenceNumber,
 };
 use itertools::Itertools;
 use strum::IntoEnumIterator;
@@ -427,12 +428,12 @@ impl PgIndexerStore {
 
     fn get_latest_object_snapshot_checkpoint_sequence_number(
         &self,
-    ) -> Result<Option<u64>, IndexerError> {
+    ) -> Result<Option<CheckpointSequenceNumber>, IndexerError> {
         read_only_blocking!(&self.blocking_cp, |conn| {
             objects_snapshot::table
                 .select(max(objects_snapshot::checkpoint_sequence_number))
                 .first::<Option<i64>>(conn)
-                .map(|v| v.map(|v| v as u64))
+                .map(|v| v.map(|v| v as CheckpointSequenceNumber))
         })
         .context("Failed reading latest object snapshot checkpoint sequence number from PostgresDB")
     }
@@ -1812,7 +1813,7 @@ impl IndexerStore for PgIndexerStore {
 
     async fn get_latest_object_snapshot_checkpoint_sequence_number(
         &self,
-    ) -> Result<Option<u64>, IndexerError> {
+    ) -> Result<Option<CheckpointSequenceNumber>, IndexerError> {
         self.execute_in_blocking_worker(|this| {
             this.get_latest_object_snapshot_checkpoint_sequence_number()
         })


### PR DESCRIPTION
# Description of change

committers should read watermark hi directly from table

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9123

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

