### PR TITLE
feat(consensus): add new metrics for commits in starfish

### DIFF
--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -379,6 +379,19 @@ impl CommitObserver {
                     .map(|x| x.transactions().len())
                     .sum::<usize>() as f64,
             );
+            // Report the number of blocks committed with transactions per commit
+            metrics
+                .non_empty_blocks_per_commit_count
+                .observe(commit.transactions.len() as f64);
+            // Report the number of blocks committed with transactions per authority
+            for verified_transaction in &commit.transactions {
+                let authority_index = verified_transaction.block_ref().author;
+                let hostname = &self.context.committee.authority(authority_index).hostname;
+                metrics
+                    .committed_non_empty_blocks_per_authority
+                    .with_label_values(&[hostname])
+                    .inc();
+            }
 
             let block_refs_for_committed_txs = commit
                 .transactions

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -181,6 +181,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) num_of_bad_nodes: IntGauge,
     pub(crate) quorum_receive_latency: Histogram,
     pub(crate) transactions_per_commit_count: Histogram,
+    pub(crate) non_empty_blocks_per_commit_count: Histogram,
+    pub(crate) committed_non_empty_blocks_per_authority: IntCounterVec,
     pub(crate) transactions_synchronizer_fetched_transactions_by_peer: IntCounterVec,
     pub(crate) transactions_synchronizer_fetched_transactions_by_authority: IntCounterVec,
     pub(crate) transactions_synchronizer_missing_transactions_by_authority: IntCounterVec,
@@ -581,6 +583,18 @@ impl NodeMetrics {
                 "transactions_per_commit_count",
                 "The number of transactions per commit.",
                 NUM_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            non_empty_blocks_per_commit_count: register_histogram_with_registry!(
+                "non_empty_blocks_per_commit_count",
+                "The number of non-empty blocks per commit.",
+                NUM_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            committed_non_empty_blocks_per_authority: register_int_counter_vec_with_registry!(
+                "committed_non_empty_blocks_per_authority",
+                "Number of blocks committed with transactions per block author",
+                &["authority"],
                 registry,
             ).unwrap(),
             bundles_with_invalid_parts: register_int_counter_vec_with_registry!(


### PR DESCRIPTION
# Description of change

PR adds metrics to Starfish to track the number of non-empty committed blocks per commit and per authority.


## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
