### PR TITLE
feat(consensus): Introduce Scoring metric store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,6 +2695,7 @@ dependencies = [
  "arc-swap",
  "consensus-config",
  "consensus-core",
+ "iota-common",
  "iota-config",
  "iota-macros",
  "iota-metrics",

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -5,6 +5,7 @@
 use std::{sync::Arc, time::Instant};
 
 use consensus_config::{AuthorityIndex, Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
+use iota_common::scoring_metrics::VersionedScoringMetrics;
 use iota_protocol_config::{ConsensusNetwork, ProtocolConfig};
 use itertools::Itertools;
 use parking_lot::RwLock;
@@ -29,7 +30,7 @@ use crate::{
     metrics::initialise_metrics,
     network::{NetworkClient as _, NetworkManager, tonic_network::TonicManager},
     round_prober::{RoundProber, RoundProberHandle},
-    scorer::Scorer,
+    scoring_metrics_store::MysticetiScoringMetricsStore,
     storage::rocksdb_store::RocksDBStore,
     subscriber::Subscriber,
     synchronizer::{Synchronizer, SynchronizerHandle},
@@ -59,6 +60,7 @@ impl ConsensusAuthority {
         transaction_verifier: Arc<dyn TransactionVerifier>,
         commit_consumer: CommitConsumer,
         registry: Registry,
+        current_local_metrics_count: Arc<VersionedScoringMetrics>,
         // A counter that keeps track of how many times the authority node has been booted while
         // the binary or the component that is calling the `ConsensusAuthority` has been
         // running. It's mostly useful to make decisions on whether amnesia recovery should
@@ -80,6 +82,7 @@ impl ConsensusAuthority {
                     transaction_verifier,
                     commit_consumer,
                     registry,
+                    current_local_metrics_count,
                     boot_counter,
                 )
                 .await;
@@ -165,6 +168,7 @@ where
         transaction_verifier: Arc<dyn TransactionVerifier>,
         commit_consumer: CommitConsumer,
         registry: Registry,
+        current_local_metrics_count: Arc<VersionedScoringMetrics>,
         boot_counter: u64,
     ) -> Self {
         assert!(
@@ -185,7 +189,13 @@ where
         );
         info!("Consensus parameters: {:?}", parameters);
         info!("Consensus committee: {:?}", committee);
-        let scorer = Arc::new(Scorer::new(committee.size()));
+
+        let scoring_metrics_store = Arc::new(MysticetiScoringMetricsStore::new(
+            committee.size(),
+            current_local_metrics_count,
+            &protocol_config,
+        ));
+
         let context = Arc::new(Context::new(
             epoch_start_timestamp_ms,
             own_index,
@@ -193,7 +203,7 @@ where
             parameters,
             protocol_config,
             initialise_metrics(registry),
-            scorer,
+            scoring_metrics_store,
             clock,
         ));
         let start_time = Instant::now();
@@ -467,6 +477,11 @@ mod tests {
 
         let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_consumer = CommitConsumer::new(sender, 0);
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+        let current_local_metrics_count = Arc::new(VersionedScoringMetrics::new(
+            committee.size(),
+            &protocol_config,
+        ));
 
         let authority = ConsensusAuthority::start(
             network_type,
@@ -474,13 +489,14 @@ mod tests {
             own_index,
             committee,
             parameters,
-            ProtocolConfig::get_for_max_version_UNSAFE(),
+            protocol_config,
             protocol_keypair,
             network_keypair,
             Arc::new(Clock::default()),
             Arc::new(txn_verifier),
             commit_consumer,
             registry,
+            current_local_metrics_count,
             0,
         )
         .await;
@@ -867,6 +883,10 @@ mod tests {
 
         let (sender, receiver) = unbounded_channel("consensus_output");
         let commit_consumer = CommitConsumer::new(sender, 0);
+        let current_local_metrics_count = Arc::new(VersionedScoringMetrics::new(
+            committee.size(),
+            &protocol_config,
+        ));
 
         let authority = ConsensusAuthority::start(
             network_type,
@@ -881,6 +901,7 @@ mod tests {
             Arc::new(txn_verifier),
             commit_consumer,
             registry,
+            current_local_metrics_count,
             boot_counter,
         )
         .await;

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -512,7 +512,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             .clone();
                         inner
                             .context
-                            .scorer
+                            .scoring_metrics_store
                             .update_scoring_metrics_on_block_receival(
                                 authority,
                                 hostname.as_str(),

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -14,7 +14,9 @@ use tokio::time::Instant;
 
 #[cfg(test)]
 use crate::metrics::test_metrics;
-use crate::{block::BlockTimestampMs, metrics::Metrics, scorer::Scorer};
+use crate::{
+    block::BlockTimestampMs, metrics::Metrics, scoring_metrics_store::MysticetiScoringMetricsStore,
+};
 /// Context contains per-epoch configuration and metrics shared by all
 /// components of this authority.
 #[derive(Clone)]
@@ -31,7 +33,8 @@ pub(crate) struct Context {
     pub protocol_config: ProtocolConfig,
     /// Metrics of this authority.
     pub metrics: Arc<Metrics>,
-    pub(crate) scorer: Arc<Scorer>,
+    /// Store for scoring metrics collected by this authority.
+    pub(crate) scoring_metrics_store: Arc<MysticetiScoringMetricsStore>,
     /// Access to local clock
     pub clock: Arc<Clock>,
 }
@@ -44,7 +47,8 @@ impl Context {
         parameters: Parameters,
         protocol_config: ProtocolConfig,
         metrics: Arc<Metrics>,
-        scorer: Arc<Scorer>,
+        scoring_metrics_store: Arc<MysticetiScoringMetricsStore>,
+
         clock: Arc<Clock>,
     ) -> Self {
         Self {
@@ -54,7 +58,7 @@ impl Context {
             parameters,
             protocol_config,
             metrics,
-            scorer,
+            scoring_metrics_store,
             clock,
         }
     }
@@ -64,13 +68,21 @@ impl Context {
     pub(crate) fn new_for_test(
         committee_size: usize,
     ) -> (Self, Vec<(NetworkKeyPair, ProtocolKeyPair)>) {
+        use iota_common::scoring_metrics::{ScoringMetricsV1, VersionedScoringMetrics};
+
         let (committee, keypairs) =
             consensus_config::local_committee_and_keys(0, vec![1; committee_size]);
         let metrics = test_metrics();
         let temp_dir = TempDir::new().unwrap();
         let clock = Arc::new(Clock::default());
-        let scorer = Arc::new(Scorer::new_dummy_for_tests(committee_size));
-
+        let current_local_metrics_count = Arc::new(VersionedScoringMetrics::V1(
+            ScoringMetricsV1::new(committee_size),
+        ));
+        let scoring_metrics_store = Arc::new(MysticetiScoringMetricsStore::new(
+            committee_size,
+            current_local_metrics_count,
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
+        ));
         let context = Context::new(
             0,
             AuthorityIndex::new_for_test(0),
@@ -81,7 +93,7 @@ impl Context {
             },
             ProtocolConfig::get_for_max_version_UNSAFE(),
             metrics,
-            scorer,
+            scoring_metrics_store,
             clock,
         );
         (context, keypairs)

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -249,13 +249,16 @@ impl DagState {
         // Initialize scoring metrics according to the metrics in store and the blocks
         // that were loaded to cache.
         let recovered_scoring_metrics = state.store.scan_scoring_metrics().expect("Database error");
-        state.context.scorer.initialize_scoring_metrics(
-            recovered_scoring_metrics,
-            &state.recent_refs_by_authority,
-            state.threshold_clock_round(),
-            &state.evicted_rounds,
-            state.context.clone(),
-        );
+        state
+            .context
+            .scoring_metrics_store
+            .initialize_scoring_metrics(
+                recovered_scoring_metrics,
+                &state.recent_refs_by_authority,
+                state.threshold_clock_round(),
+                &state.evicted_rounds,
+                state.context.clone(),
+            );
 
         if state.gc_enabled() {
             if let Some(last_commit) = last_commit {
@@ -1057,15 +1060,18 @@ impl DagState {
         for (authority_index, authority) in self.context.committee.authorities() {
             let last_eviction_round = self.evicted_rounds[authority_index];
             let current_eviction_round = self.calculate_authority_eviction_round(authority_index);
-            let metrics_to_write_from_authority = self.context.scorer.update_score(
-                authority_index,
-                authority.hostname.as_str(),
-                &self.recent_refs_by_authority[authority_index],
-                current_eviction_round,
-                last_eviction_round,
-                threshold_clock_round,
-                &self.context.metrics.node_metrics,
-            );
+            let metrics_to_write_from_authority = self
+                .context
+                .scoring_metrics_store
+                .update_scoring_metrics_on_eviction(
+                    authority_index,
+                    authority.hostname.as_str(),
+                    &self.recent_refs_by_authority[authority_index],
+                    current_eviction_round,
+                    last_eviction_round,
+                    threshold_clock_round,
+                    &self.context.metrics.node_metrics,
+                );
             if let Some(metrics_to_write_from_authority) = metrics_to_write_from_authority {
                 metrics_to_write.push((authority_index, metrics_to_write_from_authority));
             }

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -30,7 +30,6 @@ mod network;
 #[cfg(msim)]
 pub mod network;
 
-mod scorer;
 mod stake_aggregator;
 mod storage;
 mod subscriber;
@@ -54,6 +53,8 @@ mod test_dag;
 mod test_dag_builder;
 #[cfg(test)]
 mod test_dag_parser;
+
+pub mod scoring_metrics_store;
 
 /// Exported consensus API.
 pub use authority_node::ConsensusAuthority;

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -81,6 +81,7 @@ pub(crate) struct Metrics {
     pub(crate) node_metrics: NodeMetrics,
     pub(crate) network_metrics: NetworkMetrics,
 }
+
 pub(crate) struct NodeMetrics {
     pub(crate) block_commit_latency: Histogram,
     pub(crate) proposed_blocks: IntCounterVec,
@@ -131,7 +132,10 @@ pub(crate) struct NodeMetrics {
     pub(crate) uncached_missing_proposals_by_authority: IntCounterVec,
     pub(crate) equivocations_in_cache_by_authority: IntGaugeVec,
     pub(crate) missing_proposals_in_cache_by_authority: IntGaugeVec,
+    #[allow(dead_code)]
     pub(crate) score_by_authority: IntGaugeVec,
+    #[allow(dead_code)]
+    pub(crate) invalid_misbehavior_reports_by_authority: IntCounterVec,
     pub(crate) rejected_blocks: IntCounterVec,
     pub(crate) rejected_future_blocks: IntCounterVec,
     pub(crate) subscribed_blocks: IntCounterVec,
@@ -504,6 +508,12 @@ impl NodeMetrics {
             score_by_authority: register_int_gauge_vec_with_registry!(
                 "score_by_authority",
                 "Registers the authority score.",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            invalid_misbehavior_reports_by_authority: register_int_counter_vec_with_registry!(
+                "invalid_misbehavior_reports_by_authority",
+                "Number of invalid misbehavior reports received from each authority",
                 &["authority"],
                 registry,
             ).unwrap(),

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -675,8 +675,8 @@ mod tests {
         metrics
     }
 
-    #[test]
-    fn test_update_scoring_metrics_on_eviction_edge_cases() {
+    #[tokio::test]
+    async fn test_update_scoring_metrics_on_eviction_edge_cases() {
         let context = Context::new_for_test(4);
         let scoring_metrics_store = context.0.scoring_metrics_store;
         let authority_index = AuthorityIndex::new_for_test(0);

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -3,176 +3,50 @@
 
 use std::{
     collections::BTreeSet,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::{Arc, atomic::Ordering},
 };
 
 use consensus_config::AuthorityIndex;
+use iota_common::scoring_metrics::{ScoringMetricsV1, VersionedScoringMetrics};
+use iota_protocol_config::ProtocolConfig;
 use itertools::izip;
 
 use crate::{
     BlockRef, context::Context, error::ConsensusError, metrics::NodeMetrics,
     storage::StorageScoringMetrics,
 };
-
-/// The Scorer holds the scoring metrics for all authorities in the committee,
-/// which is updated according to the blocks received
-/// and the evictions that happen in storage. It also holds the partial scores
-/// for each authority, which are then added to EndOfPublishV2 and used to
-/// calculate a final score.
-pub struct Scorer {
-    scoring_metrics: ValidatorScoringMetrics,
-    partial_scores: PartialScores,
+/// Struct that holds the scoring metrics for all authorities in the committee,
+/// both cached and uncached. It also holds a shared reference to the current
+/// local metrics count used by Scorer.
+pub(crate) struct MysticetiScoringMetricsStore {
+    pub current_local_metrics_count: Arc<VersionedScoringMetrics>,
+    pub cached_metrics: Arc<VersionedScoringMetrics>,
+    pub uncached_metrics: Arc<VersionedScoringMetrics>,
 }
 
-impl Scorer {
-    pub fn new(committee_size: usize) -> Self {
-        Self {
-            scoring_metrics: ValidatorScoringMetrics::new(committee_size),
-            partial_scores: PartialScores::new(committee_size),
+impl MysticetiScoringMetricsStore {
+    pub(crate) fn new(
+        committee_size: usize,
+        current_local_metrics_count: Arc<VersionedScoringMetrics>,
+        protocol_config: &ProtocolConfig,
+    ) -> Self {
+        match protocol_config.scorer_version_as_option() {
+            None | Some(1) => Self {
+                current_local_metrics_count,
+                cached_metrics: Arc::new(VersionedScoringMetrics::V1(ScoringMetricsV1::new(
+                    committee_size,
+                ))),
+
+                uncached_metrics: Arc::new(VersionedScoringMetrics::V1(ScoringMetricsV1::new(
+                    committee_size,
+                ))),
+            },
+            _ => panic!("Unsupported scorer version"),
         }
     }
 
-    #[allow(dead_code)]
-    pub fn get_provable_partial_scores(&self) -> &Vec<PartialScore> {
-        &self.partial_scores.provable
-    }
-
-    #[allow(dead_code)]
-    pub fn get_unprovable_partial_scores(&self) -> &Vec<PartialScore> {
-        &self.partial_scores.unprovable
-    }
-
-    pub(crate) fn update_score(
-        &self,
-        authority_index: AuthorityIndex,
-        hostname: &str,
-        recent_refs: &BTreeSet<BlockRef>,
-        eviction_round: u32,
-        last_eviction_round: u32,
-        threshold_clock_round: u32,
-        node_metrics: &NodeMetrics,
-    ) -> Option<StorageScoringMetrics> {
-        // threshold_clock_round should be always at least 1.
-        // Analogously, authority_index should be a valid index.
-        if threshold_clock_round == 0
-            || authority_index.value() >= self.scoring_metrics.cached.len()
-        {
-            return None;
-        }
-
-        // Get the blocks rounds that were not evicted.
-        let cached_block_rounds = recent_refs
-            .iter()
-            .map(|block| block.round)
-            .filter(|&round| round > eviction_round && round < threshold_clock_round)
-            .collect::<Vec<u32>>();
-
-        // Update metrics according to the blocks from rounds still in cache.
-        let (cached_equivocations, missing_blocks_in_cached_rounds) =
-            calculate_scoring_metrics_for_range(
-                cached_block_rounds,
-                eviction_round + 1,
-                threshold_clock_round.saturating_sub(1),
-            );
-
-        self.scoring_metrics
-            .update_missing_blocks_and_equivocations(
-                missing_blocks_in_cached_rounds,
-                cached_equivocations,
-                hostname,
-                authority_index,
-                MetricType::Cached,
-                node_metrics,
-            );
-
-        // If no eviction happened, we do not update the metrics on storage.
-        if eviction_round == last_eviction_round {
-            return None;
-        }
-
-        // Get the evicted blocks rounds.
-        let evicted_block_rounds = recent_refs
-            .iter()
-            .map(|block| block.round)
-            .filter(|&round| round <= eviction_round)
-            .collect::<Vec<u32>>();
-
-        // Update metrics according to the blocks from evicted rounds.
-        let (evicted_equivocations, missing_blocks_in_evicted_rounds) =
-            calculate_scoring_metrics_for_range(
-                evicted_block_rounds,
-                last_eviction_round + 1,
-                eviction_round,
-            );
-
-        self.scoring_metrics
-            .update_missing_blocks_and_equivocations(
-                missing_blocks_in_evicted_rounds,
-                evicted_equivocations,
-                hostname,
-                authority_index,
-                MetricType::Uncached,
-                node_metrics,
-            );
-
-        // Update score
-        self.update_authority_score(authority_index, hostname, node_metrics);
-
-        Some(StorageScoringMetrics {
-            faulty_blocks_provable: self.scoring_metrics.uncached[authority_index]
-                .faulty_blocks_provable
-                .load(Ordering::Relaxed),
-            faulty_blocks_unprovable: self.scoring_metrics.uncached[authority_index]
-                .faulty_blocks_unprovable
-                .load(Ordering::Relaxed),
-            equivocations: self.scoring_metrics.uncached[authority_index]
-                .equivocations
-                .load(Ordering::Relaxed),
-            missing_proposals: self.scoring_metrics.uncached[authority_index]
-                .missing_proposals
-                .load(Ordering::Relaxed),
-        })
-    }
-
-    pub(crate) fn update_scoring_metrics_on_block_receival(
-        &self,
-        authority_index: AuthorityIndex,
-        hostname: &str,
-        error: ConsensusError,
-        source: &str,
-        node_metrics: &NodeMetrics,
-    ) {
-        // authority_index will be always a valid index. However, this method will
-        // panic if authority_index >= committee_size. We run this check only to avoid
-        // this panic.
-        if authority_index.value() >= self.scoring_metrics.cached.len() {
-            return;
-        }
-
-        if should_update_provable_metrics(&error, source) {
-            self.scoring_metrics.uncached[authority_index]
-                .faulty_blocks_provable
-                .fetch_add(1, Ordering::Relaxed);
-            node_metrics
-                .faulty_blocks_provable_by_authority
-                .with_label_values(&[hostname, source, error.name()])
-                .inc();
-        } else if should_update_unprovable_metrics(&error, source) {
-            self.scoring_metrics.uncached[authority_index]
-                .faulty_blocks_unprovable
-                .fetch_add(1, Ordering::Relaxed);
-            node_metrics
-                .faulty_blocks_unprovable_by_authority
-                .with_label_values(&[hostname, source, error.name()])
-                .inc();
-        } else {
-            // No scoring metrics to update.
-        }
-    }
-
+    // Initializes the scoring metrics store according to the
+    // recovered_scoring_metrics and blocks_in_cache_by_authority.
     pub(crate) fn initialize_scoring_metrics(
         &self,
         mut recovered_scoring_metrics: Vec<(AuthorityIndex, StorageScoringMetrics)>,
@@ -191,7 +65,6 @@ impl Scorer {
         // component for every authority. A perfectly functioning validator, for
         // example, will never have its metrics updated, so no metric will ever be
         // stored. For this reason, we manually "fill" this vector.
-
         if recovered_scoring_metrics.len() < context.committee.size() {
             for i in 0..context.committee.size() {
                 if !recovered_scoring_metrics
@@ -200,9 +73,9 @@ impl Scorer {
                 {
                     // We add a component with zeroed metrics for the authority with index i.
                     // This will ensure that every authority has its metrics initialized.
-                    // Note that this is correct, as if an authority does not have any
-                    // recovered metrics, it means that it never misbehaved in a way that
-                    // was detected by the node.
+                    // They are initialized as zero because if an authority does not have any
+                    // recovered metrics, it means that it never misbehaved in a way that was
+                    // detected by the node.
                     recovered_scoring_metrics.insert(
                         i,
                         (
@@ -232,22 +105,21 @@ impl Scorer {
                 equivocations,
                 missing_proposals,
             } = metrics;
-            self.scoring_metrics.initialize_faulty_blocks_metrics(
+            self.initialize_faulty_blocks_metrics(
                 faulty_blocks_provable,
                 faulty_blocks_unprovable,
                 hostname,
                 authority_index,
                 &context.metrics.node_metrics,
             );
-            self.scoring_metrics
-                .update_missing_blocks_and_equivocations(
-                    missing_proposals,
-                    equivocations,
-                    hostname,
-                    authority_index,
-                    MetricType::Uncached,
-                    &context.metrics.node_metrics,
-                );
+            self.update_missing_blocks_and_equivocations(
+                missing_proposals,
+                equivocations,
+                hostname,
+                authority_index,
+                MetricType::Uncached,
+                &context.metrics.node_metrics,
+            );
 
             // Initialize the cached scoring metrics according to blocks_in_cache.
             let block_rounds_in_cache = blocks_in_cache
@@ -260,138 +132,50 @@ impl Scorer {
                     eviction_round + 1,
                     threshold_clock_round - 1,
                 );
-            self.scoring_metrics
-                .update_missing_blocks_and_equivocations(
-                    missing_blocks_in_cached_rounds,
-                    cached_equivocations,
-                    hostname,
-                    authority_index,
-                    MetricType::Cached,
-                    &context.metrics.node_metrics,
-                );
-            // Initialize score
-            self.update_authority_score(authority_index, hostname, &context.metrics.node_metrics);
+            self.update_missing_blocks_and_equivocations(
+                missing_blocks_in_cached_rounds,
+                cached_equivocations,
+                hostname,
+                authority_index,
+                MetricType::Cached,
+                &context.metrics.node_metrics,
+            );
         }
     }
 
-    // Auxiliary function used to update scores. The `authority` parameter should be
-    // a valid index, otherwise the function will panic. This check is not
-    // performed here, as it is assumed that the caller has already checked it.
-    fn update_authority_score(
+    // Updates the scoring metrics according to the received block's
+    // authority and error encountered during its processing.
+    pub(crate) fn update_scoring_metrics_on_block_receival(
         &self,
-        authority: AuthorityIndex,
+        authority_index: AuthorityIndex,
         hostname: &str,
+        error: ConsensusError,
+        source: &str,
         node_metrics: &NodeMetrics,
     ) {
-        let (faulty_blocks_provable, faulty_blocks_unprovable, equivocations, missing_proposals) = (
-            self.scoring_metrics.uncached[authority]
-                .faulty_blocks_provable
-                .load(Ordering::Relaxed),
-            self.scoring_metrics.uncached[authority]
-                .faulty_blocks_unprovable
-                .load(Ordering::Relaxed),
-            self.scoring_metrics.uncached[authority]
-                .equivocations
-                .load(Ordering::Relaxed),
-            self.scoring_metrics.uncached[authority]
-                .missing_proposals
-                .load(Ordering::Relaxed),
-        );
+        // authority_index will be always a valid index. However, this method will
+        // panic if authority_index >= committee_size. We run this check only to avoid
+        // this panic.
+        if authority_index.value() >= self.cached_metrics.faulty_blocks_provable().len() {
+            return;
+        }
 
-        // We provisionally use the formula below to calculate the score, but changes
-        // to this function are already expected. The hardcoded parameters (which are
-        // also still provisional) represent:
-        // - No tolerance to any provably faulty misbehavior. If any is detected, the
-        //   score will be 0.
-        // - If no provably faulty blocks are detected, 50% of the score is guaranteed.
-        // - If no unprovably faulty blocks are detected, an additional 12.5% of the
-        //   score is guaranteed.
-        // - If no missing proposals are detected, an additional 37.5% of the score is
-        //   guaranteed.
-        // - The maximum achievable score is u32::MAX.
-
-        if faulty_blocks_provable > 0 || equivocations > 0 {
-            self.partial_scores.unprovable[authority].store(0, Ordering::Relaxed);
+        if should_update_provable_metrics(&error, source) {
+            self.uncached_metrics
+                .increment_faulty_blocks_provable(authority_index.value(), 1);
             node_metrics
-                .score_by_authority
-                .with_label_values(&[hostname])
-                .set(0i64);
+                .faulty_blocks_provable_by_authority
+                .with_label_values(&[hostname, source, error.name()])
+                .inc();
+        } else if should_update_unprovable_metrics(&error, source) {
+            self.uncached_metrics
+                .increment_faulty_blocks_unprovable(authority_index.value(), 1);
+            node_metrics
+                .faulty_blocks_unprovable_by_authority
+                .with_label_values(&[hostname, source, error.name()])
+                .inc();
         } else {
-            let score = (2 << 31) - 1
-                + (3 * (2 << 29) / (missing_proposals.saturating_add(1))
-                    + (2 << 29) / (faulty_blocks_unprovable.saturating_add(1)));
-            self.partial_scores.unprovable[authority].store(score, Ordering::Relaxed);
-            node_metrics
-                .score_by_authority
-                .with_label_values(&[hostname])
-                .set(score as i64);
-        }
-    }
-}
-
-pub(crate) struct ValidatorScoringMetrics {
-    pub(crate) uncached: Vec<UncachedScoringMetrics>,
-    pub(crate) cached: Vec<CachedScoringMetrics>,
-}
-
-impl ValidatorScoringMetrics {
-    pub(crate) fn new(committee_size: usize) -> Self {
-        let uncached = (0..committee_size)
-            .map(|_| UncachedScoringMetrics::new())
-            .collect();
-        let cached = (0..committee_size)
-            .map(|_| CachedScoringMetrics::new())
-            .collect();
-        Self { uncached, cached }
-    }
-
-    // Auxiliary function to update scoring metrics relative to missing blocks
-    // and equivocations. The `authority` parameter should be a valid index,
-    // otherwise the function will panic. This check is not performed here, as
-    // it is assumed that the caller has already checked it.
-    fn update_missing_blocks_and_equivocations(
-        &self,
-        missing_blocks: u64,
-        equivocations: u64,
-        hostname: &str,
-        authority: AuthorityIndex,
-        metric_type: MetricType,
-        node_metrics: &NodeMetrics,
-    ) {
-        match metric_type {
-            MetricType::Cached => {
-                self.cached[authority]
-                    .equivocations
-                    .store(equivocations, Ordering::Relaxed);
-                self.cached[authority]
-                    .missing_proposals
-                    .store(missing_blocks, Ordering::Relaxed);
-                node_metrics
-                    .equivocations_in_cache_by_authority
-                    .with_label_values(&[hostname])
-                    .set(equivocations as i64);
-                node_metrics
-                    .missing_proposals_in_cache_by_authority
-                    .with_label_values(&[hostname])
-                    .set(missing_blocks as i64);
-            }
-
-            MetricType::Uncached => {
-                self.uncached[authority]
-                    .equivocations
-                    .fetch_add(equivocations, Ordering::Relaxed);
-                self.uncached[authority]
-                    .missing_proposals
-                    .fetch_add(missing_blocks, Ordering::Relaxed);
-                node_metrics
-                    .uncached_equivocations_by_authority
-                    .with_label_values(&[hostname])
-                    .inc_by(equivocations);
-                node_metrics
-                    .uncached_missing_proposals_by_authority
-                    .with_label_values(&[hostname])
-                    .inc_by(missing_blocks);
-            }
+            // No scoring metrics need to be updated.
         }
     }
 
@@ -399,7 +183,7 @@ impl ValidatorScoringMetrics {
     // The `authority` parameter should be a valid index, otherwise the function
     // will panic. This check is not performed here, as it is assumed that the
     // caller has already checked it.
-    fn initialize_faulty_blocks_metrics(
+    pub(crate) fn initialize_faulty_blocks_metrics(
         &self,
         faulty_blocks_provable: u64,
         faulty_blocks_unprovable: u64,
@@ -415,82 +199,167 @@ impl ValidatorScoringMetrics {
             .faulty_blocks_unprovable_by_authority
             .with_label_values(&[hostname, "loaded from storage", "loaded from storage"])
             .inc_by(faulty_blocks_unprovable);
-        self.uncached[authority_index]
-            .faulty_blocks_provable
-            .store(faulty_blocks_provable, Ordering::Relaxed);
-        self.uncached[authority_index]
-            .faulty_blocks_unprovable
-            .store(faulty_blocks_unprovable, Ordering::Relaxed);
+        self.uncached_metrics
+            .store_faulty_blocks_provable(authority_index.value(), faulty_blocks_provable);
+        self.uncached_metrics
+            .store_faulty_blocks_unprovable(authority_index.value(), faulty_blocks_unprovable);
     }
-}
 
-enum MetricType {
-    Cached,
-    Uncached,
-}
-// pub struct PartialScore(pub AtomicU64);
-pub type PartialScore = AtomicU64;
+    // Auxiliary function to update scoring metrics relative to missing blocks
+    // and equivocations. The `authority` parameter should be a valid index,
+    // otherwise the function will panic. This check is not performed here, as
+    // it is assumed that the caller has already checked it.
+    pub(crate) fn update_missing_blocks_and_equivocations(
+        &self,
+        missing_blocks: u64,
+        equivocations: u64,
+        hostname: &str,
+        authority: AuthorityIndex,
+        metric_type: MetricType,
+        node_metrics: &NodeMetrics,
+    ) {
+        match metric_type {
+            MetricType::Cached => {
+                self.cached_metrics
+                    .store_equivocations(authority.value(), equivocations);
+                self.cached_metrics
+                    .store_missing_proposals(authority.value(), missing_blocks);
+                node_metrics
+                    .equivocations_in_cache_by_authority
+                    .with_label_values(&[hostname])
+                    .set(equivocations as i64);
+                node_metrics
+                    .missing_proposals_in_cache_by_authority
+                    .with_label_values(&[hostname])
+                    .set(missing_blocks as i64);
+            }
 
-#[derive(Debug)]
-pub(crate) struct UncachedScoringMetrics {
-    // Counts the number of times that a faulty block signed by the validator was already verified
-    // in the epoch.
-    pub(crate) faulty_blocks_provable: AtomicU64,
-    // Counts the number of times that a faulty block not signed by the validator was already
-    // verified in the epoch.
-    pub(crate) faulty_blocks_unprovable: AtomicU64,
-    // Counts the number of equivocations that were already evicted from cache in the epoch.
-    pub(crate) equivocations: AtomicU64,
-    // Counts the number of blocks that the validator failed to propose, or that the node did not
-    // receive, from the rounds already evicted from cache in the epoch.
-    pub(crate) missing_proposals: AtomicU64,
-}
-
-impl UncachedScoringMetrics {
-    pub(crate) fn new() -> Self {
-        Self {
-            faulty_blocks_provable: AtomicU64::new(0),
-            faulty_blocks_unprovable: AtomicU64::new(0),
-            equivocations: AtomicU64::new(0),
-            missing_proposals: AtomicU64::new(0),
+            MetricType::Uncached => {
+                self.uncached_metrics
+                    .increment_equivocations(authority.value(), equivocations);
+                self.uncached_metrics
+                    .increment_missing_proposals(authority.value(), missing_blocks);
+                node_metrics
+                    .uncached_equivocations_by_authority
+                    .with_label_values(&[hostname])
+                    .inc_by(equivocations);
+                node_metrics
+                    .uncached_missing_proposals_by_authority
+                    .with_label_values(&[hostname])
+                    .inc_by(missing_blocks);
+            }
         }
     }
-}
 
-pub(crate) struct CachedScoringMetrics {
-    // Counts the number of equivocations in cache, below the threshold clock round.
-    pub(crate) equivocations: AtomicU64,
-    // Counts the number of blocks that the validator failed to propose, or that the node did not
-    // receive yet, from the rounds stored in cache and below the threshold clock round.
-    pub(crate) missing_proposals: AtomicU64,
-}
-
-impl CachedScoringMetrics {
-    pub(crate) fn new() -> Self {
-        Self {
-            equivocations: AtomicU64::new(0),
-            missing_proposals: AtomicU64::new(0),
+    // Updates the authority's scoring metrics according to the recent changes in
+    // the DAG state, i.e., recent evictions and additions to cache. It also
+    // updates the current local metrics count used by Scorer. It returns metrics
+    // changes that should be updated in disk storage.
+    pub(crate) fn update_scoring_metrics_on_eviction(
+        &self,
+        authority_index: AuthorityIndex,
+        hostname: &str,
+        recent_refs: &BTreeSet<BlockRef>,
+        eviction_round: u32,
+        last_eviction_round: u32,
+        threshold_clock_round: u32,
+        node_metrics: &NodeMetrics,
+    ) -> Option<StorageScoringMetrics> {
+        // threshold_clock_round should be always at least 1.
+        // Analogously, authority_index should be a valid index.
+        if threshold_clock_round == 0
+            || authority_index.value() >= self.uncached_metrics.faulty_blocks_provable().len()
+        {
+            return None;
         }
+
+        // Get the blocks rounds that were not evicted.
+        let cached_block_rounds = recent_refs
+            .iter()
+            .map(|block| block.round)
+            .filter(|&round| round > eviction_round && round < threshold_clock_round)
+            .collect::<Vec<u32>>();
+
+        // Update metrics according to the blocks from rounds still in cache.
+        let (cached_equivocations, missing_blocks_in_cached_rounds) =
+            calculate_scoring_metrics_for_range(
+                cached_block_rounds,
+                eviction_round + 1,
+                threshold_clock_round.saturating_sub(1),
+            );
+
+        self.update_missing_blocks_and_equivocations(
+            missing_blocks_in_cached_rounds,
+            cached_equivocations,
+            hostname,
+            authority_index,
+            MetricType::Cached,
+            node_metrics,
+        );
+
+        // If no eviction happened, we do not update the metrics on storage.
+        if eviction_round == last_eviction_round {
+            return None;
+        }
+
+        // Get the evicted blocks rounds.
+        let evicted_block_rounds = recent_refs
+            .iter()
+            .map(|block| block.round)
+            .filter(|&round| round <= eviction_round)
+            .collect::<Vec<u32>>();
+
+        // Update metrics according to the blocks from evicted rounds.
+        let (evicted_equivocations, missing_blocks_in_evicted_rounds) =
+            calculate_scoring_metrics_for_range(
+                evicted_block_rounds,
+                last_eviction_round + 1,
+                eviction_round,
+            );
+
+        self.update_missing_blocks_and_equivocations(
+            missing_blocks_in_evicted_rounds,
+            evicted_equivocations,
+            hostname,
+            authority_index,
+            MetricType::Uncached,
+            node_metrics,
+        );
+
+        // Update current local metrics count.
+        self.update_current_local_metrics_count(authority_index);
+
+        Some(StorageScoringMetrics {
+            faulty_blocks_provable: self.uncached_metrics.faulty_blocks_provable()[authority_index]
+                .load(Ordering::Relaxed),
+            faulty_blocks_unprovable: self.uncached_metrics.faulty_blocks_unprovable()
+                [authority_index]
+                .load(Ordering::Relaxed),
+            equivocations: self.uncached_metrics.equivocations()[authority_index]
+                .load(Ordering::Relaxed),
+            missing_proposals: self.uncached_metrics.missing_proposals()[authority_index]
+                .load(Ordering::Relaxed),
+        })
     }
-}
 
-pub struct PartialScores {
-    pub provable: Vec<PartialScore>,
-    pub unprovable: Vec<PartialScore>,
-}
-
-impl PartialScores {
-    pub fn new(committee_size: usize) -> Self {
-        let provable = (0..committee_size)
-            .map(|_| AtomicU64::new(u64::MAX))
-            .collect();
-        let unprovable = (0..committee_size)
-            .map(|_| AtomicU64::new(u64::MAX))
-            .collect();
-        Self {
-            provable,
-            unprovable,
-        }
+    pub(crate) fn update_current_local_metrics_count(&self, authority_index: AuthorityIndex) {
+        let faulty_blocks_provable =
+            self.uncached_metrics.faulty_blocks_provable()[authority_index].load(Ordering::Relaxed);
+        let faulty_blocks_unprovable = self.uncached_metrics.faulty_blocks_unprovable()
+            [authority_index]
+            .load(Ordering::Relaxed);
+        let equivocations =
+            self.uncached_metrics.equivocations()[authority_index].load(Ordering::Relaxed);
+        let missing_proposals =
+            self.uncached_metrics.missing_proposals()[authority_index].load(Ordering::Relaxed);
+        self.current_local_metrics_count
+            .store_faulty_blocks_provable(authority_index.value(), faulty_blocks_provable);
+        self.current_local_metrics_count
+            .store_faulty_blocks_unprovable(authority_index.value(), faulty_blocks_unprovable);
+        self.current_local_metrics_count
+            .store_equivocations(authority_index.value(), equivocations);
+        self.current_local_metrics_count
+            .store_missing_proposals(authority_index.value(), missing_proposals);
     }
 }
 
@@ -594,20 +463,14 @@ fn is_from_commit_syncer(err: &ConsensusError) -> bool {
         || is_from_signed_block_verification(err)
 }
 
-#[cfg(test)]
-impl Scorer {
-    pub(crate) fn new_dummy_for_tests(committee_size: usize) -> Self {
-        Self::new(committee_size)
-    }
+pub(crate) enum MetricType {
+    Cached,
+    Uncached,
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::BTreeSet,
-        sync::{Arc, atomic::Ordering},
-        vec,
-    };
+    use std::{collections::BTreeSet, sync::Arc, vec};
 
     use consensus_config::{AuthorityIndex, NetworkKeyPair, ProtocolKeyPair};
     use parking_lot::RwLock;
@@ -625,7 +488,7 @@ mod tests {
         context::Context,
         dag_state::DagState,
         error::ConsensusError,
-        scorer::ValidatorScoringMetrics,
+        scoring_metrics_store::MysticetiScoringMetricsStore,
         storage::{StorageScoringMetrics, mem_store::MemStore},
         synchronizer::Synchronizer,
         test_dag_builder::DagBuilder,
@@ -682,47 +545,29 @@ mod tests {
         (keys, context, core_dispatcher, authority_service)
     }
 
-    impl ValidatorScoringMetrics {
+    impl MysticetiScoringMetricsStore {
         pub(crate) fn uncached_missing_proposals_by_authority(&self) -> Vec<u64> {
-            self.uncached
-                .iter()
-                .map(|metrics| metrics.missing_proposals.load(Ordering::Relaxed))
-                .collect()
+            self.uncached_metrics.load_missing_proposals()
         }
 
         pub(crate) fn equivocations_in_cache_by_authority(&self) -> Vec<u64> {
-            self.cached
-                .iter()
-                .map(|metrics| metrics.equivocations.load(Ordering::Relaxed))
-                .collect()
+            self.cached_metrics.load_equivocations()
         }
 
         pub(crate) fn missing_proposals_in_cache_by_authority(&self) -> Vec<u64> {
-            self.cached
-                .iter()
-                .map(|metrics| metrics.missing_proposals.load(Ordering::Relaxed))
-                .collect()
+            self.cached_metrics.load_missing_proposals()
         }
 
         pub(crate) fn uncached_equivocations_by_authority(&self) -> Vec<u64> {
-            self.uncached
-                .iter()
-                .map(|metrics| metrics.equivocations.load(Ordering::Relaxed))
-                .collect()
+            self.uncached_metrics.load_equivocations()
         }
 
         pub(crate) fn faulty_blocks_provable_by_authority(&self) -> Vec<u64> {
-            self.uncached
-                .iter()
-                .map(|metrics| metrics.faulty_blocks_provable.load(Ordering::Relaxed))
-                .collect()
+            self.uncached_metrics.load_faulty_blocks_provable()
         }
 
         pub(crate) fn faulty_blocks_unprovable_by_authority(&self) -> Vec<u64> {
-            self.uncached
-                .iter()
-                .map(|metrics| metrics.faulty_blocks_unprovable.load(Ordering::Relaxed))
-                .collect()
+            self.uncached_metrics.load_faulty_blocks_unprovable()
         }
     }
 
@@ -812,6 +657,7 @@ mod tests {
         }
         metrics
     }
+
     fn get_faulty_blocks_unprovable(context: &Arc<Context>, source: &str, error: &str) -> Vec<u64> {
         let mut metrics = Vec::new();
         for authority in context.committee.authorities() {
@@ -829,10 +675,10 @@ mod tests {
         metrics
     }
 
-    #[tokio::test]
-    async fn test_update_score_edge_cases() {
+    #[test]
+    fn test_update_scoring_metrics_on_eviction_edge_cases() {
         let context = Context::new_for_test(4);
-        let scorer = context.0.scorer;
+        let scoring_metrics_store = context.0.scoring_metrics_store;
         let authority_index = AuthorityIndex::new_for_test(0);
         let hostname = "test_host";
         let recent_refs_by_authority = BTreeSet::new();
@@ -849,7 +695,7 @@ mod tests {
         let last_evicted_round = 5;
         let eviction_round = 5;
         let threshold_clock_round = 5;
-        let stored_metrics = scorer.update_score(
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -865,7 +711,7 @@ mod tests {
         let last_evicted_round = 0;
         let eviction_round = 0;
         let threshold_clock_round = 0;
-        let stored_metrics = scorer.update_score(
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -882,7 +728,7 @@ mod tests {
         let last_evicted_round = 0;
         let eviction_round = 3;
         let threshold_clock_round = 2;
-        let stored_metrics = scorer.update_score(
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -908,7 +754,7 @@ mod tests {
         let last_evicted_round = 1;
         let eviction_round = 0;
         let threshold_clock_round = 2;
-        let stored_metrics = scorer.update_score(
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -933,7 +779,7 @@ mod tests {
         let last_evicted_round = 2;
         let eviction_round = 0;
         let threshold_clock_round = 1;
-        let stored_metrics = scorer.update_score(
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -958,7 +804,7 @@ mod tests {
         let last_evicted_round = 1;
         let eviction_round = 2;
         let threshold_clock_round = 0;
-        let stored_metrics = scorer.update_score(
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -972,7 +818,7 @@ mod tests {
         let last_evicted_round = 2;
         let eviction_round = 1;
         let threshold_clock_round = 0;
-        let stored_metrics = scorer.update_score(
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -992,7 +838,7 @@ mod tests {
         let last_evicted_round = 1;
         let eviction_round = 2;
         let threshold_clock_round = 3;
-        let stored_metrics = scorer.update_score(
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
             out_of_bounds_authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -1028,7 +874,7 @@ mod tests {
             .authorities()
             .map(|a| a.1.hostname.as_str())
             .collect();
-        let scoring_metrics = &context.scorer.scoring_metrics;
+        let scoring_metrics = &context.scoring_metrics_store;
         let node_metrics = &context.metrics.node_metrics;
         let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store.clone());
@@ -1148,12 +994,8 @@ mod tests {
         );
 
         // Clear and check all metrics
-        scoring_metrics.uncached[0]
-            .missing_proposals
-            .store(0, Ordering::Relaxed);
-        scoring_metrics.cached[0]
-            .missing_proposals
-            .store(0, Ordering::Relaxed);
+        scoring_metrics.uncached_metrics.reset();
+        scoring_metrics.cached_metrics.reset();
         node_metrics
             .uncached_missing_proposals_by_authority
             .with_label_values(&[hostnames[0]])
@@ -1268,12 +1110,8 @@ mod tests {
         }
 
         // Clear and check all metrics
-        scoring_metrics.uncached[0]
-            .missing_proposals
-            .store(0, Ordering::Relaxed);
-        scoring_metrics.cached[1]
-            .equivocations
-            .store(0, Ordering::Relaxed);
+        scoring_metrics.uncached_metrics.reset();
+        scoring_metrics.cached_metrics.reset();
         node_metrics
             .uncached_missing_proposals_by_authority
             .with_label_values(&[hostnames[0]])
@@ -1368,7 +1206,6 @@ mod tests {
         );
     }
 
-    #[ignore]
     #[tokio::test]
     async fn test_metrics_flush_and_recovery() {
         telemetry_subscribers::init_for_testing();
@@ -1386,6 +1223,9 @@ mod tests {
         context
             .protocol_config
             .set_consensus_linearize_subdag_v2_for_testing(false);
+        context
+            .protocol_config
+            .set_consensus_median_timestamp_with_checkpoint_enforcement_for_testing(false);
 
         let context = Arc::new(context);
         let hostnames: Vec<&str> = context
@@ -1393,7 +1233,7 @@ mod tests {
             .authorities()
             .map(|a| a.1.hostname.as_str())
             .collect();
-        let scoring_metrics = &context.scorer.scoring_metrics;
+        let scoring_metrics = &context.scoring_metrics_store;
         let node_metrics = &context.metrics.node_metrics;
 
         let store = Arc::new(MemStore::new());
@@ -1515,12 +1355,8 @@ mod tests {
         );
 
         // Clear and check all metrics
-        scoring_metrics.uncached[0]
-            .missing_proposals
-            .store(0, Ordering::Relaxed);
-        scoring_metrics.cached[0]
-            .missing_proposals
-            .store(0, Ordering::Relaxed);
+        scoring_metrics.uncached_metrics.reset();
+        scoring_metrics.cached_metrics.reset();
         node_metrics
             .uncached_missing_proposals_by_authority
             .with_label_values(&[hostnames[0]])
@@ -1633,15 +1469,9 @@ mod tests {
         }
 
         // Clear and check all metrics
-        scoring_metrics.uncached[0]
-            .missing_proposals
-            .store(0, Ordering::Relaxed);
-        scoring_metrics.cached[1]
-            .equivocations
-            .store(0, Ordering::Relaxed);
-        scoring_metrics.cached[0]
-            .missing_proposals
-            .store(0, Ordering::Relaxed);
+        scoring_metrics.uncached_metrics.reset();
+        scoring_metrics.cached_metrics.reset();
+        scoring_metrics.cached_metrics.reset();
         node_metrics
             .uncached_missing_proposals_by_authority
             .with_label_values(&[hostnames[0]])
@@ -1745,7 +1575,7 @@ mod tests {
         // Initialize context and authority service given a committee_size
         let committee_size = 4;
         let (_, context, _, _) = new_authority_service_for_metrics_tests(committee_size);
-        let scoring_metrics = &context.scorer.scoring_metrics;
+        let scoring_metrics = &context.scoring_metrics_store;
         let source = "handle_send_block";
         // Create a set of errors to test
         let ignored_error = ConsensusError::Shutdown;
@@ -1758,13 +1588,15 @@ mod tests {
         // Update metrics for each authority with an error that should be ignored.
         // Metrics should not be updated for this error.
         for authority in context.committee.authorities() {
-            context.scorer.update_scoring_metrics_on_block_receival(
-                authority.0,
-                authority.1.hostname.as_str(),
-                ignored_error.clone(),
-                source,
-                &context.metrics.node_metrics,
-            );
+            context
+                .scoring_metrics_store
+                .update_scoring_metrics_on_block_receival(
+                    authority.0,
+                    authority.1.hostname.as_str(),
+                    ignored_error.clone(),
+                    source,
+                    &context.metrics.node_metrics,
+                );
         }
         assert_eq!(
             [
@@ -1792,13 +1624,15 @@ mod tests {
         // Update metrics for each authority with a parsing error.
         // Only unprovable metrics should be updated for this error.
         for authority in context.committee.authorities() {
-            context.scorer.update_scoring_metrics_on_block_receival(
-                authority.0,
-                authority.1.hostname.as_str(),
-                parsing_error.clone(),
-                source,
-                &context.metrics.node_metrics,
-            );
+            context
+                .scoring_metrics_store
+                .update_scoring_metrics_on_block_receival(
+                    authority.0,
+                    authority.1.hostname.as_str(),
+                    parsing_error.clone(),
+                    source,
+                    &context.metrics.node_metrics,
+                );
         }
         assert_eq!(
             [
@@ -1826,13 +1660,15 @@ mod tests {
         // Update metrics for each authority with a signed block verification error.
         // Only provable metrics should be updated for this error.
         for authority in context.committee.authorities() {
-            context.scorer.update_scoring_metrics_on_block_receival(
-                authority.0,
-                authority.1.hostname.as_str(),
-                block_verification_error.clone(),
-                source,
-                &context.metrics.node_metrics,
-            );
+            context
+                .scoring_metrics_store
+                .update_scoring_metrics_on_block_receival(
+                    authority.0,
+                    authority.1.hostname.as_str(),
+                    block_verification_error.clone(),
+                    source,
+                    &context.metrics.node_metrics,
+                );
         }
         assert_eq!(
             [
@@ -1863,7 +1699,7 @@ mod tests {
         // Initialize context and authority service given a committee_size
         let committee_size = 4;
         let (_, context, _, _) = new_authority_service_for_metrics_tests(committee_size);
-        let scoring_metrics = &context.scorer.scoring_metrics;
+        let scoring_metrics = &context.scoring_metrics_store;
         let source = "fetch_once";
         // Create a set of errors to test
         let ignored_error = ConsensusError::Shutdown;
@@ -1873,13 +1709,15 @@ mod tests {
         // Update metrics for each authority with an error that should be ignored.
         // Metrics should not be updated for this error.
         for authority in context.committee.authorities() {
-            context.scorer.update_scoring_metrics_on_block_receival(
-                authority.0,
-                authority.1.hostname.as_str(),
-                ignored_error.clone(),
-                source,
-                &context.metrics.node_metrics,
-            );
+            context
+                .scoring_metrics_store
+                .update_scoring_metrics_on_block_receival(
+                    authority.0,
+                    authority.1.hostname.as_str(),
+                    ignored_error.clone(),
+                    source,
+                    &context.metrics.node_metrics,
+                );
         }
         assert_eq!(
             [
@@ -1907,13 +1745,15 @@ mod tests {
         // Update metrics for each authority with a parsing error.
         // Only unprovable metrics should be updated for this error.
         for authority in context.committee.authorities() {
-            context.scorer.update_scoring_metrics_on_block_receival(
-                authority.0,
-                authority.1.hostname.as_str(),
-                parsing_error.clone(),
-                source,
-                &context.metrics.node_metrics,
-            );
+            context
+                .scoring_metrics_store
+                .update_scoring_metrics_on_block_receival(
+                    authority.0,
+                    authority.1.hostname.as_str(),
+                    parsing_error.clone(),
+                    source,
+                    &context.metrics.node_metrics,
+                );
         }
         assert_eq!(
             [
@@ -1943,13 +1783,15 @@ mod tests {
         // necessarily from the peer. Thus, it is not provable that the peer actually
         // sent this block. Only unprovable metrics should be updated for this error.
         for authority in context.committee.authorities() {
-            context.scorer.update_scoring_metrics_on_block_receival(
-                authority.0,
-                authority.1.hostname.as_str(),
-                block_verification_error.clone(),
-                source,
-                &context.metrics.node_metrics,
-            );
+            context
+                .scoring_metrics_store
+                .update_scoring_metrics_on_block_receival(
+                    authority.0,
+                    authority.1.hostname.as_str(),
+                    block_verification_error.clone(),
+                    source,
+                    &context.metrics.node_metrics,
+                );
         }
         assert_eq!(
             [
@@ -1980,7 +1822,7 @@ mod tests {
         // Initialize context and authority service given a committee_size
         let committee_size = 4;
         let (_, context, _, _) = new_authority_service_for_metrics_tests(committee_size);
-        let scoring_metrics = &context.scorer.scoring_metrics;
+        let scoring_metrics = &context.scoring_metrics_store;
         let source = "process_fetched_blocks";
         // Create a set of errors to test
         let ignored_error = ConsensusError::Shutdown;
@@ -1990,13 +1832,15 @@ mod tests {
         // Update metrics for each authority with an error that should be ignored.
         // Metrics should not be updated for this error.
         for authority in context.committee.authorities() {
-            context.scorer.update_scoring_metrics_on_block_receival(
-                authority.0,
-                authority.1.hostname.as_str(),
-                ignored_error.clone(),
-                source,
-                &context.metrics.node_metrics,
-            );
+            context
+                .scoring_metrics_store
+                .update_scoring_metrics_on_block_receival(
+                    authority.0,
+                    authority.1.hostname.as_str(),
+                    ignored_error.clone(),
+                    source,
+                    &context.metrics.node_metrics,
+                );
         }
         assert_eq!(
             [
@@ -2024,13 +1868,15 @@ mod tests {
         // Update metrics for each authority with a parsing error.
         // Only unprovable metrics should be updated for this error.
         for authority in context.committee.authorities() {
-            context.scorer.update_scoring_metrics_on_block_receival(
-                authority.0,
-                authority.1.hostname.as_str(),
-                parsing_error.clone(),
-                source,
-                &context.metrics.node_metrics,
-            );
+            context
+                .scoring_metrics_store
+                .update_scoring_metrics_on_block_receival(
+                    authority.0,
+                    authority.1.hostname.as_str(),
+                    parsing_error.clone(),
+                    source,
+                    &context.metrics.node_metrics,
+                );
         }
         assert_eq!(
             [
@@ -2060,13 +1906,15 @@ mod tests {
         // necessarily from the peer. Thus, it is not provable that the peer actually
         // sent this block. Only unprovable metrics should be updated for this error.
         for authority in context.committee.authorities() {
-            context.scorer.update_scoring_metrics_on_block_receival(
-                authority.0,
-                authority.1.hostname.as_str(),
-                block_verification_error.clone(),
-                source,
-                &context.metrics.node_metrics,
-            );
+            context
+                .scoring_metrics_store
+                .update_scoring_metrics_on_block_receival(
+                    authority.0,
+                    authority.1.hostname.as_str(),
+                    block_verification_error.clone(),
+                    source,
+                    &context.metrics.node_metrics,
+                );
         }
         assert_eq!(
             [

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -20,8 +20,8 @@ use crate::{
 /// local metrics count used by Scorer.
 pub(crate) struct MysticetiScoringMetricsStore {
     pub current_local_metrics_count: Arc<VersionedScoringMetrics>,
-    pub cached_metrics: Arc<VersionedScoringMetrics>,
-    pub uncached_metrics: Arc<VersionedScoringMetrics>,
+    pub cached_metrics: VersionedScoringMetrics,
+    pub uncached_metrics: VersionedScoringMetrics,
 }
 
 impl MysticetiScoringMetricsStore {
@@ -33,13 +33,11 @@ impl MysticetiScoringMetricsStore {
         match protocol_config.scorer_version_as_option() {
             None | Some(1) => Self {
                 current_local_metrics_count,
-                cached_metrics: Arc::new(VersionedScoringMetrics::V1(ScoringMetricsV1::new(
-                    committee_size,
-                ))),
+                cached_metrics: VersionedScoringMetrics::V1(ScoringMetricsV1::new(committee_size)),
 
-                uncached_metrics: Arc::new(VersionedScoringMetrics::V1(ScoringMetricsV1::new(
+                uncached_metrics: VersionedScoringMetrics::V1(ScoringMetricsV1::new(
                     committee_size,
-                ))),
+                )),
             },
             _ => panic!("Unsupported scorer version"),
         }

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -230,13 +230,15 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                             .handle_send_block(peer, block.clone())
                             .await;
                         if let Err(e) = result {
-                            context.scorer.update_scoring_metrics_on_block_receival(
-                                peer,
-                                peer_hostname,
-                                e.clone(),
-                                "handle_send_block",
-                                &context.metrics.node_metrics,
-                            );
+                            context
+                                .scoring_metrics_store
+                                .update_scoring_metrics_on_block_receival(
+                                    peer,
+                                    peer_hostname,
+                                    e.clone(),
+                                    "handle_send_block",
+                                    &context.metrics.node_metrics,
+                                );
                             match e {
                                 ConsensusError::BlockRejected { block_ref, reason } => {
                                     debug!(

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -520,7 +520,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                 commands_sender.clone(),
                                 "live"
                             ).await {
-                                context.scorer.update_scoring_metrics_on_block_receival(
+                                context.scoring_metrics_store.update_scoring_metrics_on_block_receival(
                                     peer_index,
                                     peer_hostname,
                                     err.clone(),

--- a/consensus/simtests/Cargo.toml
+++ b/consensus/simtests/Cargo.toml
@@ -25,6 +25,7 @@ tracing.workspace = true
 # internal dependencies
 consensus-config.workspace = true
 consensus-core.workspace = true
+iota-common.workspace = true
 iota-config.workspace = true
 iota-macros.workspace = true
 iota-metrics.workspace = true

--- a/consensus/simtests/src/node.rs
+++ b/consensus/simtests/src/node.rs
@@ -15,7 +15,7 @@ use consensus_core::{
     ConsensusAuthority, TransactionClient, network::tonic_network::to_socket_addr,
     transaction::NoopTransactionVerifier,
 };
-use iota_common::scoring_metrics::ScoringMetrics;
+use iota_common::scoring_metrics::VersionedScoringMetrics;
 use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
 use iota_protocol_config::{ConsensusNetwork, ProtocolConfig};
 use parking_lot::Mutex;
@@ -275,8 +275,10 @@ pub(crate) async fn make_authority(
 
     let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
 
-    let current_local_metrics_count =
-        Arc::new(ScoringMetrics::new(committee.size(), &protocol_config));
+    let current_local_metrics_count = Arc::new(VersionedScoringMetrics::new(
+        committee.size(),
+        &protocol_config,
+    ));
     let commit_consumer = CommitConsumer::new(commit_sender, 0);
     let commit_consumer_monitor = commit_consumer.monitor();
 

--- a/consensus/simtests/src/node.rs
+++ b/consensus/simtests/src/node.rs
@@ -15,6 +15,7 @@ use consensus_core::{
     ConsensusAuthority, TransactionClient, network::tonic_network::to_socket_addr,
     transaction::NoopTransactionVerifier,
 };
+use iota_common::scoring_metrics::ScoringMetrics;
 use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
 use iota_protocol_config::{ConsensusNetwork, ProtocolConfig};
 use parking_lot::Mutex;
@@ -274,6 +275,8 @@ pub(crate) async fn make_authority(
 
     let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
 
+    let current_local_metrics_count =
+        Arc::new(ScoringMetrics::new(committee.size(), &protocol_config));
     let commit_consumer = CommitConsumer::new(commit_sender, 0);
     let commit_consumer_monitor = commit_consumer.monitor();
 
@@ -290,6 +293,7 @@ pub(crate) async fn make_authority(
         Arc::new(txn_verifier),
         commit_consumer,
         registry,
+        current_local_metrics_count,
         boot_counter,
     )
     .await;

--- a/crates/iota-common/src/lib.rs
+++ b/crates/iota-common/src/lib.rs
@@ -7,3 +7,5 @@ pub mod metrics;
 pub mod stream_ext;
 pub mod sync;
 pub mod try_iterator_ext;
+
+pub use iota_types::scoring_metrics;

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -509,7 +509,7 @@ pub struct AuthorityPerEpochStore {
     randomness_reporter: OnceCell<RandomnessReporter>,
 
     /// Component including the local view about the other authorities'
-    /// misbehaviour metrics, and received reports.
+    /// misbehavior metrics, and received reports.
     pub(crate) scorer: Arc<Scorer>,
 }
 

--- a/crates/iota-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/iota-core/src/consensus_manager/mysticeti_manager.rs
@@ -201,6 +201,7 @@ impl ConsensusManagerTrait for MysticetiManager {
             Arc::new(tx_validator.clone()),
             consumer,
             registry.clone(),
+            epoch_store.scorer.current_local_metrics_count.clone(),
             *boot_counter,
         )
         .await;

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -494,34 +494,6 @@ impl EndOfEpochTransactionKind {
         })
     }
 
-    pub fn new_change_epoch_v4(
-        next_epoch: EpochId,
-        protocol_version: ProtocolVersion,
-        storage_charge: u64,
-        computation_charge: u64,
-        computation_charge_burned: u64,
-        storage_rebate: u64,
-        non_refundable_storage_fee: u64,
-        epoch_start_timestamp_ms: u64,
-        system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>,
-        eligible_active_validators: Vec<u64>,
-        scores: Vec<u64>,
-    ) -> Self {
-        Self::ChangeEpochV4(ChangeEpochV4 {
-            epoch: next_epoch,
-            protocol_version,
-            storage_charge,
-            computation_charge,
-            computation_charge_burned,
-            storage_rebate,
-            non_refundable_storage_fee,
-            epoch_start_timestamp_ms,
-            system_packages,
-            eligible_active_validators,
-            scores,
-        })
-    }
-
     pub fn new_authenticator_state_expire(
         min_epoch: u64,
         authenticator_obj_initial_shared_version: SequenceNumber,

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -494,6 +494,34 @@ impl EndOfEpochTransactionKind {
         })
     }
 
+    pub fn new_change_epoch_v4(
+        next_epoch: EpochId,
+        protocol_version: ProtocolVersion,
+        storage_charge: u64,
+        computation_charge: u64,
+        computation_charge_burned: u64,
+        storage_rebate: u64,
+        non_refundable_storage_fee: u64,
+        epoch_start_timestamp_ms: u64,
+        system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>,
+        eligible_active_validators: Vec<u64>,
+        scores: Vec<u64>,
+    ) -> Self {
+        Self::ChangeEpochV4(ChangeEpochV4 {
+            epoch: next_epoch,
+            protocol_version,
+            storage_charge,
+            computation_charge,
+            computation_charge_burned,
+            storage_rebate,
+            non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            system_packages,
+            eligible_active_validators,
+            scores,
+        })
+    }
+
     pub fn new_authenticator_state_expire(
         min_epoch: u64,
         authenticator_obj_initial_shared_version: SequenceNumber,


### PR DESCRIPTION
```mermaid
---
config:
  gitGraph:
    {parallelCommits: true,
    mainBranchName: 'Feature',
    rotateCommitLabel: true}
---
gitGraph
   commit id: "Initial commit"
   commit id: "Old Scorer" tag: "PR8530"
  commit id: "add ChangeEpochV4" tag: "PR9159"
    commit id: "add MisbehaviorReports" tag: "PR9175"
   commit id: "add ScoringMetrics" tag: "PR9176"
   commit id: "add Scorer" tag: "PR9177"
   checkout Feature
   branch scoring-metrics-store
   commit id: "add ScoringMetricsStore"
branch report-validation
commit id: "add report validation" 
branch scoring-function
commit id: "add scoring function" 
branch report-creation
commit id: "add report creation" 
branch advance-epoch
commit id: "add advance epoch v4" 
checkout Feature
    merge scoring-metrics-store tag: "THIS PR"
```

# Description of changes

Introduces the `ScoringMetricStore`, which holds the validator scoring metrics to be updated by consensus

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Introduce Scoring metric store
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
