### PR TITLE
feat(consensus): fix consensus committed messages metric

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -281,7 +281,7 @@ pub trait ConsensusStatsAPI {
     fn is_initialized(&self) -> bool;
 
     fn get_num_messages(&self, authority: usize) -> u64;
-    fn inc_num_messages(&mut self, authority: usize) -> u64;
+    fn inc_num_messages(&mut self, authority: usize, num_of_new_messages: u64) -> u64;
 
     fn get_num_user_transactions(&self, authority: usize) -> u64;
     fn inc_num_user_transactions(&mut self, authority: usize) -> u64;
@@ -323,8 +323,8 @@ impl ConsensusStatsAPI for ConsensusStatsV1 {
         self.num_messages[authority]
     }
 
-    fn inc_num_messages(&mut self, authority: usize) -> u64 {
-        self.num_messages[authority] += 1;
+    fn inc_num_messages(&mut self, authority: usize, num_of_new_messages: u64) -> u64 {
+        self.num_messages[authority] += num_of_new_messages;
         self.num_messages[authority]
     }
 

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -295,14 +295,19 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             .with_label_values(&[&leader_author.to_string()])
             .inc();
 
+        for (authority_index, number_of_committed_headers) in
+            consensus_output.number_of_headers_in_commit_by_authority()
+        {
+            self.last_consensus_stats
+                .stats
+                .inc_num_messages(authority_index as usize, number_of_committed_headers);
+        }
+
         {
             let span = trace_span!("process_consensus_certs");
             let _guard = span.enter();
             for (authority_index, authority_transactions) in consensus_output.transactions() {
                 // TODO: consider only messages within 1~3 rounds of the leader?
-                self.last_consensus_stats
-                    .stats
-                    .inc_num_messages(authority_index as usize);
                 for (transaction, serialized_len) in authority_transactions {
                     let kind = classify(&transaction);
                     self.metrics

--- a/crates/iota-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/iota-core/src/consensus_types/consensus_output_api.rs
@@ -2,13 +2,13 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::Display;
+use std::{collections::BTreeMap, fmt::Display};
 
 use consensus_core::BlockAPI;
 use iota_types::{digests::ConsensusCommitDigest, messages_consensus::ConsensusTransaction};
+use starfish_core::BlockHeaderAPI;
 
 use crate::consensus_types::AuthorityIndex;
-
 /// A list of tuples of:
 /// (block origin authority index, all transactions contained in the block).
 /// For each transaction, returns deserialized transaction and its serialized
@@ -31,6 +31,8 @@ pub(crate) trait ConsensusOutputAPI: Display {
 
     /// Returns the digest of consensus output.
     fn consensus_digest(&self) -> ConsensusCommitDigest;
+
+    fn number_of_headers_in_commit_by_authority(&self) -> Vec<(AuthorityIndex, u64)>;
 }
 macro_rules! impl_consensus_output_api {
     (
@@ -45,7 +47,9 @@ macro_rules! impl_consensus_output_api {
         // How to read the author index value (u32/usize; we cast to AuthorityIndex)
         author = |$auth_item:ident| $author_expr:expr,
         // How to get the `&[u8]` txs iterator source (something with `.iter()` over tx buffers)
-        txs = |$txs_item:ident| $txs_expr:expr
+        txs = |$txs_item:ident| $txs_expr:expr,
+        // How to get the number of committed headers in the commit
+        committed_headers = |$committed_headers_item:ident| $committed_headers_expr:expr
     ) => {
         impl ConsensusOutputAPI for $ty {
             fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>> {
@@ -114,6 +118,18 @@ macro_rules! impl_consensus_output_api {
                 static_assertions::assert_eq_size!(ConsensusCommitDigest, $commit_digest);
                 ConsensusCommitDigest::new(self.commit_ref.digest.into_inner())
             }
+
+            fn number_of_headers_in_commit_by_authority(&self) -> Vec<(AuthorityIndex, u64)> {
+                let $self_ident = self;
+                let mut num_of_committed_headers = BTreeMap::new();
+                $committed_headers_expr
+                    .iter()
+                    .for_each(|block| {
+                        let author_index = block.author().value() as AuthorityIndex;
+                        *num_of_committed_headers.entry(author_index).or_insert(0) += 1;
+                    });
+                num_of_committed_headers.into_iter().collect()
+            }
         }
     };
 }
@@ -129,7 +145,8 @@ impl_consensus_output_api! {
     iterate = |self_, block| self_.blocks.iter(),
     round   = |block| block.round(),
     author  = |block| block.author().value(),
-    txs     = |block| block.transactions()
+    txs     = |block| block.transactions(),
+    committed_headers = |self_| self_.blocks
 }
 
 // starfish_core::CommittedSubDag:
@@ -142,5 +159,6 @@ impl_consensus_output_api! {
     iterate = |self_, vt| self_.transactions.iter(),
     round   = |vt| vt.block_ref().round,
     author  = |vt| vt.block_ref().author.value(),
-    txs     = |vt| vt.transactions()
+    txs     = |vt| vt.transactions(),
+    committed_headers = |self_| self_.headers
 }


### PR DESCRIPTION
# Description of change

PR fixes consensus_committed_messages that worked incorrectly for starfish and counted only blocks with non-empty vector of transactions.

## Links to any relevant issues

fixes #9017 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

