### PR TITLE
feat(docker): enable BuildKit and optimize build process with cache mounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ yarn-error.log*
 checkpoints_dir/*
 light_client.yaml
 **/.cache/
+Dockerfile.cache
 
 lcov.info
 **/venv/

--- a/dev-tools/pg-services-local/docker-compose.yaml
+++ b/dev-tools/pg-services-local/docker-compose.yaml
@@ -5,8 +5,12 @@ services:
       context: ../../
       dockerfile: docker/iota/Dockerfile
       args:
-        - GIT_REVISION
+        - RUST_IMAGE_VERSION=${RUST_IMAGE_VERSION:-bookworm}
+        - PROFILE=release
+        - TARGET_FOLDER=target/release
+        - CARGO_BUILD_FEATURES=${CARGO_BUILD_FEATURES:-default}
         - BUILD_DATE
+        - GIT_REVISION
     container_name: local-network
     hostname: local-network
     restart: on-failure
@@ -42,9 +46,12 @@ services:
       context: ../../
       dockerfile: docker/iota-indexer/Dockerfile
       args:
-        - GIT_REVISION
-        - BUILD_DATE
+        - RUST_IMAGE_VERSION=${RUST_IMAGE_VERSION:-bookworm}
         - PROFILE=dev
+        - TARGET_FOLDER=target/debug
+        - CARGO_BUILD_FEATURES=${CARGO_BUILD_FEATURES:-default}
+        - BUILD_DATE
+        - GIT_REVISION
     container_name: indexer-sync
     hostname: indexer-sync
     restart: on-failure
@@ -123,9 +130,12 @@ services:
       context: ../../
       dockerfile: docker/iota-graphql-rpc/Dockerfile
       args:
-        - GIT_REVISION
-        - BUILD_DATE
+        - RUST_IMAGE_VERSION=${RUST_IMAGE_VERSION:-bookworm}
         - PROFILE=dev
+        - TARGET_FOLDER=target/debug
+        - CARGO_BUILD_FEATURES=${CARGO_BUILD_FEATURES:-default}
+        - BUILD_DATE
+        - GIT_REVISION
     container_name: graphql-server
     hostname: graphql-server
     restart: on-failure

--- a/docker/iota-data-ingestion/Dockerfile
+++ b/docker/iota-data-ingestion/Dockerfile
@@ -29,11 +29,13 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build and copy the built binaries to the working directory
+# Build the binaries
 RUN cargo build --profile ${PROFILE} \
       --bin iota-data-ingestion \
-      --features ${CARGO_BUILD_FEATURES:=default} && \
-    cp $TARGET_FOLDER/iota-data-ingestion ./iota-data-ingestion
+      --features ${CARGO_BUILD_FEATURES:=default}
+
+# Copy the built binaries to the working directory
+RUN cp $TARGET_FOLDER/iota-data-ingestion ./iota-data-ingestion
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-data-ingestion/Dockerfile
+++ b/docker/iota-data-ingestion/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
@@ -28,19 +29,19 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-RUN cargo build --profile ${PROFILE} --bin iota-data-ingestion --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binary to the working directory depending on the output folder of the profile,
-# so we can copy it to the runtime image
-RUN if [ -d target/release ]; then \
-  TARGET_DIR="target/release"; \
-elif [ -d target/debug ]; then \
-  TARGET_DIR="target/debug"; \
-else \
-  echo "Error: No build directory found"; \
-  exit 1; \
-fi && \
-mv $TARGET_DIR/iota-data-ingestion ./;
+# Build with cache mounts to speed up compilation
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/iota/target,sharing=locked \
+    cargo build --profile ${PROFILE} --bin iota-data-ingestion --features ${CARGO_BUILD_FEATURES:=default} && \
+    if [ -d target/release ]; then \
+      cp target/release/iota-data-ingestion ./iota-data-ingestion; \
+    elif [ -d target/debug ]; then \
+      cp target/debug/iota-data-ingestion ./iota-data-ingestion; \
+    else \
+      echo "Error: No build directory found"; \
+      exit 1; \
+    fi
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-data-ingestion/Dockerfile
+++ b/docker/iota-data-ingestion/Dockerfile
@@ -1,9 +1,9 @@
-# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
 
 ARG PROFILE=release
+ARG TARGET_FOLDER=target/release
 ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
@@ -29,19 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build with cache mounts to speed up compilation
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/iota/target,sharing=locked \
-    cargo build --profile ${PROFILE} --bin iota-data-ingestion --features ${CARGO_BUILD_FEATURES:=default} && \
-    if [ -d target/release ]; then \
-      cp target/release/iota-data-ingestion ./iota-data-ingestion; \
-    elif [ -d target/debug ]; then \
-      cp target/debug/iota-data-ingestion ./iota-data-ingestion; \
-    else \
-      echo "Error: No build directory found"; \
-      exit 1; \
-    fi
+# Build and copy the built binaries to the working directory
+RUN cargo build --profile ${PROFILE} \
+      --bin iota-data-ingestion \
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-data-ingestion ./iota-data-ingestion
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-data-ingestion/build.sh
+++ b/docker/iota-data-ingestion/build.sh
@@ -7,4 +7,4 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 # The name of last directory in script's path is used for tag
 BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"
+DOCKER_BUILDKIT=1 "$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-graphql-rpc/Dockerfile
+++ b/docker/iota-graphql-rpc/Dockerfile
@@ -29,11 +29,13 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build and copy the built binaries to the working directory
+# Build the binaries
 RUN cargo build --profile ${PROFILE} \
       --bin iota-graphql-rpc \
-      --features ${CARGO_BUILD_FEATURES:=default} && \
-    cp $TARGET_FOLDER/iota-graphql-rpc ./iota-graphql-rpc
+      --features ${CARGO_BUILD_FEATURES:=default}
+
+# Copy the built binaries to the working directory
+RUN cp $TARGET_FOLDER/iota-graphql-rpc ./iota-graphql-rpc
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-graphql-rpc/Dockerfile
+++ b/docker/iota-graphql-rpc/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
@@ -28,19 +29,19 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-RUN cargo build --profile ${PROFILE} --bin iota-graphql-rpc --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binary to the working directory depending on the output folder of the profile,
-# so we can copy it to the runtime image
-RUN if [ -d target/release ]; then \
-  TARGET_DIR="target/release"; \
-elif [ -d target/debug ]; then \
-  TARGET_DIR="target/debug"; \
-else \
-  echo "Error: No build directory found"; \
-  exit 1; \
-fi && \
-mv $TARGET_DIR/iota-graphql-rpc ./;
+# Build with cache mounts to speed up compilation
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/iota/target,sharing=locked \
+    cargo build --profile ${PROFILE} --bin iota-graphql-rpc --features ${CARGO_BUILD_FEATURES:=default} && \
+    if [ -d target/release ]; then \
+      cp target/release/iota-graphql-rpc ./iota-graphql-rpc; \
+    elif [ -d target/debug ]; then \
+      cp target/debug/iota-graphql-rpc ./iota-graphql-rpc; \
+    else \
+      echo "Error: No build directory found"; \
+      exit 1; \
+    fi
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-graphql-rpc/Dockerfile
+++ b/docker/iota-graphql-rpc/Dockerfile
@@ -1,9 +1,9 @@
-# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
 
 ARG PROFILE=release
+ARG TARGET_FOLDER=target/release
 ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
@@ -29,19 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build with cache mounts to speed up compilation
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/iota/target,sharing=locked \
-    cargo build --profile ${PROFILE} --bin iota-graphql-rpc --features ${CARGO_BUILD_FEATURES:=default} && \
-    if [ -d target/release ]; then \
-      cp target/release/iota-graphql-rpc ./iota-graphql-rpc; \
-    elif [ -d target/debug ]; then \
-      cp target/debug/iota-graphql-rpc ./iota-graphql-rpc; \
-    else \
-      echo "Error: No build directory found"; \
-      exit 1; \
-    fi
+# Build and copy the built binaries to the working directory
+RUN cargo build --profile ${PROFILE} \
+      --bin iota-graphql-rpc \
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-graphql-rpc ./iota-graphql-rpc
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-graphql-rpc/build.sh
+++ b/docker/iota-graphql-rpc/build.sh
@@ -8,4 +8,4 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 # The name of last directory in script's path is used for tag
 BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"
+DOCKER_BUILDKIT=1 "$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-indexer/Dockerfile
+++ b/docker/iota-indexer/Dockerfile
@@ -29,11 +29,13 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build and copy the built binaries to the working directory
+# Build the binaries
 RUN cargo build --profile ${PROFILE} \
       --bin iota-indexer \
-      --features ${CARGO_BUILD_FEATURES:=default} && \
-    cp $TARGET_FOLDER/iota-indexer ./iota-indexer
+      --features ${CARGO_BUILD_FEATURES:=default}
+
+# Copy the built binaries to the working directory
+RUN cp $TARGET_FOLDER/iota-indexer ./iota-indexer
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-indexer/Dockerfile
+++ b/docker/iota-indexer/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
@@ -28,19 +29,19 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-RUN cargo build --profile ${PROFILE} --bin iota-indexer --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binary to the working directory depending on the output folder of the profile,
-# so we can copy it to the runtime image
-RUN if [ -d target/release ]; then \
-  TARGET_DIR="target/release"; \
-elif [ -d target/debug ]; then \
-  TARGET_DIR="target/debug"; \
-else \
-  echo "Error: No build directory found"; \
-  exit 1; \
-fi && \
-mv $TARGET_DIR/iota-indexer ./;
+# Build with cache mounts to speed up compilation
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/iota/target,sharing=locked \
+    cargo build --profile ${PROFILE} --bin iota-indexer --features ${CARGO_BUILD_FEATURES:=default} && \
+    if [ -d target/release ]; then \
+      cp target/release/iota-indexer ./iota-indexer; \
+    elif [ -d target/debug ]; then \
+      cp target/debug/iota-indexer ./iota-indexer; \
+    else \
+      echo "Error: No build directory found"; \
+      exit 1; \
+    fi
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-indexer/Dockerfile
+++ b/docker/iota-indexer/Dockerfile
@@ -1,9 +1,9 @@
-# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
 
 ARG PROFILE=release
+ARG TARGET_FOLDER=target/release
 ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
@@ -29,19 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build with cache mounts to speed up compilation
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/iota/target,sharing=locked \
-    cargo build --profile ${PROFILE} --bin iota-indexer --features ${CARGO_BUILD_FEATURES:=default} && \
-    if [ -d target/release ]; then \
-      cp target/release/iota-indexer ./iota-indexer; \
-    elif [ -d target/debug ]; then \
-      cp target/debug/iota-indexer ./iota-indexer; \
-    else \
-      echo "Error: No build directory found"; \
-      exit 1; \
-    fi
+# Build and copy the built binaries to the working directory
+RUN cargo build --profile ${PROFILE} \
+      --bin iota-indexer \
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-indexer ./iota-indexer
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-indexer/build.sh
+++ b/docker/iota-indexer/build.sh
@@ -8,4 +8,4 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 # The name of last directory in script's path is used for tag
 BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"
+DOCKER_BUILDKIT=1 "$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-node/Dockerfile
+++ b/docker/iota-node/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
@@ -28,19 +29,19 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-RUN cargo build --profile ${PROFILE} --bin iota-node --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binary to the working directory depending on the output folder of the profile,
-# so we can copy it to the runtime image
-RUN if [ -d target/release ]; then \
-  TARGET_DIR="target/release"; \
-elif [ -d target/debug ]; then \
-  TARGET_DIR="target/debug"; \
-else \
-  echo "Error: No build directory found"; \
-  exit 1; \
-fi && \
-mv $TARGET_DIR/iota-node ./;
+# Build with cache mounts to speed up compilation
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/iota/target,sharing=locked \
+    cargo build --profile ${PROFILE} --bin iota-node --features ${CARGO_BUILD_FEATURES:=default} && \
+    if [ -d target/release ]; then \
+      cp target/release/iota-node ./iota-node; \
+    elif [ -d target/debug ]; then \
+      cp target/debug/iota-node ./iota-node; \
+    else \
+      echo "Error: No build directory found"; \
+      exit 1; \
+    fi
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-node/Dockerfile
+++ b/docker/iota-node/Dockerfile
@@ -1,9 +1,9 @@
-# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
 
 ARG PROFILE=release
+ARG TARGET_FOLDER=target/release
 ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
@@ -29,19 +29,12 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build with cache mounts to speed up compilation
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/iota/target,sharing=locked \
-    cargo build --profile ${PROFILE} --bin iota-node --features ${CARGO_BUILD_FEATURES:=default} && \
-    if [ -d target/release ]; then \
-      cp target/release/iota-node ./iota-node; \
-    elif [ -d target/debug ]; then \
-      cp target/debug/iota-node ./iota-node; \
-    else \
-      echo "Error: No build directory found"; \
-      exit 1; \
-    fi
+# Build and copy the built binaries to the working directory
+RUN cargo build --profile ${PROFILE} \
+      --bin iota-node \
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-node ./iota-node
+
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-node/Dockerfile
+++ b/docker/iota-node/Dockerfile
@@ -29,11 +29,13 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build and copy the built binaries to the working directory
+# Build the binaries
 RUN cargo build --profile ${PROFILE} \
       --bin iota-node \
-      --features ${CARGO_BUILD_FEATURES:=default} && \
-    cp $TARGET_FOLDER/iota-node ./iota-node
+      --features ${CARGO_BUILD_FEATURES:=default}
+
+# Copy the built binaries to the working directory
+RUN cp $TARGET_FOLDER/iota-node ./iota-node
 
 
 # Production image

--- a/docker/iota-node/build.sh
+++ b/docker/iota-node/build.sh
@@ -8,4 +8,4 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 # The name of last directory in script's path is used for tag
 BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"
+DOCKER_BUILDKIT=1 "$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-proxy/Dockerfile
+++ b/docker/iota-proxy/Dockerfile
@@ -29,11 +29,13 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build and copy the built binaries to the working directory
+# Build the binaries
 RUN cargo build --profile ${PROFILE} \
       --bin iota-proxy \
-      --features ${CARGO_BUILD_FEATURES:=default} && \
-    cp $TARGET_FOLDER/iota-proxy ./iota-proxy
+      --features ${CARGO_BUILD_FEATURES:=default}
+
+# Copy the built binaries to the working directory
+RUN cp $TARGET_FOLDER/iota-proxy ./iota-proxy
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-proxy/Dockerfile
+++ b/docker/iota-proxy/Dockerfile
@@ -1,9 +1,9 @@
-# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
 
 ARG PROFILE=release
