### PR TITLE
feat(iota-core, iota-types): Introduce misbehavior reports

### DIFF
--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -87,6 +87,7 @@ pub struct BlockV1 {
     ancestors: Vec<BlockRef>,
     transactions: Vec<Transaction>,
     commit_votes: Vec<CommitVote>,
+    //  This form of misbehavior report is now deprecated
     misbehavior_reports: Vec<MisbehaviorReport>,
 }
 
@@ -625,7 +626,7 @@ impl TestBlock {
     }
 }
 
-/// A block can attach reports of misbehavior by other authorities.
+//  This form of misbehavior report is now deprecated
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct MisbehaviorReport {
     pub target: AuthorityIndex,

--- a/consensus/core/src/scorer.rs
+++ b/consensus/core/src/scorer.rs
@@ -829,8 +829,8 @@ mod tests {
         metrics
     }
 
-    #[test]
-    fn test_update_score_edge_cases() {
+    #[tokio::test]
+    async fn test_update_score_edge_cases() {
         let context = Context::new_for_test(4);
         let scorer = context.0.scorer;
         let authority_index = AuthorityIndex::new_for_test(0);

--- a/consensus/core/src/scorer.rs
+++ b/consensus/core/src/scorer.rs
@@ -169,7 +169,7 @@ impl Scorer {
                 .with_label_values(&[hostname, source, error.name()])
                 .inc();
         } else {
-            return;
+            // No scoring metrics to update.
         }
     }
 
@@ -301,7 +301,7 @@ impl Scorer {
         // We provisionally use the formula below to calculate the score, but changes
         // to this function are already expected. The hardcoded parameters (which are
         // also still provisional) represent:
-        // - No tolerance to any provably faulty misbehaviour. If any is detected, the
+        // - No tolerance to any provably faulty misbehavior. If any is detected, the
         //   score will be 0.
         // - If no provably faulty blocks are detected, 50% of the score is guaranteed.
         // - If no unprovably faulty blocks are detected, an additional 12.5% of the
@@ -1343,7 +1343,7 @@ mod tests {
         }
         dag_state.flush();
 
-        // Now all misbehaviours should be accounted for in the uncached metrics.
+        // Now all misbehaviors should be accounted for in the uncached metrics.
         assert_eq!(
             [
                 scoring_metrics.uncached_equivocations_by_authority(),
@@ -1715,7 +1715,7 @@ mod tests {
         }
         dag_state.flush();
 
-        // Now all misbehaviours should be accounted for in the uncached metrics.
+        // Now all misbehaviors should be accounted for in the uncached metrics.
         assert_eq!(
             [
                 scoring_metrics.uncached_equivocations_by_authority(),

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2673,6 +2673,19 @@ impl AuthorityPerEpochStore {
                 }
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::MisbehaviorReport(authority, _, _),
+                ..
+            }) => {
+                if &transaction.sender_authority() != authority {
+                    warn!(
+                        "MisbehaviorReport authority {} does not match its author from consensus {}",
+                        authority, transaction.certificate_author_index
+                    );
+                    // Here we should update invalid report counts for the
+                    // authority
+                }
+            }
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind:
                     ConsensusTransactionKind::CapabilityNotificationV1(AuthorityCapabilitiesV1 {
                         authority,
@@ -3908,6 +3921,13 @@ impl AuthorityPerEpochStore {
             }) => {
                 // these are partitioned earlier
                 panic!("process_consensus_transaction called with end-of-publish transaction");
+            }
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::MisbehaviorReport(_authority, _report, _),
+                ..
+            }) => {
+                // Validate report
+                Ok(ConsensusCertificateResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::CapabilityNotificationV1(capabilities),

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -592,6 +592,7 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
         ConsensusTransactionKind::CheckpointSignature(_) => "checkpoint_signature",
         ConsensusTransactionKind::EndOfPublish(_) => "end_of_publish",
         ConsensusTransactionKind::CapabilityNotificationV1(_) => "capability_notification_v1",
+        ConsensusTransactionKind::MisbehaviorReport(_, _, _) => "misbehavior_report",
         ConsensusTransactionKind::SignedCapabilityNotificationV1(_) => {
             "signed_capability_notification_v1"
         }

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -83,7 +83,8 @@ impl IotaTxValidator {
 
                 ConsensusTransactionKind::EndOfPublish(_)
                 | ConsensusTransactionKind::NewJWKFetched(_, _, _)
-                | ConsensusTransactionKind::CapabilityNotificationV1(_) => {}
+                | ConsensusTransactionKind::CapabilityNotificationV1(_)
+                | ConsensusTransactionKind::MisbehaviorReport(_, _, _) => {}
             }
         }
 

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -20,7 +20,8 @@ use shared_crypto::intent::IntentScope;
 
 use crate::{
     base_types::{
-        AuthorityName, ConciseableName, ObjectID, ObjectRef, SequenceNumber, TransactionDigest,
+        AuthorityName, CommitRound, ConciseableName, ObjectID, ObjectRef, SequenceNumber,
+        TransactionDigest,
     },
     crypto::{AuthoritySignature, DefaultHash},
     digests::{ConsensusCommitDigest, Digest},
@@ -90,6 +91,10 @@ pub enum ConsensusTransactionKey {
     NewJWKFetched(Box<(AuthorityName, JwkId, JWK)>),
     RandomnessDkgMessage(AuthorityName),
     RandomnessDkgConfirmation(AuthorityName),
+    // If a validator submits more than one report for the same round, we update the
+    // scoring metrics using the maximum reported metric, so CommitRound is sufficient to
+    // identify a report from a single AuthorityName.
+    MisbehaviorReport(AuthorityName, CommitRound),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -102,6 +107,9 @@ impl Debug for ConsensusTransactionKey {
                 write!(f, "CheckpointSignature({:?}, {:?})", name.concise(), seq)
             }
             Self::EndOfPublish(name) => write!(f, "EndOfPublish({:?})", name.concise()),
+            Self::MisbehaviorReport(name, round) => {
+                write!(f, "MisbehaviorReport({:?},{:?})", name.concise(), round)
+            }
             Self::CapabilityNotification(name, generation) => write!(
                 f,
                 "CapabilityNotification({:?}, {:?})",
@@ -260,6 +268,7 @@ pub enum ConsensusTransactionKind {
     // of `RandomnessDkgMessages` have been received locally, to complete the key generation
     // process. Contents are a serialized `fastcrypto_tbls::dkg::Confirmation`.
     RandomnessDkgConfirmation(AuthorityName, Vec<u8>),
+    MisbehaviorReport(AuthorityName, VersionedMisbehaviorReport, CommitRound),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -271,6 +280,50 @@ impl ConsensusTransactionKind {
             ConsensusTransactionKind::RandomnessDkgMessage(_, _)
                 | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
         )
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum VersionedMisbehaviorReport {
+    V1(MisbehaviorReportV1),
+}
+
+impl VersionedMisbehaviorReport {
+    pub fn verify(&self, committee_size: usize) -> bool {
+        match self {
+            VersionedMisbehaviorReport::V1(report) => report.verify(committee_size),
+        }
+    }
+}
+
+// MisbehaviorReportV1 contains lists of faulty blocks, equivocation and missing
+// proposal counts for each authority. This first version does not include any
+// type of proof.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MisbehaviorReportV1 {
+    pub faulty_blocks_provable: Vec<u64>,
+    pub faulty_blocks_unprovable: Vec<u64>,
+    pub equivocations: Vec<u64>,
+    pub missing_proposals: Vec<u64>,
+}
+
+impl MisbehaviorReportV1 {
+    pub fn verify(&self, committee_size: usize) -> bool {
+        // This version of reports are valid as long as they contain the counts for all
+        // authorities.  Future versions may contain proofs that need verification.
+        // However, since the validity of a proof is deeply coupled with the protocol
+        // version and the consensus mechanism being used, we cannot verify it here. In
+        // the future, reports should be unwrapped (or translated) to a type verifiable
+        // by the consensus crate, which means that the verification logic will probably
+        // move out of this crate.
+        if (self.faulty_blocks_provable.len() != committee_size)
+            | (self.faulty_blocks_unprovable.len() != committee_size)
+            | (self.equivocations.len() != committee_size)
+            | (self.missing_proposals.len() != committee_size)
+        {
+            return false;
+        }
+        true
     }
 }
 
@@ -464,6 +517,25 @@ impl ConsensusTransaction {
         }
     }
 
+    pub fn new_misbehavior_report_v1(
+        authority: AuthorityName,
+        report: &MisbehaviorReportV1,
+    ) -> Self {
+        let serialized_report =
+            bcs::to_bytes(report).expect("report serialization should not fail");
+        let mut hasher = DefaultHasher::new();
+        serialized_report.hash(&mut hasher);
+        let tracking_id = hasher.finish().to_le_bytes();
+        Self {
+            tracking_id,
+            kind: ConsensusTransactionKind::MisbehaviorReport(
+                authority,
+                VersionedMisbehaviorReport::V1(report.clone()),
+                1,
+            ),
+        }
+    }
+
     pub fn get_tracking_id(&self) -> u64 {
         (&self.tracking_id[..])
             .read_u64::<BigEndian>()
@@ -483,6 +555,9 @@ impl ConsensusTransaction {
             }
             ConsensusTransactionKind::EndOfPublish(authority) => {
                 ConsensusTransactionKey::EndOfPublish(*authority)
+            }
+            ConsensusTransactionKind::MisbehaviorReport(authority, _, round) => {
+                ConsensusTransactionKey::MisbehaviorReport(*authority, *round)
             }
             ConsensusTransactionKind::CapabilityNotificationV1(cap) => {
                 ConsensusTransactionKey::CapabilityNotification(cap.authority, cap.generation)

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -520,6 +520,7 @@ impl ConsensusTransaction {
     pub fn new_misbehavior_report_v1(
         authority: AuthorityName,
         report: &MisbehaviorReportV1,
+        round: CommitRound,
     ) -> Self {
         let serialized_report =
             bcs::to_bytes(report).expect("report serialization should not fail");
@@ -531,7 +532,7 @@ impl ConsensusTransaction {
             kind: ConsensusTransactionKind::MisbehaviorReport(
                 authority,
                 VersionedMisbehaviorReport::V1(report.clone()),
-                1,
+                round,
             ),
         }
     }

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -458,34 +458,6 @@ impl EndOfEpochTransactionKind {
         })
     }
 
-    pub fn new_change_epoch_v4(
-        next_epoch: EpochId,
-        protocol_version: ProtocolVersion,
-        storage_charge: u64,
-        computation_charge: u64,
-        computation_charge_burned: u64,
-        storage_rebate: u64,
-        non_refundable_storage_fee: u64,
-        epoch_start_timestamp_ms: u64,
-        system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>,
-        eligible_active_validators: Vec<u64>,
-        scores: Vec<u64>,
-    ) -> Self {
-        Self::ChangeEpochV4(ChangeEpochV4 {
-            epoch: next_epoch,
-            protocol_version,
-            storage_charge,
-            computation_charge,
-            computation_charge_burned,
-            storage_rebate,
-            non_refundable_storage_fee,
-            epoch_start_timestamp_ms,
-            system_packages,
-            eligible_active_validators,
-            scores,
-        })
-    }
-
     pub fn new_authenticator_state_expire(
         min_epoch: u64,
         authenticator_obj_initial_shared_version: SequenceNumber,

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -458,6 +458,34 @@ impl EndOfEpochTransactionKind {
         })
     }
 
+    pub fn new_change_epoch_v4(
+        next_epoch: EpochId,
+        protocol_version: ProtocolVersion,
+        storage_charge: u64,
+        computation_charge: u64,
+        computation_charge_burned: u64,
+        storage_rebate: u64,
+        non_refundable_storage_fee: u64,
+        epoch_start_timestamp_ms: u64,
+        system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>,
+        eligible_active_validators: Vec<u64>,
+        scores: Vec<u64>,
+    ) -> Self {
+        Self::ChangeEpochV4(ChangeEpochV4 {
+            epoch: next_epoch,
+            protocol_version,
+            storage_charge,
+            computation_charge,
+            computation_charge_burned,
+            storage_rebate,
+            non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            system_packages,
+            eligible_active_validators,
+            scores,
+        })
+    }
+
     pub fn new_authenticator_state_expire(
         min_epoch: u64,
         authenticator_obj_initial_shared_version: SequenceNumber,


### PR DESCRIPTION
```mermaid
---
config:
  gitGraph:
    {parallelCommits: true,
    mainBranchName: 'Feature',
    rotateCommitLabel: true}
---
gitGraph
   commit id: "Initial commit"   
commit id: "Old Scorer" tag: "PR8530"
commit id: "add ChangeEpochV4" tag: "PR9159"
   checkout Feature
    branch misbehavior-reports
   commit id: "add MisbehaviorReports"
    checkout misbehavior-reports
    branch scoring-metrics
   commit id: "add ScoringMetrics"
    checkout scoring-metrics
   branch scorer
   commit id: "add Scorer"
    checkout scorer
   branch scoring-metrics-store
   commit id: "add ScoringMetricsStore"
branch report-validation
commit id: "add report validation" 
branch scoring-function
commit id: "add scoring function" 
branch report-creation
commit id: "add report creation" 
branch advance-epoch
commit id: "add advance epoch v4" 
   checkout Feature
    merge misbehavior-reports tag: "THIS PR"
```

This PR introduces a new variant of `ConsensusTransactionKind` called `MisbehaviourReport`. It should be used to propagate a `VersionedMisbehaviorReport` (also introduced in this PR), which can contain both proofs of validator misbehavior and local views of performance metrics. 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Introduces a new variant of ConsensusTransactionKind to enable propagation of misbehavior reports
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
