### PR TITLE
feat(compiler): add authenticator attribute

### DIFF
--- a/crates/iota-move-build/src/lib.rs
+++ b/crates/iota-move-build/src/lib.rs
@@ -162,7 +162,14 @@ impl BuildConfig {
             for (_, s, info) in &u.function_infos {
                 let fn_name = s.as_str().to_string();
                 let is_test = mod_is_test || info.attributes.is_test_or_test_only();
-                fn_info_map.insert(FnInfoKey { fn_name, mod_addr }, FnInfo { is_test });
+                let authenticator_version = info.attributes.get_authenticator();
+                fn_info_map.insert(
+                    FnInfoKey { fn_name, mod_addr },
+                    FnInfo {
+                        is_test,
+                        authenticator_version,
+                    },
+                );
             }
         }
 

--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -73,6 +73,9 @@ pub struct FnInfo {
     /// If true, it's a function involved in testing (`[test]`, `[test_only]`,
     /// `[expected_failure]`)
     pub is_test: bool,
+    /// If set, function was marked to represent authenticator function of
+    /// given version.
+    pub authenticator_version: Option<u8>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]

--- a/external-crates/move/crates/move-compiler/src/iota_mode/known_attributes/authenticator.rs
+++ b/external-crates/move/crates/move-compiler/src/iota_mode/known_attributes/authenticator.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! IOTA Authenticator Attribute
+
+use std::{collections::BTreeSet, fmt};
+
+use move_core_types::u256::U256;
+use move_ir_types::location::Loc;
+use move_symbol_pool::Symbol;
+use once_cell::sync::Lazy;
+
+use crate::{
+    expansion::ast::{Attribute_, AttributeValue, Attributes},
+    shared::known_attributes::{
+        AttributePosition, FlavoredAttribute, KnownAttribute as MoveKnownAttribute,
+    },
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AuthenticatorAttribute;
+
+impl AuthenticatorAttribute {
+    pub const AUTHENTICATOR: &'static str = "authenticator";
+    pub const VERSION: &'static str = "version";
+
+    pub const fn name(&self) -> &'static str {
+        Self::AUTHENTICATOR
+    }
+
+    pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
+        static AUTHENTICATOR_POSITIONS: Lazy<BTreeSet<AttributePosition>> =
+            Lazy::new(|| BTreeSet::from([AttributePosition::Function]));
+        &AUTHENTICATOR_POSITIONS
+    }
+}
+
+//**************************************************************************************************
+// Attribute_ implementation
+//**************************************************************************************************
+
+impl Attribute_ {
+    /// Parses the authenticator attribute and returns the version number.
+    /// Only accepts #[authenticator], #[authenticator = <u8>], or
+    /// #[authenticator(version = <u8>)].
+    pub fn parse_authenticator_version(&self, loc: &Loc) -> Result<u8, (Loc, String)> {
+        use crate::expansion::ast::{AttributeName_ as AN, AttributeValue_ as AV, Value_ as V};
+        fn authenticator_version(attribute_value: &AttributeValue) -> Result<u8, (Loc, String)> {
+            match attribute_value {
+                sp!(_, AV::Value(sp!(_, V::U8(value)))) => Ok(*value),
+                sp!(_, AV::Value(sp!(_, V::InferredNum(value))))
+                    if *value <= U256::from(u8::MAX) =>
+                {
+                    Ok(value.down_cast_lossy())
+                }
+                _ => Err((
+                    attribute_value.loc,
+                    "Only unannotated or u8 literal `version` values are supported.".to_string(),
+                )),
+            }
+        }
+
+        match self {
+            Attribute_::Name(_) => Ok(1), // default version
+            Attribute_::Assigned(_, attribute_value) => authenticator_version(&attribute_value),
+            Attribute_::Parameterized(_, inner_attributes) => {
+                let version_attr = inner_attributes
+                    .get_(&AN::Unknown(Symbol::from(AuthenticatorAttribute::VERSION)));
+                let Some(sp!(_, version_value)) = version_attr else {
+                    return Err((
+                        *loc,
+                        "Missing `version` for authenticator attribute. Expected format: #[authenticator(version = ...)]".to_string(),
+                    ));
+                };
+                if let Attribute_::Assigned(_, attribute_value) = version_value {
+                    authenticator_version(&attribute_value)
+                } else {
+                    Ok(1) // default version
+                }
+            }
+        }
+    }
+}
+
+//**************************************************************************************************
+// Attributes implementation
+//**************************************************************************************************
+
+impl Attributes {
+    pub fn get_authenticator(&self) -> Option<u8> {
+        self.get_(&MoveKnownAttribute::from(AuthenticatorAttribute))
+            .and_then(|sp!(authenticator_loc, authenticator_value)| {
+                authenticator_value
+                    .parse_authenticator_version(authenticator_loc)
+                    .ok()
+            })
+    }
+}
+
+//**************************************************************************************************
+// From
+//**************************************************************************************************
+
+impl From<AuthenticatorAttribute> for MoveKnownAttribute {
+    fn from(a: AuthenticatorAttribute) -> Self {
+        Self::Flavored(FlavoredAttribute {
+            name: a.name(),
+            expected_positions: a.expected_positions(),
+        })
+    }
+}
+
+//**************************************************************************************************
+// Display
+//**************************************************************************************************
+
+impl fmt::Display for AuthenticatorAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/iota_mode/known_attributes/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/iota_mode/known_attributes/mod.rs
@@ -5,34 +5,37 @@
 
 use std::{collections::BTreeSet, fmt};
 
