### PR TITLE
chore: fix rust 1.90 compilation warnings

### DIFF
--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -124,6 +124,7 @@ type Query<ST, GB> = data::Query<ST, transactions::table, GB>;
 /// The cursor returned for each `TransactionBlock` in a connection's page of
 /// results. The `checkpoint_viewed_at` will set the consistent upper bound for
 /// subsequent queries made on this cursor.
+#[expect(unused)]
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub(crate) struct TransactionBlockCursor {
     /// The checkpoint sequence number this was viewed at.

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -124,7 +124,7 @@ type Query<ST, GB> = data::Query<ST, transactions::table, GB>;
 /// The cursor returned for each `TransactionBlock` in a connection's page of
 /// results. The `checkpoint_viewed_at` will set the consistent upper bound for
 /// subsequent queries made on this cursor.
-#[expect(unused)]
+#[allow(unused)]
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub(crate) struct TransactionBlockCursor {
     /// The checkpoint sequence number this was viewed at.

--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use typed_store_error::TypedStoreError;
 
-#[expect(unused)]
+#[allow(unused)]
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug, Error)]
 pub(crate) struct RocksErrorDef {
     message: String,
@@ -22,7 +22,7 @@ impl Display for RocksErrorDef {
     }
 }
 
-#[expect(unused)]
+#[allow(unused)]
 #[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug, Error)]
 pub(crate) enum BincodeErrorDef {
     Io(String),

--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use typed_store_error::TypedStoreError;
 
+#[expect(unused)]
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug, Error)]
 pub(crate) struct RocksErrorDef {
     message: String,
@@ -21,6 +22,7 @@ impl Display for RocksErrorDef {
     }
 }
 
+#[expect(unused)]
 #[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug, Error)]
 pub(crate) enum BincodeErrorDef {
     Io(String),

--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -2,86 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt, fmt::Display};
-
-use bincode::ErrorKind as BincodeErrorKind;
 use rocksdb::Error as RocksError;
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
 use typed_store_error::TypedStoreError;
-
-#[allow(unused)]
-#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug, Error)]
-pub(crate) struct RocksErrorDef {
-    message: String,
-}
-
-impl Display for RocksErrorDef {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        self.message.fmt(formatter)
-    }
-}
-
-#[allow(unused)]
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug, Error)]
-pub(crate) enum BincodeErrorDef {
-    Io(String),
-    InvalidUtf8Encoding(String),
-    InvalidBoolEncoding(u8),
-    InvalidCharEncoding,
-    InvalidTagEncoding(usize),
-    DeserializeAnyNotSupported,
-    SizeLimit,
-    SequenceMustHaveLength,
-    Custom(String),
-}
-
-impl fmt::Display for BincodeErrorDef {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            BincodeErrorDef::Io(ref ioerr) => write!(fmt, "io error: {ioerr}"),
-            BincodeErrorDef::InvalidUtf8Encoding(ref e) => {
-                write!(fmt, "{e}")
-            }
-            BincodeErrorDef::InvalidBoolEncoding(b) => {
-                write!(fmt, "expected 0 or 1, found {b}")
-            }
-            BincodeErrorDef::InvalidCharEncoding => write!(fmt, "{self:?}"),
-            BincodeErrorDef::InvalidTagEncoding(tag) => {
-                write!(fmt, "found {tag}")
-            }
-            BincodeErrorDef::SequenceMustHaveLength => write!(fmt, "{self:?}"),
-            BincodeErrorDef::SizeLimit => write!(fmt, "{self:?}"),
-            BincodeErrorDef::DeserializeAnyNotSupported => write!(
-                fmt,
-                "Bincode does not support the serde::Deserializer::deserialize_any method"
-            ),
-            BincodeErrorDef::Custom(ref s) => s.fmt(fmt),
-        }
-    }
-}
-
-impl From<bincode::Error> for BincodeErrorDef {
-    fn from(err: bincode::Error) -> Self {
-        match err.as_ref() {
-            BincodeErrorKind::Io(ioerr) => BincodeErrorDef::Io(ioerr.to_string()),
-            BincodeErrorKind::InvalidUtf8Encoding(utf8err) => {
-                BincodeErrorDef::InvalidUtf8Encoding(utf8err.to_string())
-            }
-            BincodeErrorKind::InvalidBoolEncoding(byte) => {
-                BincodeErrorDef::InvalidBoolEncoding(*byte)
-            }
-            BincodeErrorKind::InvalidCharEncoding => BincodeErrorDef::InvalidCharEncoding,
-            BincodeErrorKind::InvalidTagEncoding(tag) => BincodeErrorDef::InvalidTagEncoding(*tag),
-            BincodeErrorKind::DeserializeAnyNotSupported => {
-                BincodeErrorDef::DeserializeAnyNotSupported
-            }
-            BincodeErrorKind::SizeLimit => BincodeErrorDef::SizeLimit,
-            BincodeErrorKind::SequenceMustHaveLength => BincodeErrorDef::SequenceMustHaveLength,
-            BincodeErrorKind::Custom(str) => BincodeErrorDef::Custom(str.to_owned()),
-        }
-    }
-}
 
 pub fn typed_store_err_from_bincode_err(err: bincode::Error) -> TypedStoreError {
     TypedStoreError::Serialization(format!("{err}"))

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -3145,7 +3145,7 @@ fn get_mod_outer_defs(
             fun.signature
                 .type_parameters
                 .iter()
-                .map(|t| (sp(t.user_specified_name.loc, Type_::Param(t.clone()))))
+                .map(|t| sp(t.user_specified_name.loc, Type_::Param(t.clone())))
                 .collect(),
             fun.signature
                 .parameters


### PR DESCRIPTION
# Description of change

Addressing rust 1.90 compilation warnings before addressing clippy and bumping the toolchain.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes