### PR TITLE
feat(starfish): fetch and verify transactions during commit syncing

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -45,13 +45,17 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_max_headers_per_commit_sync_fetch")]
     pub max_headers_per_commit_sync_fetch: usize,
 
+    /// Number of transactions to fetch per commit sync request.
+    #[serde(default = "Parameters::default_max_transactions_per_commit_sync_fetch")]
+    pub max_transactions_per_commit_sync_fetch: usize,
+
     /// Number of block headers to fetch per periodic or live sync request
     #[serde(default = "Parameters::default_max_headers_per_regular_sync_fetch")]
     pub max_headers_per_regular_sync_fetch: usize,
 
     /// Number of transactions to fetch per request.
-    #[serde(default = "Parameters::default_max_transactions_per_fetch")]
-    pub max_transactions_per_fetch: usize,
+    #[serde(default = "Parameters::default_max_transactions_per_regular_sync_fetch")]
+    pub max_transactions_per_regular_sync_fetch: usize,
 
     /// Time to wait during node start up until the node has synced the last
     /// proposed block via the network peers. When set to `0` the sync
@@ -135,6 +139,16 @@ impl Parameters {
         }
     }
 
+    // Maximum number of transactions to fetch per commit sync request.
+    pub(crate) fn default_max_transactions_per_commit_sync_fetch() -> usize {
+        if cfg!(msim) {
+            // Exercise hitting transactions per fetch limit.
+            10
+        } else {
+            1000
+        }
+    }
+
     // Maximum number of block headers to fetch per periodic or live sync request.
     pub(crate) fn default_max_headers_per_regular_sync_fetch() -> usize {
         if cfg!(msim) {
@@ -147,7 +161,7 @@ impl Parameters {
     }
 
     // Maximum number of transactions to fetch per request.
-    pub(crate) fn default_max_transactions_per_fetch() -> usize {
+    pub(crate) fn default_max_transactions_per_regular_sync_fetch() -> usize {
         if cfg!(msim) { 10 } else { 1000 }
     }
 
@@ -209,9 +223,12 @@ impl Default for Parameters {
             max_forward_time_drift: Parameters::default_max_forward_time_drift(),
             max_headers_per_commit_sync_fetch:
                 Parameters::default_max_headers_per_commit_sync_fetch(),
+            max_transactions_per_commit_sync_fetch:
+                Parameters::default_max_transactions_per_commit_sync_fetch(),
             max_headers_per_regular_sync_fetch:
                 Parameters::default_max_headers_per_regular_sync_fetch(),
-            max_transactions_per_fetch: Parameters::default_max_transactions_per_fetch(),
+            max_transactions_per_regular_sync_fetch:
+                Parameters::default_max_transactions_per_regular_sync_fetch(),
             sync_last_known_own_block_timeout:
                 Parameters::default_sync_last_known_own_block_timeout(),
             dag_state_cached_rounds: Parameters::default_dag_state_cached_rounds(),

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -12,8 +12,9 @@ max_forward_time_drift:
   secs: 0
   nanos: 500000000
 max_headers_per_commit_sync_fetch: 1000
+max_transactions_per_commit_sync_fetch: 1000
 max_headers_per_regular_sync_fetch: 100
-max_transactions_per_fetch: 1000
+max_transactions_per_regular_sync_fetch: 1000
 sync_last_known_own_block_timeout:
   secs: 5
   nanos: 0

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -211,7 +211,6 @@ impl ConsensusAuthority {
             context.clone(),
             core_dispatcher.clone(),
             commit_vote_monitor.clone(),
-            transactions_synchronizer.clone(),
             commit_consumer_monitor.clone(),
             network_client.clone(),
             block_verifier.clone(),

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -605,8 +605,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .await
             {
                 warn!(
-                    "Errored while trying to fetch missing transactions via
-             transactions synchronizer: {err}"
+                    "Errored while trying to fetch missing transactions via transactions synchronizer: {err}"
                 );
             }
         }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -933,8 +933,20 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             return Ok(Vec::new());
         }
 
-        if block_refs.len() > self.context.parameters.max_transactions_per_fetch {
-            block_refs.truncate(self.context.parameters.max_transactions_per_fetch);
+        // Use the maximum of both limits to accommodate both commit sync and regular
+        // sync requests
+        let max_transactions = self
+            .context
+            .parameters
+            .max_transactions_per_regular_sync_fetch
+            .max(
+                self.context
+                    .parameters
+                    .max_transactions_per_commit_sync_fetch,
+            );
+
+        if block_refs.len() > max_transactions {
+            block_refs.truncate(max_transactions);
         }
 
         // Some quick validation of the requested block refs
@@ -3155,7 +3167,7 @@ mod tests {
         let (context, key_pairs) = Context::new_for_test(validators);
         let context = Context {
             parameters: Parameters {
-                max_transactions_per_fetch: 20,
+                max_transactions_per_regular_sync_fetch: 20,
                 ..context.parameters
             },
             ..context
@@ -3278,7 +3290,8 @@ mod tests {
             .await
             .expect("We should expect a correct return of serialized transactions");
 
-        block_refs_to_request_first_batch.truncate(context.parameters.max_transactions_per_fetch);
+        block_refs_to_request_first_batch
+            .truncate(context.parameters.max_transactions_per_regular_sync_fetch);
         // Verify that we received the correct number of requested transactions
         assert_eq!(
             serialized_transactions.len(),
@@ -3311,7 +3324,8 @@ mod tests {
             );
         }
 
-        block_refs_to_request_second_batch.truncate(context.parameters.max_transactions_per_fetch);
+        block_refs_to_request_second_batch
+            .truncate(context.parameters.max_transactions_per_regular_sync_fetch);
 
         let serialized_transactions = authority_service
             .handle_fetch_transactions(peer, block_refs_to_request_second_batch.clone())

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -3168,6 +3168,7 @@ mod tests {
         let context = Context {
             parameters: Parameters {
                 max_transactions_per_regular_sync_fetch: 20,
+                max_transactions_per_commit_sync_fetch: 10,
                 ..context.parameters
             },
             ..context

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -253,21 +253,28 @@ impl CertifiedCommits {
 pub(crate) struct CertifiedCommit {
     commit: Arc<TrustedCommit>,
     verified_block_headers: Vec<VerifiedBlockHeader>,
+    verified_transactions: Vec<VerifiedTransactions>,
 }
 
 impl CertifiedCommit {
     pub(crate) fn new_certified(
         commit: TrustedCommit,
         verified_block_headers: Vec<VerifiedBlockHeader>,
+        verified_transactions: Vec<VerifiedTransactions>,
     ) -> Self {
         Self {
             commit: Arc::new(commit),
             verified_block_headers,
+            verified_transactions,
         }
     }
 
     pub fn block_headers(&self) -> &[VerifiedBlockHeader] {
         &self.verified_block_headers
+    }
+
+    pub fn transactions(&self) -> &[VerifiedTransactions] {
+        &self.verified_transactions
     }
 }
 
@@ -281,12 +288,12 @@ impl Deref for CertifiedCommit {
 
 /// Digest of a consensus commit.
 #[derive(Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-pub struct CommitDigest([u8; starfish_config::DIGEST_LENGTH]);
+pub struct CommitDigest([u8; DIGEST_LENGTH]);
 
 impl CommitDigest {
     /// Lexicographic min & max digest.
-    pub const MIN: Self = Self([u8::MIN; starfish_config::DIGEST_LENGTH]);
-    pub const MAX: Self = Self([u8::MAX; starfish_config::DIGEST_LENGTH]);
+    pub const MIN: Self = Self([u8::MIN; DIGEST_LENGTH]);
+    pub const MAX: Self = Self([u8::MAX; DIGEST_LENGTH]);
 
     pub fn into_inner(self) -> [u8; starfish_config::DIGEST_LENGTH] {
         self.0

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -68,7 +68,6 @@ use crate::{
     error::{ConsensusError, ConsensusResult},
     network::{NetworkClient, SerializedTransactions},
     stake_aggregator::{QuorumThreshold, StakeAggregator},
-    transactions_synchronizer::TransactionsSynchronizerHandle,
 };
 
 // Handle to stop the CommitSyncer loop.
@@ -119,7 +118,6 @@ impl<C: NetworkClient> CommitSyncer<C> {
         context: Arc<Context>,
         core_thread_dispatcher: Arc<dyn CoreThreadDispatcher>,
         commit_vote_monitor: Arc<CommitVoteMonitor>,
-        transactions_synchronizer: Arc<TransactionsSynchronizerHandle>,
         commit_consumer_monitor: Arc<CommitConsumerMonitor>,
         network_client: Arc<C>,
         block_verifier: Arc<dyn BlockVerifier>,
@@ -130,7 +128,6 @@ impl<C: NetworkClient> CommitSyncer<C> {
             core_thread_dispatcher,
             commit_vote_monitor,
             commit_consumer_monitor,
-            transactions_synchronizer,
             network_client,
             block_verifier,
             dag_state,
@@ -259,19 +256,25 @@ impl<C: NetworkClient> CommitSyncer<C> {
     ) {
         assert!(!certified_commits.commits().is_empty());
 
-        let (total_blocks_fetched, total_blocks_size_bytes) = certified_commits
-            .commits()
-            .iter()
-            .fold((0, 0), |(blocks, bytes), c| {
-                (
-                    blocks + c.block_headers().len(),
-                    bytes
-                        + c.block_headers()
-                            .iter()
-                            .map(|b| b.serialized().len())
-                            .sum::<usize>() as u64,
-                )
-            });
+        let (total_blocks_fetched, total_headers_size_bytes, total_transactions_size_bytes) =
+            certified_commits.commits().iter().fold(
+                (0, 0, 0),
+                |(blocks, header_bytes, transaction_bytes), c| {
+                    (
+                        blocks + c.block_headers().len(),
+                        header_bytes
+                            + c.block_headers()
+                                .iter()
+                                .map(|b| b.serialized().len())
+                                .sum::<usize>() as u64,
+                        transaction_bytes
+                            + c.transactions()
+                                .iter()
+                                .map(|b| b.serialized().len())
+                                .sum::<usize>() as u64,
+                    )
+                },
+            );
 
         let metrics = &self.inner.context.metrics.node_metrics;
         metrics
@@ -282,7 +285,10 @@ impl<C: NetworkClient> CommitSyncer<C> {
             .inc_by(total_blocks_fetched as u64);
         metrics
             .commit_sync_total_fetched_block_headers_size
-            .inc_by(total_blocks_size_bytes);
+            .inc_by(total_headers_size_bytes);
+        metrics
+            .commit_sync_total_fetched_transactions_size
+            .inc_by(total_transactions_size_bytes);
 
         let (commit_start, commit_end) = (
             certified_commits.commits().first().unwrap().index(),
@@ -347,14 +353,14 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 .add_certified_commits(commits)
                 .await
             {
-                Ok((missing_blocks, missing_committed_txns)) => {
-                    if !missing_blocks.is_empty() {
+                Ok((missing_headers, missing_committed_txns)) => {
+                    if !missing_headers.is_empty() {
                         warn!(
                             "Fetched block headers have missing ancestors: {:?} for commit range {:?}",
-                            missing_blocks, fetched_commit_range
+                            missing_headers, fetched_commit_range
                         );
                     }
-                    for block_ref in missing_blocks {
+                    for block_ref in missing_headers {
                         let hostname = &self
                             .inner
                             .context
@@ -365,26 +371,24 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             .commit_sync_fetch_missing_block_headers
                             .with_label_values(&[hostname])
                             .inc();
-                        // TODO: add fetch missing transactions metric
                     }
                     if !missing_committed_txns.is_empty() {
-                        info!(
+                        warn!(
                             "Fetched blocks have {} missing committed transactions for commit range {:?}",
                             missing_committed_txns.len(),
                             fetched_commit_range
                         );
-                        // TODO: https://github.com/iotaledger/iota/issues/8376
-                        // Decide whether to rely on periodic transactions
-                        // synchronizer or make use of live one
-                        if let Err(err) = self
-                            .inner
-                            .transactions_synchronizer
-                            .fetch_transactions(missing_committed_txns)
-                            .await
-                        {
-                            warn!(
-                                "Error while trying to fetch missing transactions via transactions synchronizer: {err}"
-                            );
+                        for (block_ref, _ack_authorities) in missing_committed_txns {
+                            let hostname = &self
+                                .inner
+                                .context
+                                .committee
+                                .authority(block_ref.author)
+                                .hostname;
+                            metrics
+                                .commit_sync_fetch_missing_transactions
+                                .with_label_values(&[hostname])
+                                .inc();
                         }
                     }
                 }
@@ -678,7 +682,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             // If they do match, the returned block headers can be considered
                             // verified as well.
                             if *requested_block_ref != block_header.reference() {
-                                return Err(ConsensusError::UnexpectedBlockForCommit {
+                                return Err(ConsensusError::UnexpectedBlockHeaderForCommit {
                                     peer: target_authority,
                                     requested: *requested_block_ref,
                                     received: block_header.reference(),
@@ -707,6 +711,8 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 .map(|(i, request_block_refs)| {
                     let inner = inner.clone();
                     async move {
+                        // 8. Send out pipelined fetch requests to avoid overloading the target
+                        //    authority.
                         sleep(timeout * i as u32 / num_tx_chunks.max(1)).await;
                         let serialized_transactions = inner
                             .network_client
@@ -717,12 +723,36 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             )
                             .await?;
 
+                        // 9. Verify that the number of returned transactions is not greater than
+                        //    the number of requested transactions. It's OK if not all requested
+                        //    transactions are returned as long as the peer returns all the headers.
+                        //    We don't want to fail the whole fetch in this case.
+                        //    TransactionSynchronizer will take care of fetching missing
+                        //    transactions later.
+                        if request_block_refs.len() < serialized_transactions.len() {
+                            return Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
+                                authority: target_authority,
+                                requested: request_block_refs.len(),
+                                received_headers: serialized_transactions.len(),
+                            });
+                        }
+                        let requested_block_refs_set: BTreeSet<_> =
+                            request_block_refs.iter().cloned().collect();
                         // Deserialize to extract BlockRef and build a map directly
                         let mut result = BTreeMap::new();
                         for serialized_bytes in serialized_transactions {
                             let serialized_tx: SerializedTransactions =
                                 bcs::from_bytes(&serialized_bytes)
                                     .map_err(ConsensusError::MalformedTransactions)?;
+
+                            // 10. Verify the returned transactions match the requested block refs.
+                            if !requested_block_refs_set.contains(&serialized_tx.block_ref) {
+                                return Err(ConsensusError::UnexpectedTransactionForCommit {
+                                    peer: target_authority,
+                                    received: serialized_tx.block_ref,
+                                });
+                            }
+
                             result.insert(
                                 serialized_tx.block_ref,
                                 serialized_tx.serialized_transactions,
@@ -841,7 +871,6 @@ struct Inner<C: NetworkClient> {
     core_thread_dispatcher: Arc<dyn CoreThreadDispatcher>,
     commit_vote_monitor: Arc<CommitVoteMonitor>,
     commit_consumer_monitor: Arc<CommitConsumerMonitor>,
-    transactions_synchronizer: Arc<TransactionsSynchronizerHandle>,
     network_client: Arc<C>,
     block_verifier: Arc<dyn BlockVerifier>,
     dag_state: Arc<RwLock<DagState>>,
@@ -1006,7 +1035,6 @@ mod tests {
         error::ConsensusResult,
         network::{BlockBundleStream, NetworkClient},
         storage::mem_store::MemStore,
-        transactions_synchronizer::TransactionsSynchronizer,
     };
 
     #[derive(Default)]
@@ -1086,17 +1114,11 @@ mod tests {
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let commit_consumer_monitor = Arc::new(CommitConsumerMonitor::new(0));
-        let transactions_synchronizer = TransactionsSynchronizer::start(
-            network_client.clone(),
-            context.clone(),
-            core_thread_dispatcher.clone(),
-            dag_state.clone(),
-        );
+
         let mut commit_syncer = CommitSyncer::new(
             context,
             core_thread_dispatcher,
             commit_vote_monitor.clone(),
-            transactions_synchronizer.clone(),
             commit_consumer_monitor.clone(),
             network_client,
             block_verifier,

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -733,7 +733,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             })
             .collect();
 
-        // 7. Create transaction fetch requests (will be processed concurrently with
+        // 8. Create transaction fetch requests (will be processed concurrently with
         //    headers)
         let mut transaction_requests: FuturesOrdered<_> = if !committed_tx_refs.is_empty() {
             let num_tx_chunks = committed_tx_refs.len().div_ceil(
@@ -753,7 +753,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 .map(|(i, request_block_refs)| {
                     let inner = inner.clone();
                     async move {
-                        // 8. Send out pipelined fetch requests to avoid overloading the target
+                        // 9. Send out pipelined fetch requests to avoid overloading the target
                         //    authority.
                         sleep(timeout * i as u32 / num_tx_chunks.max(1)).await;
                         let serialized_transactions = inner
@@ -765,12 +765,12 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             )
                             .await?;
 
-                        // 9. Verify that the number of returned transactions is not greater than
-                        //    the number of requested transactions. It's OK if not all requested
-                        //    transactions are returned as long as the peer returns all the headers.
-                        //    We don't want to fail the whole fetch in this case.
-                        //    TransactionSynchronizer will take care of fetching missing
-                        //    transactions later.
+                        // 10. Verify that the number of returned transactions is not greater than
+                        //     the number of requested transactions. It's OK if not all requested
+                        //     transactions are returned as long as the peer returns all the
+                        //     headers. We don't want to fail the whole fetch in this case.
+                        //     TransactionSynchronizer will take care of fetching missing
+                        //     transactions later.
                         if request_block_refs.len() < serialized_transactions.len() {
                             return Err(ConsensusError::TooManyFetchedTransactionsReturned(
                                 target_authority,
@@ -785,7 +785,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                                 bcs::from_bytes(&serialized_bytes)
                                     .map_err(ConsensusError::MalformedTransactions)?;
 
-                            // 10. Verify the returned transactions match the requested block refs.
+                            // 11. Verify the returned transactions match the requested block refs.
                             if !requested_block_refs_set.contains(&serialized_tx.block_ref) {
                                 return Err(ConsensusError::UnexpectedTransactionForCommit {
                                     peer: target_authority,
@@ -806,7 +806,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             FuturesOrdered::new()
         };
 
-        // 8. Process header and transaction requests concurrently
+        // 12. Process header and transaction requests concurrently
         let mut fetched_block_headers = BTreeMap::new();
         let mut fetched_transactions = BTreeMap::new();
 
@@ -824,7 +824,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             }
         }
 
-        // 9. Verify transactions
+        // 13. Verify transactions
         let mut transactions_map = if !fetched_transactions.is_empty() {
             Handle::current()
                 .spawn_blocking({
@@ -844,7 +844,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             BTreeMap::new()
         };
 
-        // 10. Now create the Certified commits by assigning the block headers and
+        // 14. Now create the Certified commits by assigning the block headers and
         //     transactions to each commit and retaining the commit votes history.
         let mut certified_commits = Vec::new();
         for commit in &commits {

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -51,8 +51,10 @@ use tokio::{
 use tracing::{debug, info, warn};
 
 use crate::{
-    CommitConsumerMonitor, CommitIndex, VerifiedBlockHeader,
-    block_header::{BlockHeaderAPI, SignedBlockHeader},
+    CommitConsumerMonitor, CommitIndex, Transaction, VerifiedBlockHeader,
+    block_header::{
+        BlockHeaderAPI, BlockRef, SignedBlockHeader, TransactionsCommitment, VerifiedTransactions,
+    },
     block_verifier::BlockVerifier,
     commit::{
         CertifiedCommit, CertifiedCommits, Commit, CommitAPI as _, CommitDigest, CommitRange,
@@ -62,8 +64,9 @@ use crate::{
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
+    encoder::create_encoder,
     error::{ConsensusError, ConsensusResult},
-    network::NetworkClient,
+    network::{NetworkClient, SerializedTransactions},
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     transactions_synchronizer::TransactionsSynchronizerHandle,
 };
@@ -362,11 +365,13 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             .commit_sync_fetch_missing_block_headers
                             .with_label_values(&[hostname])
                             .inc();
+                        // TODO: add fetch missing transactions metric
                     }
                     if !missing_committed_txns.is_empty() {
                         info!(
-                            "Fetched blocks have missing committed transactions: {:?} for commit range {:?}",
-                            missing_committed_txns, fetched_commit_range
+                            "Fetched blocks have {} missing committed transactions for commit range {:?}",
+                            missing_committed_txns.len(),
+                            fetched_commit_range
                         );
                         // TODO: https://github.com/iotaledger/iota/issues/8376
                         // Decide whether to rely on periodic transactions
@@ -378,8 +383,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             .await
                         {
                             warn!(
-                                "Error while trying to fetch missing
-                         transactions via transactions synchronizer: {err}"
+                                "Error while trying to fetch missing transactions via transactions synchronizer: {err}"
                             );
                         }
                     }
@@ -609,7 +613,26 @@ impl<C: NetworkClient> CommitSyncer<C> {
             .expect("Spawn blocking should not fail")?;
 
         // 3. Fetch block headers referenced by the commits, from the same authority.
-        let block_refs: Vec<_> = commits.iter().flat_map(|c| c.blocks()).cloned().collect();
+        let mut block_refs: Vec<_> = commits.iter().flat_map(|c| c.blocks()).cloned().collect();
+
+        // 3a. Collect all committed transaction block refs from commits
+        let committed_tx_refs: Vec<BlockRef> = commits
+            .iter()
+            .flat_map(|c| c.committed_transactions())
+            .collect();
+
+        // 3b. Identify which committed transaction blocks are NOT in the committed
+        // blocks list and add them to block_refs so they get fetched together
+        let block_refs_set: BTreeSet<_> = block_refs.iter().cloned().collect();
+        let missing_tx_header_refs: Vec<BlockRef> = committed_tx_refs
+            .iter()
+            .filter(|tx_ref| !block_refs_set.contains(tx_ref))
+            .cloned()
+            .collect();
+
+        // Merge missing transaction headers into the main block_refs list
+        block_refs.extend(missing_tx_header_refs);
+
         let num_chunks = block_refs
             .len()
             .div_ceil(inner.context.parameters.max_headers_per_commit_sync_fetch)
@@ -671,15 +694,88 @@ impl<C: NetworkClient> CommitSyncer<C> {
             })
             .collect();
 
+        // 7. Create transaction fetch requests (will be processed concurrently with
+        //    headers)
+        let mut transaction_requests: FuturesOrdered<_> = if !committed_tx_refs.is_empty() {
+            let num_tx_chunks = committed_tx_refs
+                .len()
+                .div_ceil(inner.context.parameters.max_headers_per_commit_sync_fetch)
+                as u32;
+            committed_tx_refs
+                .chunks(inner.context.parameters.max_headers_per_commit_sync_fetch)
+                .enumerate()
+                .map(|(i, request_block_refs)| {
+                    let inner = inner.clone();
+                    async move {
+                        sleep(timeout * i as u32 / num_tx_chunks.max(1)).await;
+                        let serialized_transactions = inner
+                            .network_client
+                            .fetch_transactions(
+                                target_authority,
+                                request_block_refs.to_vec(),
+                                timeout,
+                            )
+                            .await?;
+
+                        // Deserialize to extract BlockRef and build a map directly
+                        let mut result = BTreeMap::new();
+                        for serialized_bytes in serialized_transactions {
+                            let serialized_tx: SerializedTransactions =
+                                bcs::from_bytes(&serialized_bytes)
+                                    .map_err(ConsensusError::MalformedTransactions)?;
+                            result.insert(
+                                serialized_tx.block_ref,
+                                serialized_tx.serialized_transactions,
+                            );
+                        }
+                        Ok::<BTreeMap<BlockRef, Bytes>, ConsensusError>(result)
+                    }
+                })
+                .collect()
+        } else {
+            FuturesOrdered::new()
+        };
+
+        // 8. Process header and transaction requests concurrently
         let mut fetched_block_headers = BTreeMap::new();
-        while let Some(result) = requests.next().await {
-            for block_header in result? {
-                fetched_block_headers.insert(block_header.reference(), block_header);
+        let mut fetched_transactions = BTreeMap::new();
+
+        loop {
+            tokio::select! {
+                Some(result) = requests.next() => {
+                    for block_header in result? {
+                        fetched_block_headers.insert(block_header.reference(), block_header);
+                    }
+                }
+                Some(result) = transaction_requests.next() => {
+                    fetched_transactions.extend(result?);
+                }
+                else => break,
             }
         }
 
-        // 8. Now create the Certified commits by assigning the block headers to each
-        //    commit and retaining the commit votes history.
+        // 9. Verify transactions
+        let mut transactions_map = if !fetched_transactions.is_empty() {
+            Handle::current()
+                .spawn_blocking({
+                    let inner = inner.clone();
+                    let fetched_block_headers_clone = fetched_block_headers.clone();
+                    move || {
+                        inner.verify_transactions(
+                            target_authority,
+                            fetched_transactions,
+                            fetched_block_headers_clone,
+                        )
+                    }
+                })
+                .await
+                .expect("Spawn blocking should not fail")?
+        } else {
+            BTreeMap::new()
+        };
+
+        // 10. Now create the Certified commits by assigning the block headers and
+        //     transactions to each commit and retaining the commit votes history.
         let mut certified_commits = Vec::new();
         for commit in &commits {
             let block_headers = commit
@@ -691,9 +787,18 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         .expect("Block should exist")
                 })
                 .collect::<Vec<_>>();
+
+            // Collect transactions for this commit
+            let commit_transactions = commit
+                .committed_transactions()
+                .iter()
+                .filter_map(|tx_ref| transactions_map.remove(tx_ref))
+                .collect::<Vec<_>>();
+
             certified_commits.push(CertifiedCommit::new_certified(
                 commit.clone(),
                 block_headers,
+                commit_transactions,
             ));
         }
 
@@ -822,6 +927,61 @@ impl<C: NetworkClient> Inner<C> {
             .map(|((_d, c), s)| TrustedCommit::new_trusted(c, s))
             .collect();
         Ok(trusted_commits)
+    }
+
+    /// Verifies transactions against their block headers and returns a map of
+    /// BlockRef to VerifiedTransactions.
+    fn verify_transactions(
+        &self,
+        peer: AuthorityIndex,
+        serialized_transactions: BTreeMap<BlockRef, Bytes>,
+        block_headers: BTreeMap<BlockRef, VerifiedBlockHeader>,
+    ) -> ConsensusResult<BTreeMap<BlockRef, VerifiedTransactions>> {
+        let mut verified_transactions_map = BTreeMap::new();
+
+        for (block_ref, inner_serialized_transactions) in serialized_transactions {
+            // Step 1: Get the block header and verify that the transactions commitment
+            // matches. This ensures the transactions we received are exactly
+            // the ones that were included in the block when it was created.
+            let block_header = block_headers
+                .get(&block_ref)
+                .expect("header for fetched transactions must exist");
+
+            let mut encoder = create_encoder(&self.context);
+            if block_header.transactions_commitment()
+                != TransactionsCommitment::compute_transactions_commitment(
+                    &inner_serialized_transactions,
+                    &self.context,
+                    &mut encoder,
+                )
+                .expect("correct computation of the transactions commitment should be successful")
+            {
+                return Err(ConsensusError::TransactionCommitmentFailure {
+                    round: block_ref.round,
+                    author: block_ref.author,
+                    peer,
+                });
+            }
+
+            // Step 2: Deserialize and verify the actual transactions vector.
+            let transactions: Vec<Transaction> = bcs::from_bytes(&inner_serialized_transactions)
+                .map_err(ConsensusError::MalformedTransactions)?;
+
+            self.block_verifier
+                .check_and_verify_transactions(&transactions)?;
+
+            // Step 3: Create a VerifiedTransactions instance and insert into map
+            let verified_transactions = VerifiedTransactions::new(
+                transactions,
+                block_ref,
+                block_header.transactions_commitment(),
+                inner_serialized_transactions,
+            );
+
+            verified_transactions_map.insert(block_ref, verified_transactions);
+        }
+
+        Ok(verified_transactions_map)
     }
 }
 

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -342,6 +342,37 @@ impl<C: NetworkClient> CommitSyncer<C> {
                     .join(","),
             );
 
+            // Compare transactions available in CertifiedCommits with
+            // committed_transactions in TrustedCommits
+            let mut expected_transactions = BTreeSet::new();
+            let mut available_transactions = BTreeSet::new();
+
+            for certified_commit in commits.commits() {
+                // Collect committed_transactions from the TrustedCommit
+                for block_ref in certified_commit.committed_transactions() {
+                    expected_transactions.insert(block_ref);
+                }
+
+                // Collect available transactions from VerifiedTransactions
+                for verified_txns in certified_commit.transactions() {
+                    available_transactions.insert(verified_txns.block_ref());
+                }
+            }
+
+            // Find missing transactions
+            let missing_transactions: Vec<_> = expected_transactions
+                .difference(&available_transactions)
+                .collect();
+
+            if !missing_transactions.is_empty() {
+                warn!(
+                    "Missing {} transaction after fetching commit range {:?}: {:?}",
+                    missing_transactions.len(),
+                    fetched_commit_range,
+                    missing_transactions,
+                );
+            }
+
             // If core thread cannot handle the incoming blocks, it is ok to block here.
             // Also it is possible to have missing ancestors because an equivocating
             // validator may produce blocks that are not included in commits but
@@ -374,9 +405,12 @@ impl<C: NetworkClient> CommitSyncer<C> {
                     }
                     if !missing_committed_txns.is_empty() {
                         warn!(
-                            "Fetched blocks have {} missing committed transactions for commit range {:?}",
-                            missing_committed_txns.len(),
-                            fetched_commit_range
+                            "Missing committed transactions after adding commit range {:?} to DAG State : {}",
+                            fetched_commit_range,
+                            missing_committed_txns
+                                .iter()
+                                .map(|(b, _)| b.to_string())
+                                .join(","),
                         );
                         for (block_ref, _ack_authorities) in missing_committed_txns {
                             let hostname = &self
@@ -814,6 +848,8 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 .map(|block_ref| {
                     fetched_block_headers
                         .remove(block_ref)
+                        // safe to call .expect here as we make sure beforehand that all headers
+                        // from the commit are fetched
                         .expect("Block should exist")
                 })
                 .collect::<Vec<_>>();

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -1038,9 +1038,6 @@ impl<C: NetworkClient> Inner<C> {
             let transactions: Vec<Transaction> = bcs::from_bytes(&inner_serialized_transactions)
                 .map_err(ConsensusError::MalformedTransactions)?;
 
-            self.block_verifier
-                .check_and_verify_transactions(&transactions)?;
-
             // Step 3: Create a VerifiedTransactions instance and insert into map
             let verified_transactions = VerifiedTransactions::new(
                 transactions,

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -40,7 +40,11 @@ use futures::{StreamExt as _, stream::FuturesOrdered};
 use iota_metrics::spawn_logged_monitored_task;
 use itertools::Itertools as _;
 use parking_lot::RwLock;
-use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
+use rand::{
+    RngCore,
+    prelude::SliceRandom as _,
+    rngs::{OsRng, ThreadRng},
+};
 use starfish_config::AuthorityIndex;
 use tokio::{
     runtime::Handle,
@@ -366,8 +370,9 @@ impl<C: NetworkClient> CommitSyncer<C> {
 
             if !missing_transactions.is_empty() {
                 warn!(
-                    "Missing {} transaction after fetching commit range {:?}: {:?}",
+                    "Missing {} out of {} transactions after fetching commit range {:?}: {:?}",
                     missing_transactions.len(),
+                    expected_transactions.len(),
                     fetched_commit_range,
                     missing_transactions,
                 );
@@ -735,12 +740,19 @@ impl<C: NetworkClient> CommitSyncer<C> {
         // 7. Create transaction fetch requests (will be processed concurrently with
         //    headers)
         let mut transaction_requests: FuturesOrdered<_> = if !committed_tx_refs.is_empty() {
-            let num_tx_chunks = committed_tx_refs
-                .len()
-                .div_ceil(inner.context.parameters.max_headers_per_commit_sync_fetch)
-                as u32;
+            let num_tx_chunks = committed_tx_refs.len().div_ceil(
+                inner
+                    .context
+                    .parameters
+                    .max_transactions_per_commit_sync_fetch,
+            ) as u32;
             committed_tx_refs
-                .chunks(inner.context.parameters.max_headers_per_commit_sync_fetch)
+                .chunks(
+                    inner
+                        .context
+                        .parameters
+                        .max_transactions_per_commit_sync_fetch,
+                )
                 .enumerate()
                 .map(|(i, request_block_refs)| {
                     let inner = inner.clone();
@@ -764,11 +776,9 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         //    TransactionSynchronizer will take care of fetching missing
                         //    transactions later.
                         if request_block_refs.len() < serialized_transactions.len() {
-                            return Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
-                                authority: target_authority,
-                                requested: request_block_refs.len(),
-                                received_headers: serialized_transactions.len(),
-                            });
+                            return Err(ConsensusError::TooManyFetchedTransactionsReturned(
+                                target_authority,
+                            ));
                         }
                         let requested_block_refs_set: BTreeSet<_> =
                             request_block_refs.iter().cloned().collect();

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -40,11 +40,7 @@ use futures::{StreamExt as _, stream::FuturesOrdered};
 use iota_metrics::spawn_logged_monitored_task;
 use itertools::Itertools as _;
 use parking_lot::RwLock;
-use rand::{
-    RngCore,
-    prelude::SliceRandom as _,
-    rngs::{OsRng, ThreadRng},
-};
+use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
 use starfish_config::AuthorityIndex;
 use tokio::{
     runtime::Handle,
@@ -413,8 +409,8 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             "Missing committed transactions after adding commit range {:?} to DAG State : {}",
                             fetched_commit_range,
                             missing_committed_txns
-                                .iter()
-                                .map(|(b, _)| b.to_string())
+                                .keys()
+                                .map(|b| b.to_string())
                                 .join(","),
                         );
                         for (block_ref, _ack_authorities) in missing_committed_txns {

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -495,7 +495,7 @@ impl Core {
             .collect();
 
         if !all_transactions.is_empty() {
-            self.add_transactions(all_transactions, TransactionSource::TransactionSynchronizer)?;
+            self.add_transactions(all_transactions, TransactionSource::CommitSyncer)?;
         }
 
         // Then collect and add block headers.

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -483,6 +483,22 @@ impl Core {
         BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
     )> {
         let _scope = monitored_scope("Core::add_certified_commits");
+
+        // First, collect and add all transactions from certified commits.
+        // Transactions must be added before processing commits to ensure they are
+        // available when creating new commits.
+        let all_transactions: Vec<VerifiedTransactions> = certified_commits
+            .commits()
+            .iter()
+            .flat_map(|commit| commit.transactions())
+            .cloned()
+            .collect();
+
+        if !all_transactions.is_empty() {
+            self.add_transactions(all_transactions, TransactionSource::TransactionSynchronizer)?;
+        }
+
+        // Then collect and add block headers.
         let block_headers = certified_commits
             .commits()
             .iter()

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -71,6 +71,7 @@ impl TransactionSource {
             TransactionSource::TransactionSynchronizer => "Transactions synchronizer",
             TransactionSource::BlockStreaming => "Block streaming",
             TransactionSource::ShardReconstructor => "Shard reconstructor",
+            TransactionSource::CommitSyncer => "Commit syncer",
             #[cfg(test)]
             TransactionSource::Test => "test",
         }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -53,6 +53,10 @@ pub(crate) enum TransactionSource {
     /// have been collected to reconstruct it.
     ShardReconstructor,
 
+    /// Transactions received via commit synchronization. Transactions are
+    /// fetched for all the committed blocks in synced commits.
+    CommitSyncer,
+
     /// Data added during testing.
     /// Only used in test code.
     #[cfg(test)]

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -126,7 +126,7 @@ pub(crate) struct DagState {
     /// Highest round of blocks accepted.
     highest_accepted_round: Round,
 
-    /// Last consensus commit of the dag.
+    /// Last pending consensus commit of the dag.
     last_commit: Option<TrustedCommit>,
 
     /// Last wall time when commit round advanced. Does not persist across

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -78,9 +78,6 @@ pub(crate) enum ConsensusError {
     )]
     TooManyFetchedTransactionsReturned(AuthorityIndex),
 
-    #[error("Too many block headers have been rteurned from authority {0}")]
-    TooManyFetchedHeadersReturned(AuthorityIndex),
-
     #[error("Too many authorities have been provided from authority {0}")]
     TooManyAuthoritiesProvided(AuthorityIndex),
 
@@ -181,10 +178,16 @@ pub(crate) enum ConsensusError {
         commit: Box<Commit>,
     },
 
-    #[error("Received unexpected block from peer {peer}: {requested:?} vs {received:?}")]
-    UnexpectedBlockForCommit {
+    #[error("Received unexpected block header from peer {peer}: {requested:?} vs {received:?}")]
+    UnexpectedBlockHeaderForCommit {
         peer: AuthorityIndex,
         requested: BlockRef,
+        received: BlockRef,
+    },
+
+    #[error("Received unexpected transaction from peer {peer}: {received:?}")]
+    UnexpectedTransactionForCommit {
+        peer: AuthorityIndex,
         received: BlockRef,
     },
 

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -674,8 +674,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 .await
             {
                 warn!(
-                    "Error while trying to fetch missing transactions via
-             transactions synchronizer: {err}"
+                    "Error while trying to fetch missing transactions via transactions synchronizer: {err}"
                 );
             }
         }

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -569,7 +569,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
     /// no error is returned then the verified blocks are immediately sent
     /// to Core for processing.
     async fn process_fetched_headers_from_authority(
-        serialized_headers: Vec<Bytes>,
+        mut serialized_headers: Vec<Bytes>,
         peer_index: AuthorityIndex,
         requested_blocks_guard: BlocksGuard,
         core_dispatcher: Arc<D>,
@@ -584,7 +584,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
             return Ok(());
         }
         if serialized_headers.len() > context.parameters.max_headers_per_regular_sync_fetch {
-            return Err(ConsensusError::TooManyFetchedHeadersReturned(peer_index));
+            debug!(
+                "Truncating fetched headers from peer {} to max allowed {} blocks",
+                peer_index, context.parameters.max_headers_per_regular_sync_fetch
+            );
+            serialized_headers.truncate(context.parameters.max_headers_per_regular_sync_fetch);
         }
 
         // Verify all the fetched block headers

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -930,7 +930,7 @@ impl NodeMetrics {
                 registry
             ).unwrap(),
             commit_sync_fetch_missing_transactions: register_int_counter_vec_with_registry!(
-                "commit_sync_fetch_missing_block_headers",
+                "commit_sync_fetch_missing_transactions",
                 "Number of committed transactions that are missing when processing transactions via commit sync.",
                 &["authority"],
                 registry

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -215,6 +215,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_fetched_commits: IntCounter,
     pub(crate) commit_sync_fetched_block_headers: IntCounter,
     pub(crate) commit_sync_total_fetched_block_headers_size: IntCounter,
+    pub(crate) commit_sync_total_fetched_transactions_size: IntCounter,
     pub(crate) commit_sync_quorum_index: IntGauge,
     pub(crate) commit_sync_highest_synced_index: IntGauge,
     pub(crate) commit_sync_highest_fetched_index: IntGauge,
@@ -224,6 +225,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_fetch_once_latency: Histogram,
     pub(crate) commit_sync_fetch_once_errors: IntCounterVec,
     pub(crate) commit_sync_fetch_missing_block_headers: IntCounterVec,
+    pub(crate) commit_sync_fetch_missing_transactions: IntCounterVec,
     pub(crate) uptime: Histogram,
 }
 
@@ -868,6 +870,11 @@ impl NodeMetrics {
                 "The total size in bytes of block headers fetched via commit syncer",
                 registry,
             ).unwrap(),
+            commit_sync_total_fetched_transactions_size: register_int_counter_with_registry!(
+                "commit_sync_total_fetched_transactions_size",
+                "The total size in bytes of transactions fetched via commit syncer",
+                registry,
+            ).unwrap(),
             commit_sync_quorum_index: register_int_gauge_with_registry!(
                 "commit_sync_quorum_index",
                 "The maximum commit index voted by a quorum of authorities",
@@ -919,6 +926,12 @@ impl NodeMetrics {
             commit_sync_fetch_missing_block_headers: register_int_counter_vec_with_registry!(
                 "commit_sync_fetch_missing_block_headers",
                 "Number of ancestor block headers that are missing when processing headers via commit sync.",
+                &["authority"],
+                registry
+            ).unwrap(),
+            commit_sync_fetch_missing_transactions: register_int_counter_vec_with_registry!(
+                "commit_sync_fetch_missing_block_headers",
+                "Number of committed transactions that are missing when processing transactions via commit sync.",
                 &["authority"],
                 registry
             ).unwrap(),

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -361,12 +361,11 @@ impl DagBuilder {
             .map(|(sub_dag, commit)| {
                 // TODO: we need to request real blocks from sub_dag after we add the
                 // corresponding field and logic in sub_dag
-                let mut block_headers = vec![];
-                for block_header in sub_dag.headers.iter() {
-                    block_headers.push(block_header.clone());
-                }
+                let block_headers = sub_dag.headers.clone();
+                let transactions = sub_dag.transactions.clone();
 
-                let certified_commit = CertifiedCommit::new_certified(commit, block_headers);
+                let certified_commit =
+                    CertifiedCommit::new_certified(commit, block_headers, transactions);
                 (sub_dag, certified_commit)
             })
             .collect()

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -447,7 +447,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
     }
 
     // The main loop to listen for the submitted commands.
-    #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %self.context.own_index)))]
+    #[cfg_attr(test, tracing::instrument(skip_all, name = "", fields(authority = %self.context.own_index
+    )))]
     async fn run(&mut self) {
         // We want the transactions synchronizer to run periodically to
         // fetch any missing transactions.
@@ -1070,9 +1071,14 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
             // Step 2: Get the block header and verify that the transactions commitment
             // matches. This ensures the transactions we received are exactly
             // the ones that were included in the block when it was created.
-            let block_header = block_headers_map
-                .get(&serialized_transactions.block_ref)
-                .expect("header for fetched transactions must exist");
+            let Some(block_header) = block_headers_map.get(&serialized_transactions.block_ref)
+            else {
+                warn!(
+                    "Received transactions for unknown block ref {:?} from peer {}",
+                    serialized_transactions.block_ref, peer_index
+                );
+                continue;
+            };
 
             let mut encoder = create_encoder(&context);
             if block_header.transactions_commitment()

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -753,7 +753,7 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                 .lock_transactions_and_active_request(
                     authority_block_refs.clone(),
                     authority,
-                    context.parameters.max_transactions_per_fetch,
+                    context.parameters.max_transactions_per_regular_sync_fetch,
                     sync_method,
                     active_requests.clone(),
                 )
@@ -1942,7 +1942,7 @@ mod tests {
             let guard = map.lock_transactions_and_active_request(
                 missing_block_refs.clone(),
                 authority,
-                context.parameters.max_transactions_per_fetch,
+                context.parameters.max_transactions_per_regular_sync_fetch,
                 sync_method,
                 active_requests.clone(),
             );
@@ -1964,7 +1964,7 @@ mod tests {
             let guard = map.lock_transactions_and_active_request(
                 missing_block_refs.clone(),
                 authority,
-                context.parameters.max_transactions_per_fetch,
+                context.parameters.max_transactions_per_regular_sync_fetch,
                 sync_method,
                 active_requests.clone(),
             );
@@ -1979,7 +1979,7 @@ mod tests {
         let guard = map.lock_transactions_and_active_request(
             missing_block_refs.clone(),
             AuthorityIndex::new_for_test(MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION as u8),
-            context.parameters.max_transactions_per_fetch,
+            context.parameters.max_transactions_per_regular_sync_fetch,
             sync_method,
             active_requests.clone(),
         );


### PR DESCRIPTION
# Description of change

This PR adds proactive transaction fetching during commit syncing to improve synchronization for nodes that are far behind or syncing from scratch.

Previously, the consensus layer relied on `TransactionsSynchronizer` for fetching missing transactions, which is tuned for filling recent small gaps. When a node is far behind, it needs to fetch large amounts of transactions, which the current synchronizer is not optimized for.

During commit syncing, the `CommitSyncer` now:
1. Identifies committed transaction block references from commits being synced
2. Fetches transaction data directly from the peer authority alongside block headers
3. Verifies transactions against their block headers to ensure integrity
4. Adds verified transactions to the DAG before processing commits

Key changes:
- **commit.rs**: Extended `CertifiedCommit` to include verified transactions alongside block headers
- **commit_syncer.rs**: Added logic to identify and collect transaction block references, implemented concurrent fetching with staggered timing, and added transaction verification
- **core.rs**: Integrated transaction extraction from certified commits before processing
- **test_dag_builder.rs**: Updated test utilities to support transaction data

## Links to any relevant issues

Resolves #9163

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes