### PR TITLE
feat: treat authenticator shared objects as TX input

### DIFF
--- a/crates/iota-analytics-indexer/src/handlers/mod.rs
+++ b/crates/iota-analytics-indexer/src/handlers/mod.rs
@@ -11,7 +11,7 @@ use iota_types::{
     base_types::ObjectID,
     effects::{TransactionEffects, TransactionEffectsAPI},
     object::{Object, Owner, bounded_visitor::BoundedVisitor},
-    transaction::{TransactionData, TransactionDataAPI},
+    transaction::{SenderSignedData, TransactionDataAPI},
 };
 use move_core_types::{
     annotated_value::{MoveStruct, MoveTypeLayout, MoveValue},
@@ -90,14 +90,14 @@ struct InputObjectTracker {
 }
 
 impl InputObjectTracker {
-    fn new(txn_data: &TransactionData) -> Self {
-        let shared: BTreeSet<ObjectID> = txn_data
+    fn new(txn: &SenderSignedData) -> Self {
+        let shared: BTreeSet<ObjectID> = txn
             .shared_input_objects()
-            .iter()
             .map(|shared_io| shared_io.id())
             .collect();
-        let coins: BTreeSet<ObjectID> = txn_data.gas().iter().map(|obj_ref| obj_ref.0).collect();
-        let input: BTreeSet<ObjectID> = txn_data
+        let tx_data = txn.transaction_data();
+        let coins: BTreeSet<ObjectID> = tx_data.gas().iter().map(|obj_ref| obj_ref.0).collect();
+        let input: BTreeSet<ObjectID> = tx_data
             .input_objects()
             .expect("Input objects must be valid")
             .iter()

--- a/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
@@ -158,7 +158,7 @@ impl TransactionHandler {
                 .input_objects()
                 .expect("Input objects must be valid")
                 .len() as u64,
-            shared_input: txn_data.shared_input_objects().len() as u64,
+            shared_input: transaction.shared_input_objects().count() as u64,
             gas_coins: txn_data.gas().len() as u64,
             created: effects.created().len() as u64,
             mutated: (effects.mutated().len() + effects.unwrapped().len()) as u64,

--- a/crates/iota-analytics-indexer/src/handlers/transaction_objects_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_objects_handler.rs
@@ -93,10 +93,12 @@ impl TransactionObjectsHandler {
         state: &mut State,
     ) {
         let transaction = &checkpoint_transaction.transaction;
+        let input_object_tracker = InputObjectTracker::new(transaction.data());
+        let object_status_tracker = ObjectStatusTracker::new(effects);
+
         let transaction_digest = transaction.digest().base58_encode();
         let txn_data = transaction.transaction_data();
-        let input_object_tracker = InputObjectTracker::new(txn_data);
-        let object_status_tracker = ObjectStatusTracker::new(effects);
+
         // input
         txn_data
             .input_objects()

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1935,7 +1935,7 @@ impl AuthorityPerEpochStore {
         // Defer transaction if it uses randomness but we aren't generating any this
         // round. Don't defer if DKG has permanently failed; in that case we
         // need to ignore.
-        if !dkg_failed && !generating_randomness && cert.transaction_data().uses_randomness() {
+        if !dkg_failed && !generating_randomness && cert.uses_randomness() {
             let deferred_from_round = previously_deferred_tx_digests
                 .get(cert.digest())
                 .map(|previous_key_suggested_gas_price_pair| {
@@ -3803,7 +3803,7 @@ impl AuthorityPerEpochStore {
                         Ok(deferral_result)
                     }
                     SchedulingResult::Schedule(start_time) => {
-                        if dkg_failed && certificate.transaction_data().uses_randomness() {
+                        if dkg_failed && certificate.uses_randomness() {
                             debug!(
                                 "Canceling randomness-using certificate for transaction {:?} because DKG failed",
                                 certificate.digest(),

--- a/crates/iota-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/iota-core/src/authority/shared_object_congestion_tracker.rs
@@ -8,7 +8,7 @@ use iota_protocol_config::PerObjectCongestionControlMode;
 use iota_types::{
     base_types::{CommitRound, ObjectID},
     executable_transaction::VerifiedExecutableTransaction,
-    transaction::{SharedInputObject, TransactionDataAPI},
+    transaction::SharedInputObject,
 };
 use tracing::instrument;
 
@@ -391,12 +391,7 @@ impl SharedObjectCongestionTracker {
             return SequencingResult::Schedule(0);
         }
 
-        let shared_input_objects = cert
-            .data()
-            .inner()
-            .intent_message()
-            .value
-            .shared_input_objects();
+        let shared_input_objects = cert.shared_input_objects().collect::<Vec<_>>();
         if shared_input_objects.is_empty() {
             // This is an owned object only transaction. No need to defer.
             return SequencingResult::Schedule(0);
@@ -684,14 +679,8 @@ pub mod shared_object_test_utils {
         previously_deferred_tx_digests: &PreviouslyDeferredTransactions,
         commit_round: CommitRound,
     ) -> SequencingResult {
-        shared_object_congestion_tracker.initialize_object_execution_slots(
-            &cert
-                .data()
-                .inner()
-                .intent_message()
-                .value
-                .shared_input_objects(),
-        );
+        let shared_input_objects = cert.shared_input_objects().collect::<Vec<_>>();
+        shared_object_congestion_tracker.initialize_object_execution_slots(&shared_input_objects);
         shared_object_congestion_tracker.try_schedule(
             cert,
             max_execution_duration_per_commit,
@@ -714,14 +703,11 @@ pub mod shared_object_test_utils {
                 PerObjectCongestionControlMode::TotalGasBudget => {
                     let transaction =
                         build_transaction(&[(*object_id, true)], *duration, TEST_ONLY_GAS_PRICE);
+                    let shared_input_objects =
+                        transaction.shared_input_objects().collect::<Vec<_>>();
                     let start_time = initialize_tracker_and_compute_tx_start_time(
                         &mut shared_object_congestion_tracker,
-                        &transaction
-                            .data()
-                            .inner()
-                            .intent_message()
-                            .value
-                            .shared_input_objects(),
+                        &shared_input_objects,
                         *duration,
                     )
                     .expect(
@@ -735,14 +721,11 @@ pub mod shared_object_test_utils {
                     for _ in 0..*duration {
                         let transaction =
                             build_transaction(&[(*object_id, true)], 1, TEST_ONLY_GAS_PRICE);
+                        let shared_input_objects =
+                            transaction.shared_input_objects().collect::<Vec<_>>();
                         let start_time = initialize_tracker_and_compute_tx_start_time(
                             &mut shared_object_congestion_tracker,
-                            &transaction
-                                .data()
-                                .inner()
-                                .intent_message()
-                                .value
-                                .shared_input_objects(),
+                            &shared_input_objects,
                             1,
                         )
                         .expect(
@@ -1249,14 +1232,10 @@ mod object_cost_tests {
         );
         let cert_duration =
             shared_object_congestion_tracker.get_estimated_execution_duration(&cert);
+        let shared_input_objects = cert.shared_input_objects().collect::<Vec<_>>();
         let start_time = initialize_tracker_and_compute_tx_start_time(
             &mut shared_object_congestion_tracker,
-            &cert
-                .data()
-                .inner()
-                .intent_message()
-                .value
-                .shared_input_objects(),
+            &shared_input_objects,
             cert_duration,
         )
         .expect("start time should be computable");
@@ -1284,14 +1263,10 @@ mod object_cost_tests {
         );
         let cert_duration =
             shared_object_congestion_tracker.get_estimated_execution_duration(&cert);
+        let shared_input_objects = cert.shared_input_objects().collect::<Vec<_>>();
         let start_time = initialize_tracker_and_compute_tx_start_time(
             &mut shared_object_congestion_tracker,
-            &cert
-                .data()
-                .inner()
-                .intent_message()
-                .value
-                .shared_input_objects(),
+            &shared_input_objects,
             cert_duration,
         )
         .expect("start time should be computable");
@@ -1340,14 +1315,10 @@ mod object_cost_tests {
         };
         let cert_duration =
             shared_object_congestion_tracker.get_estimated_execution_duration(&cert);
+        let shared_input_objects = cert.shared_input_objects().collect::<Vec<_>>();
         let start_time = initialize_tracker_and_compute_tx_start_time(
             &mut shared_object_congestion_tracker,
-            &cert
-                .data()
-                .inner()
-                .intent_message()
-                .value
-                .shared_input_objects(),
+            &shared_input_objects,
             cert_duration,
         )
         .expect("start time should be computable");
@@ -1468,14 +1439,11 @@ mod object_cost_tests {
         }
 
         let cert_duration = shared_object_congestion_tracker.get_estimated_execution_duration(&tx);
+        let shared_input_objects = tx.shared_input_objects().collect::<Vec<_>>();
         assert!(
             initialize_tracker_and_compute_tx_start_time(
                 &mut shared_object_congestion_tracker,
-                &tx.data()
-                    .inner()
-                    .intent_message()
-                    .value
-                    .shared_input_objects(),
+                &shared_input_objects,
                 cert_duration,
             )
             .is_none()
@@ -1526,14 +1494,11 @@ mod object_cost_tests {
         }
 
         let cert_duration = shared_object_congestion_tracker.get_estimated_execution_duration(&tx);
+        let shared_input_objects = tx.shared_input_objects().collect::<Vec<_>>();
         assert!(
             initialize_tracker_and_compute_tx_start_time(
                 &mut shared_object_congestion_tracker,
-                &tx.data()
-                    .inner()
-                    .intent_message()
-                    .value
-                    .shared_input_objects(),
+                &shared_input_objects,
                 cert_duration,
             )
             .is_none()
@@ -1568,14 +1533,11 @@ mod object_cost_tests {
         }
 
         let cert_duration = shared_object_congestion_tracker.get_estimated_execution_duration(&tx);
+        let shared_input_objects = tx.shared_input_objects().collect::<Vec<_>>();
         assert!(
             initialize_tracker_and_compute_tx_start_time(
                 &mut shared_object_congestion_tracker,
-                &tx.data()
-                    .inner()
-                    .intent_message()
-                    .value
-                    .shared_input_objects(),
+                &shared_input_objects,
                 cert_duration,
             )
             .is_none()

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -14,7 +14,7 @@ use iota_types::{
     storage::{
         ObjectKey, transaction_non_shared_input_object_keys, transaction_receiving_object_keys,
     },
-    transaction::{SenderSignedData, SharedInputObject, TransactionDataAPI, TransactionKey},
+    transaction::{SenderSignedData, SharedInputObject, TransactionKey},
 };
 use tracing::{debug, trace};
 
@@ -267,12 +267,7 @@ fn get_or_init_versions<'a>(
     generate_randomness: bool,
 ) -> IotaResult<HashMap<ObjectID, SequenceNumber>> {
     let mut shared_input_objects: Vec<_> = transactions
-        .flat_map(|tx| {
-            tx.transaction_data()
-                .shared_input_objects()
-                .into_iter()
-                .map(|so| so.into_id_and_version())
-        })
+        .flat_map(|tx| tx.shared_input_objects().map(|so| so.into_id_and_version()))
         .collect();
 
     if generate_randomness {

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -746,7 +746,7 @@ impl SequencedConsensusTransaction {
         else {
             return false;
         };
-        certificate.transaction_data().uses_randomness()
+        certificate.uses_randomness()
     }
 
     pub fn as_shared_object_txn(&self) -> Option<&SenderSignedData> {

--- a/crates/iota-core/src/transaction_manager.rs
+++ b/crates/iota-core/src/transaction_manager.rs
@@ -869,9 +869,7 @@ impl TransactionManager {
 
         for (object_id, queue_len, txn_age) in self.objects_queue_len_and_age(
             tx_data
-                .transaction_data()
                 .shared_input_objects()
-                .into_iter()
                 .filter_map(|r| r.mutable.then_some(r.id))
                 .collect(),
         ) {

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -6329,10 +6329,7 @@ async fn test_consensus_handler_per_object_congestion_control(
         assert!(
             cert.data().transaction_data().gas_price() >= 4000
                 || cert
-                    .data()
-                    .transaction_data()
                     .shared_input_objects()
-                    .iter()
                     .any(|obj| { obj.id() == shared_objects[1].id() })
         );
     }
@@ -6389,10 +6386,7 @@ async fn test_consensus_handler_per_object_congestion_control(
         assert!(
             cert.data().transaction_data().gas_price() >= 2000
                 || cert
-                    .data()
-                    .transaction_data()
                     .shared_input_objects()
-                    .iter()
                     .any(|obj| { obj.id() == shared_objects[1].id() })
         );
     }

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -35,9 +35,7 @@ use iota_types::{
     messages_checkpoint::{CheckpointContentsDigest, VerifiedCheckpoint},
     object::Object,
     storage::{ObjectStore, ReadStore},
-    transaction::{
-        InputObjects, Transaction, TransactionData, TransactionDataAPI, TransactionKind,
-    },
+    transaction::{InputObjects, Transaction, TransactionData, TransactionKind},
 };
 pub use move_transactional_test_runner::framework::{
     create_adapter, run_tasks_with_adapter, run_test_impl,
@@ -122,11 +120,7 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         &mut self,
         transaction: Transaction,
     ) -> anyhow::Result<(TransactionEffects, Option<ExecutionError>)> {
-        let with_shared = transaction
-            .data()
-            .intent_message()
-            .value
-            .contains_shared_object();
+        let with_shared = transaction.contains_shared_object();
         let (_, effects, execution_error) = send_and_confirm_transaction_with_execution_error(
             &self.validator,
             Some(&self.fullnode),

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -59,7 +59,7 @@ use iota_types::{
     storage::{ObjectStore, ReadStore, RestStateReader},
     transaction::{
         Argument, CallArg, Command, ProgrammableTransaction, Transaction, TransactionData,
-        TransactionDataAPI, TransactionKind, VerifiedTransaction,
+        TransactionKind, VerifiedTransaction,
     },
     utils::{to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers},
 };
@@ -1580,11 +1580,7 @@ impl IotaTestAdapter {
     }
 
     async fn execute_txn(&mut self, transaction: Transaction) -> anyhow::Result<TxnSummary> {
-        let with_shared = transaction
-            .data()
-            .intent_message()
-            .value
-            .contains_shared_object();
+        let with_shared = transaction.contains_shared_object();
         let (effects, error_opt) = self.executor.execute_txn(transaction).await?;
         let digest = effects.transaction_digest();
 

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -1985,7 +1985,8 @@ impl TransactionData {
 
     /// Checks if the transaction data contains the `Random` object as an
     /// input.
-    /// This function does not check shared objects associated with
+    ///
+    /// IMPORTANT: This function does not check shared objects associated with
     /// `MoveAuthenticator` signatures. To check those objects as well, use the
     /// corresponding function from `SenderSignedData`.
     pub fn uses_randomness(&self) -> bool {
@@ -2030,13 +2031,15 @@ pub trait TransactionDataAPI {
     fn expiration(&self) -> &TransactionExpiration;
 
     /// Checks if the transaction data contains at least one shared object.
-    /// This function does not check shared objects associated with
+    ///
+    /// IMPORTANT: This function does not check shared objects associated with
     /// `MoveAuthenticator` signatures. To check those objects as well, use the
     /// corresponding function from `SenderSignedData`.
     fn contains_shared_object(&self) -> bool;
 
     /// Returns a list of the transaction data shared input objects.
-    /// This function does not return shared objects associated with
+    ///
+    /// IMPORTANT: This function does not return shared objects associated with
     /// `MoveAuthenticator` signatures. To check those objects as well, use the
     /// corresponding function from `SenderSignedData`.
     fn shared_input_objects(&self) -> Vec<SharedInputObject>;

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2597,27 +2597,6 @@ impl SenderSignedData {
             Ok((input_objects, None, None))
         }
     }
-}
-
-impl Message for SenderSignedData {
-    type DigestType = TransactionDigest;
-    const SCOPE: IntentScope = IntentScope::SenderSignedTransaction;
-
-    /// Computes the tx digest that encodes the Rust type prefix from Signable
-    /// trait.
-    fn digest(&self) -> Self::DigestType {
-        self.intent_message().value.digest()
-    }
-}
-
-impl<S> Envelope<SenderSignedData, S> {
-    pub fn sender_address(&self) -> IotaAddress {
-        self.data().intent_message().value.sender()
-    }
-
-    pub fn gas(&self) -> &[ObjectRef] {
-        self.data().intent_message().value.gas()
-    }
 
     pub fn contains_shared_object(&self) -> bool {
         self.shared_input_objects().next().is_some()
@@ -2640,14 +2619,39 @@ impl<S> Envelope<SenderSignedData, S> {
                 Vec::new().into_iter()
             };
 
-        self.data()
-            .inner()
+        self.inner()
             .intent_message
             .value
             .shared_input_objects()
             .into_iter()
             .chain(authenticator_shared_objects)
             .unique()
+    }
+
+    pub fn uses_randomness(&self) -> bool {
+        self.shared_input_objects()
+            .any(|obj| obj.id() == IOTA_RANDOMNESS_STATE_OBJECT_ID)
+    }
+}
+
+impl Message for SenderSignedData {
+    type DigestType = TransactionDigest;
+    const SCOPE: IntentScope = IntentScope::SenderSignedTransaction;
+
+    /// Computes the tx digest that encodes the Rust type prefix from Signable
+    /// trait.
+    fn digest(&self) -> Self::DigestType {
+        self.intent_message().value.digest()
+    }
+}
+
+impl<S> Envelope<SenderSignedData, S> {
+    pub fn sender_address(&self) -> IotaAddress {
+        self.data().intent_message().value.sender()
+    }
+
+    pub fn gas(&self) -> &[ObjectRef] {
+        self.data().intent_message().value.gas()
     }
 
     // Returns the primary key for this transaction.

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -1983,6 +1983,11 @@ impl TransactionData {
         )
     }
 
+    /// Checks if the transaction data contains the `Random` object as an
+    /// input.
+    /// This function does not check shared objects associated with
+    /// `MoveAuthenticator` signatures. To check those objects as well, use the
+    /// corresponding function from `SenderSignedData`.
     pub fn uses_randomness(&self) -> bool {
         self.shared_input_objects()
             .iter()
@@ -2024,8 +2029,16 @@ pub trait TransactionDataAPI {
 
     fn expiration(&self) -> &TransactionExpiration;
 
+    /// Checks if the transaction data contains at least one shared object.
+    /// This function does not check shared objects associated with
+    /// `MoveAuthenticator` signatures. To check those objects as well, use the
+    /// corresponding function from `SenderSignedData`.
     fn contains_shared_object(&self) -> bool;
 
+    /// Returns a list of the transaction data shared input objects.
+    /// This function does not return shared objects associated with
+    /// `MoveAuthenticator` signatures. To check those objects as well, use the
+    /// corresponding function from `SenderSignedData`.
     fn shared_input_objects(&self) -> Vec<SharedInputObject>;
 
     fn move_calls(&self) -> Vec<(&ObjectID, &str, &str)>;
@@ -2598,6 +2611,8 @@ impl SenderSignedData {
         }
     }
 
+    /// Checks if `SenderSignedData` contains at least one shared object.
+    /// This function checks shared objects from the `MoveAuthenticator` if any.
     pub fn contains_shared_object(&self) -> bool {
         self.shared_input_objects().next().is_some()
     }
@@ -2628,6 +2643,9 @@ impl SenderSignedData {
             .unique()
     }
 
+    /// Checks if `SenderSignedData` contains the `Random` object as an
+    /// input.
+    /// This function checks shared objects from the `MoveAuthenticator` if any.
     pub fn uses_randomness(&self) -> bool {
         self.shared_input_objects()
             .any(|obj| obj.id() == IOTA_RANDOMNESS_STATE_OBJECT_ID)


### PR DESCRIPTION
# Description of change

Authenticator shared objects are treated as TX input.

## Links to any relevant issues

fixes #8937
fixes #9131 

