### PR TITLE
fix(ci): Use GitHub Runners in Changeset Publish workflows

### DIFF
--- a/.github/workflows/changesets-snapshot-release.yml
+++ b/.github/workflows/changesets-snapshot-release.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   snapshot:
-    runs-on: self-hosted-x64
+    runs-on: ubuntu-latest
     steps:
       - name: checkout code repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/.github/workflows/changesets_publish.yml
+++ b/.github/workflows/changesets_publish.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: self-hosted-x64
+    runs-on: ubuntu-latest
     steps:
       - name: checkout code repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
Fixes https://github.com/iotaledger/iota/actions/runs/19107879114/job/54596651388

>  Unsupported GitHub Actions runner environment: "self-hosted". Only "github-hosted" runners are supported when publishing with provenance. 