+ARG TARGET_FOLDER=target/release
 ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
@@ -29,20 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build with cache mounts to speed up compilation
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/iota/target,sharing=locked \
-    cargo build --profile ${PROFILE} --bin iota-proxy && \
-    if [ -d target/release ]; then \
-      cp target/release/iota-proxy ./iota-proxy; \
-    elif [ -d target/debug ]; then \
-      cp target/debug/iota-proxy ./iota-proxy; \
-    else \
-      echo "Error: No build directory found"; \
-      exit 1; \
-    fi
-
+# Build and copy the built binaries to the working directory
+RUN cargo build --profile ${PROFILE} \
+      --bin iota-proxy \
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-proxy ./iota-proxy
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-proxy/Dockerfile
+++ b/docker/iota-proxy/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
@@ -28,19 +29,19 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-RUN cargo build --profile ${PROFILE} --bin iota-proxy
-
-# Copy the built binary to the working directory depending on the output folder of the profile,
-# so we can copy it to the runtime image
-RUN if [ -d target/release ]; then \
-  TARGET_DIR="target/release"; \
-elif [ -d target/debug ]; then \
-  TARGET_DIR="target/debug"; \
-else \
-  echo "Error: No build directory found"; \
-  exit 1; \
-fi && \
-mv $TARGET_DIR/iota-proxy ./;
+# Build with cache mounts to speed up compilation
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/iota/target,sharing=locked \
+    cargo build --profile ${PROFILE} --bin iota-proxy && \
+    if [ -d target/release ]; then \
+      cp target/release/iota-proxy ./iota-proxy; \
+    elif [ -d target/debug ]; then \
+      cp target/debug/iota-proxy ./iota-proxy; \
+    else \
+      echo "Error: No build directory found"; \
+      exit 1; \
+    fi
 
 
 # Production image

--- a/docker/iota-proxy/build.sh
+++ b/docker/iota-proxy/build.sh
@@ -8,4 +8,4 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 # The name of last directory in script's path is used for tag
 BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"
+DOCKER_BUILDKIT=1 "$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-rest-kv/Dockerfile
+++ b/docker/iota-rest-kv/Dockerfile
@@ -1,9 +1,9 @@
-# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
 
 ARG PROFILE=release
+ARG TARGET_FOLDER=target/release
 ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
@@ -29,19 +29,12 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build with cache mounts to speed up compilation
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/iota/target,sharing=locked \
-    cargo build --profile ${PROFILE} --bin iota-rest-kv --features ${CARGO_BUILD_FEATURES:=default} && \
-    if [ -d target/release ]; then \
-      cp target/release/iota-rest-kv ./iota-rest-kv; \
-    elif [ -d target/debug ]; then \
-      cp target/debug/iota-rest-kv ./iota-rest-kv; \
-    else \
-      echo "Error: No build directory found"; \
-      exit 1; \
-    fi
+# Build and copy the built binaries to the working directory
+RUN cargo build --profile ${PROFILE} \
+      --bin iota-rest-kv \
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-rest-kv ./iota-rest-kv
+
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-rest-kv/Dockerfile
+++ b/docker/iota-rest-kv/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
@@ -28,19 +29,19 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-RUN cargo build --profile ${PROFILE} --bin iota-rest-kv --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binary to the working directory depending on the output folder of the profile,
-# so we can copy it to the runtime image
-RUN if [ -d target/release ]; then \
-  TARGET_DIR="target/release"; \
-elif [ -d target/debug ]; then \
-  TARGET_DIR="target/debug"; \
-else \
-  echo "Error: No build directory found"; \
-  exit 1; \
-fi && \
-mv $TARGET_DIR/iota-rest-kv ./;
+# Build with cache mounts to speed up compilation
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/iota/target,sharing=locked \
+    cargo build --profile ${PROFILE} --bin iota-rest-kv --features ${CARGO_BUILD_FEATURES:=default} && \
+    if [ -d target/release ]; then \
+      cp target/release/iota-rest-kv ./iota-rest-kv; \
+    elif [ -d target/debug ]; then \
+      cp target/debug/iota-rest-kv ./iota-rest-kv; \
+    else \
+      echo "Error: No build directory found"; \
+      exit 1; \
+    fi
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-rest-kv/Dockerfile
+++ b/docker/iota-rest-kv/Dockerfile
@@ -29,11 +29,13 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build and copy the built binaries to the working directory
+# Build the binaries
 RUN cargo build --profile ${PROFILE} \
       --bin iota-rest-kv \
-      --features ${CARGO_BUILD_FEATURES:=default} && \
-    cp $TARGET_FOLDER/iota-rest-kv ./iota-rest-kv
+      --features ${CARGO_BUILD_FEATURES:=default}
+
+# Copy the built binaries to the working directory
+RUN cp $TARGET_FOLDER/iota-rest-kv ./iota-rest-kv
 
 
 # Production image

--- a/docker/iota-rest-kv/build.sh
+++ b/docker/iota-rest-kv/build.sh
@@ -7,4 +7,4 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 # The name of last directory in script's path is used for tag
 BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"
+DOCKER_BUILDKIT=1 "$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-rosetta/Dockerfile
+++ b/docker/iota-rosetta/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
@@ -28,21 +29,21 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-RUN cargo build --profile ${PROFILE} \
-  --bin iota-rosetta \
-  --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binary to the working directory depending on the output folder of the profile,
-# so we can copy it to the runtime image
-RUN if [ -d target/release ]; then \
-  TARGET_DIR="target/release"; \
-elif [ -d target/debug ]; then \
-  TARGET_DIR="target/debug"; \
-else \
-  echo "Error: No build directory found"; \
-  exit 1; \
-fi && \
-mv $TARGET_DIR/iota-rosetta ./;
+# Build with cache mounts to speed up compilation
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/iota/target,sharing=locked \
+    cargo build --profile ${PROFILE} \
+      --bin iota-rosetta \
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    if [ -d target/release ]; then \
+      cp target/release/iota-rosetta ./iota-rosetta; \
+    elif [ -d target/debug ]; then \
+      cp target/debug/iota-rosetta ./iota-rosetta; \
+    else \
+      echo "Error: No build directory found"; \
+      exit 1; \
+    fi
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-rosetta/Dockerfile
+++ b/docker/iota-rosetta/Dockerfile
@@ -29,11 +29,13 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build and copy the built binaries to the working directory
+# Build the binaries
 RUN cargo build --profile ${PROFILE} \
       --bin iota-rosetta \
-      --features ${CARGO_BUILD_FEATURES:=default} && \
-    cp $TARGET_FOLDER/iota-rosetta ./iota-rosetta
+      --features ${CARGO_BUILD_FEATURES:=default}
+
+# Copy the built binaries to the working directory
+RUN cp $TARGET_FOLDER/iota-rosetta ./iota-rosetta
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-rosetta/Dockerfile
+++ b/docker/iota-rosetta/Dockerfile
@@ -1,9 +1,9 @@
-# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
 
 ARG PROFILE=release
+ARG TARGET_FOLDER=target/release
 ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
@@ -29,21 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build with cache mounts to speed up compilation
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/iota/target,sharing=locked \
-    cargo build --profile ${PROFILE} \
+# Build and copy the built binaries to the working directory
+RUN cargo build --profile ${PROFILE} \
       --bin iota-rosetta \
       --features ${CARGO_BUILD_FEATURES:=default} && \
-    if [ -d target/release ]; then \
-      cp target/release/iota-rosetta ./iota-rosetta; \
-    elif [ -d target/debug ]; then \
-      cp target/debug/iota-rosetta ./iota-rosetta; \
-    else \
-      echo "Error: No build directory found"; \
-      exit 1; \
-    fi
+    cp $TARGET_FOLDER/iota-rosetta ./iota-rosetta
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-rosetta/build.sh
+++ b/docker/iota-rosetta/build.sh
@@ -8,4 +8,4 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 # The name of last directory in script's path is used for tag
 BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"
+DOCKER_BUILDKIT=1 "$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-source-validation-service/Dockerfile
+++ b/docker/iota-source-validation-service/Dockerfile
@@ -1,9 +1,9 @@
-# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
 
 ARG PROFILE=release
+ARG TARGET_FOLDER=target/release
 ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
@@ -29,19 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build with cache mounts to speed up compilation
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/iota/target,sharing=locked \
-    cargo build --profile ${PROFILE} --bin iota-source-validation-service --features ${CARGO_BUILD_FEATURES:=default} && \
-    if [ -d target/release ]; then \
-      cp target/release/iota-source-validation-service ./iota-source-validation-service; \
-    elif [ -d target/debug ]; then \
-      cp target/debug/iota-source-validation-service ./iota-source-validation-service; \
-    else \
-      echo "Error: No build directory found"; \
-      exit 1; \
-    fi
+# Build and copy the built binaries to the working directory
+RUN cargo build --profile ${PROFILE} \
+      --bin iota-source-validation-service \
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-source-validation-service ./iota-source-validation-service
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-source-validation-service/Dockerfile
+++ b/docker/iota-source-validation-service/Dockerfile
@@ -29,11 +29,13 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build and copy the built binaries to the working directory
+# Build the binaries
 RUN cargo build --profile ${PROFILE} \
       --bin iota-source-validation-service \
-      --features ${CARGO_BUILD_FEATURES:=default} && \
-    cp $TARGET_FOLDER/iota-source-validation-service ./iota-source-validation-service
+      --features ${CARGO_BUILD_FEATURES:=default}
+
+# Copy the built binaries to the working directory
+RUN cp $TARGET_FOLDER/iota-source-validation-service ./iota-source-validation-service
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-source-validation-service/Dockerfile
+++ b/docker/iota-source-validation-service/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
@@ -28,19 +29,19 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-RUN cargo build --profile ${PROFILE} --bin iota-source-validation-service --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binary to the working directory depending on the output folder of the profile,
-# so we can copy it to the runtime image
-RUN if [ -d target/release ]; then \
-  TARGET_DIR="target/release"; \
-elif [ -d target/debug ]; then \
-  TARGET_DIR="target/debug"; \
-else \
-  echo "Error: No build directory found"; \
-  exit 1; \
-fi && \
-mv $TARGET_DIR/iota-source-validation-service ./;
+# Build with cache mounts to speed up compilation
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/iota/target,sharing=locked \
+    cargo build --profile ${PROFILE} --bin iota-source-validation-service --features ${CARGO_BUILD_FEATURES:=default} && \
+    if [ -d target/release ]; then \
+      cp target/release/iota-source-validation-service ./iota-source-validation-service; \
+    elif [ -d target/debug ]; then \
+      cp target/debug/iota-source-validation-service ./iota-source-validation-service; \
+    else \
+      echo "Error: No build directory found"; \
+      exit 1; \
+    fi
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-source-validation-service/build.sh
+++ b/docker/iota-source-validation-service/build.sh
@@ -8,4 +8,4 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 # The name of last directory in script's path is used for tag
 BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"
+DOCKER_BUILDKIT=1 "$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-tools/Dockerfile
+++ b/docker/iota-tools/Dockerfile
@@ -1,9 +1,9 @@
-# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
 
 ARG PROFILE=release
+ARG TARGET_FOLDER=target/release
 ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
@@ -31,11 +31,8 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build with cache mounts to speed up compilation
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/iota/target,sharing=locked \
-    cargo build --profile ${PROFILE} \
+# Build and copy the built binaries to the working directory
+RUN cargo build --profile ${PROFILE} \
       --bin iota-node \
       --bin stress \
       --bin iota-analytics-indexer \
@@ -45,28 +42,14 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
       --bin iota-tool \
       --bin iota-genesis-builder \
       --features ${CARGO_BUILD_FEATURES:=default} && \
-    if [ -d target/release ]; then \
-      cp target/release/iota-node ./iota-node && \
-      cp target/release/stress ./stress && \
-      cp target/release/iota-analytics-indexer ./iota-analytics-indexer && \
-      cp target/release/iota ./iota && \
-      cp target/release/iota-faucet ./iota-faucet && \
-      cp target/release/iota-cluster-test ./iota-cluster-test && \
-      cp target/release/iota-tool ./iota-tool && \
-      cp target/release/iota-genesis-builder ./iota-genesis-builder; \
-    elif [ -d target/debug ]; then \
-      cp target/debug/iota-node ./iota-node && \
-      cp target/debug/stress ./stress && \
-      cp target/debug/iota-analytics-indexer ./iota-analytics-indexer && \
-      cp target/debug/iota ./iota && \
-      cp target/debug/iota-faucet ./iota-faucet && \
-      cp target/debug/iota-cluster-test ./iota-cluster-test && \
-      cp target/debug/iota-tool ./iota-tool && \
-      cp target/debug/iota-genesis-builder ./iota-genesis-builder; \
-    else \
-      echo "Error: No build directory found"; \
-      exit 1; \
-    fi
+    cp $TARGET_FOLDER/iota-node ./iota-node && \
+    cp $TARGET_FOLDER/stress ./stress && \
+    cp $TARGET_FOLDER/iota-analytics-indexer ./iota-analytics-indexer && \
+    cp $TARGET_FOLDER/iota ./iota && \
+    cp $TARGET_FOLDER/iota-faucet ./iota-faucet && \
+    cp $TARGET_FOLDER/iota-cluster-test ./iota-cluster-test && \
+    cp $TARGET_FOLDER/iota-tool ./iota-tool && \
+    cp $TARGET_FOLDER/iota-genesis-builder ./iota-genesis-builder
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-tools/Dockerfile
+++ b/docker/iota-tools/Dockerfile
@@ -31,7 +31,7 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build and copy the built binaries to the working directory
+# Build the binaries
 RUN cargo build --profile ${PROFILE} \
       --bin iota-node \
       --bin stress \
@@ -41,8 +41,10 @@ RUN cargo build --profile ${PROFILE} \
       --bin iota-cluster-test \
       --bin iota-tool \
       --bin iota-genesis-builder \
-      --features ${CARGO_BUILD_FEATURES:=default} && \
-    cp $TARGET_FOLDER/iota-node ./iota-node && \
+      --features ${CARGO_BUILD_FEATURES:=default}
+
+# Copy the built binaries to the working directory
+RUN cp $TARGET_FOLDER/iota-node ./iota-node && \
     cp $TARGET_FOLDER/stress ./stress && \
     cp $TARGET_FOLDER/iota-analytics-indexer ./iota-analytics-indexer && \
     cp $TARGET_FOLDER/iota ./iota && \

