### PR TITLE
fix(ci): Uninstall yarn in Changeset Publish workflow

### DIFF
--- a/.github/workflows/changesets-snapshot-release.yml
+++ b/.github/workflows/changesets-snapshot-release.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Update npm
         run: npm install -g npm@latest
 
+      - name: Uninstall yarn # https://github.com/postmanlabs/postman-code-generators/issues/792
+        run: npm uninstall -g yarn || true
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/changesets_publish.yml
+++ b/.github/workflows/changesets_publish.yml
@@ -29,6 +29,8 @@ jobs:
           cache: "pnpm"
       - name: Update npm
         run: npm install -g npm@latest
+      - name: Uninstall yarn # https://github.com/postmanlabs/postman-code-generators/issues/792
+        run: npm uninstall -g yarn || true
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build packages


### PR DESCRIPTION
Its causing issues because the github runners come with yarn by default and it generates issues because of https://github.com/postmanlabs/postman-code-generators/issues/792