### PR TITLE
fix(docker): determine build script location to resolve relative paths correctly

### DIFF
--- a/docker/iota-data-ingestion/build.sh
+++ b/docker/iota-data-ingestion/build.sh
@@ -4,6 +4,7 @@
 
 # Determine script's location to resolve the relative path correctly
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
-cd "$SCRIPT_DIR"
+# The name of last directory in script's path is used for tag
+BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-./../utils/build-script.sh --image-tag "iotaledger/iota-data-ingestion"
+"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-data-ingestion/build.sh
+++ b/docker/iota-data-ingestion/build.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Determine script's location to resolve the relative path correctly
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 cd "$SCRIPT_DIR"
 
 ./../utils/build-script.sh --image-tag "iotaledger/iota-data-ingestion"

--- a/docker/iota-data-ingestion/build.sh
+++ b/docker/iota-data-ingestion/build.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 # Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
+
+# Determine script's location to resolve the relative path correctly
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+cd "$SCRIPT_DIR"
+
 ./../utils/build-script.sh --image-tag "iotaledger/iota-data-ingestion"

--- a/docker/iota-graphql-rpc/build.sh
+++ b/docker/iota-graphql-rpc/build.sh
@@ -5,6 +5,7 @@
 
 # Determine script's location to resolve the relative path correctly
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
-cd "$SCRIPT_DIR"
+# The name of last directory in script's path is used for tag
+BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-./../utils/build-script.sh --image-tag "iotaledger/iota-graphql-rpc"
+"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-graphql-rpc/build.sh
+++ b/docker/iota-graphql-rpc/build.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Determine script's location to resolve the relative path correctly
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 cd "$SCRIPT_DIR"
 
 ./../utils/build-script.sh --image-tag "iotaledger/iota-graphql-rpc"

--- a/docker/iota-graphql-rpc/build.sh
+++ b/docker/iota-graphql-rpc/build.sh
@@ -2,4 +2,9 @@
 # Copyright (c) Mysten Labs, Inc.
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
+
+# Determine script's location to resolve the relative path correctly
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+cd "$SCRIPT_DIR"
+
 ./../utils/build-script.sh --image-tag "iotaledger/iota-graphql-rpc"

--- a/docker/iota-indexer/build.sh
+++ b/docker/iota-indexer/build.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Determine script's location to resolve the relative path correctly
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 cd "$SCRIPT_DIR"
 
 ./../utils/build-script.sh --image-tag "iotaledger/iota-indexer"

--- a/docker/iota-indexer/build.sh
+++ b/docker/iota-indexer/build.sh
@@ -2,4 +2,9 @@
 # Copyright (c) Mysten Labs, Inc.
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
+
+# Determine script's location to resolve the relative path correctly
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+cd "$SCRIPT_DIR"
+
 ./../utils/build-script.sh --image-tag "iotaledger/iota-indexer"

--- a/docker/iota-indexer/build.sh
+++ b/docker/iota-indexer/build.sh
@@ -5,6 +5,7 @@
 
 # Determine script's location to resolve the relative path correctly
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
-cd "$SCRIPT_DIR"
+# The name of last directory in script's path is used for tag
+BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-./../utils/build-script.sh --image-tag "iotaledger/iota-indexer"
+"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-node/build.sh
+++ b/docker/iota-node/build.sh
@@ -2,4 +2,9 @@
 # Copyright (c) Mysten Labs, Inc.
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
+
+# Determine script's location to resolve the relative path correctly
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+cd "$SCRIPT_DIR"
+
 ./../utils/build-script.sh --image-tag "iotaledger/iota-node"

--- a/docker/iota-node/build.sh
+++ b/docker/iota-node/build.sh
@@ -5,6 +5,7 @@
 
 # Determine script's location to resolve the relative path correctly
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
-cd "$SCRIPT_DIR"
+# The name of last directory in script's path is used for tag
+BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-./../utils/build-script.sh --image-tag "iotaledger/iota-node"
+"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-node/build.sh
+++ b/docker/iota-node/build.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Determine script's location to resolve the relative path correctly
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 cd "$SCRIPT_DIR"
 
 ./../utils/build-script.sh --image-tag "iotaledger/iota-node"

--- a/docker/iota-proxy/build.sh
+++ b/docker/iota-proxy/build.sh
@@ -2,4 +2,9 @@
 # Copyright (c) Mysten Labs, Inc.
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
+
+# Determine script's location to resolve the relative path correctly
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+cd "$SCRIPT_DIR"
+
 ./../utils/build-script.sh --image-tag "iotaledger/iota-proxy"

--- a/docker/iota-proxy/build.sh
+++ b/docker/iota-proxy/build.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Determine script's location to resolve the relative path correctly
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 cd "$SCRIPT_DIR"
 
 ./../utils/build-script.sh --image-tag "iotaledger/iota-proxy"

--- a/docker/iota-proxy/build.sh
+++ b/docker/iota-proxy/build.sh
@@ -5,6 +5,7 @@
 
 # Determine script's location to resolve the relative path correctly
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
-cd "$SCRIPT_DIR"
+# The name of last directory in script's path is used for tag
+BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-./../utils/build-script.sh --image-tag "iotaledger/iota-proxy"
+"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-rest-kv/build.sh
+++ b/docker/iota-rest-kv/build.sh
@@ -4,6 +4,7 @@
 
 # Determine script's location to resolve the relative path correctly
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
-cd "$SCRIPT_DIR"
+# The name of last directory in script's path is used for tag
+BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-./../utils/build-script.sh --image-tag "iotaledger/iota-rest-kv"
+"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-rest-kv/build.sh
+++ b/docker/iota-rest-kv/build.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 # Copyright (c) 2025 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
+
+# Determine script's location to resolve the relative path correctly
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+cd "$SCRIPT_DIR"
+
 ./../utils/build-script.sh --image-tag "iotaledger/iota-rest-kv"

--- a/docker/iota-rest-kv/build.sh
+++ b/docker/iota-rest-kv/build.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Determine script's location to resolve the relative path correctly
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 cd "$SCRIPT_DIR"
 
 ./../utils/build-script.sh --image-tag "iotaledger/iota-rest-kv"

--- a/docker/iota-rosetta/build.sh
+++ b/docker/iota-rosetta/build.sh
@@ -5,6 +5,7 @@
 
 # Determine script's location to resolve the relative path correctly
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
-cd "$SCRIPT_DIR"
+# The name of last directory in script's path is used for tag
+BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-./../utils/build-script.sh --image-tag "iotaledger/iota-rosetta"
+"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-rosetta/build.sh
+++ b/docker/iota-rosetta/build.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Determine script's location to resolve the relative path correctly
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 cd "$SCRIPT_DIR"
 
 ./../utils/build-script.sh --image-tag "iotaledger/iota-rosetta"

--- a/docker/iota-rosetta/build.sh
+++ b/docker/iota-rosetta/build.sh
@@ -2,4 +2,9 @@
 # Copyright (c) Mysten Labs, Inc.
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
-./../../docker/utils/build-script.sh --image-tag "iotaledger/iota-rosetta"
+
+# Determine script's location to resolve the relative path correctly
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+cd "$SCRIPT_DIR"
+
+./../utils/build-script.sh --image-tag "iotaledger/iota-rosetta"

--- a/docker/iota-source-validation-service/build.sh
+++ b/docker/iota-source-validation-service/build.sh
@@ -2,4 +2,9 @@
 # Copyright (c) Mysten Labs, Inc.
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
+
+# Determine script's location to resolve the relative path correctly
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+cd "$SCRIPT_DIR"
+
 ./../utils/build-script.sh --image-tag "iotaledger/iota-source-validation-service"

--- a/docker/iota-source-validation-service/build.sh
+++ b/docker/iota-source-validation-service/build.sh
@@ -5,6 +5,7 @@
 
 # Determine script's location to resolve the relative path correctly
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
-cd "$SCRIPT_DIR"
+# The name of last directory in script's path is used for tag
+BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-./../utils/build-script.sh --image-tag "iotaledger/iota-source-validation-service"
+"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-source-validation-service/build.sh
+++ b/docker/iota-source-validation-service/build.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Determine script's location to resolve the relative path correctly
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 cd "$SCRIPT_DIR"
 
 ./../utils/build-script.sh --image-tag "iotaledger/iota-source-validation-service"

