### PR TITLE
fix(consensus): track failures to choose optimal peers and adjust parameters in the Starfish transaction synchronizer

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -148,7 +148,7 @@ impl Parameters {
 
     // Maximum number of transactions to fetch per request.
     pub(crate) fn default_max_transactions_per_fetch() -> usize {
-        if cfg!(msim) { 10 } else { 100 }
+        if cfg!(msim) { 10 } else { 1000 }
     }
 
     pub(crate) fn default_sync_last_known_own_block_timeout() -> Duration {

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -13,7 +13,7 @@ max_forward_time_drift:
   nanos: 500000000
 max_headers_per_commit_sync_fetch: 1000
 max_headers_per_regular_sync_fetch: 100
-max_transactions_per_fetch: 100
+max_transactions_per_fetch: 1000
 sync_last_known_own_block_timeout:
   secs: 5
   nanos: 0

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -181,7 +181,6 @@ impl ConsensusAuthority {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1315,7 +1315,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -1393,7 +1392,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -1482,7 +1480,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -1562,7 +1559,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -1700,7 +1696,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -1827,7 +1822,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -2094,7 +2088,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -2250,7 +2243,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -2422,7 +2414,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -2738,7 +2729,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -2880,7 +2870,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -3043,7 +3032,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -3228,7 +3216,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -930,7 +930,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_thread_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
         let mut commit_syncer = CommitSyncer::new(

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -1668,7 +1668,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -1737,7 +1736,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 
@@ -1820,7 +1818,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
         // Create some test block headers
@@ -1932,7 +1929,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
         // AND stub some missing blocks. The highest accepted round is 0.
@@ -2068,7 +2064,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
         // AND stub some missing blocks. The highest accepted round is 0. Create blocks
@@ -2219,7 +2214,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
         // Create some test block headers
@@ -2722,7 +2716,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
 

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -203,7 +203,6 @@ mod tests {
     use crate::{
         BlockRef, Round, TestBlockHeader,
         block_header::VerifiedBlock,
-        block_verifier::NoopBlockVerifier,
         commit::CommitRange,
         context::Context,
         core::{CoreSignals, ReasonToCreateBlock},
@@ -286,12 +285,10 @@ mod tests {
         let start = Instant::now();
 
         let (mut signals, signal_receivers) = CoreSignals::new(context.clone());
-        let block_verifier = Arc::new(NoopBlockVerifier {});
         let transactions_synchronizer = TransactionsSynchronizer::start(
             Arc::new(FakeNetworkClient::default()),
             context.clone(),
             dispatcher.clone(),
-            block_verifier,
             Arc::new(RwLock::new(DagState::new(
                 context.clone(),
                 Arc::new(MemStore::new()),
@@ -381,13 +378,11 @@ mod tests {
             ..Default::default()
         };
         let context = Arc::new(context.with_parameters(parameters));
-        let block_verifier = Arc::new(NoopBlockVerifier {});
 
         let transactions_synchronizer = TransactionsSynchronizer::start(
             Arc::new(FakeNetworkClient::default()),
             context.clone(),
             dispatcher.clone(),
-            block_verifier.clone(),
             Arc::new(RwLock::new(DagState::new(
                 context.clone(),
                 Arc::new(MemStore::new()),

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -35,7 +35,7 @@ use crate::{
 
 const EVICTION_TIMEOUT: Duration = Duration::from_secs(1);
 
-const SEND_TO_CORE_RECONSTRUCTED_TXS_TIMEOUT: Duration = Duration::from_millis(100);
+const SEND_TO_CORE_RECONSTRUCTED_TXS_TIMEOUT: Duration = Duration::from_millis(20);
 const NUMBER_OF_RECONSTRUCTION_WORKERS: usize = 5;
 
 /// Using transaction messages we update the state of shard reconstructor

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -92,12 +92,15 @@ impl SyncMethod {
 /// fetching from peers.
 struct LastFailureByPeer {
     inner: Mutex<Vec<Option<Instant>>>,
+    context: Context,
 }
 
 impl LastFailureByPeer {
-    fn new(committee_size: usize) -> Arc<Self> {
+    fn new(context: &Context) -> Arc<Self> {
+        let committee_size = context.committee.size();
         Arc::new(Self {
             inner: Mutex::new(vec![None; committee_size]),
+            context: context.clone(),
         })
     }
     fn update_with_new_instant(self: &Arc<Self>, peer: AuthorityIndex, new_instant: Instant) {
@@ -107,10 +110,7 @@ impl LastFailureByPeer {
 
     /// Determine which authorities are less reliable to fetch transactions.
     /// Returns less than f+1 authorities by stake.
-    fn get_excluded_authorities_by_stake(
-        self: &Arc<Self>,
-        context: &Context,
-    ) -> BTreeSet<AuthorityIndex> {
+    fn get_excluded_authorities_by_stake(self: &Arc<Self>) -> BTreeSet<AuthorityIndex> {
         let last_round_by_peer = { self.inner.lock().clone() };
 
         let mut indexed_rounds: Vec<(AuthorityIndex, Instant)> = last_round_by_peer
@@ -126,8 +126,8 @@ impl LastFailureByPeer {
         let mut excluded_authorities = BTreeSet::new();
         let mut stake = 0;
         for (authority_index, _last_instant) in indexed_rounds {
-            stake += context.committee.stake(authority_index);
-            if context.committee.reached_validity(stake) {
+            stake += self.context.committee.stake(authority_index);
+            if self.context.committee.reached_validity(stake) {
                 break;
             }
             excluded_authorities.insert(authority_index);
@@ -415,7 +415,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
 
         let mut tasks = JoinSet::new();
         let active_requests = InflightActiveRequests::new();
-        let last_failure_by_peer = LastFailureByPeer::new(context.committee.size());
+        let last_failure_by_peer = LastFailureByPeer::new(&context);
         // Spawn the live fetcher task
         let live_fetcher_async = Self::live_fetcher(
             active_requests.clone(),
@@ -746,8 +746,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 Box::new(blocks_by_authority.into_iter())
             } else {
                 // Get less than f+1 excluded authorities by stake
-                let excluded_authorities =
-                    last_failure_by_peer.get_excluded_authorities_by_stake(&context);
+                let excluded_authorities = last_failure_by_peer.get_excluded_authorities_by_stake();
                 // Exclude authorities with latest recorded failures
                 let mut vec: Vec<_> = blocks_by_authority
                     .into_iter()
@@ -2030,6 +2029,70 @@ mod tests {
         drop(all_guards);
 
         assert_eq!(map.num_of_locked_transactions(), 0);
+    }
+
+    #[tokio::test]
+    async fn excluded_authorities_updates_and_results() {
+        telemetry_subscribers::init_for_testing();
+
+        // GIVEN a committee of 7 authorities
+        let (context, _) = Context::new_for_test(7);
+        let context = Arc::new(context);
+
+        let last_failure = LastFailureByPeer::new(&context);
+        let now = Instant::now();
+
+        // WHEN: no updates → excluded set should be empty
+        let mut excluded = last_failure.get_excluded_authorities_by_stake();
+        assert!(
+            excluded.is_empty(),
+            "Initially no authorities should be excluded"
+        );
+
+        // WHEN: authority 1 fails now
+        last_failure.update_with_new_instant(AuthorityIndex::new_for_test(1), now);
+        excluded = last_failure.get_excluded_authorities_by_stake();
+        assert!(
+            excluded.contains(&AuthorityIndex::new_for_test(1)),
+            "Authority 1 should be excluded after failure"
+        );
+
+        // WHEN: authority 2 fails later
+        last_failure.update_with_new_instant(
+            AuthorityIndex::new_for_test(2),
+            now + Duration::from_millis(50),
+        );
+        excluded = last_failure.get_excluded_authorities_by_stake();
+        assert!(
+            excluded.contains(&AuthorityIndex::new_for_test(2)),
+            "Authority 2 (latest failure) should be excluded"
+        );
+        assert!(
+            excluded.contains(&AuthorityIndex::new_for_test(1)),
+            "Authority 1 should remain excluded as an older failure"
+        );
+
+        // WHEN: authority 3 fails even later (newest)
+        last_failure.update_with_new_instant(
+            AuthorityIndex::new_for_test(3),
+            now + Duration::from_millis(100),
+        );
+        excluded = last_failure.get_excluded_authorities_by_stake();
+
+        // THEN: authority 3 should now be the first excluded one (most recent),
+        // but the total excluded stake must remain below the validity threshold.
+        assert!(
+            excluded.contains(&AuthorityIndex::new_for_test(3)),
+            "Newest failed authority (3) should be excluded"
+        );
+        assert!(
+            excluded.contains(&AuthorityIndex::new_for_test(2)),
+            "Newest failed authority (3) should be excluded"
+        );
+        assert!(
+            excluded.len() <= 2,
+            "Excluded authorities should be strictly less than f+1 stake limit"
+        );
     }
 
     struct MockNetworkClient {

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -370,10 +370,7 @@ impl TransactionsSynchronizerHandle {
 ///    periodic basis or is triggered immediately after explicit fetches
 ///    described in (1), ensuring continued transaction retrieval if gaps
 ///    persist.
-pub(crate) struct TransactionsSynchronizer<
-    C: NetworkClient,
-    D: CoreThreadDispatcher,
-> {
+pub(crate) struct TransactionsSynchronizer<C: NetworkClient, D: CoreThreadDispatcher> {
     context: Arc<Context>,
     commands_receiver: Receiver<Command>,
     live_fetch_requests: Sender<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>,
@@ -387,9 +384,7 @@ pub(crate) struct TransactionsSynchronizer<
     last_failure_by_peer: Arc<LastFailureByPeer>,
 }
 
-impl<C: NetworkClient, D: CoreThreadDispatcher>
-    TransactionsSynchronizer<C, D>
-{
+impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
     /// Starts the transactions synchronizer, which is responsible for fetching
     /// transactions from other authorities and managing transaction
     /// synchronization tasks.
@@ -1143,7 +1138,6 @@ mod tests {
             BlockHeaderDigest, BlockRef, TransactionsCommitment, VerifiedBlock,
             VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
         },
-        block_verifier::NoopBlockVerifier,
         commit::{CertifiedCommits, CommitRange},
         context::Context,
         core::ReasonToCreateBlock,
@@ -1159,7 +1153,6 @@ mod tests {
         // GIVEN
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
         let store = Arc::new(MemStore::new());
@@ -1170,7 +1163,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
         let mut encoder = create_encoder(&context);
@@ -1261,7 +1253,6 @@ mod tests {
         // GIVEN
         let (context, _) = Context::new_for_test(LIVE_FETCH_TRANSACTIONS_CONCURRENCY * 3);
         let context = Arc::new(context);
-        let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
         let store = Arc::new(MemStore::new());
@@ -1272,7 +1263,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
         let mut encoder = create_encoder(&context);
@@ -1379,7 +1369,6 @@ mod tests {
         // GIVEN
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
         let store = Arc::new(MemStore::new());
@@ -1390,7 +1379,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
         let mut encoder = create_encoder(&context);
@@ -1500,7 +1488,6 @@ mod tests {
         // GIVEN
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
         let store = Arc::new(MemStore::new());
@@ -1511,7 +1498,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
         let mut encoder = create_encoder(&context);
@@ -1610,7 +1596,6 @@ mod tests {
         // GIVEN
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
         let store = Arc::new(MemStore::new());
@@ -1621,7 +1606,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
         let mut encoder = create_encoder(&context);
@@ -1722,7 +1706,6 @@ mod tests {
         // GIVEN
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
         let store = Arc::new(MemStore::new());
@@ -1733,7 +1716,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
         let mut encoder = create_encoder(&context);
@@ -1834,7 +1816,6 @@ mod tests {
         // GIVEN
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
         let store = Arc::new(MemStore::new());
@@ -1845,7 +1826,6 @@ mod tests {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            block_verifier.clone(),
             dag_state.clone(),
         );
         let mut encoder = create_encoder(&context);

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -125,7 +125,7 @@ impl LastFailureByPeer {
 
         let mut excluded_authorities = BTreeSet::new();
         let mut stake = 0;
-        for (authority_index, last_instant) in indexed_rounds {
+        for (authority_index, _last_instant) in indexed_rounds {
             stake += context.committee.stake(authority_index);
             if context.committee.reached_validity(stake) {
                 break;

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -106,8 +106,11 @@ impl LastFailureByPeer {
     }
 
     /// Determine which authorities are less reliable to fetch transactions.
-    /// Leave at least f+1 authorities.
-    fn get_excluded_authorities(self: &Arc<Self>) -> BTreeSet<AuthorityIndex> {
+    /// Returns less than f+1 authorities by stake.
+    fn get_excluded_authorities_by_stake(
+        self: &Arc<Self>,
+        context: &Context,
+    ) -> BTreeSet<AuthorityIndex> {
         let last_round_by_peer = { self.inner.lock().clone() };
 
         let mut indexed_rounds: Vec<(AuthorityIndex, Instant)> = last_round_by_peer
@@ -120,13 +123,15 @@ impl LastFailureByPeer {
 
         indexed_rounds.sort_by_key(|&(_, instant)| std::cmp::Reverse(instant));
 
-        // Exclude at most 2/3 of authorities with latest failures
-        let exclude_count = 2 * (last_round_by_peer.len() - 1) / 3;
-        let excluded_authorities: BTreeSet<AuthorityIndex> = indexed_rounds
-            .into_iter()
-            .take(exclude_count)
-            .map(|(idx, _)| idx)
-            .collect();
+        let mut excluded_authorities = BTreeSet::new();
+        let mut stake = 0;
+        for (authority_index, last_instant) in indexed_rounds {
+            stake += context.committee.stake(authority_index);
+            if context.committee.reached_validity(stake) {
+                break;
+            }
+            excluded_authorities.insert(authority_index);
+        }
 
         excluded_authorities
     }
@@ -740,7 +745,9 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 // Stable order for tests
                 Box::new(blocks_by_authority.into_iter())
             } else {
-                let excluded_authorities = last_failure_by_peer.get_excluded_authorities();
+                // Get less than f+1 excluded authorities by stake
+                let excluded_authorities =
+                    last_failure_by_peer.get_excluded_authorities_by_stake(&context);
                 // Exclude authorities with latest recorded failures
                 let mut vec: Vec<_> = blocks_by_authority
                     .into_iter()

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -197,9 +197,10 @@ impl InflightTransactionsMap {
     /// Locks the transactions to be fetched for the assigned `peer`. We
     /// want to avoid re-fetching the missing transactions from too many
     /// authorities at the same time, thus we limit the concurrency per
-    /// transaction by attempting to lock per block. In addition, we check
+    /// transaction by attempting to lock per block_ref. In addition, we check
     /// whether a given `peer` has many concurrent requests. If so, we will
-    /// not lock transactions. The method return
+    /// not lock transactions. The method return optionally two guards. One for the fetched transactions
+    /// and one for active fetch request.
     fn lock_transactions_and_active_request(
         self: &Arc<Self>,
         missing_block_refs: BTreeSet<BlockRef>,

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -813,8 +813,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             if let Err(err) = result {
                 last_failure_by_peer.update_with_new_instant(peer, Instant::now());
                 warn!(
-                    "[{}] Error when fetching and processing transactions from authority: {err}",
-                    sync_method.get_string()
+                    "[{}] Error when fetching and processing transactions from authority {peer}: {err}",
+                    sync_method.get_string(),
                 );
             }
         }

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -56,9 +56,8 @@ const PERIODIC_FETCH_TRANSACTIONS_CONCURRENCY: usize = 4;
 const MAX_CONCURRENT_REQUESTS_PER_AUTHORITY: usize = 2;
 
 /// The maximum number of assigned peers per one call of transaction fetch
-/// It allows to globally limit the number of spawned tasks by the transaction
-/// synchronizer: LIVE_FETCH_TRANSACTIONS_CONCURRENCY *
-/// PERIODIC_FETCH_TRANSACTIONS_CONCURRENCY *
+/// It allows to globally limit the number of spawned tasks by
+/// (LIVE_FETCH_TRANSACTIONS_CONCURRENCY + PERIODIC_FETCH_TRANSACTIONS_CONCURRENCY) *
 /// MAX_ASSIGNED_AUTHORITIES_PER_TRANSACTION_FETCH
 const MAX_ASSIGNED_AUTHORITIES_PER_TRANSACTION_FETCH: usize = 4;
 
@@ -105,10 +104,12 @@ impl LastFailureByPeer {
         inner[peer] = Some(new_instant);
     }
 
+    /// Determine which authorities are less reliable to fetch transactions. Leave at least f+1
+    /// authorities.
     fn get_excluded_authorities(self: &Arc<Self>) -> BTreeSet<AuthorityIndex> {
         let last_round_by_peer = { self.inner.lock().clone() };
 
-        // Determine which authorities to exclude
+
         let mut indexed_rounds: Vec<(AuthorityIndex, Instant)> = last_round_by_peer
             .iter()
             .enumerate()
@@ -119,8 +120,8 @@ impl LastFailureByPeer {
 
         indexed_rounds.sort_by_key(|&(_, instant)| std::cmp::Reverse(instant));
 
-        // Exclude 2/3 of authorities with latest failures
-        let exclude_count = 2 * last_round_by_peer.len() / 3;
+        // Exclude at most 2/3 of authorities with latest failures
+        let exclude_count = 2 * (last_round_by_peer.len() - 1 ) / 3;
         let excluded_authorities: BTreeSet<AuthorityIndex> = indexed_rounds
             .into_iter()
             .take(exclude_count)
@@ -131,7 +132,7 @@ impl LastFailureByPeer {
     }
 }
 
-/// Tracks the number of concurrent requests to each peer. Counts the number of
+/// Tracks the number of concurrent transaction fetch requests to each peer. Counts the number of
 /// fetch requests separately for periodic and live transaction synchronizer as
 /// they serve different purposes.
 struct InflightActiveRequests {

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -27,7 +27,7 @@ use tokio::{
     runtime::Handle,
     sync::{Semaphore, mpsc::error::TrySendError, oneshot},
     task::{JoinError, JoinSet},
-    time::{Instant, sleep, sleep_until, timeout},
+    time::{Instant, sleep_until, timeout},
 };
 use tracing::{debug, info, warn};
 
@@ -44,27 +44,34 @@ use crate::{
 };
 
 /// The number of concurrent live transaction fetch requests
-const LIVE_FETCH_TRANSACTIONS_CONCURRENCY: usize = 1;
-const PERIODIC_FETCH_TRANSACTIONS_CONCURRENCY: usize = 1;
+/// Set to the maximum number of rounds per second as it can be called by newly
+/// produced commits only
+const LIVE_FETCH_TRANSACTIONS_CONCURRENCY: usize = 20;
+
+/// The number of concurrent periodic transaction fetch requests
+const PERIODIC_FETCH_TRANSACTIONS_CONCURRENCY: usize = 4;
 
 /// The maximum number of concurrent request per authority for fetching
-/// transactions Used separately for live fetches and periodic fetches.
-const MAX_CONCURRENT_REQUESTS_PER_AUTHORITY: usize = 5;
+/// transactions. It is used separately for live and periodic fetches
+const MAX_CONCURRENT_REQUESTS_PER_AUTHORITY: usize = 2;
+
+/// The maximum number of assigned peers per one call of transaction fetch
+/// It allows to globally limit the number of spawned tasks by the transaction
+/// synchronizer: LIVE_FETCH_TRANSACTIONS_CONCURRENCY *
+/// PERIODIC_FETCH_TRANSACTIONS_CONCURRENCY *
+/// MAX_ASSIGNED_AUTHORITIES_PER_TRANSACTION_FETCH
+const MAX_ASSIGNED_AUTHORITIES_PER_TRANSACTION_FETCH: usize = 4;
 
 /// Timeout for the transactions synchronizer to run periodically and fetch
 /// missing transactions.
-const TRANSACTIONS_SYNCHRONIZER_TIMEOUT: Duration = Duration::from_millis(200);
+const TRANSACTIONS_SYNCHRONIZER_TIMEOUT: Duration = Duration::from_millis(500);
 
-/// Timeout to fetch transactions from a given peer.
-const FETCH_REQUEST_TIMEOUT: Duration = Duration::from_millis(500);
-
-/// Timeout to fetch and process transactions from all peers in one call of
-/// `fetch_and_process_transactions_from_authorities`.
-const FETCH_AND_PROCESS_FROM_PEERS_TIMEOUT: Duration = Duration::from_millis(700);
+/// Timeout that is given to fetch transactions from a given peer.
+const FETCH_REQUEST_TIMEOUT: Duration = Duration::from_millis(2000);
 
 /// Maximum number of authorities that can concurrently fetch transactions for a
 /// given block ref.
-const MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION: usize = 3;
+const MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION: usize = 2;
 
 #[derive(Debug, Clone, Copy, Ord, Eq, PartialOrd, PartialEq)]
 enum SyncMethod {
@@ -81,36 +88,80 @@ impl SyncMethod {
     }
 }
 
-struct ActiveRequestGuard {
-    authority: AuthorityIndex,
-    sync_method: SyncMethod,
-    active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, SyncMethod), usize>>>,
+/// Records when the transaction synchronizer failed for the last time when
+/// fetching from peers.
+struct LastFailureByPeer {
+    inner: Mutex<Vec<Option<Instant>>>,
 }
 
-impl ActiveRequestGuard {
-    fn new(
-        authority: AuthorityIndex,
-        sync_method: SyncMethod,
-        active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, SyncMethod), usize>>>,
-    ) -> Self {
-        {
-            let mut map = active_requests.lock();
-            *map.entry((authority, sync_method)).or_insert(0) += 1;
-        }
-        Self {
-            authority,
-            sync_method,
-            active_requests,
+impl LastFailureByPeer {
+    fn new(committee_size: usize) -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(vec![None; committee_size]),
+        })
+    }
+    fn update_with_new_instant(self: &Arc<Self>, peer: AuthorityIndex, new_instant: Instant) {
+        let mut inner = self.inner.lock();
+        inner[peer] = Some(new_instant);
+    }
+
+    fn get_excluded_authorities(self: &Arc<Self>) -> BTreeSet<AuthorityIndex> {
+        let last_round_by_peer = { self.inner.lock().clone() };
+
+        // Determine which authorities to exclude
+        let mut indexed_rounds: Vec<(AuthorityIndex, Instant)> = last_round_by_peer
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, last_instant)| {
+                last_instant.map(|last_instant| (AuthorityIndex::from(idx as u8), last_instant))
+            })
+            .collect();
+
+        indexed_rounds.sort_by_key(|&(_, instant)| std::cmp::Reverse(instant));
+
+        // Exclude 2/3 of authorities with latest failures
+        let exclude_count = 2 * last_round_by_peer.len() / 3;
+        let excluded_authorities: BTreeSet<AuthorityIndex> = indexed_rounds
+            .into_iter()
+            .take(exclude_count)
+            .map(|(idx, _)| idx)
+            .collect();
+
+        excluded_authorities
+    }
+}
+
+/// Tracks the number of concurrent requests to each peer. Counts the number of
+/// fetch requests separately for periodic and live transaction synchronizer as
+/// they serve different purposes.
+struct InflightActiveRequests {
+    inner: Mutex<BTreeMap<(AuthorityIndex, SyncMethod), usize>>,
+}
+
+impl InflightActiveRequests {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(BTreeMap::new()),
+        })
+    }
+    fn unlock_active_request(&self, peer: AuthorityIndex, sync_method: SyncMethod) {
+        let mut inner = self.inner.lock();
+        if let Some(val) = inner.get_mut(&(peer, sync_method)) {
+            *val = val.saturating_sub(1);
         }
     }
 }
 
+struct ActiveRequestGuard {
+    peer: AuthorityIndex,
+    sync_method: SyncMethod,
+    active_requests: Arc<InflightActiveRequests>,
+}
+
 impl Drop for ActiveRequestGuard {
     fn drop(&mut self) {
-        let mut map = self.active_requests.lock();
-        if let Some(val) = map.get_mut(&(self.authority, self.sync_method)) {
-            *val = val.saturating_sub(1);
-        }
+        self.active_requests
+            .unlock_active_request(self.peer, self.sync_method);
     }
 }
 
@@ -142,49 +193,78 @@ impl InflightTransactionsMap {
         })
     }
 
-    /// Locks the transactions to be fetched for the assigned `peer_index`. We
+    /// Locks the transactions to be fetched for the assigned `peer`. We
     /// want to avoid re-fetching the missing transactions from too many
     /// authorities at the same time, thus we limit the concurrency per
-    /// transaction by attempting to lock per block. If a transaction is
-    /// already fetched by the maximum allowed number of authorities, then
-    /// the block ref will not be included in the returned set. The method
-    /// returns all the block refs that have been successfully locked and
-    /// allowed to be fetched.
-    fn lock_transactions(
+    /// transaction by attempting to lock per block. In addition, we check
+    /// whether a given `peer` has many concurrent requests. If so, we will
+    /// not lock transactions. The method return
+    fn lock_transactions_and_active_request(
         self: &Arc<Self>,
         missing_block_refs: BTreeSet<BlockRef>,
         peer: AuthorityIndex,
         max_number_transactions_per_fetch: usize,
-    ) -> Option<TransactionsGuard> {
-        let mut blocks = BTreeSet::new();
-        let mut inner = self.inner.lock();
+        sync_method: SyncMethod,
+        active_requests: Arc<InflightActiveRequests>,
+    ) -> Option<(TransactionsGuard, ActiveRequestGuard)> {
+        // Lock both maps
+        let mut transaction_map = self.inner.lock();
+        let mut active_requests_locked = active_requests.inner.lock();
+
+        // Ensure we have a counter for this (peer, method)
+        let req_entry = active_requests_locked
+            .entry((peer, sync_method))
+            .or_insert(0);
+
+        // Enforce per-peer concurrent fetch cap
+        if *req_entry >= MAX_CONCURRENT_REQUESTS_PER_AUTHORITY {
+            return None;
+        }
+
+        // Now try to lock transactions
+        let mut selected_transactions_to_fetch = BTreeSet::new();
         let mut selected_block_refs_num = 0;
 
         for block_ref in missing_block_refs {
-            // check that the number of authorities that are already instructed to fetch the
-            // transaction is not higher than the allowed and the `peer_index` has not
-            // already been instructed to do that.
-            let authorities = inner.entry(block_ref).or_default();
+            let authorities = transaction_map.entry(block_ref).or_default();
+
             if authorities.len() < MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION
                 && authorities.insert(peer)
             {
-                blocks.insert(block_ref);
+                selected_transactions_to_fetch.insert(block_ref);
                 selected_block_refs_num += 1;
-            }
-            if selected_block_refs_num >= max_number_transactions_per_fetch {
-                break;
+
+                if selected_block_refs_num >= max_number_transactions_per_fetch {
+                    break;
+                }
             }
         }
 
-        if blocks.is_empty() {
-            None
-        } else {
-            Some(TransactionsGuard {
-                map: self.clone(),
-                block_refs: blocks,
-                peer,
-            })
+        // If we couldn’t lock any transactions, don’t bump the request counter
+        if selected_transactions_to_fetch.is_empty() {
+            return None;
         }
+
+        // We actually got some work → count an active request
+        *req_entry += 1;
+
+        // Drop locks before returning guards
+        drop(transaction_map);
+        drop(active_requests_locked);
+
+        let transactions_guard = TransactionsGuard {
+            map: self.clone(),
+            block_refs: selected_transactions_to_fetch,
+            peer,
+        };
+
+        let active_request_guard = ActiveRequestGuard {
+            peer,
+            sync_method,
+            active_requests: active_requests.clone(),
+        };
+
+        Some((transactions_guard, active_request_guard))
     }
 
     /// Unlocks the provided block references for the given `peer`. The
@@ -294,12 +374,13 @@ pub(crate) struct TransactionsSynchronizer<
     live_fetch_requests: Sender<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>,
     core_dispatcher: Arc<D>,
     dag_state: Arc<RwLock<DagState>>,
-    active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, SyncMethod), usize>>>,
+    active_requests: Arc<InflightActiveRequests>,
     fetch_transactions_scheduler_task: JoinSet<()>,
     network_client: Arc<C>,
     block_verifier: Arc<V>,
     inflight_transactions_map: Arc<InflightTransactionsMap>,
     commands_sender: Sender<Command>,
+    last_failure_by_peer: Arc<LastFailureByPeer>,
 }
 
 impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
@@ -326,7 +407,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         );
 
         let mut tasks = JoinSet::new();
-        let active_requests = Arc::new(Mutex::new(BTreeMap::new()));
+        let active_requests = InflightActiveRequests::new();
+        let last_failure_by_peer = LastFailureByPeer::new(context.committee.size());
         // Spawn the live fetcher task
         let live_fetcher_async = Self::live_fetcher(
             active_requests.clone(),
@@ -337,6 +419,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             live_fetch_receiver,
             block_verifier.clone(),
             inflight_transactions_map.clone(),
+            last_failure_by_peer.clone(),
         );
         tasks.spawn(monitored_future!(live_fetcher_async));
 
@@ -356,6 +439,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 inflight_transactions_map,
                 commands_sender: commands_sender_clone,
                 dag_state,
+                last_failure_by_peer,
             };
             s.run().await;
         }));
@@ -439,7 +523,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
 
     // The live fetcher task that processes fetch requests from the queue
     async fn live_fetcher(
-        active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, SyncMethod), usize>>>,
+        active_requests: Arc<InflightActiveRequests>,
         network_client: Arc<C>,
         context: Arc<Context>,
         core_dispatcher: Arc<D>,
@@ -447,6 +531,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         mut receiver: Receiver<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>,
         block_verifier: Arc<V>,
         inflight_transactions_map: Arc<InflightTransactionsMap>,
+        last_failure_by_peer: Arc<LastFailureByPeer>,
     ) {
         let semaphore = Arc::new(Semaphore::new(LIVE_FETCH_TRANSACTIONS_CONCURRENCY));
 
@@ -467,7 +552,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     let core_dispatcher = core_dispatcher.clone();
                     let block_verifier = block_verifier.clone();
                     let dag_state = dag_state.clone();
-
+                    let last_failure_by_peer = last_failure_by_peer.clone();
                     tokio::spawn(async move {
                         Self::fetch_and_process_transactions_from_authorities(
                             context,
@@ -478,6 +563,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                             core_dispatcher,
                             block_verifier,
                             dag_state,
+                            last_failure_by_peer,
                             SyncMethod::Live,
                         )
                         .await;
@@ -560,6 +646,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         let dag_state = self.dag_state.clone();
         let inflight_transactions_map = self.inflight_transactions_map.clone();
         let active_requests = self.active_requests.clone();
+        let last_failure_by_round = self.last_failure_by_peer.clone();
 
         self.fetch_transactions_scheduler_task
             .spawn(monitored_future!(async move {
@@ -580,6 +667,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     core_dispatcher,
                     block_verifier,
                     dag_state,
+                    last_failure_by_round,
                     SyncMethod::Periodic,
                 )
                 .await;
@@ -599,13 +687,14 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
     /// Fetches missing transactions from authorities.
     async fn fetch_and_process_transactions_from_authorities(
         context: Arc<Context>,
-        active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, SyncMethod), usize>>>,
+        active_requests: Arc<InflightActiveRequests>,
         inflight_transactions_map: Arc<InflightTransactionsMap>,
         network_client: Arc<C>,
         missing_transactions: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
         core_dispatcher: Arc<D>,
         block_verifier: Arc<V>,
         dag_state: Arc<RwLock<DagState>>,
+        last_failure_by_peer: Arc<LastFailureByPeer>,
         sync_method: SyncMethod,
     ) {
         // Build a mapping from authority -> set of BlockRefs it has acknowledged
@@ -649,54 +738,61 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 // Stable order for tests
                 Box::new(blocks_by_authority.into_iter())
             } else {
-                let mut vec: Vec<_> = blocks_by_authority.into_iter().collect();
+                let excluded_authorities = last_failure_by_peer.get_excluded_authorities();
+                // Exclude authorities with latest recorded failures
+                let mut vec: Vec<_> = blocks_by_authority
+                    .into_iter()
+                    .filter(|(authority, _)| !excluded_authorities.contains(authority))
+                    .collect();
                 vec.shuffle(&mut rng);
                 Box::new(vec.into_iter())
             };
 
         let mut request_futures = FuturesUnordered::new();
 
+        let mut assigned_authorities_for_transaction_fetch = 0;
+
         for (authority, authority_block_refs) in iter_authorities {
-            {
-                let count = active_requests
-                    .lock()
-                    .get(&(authority, sync_method))
-                    .copied()
-                    .unwrap_or(0);
-
-                // Skip assigning a request if the limit is reached
-                if count >= MAX_CONCURRENT_REQUESTS_PER_AUTHORITY {
-                    let peer_hostname = &context.committee.authority(authority).hostname;
-                    debug!(
-                        "Skipping fetch for authority {peer_hostname} as the maximum number of concurrent requests is reached"
-                    );
-                    continue;
-                }
-            }
-
-            // * If transactions are successfully locked, then send a request to the network
-            //   client to fetch the transactions from the authority. If the fetch is
-            //   successful, then process the transactions and send them to the core for
-            //   processing.
-            if let Some(transactions_guard) = inflight_transactions_map.lock_transactions(
-                authority_block_refs.clone(),
-                authority,
-                context.parameters.max_transactions_per_fetch,
-            ) {
-                let active_request_guard =
-                    ActiveRequestGuard::new(authority, sync_method, active_requests.clone());
-
-                request_futures.push(Self::fetch_and_process_transactions_from_authority(
+            // * If transactions are successfully locked, and we didn't make too many to
+            //   this authority, then send a request to the network client to fetch the
+            //   transactions from the authority. If the fetch is successful, then process
+            //   the transactions and send them to the core for processing.
+            if let Some((transactions_guard, active_request_guard)) = inflight_transactions_map
+                .lock_transactions_and_active_request(
+                    authority_block_refs.clone(),
                     authority,
-                    context.clone(),
-                    transactions_guard,
-                    network_client.clone(),
-                    core_dispatcher.clone(),
-                    block_verifier.clone(),
-                    dag_state.clone(),
+                    context.parameters.max_transactions_per_fetch,
                     sync_method,
-                    active_request_guard,
-                ));
+                    active_requests.clone(),
+                )
+            {
+                let context = context.clone();
+                let network_client = network_client.clone();
+                let core_dispatcher = core_dispatcher.clone();
+                let block_verifier = block_verifier.clone();
+                let dag_state = dag_state.clone();
+                request_futures.push(async move {
+                    let result = Self::fetch_and_process_transactions_from_authority(
+                        authority,
+                        context,
+                        transactions_guard,
+                        network_client,
+                        core_dispatcher,
+                        block_verifier,
+                        dag_state,
+                        sync_method,
+                        active_request_guard,
+                    )
+                    .await;
+                    (authority, result)
+                });
+
+                assigned_authorities_for_transaction_fetch += 1;
+                if assigned_authorities_for_transaction_fetch
+                    == MAX_ASSIGNED_AUTHORITIES_PER_TRANSACTION_FETCH
+                {
+                    break;
+                }
             }
         }
 
@@ -704,26 +800,15 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             return;
         }
 
-        // Each fetch request has its own timeout, but processing not.
-        // Using timeout, we limit the overall time spent primarily on processing
-        let timeout = sleep(FETCH_AND_PROCESS_FROM_PEERS_TIMEOUT);
-
-        tokio::pin!(timeout);
-
-        loop {
-            tokio::select! {
-                    Some(res) = request_futures.next() => {
-                        if let Err(err) = res {
-                            warn!("[{}] Error when fetching and processing transactions from authority: {err}", sync_method.get_string());
-                        }
-            },
-                    _ = &mut timeout => {
-                        warn!("[{}] Timed out while fetching and processing missing transactions", sync_method.get_string());
-                         // Drop all pending requests immediately — frees all transaction guards
-                        drop(request_futures);
-                        break;
-                    }
-                }
+        // Await all authority requests to complete
+        while let Some((peer, result)) = request_futures.next().await {
+            if let Err(err) = result {
+                last_failure_by_peer.update_with_new_instant(peer, Instant::now());
+                warn!(
+                    "[{}] Error when fetching and processing transactions from authority: {err}",
+                    sync_method.get_string()
+                );
+            }
         }
     }
 
@@ -747,7 +832,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             sync_method.get_string(),
         );
 
-        let (fetched_serialized_transactions, transactions_guard, _peer_index) =
+        let (fetched_serialized_transactions, transactions_guard, peer) =
             Self::fetch_transactions_request(
                 network_client.clone(),
                 peer,
@@ -759,6 +844,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             .await?;
 
         let total_fetched = fetched_serialized_transactions.len();
+
         debug!(
             "Transactions from {total_requested} blocks requested, fetched from {total_fetched} blocks"
         );
@@ -838,6 +924,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                         err.name(),
                     ])
                     .inc();
+
                 Err(err) // network error
             }
             Err(err) => {
@@ -1186,7 +1273,7 @@ mod tests {
     async fn live_syncing_with_saturated_tasks() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
-        let (context, _) = Context::new_for_test(4);
+        let (context, _) = Context::new_for_test(LIVE_FETCH_TRANSACTIONS_CONCURRENCY * 3);
         let context = Arc::new(context);
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
@@ -1205,7 +1292,7 @@ mod tests {
         let mut encoder = create_encoder(&context);
 
         // Create block round author pairs
-        let block_round_authors = (1..LIVE_FETCH_TRANSACTIONS_CONCURRENCY * 2 + 1)
+        let block_round_authors = (1..=LIVE_FETCH_TRANSACTIONS_CONCURRENCY * 3)
             .map(|i| (i as Round, 1u8))
             .collect::<Vec<_>>();
 
@@ -1242,17 +1329,18 @@ mod tests {
         }
 
         // Create a map of block refs to authorities that have them
-        let mut missing_transactions = BTreeMap::new();
-        for header in &block_headers {
+        let mut missing_transactions = Vec::new();
+        for (index, header) in block_headers.iter().enumerate() {
             let mut authorities = BTreeSet::new();
-            authorities.insert(AuthorityIndex::new_for_test(1));
-            missing_transactions.insert(header.reference(), authorities);
+            let from_whom = AuthorityIndex::new_for_test(index as u8 + 1);
+            authorities.insert(from_whom);
+            network_client.set_timeout_peer(from_whom).await;
+            let mut missing_txs = BTreeMap::new();
+            missing_txs.insert(header.reference(), authorities);
+            missing_transactions.push(missing_txs)
         }
 
         // Delay fetch transactions response to simulate saturation deterministically.
-        network_client
-            .set_timeout_peer(AuthorityIndex::new_for_test(1))
-            .await;
 
         // Add block headers to the dag state
         dag_state.write().accept_block_headers(block_headers);
@@ -1260,19 +1348,22 @@ mod tests {
         // WHEN
         // Send many requests to saturate the tasks
         let mut results = Vec::new();
-        for _ in 0..LIVE_FETCH_TRANSACTIONS_CONCURRENCY * 3 {
+        for missing_transactions_to_request in missing_transactions
+            .iter()
+            .take(LIVE_FETCH_TRANSACTIONS_CONCURRENCY * 3)
+        {
             results.push(
                 handle
-                    .fetch_transactions(missing_transactions.clone())
+                    .fetch_transactions(missing_transactions_to_request.clone())
                     .await,
             );
         }
 
         // THEN
-        // FETCH_TRANSACTIONS_CONCURRENCY tasks will start processing, another set of
-        // FETCH_TRANSACTIONS_CONCURRENCY tasks will be stuck in the queue, and the last
-        // FETCH_TRANSACTIONS_CONCURRENCY tasks will be returned with
-        // TransactionSynchronizerSaturated error.
+        // LIVE_FETCH_TRANSACTIONS_CONCURRENCY tasks will start processing, another set
+        // of LIVE_FETCH_TRANSACTIONS_CONCURRENCY tasks will be stuck in the
+        // queue, and the last LIVE_FETCH_TRANSACTIONS_CONCURRENCY tasks will be
+        // returned with TransactionSynchronizerSaturated error.
         // The test should be deterministic because the responses will timeout, so all
         // tasks should be sent to the queue before the first request is processed.
         let successes = results.iter().filter(|r| r.is_ok()).count();
@@ -1851,77 +1942,87 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn inflight_transactions_map() {
+    async fn inflight_transactions_map_with_active_requests() {
         telemetry_subscribers::init_for_testing();
+
         // GIVEN
         let map = InflightTransactionsMap::new();
+        let active_requests = InflightActiveRequests::new();
+        let sync_method = SyncMethod::Periodic;
+
         let some_block_refs = [
             BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
             BlockRef::new(10, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
             BlockRef::new(12, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
             BlockRef::new(15, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
         ];
-        let context = Context::new_for_test(4).0;
+        let context = Context::new_for_test(10).0;
         let missing_block_refs = some_block_refs.iter().cloned().collect::<BTreeSet<_>>();
 
-        // Lock & unlock transactions
-        {
-            let mut all_guards = Vec::new();
+        // We keep both guards so that drops happen at the end
+        let mut all_guards: Vec<(TransactionsGuard, ActiveRequestGuard)> = Vec::new();
 
-            // Try to acquire the transaction locks for authorities 0, 1 & 2
-            for i in 0..=2 {
-                let authority = AuthorityIndex::new_for_test(i);
+        // Try to acquire the transaction locks for authorities
+        // 0..MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION
+        for i in 0..=MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION {
+            let authority = AuthorityIndex::new_for_test(i as u8);
 
-                let guard = map.lock_transactions(
-                    missing_block_refs.clone(),
-                    authority,
-                    context.parameters.max_transactions_per_fetch,
-                );
-                let guard = guard.expect("Guard should be created");
-                assert_eq!(guard.block_refs.len(), 4);
-
-                all_guards.push(guard);
-
-                // trying to acquire any of them again will not succeed
-                let guard = map.lock_transactions(
-                    missing_block_refs.clone(),
-                    authority,
-                    context.parameters.max_transactions_per_fetch,
-                );
-                assert!(guard.is_none());
-            }
-
-            // Trying to acquire for authority 3 it will fail - as we have maxed out the
-            // number of allowed peers (MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION = 3)
-            let authority_3 = AuthorityIndex::new_for_test(3);
-
-            let guard = map.lock_transactions(
+            let guard = map.lock_transactions_and_active_request(
                 missing_block_refs.clone(),
-                authority_3,
+                authority,
                 context.parameters.max_transactions_per_fetch,
+                sync_method,
+                active_requests.clone(),
+            );
+
+            if i == MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION {
+                // Trying to acquire for authority MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION will
+                // fail - as we have maxed out the number of allowed peers for
+                // each transaction
+                assert!(guard.is_none());
+                break;
+            }
+            let (tx_guard, ar_guard) = guard.expect("Guard should be created");
+            assert_eq!(tx_guard.block_refs.len(), 4);
+
+            all_guards.push((tx_guard, ar_guard));
+
+            // trying to acquire any of them again for the *same* authority should not
+            // succeed
+            let guard = map.lock_transactions_and_active_request(
+                missing_block_refs.clone(),
+                authority,
+                context.parameters.max_transactions_per_fetch,
+                sync_method,
+                active_requests.clone(),
             );
             assert!(guard.is_none());
-
-            // Explicitly drop the guard of authority 1 and try for authority 3 again - it
-            // will now succeed
-            drop(all_guards.remove(0));
-
-            let guard = map.lock_transactions(
-                missing_block_refs.clone(),
-                authority_3,
-                context.parameters.max_transactions_per_fetch,
-            );
-            let guard = guard.expect("Guard should be successfully acquired");
-
-            assert_eq!(guard.block_refs, missing_block_refs);
-
-            // Dropping all guards should unlock on the block refs
-            drop(guard);
-            drop(all_guards);
-
-            assert_eq!(map.num_of_locked_transactions(), 0);
         }
+
+        // Explicitly drop the guard of authority 1 (the first we stored) and try for
+        // authority 3 again - it will now succeed because one slot per-block
+        // got freed
+        drop(all_guards.remove(0));
+
+        let guard = map.lock_transactions_and_active_request(
+            missing_block_refs.clone(),
+            AuthorityIndex::new_for_test(MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION as u8),
+            context.parameters.max_transactions_per_fetch,
+            sync_method,
+            active_requests.clone(),
+        );
+        let (tx_guard, active_request_guard) =
+            guard.expect("Guard should be successfully acquired");
+        assert_eq!(tx_guard.block_refs, missing_block_refs);
+
+        // Dropping all guards should unlock all block refs
+        drop(tx_guard);
+        drop(active_request_guard);
+        drop(all_guards);
+
+        assert_eq!(map.num_of_locked_transactions(), 0);
     }
+
     struct MockNetworkClient {
         transactions: Arc<Mutex<HashMap<(AuthorityIndex, BlockRef), Bytes>>>,
         error_peers: Arc<Mutex<HashMap<AuthorityIndex, ConsensusError>>>,

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -34,7 +34,6 @@ use tracing::{debug, info, warn};
 use crate::{
     Transaction, VerifiedBlockHeader,
     block_header::{BlockRef, TransactionsCommitment, VerifiedTransactions},
-    block_verifier::BlockVerifier,
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::{DagState, TransactionSource},
@@ -373,7 +372,6 @@ impl TransactionsSynchronizerHandle {
 ///    persist.
 pub(crate) struct TransactionsSynchronizer<
     C: NetworkClient,
-    V: BlockVerifier,
     D: CoreThreadDispatcher,
 > {
     context: Arc<Context>,
@@ -384,14 +382,13 @@ pub(crate) struct TransactionsSynchronizer<
     active_requests: Arc<InflightActiveRequests>,
     fetch_transactions_scheduler_task: JoinSet<()>,
     network_client: Arc<C>,
-    block_verifier: Arc<V>,
     inflight_transactions_map: Arc<InflightTransactionsMap>,
     commands_sender: Sender<Command>,
     last_failure_by_peer: Arc<LastFailureByPeer>,
 }
 
-impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
-    TransactionsSynchronizer<C, V, D>
+impl<C: NetworkClient, D: CoreThreadDispatcher>
+    TransactionsSynchronizer<C, D>
 {
     /// Starts the transactions synchronizer, which is responsible for fetching
     /// transactions from other authorities and managing transaction
@@ -400,7 +397,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         network_client: Arc<C>,
         context: Arc<Context>,
         core_dispatcher: Arc<D>,
-        block_verifier: Arc<V>,
         dag_state: Arc<RwLock<DagState>>,
     ) -> Arc<TransactionsSynchronizerHandle> {
         let (commands_sender, commands_receiver) =
@@ -424,7 +420,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             core_dispatcher.clone(),
             dag_state.clone(),
             live_fetch_receiver,
-            block_verifier.clone(),
             inflight_transactions_map.clone(),
             last_failure_by_peer.clone(),
         );
@@ -442,7 +437,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 fetch_transactions_scheduler_task: JoinSet::new(),
                 active_requests,
                 network_client,
-                block_verifier,
                 inflight_transactions_map,
                 commands_sender: commands_sender_clone,
                 dag_state,
@@ -536,7 +530,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         core_dispatcher: Arc<D>,
         dag_state: Arc<RwLock<DagState>>,
         mut receiver: Receiver<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>,
-        block_verifier: Arc<V>,
         inflight_transactions_map: Arc<InflightTransactionsMap>,
         last_failure_by_peer: Arc<LastFailureByPeer>,
     ) {
@@ -557,7 +550,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     let inflight_transactions_map = inflight_transactions_map.clone();
                     let network_client = network_client.clone();
                     let core_dispatcher = core_dispatcher.clone();
-                    let block_verifier = block_verifier.clone();
                     let dag_state = dag_state.clone();
                     let last_failure_by_peer = last_failure_by_peer.clone();
                     tokio::spawn(async move {
@@ -568,7 +560,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                             network_client,
                             missing_transactions_block_refs,
                             core_dispatcher,
-                            block_verifier,
                             dag_state,
                             last_failure_by_peer,
                             SyncMethod::Live,
@@ -649,7 +640,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         let network_client = self.network_client.clone();
         let core_dispatcher = self.core_dispatcher.clone();
         let commands_sender = self.commands_sender.clone();
-        let block_verifier = self.block_verifier.clone();
         let dag_state = self.dag_state.clone();
         let inflight_transactions_map = self.inflight_transactions_map.clone();
         let active_requests = self.active_requests.clone();
@@ -672,7 +662,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     network_client,
                     missing_transactions,
                     core_dispatcher,
-                    block_verifier,
                     dag_state,
                     last_failure_by_round,
                     SyncMethod::Periodic,
@@ -699,7 +688,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         network_client: Arc<C>,
         missing_transactions: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
         core_dispatcher: Arc<D>,
-        block_verifier: Arc<V>,
         dag_state: Arc<RwLock<DagState>>,
         last_failure_by_peer: Arc<LastFailureByPeer>,
         sync_method: SyncMethod,
@@ -777,7 +765,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 let context = context.clone();
                 let network_client = network_client.clone();
                 let core_dispatcher = core_dispatcher.clone();
-                let block_verifier = block_verifier.clone();
                 let dag_state = dag_state.clone();
                 request_futures.push(async move {
                     let result = Self::fetch_and_process_transactions_from_authority(
@@ -786,7 +773,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                         transactions_guard,
                         network_client,
                         core_dispatcher,
-                        block_verifier,
                         dag_state,
                         sync_method,
                         active_request_guard,
@@ -827,7 +813,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         transactions_guard: TransactionsGuard,
         network_client: Arc<C>,
         core_dispatcher: Arc<D>,
-        block_verifier: Arc<V>,
         dag_state: Arc<RwLock<DagState>>,
         sync_method: SyncMethod,
         _active_guard: ActiveRequestGuard,
@@ -863,7 +848,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             transactions_guard,
             core_dispatcher.clone(),
             context,
-            block_verifier.clone(),
             dag_state.clone(),
             sync_method,
         )
@@ -974,7 +958,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         requested_transactions_guard: TransactionsGuard,
         core_dispatcher: Arc<D>,
         context: Arc<Context>,
-        block_verifier: Arc<V>,
         dag_state: Arc<RwLock<DagState>>,
         sync_method: SyncMethod,
     ) -> ConsensusResult<()> {
@@ -1006,13 +989,10 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                         .expect("block header for requested transactions must exist");
                     block_headers_map.insert(block_header.reference(), block_header);
                 }
-
-                let block_verifier = block_verifier.clone();
                 let context_cloned = context.clone();
                 move || {
                     Self::verify_transactions(
                         serialized_transactions,
-                        block_verifier,
                         peer_index,
                         block_headers_map,
                         context_cloned,
@@ -1077,7 +1057,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
 
     fn verify_transactions(
         serialized_transactions_bytes: Vec<Bytes>,
-        block_verifier: Arc<V>,
         peer_index: AuthorityIndex,
         block_headers_map: BTreeMap<BlockRef, VerifiedBlockHeader>,
         context: Arc<Context>,
@@ -1116,12 +1095,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 });
             }
 
-            // Step 3: Deserialize and verify the actual transactions vector.
+            // Step 3: Deserialize the actual transactions vector. We are ensure that they
+            // are verified since the quorum already acknowledged and verified
             let transactions: Vec<Transaction> =
                 bcs::from_bytes(&serialized_transactions.serialized_transactions)
                     .map_err(ConsensusError::MalformedTransactions)?;
-
-            block_verifier.check_and_verify_transactions(&transactions)?;
 
             // Step 4: Create a VerifiedTransactions instance containing both the verified
             // transactions and their original serialized form for efficient re-sharing

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -57,7 +57,8 @@ const MAX_CONCURRENT_REQUESTS_PER_AUTHORITY: usize = 2;
 
 /// The maximum number of assigned peers per one call of transaction fetch
 /// It allows to globally limit the number of spawned tasks by
-/// (LIVE_FETCH_TRANSACTIONS_CONCURRENCY + PERIODIC_FETCH_TRANSACTIONS_CONCURRENCY) *
+/// (LIVE_FETCH_TRANSACTIONS_CONCURRENCY +
+/// PERIODIC_FETCH_TRANSACTIONS_CONCURRENCY) *
 /// MAX_ASSIGNED_AUTHORITIES_PER_TRANSACTION_FETCH
 const MAX_ASSIGNED_AUTHORITIES_PER_TRANSACTION_FETCH: usize = 4;
 
@@ -104,11 +105,10 @@ impl LastFailureByPeer {
         inner[peer] = Some(new_instant);
     }
 
-    /// Determine which authorities are less reliable to fetch transactions. Leave at least f+1
-    /// authorities.
+    /// Determine which authorities are less reliable to fetch transactions.
+    /// Leave at least f+1 authorities.
     fn get_excluded_authorities(self: &Arc<Self>) -> BTreeSet<AuthorityIndex> {
         let last_round_by_peer = { self.inner.lock().clone() };
-
 
         let mut indexed_rounds: Vec<(AuthorityIndex, Instant)> = last_round_by_peer
             .iter()
@@ -121,7 +121,7 @@ impl LastFailureByPeer {
         indexed_rounds.sort_by_key(|&(_, instant)| std::cmp::Reverse(instant));
 
         // Exclude at most 2/3 of authorities with latest failures
-        let exclude_count = 2 * (last_round_by_peer.len() - 1 ) / 3;
+        let exclude_count = 2 * (last_round_by_peer.len() - 1) / 3;
         let excluded_authorities: BTreeSet<AuthorityIndex> = indexed_rounds
             .into_iter()
             .take(exclude_count)
@@ -132,9 +132,9 @@ impl LastFailureByPeer {
     }
 }
 
-/// Tracks the number of concurrent transaction fetch requests to each peer. Counts the number of
-/// fetch requests separately for periodic and live transaction synchronizer as
-/// they serve different purposes.
+/// Tracks the number of concurrent transaction fetch requests to each peer.
+/// Counts the number of fetch requests separately for periodic and live
+/// transaction synchronizer as they serve different purposes.
 struct InflightActiveRequests {
     inner: Mutex<BTreeMap<(AuthorityIndex, SyncMethod), usize>>,
 }
@@ -199,8 +199,8 @@ impl InflightTransactionsMap {
     /// authorities at the same time, thus we limit the concurrency per
     /// transaction by attempting to lock per block_ref. In addition, we check
     /// whether a given `peer` has many concurrent requests. If so, we will
-    /// not lock transactions. The method return optionally two guards. One for the fetched transactions
-    /// and one for active fetch request.
+    /// not lock transactions. The method return optionally two guards. One for
+    /// the fetched transactions and one for active fetch request.
     fn lock_transactions_and_active_request(
         self: &Arc<Self>,
         missing_block_refs: BTreeSet<BlockRef>,


### PR DESCRIPTION
# Description of change

Transaction synchronizer fetches transactions either slowly or with some warning in many scenarios:
-  after commit syncer has synced a big number of certified commits, the transactions from the committed subDAGs are fetched quite slowly.
- when some connections are blocked, the transaction synchronizer produces too many failures with blocked peers.

In this PR, 
- we tune parameters of the transaction synchronizer to increase the number of concurrent high-level task and control the total number of spawned tasks.
- we introduce a simple memory tracking when the transaction fetch has failed for the last time for each given peer. This memory is then used to take proper peers for fetching
- we remove transaction verification from the transaction synchronizer (similarly to how it was done in the commit syncer) since the verification and validity of transactions was already performed by a quorum of the network.

## Links to any relevant issues

Fixes #9162 

## How the change has been tested
We have tested the change using the fuzz testing scenarios.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