--- a/docker/iota-tools/Dockerfile
+++ b/docker/iota-tools/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
@@ -30,35 +31,42 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-RUN cargo build --profile ${PROFILE} \
-  --bin iota-node \
-  --bin stress \
-  --bin iota-analytics-indexer \
-  --bin iota \
-  --bin iota-faucet \
-  --bin iota-cluster-test \
-  --bin iota-tool \
-  --bin iota-genesis-builder \
-  --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binary to the working directory depending on the output folder of the profile,
-# so we can copy it to the runtime image
-RUN if [ -d target/release ]; then \
-  TARGET_DIR="target/release"; \
-elif [ -d target/debug ]; then \
-  TARGET_DIR="target/debug"; \
-else \
-  echo "Error: No build directory found"; \
-  exit 1; \
-fi && \
-mv $TARGET_DIR/iota-node ./ && \
-mv $TARGET_DIR/stress ./ && \
-mv $TARGET_DIR/iota-analytics-indexer ./ && \
-mv $TARGET_DIR/iota ./ && \
-mv $TARGET_DIR/iota-faucet ./ && \
-mv $TARGET_DIR/iota-cluster-test ./ && \
-mv $TARGET_DIR/iota-tool ./ && \
-mv $TARGET_DIR/iota-genesis-builder ./;
+# Build with cache mounts to speed up compilation
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/iota/target,sharing=locked \
+    cargo build --profile ${PROFILE} \
+      --bin iota-node \
+      --bin stress \
+      --bin iota-analytics-indexer \
+      --bin iota \
+      --bin iota-faucet \
+      --bin iota-cluster-test \
+      --bin iota-tool \
+      --bin iota-genesis-builder \
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    if [ -d target/release ]; then \
+      cp target/release/iota-node ./iota-node && \
+      cp target/release/stress ./stress && \
+      cp target/release/iota-analytics-indexer ./iota-analytics-indexer && \
+      cp target/release/iota ./iota && \
+      cp target/release/iota-faucet ./iota-faucet && \
+      cp target/release/iota-cluster-test ./iota-cluster-test && \
+      cp target/release/iota-tool ./iota-tool && \
+      cp target/release/iota-genesis-builder ./iota-genesis-builder; \
+    elif [ -d target/debug ]; then \
+      cp target/debug/iota-node ./iota-node && \
+      cp target/debug/stress ./stress && \
+      cp target/debug/iota-analytics-indexer ./iota-analytics-indexer && \
+      cp target/debug/iota ./iota && \
+      cp target/debug/iota-faucet ./iota-faucet && \
+      cp target/debug/iota-cluster-test ./iota-cluster-test && \
+      cp target/debug/iota-tool ./iota-tool && \
+      cp target/debug/iota-genesis-builder ./iota-genesis-builder; \
+    else \
+      echo "Error: No build directory found"; \
+      exit 1; \
+    fi
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-tools/build.sh
+++ b/docker/iota-tools/build.sh
@@ -8,4 +8,4 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 # The name of last directory in script's path is used for tag
 BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"
+DOCKER_BUILDKIT=1 "$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota/Dockerfile
+++ b/docker/iota/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
@@ -28,19 +29,19 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-RUN cargo build --profile ${PROFILE} --bin iota --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binary to the working directory depending on the output folder of the profile,
-# so we can copy it to the runtime image
-RUN if [ -d target/release ]; then \
-  TARGET_DIR="target/release"; \
-elif [ -d target/debug ]; then \
-  TARGET_DIR="target/debug"; \
-else \
-  echo "Error: No build directory found"; \
-  exit 1; \
-fi && \
-mv $TARGET_DIR/iota ./;
+# Build with cache mounts to speed up compilation
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/iota/target,sharing=locked \
+    cargo build --profile ${PROFILE} --bin iota --features ${CARGO_BUILD_FEATURES:=default} && \
+    if [ -d target/release ]; then \
+      cp target/release/iota ./iota; \
+    elif [ -d target/debug ]; then \
+      cp target/debug/iota ./iota; \
+    else \
+      echo "Error: No build directory found"; \
+      exit 1; \
+    fi
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota/Dockerfile
+++ b/docker/iota/Dockerfile
@@ -1,9 +1,9 @@
-# syntax=docker/dockerfile:1
 # Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
 ARG RUST_IMAGE_VERSION=bookworm
 FROM rust:${RUST_IMAGE_VERSION} AS builder
 
 ARG PROFILE=release
+ARG TARGET_FOLDER=target/release
 ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
@@ -12,6 +12,7 @@ ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "/iota"
 
 # Install build dependencies, including clang and lld for faster linking
+# libudev for Ledger hardware wallets
 RUN apt update && apt install -y cmake clang lld libudev-dev protobuf-compiler
 
 # Configure Rust to use clang and lld as the linker
