### PR TITLE
refactor(consensus): truncate requestes blockrefs when fetching transactions

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -3239,7 +3239,7 @@ mod tests {
             all_block_headers.push(dag_builder.block_headers(round..=round));
         }
 
-        let block_refs_to_request_first_batch: Vec<BlockRef> = (1..=rounds)
+        let mut block_refs_to_request_first_batch: Vec<BlockRef> = (1..=rounds)
             .flat_map(|round| {
                 all_block_headers[round as usize]
                     .iter()
@@ -3261,6 +3261,7 @@ mod tests {
             .await
             .expect("We should expect a correct return of serialized transactions");
 
+        block_refs_to_request_first_batch.truncate(context.parameters.max_transactions_per_fetch);
         // Verify that we received the correct number of requested transactions
         assert_eq!(
             serialized_transactions.len(),

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -663,17 +663,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         fail_point_async!("consensus-rpc-response");
 
         // Some quick validation of the requested block refs
-        for block in &block_refs {
-            if !self.context.committee.is_valid_index(block.author) {
-                return Err(ConsensusError::InvalidAuthorityIndex {
-                    index: block.author,
-                    max: self.context.committee.size(),
-                });
-            }
-            if block.round == GENESIS_ROUND {
-                return Err(ConsensusError::UnexpectedGenesisHeaderRequested);
-            }
-        }
+        ConsensusError::quick_validation_requested_block_refs(&block_refs, peer, &self.context.committee)?;
 
         if !highest_accepted_rounds.is_empty()
             && highest_accepted_rounds.len() != self.context.committee.size()
@@ -842,14 +832,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         // Ensure that those are valid authorities
-        for authority in &authorities {
-            if !self.context.committee.is_valid_index(*authority) {
-                return Err(ConsensusError::InvalidAuthorityIndex {
-                    index: *authority,
-                    max: self.context.committee.size(),
-                });
-            }
-        }
+        ConsensusError::quick_validation_authority_indices(&authorities, &self.context.committee)?;
 
         // Read from the dag state to find the latest block headers.
         // TODO: at the moment we don't look into the block manager for suspended
@@ -908,7 +891,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
     async fn handle_fetch_transactions(
         &self,
         peer: AuthorityIndex,
-        block_refs: Vec<BlockRef>,
+        mut block_refs: Vec<BlockRef>,
     ) -> ConsensusResult<Vec<Bytes>> {
         fail_point_async!("consensus-rpc-response");
 
@@ -917,21 +900,11 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         if block_refs.len() > self.context.parameters.max_transactions_per_fetch {
-            return Err(ConsensusError::TooManyFetchTransactionsRequested(peer));
+            block_refs.truncate(self.context.parameters.max_transactions_per_fetch);
         }
 
         // Some quick validation of the requested block refs
-        for block in &block_refs {
-            if !self.context.committee.is_valid_index(block.author) {
-                return Err(ConsensusError::InvalidAuthorityIndex {
-                    index: block.author,
-                    max: self.context.committee.size(),
-                });
-            }
-            if block.round == GENESIS_ROUND {
-                return Err(ConsensusError::UnexpectedGenesisTransactionsRequested);
-            }
-        }
+        ConsensusError::quick_validation_requested_block_refs(&block_refs, peer, &self.context.committee)?;
 
         // Get the transactions from the dag state
         let transactions = self

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -663,7 +663,11 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         fail_point_async!("consensus-rpc-response");
 
         // Some quick validation of the requested block refs
-        ConsensusError::quick_validation_requested_block_refs(&block_refs, peer, &self.context.committee)?;
+        ConsensusError::quick_validation_requested_block_refs(
+            &block_refs,
+            peer,
+            &self.context.committee,
+        )?;
 
         if !highest_accepted_rounds.is_empty()
             && highest_accepted_rounds.len() != self.context.committee.size()
@@ -904,7 +908,11 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         // Some quick validation of the requested block refs
-        ConsensusError::quick_validation_requested_block_refs(&block_refs, peer, &self.context.committee)?;
+        ConsensusError::quick_validation_requested_block_refs(
+            &block_refs,
+            peer,
+            &self.context.committee,
+        )?;
 
         // Get the transactions from the dag state
         let transactions = self
@@ -3231,7 +3239,7 @@ mod tests {
             all_block_headers.push(dag_builder.block_headers(round..=round));
         }
 
-        let mut block_refs_to_request_first_batch: Vec<BlockRef> = (1..=rounds)
+        let block_refs_to_request_first_batch: Vec<BlockRef> = (1..=rounds)
             .flat_map(|round| {
                 all_block_headers[round as usize]
                     .iter()
@@ -3248,19 +3256,10 @@ mod tests {
             .collect();
 
         let peer = context.committee.to_authority_index(1).unwrap();
-        let err = authority_service
-            .handle_fetch_transactions(peer, block_refs_to_request_first_batch.clone())
-            .await
-            .expect_err("Expected TooManyFetchTransactionsRequested error");
-
-        assert!(matches!(err, ConsensusError::TooManyFetchTransactionsRequested(p) if p == peer));
-
-        block_refs_to_request_first_batch.truncate(context.parameters.max_transactions_per_fetch);
-
         let serialized_transactions = authority_service
             .handle_fetch_transactions(peer, block_refs_to_request_first_batch.clone())
             .await
-            .expect("Should return a valid vector of serialized transactions");
+            .expect("We should expect a correct return of serialized transactions");
 
         // Verify that we received the correct number of requested transactions
         assert_eq!(

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -653,15 +653,8 @@ impl SignedBlockHeader {
     /// the full block header should be done via BlockHeaderVerifier.
     pub(crate) fn verify_signature(&self, context: &Context) -> ConsensusResult<()> {
         let block_header = &self.inner;
-        let committee = &context.committee;
-        ensure!(
-            committee.is_valid_index(block_header.author()),
-            ConsensusError::InvalidAuthorityIndex {
-                index: block_header.author(),
-                max: committee.size() - 1
-            }
-        );
-        let authority = committee.authority(block_header.author());
+        ConsensusError::quick_validation_authority_indices(&[block_header.author()], &context.committee)?;
+        let authority = context.committee.authority(block_header.author());
         verify_block_header_signature(block_header, self.signature(), &authority.protocol_key)
     }
 

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -23,7 +23,6 @@ use crate::{
     commit::CommitVote,
     context::Context,
     encoder::ShardEncoder,
-    ensure,
     error::{ConsensusError, ConsensusResult},
 };
 
@@ -653,7 +652,10 @@ impl SignedBlockHeader {
     /// the full block header should be done via BlockHeaderVerifier.
     pub(crate) fn verify_signature(&self, context: &Context) -> ConsensusResult<()> {
         let block_header = &self.inner;
-        ConsensusError::quick_validation_authority_indices(&[block_header.author()], &context.committee)?;
+        ConsensusError::quick_validation_authority_indices(
+            &[block_header.author()],
+            &context.committee,
+        )?;
         let authority = context.committee.authority(block_header.author());
         verify_block_header_signature(block_header, self.signature(), &authority.protocol_key)
     }

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -100,7 +100,7 @@ impl BlockVerifier for SignedBlockVerifier {
         if block.round() == 0 {
             return Err(ConsensusError::UnexpectedGenesisHeader);
         }
-        ConsensusError::quick_validation_authority_indices(&[block.author()], &committee)?;
+        ConsensusError::quick_validation_authority_indices(&[block.author()], committee)?;
 
         // Verify the block's signature.
         block.verify_signature(&self.context)?;
@@ -122,7 +122,7 @@ impl BlockVerifier for SignedBlockVerifier {
         let mut seen_ancestors = vec![false; committee.size()];
         let mut parent_stakes = 0;
         for (i, ancestor) in block.ancestors().iter().enumerate() {
-            ConsensusError::quick_validation_authority_indices(&[block.author()], &committee)?;
+            ConsensusError::quick_validation_authority_indices(&[block.author()], committee)?;
             if (i == 0 && ancestor.author != block.author())
                 || (i > 0 && ancestor.author == block.author())
             {

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -100,12 +100,7 @@ impl BlockVerifier for SignedBlockVerifier {
         if block.round() == 0 {
             return Err(ConsensusError::UnexpectedGenesisHeader);
         }
-        if !committee.is_valid_index(block.author()) {
-            return Err(ConsensusError::InvalidAuthorityIndex {
-                index: block.author(),
-                max: committee.size() - 1,
-            });
-        }
+        ConsensusError::quick_validation_authority_indices(&[block.author()], &committee)?;
 
         // Verify the block's signature.
         block.verify_signature(&self.context)?;
@@ -127,12 +122,7 @@ impl BlockVerifier for SignedBlockVerifier {
         let mut seen_ancestors = vec![false; committee.size()];
         let mut parent_stakes = 0;
         for (i, ancestor) in block.ancestors().iter().enumerate() {
-            if !committee.is_valid_index(ancestor.author) {
-                return Err(ConsensusError::InvalidAuthorityIndex {
-                    index: ancestor.author,
-                    max: committee.size() - 1,
-                });
-            }
+            ConsensusError::quick_validation_authority_indices(&[block.author()], &committee)?;
             if (i == 0 && ancestor.author != block.author())
                 || (i > 0 && ancestor.author == block.author())
             {

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::error::FastCryptoError;
-use starfish_config::{AuthorityIndex, Epoch, Stake};
+use starfish_config::{AuthorityIndex, Committee, Epoch, Stake};
 use strum_macros::IntoStaticStr;
 use thiserror::Error;
 use typed_store::TypedStoreError;
@@ -12,6 +12,7 @@ use crate::{
     block_header::{BlockRef, Round},
     commit::{Commit, CommitIndex},
 };
+use crate::block_header::GENESIS_ROUND;
 
 /// Errors that can occur when processing blocks, reading from storage, or
 /// encountering shutdown.
@@ -56,8 +57,8 @@ pub(crate) enum ConsensusError {
     #[error("Genesis transactions should not be queried!")]
     UnexpectedGenesisTransactionsRequested,
 
-    #[error("Genesis block headers should not be queried!")]
-    UnexpectedGenesisHeaderRequested,
+    #[error("Genesis block headers are requested from {peer}!")]
+    UnexpectedGenesisHeaderRequested{peer: AuthorityIndex},
 
     #[error(
         "Expected {requested} but received {received_headers} block headers from authority {authority}"
@@ -97,6 +98,9 @@ pub(crate) enum ConsensusError {
 
     #[error("Invalid authority index: {index} > {max}")]
     InvalidAuthorityIndex { index: AuthorityIndex, max: usize },
+
+    #[error("Invalid authority index: {index} > {max} from peer {peer}")]
+    InvalidAuthorityIndexRequested { index: AuthorityIndex, max: usize, peer: AuthorityIndex },
 
     #[error("Failed to deserialize signature: {0}")]
     MalformedSignature(FastCryptoError),
@@ -249,11 +253,48 @@ pub(crate) enum ConsensusError {
 }
 
 impl ConsensusError {
-    /// Returns the error name - only the enun name without any parameters - as
+    /// Returns the error name - only the enum name without any parameters - as
     /// a static string.
     pub fn name(&self) -> &'static str {
         self.into()
     }
+
+    pub fn quick_validation_requested_block_refs(
+        block_refs: &[BlockRef],
+        peer: AuthorityIndex,
+        committee: &Committee
+    ) -> ConsensusResult<()> {
+        for block in block_refs {
+            if !committee.is_valid_index(block.author) {
+                return Err(ConsensusError::InvalidAuthorityIndexRequested {
+                    index: block.author,
+                    max: committee.size(),
+                    peer
+                });
+            }
+            if block.round == GENESIS_ROUND {
+                return Err(ConsensusError::UnexpectedGenesisHeaderRequested);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn quick_validation_authority_indices(
+        authorities: &[AuthorityIndex],
+        committee: &Committee,
+    ) -> ConsensusResult<()> {
+        // Ensure that those are valid authorities
+        for authority in &authorities {
+            if !committee.is_valid_index(*authority) {
+                return Err(ConsensusError::InvalidAuthorityIndex {
+                    index: *authority,
+                    max: committee.size(),
+                });
+            }
+        }
+        Ok(())
+    }
+
 }
 
 pub type ConsensusResult<T> = Result<T, ConsensusError>;

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -9,10 +9,9 @@ use thiserror::Error;
 use typed_store::TypedStoreError;
 
 use crate::{
-    block_header::{BlockRef, Round},
+    block_header::{BlockRef, GENESIS_ROUND, Round},
     commit::{Commit, CommitIndex},
 };
-use crate::block_header::GENESIS_ROUND;
 
 /// Errors that can occur when processing blocks, reading from storage, or
 /// encountering shutdown.
@@ -54,11 +53,8 @@ pub(crate) enum ConsensusError {
     #[error("Genesis block headers should only be generated from Committee!")]
     UnexpectedGenesisHeader,
 
-    #[error("Genesis transactions should not be queried!")]
-    UnexpectedGenesisTransactionsRequested,
-
-    #[error("Genesis block headers are requested from {peer}!")]
-    UnexpectedGenesisHeaderRequested{peer: AuthorityIndex},
+    #[error("Genesis block headers or transactions are requested from {peer}!")]
+    UnexpectedGenesisRequested { peer: AuthorityIndex },
 
     #[error(
         "Expected {requested} but received {received_headers} block headers from authority {authority}"
@@ -85,9 +81,6 @@ pub(crate) enum ConsensusError {
     #[error("Too many block headers have been rteurned from authority {0}")]
     TooManyFetchedHeadersReturned(AuthorityIndex),
 
-    #[error("Too many transaction bundles have been requested from authority {0}")]
-    TooManyFetchTransactionsRequested(AuthorityIndex),
-
     #[error("Too many authorities have been provided from authority {0}")]
     TooManyAuthoritiesProvided(AuthorityIndex),
 
@@ -100,7 +93,11 @@ pub(crate) enum ConsensusError {
     InvalidAuthorityIndex { index: AuthorityIndex, max: usize },
 
     #[error("Invalid authority index: {index} > {max} from peer {peer}")]
-    InvalidAuthorityIndexRequested { index: AuthorityIndex, max: usize, peer: AuthorityIndex },
+    InvalidAuthorityIndexRequested {
+        index: AuthorityIndex,
+        max: usize,
+        peer: AuthorityIndex,
+    },
 
     #[error("Failed to deserialize signature: {0}")]
     MalformedSignature(FastCryptoError),
@@ -262,18 +259,18 @@ impl ConsensusError {
     pub fn quick_validation_requested_block_refs(
         block_refs: &[BlockRef],
         peer: AuthorityIndex,
-        committee: &Committee
+        committee: &Committee,
     ) -> ConsensusResult<()> {
         for block in block_refs {
             if !committee.is_valid_index(block.author) {
                 return Err(ConsensusError::InvalidAuthorityIndexRequested {
                     index: block.author,
                     max: committee.size(),
-                    peer
+                    peer,
                 });
             }
             if block.round == GENESIS_ROUND {
-                return Err(ConsensusError::UnexpectedGenesisHeaderRequested);
+                return Err(ConsensusError::UnexpectedGenesisRequested { peer });
             }
         }
         Ok(())
@@ -284,7 +281,7 @@ impl ConsensusError {
         committee: &Committee,
     ) -> ConsensusResult<()> {
         // Ensure that those are valid authorities
-        for authority in &authorities {
+        for authority in authorities {
             if !committee.is_valid_index(*authority) {
                 return Err(ConsensusError::InvalidAuthorityIndex {
                     index: *authority,
@@ -294,7 +291,6 @@ impl ConsensusError {
         }
         Ok(())
     }
-
 }
 
 pub type ConsensusResult<T> = Result<T, ConsensusError>;


### PR DESCRIPTION
# Description of change

In this PR, we truncate the block_refs to the required size when receiving a request to fetch transactions. This is done in the line of the header synchronizer, which allows for easy change of the local parameters without changing the protocol config.

## Links to any relevant issues

#9140

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