--- a/docker/iota-tools/build.sh
+++ b/docker/iota-tools/build.sh
@@ -5,6 +5,7 @@
 
 # Determine script's location to resolve the relative path correctly
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
-cd "$SCRIPT_DIR"
+# The name of last directory in script's path is used for tag
+BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-./../utils/build-script.sh --image-tag "iotaledger/iota-tools"
+"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-tools/build.sh
+++ b/docker/iota-tools/build.sh
@@ -2,4 +2,9 @@
 # Copyright (c) Mysten Labs, Inc.
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
+
+# Determine script's location to resolve the relative path correctly
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+cd "$SCRIPT_DIR"
+
 ./../utils/build-script.sh --image-tag "iotaledger/iota-tools"

--- a/docker/iota-tools/build.sh
+++ b/docker/iota-tools/build.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Determine script's location to resolve the relative path correctly
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 cd "$SCRIPT_DIR"
 
 ./../utils/build-script.sh --image-tag "iotaledger/iota-tools"

--- a/docker/iota/build.sh
+++ b/docker/iota/build.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Determine script's location to resolve the relative path correctly
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 cd "$SCRIPT_DIR"
 
 ./../utils/build-script.sh --image-tag "iotaledger/iota"

--- a/docker/iota/build.sh
+++ b/docker/iota/build.sh
@@ -2,4 +2,9 @@
 # Copyright (c) Mysten Labs, Inc.
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
+
+# Determine script's location to resolve the relative path correctly
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" >/dev/null && pwd -P)
+cd "$SCRIPT_DIR"
+
 ./../utils/build-script.sh --image-tag "iotaledger/iota"

--- a/docker/iota/build.sh
+++ b/docker/iota/build.sh
@@ -5,6 +5,7 @@
 
 # Determine script's location to resolve the relative path correctly
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
-cd "$SCRIPT_DIR"
+# The name of last directory in script's path is used for tag
+BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-./../utils/build-script.sh --image-tag "iotaledger/iota"
+"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/utils/build-script.sh
+++ b/docker/utils/build-script.sh
@@ -11,9 +11,6 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 # Source common.sh from the utils directory
 source "$REPO_ROOT/scripts/utils/common.sh"
 
-# Get the current working directory where the script was called
-CURRENT_WORKING_DIR="$(pwd)"
-DOCKERFILE="$CURRENT_WORKING_DIR/Dockerfile"
 GIT_REVISION="$(git describe --always --abbrev=12 --dirty --exclude '*')"
 BUILD_DATE="$(date -u +'%Y-%m-%d')"
 PROFILE="release"
@@ -46,6 +43,8 @@ if [ -z "$IMAGE_TAG" ]; then
     print_step "Usage: $0 --image-tag <image_tag>"
     exit 1
 fi
+
+DOCKERFILE="$REPO_ROOT/docker/$(basename "$IMAGE_TAG")/Dockerfile"
 
 print_step "Parse the rust toolchain version from 'rust-toolchain.toml'..."
 RUST_VERSION=$(grep -oE 'channel = "[^"]+' ${REPO_ROOT}/rust-toolchain.toml | sed 's/channel = "//')


### PR DESCRIPTION
# Description of change

The docker build scripts invoke another script using a relative path, so running them from some other directory, different from their location, will not work. For example, the instructions we have here https://github.com/iotaledger/iota/tree/develop/dev-tools/iota-private-network#1-build-docker-images do not work (__at least on Linux__) exactly because of this problem. This PR adds changes to determine docker build scripts' location so that relative paths used in the scripts can be resolved correctly.

## How the change has been tested

Build a docker image, for example `iota-node`, from different working directories:

- From the root directory of the monorepo:

   ```sh
   cd $(git rev-parse --show-toplevel)
   docker/iota-node/build.sh -t iota-node --no-cache
   ```

   On `develop`, the build command fails with `docker/iota-node/build.sh: line 5: ./../utils/build-script.sh: No such file or directory`.

- From the `dev-tools/iota-private-network` directory as instructed [here](https://github.com/iotaledger/iota/tree/develop/dev-tools/iota-private-network#1-build-docker-images):

   ```sh
   cd "$(git rev-parse --show-toplevel)/dev-tools/iota-private-network"
   ../../docker/iota-node/build.sh -t iota-node --no-cache
   ```

   On `develop`, the build command fails with `../../docker/iota-node/build.sh: line 5: ./../utils/build-script.sh: No such file or directory`.

- From the `docker/iota-node` directory:

   ```sh
   cd "$(git rev-parse --show-toplevel)/docker/iota-node"
   ./build.sh -t iota-node --no-cache
   ```

   Only this build command seems to work on `develop`, meaning that we must first navigate to the build script directory and then run the script from there. 