@@ -29,19 +30,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build with cache mounts to speed up compilation
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/iota/target,sharing=locked \
-    cargo build --profile ${PROFILE} --bin iota --features ${CARGO_BUILD_FEATURES:=default} && \
-    if [ -d target/release ]; then \
-      cp target/release/iota ./iota; \
-    elif [ -d target/debug ]; then \
-      cp target/debug/iota ./iota; \
-    else \
-      echo "Error: No build directory found"; \
-      exit 1; \
-    fi
+# Build and copy the built binaries to the working directory
+RUN cargo build --profile ${PROFILE} \
+      --bin iota \
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota ./iota
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota/Dockerfile
+++ b/docker/iota/Dockerfile
@@ -30,11 +30,13 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build and copy the built binaries to the working directory
+# Build the binaries
 RUN cargo build --profile ${PROFILE} \
       --bin iota \
-      --features ${CARGO_BUILD_FEATURES:=default} && \
-    cp $TARGET_FOLDER/iota ./iota
+      --features ${CARGO_BUILD_FEATURES:=default}
+
+# Copy the built binaries to the working directory
+RUN cp $TARGET_FOLDER/iota ./iota
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota/build.sh
+++ b/docker/iota/build.sh
@@ -8,4 +8,4 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
 # The name of last directory in script's path is used for tag
 BASE_NAME="$(basename "$SCRIPT_DIR")"
 
-"$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"
+DOCKER_BUILDKIT=1 "$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/utils/build-script.sh
+++ b/docker/utils/build-script.sh
@@ -65,6 +65,9 @@ echo "build date:                 $BUILD_DATE"
 echo "git revision:               $GIT_REVISION"
 echo
 
+# Enable BuildKit for cache mount support
+export DOCKER_BUILDKIT=1
+
 docker build -f "$DOCKERFILE" "$REPO_ROOT" \
 	-t ${IMAGE_TAG} \
 	--build-arg RUST_IMAGE_VERSION="${RUST_IMAGE_VERSION}" \

--- a/docker/utils/build-script.sh
+++ b/docker/utils/build-script.sh
@@ -14,6 +14,11 @@ source "$REPO_ROOT/scripts/utils/common.sh"
 GIT_REVISION="$(git describe --always --abbrev=12 --dirty --exclude '*')"
 BUILD_DATE="$(date -u +'%Y-%m-%d')"
 PROFILE="release"
+TARGET_FOLDER="target/$PROFILE"
+# If the build profile is dev, set the target folder to debug
+if [ "$PROFILE" = "dev" ]; then
+    TARGET_FOLDER="target/debug"
+fi
 IMAGE_TAG=""
 
 # Parse command line arguments
@@ -65,13 +70,31 @@ echo "build date:                 $BUILD_DATE"
 echo "git revision:               $GIT_REVISION"
 echo
 
-# Enable BuildKit for cache mount support
-export DOCKER_BUILDKIT=1
+# Check if we should use cache mounts
+if [ "${DOCKER_BUILDKIT:-0}" = "1" ]; then
+	print_step "Cache mounts enabled - creating temporary Dockerfile with cache support"
+	DOCKERFILE_TMP="${DOCKERFILE}.cache"
+
+	# Add BuildKit syntax and inject cache mounts before cargo build
+	{
+		echo "# syntax=docker/dockerfile:1"
+		sed 's/^RUN cargo build --profile \${PROFILE}/RUN --mount=type=cache,target=\/usr\/local\/cargo\/registry \\\
+    --mount=type=cache,target=\/usr\/local\/cargo\/git \\\
+    --mount=type=cache,target=\/iota\/target,sharing=locked \\\
+    cargo build --profile ${PROFILE}/' "$DOCKERFILE"
+	} > "$DOCKERFILE_TMP"
+	
+	DOCKERFILE="$DOCKERFILE_TMP"
+	
+	# Ensure cleanup on exit
+	trap "rm -f $DOCKERFILE_TMP" EXIT
+fi
 
 docker build -f "$DOCKERFILE" "$REPO_ROOT" \
 	-t ${IMAGE_TAG} \
 	--build-arg RUST_IMAGE_VERSION="${RUST_IMAGE_VERSION}" \
 	--build-arg PROFILE="$PROFILE" \
+	--build-arg TARGET_FOLDER="$TARGET_FOLDER" \
 	--build-arg CARGO_BUILD_FEATURES="$CARGO_BUILD_FEATURES" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \


### PR DESCRIPTION
# Description of change

This PR optimizes the Docker build process by enabling BuildKit and implementing cache mounts across all Dockerfiles in the repository.

The changes improve build performance by leveraging BuildKit's cache mount feature to persist:
- Cargo package registry (`/usr/local/cargo/registry`)
- Git dependencies (`/usr/local/cargo/git`)
- Compiled artifacts (`/iota/target` with locked sharing)

All Dockerfiles now declare BuildKit syntax support and use optimized RUN commands that leverage these cache mounts, significantly reducing rebuild times for iterative development.

## Links to any relevant issues

N/A

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes