### PR TITLE
chore: bump rust toolchain to 1.90

### DIFF
--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -730,7 +730,7 @@ impl CheckpointExecutor {
         } else {
             assert_eq!(seq, 0);
         }
-        if seq % CHECKPOINT_PROGRESS_LOG_COUNT_INTERVAL == 0 {
+        if seq.is_multiple_of(CHECKPOINT_PROGRESS_LOG_COUNT_INTERVAL) {
             info!("Finished syncing and executing checkpoint {}", seq);
         }
 

--- a/crates/iota-core/src/consensus_manager/mod.rs
+++ b/crates/iota-core/src/consensus_manager/mod.rs
@@ -163,7 +163,7 @@ impl ConsensusManager {
                 "mysticeti" => return ConsensusProtocol::Mysticeti,
                 "starfish" => return ConsensusProtocol::Starfish,
                 "swap_each_epoch" => {
-                    let protocol = if epoch_store.epoch() % 2 == 0 {
+                    let protocol = if epoch_store.epoch().is_multiple_of(2) {
                         ConsensusProtocol::Starfish
                     } else {
                         ConsensusProtocol::Mysticeti

--- a/crates/iota-core/src/par_index_live_object_set.rs
+++ b/crates/iota-core/src/par_index_live_object_set.rs
@@ -90,7 +90,7 @@ fn live_object_set_index_task<T: LiveObjectIndexer>(
         .filter_map(LiveObject::to_normal)
     {
         object_scanned += 1;
-        if object_scanned % 2_000_000 == 0 {
+        if object_scanned.is_multiple_of(2_000_000) {
             info!(
                 "[Index] Task {}: object scanned: {}",
                 task_id, object_scanned

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -1378,7 +1378,7 @@ async fn sync_checkpoint_contents<S>(
             ));
         }
 
-        if highest_synced.sequence_number() % checkpoint_content_download_concurrency as u64 == 0
+        if highest_synced.sequence_number().is_multiple_of(checkpoint_content_download_concurrency as u64)
             || checkpoint_contents_tasks.is_empty()
         {
             // Periodically notify event loop to notify our peers that we've synced to a new

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -1378,7 +1378,9 @@ async fn sync_checkpoint_contents<S>(
             ));
         }
 
-        if highest_synced.sequence_number().is_multiple_of(checkpoint_content_download_concurrency as u64)
+        if highest_synced
+            .sequence_number()
+            .is_multiple_of(checkpoint_content_download_concurrency as u64)
             || checkpoint_contents_tasks.is_empty()
         {
             // Periodically notify event loop to notify our peers that we've synced to a new

--- a/crates/starfish/core/src/encoder.rs
+++ b/crates/starfish/core/src/encoder.rs
@@ -112,7 +112,7 @@ fn create_shards_from_serialized_transactions(
     let mut shard_bytes = (bytes_length + 4).div_ceil(info_length);
 
     // Ensure shard_bytes meets alignment requirements.
-    if shard_bytes % 2 != 0 {
+    if !shard_bytes.is_multiple_of(2) {
         shard_bytes += 1;
     }
 

--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -75,7 +75,7 @@ impl SamplingInterval {
     }
     pub fn sample(&self) -> bool {
         if self.once_every_duration.is_zero() {
-            self.counter.fetch_add(1, Ordering::Relaxed) % (self.after_num_ops + 1) == 0
+            self.counter.fetch_add(1, Ordering::Relaxed).is_multiple_of(self.after_num_ops + 1)
         } else {
             self.counter.fetch_add(1, Ordering::Relaxed) == 0
         }

--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -75,7 +75,9 @@ impl SamplingInterval {
     }
     pub fn sample(&self) -> bool {
         if self.once_every_duration.is_zero() {
-            self.counter.fetch_add(1, Ordering::Relaxed).is_multiple_of(self.after_num_ops + 1)
+            self.counter
+                .fetch_add(1, Ordering::Relaxed)
+                .is_multiple_of(self.after_num_ops + 1)
         } else {
             self.counter.fetch_add(1, Ordering::Relaxed) == 0
         }

--- a/iota-execution/latest/iota-move-natives/src/crypto/group_ops.rs
+++ b/iota-execution/latest/iota-move-natives/src/crypto/group_ops.rs
@@ -602,8 +602,8 @@ where
 {
     if points.is_empty()
         || scalars.is_empty()
-        || scalars.len() % SCALAR_SIZE != 0
-        || points.len() % POINT_SIZE != 0
+        || !scalars.len().is_multiple_of(SCALAR_SIZE)
+        || !points.len().is_multiple_of(POINT_SIZE)
         || points.len() / POINT_SIZE != scalars.len() / SCALAR_SIZE
     {
         return Ok(NativeResult::err(context.gas_used(), INVALID_INPUT_ERROR));

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.89"
+channel = "1.90"


### PR DESCRIPTION
# Description of change

Bump rust toolchain to 1.90 and fix new clippy lints.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes