### PR TITLE
refactor(consensus): speedup flushing and getting serialized transactions and headers in Dag State

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -24,6 +24,7 @@ use crate::{
     core::{Core, CoreSignals},
     core_thread::{ChannelCoreThreadDispatcher, CoreThreadHandle},
     dag_state::DagState,
+    header_synchronizer::{HeaderSynchronizer, HeaderSynchronizerHandle},
     leader_schedule::LeaderSchedule,
     leader_timeout::{LeaderTimeoutTask, LeaderTimeoutTaskHandle},
     metrics::initialise_metrics,
@@ -31,7 +32,6 @@ use crate::{
     shard_reconstructor::{ShardReconstructor, ShardReconstructorHandle},
     storage::rocksdb_store::RocksDBStore,
     subscriber::Subscriber,
-    synchronizer::{Synchronizer, SynchronizerHandle},
     transaction::{TransactionClient, TransactionConsumer, TransactionVerifier},
     transactions_synchronizer::{TransactionsSynchronizer, TransactionsSynchronizerHandle},
 };
@@ -40,7 +40,7 @@ pub struct ConsensusAuthority {
     context: Arc<Context>,
     start_time: Instant,
     transaction_client: Arc<TransactionClient>,
-    synchronizer: Arc<SynchronizerHandle>,
+    header_synchronizer: Arc<HeaderSynchronizerHandle>,
     transactions_synchronizer: Arc<TransactionsSynchronizerHandle>,
     commit_consumer_monitor: Arc<CommitConsumerMonitor>,
     shard_reconstructor: Arc<ShardReconstructorHandle>,
@@ -197,7 +197,7 @@ impl ConsensusAuthority {
 
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
@@ -224,7 +224,7 @@ impl ConsensusAuthority {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer.clone(),
+            header_synchronizer.clone(),
             transactions_synchronizer.clone(),
             core_dispatcher,
             signals_receivers.block_broadcast_receiver(),
@@ -257,7 +257,7 @@ impl ConsensusAuthority {
             context,
             start_time,
             transaction_client: Arc::new(tx_client),
-            synchronizer,
+            header_synchronizer,
             shard_reconstructor,
             cordial_knowledge,
             transactions_synchronizer,
@@ -279,7 +279,7 @@ impl ConsensusAuthority {
         );
 
         // First shutdown components calling into Core.
-        if let Err(e) = self.synchronizer.stop().await {
+        if let Err(e) = self.header_synchronizer.stop().await {
             if e.is_panic() {
                 std::panic::resume_unwind(e.into_panic());
             }

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -572,11 +572,11 @@ mod tests {
                     if let Ok(Some(committed_subdag)) =
                         tokio::time::timeout(remaining, receiver.recv()).await
                     {
-                        for block in &committed_subdag.blocks {
-                            if block.round() > GENESIS_ROUND {
-                                let author_index = block.author();
+                        for header in &committed_subdag.headers {
+                            if header.round() > GENESIS_ROUND {
+                                let author_index = header.author();
                                 last_round_committed_blocks[author_index] =
-                                    max(last_round_committed_blocks[author_index], block.round());
+                                    max(last_round_committed_blocks[author_index], header.round());
                             }
                         }
 
@@ -780,8 +780,8 @@ mod tests {
                 .await
                 .expect("Timed out while waiting for at least one committed block from authority 1")
         {
-            for block in &result.blocks {
-                if block.round() > GENESIS_ROUND && block.author() == index_1 {
+            for header in &result.headers {
+                if header.round() > GENESIS_ROUND && header.author() == index_1 {
                     break 'outer;
                 }
             }
@@ -861,8 +861,8 @@ mod tests {
         // authority
         let received_from_authority_1 = timeout(Duration::from_secs(10), async {
             'outer: while let Some(result) = receiver_1.recv().await {
-                for block in &result.blocks {
-                    if block.round() > GENESIS_ROUND && block.author() == index_1 {
+                for header in &result.headers {
+                    if header.round() > GENESIS_ROUND && header.author() == index_1 {
                         break 'outer;
                     }
                 }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -36,6 +36,7 @@ use crate::{
     dag_state::DagState,
     encoder::ShardEncoder,
     error::{ConsensusError, ConsensusResult},
+    header_synchronizer::HeaderSynchronizerHandle,
     network::{
         BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockBundle,
         SerializedBlockBundleParts, SerializedHeaderAndTransactions, SerializedTransactions,
@@ -43,7 +44,6 @@ use crate::{
     shard_reconstructor::TransactionMessage,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::Store,
-    synchronizer::SynchronizerHandle,
     transactions_synchronizer::TransactionsSynchronizerHandle,
 };
 
@@ -98,7 +98,7 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     context: Arc<Context>,
     commit_vote_monitor: Arc<CommitVoteMonitor>,
     block_verifier: Arc<dyn BlockVerifier>,
-    synchronizer: Arc<SynchronizerHandle>,
+    synchronizer: Arc<HeaderSynchronizerHandle>,
     transactions_synchronizer: Arc<TransactionsSynchronizerHandle>,
     core_dispatcher: Arc<C>,
     rx_block_broadcaster: broadcast::Receiver<VerifiedBlock>,
@@ -124,7 +124,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         context: Arc<Context>,
         block_verifier: Arc<dyn BlockVerifier>,
         commit_vote_monitor: Arc<CommitVoteMonitor>,
-        synchronizer: Arc<SynchronizerHandle>,
+        header_synchronizer: Arc<HeaderSynchronizerHandle>,
         transactions_synchronizer: Arc<TransactionsSynchronizerHandle>,
         core_dispatcher: Arc<C>,
         rx_block_broadcaster: broadcast::Receiver<VerifiedBlock>,
@@ -142,7 +142,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             context,
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            synchronizer: header_synchronizer,
             transactions_synchronizer,
             core_dispatcher,
             rx_block_broadcaster,
@@ -1218,6 +1218,7 @@ mod tests {
         dag_state::{DagState, TransactionSource},
         encoder::create_encoder,
         error::{ConsensusError, ConsensusResult},
+        header_synchronizer::HeaderSynchronizer,
         leader_schedule::LeaderSchedule,
         network::{
             BlockBundle, BlockBundleStream, NetworkClient, NetworkService, SerializedBlock,
@@ -1225,7 +1226,6 @@ mod tests {
             SerializedTransactions,
         },
         storage::{Store, mem_store::MemStore},
-        synchronizer::Synchronizer,
         test_dag_builder::DagBuilder,
         transaction::TransactionConsumer,
         transactions_synchronizer::TransactionsSynchronizer,
@@ -1307,7 +1307,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
@@ -1322,7 +1322,7 @@ mod tests {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            header_synchronizer,
             transactions_synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
@@ -1385,7 +1385,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
@@ -1400,7 +1400,7 @@ mod tests {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            header_synchronizer,
             transactions_synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
@@ -1474,7 +1474,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
@@ -1489,7 +1489,7 @@ mod tests {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            header_synchronizer,
             transactions_synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
@@ -1554,7 +1554,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
@@ -1569,7 +1569,7 @@ mod tests {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            header_synchronizer,
             transactions_synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
@@ -1692,7 +1692,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
@@ -1707,7 +1707,7 @@ mod tests {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            header_synchronizer,
             transactions_synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
@@ -1819,7 +1819,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
@@ -1835,7 +1835,7 @@ mod tests {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            header_synchronizer,
             transactions_synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
@@ -2086,7 +2086,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
@@ -2100,7 +2100,7 @@ mod tests {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            header_synchronizer,
             transactions_synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
@@ -2242,7 +2242,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
@@ -2256,7 +2256,7 @@ mod tests {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            header_synchronizer,
             transactions_synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
@@ -2414,7 +2414,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
@@ -2430,7 +2430,7 @@ mod tests {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            header_synchronizer,
             transactions_synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
@@ -2730,7 +2730,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
@@ -2746,7 +2746,7 @@ mod tests {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            header_synchronizer,
             transactions_synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
@@ -2872,7 +2872,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
@@ -2888,7 +2888,7 @@ mod tests {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            header_synchronizer,
             transactions_synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
@@ -3035,7 +3035,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
@@ -3051,7 +3051,7 @@ mod tests {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            header_synchronizer,
             transactions_synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
@@ -3220,7 +3220,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let synchronizer = Synchronizer::start(
+        let header_synchronizer = HeaderSynchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
@@ -3236,7 +3236,7 @@ mod tests {
             context.clone(),
             block_verifier,
             commit_vote_monitor,
-            synchronizer,
+            header_synchronizer,
             transactions_synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -38,7 +38,7 @@ use crate::{
     error::{ConsensusError, ConsensusResult},
     network::{
         BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockBundle,
-        SerializedBlockBundleParts, SerializedHeaderAndTransactions, SerializedTransactions,
+        SerializedBlockBundleParts, SerializedHeaderAndTransactions,
     },
     shard_reconstructor::TransactionMessage,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -935,20 +935,20 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         // Get the transactions from the dag state
-        let transactions = self.dag_state.read().get_transactions(&block_refs);
+        let transactions = self
+            .dag_state
+            .read()
+            .get_serialized_transactions(&block_refs);
 
         // Return the serialized transactions
         let result = transactions
             .into_iter()
             .flatten()
-            .map(|transaction| {
+            .map(|serialized_transaction| {
                 Bytes::from(
-                    bcs::to_bytes(&SerializedTransactions {
-                        block_ref: transaction.block_ref(),
-                        serialized_transactions: transaction.serialized().clone(),
-                    })
-                    .map_err(ConsensusError::SerializationFailure)
-                    .expect("serialization should succeed"),
+                    bcs::to_bytes(&serialized_transaction)
+                        .map_err(ConsensusError::SerializationFailure)
+                        .expect("serialization should succeed"),
                 )
             })
             .collect::<Vec<_>>();

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -38,7 +38,7 @@ use crate::{
     error::{ConsensusError, ConsensusResult},
     network::{
         BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockBundle,
-        SerializedBlockBundleParts, SerializedHeaderAndTransactions,
+        SerializedBlockBundleParts, SerializedHeaderAndTransactions, SerializedTransactions,
     },
     shard_reconstructor::TransactionMessage,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -708,12 +708,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             block_refs.truncate(max_fetch_size);
         }
 
-        // Get requested blocks from store.
-        let blocks = if commit_sync_handle {
+        // Get requested block headers from store.
+        let serialized_headers = if commit_sync_handle {
             // For commit sync, we respond with all blocks from the store
             self.dag_state
                 .read()
-                .get_block_headers(&block_refs)
+                .get_serialized_block_headers(&block_refs)
                 .into_iter()
                 .flatten()
                 .collect()
@@ -723,8 +723,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             block_refs.sort();
             block_refs.dedup();
             let dag_state = self.dag_state.read();
-            let mut blocks = dag_state
-                .get_block_headers(&block_refs)
+            let mut headers = dag_state
+                .get_serialized_block_headers(&block_refs)
                 .into_iter()
                 .flatten()
                 .collect::<Vec<_>>();
@@ -733,7 +733,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             // available in cache. Compute the lowest missing round per
             // requested authority.
             let mut lowest_missing_rounds = BTreeMap::<AuthorityIndex, Round>::new();
-            for block_ref in blocks.iter().map(|b| b.reference()) {
+            for block_ref in block_refs.iter() {
                 let entry = lowest_missing_rounds
                     .entry(block_ref.author)
                     .or_insert(block_ref.round);
@@ -754,30 +754,29 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                     continue;
                 }
 
-                let missing_blocks = dag_state.get_cached_block_headers_in_range(
+                let missing_headers = dag_state.get_cached_block_headers_in_range(
                     authority,
                     highest_accepted_round + 1,
                     lowest_missing_round,
                     self.context
                         .parameters
                         .max_headers_per_regular_sync_fetch
-                        .saturating_sub(blocks.len()),
+                        .saturating_sub(headers.len()),
                 );
-                blocks.extend(missing_blocks);
-                if blocks.len() >= self.context.parameters.max_headers_per_regular_sync_fetch {
-                    blocks.truncate(self.context.parameters.max_headers_per_regular_sync_fetch);
+                let serialized_missing_headers: Vec<_> = missing_headers
+                    .into_iter()
+                    .map(|header| header.serialized().clone())
+                    .collect();
+                headers.extend(serialized_missing_headers);
+                if headers.len() >= self.context.parameters.max_headers_per_regular_sync_fetch {
+                    headers.truncate(self.context.parameters.max_headers_per_regular_sync_fetch);
                     break;
                 }
             }
 
-            blocks
+            headers
         };
-        // Return the serialized blocks
-        let bytes = blocks
-            .into_iter()
-            .map(|block| block.serialized().clone())
-            .collect::<Vec<_>>();
-        Ok(bytes)
+        Ok(serialized_headers)
     }
 
     async fn handle_fetch_commits(
@@ -824,7 +823,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
         let certifier_block_headers = self
             .store
-            .read_block_headers(&certifier_block_refs)?
+            .read_verified_block_headers(&certifier_block_refs)?
             .into_iter()
             .flatten()
             .collect();
@@ -941,17 +940,22 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .get_serialized_transactions(&block_refs);
 
         // Return the serialized transactions
-        let result = transactions
+        let result: Vec<_> = transactions
             .into_iter()
-            .flatten()
-            .map(|serialized_transaction| {
-                Bytes::from(
-                    bcs::to_bytes(&serialized_transaction)
+            .zip(block_refs)
+            .filter_map(|(opt_serialized_tx, block_ref)| {
+                opt_serialized_tx.map(|serialized_tx| {
+                    Bytes::from(
+                        bcs::to_bytes(&SerializedTransactions {
+                            block_ref,
+                            serialized_transactions: serialized_tx,
+                        })
                         .map_err(ConsensusError::SerializationFailure)
                         .expect("serialization should succeed"),
-                )
+                    )
+                })
             })
-            .collect::<Vec<_>>();
+            .collect();
 
         Ok(result)
     }

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -200,7 +200,7 @@ impl BaseCommitter {
             let ancestor = self
                 .dag_state
                 .read()
-                .get_block_header(ancestor)
+                .get_verified_block_header(ancestor)
                 .unwrap_or_else(|| panic!("Block not found in storage: {ancestor:?}"));
             if let Some(support) = self.find_supported_block(leader_slot, &ancestor) {
                 return Some(support);
@@ -239,7 +239,7 @@ impl BaseCommitter {
             let is_vote = if let Some(is_vote) = all_votes.get(reference) {
                 *is_vote
             } else {
-                let potential_vote = self.dag_state.read().get_block_header(reference);
+                let potential_vote = self.dag_state.read().get_verified_block_header(reference);
 
                 let is_vote = {
                     let potential_vote = potential_vote

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -266,7 +266,7 @@ impl CertifiedCommit {
         }
     }
 
-    pub fn blocks(&self) -> &[VerifiedBlockHeader] {
+    pub fn block_headers(&self) -> &[VerifiedBlockHeader] {
         &self.verified_block_headers
     }
 }
@@ -361,17 +361,17 @@ pub type CommitVote = CommitRef;
 pub struct SubDagBase {
     /// A reference to the leader of the sub-dag
     pub leader: BlockRef,
-    /// All the committed blocks that are part of this sub-dag
-    pub blocks: Vec<VerifiedBlockHeader>,
+    /// All the block headers that are traversed on DAG starting with the leader
+    pub headers: Vec<VerifiedBlockHeader>,
     /// The timestamp of the commit, obtained from the timestamp of the leader
     /// block.
     pub timestamp_ms: BlockTimestampMs,
     /// The reference of the commit.
     /// First commit after genesis has a index of 1, then every next commit has
-    /// a index incremented by 1.
+    /// an index incremented by 1.
     pub commit_ref: CommitRef,
     /// Optional scores that are provided as part of the consensus output to
-    /// IOTA that can then be used by IOTA for future submission to
+    /// IOTA that can then be used by IOTA for future transaction submission to
     /// consensus.
     pub reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
 }
@@ -382,12 +382,12 @@ impl SubDagBase {
     pub(crate) fn transaction_acknowledgments(
         &self,
     ) -> HashMap<(Round, AuthorityIndex), Vec<BlockRef>> {
-        self.blocks
+        self.headers
             .iter()
-            .map(|block| {
+            .map(|header| {
                 (
-                    (block.round(), block.author()),
-                    block.acknowledgments().to_vec(),
+                    (header.round(), header.author()),
+                    header.acknowledgments().to_vec(),
                 )
             })
             .fold(
@@ -407,7 +407,7 @@ impl SubDagBase {
     fn format_block_refs(&self) -> String {
         format_block_digests(
             &self
-                .blocks
+                .headers
                 .iter()
                 .map(|b| b.reference())
                 .collect::<Vec<_>>(),
@@ -459,7 +459,7 @@ impl CommittedSubDag {
     /// Creates a new committed sub dag.
     pub fn new(
         leader: BlockRef,
-        blocks: Vec<VerifiedBlockHeader>,
+        headers: Vec<VerifiedBlockHeader>,
         transactions: Vec<VerifiedTransactions>,
         timestamp_ms: BlockTimestampMs,
         commit_ref: CommitRef,
@@ -468,7 +468,7 @@ impl CommittedSubDag {
         Self {
             base: SubDagBase {
                 leader,
-                blocks,
+                headers,
                 timestamp_ms,
                 commit_ref,
                 reputation_scores_desc,
@@ -548,7 +548,7 @@ impl PendingSubDag {
     /// Creates a new pending sub dag.
     pub fn new(
         leader: BlockRef,
-        blocks: Vec<VerifiedBlockHeader>,
+        headers: Vec<VerifiedBlockHeader>,
         committed_transaction_refs: Vec<BlockRef>,
         timestamp_ms: BlockTimestampMs,
         commit_ref: CommitRef,
@@ -557,7 +557,7 @@ impl PendingSubDag {
         Self {
             base: SubDagBase {
                 leader,
-                blocks,
+                headers,
                 timestamp_ms,
                 commit_ref,
                 reputation_scores_desc,
@@ -957,14 +957,14 @@ mod tests {
         assert_eq!(subdag.leader, leader_ref);
         assert_eq!(subdag.timestamp_ms, leader_block.timestamp_ms());
         assert_eq!(
-            subdag.blocks.len(),
+            subdag.headers.len(),
             (num_authorities as u32 * WAVE_LENGTH) as usize + 1
         );
         assert_eq!(subdag.commit_ref, commit.reference());
         assert_eq!(subdag.committed_transaction_refs, first_round_references);
         assert_eq!(subdag.reputation_scores_desc, vec![]);
         let transactions = store
-            .read_transactions(&subdag.committed_transaction_refs)
+            .read_verified_transactions(&subdag.committed_transaction_refs)
             .expect("We should have the transactions referenced in the commit data")
             .into_iter()
             .flatten()
@@ -1042,7 +1042,7 @@ mod tests {
         assert_eq!(pending_subdag.leader, leader_ref);
         assert_eq!(pending_subdag.timestamp_ms, leader_block.timestamp_ms());
         assert_eq!(
-            pending_subdag.blocks.len(),
+            pending_subdag.headers.len(),
             (num_authorities as u32 * WAVE_LENGTH) as usize + 1
         );
         assert_eq!(pending_subdag.commit_ref, commit.reference());

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -621,7 +621,7 @@ pub fn load_pending_subdag_from_store(
 ) -> PendingSubDag {
     let mut leader_block_idx = None;
     let commit_block_headers = store
-        .read_block_headers(commit.blocks())
+        .read_verified_block_headers(commit.blocks())
         .expect("We should have the block referenced in the commit data");
     let block_headers = commit_block_headers
         .into_iter()

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -333,7 +333,7 @@ impl CommitObserver {
                 "Pending subdag {} with leader {} has {} blocks",
                 commit.commit_ref,
                 commit.leader,
-                commit.blocks.len()
+                commit.headers.len()
             );
 
             metrics
@@ -344,11 +344,11 @@ impl CommitObserver {
                 .set(commit.commit_ref.index as i64);
             metrics
                 .blocks_per_commit_count
-                .observe(commit.blocks.len() as f64);
+                .observe(commit.headers.len() as f64);
 
-            for block in &commit.blocks {
+            for header in &commit.headers {
                 let latency_ms = utc_now
-                    .checked_sub(block.timestamp_ms())
+                    .checked_sub(header.timestamp_ms())
                     .unwrap_or_default();
                 metrics
                     .block_commit_latency
@@ -494,13 +494,13 @@ mod tests {
             if idx == 0 {
                 // First subdag includes the leader block plus all ancestor blocks
                 // of the leader minus the genesis round blocks
-                assert_eq!(subdag.blocks.len(), 1);
+                assert_eq!(subdag.headers.len(), 1);
             } else {
                 // Every subdag after will be missing the leader block from the previous
                 // committed subdag
-                assert_eq!(subdag.blocks.len(), num_authorities);
+                assert_eq!(subdag.headers.len(), num_authorities);
             }
-            for block_header in subdag.blocks.iter() {
+            for block_header in subdag.headers.iter() {
                 expected_stored_refs.push(block_header.reference());
                 assert!(block_header.round() <= leaders[idx].round());
             }

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -479,7 +479,7 @@ mod tests {
                 .collect::<Vec<_>>();
             let blocks = dag_state
                 .read()
-                .get_block_headers(&block_refs)
+                .get_verified_block_headers(&block_refs)
                 .into_iter()
                 .map(|block_opt| block_opt.expect("We should have all blocks in dag state."));
             let calculated_ts =

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -261,9 +261,9 @@ impl<C: NetworkClient> CommitSyncer<C> {
             .iter()
             .fold((0, 0), |(blocks, bytes), c| {
                 (
-                    blocks + c.blocks().len(),
+                    blocks + c.block_headers().len(),
                     bytes
-                        + c.blocks()
+                        + c.block_headers()
                             .iter()
                             .map(|b| b.serialized().len())
                             .sum::<usize>() as u64,
@@ -328,7 +328,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 commits
                     .commits()
                     .iter()
-                    .flat_map(|c| c.blocks())
+                    .flat_map(|c| c.block_headers())
                     .map(|b| b.reference().to_string())
                     .join(","),
             );

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -559,16 +559,18 @@ impl CordialKnowledge {
     /// Called when older rounds should be pruned globally.
     fn handle_evict_below(
         &mut self,
-        rounds: Vec<Round>,
+        evicted_rounds: Vec<Round>,
     ) -> Option<Vec<Vec<ConnectionKnowledgeMessage>>> {
         // Evict locally
         for (index, btree_map) in &mut self.cordial_knowledge.iter_mut().enumerate() {
-            let split_round = rounds[index];
+            // Increase by 1 for splitting as the evicted rounds are gone from memory
+            let split_round = evicted_rounds[index] + 1;
+            // Remove everything strictly below this round
             *btree_map = btree_map.split_off(&split_round);
         }
 
         // Prepare message for per-connection knowledge about eviction
-        self.prepare_evict_msgs(rounds)
+        self.prepare_evict_msgs(evicted_rounds)
     }
     #[inline]
     fn prepare_evict_msgs(
@@ -848,15 +850,15 @@ impl ConnectionKnowledge {
     }
 
     /// Evict all connection knowledge below the given rounds (exclusive)
-    fn evict_below(&mut self, rounds_exclusive: Vec<Round>) {
+    fn evict_below(&mut self, rounds_to_evict_exclusive: Vec<Round>) {
         for (index, map) in self.headers_not_known.iter_mut().enumerate() {
-            let threshold_round = rounds_exclusive[index];
+            let threshold_round = rounds_to_evict_exclusive[index] + 1;
             // Keep only entries >= threshold
             *map = map.split_off(&threshold_round);
         }
 
         for (index, map) in self.shards_not_known.iter_mut().enumerate() {
-            let threshold_round = rounds_exclusive[index];
+            let threshold_round = rounds_to_evict_exclusive[index] + 1;
             *map = map.split_off(&threshold_round);
         }
     }
@@ -967,7 +969,7 @@ impl ConnectionKnowledge {
         //    be marked as known
         let own_index = self.context.own_index;
         let mut rounds = vec![Round::MIN; self.context.committee.size()];
-        rounds[own_index] = round_upper_bound_exclusive + 1; // We are supposed to send own block of this round in a bundle when calling this function with this parameter
+        rounds[own_index] = round_upper_bound_exclusive; // We are supposed to send own block of this round in a bundle when calling this function with this parameter
 
         self.evict_below(rounds);
 

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -850,15 +850,15 @@ impl ConnectionKnowledge {
     }
 
     /// Evict all connection knowledge below the given rounds (exclusive)
-    fn evict_below(&mut self, rounds_to_evict_exclusive: Vec<Round>) {
+    fn evict_below(&mut self, evicted_rounds: Vec<Round>) {
         for (index, map) in self.headers_not_known.iter_mut().enumerate() {
-            let threshold_round = rounds_to_evict_exclusive[index] + 1;
+            let threshold_round = evicted_rounds[index] + 1;
             // Keep only entries >= threshold
             *map = map.split_off(&threshold_round);
         }
 
         for (index, map) in self.shards_not_known.iter_mut().enumerate() {
-            let threshold_round = rounds_to_evict_exclusive[index] + 1;
+            let threshold_round = evicted_rounds[index] + 1;
             *map = map.split_off(&threshold_round);
         }
     }
@@ -964,12 +964,12 @@ impl ConnectionKnowledge {
     /// Used by AuthorityService to create a block bundle
     /// to send to the peer.
     pub fn create_bundle(&mut self, block: VerifiedBlock) -> BlockBundle {
-        let round_upper_bound_exclusive = block.round();
+        let block_round = block.round();
         // 1. Own headers and shards for round up to round_upper_bound_exclusive should
         //    be marked as known
         let own_index = self.context.own_index;
         let mut rounds = vec![Round::MIN; self.context.committee.size()];
-        rounds[own_index] = round_upper_bound_exclusive; // We are supposed to send own block of this round in a bundle when calling this function with this parameter
+        rounds[own_index] = block_round; // We are supposed to send own block of this round in a bundle when calling this function with this parameter
 
         self.evict_below(rounds);
 
@@ -981,8 +981,7 @@ impl ConnectionKnowledge {
             .enumerate()
             .filter(|(_authority_index, &opt_round)| {
                 if let Some(round) = opt_round {
-                    round.saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS)
-                        >= round_upper_bound_exclusive
+                    round.saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS) >= block_round
                 } else {
                     false
                 }
@@ -990,10 +989,8 @@ impl ConnectionKnowledge {
             .map(|(authority_index, _opt_round)| authority_index)
             .collect();
 
-        let useful_headers_block_refs_to_peer = self.take_useful_header_block_refs_round(
-            round_upper_bound_exclusive,
-            &useful_headers_authors_to_peer,
-        );
+        let useful_headers_block_refs_to_peer =
+            self.take_useful_header_block_refs_round(block_round, &useful_headers_authors_to_peer);
 
         let useful_headers_to_peer: Vec<VerifiedBlockHeader> = {
             let dag_state_read = self.dag_state.read();
@@ -1012,8 +1009,7 @@ impl ConnectionKnowledge {
             .enumerate()
             .filter(|(_authority_index, &opt_round)| {
                 if let Some(round) = opt_round {
-                    round.saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS)
-                        >= round_upper_bound_exclusive
+                    round.saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS) >= block_round
                 } else {
                     false
                 }
@@ -1021,10 +1017,8 @@ impl ConnectionKnowledge {
             .map(|(authority_index, _opt_round)| authority_index)
             .collect();
 
-        let useful_shards_block_refs_to_peer = self.take_useful_shard_block_refs_round(
-            round_upper_bound_exclusive,
-            &useful_shards_authors_to_peer,
-        );
+        let useful_shards_block_refs_to_peer =
+            self.take_useful_shard_block_refs_round(block_round, &useful_shards_authors_to_peer);
         let useful_shards_to_peer: Vec<Bytes> = {
             let dag_state_read = self.dag_state.read();
             dag_state_read
@@ -1044,8 +1038,7 @@ impl ConnectionKnowledge {
             .enumerate()
             .filter(|(_authority_index, &opt_round)| {
                 if let Some(round) = opt_round {
-                    round.saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS)
-                        >= round_upper_bound_exclusive
+                    round.saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS) >= block_round
                 } else {
                     false
                 }
@@ -1060,8 +1053,7 @@ impl ConnectionKnowledge {
             .enumerate()
             .filter(|(_authority_index, &opt_round)| {
                 if let Some(round) = opt_round {
-                    round.saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS)
-                        >= round_upper_bound_exclusive
+                    round.saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS) >= block_round
                 } else {
                     false
                 }

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2359,7 +2359,7 @@ mod test {
             core_catch_up
                 .dag_state
                 .read()
-                .get_block_headers(&[first_missing_transaction_from_skipped])[0]
+                .get_verified_block_headers(&[first_missing_transaction_from_skipped])[0]
                 .is_none()
         );
         let last_solid_commit_round = core_catch_up

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -26,6 +26,10 @@ use tokio::{
 use tracing::{debug, info, instrument, trace, warn};
 
 #[cfg(test)]
+use crate::storage::Store;
+#[cfg(test)]
+use crate::storage::rocksdb_store::RocksDBStore;
+#[cfg(test)]
 use crate::{CommitConsumer, CommittedSubDag, TransactionClient, storage::mem_store::MemStore};
 use crate::{
     Transaction,
@@ -482,7 +486,7 @@ impl Core {
         let block_headers = certified_commits
             .commits()
             .iter()
-            .flat_map(|commit| commit.blocks())
+            .flat_map(|commit| commit.block_headers())
             .cloned()
             .collect::<Vec<_>>();
 
@@ -1216,7 +1220,13 @@ pub(crate) fn create_cores(context: Context, authorities: Vec<Stake>) -> Vec<Cor
 
     for index in 0..authorities.len() {
         let own_index = AuthorityIndex::new_for_test(index as u8);
-        let core = CoreTextFixture::new(context.clone(), authorities.clone(), own_index, false);
+        let core = CoreTextFixture::new(
+            context.clone(),
+            authorities.clone(),
+            own_index,
+            false,
+            false,
+        );
         cores.push(core);
     }
     cores
@@ -1227,9 +1237,8 @@ pub(crate) struct CoreTextFixture {
     pub core: Core,
     pub signal_receivers: CoreSignalsReceivers,
     pub block_receiver: broadcast::Receiver<VerifiedBlock>,
-    #[expect(unused)]
     pub commit_receiver: UnboundedReceiver<CommittedSubDag>,
-    pub store: Arc<MemStore>,
+    pub store: Arc<dyn Store>,
 }
 
 #[cfg(test)]
@@ -1239,6 +1248,7 @@ impl CoreTextFixture {
         authorities: Vec<Stake>,
         own_index: AuthorityIndex,
         sync_last_known_own_block: bool,
+        with_rocksdb: bool,
     ) -> Self {
         let (committee, mut signers) = local_committee_and_keys(0, authorities.clone());
         let mut context = context.clone();
@@ -1250,7 +1260,12 @@ impl CoreTextFixture {
             .set_consensus_bad_nodes_stake_threshold_for_testing(33);
 
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new());
+        let store: Arc<dyn Store> = if !with_rocksdb {
+            Arc::new(MemStore::new())
+        } else {
+            let store_path = context.parameters.db_path.as_path().to_str().unwrap();
+            Arc::new(RocksDBStore::new(store_path))
+        };
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
@@ -1300,7 +1315,10 @@ impl CoreTextFixture {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::BTreeSet, time::Duration};
+    use std::{
+        collections::{BTreeSet, HashSet},
+        time::Duration,
+    };
 
     use futures::{StreamExt, stream::FuturesUnordered};
     use iota_metrics::monitored_mpsc::unbounded_channel;
@@ -2227,6 +2245,175 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_sequenced_transactions_no_headers() {
+        telemetry_subscribers::init_for_testing();
+        let committee_size = 10;
+        let (context, _key_pairs) = Context::new_for_test(committee_size);
+        let own_index = AuthorityIndex::new_for_test(0);
+        let core_fixture_own = CoreTextFixture::new(
+            context.clone(),
+            vec![1; committee_size],
+            own_index,
+            true,
+            false,
+        );
+        // create a DAG of 2*gc_depth rounds
+        let mut dag_builder = DagBuilder::new(Arc::new(context.clone()));
+        let gc_depth = context.protocol_config.gc_depth();
+        let cached_rounds = core_fixture_own
+            .core
+            .context
+            .parameters
+            .dag_state_cached_rounds;
+        // One authority will try to catch up, so it does not create any block
+        let catch_up_index = AuthorityIndex::new_for_test((committee_size - 1) as u8);
+        let core_fixture_catch_up = CoreTextFixture::new(
+            context.clone(),
+            vec![1; committee_size],
+            catch_up_index,
+            true,
+            true,
+        );
+        let active_authorities = (0..(committee_size - 1) as u8)
+            .map(AuthorityIndex::new_for_test)
+            .collect::<Vec<_>>();
+        // Blocks of one authority will not be referenced, but acknowledged
+        let authority_to_skip = AuthorityIndex::new_for_test((committee_size - 2) as u8);
+        let authorities_to_skip_ancestors = vec![authority_to_skip, catch_up_index];
+
+        let num_rounds_with_skip_ancestors = cached_rounds + gc_depth;
+        let total_rounds = 2 * num_rounds_with_skip_ancestors;
+        dag_builder
+            .layers(1..=num_rounds_with_skip_ancestors)
+            .authorities(active_authorities.clone())
+            .skip_ancestor_links(authorities_to_skip_ancestors)
+            .build();
+        let authorities_to_skip_ancestors = vec![catch_up_index];
+        dag_builder
+            .layers(num_rounds_with_skip_ancestors + 1..=total_rounds)
+            .authorities(active_authorities)
+            .skip_ancestor_links(authorities_to_skip_ancestors)
+            .build();
+        let sub_dags_and_commits = dag_builder.get_sub_dag_and_certified_commits(1..=total_rounds);
+
+        let (mut core_own, mut commit_receiver_own) =
+            (core_fixture_own.core, core_fixture_own.commit_receiver);
+        let _ = core_own.add_blocks(dag_builder.blocks(1..=total_rounds));
+        let mut existing_headers = HashSet::new();
+        let mut all_traversed_headers = Vec::new();
+        let mut all_sequenced_transactions = Vec::new();
+        // Check the commits that are produced after processing blocks.
+        // Record traversed headers and sequenced transactions
+        while let Some(sub_dag) = commit_receiver_own.recv().await {
+            let sub_dag_leader_round = sub_dag.leader.round;
+            let CommittedSubDag { base, transactions } = sub_dag;
+
+            for header in &base.headers {
+                existing_headers.insert(header.reference());
+            }
+            all_traversed_headers.extend(base.headers.clone());
+            for transaction in &transactions {
+                // Transactions from all authors except authority_to_skip should also have a
+                // corresponding block_ref being traversed in the committed sub_dag
+                // Same after num_rounds_with_skip_ancestors
+                if transaction.block_ref().author != authority_to_skip
+                    || transaction.block_ref().round >= num_rounds_with_skip_ancestors
+                {
+                    assert!(
+                        existing_headers.contains(&transaction.block_ref()),
+                        "{}",
+                        transaction.block_ref()
+                    );
+                } else {
+                    assert!(
+                        !existing_headers.contains(&transaction.block_ref()),
+                        "{}",
+                        transaction.block_ref()
+                    );
+                }
+            }
+            all_sequenced_transactions.extend(transactions);
+            if sub_dag_leader_round == total_rounds - 2 {
+                break;
+            }
+        }
+        // Now the node that tries to catch up will sync the certified commits
+        // The commits contains only the headers
+        let certified_commits = sub_dags_and_commits
+            .iter()
+            .map(|(_, c)| c.clone())
+            .collect::<Vec<_>>();
+        let mut core_catch_up = core_fixture_catch_up.core;
+        let (missing_references, missing_transactions) = core_catch_up
+            .add_certified_commits(CertifiedCommits::new(certified_commits))
+            .expect("We should not fail with certified commits");
+        assert!(missing_references.is_empty());
+        let first_missing_transaction_from_skipped = *missing_transactions
+            .iter()
+            .find(|(a, _)| a.author == authority_to_skip)
+            .unwrap()
+            .0;
+        // Ensure that the block header corresponding to the
+        // first_missing_transaction_from_skipped is not in dag_state
+        assert!(
+            core_catch_up
+                .dag_state
+                .read()
+                .get_block_headers(&[first_missing_transaction_from_skipped])[0]
+                .is_none()
+        );
+        let last_solid_commit_round = core_catch_up
+            .dag_state
+            .read()
+            .last_solid_commit_leader_round()
+            .unwrap();
+        // Latest solid (with all transactions being locally available) leader round is
+        // 2 as only transactions from round 0 could be sequenced at this point.
+        // All other transactions are not yet synced
+        assert_eq!(last_solid_commit_round, 2u32);
+        // Now assume that the missing transactions were synced by the transaction
+        // synchronizer
+        let missing_verified_transactions: Vec<_> = all_sequenced_transactions
+            .into_iter()
+            .filter(|tx| missing_transactions.contains_key(&tx.block_ref()))
+            .collect();
+        core_catch_up
+            .add_transactions(
+                missing_verified_transactions,
+                crate::dag_state::TransactionSource::TransactionSynchronizer,
+            )
+            .unwrap();
+
+        let last_commit_round = core_catch_up.dag_state.read().last_commit_round();
+        let last_solid_commit_round = core_catch_up
+            .dag_state
+            .read()
+            .last_solid_commit_leader_round()
+            .unwrap();
+        // Latest solid (with all transactions being locally available) leader round
+        // coincides now with last_commit_round
+        assert_eq!(last_solid_commit_round, last_commit_round);
+        // Flush to evict verified transactions from first rounds;
+        core_catch_up.dag_state.write().flush();
+        // Try to get a verified transaction from skipped authority. It should be
+        // impossible with get_verified_transactions() method since the header
+        // is not available
+        let opt_verified_transaction = core_catch_up
+            .dag_state
+            .read()
+            .get_verified_transactions(&[first_missing_transaction_from_skipped]);
+        assert!(opt_verified_transaction[0].is_none());
+        // Try to get a serialized transaction from skipped authority. It should now be
+        // impossible with get_serialized_transactions() method since it just
+        // reads bytes from storage
+        let opt_serialized_transaction = core_catch_up
+            .dag_state
+            .read()
+            .get_serialized_transactions(&[first_missing_transaction_from_skipped]);
+        assert!(opt_serialized_transaction[0].is_some());
+    }
+
+    #[tokio::test]
     async fn test_add_certified_commits() {
         telemetry_subscribers::init_for_testing();
 
@@ -2237,7 +2424,7 @@ mod test {
         });
 
         let authority_index = AuthorityIndex::new_for_test(0);
-        let core = CoreTextFixture::new(context, vec![1, 1, 1, 1], authority_index, true);
+        let core = CoreTextFixture::new(context, vec![1, 1, 1, 1], authority_index, true, false);
         let store = core.store.clone();
         let mut core = core.core;
 

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -425,7 +425,7 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         CoreError,
     > {
         for commit in commits.commits() {
-            for block in commit.blocks() {
+            for block in commit.block_headers() {
                 self.highest_received_rounds[block.author()]
                     .fetch_max(block.round(), Ordering::AcqRel);
             }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -30,6 +30,7 @@ use crate::{
     context::Context,
     cordial_knowledge::CordialKnowledgeMessage,
     leader_scoring::{ReputationScores, ScoringSubdag},
+    network::SerializedTransactions,
     storage::{Store, WriteBatch},
     threshold_clock::ThresholdClock,
 };
@@ -98,14 +99,15 @@ pub(crate) struct DagState {
     /// are kept in memory.
     recent_block_headers: BTreeMap<BlockRef, VerifiedBlockHeader>,
 
-    /// Contains recent transactions. It contains
-    /// MAX_TRANSACTIONS_ACK_DEPTH + MAX_LINEARIZER_DEPTH =
-    /// (protocol_config.gc_depth * 2) from the round of the last consumed
-    /// commit. Note: all transactions in blocks below that round are
-    /// evicted from memory.
-    recent_transactions: BTreeMap<BlockRef, VerifiedTransactions>,
-    /// Contains recent shards with their Merkle proofs.
-    recent_shards: BTreeMap<BlockRef, Bytes>,
+    /// Contains recent verified transactions per authority. To access a transaction with a given block_ref, one
+    /// needs to read first the entry with index block_ref.author.
+    /// Evicted using the minimum between GC round for the last solid leader round
+    /// evicted rounds by authority.
+    recent_transactions_by_authority: Vec<BTreeMap<BlockRef, VerifiedTransactions>>,
+    /// Contains recent own serialized shards with their Merkle proofs per authority. To access own shard for a given block_ref, one
+    /// needs to read first the entry with index block_ref.author.
+    /// Eviction is aligned with headers
+    recent_shards_by_authority: Vec<BTreeMap<BlockRef, Bytes>>,
     /// Indexes recent block headers refs by their authorities.
     /// Vec position corresponds to the authority index.
     recent_headers_refs_by_authority: Vec<BTreeSet<BlockRef>>,
@@ -235,8 +237,8 @@ impl DagState {
             context,
             genesis,
             recent_block_headers: BTreeMap::new(),
-            recent_transactions: BTreeMap::new(),
-            recent_shards: BTreeMap::new(),
+            recent_transactions_by_authority: vec![BTreeMap::new(); num_authorities],
+            recent_shards_by_authority: vec![BTreeMap::new(); num_authorities],
             recent_headers_refs_by_authority: vec![BTreeSet::new(); num_authorities],
             threshold_clock,
             highest_accepted_round: 0,
@@ -368,8 +370,7 @@ impl DagState {
         source: TransactionSource,
     ) {
         let block_ref = transactions.block_ref();
-        if self
-            .recent_transactions
+        if self.recent_transactions_by_authority[block_ref.author]
             .insert(block_ref, transactions.clone())
             .is_none()
         {
@@ -411,8 +412,7 @@ impl DagState {
 
     pub(crate) fn add_shard(&mut self, shard: VerifiedOwnShard) {
         let block_ref = shard.block_ref;
-        if self
-            .recent_shards
+        if self.recent_shards_by_authority[block_ref.author]
             .insert(block_ref, shard.serialized_shard)
             .is_none()
         {
@@ -426,7 +426,15 @@ impl DagState {
         }
     }
 
-    pub fn update_last_solid_commit_leader_round(&mut self, last_solid_commit_leader_round: Round) {
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn last_solid_commit_leader_round(&self) -> Option<Round> {
+        self.last_solid_commit_leader_round
+    }
+
+    pub(crate) fn update_last_solid_commit_leader_round(
+        &mut self,
+        last_solid_commit_leader_round: Round,
+    ) {
         let max_commit_round = self
             .last_committed_rounds
             .iter()
@@ -479,7 +487,7 @@ impl DagState {
     }
 
     fn update_transaction_metadata(&mut self, transaction: &VerifiedTransactions) {
-        self.recent_transactions
+        self.recent_transactions_by_authority[transaction.block_ref().author]
             .insert(transaction.block_ref(), transaction.clone());
     }
 
@@ -500,7 +508,7 @@ impl DagState {
     /// Gets transactions by checking cached recent transactions in memory, then
     /// storage. An element is None when the corresponding transaction is not
     /// found.
-    pub(crate) fn get_transactions(
+    pub(crate) fn get_verified_transactions(
         &self,
         block_refs: &[BlockRef],
     ) -> Vec<Option<VerifiedTransactions>> {
@@ -519,7 +527,9 @@ impl DagState {
                 }
                 continue;
             }
-            if let Some(transaction) = self.recent_transactions.get(block_ref) {
+            if let Some(transaction) =
+                self.recent_transactions_by_authority[block_ref.author].get(block_ref)
+            {
                 transactions[index] = Some(transaction.clone());
                 continue;
             }
@@ -536,13 +546,70 @@ impl DagState {
             .collect::<Vec<_>>();
         let store_results = self
             .store
-            .read_transactions(&missing_refs)
+            .read_verified_transactions(&missing_refs)
             .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"));
         self.context
             .metrics
             .node_metrics
             .dag_state_store_read_count
-            .with_label_values(&["get_transactions"])
+            .with_label_values(&["get_verified_transactions"])
+            .inc();
+
+        for ((index, _), result) in missing.into_iter().zip(store_results.into_iter()) {
+            transactions[index] = result;
+        }
+
+        transactions
+    }
+
+    /// Gets serialized transactions by checking cached recent transactions in
+    /// memory, then storage. An element is None when the corresponding
+    /// transaction is not found.
+    pub(crate) fn get_serialized_transactions(
+        &self,
+        block_refs: &[BlockRef],
+    ) -> Vec<Option<SerializedTransactions>> {
+        let mut transactions = vec![None; block_refs.len()];
+        let mut missing = Vec::new();
+
+        for (index, block_ref) in block_refs.iter().enumerate() {
+            if block_ref.round == GENESIS_ROUND {
+                // Allow the caller to handle the invalid genesis ancestor error.
+                if let Some(transaction) = self
+                    .genesis
+                    .get(block_ref)
+                    .map(|block| block.verified_transactions.clone())
+                {
+                    transactions[index] = Some(SerializedTransactions::from(transaction));
+                }
+                continue;
+            }
+            if let Some(transaction) =
+                self.recent_transactions_by_authority[block_ref.author].get(block_ref)
+            {
+                transactions[index] = Some(SerializedTransactions::from(transaction.clone()));
+                continue;
+            }
+            missing.push((index, block_ref));
+        }
+
+        if missing.is_empty() {
+            return transactions;
+        }
+
+        let missing_refs = missing
+            .iter()
+            .map(|(_, block_ref)| **block_ref)
+            .collect::<Vec<_>>();
+        let store_results = self
+            .store
+            .read_serialized_transactions(&missing_refs)
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"));
+        self.context
+            .metrics
+            .node_metrics
+            .dag_state_store_read_count
+            .with_label_values(&["get_serialized_transactions"])
             .inc();
 
         for ((index, _), result) in missing.into_iter().zip(store_results.into_iter()) {
@@ -639,7 +706,7 @@ impl DagState {
     pub(crate) fn get_cached_shards(&self, block_refs: &[BlockRef]) -> Vec<Option<Bytes>> {
         let mut shards: Vec<Option<Bytes>> = vec![None; block_refs.len()];
         for (index, block_ref) in block_refs.iter().enumerate() {
-            if let Some(shard) = self.recent_shards.get(block_ref) {
+            if let Some(shard) = self.recent_shards_by_authority[block_ref.author].get(block_ref) {
                 shards[index] = Some(shard.clone());
             }
         }
@@ -748,8 +815,7 @@ impl DagState {
                 .recent_block_headers
                 .get(last)
                 .expect("Block header should exist for the most recent blocks");
-            let transactions = self
-                .recent_transactions
+            let transactions = self.recent_transactions_by_authority[last.author]
                 .get(last)
                 .expect("Transactions should exist for the most recent blocks");
             return VerifiedBlock::new(header.clone(), transactions.clone());
@@ -806,7 +872,8 @@ impl DagState {
             Unbounded,
         )) {
             let header_opt = self.recent_block_headers.get(block_ref);
-            let transactions_opt = self.recent_transactions.get(block_ref);
+            let transactions_opt =
+                self.recent_transactions_by_authority[block_ref.author].get(block_ref);
             if let (Some(header), Some(transactions)) = (header_opt, transactions_opt) {
                 blocks.push(VerifiedBlock::new(header.clone(), transactions.clone()));
             } else {
@@ -1087,7 +1154,7 @@ impl DagState {
                 }
                 continue;
             }
-            if self.recent_transactions.contains_key(&block_ref) {
+            if self.recent_transactions_by_authority[block_ref.author].contains_key(&block_ref) {
                 exist[index] = true;
             } else {
                 missing.push((index, block_ref));
@@ -1277,28 +1344,37 @@ impl DagState {
 
     /// Clean up old shards. Used after flushing.
     pub(crate) fn evict_shards(&mut self) {
-        self.recent_shards
-            .retain(|block_ref, _| block_ref.round > self.evicted_rounds[block_ref.author]);
+        for (authority_index, _) in self.context.committee.authorities() {
+            let eviction_round = self.calculate_authority_eviction_round(authority_index);
+
+            // Evict everything below split_key
+            let split_key =
+                BlockRef::new(eviction_round + 1, authority_index, BlockHeaderDigest::MIN);
+            self.recent_shards_by_authority[authority_index] =
+                self.recent_shards_by_authority[authority_index].split_off(&split_key);
+        }
     }
 
-    /// Function removes stalled transactions that are older than  "last consume
+    /// Function removes stalled transactions that are older than the minimum between  "last solid
     /// leader round minus MAX_TRANSACTIONS_ACK_DEPTH
     /// (protocol_config.gc_depth) minus MAX_LINEARIZER_DEPTH
-    /// (protocol_config.gc_depth)"
+    /// (protocol_config.gc_depth)" or the eviction round of corresponding authority
     pub(crate) fn evict_transactions(&mut self) {
         let transaction_gc_round = self.gc_round_for_last_solid_commit();
-        let header_eviction_round = self.calculate_authority_eviction_round(self.context.own_index);
-        let transaction_eviction_round = min(transaction_gc_round, header_eviction_round + 1);
-        // Construct a dummy BlockRef with the minimum round to split on.
-        // All entries < dummy will be removed.
-        let lower_bound = BlockRef::new(
-            transaction_eviction_round,
-            AuthorityIndex::ZERO,
-            BlockHeaderDigest::MIN,
-        );
+        for (authority_index, _) in self.context.committee.authorities() {
+            let eviction_round = self.calculate_authority_eviction_round(authority_index);
+            // Take minimum between transaction_gc_round and eviction_round
+            let transaction_eviction_round = min(transaction_gc_round, eviction_round + 1);
 
-        // Remove entries with round < min_round
-        self.recent_transactions = self.recent_transactions.split_off(&lower_bound);
+            // Evict everything below split_key
+            let split_key = BlockRef::new(
+                transaction_eviction_round,
+                authority_index,
+                BlockHeaderDigest::MIN,
+            );
+            self.recent_transactions_by_authority[authority_index] =
+                self.recent_transactions_by_authority[authority_index].split_off(&split_key);
+        }
     }
 
     /// Return the garbage collection round with respect to the last solid
@@ -1514,12 +1590,18 @@ impl DagState {
         metrics
             .dag_state_recent_headers
             .set(self.recent_block_headers.len() as i64);
-        metrics
-            .dag_state_recent_shards
-            .set(self.recent_shards.len() as i64);
-        metrics
-            .dag_state_recent_transactions
-            .set(self.recent_transactions.len() as i64);
+        metrics.dag_state_recent_shards.set(
+            self.recent_shards_by_authority
+                .iter()
+                .map(BTreeMap::len)
+                .sum::<usize>() as i64,
+        );
+        metrics.dag_state_recent_transactions.set(
+            self.recent_transactions_by_authority
+                .iter()
+                .map(BTreeMap::len)
+                .sum::<usize>() as i64,
+        );
         metrics.dag_state_recent_refs.set(
             self.recent_headers_refs_by_authority
                 .iter()
@@ -2279,7 +2361,7 @@ mod test {
 
         // All transactions should be found in DagState.
         let result = dag_state
-            .get_transactions(&block_refs)
+            .get_verified_transactions(&block_refs)
             .into_iter()
             .map(|b| b.unwrap())
             .collect::<Vec<_>>();
@@ -2319,7 +2401,7 @@ mod test {
         // Transactions from the first 5 rounds should be found in DagState.
         let vec_transactions = dag_builder.transactions(1..=5);
         let result = dag_state
-            .get_transactions(&block_refs)
+            .get_verified_transactions(&block_refs)
             .into_iter()
             .map(|b| b.unwrap())
             .collect::<Vec<_>>();
@@ -2345,7 +2427,7 @@ mod test {
             .collect::<Vec<_>>();
         assert!(retrieved_block_headers.is_empty());
         let retrieved_transactions = dag_state
-            .get_transactions(&block_refs)
+            .get_verified_transactions(&block_refs)
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();
@@ -2998,7 +3080,7 @@ mod test {
         let expected_transactions_in_dag = dag_builder.transactions(gc_round + 1..=num_rounds);
         // All transactions should be found in DagState or store.
         let result = dag_state
-            .get_transactions(&block_refs_with_transactions_in_dag)
+            .get_verified_transactions(&block_refs_with_transactions_in_dag)
             .into_iter()
             .map(|b| b.unwrap())
             .collect::<Vec<_>>();
@@ -3018,7 +3100,7 @@ mod test {
 
         // All transactions should be found in DagState or store.
         let result = dag_state
-            .get_transactions(&block_refs)
+            .get_verified_transactions(&block_refs)
             .into_iter()
             .map(|b| b.unwrap())
             .collect::<Vec<_>>();
@@ -3030,7 +3112,7 @@ mod test {
                 .metrics
                 .node_metrics
                 .dag_state_store_read_count
-                .with_label_values(&["get_transactions"])
+                .with_label_values(&["get_verified_transactions"])
                 .get(),
             1,
             "dag_state_store_read_count for get_transactions should be one"

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -30,7 +30,6 @@ use crate::{
     context::Context,
     cordial_knowledge::CordialKnowledgeMessage,
     leader_scoring::{ReputationScores, ScoringSubdag},
-    network::SerializedTransactions,
     storage::{Store, WriteBatch},
     threshold_clock::ThresholdClock,
 };
@@ -99,12 +98,14 @@ pub(crate) struct DagState {
     /// are kept in memory.
     recent_block_headers: BTreeMap<BlockRef, VerifiedBlockHeader>,
 
-    /// Contains recent verified transactions per authority. To access a transaction with a given block_ref, one
-    /// needs to read first the entry with index block_ref.author.
-    /// Evicted using the minimum between GC round for the last solid leader round
-    /// evicted rounds by authority.
+    /// Contains recent verified transactions per authority. To access a
+    /// transaction with a given block_ref, one needs to read first the
+    /// entry with index block_ref.author. Evicted using the minimum between
+    /// GC round for the last solid leader round evicted rounds by
+    /// authority.
     recent_transactions_by_authority: Vec<BTreeMap<BlockRef, VerifiedTransactions>>,
-    /// Contains recent own serialized shards with their Merkle proofs per authority. To access own shard for a given block_ref, one
+    /// Contains recent own serialized shards with their Merkle proofs per
+    /// authority. To access own shard for a given block_ref, one
     /// needs to read first the entry with index block_ref.author.
     /// Eviction is aligned with headers
     recent_shards_by_authority: Vec<BTreeMap<BlockRef, Bytes>>,
@@ -568,7 +569,7 @@ impl DagState {
     pub(crate) fn get_serialized_transactions(
         &self,
         block_refs: &[BlockRef],
-    ) -> Vec<Option<SerializedTransactions>> {
+    ) -> Vec<Option<Bytes>> {
         let mut transactions = vec![None; block_refs.len()];
         let mut missing = Vec::new();
 
@@ -580,14 +581,14 @@ impl DagState {
                     .get(block_ref)
                     .map(|block| block.verified_transactions.clone())
                 {
-                    transactions[index] = Some(SerializedTransactions::from(transaction));
+                    transactions[index] = Some(transaction.serialized().clone());
                 }
                 continue;
             }
             if let Some(transaction) =
                 self.recent_transactions_by_authority[block_ref.author].get(block_ref)
             {
-                transactions[index] = Some(SerializedTransactions::from(transaction.clone()));
+                transactions[index] = Some(transaction.serialized().clone());
                 continue;
             }
             missing.push((index, block_ref));
@@ -621,16 +622,19 @@ impl DagState {
 
     /// Gets a block header by checking cached recent blocks then storage.
     /// Returns None when the block is not found.
-    pub(crate) fn get_block_header(&self, reference: &BlockRef) -> Option<VerifiedBlockHeader> {
-        self.get_block_headers(&[*reference])
+    pub(crate) fn get_verified_block_header(
+        &self,
+        reference: &BlockRef,
+    ) -> Option<VerifiedBlockHeader> {
+        self.get_verified_block_headers(&[*reference])
             .pop()
             .expect("Exactly one element should be returned")
     }
 
-    /// Gets block headers by checking genesis, cached recent block headers in
-    /// memory, then storage. An element is None when the corresponding
-    /// block header is not found.
-    pub(crate) fn get_block_headers(
+    /// Gets verified block headers by checking genesis, cached recent block
+    /// headers in memory, then storage. An element is None when the
+    /// corresponding block header is not found.
+    pub(crate) fn get_verified_block_headers(
         &self,
         block_refs: &[BlockRef],
     ) -> Vec<Option<VerifiedBlockHeader>> {
@@ -644,8 +648,8 @@ impl DagState {
                 }
                 continue;
             }
-            if let Some(block) = self.recent_block_headers.get(block_ref) {
-                block_headers[index] = Some(block.clone());
+            if let Some(block_header) = self.recent_block_headers.get(block_ref) {
+                block_headers[index] = Some(block_header.clone());
                 continue;
             }
             missing_headers.push((index, block_ref));
@@ -661,14 +665,65 @@ impl DagState {
             .collect::<Vec<_>>();
         let store_results = self
             .store
-            .read_block_headers(&missing_refs)
+            .read_verified_block_headers(&missing_refs)
             .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"));
 
         self.context
             .metrics
             .node_metrics
             .dag_state_store_read_count
-            .with_label_values(&["get_block_headers"])
+            .with_label_values(&["get_verified_block_headers"])
+            .inc();
+
+        for ((index, _), result) in missing_headers.into_iter().zip(store_results.into_iter()) {
+            block_headers[index] = result;
+        }
+
+        block_headers
+    }
+
+    /// Gets serialized block headers by checking genesis, cached recent block
+    /// headers in memory, then storage. An element is None when the
+    /// corresponding block header is not found.
+    pub(crate) fn get_serialized_block_headers(
+        &self,
+        block_refs: &[BlockRef],
+    ) -> Vec<Option<Bytes>> {
+        let mut block_headers: Vec<Option<Bytes>> = vec![None; block_refs.len()];
+        let mut missing_headers = Vec::new();
+        for (index, block_ref) in block_refs.iter().enumerate() {
+            if block_ref.round == GENESIS_ROUND {
+                // Allow the caller to handle the invalid genesis ancestor error.
+                if let Some(block) = self.genesis.get(block_ref) {
+                    block_headers[index] = Some(block.verified_block_header.serialized().clone());
+                }
+                continue;
+            }
+            if let Some(block) = self.recent_block_headers.get(block_ref) {
+                block_headers[index] = Some(block.serialized().clone());
+                continue;
+            }
+            missing_headers.push((index, block_ref));
+        }
+
+        if missing_headers.is_empty() {
+            return block_headers;
+        }
+
+        let missing_refs = missing_headers
+            .iter()
+            .map(|(_, block_ref)| **block_ref)
+            .collect::<Vec<_>>();
+        let store_results = self
+            .store
+            .read_serialized_block_headers(&missing_refs)
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"));
+
+        self.context
+            .metrics
+            .node_metrics
+            .dag_state_store_read_count
+            .with_label_values(&["get_serialized_block_headers"])
             .inc();
 
         for ((index, _), result) in missing_headers.into_iter().zip(store_results.into_iter()) {
@@ -786,7 +841,7 @@ impl DagState {
                 break;
             }
             let block_ref = linked.pop_last().unwrap();
-            let Some(block) = self.get_block_header(&block_ref) else {
+            let Some(block) = self.get_verified_block_header(&block_ref) else {
                 panic!("Block Header {block_ref:?} should exist in DAG!");
             };
             linked.extend(
@@ -797,7 +852,8 @@ impl DagState {
                     .cloned(),
             );
         }
-        let block_headers = self.get_block_headers(&linked.iter().cloned().collect::<Vec<_>>());
+        let block_headers =
+            self.get_verified_block_headers(&linked.iter().cloned().collect::<Vec<_>>());
         block_headers
             .into_iter()
             .map(|opt| opt.unwrap_or_else(|| panic!("Block should exist in DAG!")))
@@ -1355,10 +1411,11 @@ impl DagState {
         }
     }
 
-    /// Function removes stalled transactions that are older than the minimum between  "last solid
-    /// leader round minus MAX_TRANSACTIONS_ACK_DEPTH
+    /// Function removes stalled transactions that are older than the minimum
+    /// between "last solid leader round minus MAX_TRANSACTIONS_ACK_DEPTH
     /// (protocol_config.gc_depth) minus MAX_LINEARIZER_DEPTH
-    /// (protocol_config.gc_depth)" or the eviction round of corresponding authority
+    /// (protocol_config.gc_depth)" and the eviction round of corresponding
+    /// authority
     pub(crate) fn evict_transactions(&mut self) {
         let transaction_gc_round = self.gc_round_for_last_solid_commit();
         for (authority_index, _) in self.context.committee.authorities() {
@@ -1768,7 +1825,7 @@ mod test {
         // Check uncommitted block headers that exist.
         for (block_ref, block_header) in &block_headers {
             assert_eq!(
-                &dag_state.get_block_header(block_ref).unwrap(),
+                &dag_state.get_verified_block_header(block_ref).unwrap(),
                 block_header
             );
         }
@@ -1777,7 +1834,7 @@ mod test {
         let last_ref = block_headers.keys().last().unwrap();
         assert!(
             dag_state
-                .get_block_header(&BlockRef::new(
+                .get_verified_block_header(&BlockRef::new(
                     last_ref.round,
                     last_ref.author,
                     BlockHeaderDigest::MIN
@@ -2237,7 +2294,7 @@ mod test {
         genesis_refs.extend(block_refs);
         block_refs = genesis_refs;
 
-        let result = dag_state.get_block_headers(&block_refs);
+        let result = dag_state.get_verified_block_headers(&block_refs);
 
         let mut expected_headers = block_headers
             .clone()
@@ -2274,7 +2331,7 @@ mod test {
                 BlockHeaderDigest::default(),
             ),
         );
-        let result = dag_state.get_block_headers(&block_refs);
+        let result = dag_state.get_verified_block_headers(&block_refs);
 
         // Then all should be found apart from the last one
         expected_headers.insert(3, None);
@@ -2342,7 +2399,7 @@ mod test {
             .collect::<Vec<_>>();
 
         let result = dag_state
-            .get_block_headers(&block_refs)
+            .get_verified_block_headers(&block_refs)
             .into_iter()
             .map(|b| b.unwrap())
             .collect::<Vec<_>>();
@@ -2393,7 +2450,7 @@ mod test {
             .map(|block_header| block_header.reference())
             .collect::<Vec<_>>();
         let result = dag_state
-            .get_block_headers(&block_refs)
+            .get_verified_block_headers(&block_refs)
             .into_iter()
             .map(|b| b.unwrap())
             .collect::<Vec<_>>();
@@ -2421,7 +2478,7 @@ mod test {
             .map(|block_header| block_header.reference())
             .collect::<Vec<_>>();
         let retrieved_block_headers = dag_state
-            .get_block_headers(&block_refs)
+            .get_verified_block_headers(&block_refs)
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -187,7 +187,8 @@ impl DataManager {
     ) -> Result<CommittedSubDag, Vec<BlockRef>> {
         let dag_state = self.dag_state.read();
         // Get transactions and check if any are missing
-        let transaction_results = dag_state.get_transactions(&subdag.committed_transaction_refs);
+        let transaction_results =
+            dag_state.get_verified_transactions(&subdag.committed_transaction_refs);
         let mut missing = Vec::new();
         for (i, tx_opt) in transaction_results.iter().enumerate() {
             if tx_opt.is_none() {
@@ -204,7 +205,7 @@ impl DataManager {
 
             Ok(CommittedSubDag::new(
                 subdag.leader,
-                subdag.base.blocks.clone(),
+                subdag.base.headers.clone(),
                 transactions,
                 subdag.timestamp_ms,
                 subdag.commit_ref,

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -81,7 +81,7 @@ struct BlocksGuard {
 
 impl Drop for BlocksGuard {
     fn drop(&mut self) {
-        self.map.unlock_blocks(&self.block_refs, self.peer);
+        self.map.unlock_headers(&self.block_refs, self.peer);
     }
 }
 
@@ -101,19 +101,20 @@ impl InflightBlockHeadersMap {
         })
     }
 
-    /// Locks the blocks to be fetched for the assigned `peer_index`. We want to
-    /// avoid re-fetching the missing blocks from too many authorities at
-    /// the same time, thus we limit the concurrency per block by attempting
-    /// to lock per block. If a block is already fetched by the maximum allowed
-    /// number of authorities, then the block ref will not be included in the
-    /// returned set. The method returns all the block refs that have been
-    /// successfully locked and allowed to be fetched.
-    fn lock_blocks(
+    /// Locks the block headers to be fetched for the assigned `peer_index`. We
+    /// want to avoid re-fetching the missing block headers from too many
+    /// authorities at the same time, thus we limit the concurrency per
+    /// block by attempting to lock per block. If a header is already
+    /// fetched by the maximum allowed number of authorities, then the block
+    /// ref will not be included in the returned set. The method returns all
+    /// the block refs that have been successfully locked and allowed to be
+    /// fetched.
+    fn lock_headers(
         self: &Arc<Self>,
         missing_block_refs: BTreeSet<BlockRef>,
         peer: AuthorityIndex,
     ) -> Option<BlocksGuard> {
-        let mut blocks = BTreeSet::new();
+        let mut block_refs = BTreeSet::new();
         let mut inner = self.inner.lock();
 
         for block_ref in missing_block_refs {
@@ -125,16 +126,16 @@ impl InflightBlockHeadersMap {
                 && authorities.get(&peer).is_none()
             {
                 assert!(authorities.insert(peer));
-                blocks.insert(block_ref);
+                block_refs.insert(block_ref);
             }
         }
 
-        if blocks.is_empty() {
+        if block_refs.is_empty() {
             None
         } else {
             Some(BlocksGuard {
                 map: self.clone(),
-                block_refs: blocks,
+                block_refs,
                 peer,
             })
         }
@@ -144,11 +145,11 @@ impl InflightBlockHeadersMap {
     /// unlocking is strict, meaning that if this method is called for a
     /// specific block ref and peer more times than the corresponding lock
     /// has been called, it will panic.
-    fn unlock_blocks(self: &Arc<Self>, block_refs: &BTreeSet<BlockRef>, peer: AuthorityIndex) {
+    fn unlock_headers(self: &Arc<Self>, block_refs: &BTreeSet<BlockRef>, peer: AuthorityIndex) {
         // Now mark all the blocks as fetched from the map
-        let mut blocks_to_fetch = self.inner.lock();
+        let mut headers_to_fetch = self.inner.lock();
         for block_ref in block_refs {
-            let authorities = blocks_to_fetch
+            let authorities = headers_to_fetch
                 .get_mut(block_ref)
                 .expect("Should have found a non empty map");
 
@@ -156,7 +157,7 @@ impl InflightBlockHeadersMap {
 
             // if the last one then just clean up
             if authorities.is_empty() {
-                blocks_to_fetch.remove(block_ref);
+                headers_to_fetch.remove(block_ref);
             }
         }
     }
@@ -176,11 +177,11 @@ impl InflightBlockHeadersMap {
         drop(blocks_guard);
 
         // Now create new guard
-        self.lock_blocks(block_refs, peer)
+        self.lock_headers(block_refs, peer)
     }
 
     #[cfg(test)]
-    fn num_of_locked_blocks(self: &Arc<Self>) -> usize {
+    fn num_of_locked_headers(self: &Arc<Self>) -> usize {
         let inner = self.inner.lock();
         inner.len()
     }
@@ -196,12 +197,12 @@ enum Command {
     KickOffScheduler,
 }
 
-pub(crate) struct SynchronizerHandle {
+pub(crate) struct HeaderSynchronizerHandle {
     commands_sender: Sender<Command>,
     tasks: tokio::sync::Mutex<JoinSet<()>>,
 }
 
-impl SynchronizerHandle {
+impl HeaderSynchronizerHandle {
     /// Explicitly asks from the synchronizer to fetch block headers - provided
     /// the block_refs set - from the peer authority.
     pub(crate) async fn fetch_headers(
@@ -267,7 +268,7 @@ impl SynchronizerHandle {
 /// Additionally to the above, the synchronizer can synchronize and fetch the
 /// last own proposed header from the network peers as best effort approach to
 /// recover node from amnesia and avoid making the node equivocate.
-pub(crate) struct Synchronizer<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> {
+pub(crate) struct HeaderSynchronizer<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> {
     context: Arc<Context>,
     commands_receiver: Receiver<Command>,
     fetch_block_senders: BTreeMap<AuthorityIndex, Sender<BlocksGuard>>,
@@ -283,9 +284,9 @@ pub(crate) struct Synchronizer<C: NetworkClient, V: BlockVerifier, D: CoreThread
     commands_sender: Sender<Command>,
 }
 
-impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C, V, D> {
-    /// Starts the synchronizer, which is responsible for fetching blocks from
-    /// other authorities and managing block synchronization tasks.
+impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchronizer<C, V, D> {
+    /// Starts the synchronizer, which is responsible for fetching block headers
+    /// from other authorities and managing block synchronization tasks.
     pub fn start(
         network_client: Arc<C>,
         context: Arc<Context>,
@@ -295,7 +296,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         block_verifier: Arc<V>,
         dag_state: Arc<RwLock<DagState>>,
         sync_last_known_own_block: bool,
-    ) -> Arc<SynchronizerHandle> {
+    ) -> Arc<HeaderSynchronizerHandle> {
         let (commands_sender, commands_receiver) =
             channel("consensus_synchronizer_commands", 1_000);
         let inflight_block_headers_map = InflightBlockHeadersMap::new();
@@ -355,7 +356,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             s.run().await;
         }));
 
-        Arc::new(SynchronizerHandle {
+        Arc::new(HeaderSynchronizerHandle {
             commands_sender,
             tasks: tokio::sync::Mutex::new(tasks),
         })
@@ -388,7 +389,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                 .take(self.context.parameters.max_headers_per_regular_sync_fetch)
                                 .collect();
 
-                            let blocks_guard = self.inflight_block_headers_map.lock_blocks(missing_block_refs, peer_index);
+                            let blocks_guard = self.inflight_block_headers_map.lock_headers(missing_block_refs, peer_index);
                             let Some(blocks_guard) = blocks_guard else {
                                 result.send(Ok(())).ok();
                                 continue;
@@ -1276,7 +1277,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
             // Lock the block headers to be fetched. If no lock can be acquired for any of
             // the block headers then don't bother.
-            if let Some(blocks_guard) = inflight_block_headers.lock_blocks(block_refs.clone(), peer)
+            if let Some(blocks_guard) =
+                inflight_block_headers.lock_headers(block_refs.clone(), peer)
             {
                 info!(
                     "Periodic sync of {} missing block headers from peer {} {}: {}",
@@ -1422,12 +1424,12 @@ mod tests {
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
         dag_state::{DagState, TransactionSource},
         error::{ConsensusError, ConsensusResult},
+        header_synchronizer::{
+            FETCH_BLOCK_HEADERS_CONCURRENCY, FETCH_REQUEST_TIMEOUT, HeaderSynchronizer,
+            InflightBlockHeadersMap,
+        },
         network::{BlockBundleStream, NetworkClient},
         storage::mem_store::MemStore,
-        synchronizer::{
-            FETCH_BLOCK_HEADERS_CONCURRENCY, FETCH_REQUEST_TIMEOUT, InflightBlockHeadersMap,
-            Synchronizer,
-        },
         transactions_synchronizer::TransactionsSynchronizer,
     };
 
@@ -1585,14 +1587,14 @@ mod tests {
             for i in 1..=3 {
                 let authority = AuthorityIndex::new_for_test(i);
 
-                let guard = map.lock_blocks(missing_block_refs.clone(), authority);
+                let guard = map.lock_headers(missing_block_refs.clone(), authority);
                 let guard = guard.expect("Guard should be created");
                 assert_eq!(guard.block_refs.len(), 4);
 
                 all_guards.push(guard);
 
                 // trying to acquire any of them again will not succeed
-                let guard = map.lock_blocks(missing_block_refs.clone(), authority);
+                let guard = map.lock_headers(missing_block_refs.clone(), authority);
                 assert!(guard.is_none());
             }
 
@@ -1600,14 +1602,14 @@ mod tests {
             // number of allowed peers
             let authority_4 = AuthorityIndex::new_for_test(4);
 
-            let guard = map.lock_blocks(missing_block_refs.clone(), authority_4);
+            let guard = map.lock_headers(missing_block_refs.clone(), authority_4);
             assert!(guard.is_none());
 
             // Explicitly drop the guard of authority 1 and try for authority 4 again - it
             // will now succeed
             drop(all_guards.remove(0));
 
-            let guard = map.lock_blocks(missing_block_refs.clone(), authority_4);
+            let guard = map.lock_headers(missing_block_refs.clone(), authority_4);
             let guard = guard.expect("Guard should be successfully acquired");
 
             assert_eq!(guard.block_refs, missing_block_refs);
@@ -1616,7 +1618,7 @@ mod tests {
             drop(guard);
             drop(all_guards);
 
-            assert_eq!(map.num_of_locked_blocks(), 0);
+            assert_eq!(map.num_of_locked_headers(), 0);
         }
 
         // Swap locks
@@ -1624,7 +1626,7 @@ mod tests {
             // acquire a lock for authority 1
             let authority_1 = AuthorityIndex::new_for_test(1);
             let guard = map
-                .lock_blocks(missing_block_refs.clone(), authority_1)
+                .lock_headers(missing_block_refs.clone(), authority_1)
                 .unwrap();
 
             // Now swap the locks for authority 2
@@ -1638,13 +1640,13 @@ mod tests {
             // authorities 3 & 4, but not for 5
             for i in 3..=4 {
                 let authority = AuthorityIndex::new_for_test(i);
-                let guard = map.lock_blocks(missing_block_refs.clone(), authority);
+                let guard = map.lock_headers(missing_block_refs.clone(), authority);
                 let guard = guard.expect("Guard should be created");
                 assert_eq!(guard.block_refs.len(), 4);
                 all_guards.push(guard);
             }
             let authority = AuthorityIndex::new_for_test(5);
-            let guard = map.lock_blocks(missing_block_refs.clone(), authority);
+            let guard = map.lock_headers(missing_block_refs.clone(), authority);
             assert!(guard.is_none());
         }
     }
@@ -1669,7 +1671,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let handle = Synchronizer::start(
+        let handle = HeaderSynchronizer::start(
             network_client.clone(),
             context,
             core_dispatcher.clone(),
@@ -1738,7 +1740,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let handle = Synchronizer::start(
+        let handle = HeaderSynchronizer::start(
             network_client.clone(),
             context,
             core_dispatcher.clone(),
@@ -1875,7 +1877,7 @@ mod tests {
             .await;
 
         // WHEN start the synchronizer and wait for a couple of seconds
-        let handle = Synchronizer::start(
+        let handle = HeaderSynchronizer::start(
             network_client.clone(),
             context,
             core_dispatcher.clone(),
@@ -2020,7 +2022,7 @@ mod tests {
 
         // Start the synchronizer and wait for a couple of seconds where normally
         // the synchronizer should have kicked in.
-        let handle = Synchronizer::start(
+        let handle = HeaderSynchronizer::start(
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
@@ -2129,7 +2131,7 @@ mod tests {
 
         // Start the synchronizer and wait for a couple of seconds where normally
         // the synchronizer should have kicked in.
-        let handle = Synchronizer::start(
+        let handle = HeaderSynchronizer::start(
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
@@ -2283,7 +2285,7 @@ mod tests {
             .await;
 
         // WHEN start the synchronizer and wait for a couple of seconds
-        let handle = Synchronizer::start(
+        let handle = HeaderSynchronizer::start(
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
@@ -2476,15 +2478,18 @@ mod tests {
 
             // 4) Invoke knowledge-based fetch and random fallback selection
             //    deterministically
-            let results = Synchronizer::<MockNetworkClient, NoopBlockVerifier, SyncMockDispatcher>
-            ::fetch_block_headers_from_authorities_periodic(
+            let results = HeaderSynchronizer::<
+                MockNetworkClient,
+                NoopBlockVerifier,
+                SyncMockDispatcher,
+            >::fetch_block_headers_from_authorities_periodic(
                 context.clone(),
                 inflight.clone(),
                 network_client.clone(),
                 missing_blocks,
                 dag_state.clone(),
             )
-                .await;
+            .await;
 
             // 5) Knowledge-based fetches should go to 2 and 3, additional random requests
             //    go to 1 (only one authority because in additional requests we ask
@@ -2639,7 +2644,7 @@ mod tests {
             .await;
 
         // 5) Execute the fetch logic
-        let results = Synchronizer::<
+        let results = HeaderSynchronizer::<
             MockNetworkClient,
             NoopBlockVerifier,
             SyncMockDispatcher,
@@ -2720,7 +2725,7 @@ mod tests {
             dag_state.clone(),
         );
 
-        let handle = Synchronizer::start(
+        let handle = HeaderSynchronizer::start(
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -515,7 +515,7 @@ mod tests {
         let mut block_headers_to_write = vec![];
 
         for (sub_dag, commit) in dag_builder.get_sub_dag_and_commits(1..=11) {
-            for block_headers in sub_dag.blocks.iter() {
+            for block_headers in sub_dag.headers.iter() {
                 block_headers_to_write.push(block_headers.clone());
             }
 
@@ -623,11 +623,11 @@ mod tests {
         let mut expected_scored_subdags = vec![];
         let mut expected_commits = vec![];
 
-        let mut blocks_to_write = vec![];
+        let mut headers_to_write = vec![];
 
         for (sub_dag, commit) in dag_builder.get_sub_dag_and_commits(1..=2) {
-            for block in sub_dag.blocks.iter() {
-                blocks_to_write.push(block.clone());
+            for header in sub_dag.headers.iter() {
+                headers_to_write.push(header.clone());
             }
             expected_commits.push(commit);
             expected_scored_subdags.push(sub_dag);
@@ -641,7 +641,7 @@ mod tests {
         store
             .write(
                 WriteBatch::default()
-                    .block_headers(blocks_to_write)
+                    .block_headers(headers_to_write)
                     .commits(expected_commits),
             )
             .unwrap();

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -125,11 +125,11 @@ impl ScoringSubdag {
             self.leaders.insert(subdag.leader);
             // Check each block in subdag. Blocks are in order so we should traverse the
             // oldest blocks first
-            for block in subdag.blocks {
-                for ancestor in block.ancestors() {
+            for header in subdag.headers {
+                for ancestor in header.ancestors() {
                     // Weak links may point to blocks with lower round numbers
                     // than strong links.
-                    if ancestor.round != block.round().saturating_sub(1) {
+                    if ancestor.round != header.round().saturating_sub(1) {
                         continue;
                     }
                     // If a blocks strong linked ancestor is in leaders, then
@@ -139,14 +139,14 @@ impl ScoringSubdag {
                         // with strong linked ancestors to leader.
                         tracing::trace!(
                             "Found a vote {} for leader {ancestor} from authority {}",
-                            block.reference(),
-                            block.author()
+                            header.reference(),
+                            header.author()
                         );
                         assert!(
                             self.votes
-                                .insert(block.reference(), StakeAggregator::new())
+                                .insert(header.reference(), StakeAggregator::new())
                                 .is_none(),
-                            "Vote {block} already exists. Duplicate vote found for leader {ancestor}"
+                            "Vote {header} already exists. Duplicate vote found for leader {ancestor}"
                         );
                     }
                     if let Some(stake) = self.votes.get_mut(ancestor) {
@@ -156,7 +156,7 @@ impl ScoringSubdag {
                             "Found a distributed vote {ancestor} from authority {}",
                             ancestor.author
                         );
-                        stake.add(block.author(), &self.context.committee);
+                        stake.add(header.author(), &self.context.committee);
                     }
                 }
             }

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -28,10 +28,10 @@ mod network;
 #[cfg(msim)]
 pub mod network;
 
+mod header_synchronizer;
 mod stake_aggregator;
 mod storage;
 mod subscriber;
-mod synchronizer;
 mod threshold_clock;
 #[cfg(not(msim))]
 mod transaction;

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -473,23 +473,23 @@ mod tests {
 
             if idx == 0 {
                 // First subdag includes the leader block only and no committed data
-                assert_eq!(subdag.blocks.len(), 1);
+                assert_eq!(subdag.headers.len(), 1);
                 assert_eq!(subdag.committed_transaction_refs.len(), 0);
             } else if idx == 1 {
                 // Genesis blocks are included in the first commit
-                assert_eq!(subdag.blocks.len(), num_authorities);
+                assert_eq!(subdag.headers.len(), num_authorities);
                 // Transactions from genesis are not committed
                 assert_eq!(subdag.committed_transaction_refs.len(), 0);
             } else {
                 // Every subdag after will be missing the leader block from the previous
                 // committed subdag
-                assert_eq!(subdag.blocks.len(), num_authorities);
+                assert_eq!(subdag.headers.len(), num_authorities);
                 // Every subdag after the first one will have all the committed transactions
                 // from 2 rounds before the leader round
                 assert_eq!(subdag.committed_transaction_refs.len(), num_authorities);
             }
-            for block in subdag.blocks.iter() {
-                assert!(block.round() <= leaders[idx].round());
+            for header in subdag.headers.iter() {
+                assert!(header.round() <= leaders[idx].round());
             }
 
             for committed_transactions_ref in subdag.committed_transaction_refs.iter() {
@@ -676,9 +676,9 @@ mod tests {
 
         let expected_ts = median_timestamp_by_stake(
             &context,
-            subdag.blocks.iter().filter_map(|block| {
-                if block.round() == subdag.leader.round - 1 {
-                    Some(block.clone())
+            subdag.headers.iter().filter_map(|header| {
+                if header.round() == subdag.leader.round - 1 {
+                    Some(header.clone())
                 } else {
                     None
                 }
@@ -693,15 +693,15 @@ mod tests {
             .sort_by(|a, b| a.round.cmp(&b.round).then_with(|| a.author.cmp(&b.author)));
         assert_eq!(
             subdag
-                .blocks
+                .headers
                 .clone()
                 .into_iter()
                 .map(|b| b.reference())
                 .collect::<Vec<_>>(),
             block_refs_wave_2
         );
-        for block in subdag.blocks.iter() {
-            assert!(block.round() <= expected_second_commit.leader().round);
+        for header in subdag.headers.iter() {
+            assert!(header.round() <= expected_second_commit.leader().round);
         }
     }
 
@@ -793,11 +793,11 @@ mod tests {
 
             if idx == 0 {
                 // First subdag includes the leader block only
-                assert_eq!(subdag.blocks.len(), 1);
+                assert_eq!(subdag.headers.len(), 1);
                 // First subdag does not commit any transactions
                 assert_eq!(subdag.committed_transaction_refs.len(), 0);
             } else if idx == 1 {
-                assert_eq!(subdag.blocks.len(), 3);
+                assert_eq!(subdag.headers.len(), 3);
                 // The second subdag does not commit any transactions either yet
                 assert_eq!(subdag.committed_transaction_refs.len(), 0);
             } else if idx == 2 {
@@ -807,7 +807,7 @@ mod tests {
                 //   missing
                 // * 2 blocks on round 2, again as no commit happened on round 3, we commit the
                 //   "sub dag" of leader of round 3, which will be another 2 blocks
-                assert_eq!(subdag.blocks.len(), 6);
+                assert_eq!(subdag.headers.len(), 6);
 
                 // We commit transactions from:
                 // * 3 blocks on round 1, as no commit happened on round 3 since the leader was
@@ -827,9 +827,9 @@ mod tests {
                 }
             } else {
                 // we expect to see all blocks of round >= 1
-                assert_eq!(subdag.blocks.len(), 6);
+                assert_eq!(subdag.headers.len(), 6);
                 assert!(
-                    subdag.blocks.iter().all(|block| block.round() >= 1),
+                    subdag.headers.iter().all(|block| block.round() >= 1),
                     "Found blocks that are of round < 1."
                 );
 
@@ -845,8 +845,8 @@ mod tests {
                     assert_eq!(authors, (0..=3).map(AuthorityIndex::new_for_test).collect());
                 }
             }
-            for block in subdag.blocks.iter() {
-                assert!(block.round() <= leaders[idx].round());
+            for header in subdag.headers.iter() {
+                assert!(header.round() <= leaders[idx].round());
             }
 
             for committed_transactions_ref in subdag.committed_transaction_refs.iter() {

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -34,7 +34,7 @@ impl BlockStoreAPI
     for parking_lot::lock_api::RwLockReadGuard<'_, parking_lot::RawRwLock, DagState>
 {
     fn get_block_headers(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlockHeader>> {
-        DagState::get_block_headers(self, refs)
+        DagState::get_verified_block_headers(self, refs)
     }
 }
 

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -32,7 +32,7 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     Round, VerifiedBlockHeader,
-    block_header::{BlockRef, VerifiedBlock, VerifiedTransactions},
+    block_header::{BlockRef, VerifiedBlock},
     commit::{CommitRange, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
 };
@@ -385,15 +385,6 @@ impl TryFrom<BlockBundle> for SerializedBlockBundle {
 pub(crate) struct SerializedTransactions {
     pub(crate) block_ref: BlockRef,
     pub(crate) serialized_transactions: Bytes,
-}
-
-impl SerializedTransactions {
-    pub fn from(verified_transactions: VerifiedTransactions) -> Self {
-        Self {
-            block_ref: verified_transactions.block_ref(),
-            serialized_transactions: verified_transactions.serialized().clone(),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -32,10 +32,11 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     Round, VerifiedBlockHeader,
-    block_header::{BlockRef, VerifiedBlock},
+    block_header::{BlockRef, VerifiedBlock, VerifiedTransactions},
     commit::{CommitRange, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
 };
+
 // Tonic generated RPC stubs.
 mod tonic_gen {
     include!(concat!(env!("OUT_DIR"), "/consensus.ConsensusService.rs"));
@@ -384,6 +385,15 @@ impl TryFrom<BlockBundle> for SerializedBlockBundle {
 pub(crate) struct SerializedTransactions {
     pub(crate) block_ref: BlockRef,
     pub(crate) serialized_transactions: Bytes,
+}
+
+impl SerializedTransactions {
+    pub fn from(verified_transactions: VerifiedTransactions) -> Self {
+        Self {
+            block_ref: verified_transactions.block_ref(),
+            serialized_transactions: verified_transactions.serialized().clone(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -505,7 +505,9 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                 let mut to_stay_transactions = BTreeMap::new();
                 let block_headers_opt = {
                     let block_refs: Vec<BlockRef> = transactions_map.keys().copied().collect();
-                    self.dag_state.read().get_block_headers(&block_refs)
+                    self.dag_state
+                        .read()
+                        .get_verified_block_headers(&block_refs)
                 };
                 for (block_header_opt, (block_ref, transactions)) in block_headers_opt
                     .into_iter()

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -21,6 +21,7 @@ use crate::{
         TrustedCommit,
     },
     error::ConsensusResult,
+    network::SerializedTransactions,
 };
 
 /// In-memory storage for testing.
@@ -99,7 +100,7 @@ impl Store for MemStore {
         Ok(())
     }
 
-    fn read_transactions(
+    fn read_verified_transactions(
         &self,
         refs: &[BlockRef],
     ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>> {
@@ -116,6 +117,24 @@ impl Store for MemStore {
         Ok(transactions)
     }
 
+    fn read_serialized_transactions(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<SerializedTransactions>>> {
+        let inner = self.inner.read();
+        let transactions = refs
+            .iter()
+            .map(|r| {
+                let tx = inner
+                    .transactions
+                    .get(&(r.round, r.author, r.digest))
+                    .cloned();
+                tx.map(SerializedTransactions::from)
+            })
+            .collect();
+        Ok(transactions)
+    }
+
     // TODO: Do we need this method or will DAGState always try to read both headers
     // and transactions separately?
     fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
@@ -124,7 +143,7 @@ impl Store for MemStore {
         let inner = self.inner.read();
         // Get both headers and transactions for the given references
         let headers = self.read_block_headers(refs)?;
-        let transactions = self.read_transactions(refs)?;
+        let transactions = self.read_verified_transactions(refs)?;
         drop(inner); // Explicitly drop the read lock before combining results
 
         // Combine them into blocks if both parts exist

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -7,6 +7,7 @@ use std::{
     ops::Bound::Included,
 };
 
+use bytes::Bytes;
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
 
@@ -21,7 +22,6 @@ use crate::{
         TrustedCommit,
     },
     error::ConsensusResult,
-    network::SerializedTransactions,
 };
 
 /// In-memory storage for testing.
@@ -120,16 +120,15 @@ impl Store for MemStore {
     fn read_serialized_transactions(
         &self,
         refs: &[BlockRef],
-    ) -> ConsensusResult<Vec<Option<SerializedTransactions>>> {
+    ) -> ConsensusResult<Vec<Option<Bytes>>> {
         let inner = self.inner.read();
         let transactions = refs
             .iter()
             .map(|r| {
-                let tx = inner
+                inner
                     .transactions
                     .get(&(r.round, r.author, r.digest))
-                    .cloned();
-                tx.map(SerializedTransactions::from)
+                    .map(|tx| tx.serialized().clone())
             })
             .collect();
         Ok(transactions)
@@ -142,7 +141,7 @@ impl Store for MemStore {
         // transactions reads
         let inner = self.inner.read();
         // Get both headers and transactions for the given references
-        let headers = self.read_block_headers(refs)?;
+        let headers = self.read_verified_block_headers(refs)?;
         let transactions = self.read_verified_transactions(refs)?;
         drop(inner); // Explicitly drop the read lock before combining results
 
@@ -230,7 +229,7 @@ impl Store for MemStore {
         Ok(blocks)
     }
 
-    fn read_block_headers(
+    fn read_verified_block_headers(
         &self,
         refs: &[BlockRef],
     ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>> {
@@ -245,6 +244,23 @@ impl Store for MemStore {
             })
             .collect();
         Ok(block_headers)
+    }
+
+    fn read_serialized_block_headers(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<Bytes>>> {
+        let inner = self.inner.read();
+        let serialized_headers = refs
+            .iter()
+            .map(|r| {
+                inner
+                    .block_headers
+                    .get(&(r.round, r.author, r.digest))
+                    .map(|header| header.serialized().clone())
+            })
+            .collect();
+        Ok(serialized_headers)
     }
 
     fn contains_block_at_slot(&self, slot: Slot) -> ConsensusResult<bool> {

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     block_header::{BlockRef, Round, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions},
     commit::{CommitInfo, CommitRange, CommitRef, TrustedCommit},
     error::ConsensusResult,
+    network::SerializedTransactions,
 };
 
 /// A common interface for consensus storage.
@@ -35,10 +36,16 @@ pub(crate) trait Store: Send + Sync {
     ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>>;
 
     /// Reads transactions for the given refs.
-    fn read_transactions(
+    fn read_verified_transactions(
         &self,
         refs: &[BlockRef],
     ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>>;
+
+    /// Reads transactions for the given refs.
+    fn read_serialized_transactions(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<SerializedTransactions>>>;
 
     /// Checks if transactions exist in the store.
     fn contains_transactions(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>>;
@@ -83,7 +90,7 @@ pub(crate) trait Store: Send + Sync {
     ) -> ConsensusResult<Vec<VerifiedTransactions>> {
         let refs = self.scan_references_by_author(author, start_round)?;
         let results = self
-            .read_transactions(refs.as_slice())?
+            .read_verified_transactions(refs.as_slice())?
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod rocksdb_store;
 #[cfg(test)]
 mod store_tests;
 
+use bytes::Bytes;
 use starfish_config::AuthorityIndex;
 
 use crate::{
@@ -16,7 +17,6 @@ use crate::{
     block_header::{BlockRef, Round, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions},
     commit::{CommitInfo, CommitRange, CommitRef, TrustedCommit},
     error::ConsensusResult,
-    network::SerializedTransactions,
 };
 
 /// A common interface for consensus storage.
@@ -29,23 +29,29 @@ pub(crate) trait Store: Send + Sync {
     #[cfg_attr(not(test), expect(dead_code))]
     fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>>;
 
-    /// Reads block headers for the given refs.
-    fn read_block_headers(
+    /// Read and get verified block headers for the given refs.
+    fn read_verified_block_headers(
         &self,
         refs: &[BlockRef],
     ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>>;
 
-    /// Reads transactions for the given refs.
+    /// Read and get serialized block headers for the given refs.
+    fn read_serialized_block_headers(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<Bytes>>>;
+
+    /// Read and get verified transactions for the given refs.
     fn read_verified_transactions(
         &self,
         refs: &[BlockRef],
     ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>>;
 
-    /// Reads transactions for the given refs.
+    /// Read and get serialized transactions for the given refs.
     fn read_serialized_transactions(
         &self,
         refs: &[BlockRef],
-    ) -> ConsensusResult<Vec<Option<SerializedTransactions>>>;
+    ) -> ConsensusResult<Vec<Option<Bytes>>>;
 
     /// Checks if transactions exist in the store.
     fn contains_transactions(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>>;
@@ -102,7 +108,7 @@ pub(crate) trait Store: Send + Sync {
         start_round: Round,
     ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
         let refs = self.scan_references_by_author(author, start_round)?;
-        let results = self.read_block_headers(refs.as_slice())?;
+        let results = self.read_verified_block_headers(refs.as_slice())?;
         let mut block_headers = Vec::with_capacity(refs.len());
         for (r, block) in refs.into_iter().zip(results.into_iter()) {
             block_headers.push(

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -24,6 +24,7 @@ use crate::{
     },
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
+    network::SerializedTransactions,
 };
 
 /// Persistent storage with RocksDB.
@@ -264,7 +265,8 @@ impl Store for RocksDBStore {
         Ok(block_headers)
     }
 
-    fn read_transactions(
+    /// Return Verified Transactions by deserializing and computing commitment
+    fn read_verified_transactions(
         &self,
         refs: &[BlockRef],
     ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>> {
@@ -301,6 +303,33 @@ impl Store for RocksDBStore {
                 );
 
                 result.push(Some(verified_transactions));
+            } else {
+                result.push(None);
+            }
+        }
+        Ok(result)
+    }
+
+    /// Return Serialized Transactions without deserialization and computing
+    /// commitment
+    fn read_serialized_transactions(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<SerializedTransactions>>> {
+        let keys = refs
+            .iter()
+            .map(|r| (r.round, r.author, r.digest))
+            .collect::<Vec<_>>();
+        let serialized_vec_transactions = self.transactions.multi_get(keys.clone())?;
+        let mut result = Vec::with_capacity(refs.len());
+        for (block_ref, serialized_transactions) in refs.iter().zip(serialized_vec_transactions) {
+            if let Some(serialized_transactions) = serialized_transactions {
+                // Build serialized transactions
+                let serialized_transactions = SerializedTransactions {
+                    block_ref: *block_ref,
+                    serialized_transactions,
+                };
+                result.push(Some(serialized_transactions));
             } else {
                 result.push(None);
             }

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -24,7 +24,6 @@ use crate::{
     },
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
-    network::SerializedTransactions,
 };
 
 /// Persistent storage with RocksDB.
@@ -241,15 +240,13 @@ impl Store for RocksDBStore {
         Ok(blocks)
     }
 
-    fn read_block_headers(
+    /// Return Verified Block Headers by reading their entries from storage and
+    /// deserializing them
+    fn read_verified_block_headers(
         &self,
         refs: &[BlockRef],
     ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>> {
-        let keys = refs
-            .iter()
-            .map(|r| (r.round, r.author, r.digest))
-            .collect::<Vec<_>>();
-        let serialized_block_headers = self.block_headers.multi_get(keys)?;
+        let serialized_block_headers = self.read_serialized_block_headers(refs)?;
         let mut block_headers = vec![];
         for (key, serialized_block_header) in refs.iter().zip(serialized_block_headers) {
             if let Some(serialized_block_header) = serialized_block_header {
@@ -265,20 +262,28 @@ impl Store for RocksDBStore {
         Ok(block_headers)
     }
 
-    /// Return Verified Transactions by deserializing and computing commitment
-    fn read_verified_transactions(
+    /// Return Bytes of Block Headers by reading their entries from storage
+    fn read_serialized_block_headers(
         &self,
         refs: &[BlockRef],
-    ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>> {
+    ) -> ConsensusResult<Vec<Option<Bytes>>> {
         let keys = refs
             .iter()
             .map(|r| (r.round, r.author, r.digest))
             .collect::<Vec<_>>();
-        let serialized_vec_transactions = self.transactions.multi_get(keys.clone())?;
-        // read headers to collect commitment
-        // TODO::optimize it later by storing commitment separately or together with
-        // transactions
         let serialized_block_headers = self.block_headers.multi_get(keys)?;
+        Ok(serialized_block_headers)
+    }
+
+    /// Return Verified Transactions by reading both transactions and headers
+    /// from storage, deserializing them and assembling into the required output
+    fn read_verified_transactions(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>> {
+        let serialized_vec_transactions = self.read_serialized_transactions(refs)?;
+        let serialized_block_headers = self.read_serialized_block_headers(refs)?;
+        // TODO::optimize it later by storing commitment together with transactions
         let mut result = Vec::with_capacity(refs.len());
         for ((block_ref, serialized_block_header), serialized_transactions) in refs
             .iter()
@@ -293,8 +298,8 @@ impl Store for RocksDBStore {
                         .map_err(ConsensusError::MalformedHeader)?;
                 let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
                     .map_err(ConsensusError::MalformedTransactions)?;
-
-                // We don't check the transactions commitment as it's loaded from storage.
+                // We don't check the transactions commitment from the header as it's loaded
+                // from storage. Assemble verified transactions
                 let verified_transactions = VerifiedTransactions::new(
                     transactions,
                     *block_ref,
@@ -310,31 +315,18 @@ impl Store for RocksDBStore {
         Ok(result)
     }
 
-    /// Return Serialized Transactions without deserialization and computing
-    /// commitment
+    /// Return Bytes of corresponding Transactions by reading their entries from
+    /// storage
     fn read_serialized_transactions(
         &self,
         refs: &[BlockRef],
-    ) -> ConsensusResult<Vec<Option<SerializedTransactions>>> {
+    ) -> ConsensusResult<Vec<Option<Bytes>>> {
         let keys = refs
             .iter()
             .map(|r| (r.round, r.author, r.digest))
             .collect::<Vec<_>>();
         let serialized_vec_transactions = self.transactions.multi_get(keys.clone())?;
-        let mut result = Vec::with_capacity(refs.len());
-        for (block_ref, serialized_transactions) in refs.iter().zip(serialized_vec_transactions) {
-            if let Some(serialized_transactions) = serialized_transactions {
-                // Build serialized transactions
-                let serialized_transactions = SerializedTransactions {
-                    block_ref: *block_ref,
-                    serialized_transactions,
-                };
-                result.push(Some(serialized_transactions));
-            } else {
-                result.push(None);
-            }
-        }
-        Ok(result)
+        Ok(serialized_vec_transactions)
     }
 
     fn contains_transactions(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -299,7 +299,7 @@ async fn read_and_contain_transactions(
     // Test reading all transactions
     let refs: Vec<_> = written_blocks.iter().map(|b| b.reference()).collect();
     let read_txs = store
-        .read_transactions(&refs)
+        .read_verified_transactions(&refs)
         .expect("Read txs should not fail");
 
     assert_eq!(read_txs.len(), written_blocks.len());
@@ -318,7 +318,7 @@ async fn read_and_contain_transactions(
     // Test reading subset of transactions
     let subset_refs = vec![refs[1], refs[3], refs[5]];
     let read_subset = store
-        .read_transactions(&subset_refs)
+        .read_verified_transactions(&subset_refs)
         .expect("Read subset should not fail");
     assert_eq!(read_subset.len(), 3);
     assert_eq!(
@@ -347,7 +347,7 @@ async fn read_and_contain_transactions(
         BlockHeaderDigest::default(),
     );
     let read_missing = store
-        .read_transactions(&[missing_ref])
+        .read_verified_transactions(&[missing_ref])
         .expect("Read missing should not fail");
     assert_eq!(read_missing.len(), 1);
     assert!(read_missing[0].is_none());

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -71,7 +71,7 @@ async fn read_and_contain_block_headers(
     // Test basic header read
     let refs = vec![written_blocks[0].reference()];
     let read_headers = store
-        .read_block_headers(&refs)
+        .read_verified_block_headers(&refs)
         .expect("Read headers should not fail");
     assert_eq!(read_headers.len(), 1);
     assert_eq!(
@@ -86,7 +86,7 @@ async fn read_and_contain_block_headers(
         written_blocks[1].reference(),
     ];
     let read_headers = store
-        .read_block_headers(&refs)
+        .read_verified_block_headers(&refs)
         .expect("Read headers should not fail");
     assert_eq!(read_headers.len(), 3);
     assert_eq!(
@@ -113,7 +113,7 @@ async fn read_and_contain_block_headers(
         written_blocks[2].reference(),
     ];
     let read_headers = store
-        .read_block_headers(&refs)
+        .read_verified_block_headers(&refs)
         .expect("Read headers should not fail");
     assert_eq!(read_headers.len(), 3);
     assert_eq!(

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -362,7 +362,7 @@ impl DagBuilder {
                 // TODO: we need to request real blocks from sub_dag after we add the
                 // corresponding field and logic in sub_dag
                 let mut block_headers = vec![];
-                for block_header in sub_dag.blocks.iter() {
+                for block_header in sub_dag.headers.iter() {
                     block_headers.push(block_header.clone());
                 }
 
@@ -741,7 +741,7 @@ impl<'a> LayerBuilder<'a> {
         assert!(self.specified_authorities.is_some());
         self.skip_ancestor_links = Some(ancestors_to_skip);
         self.fully_linked_ancestors = false;
-        self.build()
+        self
     }
 
     // Add random weak links to the current layer round using a seed, if provided

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -904,7 +904,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     .iter()
                     .cloned()
                     .collect();
-                let block_headers_vec = dag_state.read().get_block_headers(&block_refs);
+                let block_headers_vec = dag_state.read().get_verified_block_headers(&block_refs);
                 let mut block_headers_map = BTreeMap::new();
                 for block_header_opt in block_headers_vec.into_iter() {
                     let block_header = block_header_opt


### PR DESCRIPTION
# Description of change

In this PR, we refactor multiple components:
- two new methods in `DagState `- `get_serialized_transactions()` and `get_serialized_block_headers()`. They are used when `HeaderSynchronizer` or `TransactionsSynchronizer` of a peer requests bytes of headers or transactions from the local node. This allows to not deserialize headers or transactions while the DagState is locked for the read operation.
- the fields of  in `DagState ` - `recent_shards` and `recent_transactions` are replaced in favour of `recent_shards_by_authority` and `recent_transactions_by_authority`. This is important to improve the time we spend for eviction (since it took a linear time before for every `flush()` call). Also, when doing commit syncing it allows to evict transactions faster
- Synchronizer is now called HeaderSynchronizer to avoid confusion
- Many fields called `blocks` are replaced by `headers`
- A new test `test_sequenced_transactions_no_headers` is added. It allows to check the case when some transactions are sequenced but the corresponding block headers are not.

## Links to any relevant issues

Fixes #9089 and #9134 and partially #7528

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