+use authenticator::AuthenticatorAttribute;
+
 use crate::shared::known_attributes::{AttributePosition, KnownAttribute as MoveKnownAttribute};
+
+pub mod authenticator;
 
 /// The list of attribute types recognized by the compiler for the IOTA
 /// Flavor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum KnownAttribute {}
+pub enum KnownAttribute {
+    Authenticator(AuthenticatorAttribute),
+}
 
 impl KnownAttribute {
-    pub fn resolve(_attribute_str: impl AsRef<str>) -> Option<MoveKnownAttribute> {
-        // Some(match attribute_str.as_ref() {
-        //     Attribute::ATTRIBUTE => Attribute.into(),
-        //     _ => return None,
-        // })
-        return None;
+    pub fn resolve(attribute_str: impl AsRef<str>) -> Option<MoveKnownAttribute> {
+        Some(match attribute_str.as_ref() {
+            AuthenticatorAttribute::AUTHENTICATOR => AuthenticatorAttribute.into(),
+            _ => return None,
+        })
     }
 
     pub const fn name(&self) -> &str {
-        // match self {
-        //    Self::Attribute(a) => a.name(),
-        //}
-        unimplemented!()
+        match self {
+            Self::Authenticator(a) => a.name(),
+        }
     }
 
     pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
-        // match self {
-        //    Self::Attribute(a) => a.expected_positions(),
-        //}
-        unimplemented!()
+        match self {
+            Self::Authenticator(a) => a.expected_positions(),
+        }
     }
 }
 
@@ -41,10 +44,10 @@ impl KnownAttribute {
 //**************************************************************************************************
 
 impl fmt::Display for KnownAttribute {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // match self {
-        //    Self::Authenticator(a) => a.fmt(f),
-        //}
-        unimplemented!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Authenticator(a) => a.fmt(f),
+        }
     }
 }
+

