### PR TITLE
feat(iota-types): Add scoring metrics type

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -2072,6 +2072,7 @@
                 "reward_slashing_rate": {
                   "u64": "10000"
                 },
+                "scorer_version": null,
                 "storage_gas_price": {
                   "u64": "76"
                 },

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1173,6 +1173,14 @@ pub struct ProtocolConfig {
     /// for any single commit. Any overshoot is tracked as a debt that must
     /// be accounted for in subsequent commits.
     max_congestion_limit_overshoot_per_commit: Option<u64>,
+
+    /// Scorer version. When set to `None`, MisbehaviorReports are not sent nor
+    /// considered valid. When set to `Some(version)`, scores are included in
+    /// the MisbehaviorReports messages, where `version` determines the scoring
+    /// formulas and metrics to be used. Even if set to None, the Scorer
+    /// component is created, having access to metrics and being able to expose
+    /// validator scores.
+    scorer_version: Option<u16>,
 }
 
 // feature flags
@@ -2002,6 +2010,8 @@ impl ProtocolConfig {
             consensus_max_acknowledgments_per_block: None,
 
             max_congestion_limit_overshoot_per_commit: None,
+
+            scorer_version: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };

--- a/crates/iota-types/src/lib.rs
+++ b/crates/iota-types/src/lib.rs
@@ -79,6 +79,7 @@ pub mod passkey_authenticator;
 pub mod programmable_transaction_builder;
 pub mod quorum_driver_types;
 pub mod randomness_state;
+pub mod scoring_metrics;
 pub mod signature;
 pub mod signature_verification;
 pub mod stardust;

--- a/crates/iota-types/src/scoring_metrics.rs
+++ b/crates/iota-types/src/scoring_metrics.rs
@@ -1,0 +1,291 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use iota_protocol_config::ProtocolConfig;
+
+use crate::messages_consensus::{MisbehaviorReportV1, VersionedMisbehaviorReport};
+
+// This struct represents the scoring metrics collected by all authorities. They
+// are stored locally by each authority and then converted to a misbehavior
+// report when they share their metrics with the network. When a report is
+// received, it is also used to update a variable of this type stored in the
+// Scorer. Any metric contained in this struct must be guaranteed to be
+// monotonically increasing, because of the way updates are applied from
+// reports.
+pub enum VersionedScoringMetrics {
+    V1(ScoringMetricsV1),
+}
+
+// Basic getters, setters and increments for the metrics.
+impl VersionedScoringMetrics {
+    pub fn new(committee_size: usize, protocol_config: &ProtocolConfig) -> Self {
+        match protocol_config.scorer_version_as_option() {
+            None | Some(1) => VersionedScoringMetrics::V1(ScoringMetricsV1::new(committee_size)),
+            _ => panic!("Unsupported scorer version"),
+        }
+    }
+
+    pub fn increment_faulty_blocks_provable(&self, authority_index: usize, increment: u64) {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => {
+                metrics.faulty_blocks_provable[authority_index]
+                    .fetch_add(increment, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub fn increment_faulty_blocks_unprovable(&self, authority_index: usize, increment: u64) {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => {
+                metrics.faulty_blocks_unprovable[authority_index]
+                    .fetch_add(increment, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub fn increment_equivocations(&self, authority_index: usize, increment: u64) {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => {
+                metrics.equivocations[authority_index].fetch_add(increment, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub fn increment_missing_proposals(&self, authority_index: usize, increment: u64) {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => {
+                metrics.missing_proposals[authority_index].fetch_add(increment, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub fn store_faulty_blocks_provable(&self, authority_index: usize, value: u64) {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => {
+                metrics.faulty_blocks_provable[authority_index].store(value, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub fn store_faulty_blocks_unprovable(&self, authority_index: usize, value: u64) {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => {
+                metrics.faulty_blocks_unprovable[authority_index].store(value, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub fn store_equivocations(&self, authority_index: usize, value: u64) {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => {
+                metrics.equivocations[authority_index].store(value, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub fn store_missing_proposals(&self, authority_index: usize, value: u64) {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => {
+                metrics.missing_proposals[authority_index].store(value, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub fn load_faulty_blocks_provable(&self) -> Vec<u64> {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => metrics
+                .faulty_blocks_provable
+                .iter()
+                .map(|metric| metric.load(Ordering::Relaxed))
+                .collect(),
+        }
+    }
+
+    pub fn load_faulty_blocks_unprovable(&self) -> Vec<u64> {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => metrics
+                .faulty_blocks_unprovable
+                .iter()
+                .map(|metric| metric.load(Ordering::Relaxed))
+                .collect(),
+        }
+    }
+
+    pub fn load_equivocations(&self) -> Vec<u64> {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => metrics
+                .equivocations
+                .iter()
+                .map(|metric| metric.load(Ordering::Relaxed))
+                .collect(),
+        }
+    }
+
+    pub fn load_missing_proposals(&self) -> Vec<u64> {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => metrics
+                .missing_proposals
+                .iter()
+                .map(|metric| metric.load(Ordering::Relaxed))
+                .collect(),
+        }
+    }
+
+    pub fn faulty_blocks_provable(&self) -> &Vec<AtomicU64> {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => &metrics.faulty_blocks_provable,
+        }
+    }
+
+    pub fn faulty_blocks_unprovable(&self) -> &Vec<AtomicU64> {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => &metrics.faulty_blocks_unprovable,
+        }
+    }
+
+    pub fn equivocations(&self) -> &Vec<AtomicU64> {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => &metrics.equivocations,
+        }
+    }
+
+    pub fn missing_proposals(&self) -> &Vec<AtomicU64> {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => &metrics.missing_proposals,
+        }
+    }
+
+    pub fn reset(&self) {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => {
+                for metric in &metrics.faulty_blocks_provable {
+                    metric.store(0, Ordering::Relaxed);
+                }
+                for metric in &metrics.faulty_blocks_unprovable {
+                    metric.store(0, Ordering::Relaxed);
+                }
+                for metric in &metrics.equivocations {
+                    metric.store(0, Ordering::Relaxed);
+                }
+                for metric in &metrics.missing_proposals {
+                    metric.store(0, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+}
+
+impl VersionedScoringMetrics {
+    // Given a VersionedMisbehaviorReport received from another authority, we use
+    // this method to update the received scoring metrics counts. To avoid
+    // updates to be dependent on the order they are applied, we only effectively
+    // update counts that are increased by the report. This also means that any type
+    // of metric contained in this struct must be guaranteed to be monotonically
+    // increasing. Example: number of faulty blocks detected for a given authority
+    // is monotonically increasing by design; average faulty blocks per minute is
+    // not.
+    pub fn update_from_report(&self, report: &VersionedMisbehaviorReport) {
+        match (self, report) {
+            (VersionedScoringMetrics::V1(metrics), VersionedMisbehaviorReport::V1(report_v1)) => {
+                for (i, value) in report_v1.faulty_blocks_provable.iter().enumerate() {
+                    metrics.faulty_blocks_provable[i].fetch_max(*value, Ordering::Relaxed);
+                }
+                for (i, value) in report_v1.faulty_blocks_unprovable.iter().enumerate() {
+                    metrics.faulty_blocks_unprovable[i].fetch_max(*value, Ordering::Relaxed);
+                }
+                for (i, value) in report_v1.equivocations.iter().enumerate() {
+                    metrics.equivocations[i].fetch_max(*value, Ordering::Relaxed);
+                }
+                for (i, value) in report_v1.missing_proposals.iter().enumerate() {
+                    metrics.missing_proposals[i].fetch_max(*value, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+
+    // Given a VersionedMisbehaviorReport, create a VersionedScoringMetrics struct
+    // with the same values. Used when an authority receives a report from the
+    // network and needs to create a local copy of the metrics contained in it.
+    pub fn from_report(report: &VersionedMisbehaviorReport) -> Self {
+        match report {
+            VersionedMisbehaviorReport::V1(report_v1) => {
+                let committee_size = report_v1.faulty_blocks_provable.len();
+                let metrics = ScoringMetricsV1::new(committee_size);
+                for (i, value) in report_v1.faulty_blocks_provable.iter().enumerate() {
+                    metrics.faulty_blocks_provable[i].store(*value, Ordering::Relaxed);
+                }
+                for (i, value) in report_v1.faulty_blocks_unprovable.iter().enumerate() {
+                    metrics.faulty_blocks_unprovable[i].store(*value, Ordering::Relaxed);
+                }
+                for (i, value) in report_v1.equivocations.iter().enumerate() {
+                    metrics.equivocations[i].store(*value, Ordering::Relaxed);
+                }
+                for (i, value) in report_v1.missing_proposals.iter().enumerate() {
+                    metrics.missing_proposals[i].store(*value, Ordering::Relaxed);
+                }
+                VersionedScoringMetrics::V1(metrics)
+            }
+        }
+    }
+
+    // Given a VersionedScoringMetrics struct, create a VersionedMisbehaviorReport
+    // with the same values. Used when an authority needs to share its local
+    // metrics with the network.
+    pub fn to_report(&self) -> VersionedMisbehaviorReport {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => {
+                let faulty_blocks_provable = metrics
+                    .faulty_blocks_provable
+                    .iter()
+                    .map(|metric| metric.load(Ordering::Relaxed))
+                    .collect();
+                let faulty_blocks_unprovable = metrics
+                    .faulty_blocks_unprovable
+                    .iter()
+                    .map(|metric| metric.load(Ordering::Relaxed))
+                    .collect();
+                let equivocations = metrics
+                    .equivocations
+                    .iter()
+                    .map(|metric| metric.load(Ordering::Relaxed))
+                    .collect();
+                let missing_proposals = metrics
+                    .missing_proposals
+                    .iter()
+                    .map(|metric| metric.load(Ordering::Relaxed))
+                    .collect();
+                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                    faulty_blocks_provable,
+                    faulty_blocks_unprovable,
+                    equivocations,
+                    missing_proposals,
+                })
+            }
+        }
+    }
+}
+
+pub struct ScoringMetricsV1 {
+    faulty_blocks_provable: Vec<AtomicU64>,
+    faulty_blocks_unprovable: Vec<AtomicU64>,
+    equivocations: Vec<AtomicU64>,
+    missing_proposals: Vec<AtomicU64>,
+}
+
+impl ScoringMetricsV1 {
+    pub fn new(committee_size: usize) -> Self {
+        Self {
+            // Blocks considered faulty with provable evidence, i.e., they pass the signature check.
+            faulty_blocks_provable: (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
+            // Blocks considered faulty before passing the signature check.
+            faulty_blocks_unprovable: (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
+            // Number of additional blocks issued by a validator within rounds where another block
+            // was already produced by them.
+            equivocations: (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
+            // Number or rounds that the authority did not propose any block
+            missing_proposals: (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
+        }
+    }
+}

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -494,34 +494,6 @@ impl EndOfEpochTransactionKind {
         })
     }
 
-    pub fn new_change_epoch_v4(
-        next_epoch: EpochId,
-        protocol_version: ProtocolVersion,
-        storage_charge: u64,
-        computation_charge: u64,
-        computation_charge_burned: u64,
-        storage_rebate: u64,
-        non_refundable_storage_fee: u64,
-        epoch_start_timestamp_ms: u64,
-        system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>,
-        eligible_active_validators: Vec<u64>,
-        scores: Vec<u64>,
-    ) -> Self {
-        Self::ChangeEpochV4(ChangeEpochV4 {
-            epoch: next_epoch,
-            protocol_version,
-            storage_charge,
-            computation_charge,
-            computation_charge_burned,
-            storage_rebate,
-            non_refundable_storage_fee,
-            epoch_start_timestamp_ms,
-            system_packages,
-            eligible_active_validators,
-            scores,
-        })
-    }
-
     pub fn new_authenticator_state_expire(
         min_epoch: u64,
         authenticator_obj_initial_shared_version: SequenceNumber,


### PR DESCRIPTION
```mermaid
---
config:
  gitGraph:
    {parallelCommits: true,
    mainBranchName: 'Feature',
    rotateCommitLabel: true}
---
gitGraph
   commit id: "Initial commit"
   commit id: "Old Scorer" tag: "PR8530"
 commit id: "add ChangeEpochV4" tag: "PR9159"
   commit id: "add MisbehaviorReports" tag: "PR9175"
   checkout Feature
    branch scoring-metrics
   commit id: "add ScoringMetrics"
    checkout scoring-metrics
   branch scorer
   commit id: "add Scorer"
    checkout scorer
   branch scoring-metrics-store
   commit id: "add ScoringMetricsStore"
branch report-validation
commit id: "add report validation" 
branch scoring-function
commit id: "add scoring function" 
branch report-creation
commit id: "add report creation" 
branch advance-epoch
commit id: "add advance epoch v4" 
 checkout Feature
    merge scoring-metrics tag: "THIS PR"

```
# Description of changes

This PR adds a new `VersionedScoringMetrics` type. `ScoringMetricsV1` is currently an atomic version of `MisbehaviorReportV1`, even though this is expected to change in their future versions. `VersionedScoringMetrics ` should be used to store misbehavior metrics about the rest of the committee and collected in the node, but also to store the information received in the misbehavior reports received from other authorities.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Introduces the VersionedScoringMetrics type, used to store misbehavior metrics about all authorities
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
