### PR TITLE
feat(iota-core): Introduce Scorer

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -137,10 +137,14 @@ pub(crate) type EncG = bls12381::G2Element;
 #[path = "consensus_quarantine.rs"]
 pub(crate) mod consensus_quarantine;
 
+#[path = "scorer.rs"]
+pub(crate) mod scorer;
+
 use consensus_quarantine::{
     ConsensusCommitOutput, ConsensusOutputCache, ConsensusOutputQuarantine,
 };
 use iota_types::crypto::AuthorityPublicKey;
+use scorer::Scorer;
 
 // CertLockGuard and CertTxGuard are functionally identical right now, but we
 // retain a distinction anyway. If we need to support distributed object
@@ -503,6 +507,10 @@ pub struct AuthorityPerEpochStore {
     /// State machine managing randomness DKG and generation.
     randomness_manager: OnceCell<tokio::sync::Mutex<RandomnessManager>>,
     randomness_reporter: OnceCell<RandomnessReporter>,
+
+    /// Component including the local view about the other authorities'
+    /// misbehaviour metrics, and received reports.
+    pub(crate) scorer: Arc<Scorer>,
 }
 
 /// AuthorityEpochTables contains tables that contain data that is only valid
@@ -969,10 +977,12 @@ impl AuthorityPerEpochStore {
         let consensus_output_cache =
             ConsensusOutputCache::new(&epoch_start_configuration, &tables, metrics.clone());
 
+        let voting_power = committee.members().map(|(_, v)| *v).collect::<Vec<u64>>();
+
         let s = Arc::new(Self {
             name,
             committee,
-            protocol_config,
+            protocol_config: protocol_config.clone(),
             tables: ArcSwapOption::new(Some(Arc::new(tables))),
             consensus_output_cache,
             consensus_quarantine: RwLock::new(ConsensusOutputQuarantine::new(
@@ -1004,6 +1014,7 @@ impl AuthorityPerEpochStore {
             jwk_aggregator,
             randomness_manager: OnceCell::new(),
             randomness_reporter: OnceCell::new(),
+            scorer: Arc::new(Scorer::new(voting_power, &protocol_config)),
         });
 
         s.update_buffer_stake_metric();
@@ -2681,8 +2692,8 @@ impl AuthorityPerEpochStore {
                         "MisbehaviorReport authority {} does not match its author from consensus {}",
                         authority, transaction.certificate_author_index
                     );
-                    // Here we should update invalid report counts for the
-                    // authority
+                    self.scorer
+                        .update_invalid_reports_count(transaction.certificate_author_index);
                 }
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -17,10 +17,10 @@ const MAX_SCORE: u64 = u64::MAX;
 #[expect(dead_code)]
 pub struct Scorer {
     pub(crate) current_local_metrics_count: Arc<VersionedScoringMetrics>,
-    received_metrics: Vec<Arc<VersionedScoringMetrics>>,
-    metrics_missing_from: Vec<Arc<AtomicBool>>,
+    received_metrics: Vec<VersionedScoringMetrics>,
+    metrics_missing_from: Vec<AtomicBool>,
     pub(crate) current_scores: Scores,
-    invalid_reports_count: Vec<Arc<AtomicU64>>,
+    invalid_reports_count: Vec<AtomicU64>,
     voting_power: Vec<u64>,
     version: ScorerVersion,
 }
@@ -39,13 +39,10 @@ impl Scorer {
                     (0..committee_size)
                         .map(|_| {
                             (
-                                Arc::new(VersionedScoringMetrics::new(
-                                    committee_size,
-                                    protocol_config,
-                                )),
-                                Arc::new(AtomicBool::new(true)),
+                                VersionedScoringMetrics::new(committee_size, protocol_config),
+                                AtomicBool::new(true),
                                 AtomicU64::new(0),
-                                Arc::new(AtomicU64::new(0)),
+                                AtomicU64::new(0),
                             )
                         })
                         .collect();

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -1,0 +1,169 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
+
+use iota_protocol_config::ProtocolConfig;
+use iota_types::{
+    messages_consensus::VersionedMisbehaviorReport, scoring_metrics::VersionedScoringMetrics,
+};
+
+#[allow(unused)]
+const MAX_SCORE: u64 = u64::MAX;
+
+#[expect(dead_code)]
+pub struct Scorer {
+    pub(crate) current_local_metrics_count: Arc<VersionedScoringMetrics>,
+    received_metrics: Vec<Arc<VersionedScoringMetrics>>,
+    metrics_missing_from: Vec<Arc<AtomicBool>>,
+    pub(crate) current_scores: Scores,
+    invalid_reports_count: Vec<Arc<AtomicU64>>,
+    voting_power: Vec<u64>,
+    version: ScorerVersion,
+}
+
+impl Scorer {
+    pub fn new(voting_power: Vec<u64>, protocol_config: &ProtocolConfig) -> Self {
+        let committee_size = voting_power.len();
+        match protocol_config.scorer_version_as_option() {
+            None | Some(1) => {
+                let current_local_metrics_count = Arc::new(VersionedScoringMetrics::new(
+                    committee_size,
+                    protocol_config,
+                ));
+
+                let (received_metrics, metrics_missing_from, current_scores, invalid_reports_count) =
+                    (0..committee_size)
+                        .map(|_| {
+                            (
+                                Arc::new(VersionedScoringMetrics::new(
+                                    committee_size,
+                                    protocol_config,
+                                )),
+                                Arc::new(AtomicBool::new(true)),
+                                AtomicU64::new(0),
+                                Arc::new(AtomicU64::new(0)),
+                            )
+                        })
+                        .collect();
+
+                Self {
+                    current_local_metrics_count,
+                    received_metrics,
+                    metrics_missing_from,
+                    current_scores,
+                    invalid_reports_count,
+                    voting_power,
+                    version: ScorerVersion::V1,
+                }
+            }
+            _ => panic!("Unsupported scorer version"),
+        }
+    }
+
+    pub(crate) fn update_invalid_reports_count(&self, authority: u32) {
+        self.invalid_reports_count[authority as usize].fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn update_scores(&self) {
+        match self.version {
+            ScorerVersion::V1 => self.update_scores_v1(),
+        };
+    }
+
+    #[expect(dead_code)]
+    pub(crate) fn update_received_reports_and_score(
+        &self,
+        authority: u32,
+        report: &VersionedMisbehaviorReport,
+    ) {
+        self.received_metrics[authority as usize].update_from_report(report);
+        self.metrics_missing_from[authority as usize].store(false, Ordering::Relaxed);
+        self.update_scores();
+    }
+
+    fn update_scores_v1(&self) {
+        // Placeholder
+    }
+}
+
+pub(crate) enum ScorerVersion {
+    V1,
+}
+
+pub(crate) type Scores = Vec<Score>;
+pub(crate) type Score = AtomicU64;
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+
+    use iota_protocol_config::{ConsensusChoice, ProtocolConfig};
+
+    use super::*;
+
+    fn mock_protocol_config(consensus_choice: ConsensusChoice) -> ProtocolConfig {
+        let mut config = ProtocolConfig::get_for_max_version_UNSAFE();
+        config.set_consensus_choice_for_testing(consensus_choice);
+        config
+    }
+
+    #[test]
+    fn test_scorer_initialization() {
+        let voting_power = vec![10, 20, 30];
+        let committee_size = voting_power.len();
+        let protocol_config = mock_protocol_config(ConsensusChoice::Mysticeti);
+
+        let scorer = Scorer::new(voting_power, &protocol_config);
+
+        assert_eq!(scorer.current_scores.len(), committee_size);
+        assert_eq!(scorer.invalid_reports_count.len(), committee_size);
+
+        // Add more
+    }
+
+    #[test]
+    fn test_update_invalid_reports_count() {
+        let voting_power = vec![10, 20, 30];
+
+        let protocol_config = mock_protocol_config(ConsensusChoice::Mysticeti);
+
+        let scorer = Scorer::new(voting_power, &protocol_config);
+
+        let authority_index = 2;
+
+        // Before update
+        assert_eq!(
+            scorer.invalid_reports_count[authority_index as usize].load(Ordering::Relaxed),
+            0
+        );
+
+        // Call the method
+        scorer.update_invalid_reports_count(authority_index);
+
+        // After update
+        assert_eq!(
+            scorer.invalid_reports_count[authority_index as usize].load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[test]
+    fn test_update_scores() {
+        let voting_power = vec![10, 20, 30];
+
+        let protocol_config = mock_protocol_config(ConsensusChoice::Mysticeti);
+
+        let scorer = Scorer::new(voting_power, &protocol_config);
+
+        // Before calling update_scores, all scores should be 0
+        for score in scorer.current_scores.iter() {
+            assert_eq!(score.load(Ordering::Relaxed), 0);
+        }
+
+        // Add logic
+    }
+}

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -494,34 +494,6 @@ impl EndOfEpochTransactionKind {
         })
     }
 
-    pub fn new_change_epoch_v4(
-        next_epoch: EpochId,
-        protocol_version: ProtocolVersion,
-        storage_charge: u64,
-        computation_charge: u64,
-        computation_charge_burned: u64,
-        storage_rebate: u64,
-        non_refundable_storage_fee: u64,
-        epoch_start_timestamp_ms: u64,
-        system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>,
-        eligible_active_validators: Vec<u64>,
-        scores: Vec<u64>,
-    ) -> Self {
-        Self::ChangeEpochV4(ChangeEpochV4 {
-            epoch: next_epoch,
-            protocol_version,
-            storage_charge,
-            computation_charge,
-            computation_charge_burned,
-            storage_rebate,
-            non_refundable_storage_fee,
-            epoch_start_timestamp_ms,
-            system_packages,
-            eligible_active_validators,
-            scores,
-        })
-    }
-
     pub fn new_authenticator_state_expire(
         min_epoch: u64,
         authenticator_obj_initial_shared_version: SequenceNumber,

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -494,6 +494,34 @@ impl EndOfEpochTransactionKind {
         })
     }
 
+    pub fn new_change_epoch_v4(
+        next_epoch: EpochId,
+        protocol_version: ProtocolVersion,
+        storage_charge: u64,
+        computation_charge: u64,
+        computation_charge_burned: u64,
+        storage_rebate: u64,
+        non_refundable_storage_fee: u64,
+        epoch_start_timestamp_ms: u64,
+        system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>,
+        eligible_active_validators: Vec<u64>,
+        scores: Vec<u64>,
+    ) -> Self {
+        Self::ChangeEpochV4(ChangeEpochV4 {
+            epoch: next_epoch,
+            protocol_version,
+            storage_charge,
+            computation_charge,
+            computation_charge_burned,
+            storage_rebate,
+            non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            system_packages,
+            eligible_active_validators,
+            scores,
+        })
+    }
+
     pub fn new_authenticator_state_expire(
         min_epoch: u64,
         authenticator_obj_initial_shared_version: SequenceNumber,


### PR DESCRIPTION
```mermaid
---
config:
  gitGraph:
    {parallelCommits: true,
    mainBranchName: 'Feature',
    rotateCommitLabel: true}
---
gitGraph
   commit id: "Initial commit"
   commit id: "Old Scorer" tag: "PR8530"
 commit id: "add ChangeEpochV4" tag: "PR9159"
    commit id: "add MisbehaviorReports" tag: "PR9175"
   commit id: "add ScoringMetrics" tag: "PR9176"
  checkout Feature
   branch scorer
   commit id: "add Scorer"
    checkout scorer
   branch scoring-metrics-store
   commit id: "add ScoringMetricsStore"
branch report-validation
commit id: "add report validation" 
branch scoring-function
commit id: "add scoring function" 
branch report-creation
commit id: "add report creation" 
branch advance-epoch
commit id: "add advance epoch v4" 
 checkout Feature
    merge scorer tag: "THIS PR"
```

# Description of changes

Introduces the new Scorer struct.
TO DO: add alias to ScoringMetrics


## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Introduce Scorer component, which holds all info about metrics, reports and scores.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