--- a/external-crates/move/crates/move-compiler/src/iota_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/iota_mode/typing.rs
@@ -11,8 +11,8 @@ use crate::{
     diag,
     diagnostics::{Diagnostic, DiagnosticReporter, Diagnostics, warning_filters::WarningFilters},
     editions::Flavor,
-    expansion::ast::{AbilitySet, Fields, ModuleIdent, Mutability, Visibility},
-    iota_mode::*,
+    expansion::ast::{AbilitySet, Attribute_, Fields, ModuleIdent, Mutability, Visibility},
+    iota_mode::{known_attributes as iota_known_attributes, *},
     naming::ast::{
         self as N, BuiltinTypeName_, FunctionSignature, StructFields, Type, Type_, TypeName_, Var,
     },
@@ -305,6 +305,11 @@ fn function(context: &mut Context, name: FunctionName, fdef: &T::Function) {
     }
     if let Some(entry_loc) = entry {
         entry_signature(context, *entry_loc, name, signature);
+    }
+    if let Some(sp!(authenticator_loc, authenticator_value)) =
+        attributes.get_(&iota_known_attributes::authenticator::AuthenticatorAttribute.into())
+    {
+        authenticator_attribute(context, authenticator_loc, authenticator_value);
     }
     if let sp!(_, T::FunctionBody_::Defined(seq)) = body {
         context.visit_seq(body.loc, seq)
@@ -1107,4 +1112,17 @@ fn check_private_transfer(context: &mut Context, loc: Loc, mcall: &ModuleCall) {
         }
         context.add_diag(diag)
     }
+}
+
+/// Checks the `authenticator` attribute for a valid version field.
+/// Only accepts #[authenticator], #[authenticator = <u8>], or
+/// #[authenticator(version = <u8>)].
+fn authenticator_attribute(
+    context: &mut Context,
+    authenticator_loc: &Loc,
+    authenticator_value: &Attribute_,
+) {
+    let _ = authenticator_value
+        .parse_authenticator_version(authenticator_loc)
+        .map_err(|(loc, err)| context.add_diag(diag!(Attributes::InvalidValue, (loc, err))));
 }

--- a/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/assigned/version_literals.move
+++ b/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/assigned/version_literals.move
@@ -1,0 +1,22 @@
+module 0x42::M {
+  #[authenticator = 3]
+  public fun authenticator_function_inferred() {}
+
+  #[authenticator = 3u8]
+  public fun authenticator_function_u8() {}
+
+  #[authenticator = 3u16]
+  public fun authenticator_function_u16() {}
+
+  #[authenticator = 3u32]
+  public fun authenticator_function_u32() {}
+
+  #[authenticator = 3u64]
+  public fun authenticator_function_u64() {}
+
+  #[authenticator = 3u128]
+  public fun authenticator_function_u128() {}
+
+  #[authenticator = 3u256]
+  public fun authenticator_function_u256() {}
+}

--- a/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/assigned/version_literals.snap
+++ b/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/assigned/version_literals.snap
@@ -1,0 +1,36 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: iota
+  edition: legacy
+  lint: false
+---
+error[E10003]: invalid attribute value
+  ┌─ tests/iota_mode/authenticator_attribute/assigned/version_literals.move:8:21
+  │
+8 │   #[authenticator = 3u16]
+  │                     ^^^^ Only unannotated or u8 literal `version` values are supported.
+
+error[E10003]: invalid attribute value
+   ┌─ tests/iota_mode/authenticator_attribute/assigned/version_literals.move:11:21
+   │
+11 │   #[authenticator = 3u32]
+   │                     ^^^^ Only unannotated or u8 literal `version` values are supported.
+
+error[E10003]: invalid attribute value
+   ┌─ tests/iota_mode/authenticator_attribute/assigned/version_literals.move:14:21
+   │
+14 │   #[authenticator = 3u64]
+   │                     ^^^^ Only unannotated or u8 literal `version` values are supported.
+
+error[E10003]: invalid attribute value
+   ┌─ tests/iota_mode/authenticator_attribute/assigned/version_literals.move:17:21
+   │
+17 │   #[authenticator = 3u128]
+   │                     ^^^^^ Only unannotated or u8 literal `version` values are supported.
+
+error[E10003]: invalid attribute value
+   ┌─ tests/iota_mode/authenticator_attribute/assigned/version_literals.move:20:21
+   │
+20 │   #[authenticator = 3u256]
+   │                     ^^^^^ Only unannotated or u8 literal `version` values are supported.

--- a/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/assigned/zero_value_accepted.move
+++ b/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/assigned/zero_value_accepted.move
@@ -1,0 +1,6 @@
+module 0x42::M {
+  // The value of zero is incorrect, but the compiler does not know about this.
+  // The verifier must handle whether or not the authenticator is within the accepted limits.
+  #[authenticator = 0]
+  public fun authenticator_function() {}
+}

--- a/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/assigned/zero_value_accepted.snap
+++ b/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/assigned/zero_value_accepted.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: iota
+  edition: legacy
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/named/value_not_assigned.move
+++ b/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/named/value_not_assigned.move
@@ -1,0 +1,5 @@
+module 0x42::M {
+  // Means authenticator version 1.
+  #[authenticator]
+  public fun authenticator_function() {}
+}

--- a/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/named/value_not_assigned.snap
+++ b/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/named/value_not_assigned.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: iota
+  edition: legacy
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/parameterized/version_literals.move
+++ b/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/parameterized/version_literals.move
@@ -1,0 +1,22 @@
+module 0x42::M {
+  #[authenticator(version = 3)]
+  public fun authenticator_function_inferred() {}
+
+  #[authenticator(version = 3u8)]
+  public fun authenticator_function_u8() {}
+
+  #[authenticator(version = 3u16)]
+  public fun authenticator_function_u16() {}
+
+  #[authenticator(version = 3u32)]
+  public fun authenticator_function_u32() {}
+
+  #[authenticator(version = 3u64)]
+  public fun authenticator_function_u64() {}
+
+  #[authenticator(version = 3u128)]
+  public fun authenticator_function_u128() {}
+
+  #[authenticator(version = 3u256)]
+  public fun authenticator_function_u256() {}
+}

--- a/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/parameterized/version_literals.snap
+++ b/external-crates/move/crates/move-compiler/tests/iota_mode/authenticator_attribute/parameterized/version_literals.snap
@@ -1,0 +1,36 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: iota
+  edition: legacy
+  lint: false
+---
+error[E10003]: invalid attribute value
+  ┌─ tests/iota_mode/authenticator_attribute/parameterized/version_literals.move:8:29
+  │
+8 │   #[authenticator(version = 3u16)]
+  │                             ^^^^ Only unannotated or u8 literal `version` values are supported.
+
+error[E10003]: invalid attribute value
+   ┌─ tests/iota_mode/authenticator_attribute/parameterized/version_literals.move:11:29
+   │
+11 │   #[authenticator(version = 3u32)]
+   │                             ^^^^ Only unannotated or u8 literal `version` values are supported.
+
+error[E10003]: invalid attribute value
+   ┌─ tests/iota_mode/authenticator_attribute/parameterized/version_literals.move:14:29
+   │
+14 │   #[authenticator(version = 3u64)]
+   │                             ^^^^ Only unannotated or u8 literal `version` values are supported.
+
+error[E10003]: invalid attribute value
+   ┌─ tests/iota_mode/authenticator_attribute/parameterized/version_literals.move:17:29
+   │
+17 │   #[authenticator(version = 3u128)]
+   │                             ^^^^^ Only unannotated or u8 literal `version` values are supported.
+
+error[E10003]: invalid attribute value
+   ┌─ tests/iota_mode/authenticator_attribute/parameterized/version_literals.move:20:29
+   │
+20 │   #[authenticator(version = 3u256)]
+   │                             ^^^^^ Only unannotated or u8 literal `version` values are supported.


### PR DESCRIPTION
# Description of change

To support defining authenticator functions for the IOTA abstract account workflow the user must be able to
specify in Move code which functions should be considered "authenticators".
Moreover in the future there may be more than one version of authenticators so a version number must be supported as well.

This PR provides three formats to define a move authenticator with version.
As a Named attribute:
```
#[authenticator]
public fun authenticator_fun(...)
```
In this case the version number is inferred to be 1.

As an Assigned attribute:
```
#[authenticator = 1]
public fun authenticator_fun(...)
```
Where the version number is assigned explicitly.

And as a Parametrized attribute:
```
#[authenticator(version = 1)]
public fun authenticator_fun(...)
```
In this format the user must explicitly spell out the version number and assign a value to it. While the format is verbose, it may become a preferred variant as it could potentially be extended with additional features like:
```
#[authenticator(version = 1,  something_else = 53)]
```

## Implementation notes
Attributes do NOT reach the bytecode. Instead these are stored into the `FunctionInfo` and this passed upward. Later PRs will deal with handling the Authenticator attribute from within the `FunctionInfo` (in this PR, just `iota_types::move_package::FnInfo` was extended to support the authenticator version).

## Links to any relevant issues

Fixes #8860 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
