### PR TITLE
feat(compiler): add a new known attribute based on Flavor and move the attr logic into iota_mode

### DIFF
--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     diag,
     diagnostics::{Diagnostic, DiagnosticReporter},
-    shared::string_utils::format_oxford_list,
+    shared::{known_attributes::KnownAttribute, string_utils::format_oxford_list},
 };
 
 //**************************************************************************************************
@@ -211,8 +211,9 @@ impl Edition {
         Self::DEVELOPMENT,
         Self::E2024,
     ];
-    // NB: This is the list of editions that are considered "valid" for the purposes of the Move.
-    // This list should be kept in order from oldest edition to newest.
+    // NB: This is the list of editions that are considered "valid" for the purposes
+    // of the Move. This list should be kept in order from oldest edition to
+    // newest.
     pub const VALID: &'static [Self] = &[
         Self::LEGACY,
         Self::E2024_ALPHA,
@@ -287,6 +288,14 @@ impl Flavor {
     pub const CORE: &'static str = "core";
     pub const IOTA: &'static str = "iota";
     pub const ALL: &'static [Self] = &[Self::Core, Self::Iota];
+
+    pub fn resolve_known_attribute(self, attribute_str: impl AsRef<str>) -> Option<KnownAttribute> {
+        use crate::iota_mode::known_attributes::KnownAttribute as IotaKnownAttribute;
+        match self {
+            Flavor::Core => None,
+            Flavor::Iota => IotaKnownAttribute::resolve(attribute_str),
+        }
+    }
 }
 
 impl FeatureGate {

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -3,14 +3,28 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    iter::IntoIterator,
+    sync::{Arc, Mutex},
+};
+
+use move_core_types::{
+    account_address::AccountAddress,
+    parsing::parser::{parse_u16, parse_u32, parse_u256},
+};
+use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
+use move_symbol_pool::Symbol;
+
 use crate::{
-    diag,
+    FullyCompiledProgram, diag,
     diagnostics::{
-        warning_filters::{
-            WarningFilter, WarningFilters, WarningFiltersBuilder, WarningFiltersTable, FILTER_ALL,
-            FILTER_UNUSED,
-        },
         Diagnostic, DiagnosticReporter, Diagnostics,
+        warning_filters::{
+            FILTER_ALL, FILTER_UNUSED, WarningFilter, WarningFilters, WarningFiltersBuilder,
+            WarningFiltersTable,
+        },
     },
     editions::{self, Edition, FeatureGate, Flavor},
     expansion::{
@@ -21,23 +35,23 @@ use crate::{
         ast::{self as E, Address, Fields, ModuleIdent, ModuleIdent_},
         byte_string, hex_string,
         name_validation::{
-            check_restricted_name_all_cases, check_valid_address_name,
-            check_valid_function_parameter_name, check_valid_local_name,
+            IMPLICIT_IOTA_MEMBERS, IMPLICIT_IOTA_MODULES, IMPLICIT_STD_MEMBERS,
+            IMPLICIT_STD_MODULES, ModuleMemberKind, NameCase, check_restricted_name_all_cases,
+            check_valid_address_name, check_valid_function_parameter_name, check_valid_local_name,
             check_valid_module_member_alias, check_valid_module_member_name,
-            check_valid_type_parameter_name, valid_local_variable_name, ModuleMemberKind, NameCase,
-            IMPLICIT_STD_MEMBERS, IMPLICIT_STD_MODULES, IMPLICIT_IOTA_MEMBERS, IMPLICIT_IOTA_MODULES,
+            check_valid_type_parameter_name, valid_local_variable_name,
         },
         path_expander::{
-            access_result, Access, LegacyPathExpander, ModuleAccessResult, Move2024PathExpander,
-            PathExpander,
+            Access, LegacyPathExpander, ModuleAccessResult, Move2024PathExpander, PathExpander,
+            access_result,
         },
         translate::known_attributes::{DiagnosticAttribute, KnownAttribute},
     },
     ice, ice_assert,
     parser::ast::{
-        self as P, Ability, BlockLabel, ConstantName, DatatypeName, Field, FieldBindings,
-        FunctionName, ModuleName, NameAccess, Var, VariantName, ENTRY_MODIFIER, MACRO_MODIFIER,
-        NATIVE_MODIFIER,
+        self as P, Ability, BlockLabel, ConstantName, DatatypeName, ENTRY_MODIFIER, Field,
+        FieldBindings, FunctionName, MACRO_MODIFIER, ModuleName, NATIVE_MODIFIER, NameAccess, Var,
+        VariantName,
     },
     shared::{
         ide::{IDEAnnotation, IDEInfo},
@@ -46,17 +60,6 @@ use crate::{
         unique_map::UniqueMap,
         *,
     },
-    FullyCompiledProgram,
-};
-use move_core_types::account_address::AccountAddress;
-use move_core_types::parsing::parser::{parse_u16, parse_u256, parse_u32};
-use move_ir_types::location::*;
-use move_proc_macros::growing_stack;
-use move_symbol_pool::Symbol;
-use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
-    iter::IntoIterator,
-    sync::{Arc, Mutex},
 };
 
 //**************************************************************************************************
@@ -450,8 +453,10 @@ fn default_aliases(context: &mut Context) -> AliasMapBuilder {
                 .map(|(m, mem, k)| (std_address, m, mem, k)),
         );
     }
-    // if iota is defined and the current package is in IOTA mode, add implicit iota aliases
-    if iota_address.is_some() && context.env().package_config(current_package).flavor == Flavor::Iota
+    // if iota is defined and the current package is in IOTA mode, add implicit iota
+    // aliases
+    if iota_address.is_some()
+        && context.env().package_config(current_package).flavor == Flavor::Iota
     {
         let iota_address = iota_address.unwrap();
         modules.extend(
@@ -1163,7 +1168,8 @@ fn gate_known_attribute(context: &mut Context, loc: Loc, known: &KnownAttribute)
         | KnownAttribute::DefinesPrimitive(_)
         | KnownAttribute::External(_)
         | KnownAttribute::Syntax(_)
-        | KnownAttribute::Deprecation(_) => (),
+        | KnownAttribute::Deprecation(_)
+        | KnownAttribute::Flavored(_) => (),
         KnownAttribute::Error(_) => {
             let pkg = context.current_package();
             context.check_feature(pkg, FeatureGate::CleverAssertions, loc);
@@ -1184,7 +1190,9 @@ fn unique_attributes(
             | E::Attribute_::Assigned(n, _)
             | E::Attribute_::Parameterized(n, _) => *n,
         };
-        let name_ = match known_attributes::KnownAttribute::resolve(sym) {
+        let current_package = context.current_package();
+        let flavor = context.env().flavor(current_package);
+        let name_ = match known_attributes::KnownAttribute::resolve(sym, flavor) {
             None => E::AttributeName_::Unknown(sym),
             Some(known) => {
                 debug_assert!(known.name() == sym.as_str());

--- a/external-crates/move/crates/move-compiler/src/iota_mode/known_attributes/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/iota_mode/known_attributes/mod.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! IOTA Known Attributes
+
+use std::{collections::BTreeSet, fmt};
+
+use crate::shared::known_attributes::{AttributePosition, KnownAttribute as MoveKnownAttribute};
+
+/// The list of attribute types recognized by the compiler for the IOTA
+/// Flavor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum KnownAttribute {}
+
+impl KnownAttribute {
+    pub fn resolve(_attribute_str: impl AsRef<str>) -> Option<MoveKnownAttribute> {
+        // Some(match attribute_str.as_ref() {
+        //     Attribute::ATTRIBUTE => Attribute.into(),
+        //     _ => return None,
+        // })
+        return None;
+    }
+
+    pub const fn name(&self) -> &str {
+        // match self {
+        //    Self::Attribute(a) => a.name(),
+        //}
+        unimplemented!()
+    }
+
+    pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
+        // match self {
+        //    Self::Attribute(a) => a.expected_positions(),
+        //}
+        unimplemented!()
+    }
+}
+
+//**************************************************************************************************
+// Display
+//**************************************************************************************************
+
+impl fmt::Display for KnownAttribute {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // match self {
+        //    Self::Authenticator(a) => a.fmt(f),
+        //}
+        unimplemented!()
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/iota_mode/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/iota_mode/mod.rs
@@ -9,6 +9,7 @@ use crate::diagnostics::codes::{DiagnosticInfo, Severity, custom};
 
 pub mod id_leak;
 pub mod info;
+pub mod known_attributes;
 pub mod linters;
 pub mod typing;
 

--- a/external-crates/move/crates/move-compiler/src/iota_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/iota_mode/typing.rs
@@ -9,18 +9,18 @@ use move_symbol_pool::Symbol;
 
 use crate::{
     diag,
-    diagnostics::{warning_filters::WarningFilters, Diagnostic, DiagnosticReporter, Diagnostics},
+    diagnostics::{Diagnostic, DiagnosticReporter, Diagnostics, warning_filters::WarningFilters},
     editions::Flavor,
     expansion::ast::{AbilitySet, Fields, ModuleIdent, Mutability, Visibility},
+    iota_mode::*,
     naming::ast::{
-        self as N, BuiltinTypeName_, FunctionSignature, StructFields, Type, TypeName_, Type_, Var,
+        self as N, BuiltinTypeName_, FunctionSignature, StructFields, Type, Type_, TypeName_, Var,
     },
     parser::ast::{Ability_, DatatypeName, DocComment, FunctionName, TargetKind},
-    shared::{program_info::TypingProgramInfo, CompilationEnv, Identifier},
-    iota_mode::*,
+    shared::{CompilationEnv, Identifier, program_info::TypingProgramInfo},
     typing::{
         ast::{self as T, ModuleCall},
-        core::{ability_not_satisfied_tips, error_format, error_format_, Subst},
+        core::{Subst, ability_not_satisfied_tips, error_format, error_format_},
         visitor::{TypingVisitorConstructor, TypingVisitorContext},
     },
 };

--- a/external-crates/move/crates/move-compiler/src/parser/verification_attribute_filter.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/verification_attribute_filter.rs
@@ -9,6 +9,7 @@ use move_symbol_pool::Symbol;
 use crate::{
     diag,
     diagnostics::DiagnosticReporter,
+    editions::Flavor,
     parser::{
         ast as P,
         filter::{FilterContext, filter_program},
@@ -48,7 +49,12 @@ impl FilterContext for Context<'_> {
     // * It is annotated #[verify_only] and verify mode is not set
     fn should_remove_by_attributes(&mut self, attrs: &[P::Attributes]) -> bool {
         use known_attributes::VerificationAttribute;
-        let flattened_attrs: Vec<_> = attrs.iter().flat_map(verification_attributes).collect();
+        let current_package = self.current_package;
+        let flavor = self.env.flavor(current_package);
+        let flattened_attrs: Vec<_> = attrs
+            .iter()
+            .flat_map(|attr| verification_attributes(attr, flavor))
+            .collect();
         let is_verify_only_loc = flattened_attrs
             .iter()
             .map(|attr| match attr {
@@ -91,16 +97,17 @@ pub fn program(compilation_env: &CompilationEnv, prog: P::Program) -> P::Program
 
 fn verification_attributes(
     attrs: &P::Attributes,
+    flavor: Flavor,
 ) -> Vec<(Loc, known_attributes::VerificationAttribute)> {
     use known_attributes::KnownAttribute;
     attrs
         .value
         .iter()
-        .filter_map(
-            |attr| match KnownAttribute::resolve(attr.value.attribute_name().value)? {
+        .filter_map(|attr| {
+            match KnownAttribute::resolve(attr.value.attribute_name().value, flavor)? {
                 KnownAttribute::Verification(verify_attr) => Some((attr.loc, verify_attr)),
                 _ => None,
-            },
-        )
+            }
+        })
         .collect()
 }

--- a/external-crates/move/crates/move-compiler/src/shared/known_attributes.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/known_attributes.rs
@@ -2,10 +2,96 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! Attributes
+//!
+//! The compiler has a built in system for processing arbitrary attributes,
+//! but has no generalized concept of validating or storing them.
+//! A fully compiled program will loose all attributes by the end of compilation
+//! and while attributes are initially processed and propagated through the
+//! stages, they have no effect until they are handled by the developer.
+//! This means that adding an attribute stub is simple, but properly handling it
+//! may happen on an arbitrary stage of compilation.
+//!
+//! ## Processing stages
+//!
+//! The **parser** stage of compilation will extract everything the compiler
+//! understands about an attribute. Where is it from, what form does it have,
+//! but nothing else is known.
+//! During the **expansion** stage an attribute will be turned into a
+//! [KnownAttribute] or unknown attribute after it passed the
+//! [AttributePosition] check and any associated values will be attached to it.
+//! After this point the attributes will propagate through the stages up until
+//! **to_bytecode** at which point they will be discarded completely.
+//!
+//! ## Structure
+//!
+//! There are tree types of attributes, defined in the **expansion**
+//! stage.
+//!
+//! Named attributes, which only have an identifier to them.
+//! ```text
+//! #[NamedAttribute]
+//! ....
+//! ```
+//! which can be listed in one unit or separated into more lines:
+//! ```text
+//! #[NamedAttribute1, NamedAttribute2]
+//! ...
+//!
+//! #[NamedAttribute1]
+//! #[NamedAttribute2]
+//! ...
+//! ```
+//! Assigned attributes, which also have an associated value:
+//! ```text
+//! #[AssignedAttribute = AttributeValue]
+//! ...
+//! ```
+//! which can be listed/grouped similarly to the named version above.
+//!
+//! Parameterized attributes, which can recursively contain
+//! all other types of attributes:
+//! ```text
+//! #[Parameterized(NamedAttribute)]
+//! ...
+//!
+//! #[Parameterized(AssignedAttribute = AttributeValue)]
+//! ...
+//!
+//! #[Parameterized(Parameterized(...))]
+//! ...
+//! ```
+//! which follows the same listing rules as seen above.
+//!
+//! The compiler ensures that no duplicate attributes are specified
+//! and checks if the values fit into a set of allowed types, but
+//! there is no further validation. Everything else is up to the
+//! developer.
+//!
+//! ## Attribute implementation patterns
+//!
+//! Simple **named** and **assigned** attributes are easy to implement and apart
+//! from setting the appropriate [AttributePosition] and trait implementations
+//! only require a type check to be implemented by the developer.
+//!
+//! **Parameterized** attributes are considerably trickier to be used properly
+//! as they can contain other attribute types recursively, but
+//! [AttributePosition] is not capable of expressing that a given attribute may
+//! only appear in such a nested structure. This means that after defining the
+//! top level **parameterized** attribute it is up the developer to define
+//! exactly what internal formats are expected.
+//! For example see [TestingAttribute::ExpectedFailure] implementation.
+
 use std::{collections::BTreeSet, fmt};
 
 use once_cell::sync::Lazy;
 
+use crate::editions::Flavor;
+
+/// All the code positions at which an attribute may be placed
+/// at in code.
+///
+/// A [KnownAttribute] specifies on which positions it may appear.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AttributePosition {
     AddressBlock,
@@ -19,6 +105,10 @@ pub enum AttributePosition {
     Spec,
 }
 
+/// The list of attribute types recognized by the compiler.
+///
+/// These variants not necessarily specify a single attribute
+/// , but a whole class of them like [KnownAttribute::Testing].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum KnownAttribute {
     Testing(TestingAttribute),
@@ -30,6 +120,7 @@ pub enum KnownAttribute {
     Syntax(SyntaxAttribute),
     Error(ErrorAttribute),
     Deprecation(DeprecationAttribute),
+    Flavored(FlavoredAttribute),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -80,6 +171,12 @@ pub struct ErrorAttribute;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DeprecationAttribute;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FlavoredAttribute {
+    pub name: &'static str,
+    pub expected_positions: &'static BTreeSet<AttributePosition>,
+}
+
 impl AttributePosition {
     const ALL: &'static [Self] = &[
         Self::AddressBlock,
@@ -94,23 +191,25 @@ impl AttributePosition {
 }
 
 impl KnownAttribute {
-    pub fn resolve(attribute_str: impl AsRef<str>) -> Option<Self> {
-        Some(match attribute_str.as_ref() {
-            TestingAttribute::TEST => TestingAttribute::Test.into(),
-            TestingAttribute::TEST_ONLY => TestingAttribute::TestOnly.into(),
-            TestingAttribute::EXPECTED_FAILURE => TestingAttribute::ExpectedFailure.into(),
-            TestingAttribute::RAND_TEST => TestingAttribute::RandTest.into(),
-            VerificationAttribute::VERIFY_ONLY => VerificationAttribute::VerifyOnly.into(),
-            NativeAttribute::BYTECODE_INSTRUCTION => NativeAttribute::BytecodeInstruction.into(),
-            DiagnosticAttribute::ALLOW => DiagnosticAttribute::Allow.into(),
-            DiagnosticAttribute::LINT_ALLOW => DiagnosticAttribute::LintAllow.into(),
-            DefinesPrimitive::DEFINES_PRIM => DefinesPrimitive.into(),
-            ExternalAttribute::EXTERNAL => ExternalAttribute.into(),
-            SyntaxAttribute::SYNTAX => SyntaxAttribute::Syntax.into(),
-            ErrorAttribute::ERROR => ErrorAttribute.into(),
-            DeprecationAttribute::DEPRECATED => DeprecationAttribute.into(),
-            _ => return None,
-        })
+    pub fn resolve(attribute_str: impl AsRef<str>, flavor: Flavor) -> Option<Self> {
+        match attribute_str.as_ref() {
+            TestingAttribute::TEST => Some(TestingAttribute::Test.into()),
+            TestingAttribute::TEST_ONLY => Some(TestingAttribute::TestOnly.into()),
+            TestingAttribute::EXPECTED_FAILURE => Some(TestingAttribute::ExpectedFailure.into()),
+            TestingAttribute::RAND_TEST => Some(TestingAttribute::RandTest.into()),
+            VerificationAttribute::VERIFY_ONLY => Some(VerificationAttribute::VerifyOnly.into()),
+            NativeAttribute::BYTECODE_INSTRUCTION => {
+                Some(NativeAttribute::BytecodeInstruction.into())
+            }
+            DiagnosticAttribute::ALLOW => Some(DiagnosticAttribute::Allow.into()),
+            DiagnosticAttribute::LINT_ALLOW => Some(DiagnosticAttribute::LintAllow.into()),
+            DefinesPrimitive::DEFINES_PRIM => Some(DefinesPrimitive.into()),
+            ExternalAttribute::EXTERNAL => Some(ExternalAttribute.into()),
+            SyntaxAttribute::SYNTAX => Some(SyntaxAttribute::Syntax.into()),
+            ErrorAttribute::ERROR => Some(ErrorAttribute.into()),
+            DeprecationAttribute::DEPRECATED => Some(DeprecationAttribute.into()),
+            _ => flavor.resolve_known_attribute(attribute_str),
+        }
     }
 
     pub const fn name(&self) -> &str {
@@ -124,6 +223,7 @@ impl KnownAttribute {
             Self::Syntax(a) => a.name(),
             Self::Error(a) => a.name(),
             Self::Deprecation(a) => a.name(),
+            Self::Flavored(a) => a.name(),
         }
     }
 
@@ -138,6 +238,7 @@ impl KnownAttribute {
             Self::Syntax(a) => a.expected_positions(),
             Self::Error(a) => a.expected_positions(),
             Self::Deprecation(a) => a.expected_positions(),
+            Self::Flavored(a) => a.expected_positions(),
         }
     }
 }
@@ -357,6 +458,16 @@ impl DeprecationAttribute {
     }
 }
 
+impl FlavoredAttribute {
+    pub const fn name(&self) -> &str {
+        self.name
+    }
+
+    pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
+        self.expected_positions
+    }
+}
+
 //**************************************************************************************************
 // Display
 //**************************************************************************************************
@@ -389,6 +500,7 @@ impl fmt::Display for KnownAttribute {
             Self::Syntax(a) => a.fmt(f),
             Self::Error(a) => a.fmt(f),
             Self::Deprecation(a) => a.fmt(f),
+            Self::Flavored(a) => a.fmt(f),
         }
     }
 }
@@ -447,6 +559,12 @@ impl fmt::Display for DeprecationAttribute {
     }
 }
 
+impl fmt::Display for FlavoredAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
 //**************************************************************************************************
 // From
 //**************************************************************************************************
@@ -494,5 +612,10 @@ impl From<ErrorAttribute> for KnownAttribute {
 impl From<DeprecationAttribute> for KnownAttribute {
     fn from(a: DeprecationAttribute) -> Self {
         Self::Deprecation(a)
+    }
+}
+impl From<FlavoredAttribute> for KnownAttribute {
+    fn from(a: FlavoredAttribute) -> Self {
+        Self::Flavored(a)
     }
 }

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -3,6 +3,24 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    hash::Hash,
+    path::PathBuf,
+    sync::{
+        Arc, Mutex, OnceLock, RwLock,
+        atomic::{AtomicUsize, Ordering as AtomicOrdering},
+    },
+};
+
+use clap::*;
+use move_command_line_common::files::FileHash;
+use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
+use petgraph::{algo::astar as petgraph_astar, graphmap::DiGraphMap};
+use vfs::{VfsError, VfsPath};
+
 use crate::{
     cfgir::{
         ast as G,
@@ -10,44 +28,28 @@ use crate::{
     },
     command_line as cli,
     diagnostics::{
+        DiagnosticReporter, Diagnostics, DiagnosticsFormat,
         codes::{DiagnosticsID, Severity},
         warning_filters::{
-            FilterName, FilterPrefix, WarningFilter, WarningFiltersBuilder, WarningFiltersScope,
-            WarningFiltersTable, FILTER_ALL,
+            FILTER_ALL, FilterName, FilterPrefix, WarningFilter, WarningFiltersBuilder,
+            WarningFiltersScope, WarningFiltersTable,
         },
-        DiagnosticReporter, Diagnostics, DiagnosticsFormat,
     },
-    editions::{check_feature_or_error, feature_edition_error_msg, Edition, FeatureGate, Flavor},
+    editions::{Edition, FeatureGate, Flavor, check_feature_or_error, feature_edition_error_msg},
     expansion::ast as E,
     hlir::ast as H,
+    iota_mode,
     naming::ast as N,
     parser::ast as P,
     shared::{
         files::{FileName, MappedFiles},
         ide::IDEInfo,
     },
-    iota_mode,
     typing::{
         ast as T,
         visitor::{TypingVisitor, TypingVisitorObj},
     },
 };
-use clap::*;
-use move_command_line_common::files::FileHash;
-use move_ir_types::location::*;
-use move_symbol_pool::Symbol;
-use petgraph::{algo::astar as petgraph_astar, graphmap::DiGraphMap};
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt,
-    hash::Hash,
-    path::PathBuf,
-    sync::{
-        atomic::{AtomicUsize, Ordering as AtomicOrdering},
-        Arc, Mutex, OnceLock, RwLock,
-    },
-};
-use vfs::{VfsError, VfsPath};
 
 pub mod ast_debug;
 pub mod files;
@@ -61,21 +63,17 @@ pub mod unique_map;
 pub mod unique_set;
 
 pub use ast_debug::AstDebug;
-
-//**************************************************************************************************
-// Numbers
-//**************************************************************************************************
-
-pub use move_core_types::parsing::parser::{
-    parse_address_number as parse_address, parse_u128, parse_u16, parse_u256, parse_u32, parse_u64,
-    parse_u8, NumberFormat,
-};
-
 //**************************************************************************************************
 // Address
 //**************************************************************************************************
-
 pub use move_core_types::parsing::address::NumericalAddress;
+//**************************************************************************************************
+// Numbers
+//**************************************************************************************************
+pub use move_core_types::parsing::parser::{
+    NumberFormat, parse_address_number as parse_address, parse_u8, parse_u16, parse_u32, parse_u64,
+    parse_u128, parse_u256,
+};
 
 pub fn parse_named_address(s: &str) -> anyhow::Result<(String, NumericalAddress)> {
     let before_after = s.split('=').collect::<Vec<_>>();
@@ -480,6 +478,10 @@ impl CompilationEnv {
 
     pub fn edition(&self, package: Option<Symbol>) -> Edition {
         self.package_config(package).edition
+    }
+
+    pub fn flavor(&self, package: Option<Symbol>) -> Flavor {
+        self.package_config(package).flavor
     }
 
     pub fn package_config(&self, package: Option<Symbol>) -> &PackageConfig {
@@ -1057,8 +1059,8 @@ impl SaveHook {
 ///   of the macro and how it disassembles and pushes values across its
 ///   computation.
 ///
-/// Examples of usage can be found in `expansion/`, `naming/`, `typing/`, and `hlir/`, in their
-/// respective `translation.rs` implementations.
+/// Examples of usage can be found in `expansion/`, `naming/`, `typing/`, and
+/// `hlir/`, in their respective `translation.rs` implementations.
 macro_rules! process_binops {
     ($optype:ty,
      $valtype:ty,

--- a/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
@@ -5,18 +5,19 @@
 
 use std::sync::Arc;
 
-use move_ir_types::location::{sp, Loc};
+use move_ir_types::location::{Loc, sp};
 use move_symbol_pool::Symbol;
 
 use crate::{
     command_line::compiler::FullyCompiledProgram,
     diag,
     diagnostics::DiagnosticReporter,
+    editions::Flavor,
     parser::{
         ast::{self as P, DocComment, NamePath, PathEntry},
-        filter::{filter_program, FilterContext},
+        filter::{FilterContext, filter_program},
     },
-    shared::{known_attributes, CompilationEnv},
+    shared::{CompilationEnv, known_attributes},
 };
 
 struct Context<'env> {
@@ -68,7 +69,12 @@ impl FilterContext for Context<'_> {
     // * If it is a library and is annotated as #[test]
     fn should_remove_by_attributes(&mut self, attrs: &[P::Attributes]) -> bool {
         use known_attributes::TestingAttribute;
-        let flattened_attrs: Vec<_> = attrs.iter().flat_map(test_attributes).collect();
+        let current_package = self.current_package;
+        let flavor = self.env.flavor(current_package);
+        let flattened_attrs: Vec<_> = attrs
+            .iter()
+            .flat_map(|attrs| test_attributes(attrs, flavor))
+            .collect();
         let is_test_only = flattened_attrs.iter().any(|attr| {
             matches!(
                 attr.1,
@@ -166,11 +172,11 @@ fn check_has_unit_test_module(
     true
 }
 
-/// If a module is being compiled in test mode, create a dummy function that calls a native
-/// function `0x1::unit_test::poison` that only exists if the VM is being run
-/// with the "unit_test" feature flag set. This will then cause the module to fail to link if
-/// an attempt is made to publish a module that has been compiled in test mode on a VM that is not
-/// running in test mode.
+/// If a module is being compiled in test mode, create a dummy function that
+/// calls a native function `0x1::unit_test::poison` that only exists if the VM
+/// is being run with the "unit_test" feature flag set. This will then cause the
+/// module to fail to link if an attempt is made to publish a module that has
+/// been compiled in test mode on a VM that is not running in test mode.
 fn create_test_poison(mloc: Loc) -> P::ModuleMember {
     let signature = P::FunctionSignature {
         type_parameters: vec![],
@@ -235,13 +241,16 @@ fn create_test_poison(mloc: Loc) -> P::ModuleMember {
     })
 }
 
-fn test_attributes(attrs: &P::Attributes) -> Vec<(Loc, known_attributes::TestingAttribute)> {
+fn test_attributes(
+    attrs: &P::Attributes,
+    flavor: Flavor,
+) -> Vec<(Loc, known_attributes::TestingAttribute)> {
     use known_attributes::KnownAttribute;
     attrs
         .value
         .iter()
-        .filter_map(
-            |attr| match KnownAttribute::resolve(attr.value.attribute_name().value)? {
+        .filter_map(|attr| {
+            match KnownAttribute::resolve(attr.value.attribute_name().value, flavor)? {
                 KnownAttribute::Testing(test_attr) => Some((attr.loc, test_attr)),
                 KnownAttribute::Verification(_)
                 | KnownAttribute::Native(_)
@@ -250,8 +259,9 @@ fn test_attributes(attrs: &P::Attributes) -> Vec<(Loc, known_attributes::Testing
                 | KnownAttribute::External(_)
                 | KnownAttribute::Syntax(_)
                 | KnownAttribute::Error(_)
-                | KnownAttribute::Deprecation(_) => None,
-            },
-        )
+                | KnownAttribute::Deprecation(_)
+                | KnownAttribute::Flavored(_) => None,
+            }
+        })
         .collect()
 }


### PR DESCRIPTION
# Description of change

Added a generic FlavoredAttribute which can then allow us to define new attributes within the iota_mode compiler part. 

## Links to any relevant issues

Fixes #9186

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes