### PR TITLE
feat(move-build,verifier): fill authenticator metadata during package build and check its validity

### DIFF
--- a/crates/iota-move-build/src/lib.rs
+++ b/crates/iota-move-build/src/lib.rs
@@ -23,8 +23,8 @@ use iota_types::{
     error::{IotaError, IotaResult},
     is_system_package,
     move_package::{
-        FnInfo, FnInfoKey, FnInfoMap, MovePackage, RuntimeModuleMetadata,
-        RuntimeModuleMetadataWrapper,
+        FnInfo, FnInfoKey, FnInfoMap, IotaAttribute, MovePackage, RuntimeModuleMetadata,
+        RuntimeModuleMetadataWrapper, get_authenticator_version_from_fun,
     },
 };
 use iota_verifier::verifier as iota_bytecode_verifier;
@@ -360,26 +360,24 @@ fn collect_bytecode_deps(
 }
 
 /// Fill metadata
-fn fill_metadata(package: &mut MoveCompiledPackage, _fn_info_map: &FnInfoMap) -> IotaResult<()> {
+fn fill_metadata(package: &mut MoveCompiledPackage, fn_info_map: &FnInfoMap) -> IotaResult<()> {
     for module in package
         .root_compiled_units
         .iter_mut()
         .map(|unit| &mut unit.unit.module)
     {
-        let runtime_metadata = RuntimeModuleMetadata::default();
-        // for fn_def in &module.function_defs {
-        //    let fn_handle = module.function_handle_at(fn_def.function);
-        //    let fn_name = module.identifier_at(fn_handle.name);
-        //    fill metadata with custom logic
-        //    if let Some(version) =
-        //    get_attribute(fn_name, module, fn_info_map)
-        //.   {
-        //       runtime_metadata.add_function_attribute(
-        //           fn_name.to_string(),
-        //           IotaAttribute::attribute(version),
-        //       );
-        //    };
-        // }
+        let mut runtime_metadata = RuntimeModuleMetadata::default();
+        for fn_def in &module.function_defs {
+            let fn_handle = module.function_handle_at(fn_def.function);
+            let fn_name = module.identifier_at(fn_handle.name);
+            if let Some(version) = get_authenticator_version_from_fun(fn_name, module, fn_info_map)
+            {
+                runtime_metadata.add_function_attribute(
+                    fn_name.to_string(),
+                    IotaAttribute::authenticator_attribute(version),
+                );
+            };
+        }
         if !runtime_metadata.is_empty() {
             module.metadata.push(move_core_types::metadata::Metadata {
                 key: IOTA_METADATA_KEY.to_vec(),

--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -663,6 +663,24 @@ pub fn is_test_fun(name: &IdentStr, module: &CompiledModule, fn_info_map: &FnInf
     }
 }
 
+pub fn get_authenticator_version_from_fun(
+    name: &IdentStr,
+    module: &CompiledModule,
+    fn_info_map: &FnInfoMap,
+) -> Option<u8> {
+    let fn_name = name.to_string();
+    let mod_handle = module.self_handle();
+    let mod_addr = *module.address_identifier_at(mod_handle.address);
+    let fn_info_key = FnInfoKey { fn_name, mod_addr };
+    match fn_info_map.get(&fn_info_key) {
+        Some(FnInfo {
+            is_test: _,
+            authenticator_version: Some(v),
+        }) => Some(*v),
+        _ => None,
+    }
+}
+
 pub fn normalize_modules<'a, I>(
     modules: I,
     binary_config: &BinaryConfig,
@@ -877,6 +895,14 @@ pub enum RuntimeModuleMetadata {
 }
 
 impl RuntimeModuleMetadata {
+    pub fn add_function_attribute(&mut self, function_name: String, attribute: IotaAttribute) {
+        match self {
+            RuntimeModuleMetadata::V1(metadata) => {
+                metadata.add_function_attribute(function_name, attribute)
+            }
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
         match self {
             RuntimeModuleMetadata::V1(metadata) => metadata.is_empty(),
@@ -923,7 +949,18 @@ impl TryFrom<RuntimeModuleMetadataWrapper> for RuntimeModuleMetadata {
 /// The list of iota attribute types recognized by the compiler.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum IotaAttribute {
-    // Attribute(Attribute),
+    Authenticator(AuthenticatorAttribute),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct AuthenticatorAttribute {
+    version: u8,
+}
+
+impl IotaAttribute {
+    pub fn authenticator_attribute(version: u8) -> Self {
+        IotaAttribute::Authenticator(AuthenticatorAttribute { version })
+    }
 }
 
 /// V1 of IOTA specific metadata.

--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -954,7 +954,7 @@ pub enum IotaAttribute {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct AuthenticatorAttribute {
-    version: u8,
+    pub version: u8,
 }
 
 impl IotaAttribute {

--- a/iota-execution/latest/iota-move-natives/src/account.rs
+++ b/iota-execution/latest/iota-move-natives/src/account.rs
@@ -82,7 +82,7 @@ pub fn check_auth_info_v1(
         );
     };
 
-    if let Err(execution_error) = account_auth_verifier::verify_authenticate_func(
+    if let Err(execution_error) = account_auth_verifier::verify_authenticate_func_v1(
         &compiled_module,
         function_identifier,
         &context.type_to_type_tag(&ty_args[0])?,

--- a/iota-execution/latest/iota-verifier/src/account_auth_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/account_auth_verifier.rs
@@ -37,7 +37,7 @@ use crate::verification_failure;
 /// - the last two arguments in order are AuthContext and TxContext
 /// - AuthContext has to be an immutable reference
 /// - TxContext has to be an immutable reference
-pub fn verify_authenticate_func(
+pub fn verify_authenticate_func_v1(
     module: &CompiledModule,
     function_identifier: Identifier,
     account_type: &TypeTag,

--- a/iota-execution/latest/iota-verifier/src/runtime_module_metadata.rs
+++ b/iota-execution/latest/iota-verifier/src/runtime_module_metadata.rs
@@ -9,12 +9,13 @@
 //! metadata version.
 
 use iota_types::{
+    Identifier,
     error::ExecutionError,
-    move_package::{RuntimeModuleMetadata, RuntimeModuleMetadataWrapper},
+    move_package::{IotaAttribute, RuntimeModuleMetadata, RuntimeModuleMetadataWrapper},
 };
 use move_binary_format::{file_format::CompiledModule, file_format_common::IOTA_METADATA_KEY};
 
-use crate::verification_failure;
+use crate::{account_auth_verifier::verify_authenticate_func_v1, verification_failure};
 
 /// Verifies the runtime module metadata of the given module.
 /// If the module does not contain any runtime metadata, just pass.
@@ -59,11 +60,56 @@ pub fn verify_module(module: &CompiledModule) -> Result<(), ExecutionError> {
 }
 
 fn verify_runtime_metadata(
-    _module: &CompiledModule,
-    _metadata: &RuntimeModuleMetadata,
+    module: &CompiledModule,
+    metadata: &RuntimeModuleMetadata,
 ) -> Result<(), ExecutionError> {
-    // Currently no checks are implemented for the runtime metadata.
-    // Future checks can be added here as needed.
-
+    for (fn_name, fn_attributes) in metadata.fun_attributes_iter() {
+        // Temporary code to get the function signature and pass it to
+        // verify_authenticate_func_v1
+        let type_tag = {
+            let (_, fn_def) = module.find_function_def_by_name(fn_name.as_str()).unwrap();
+            let fn_handle = module.function_handle_at(fn_def.function);
+            let fn_sig = module.signature_at(fn_handle.parameters);
+            let sig_token = &fn_sig.0[0];
+            let move_binary_format::file_format::SignatureToken::Reference(ref_param) = sig_token
+            else {
+                return Err(verification_failure(format!(
+                    "The first parameter of authenticator function {fn_name} must be a reference type"
+                )));
+            };
+            move_binary_format::normalized::Type::new(module, ref_param)
+                .into_type_tag()
+                .unwrap()
+        };
+        // end of temporary code
+        // Verify each function attribute
+        for attribute in fn_attributes {
+            match attribute {
+                IotaAttribute::Authenticator(attr) => {
+                    // Verify authenticator attribute
+                    match attr.version {
+                        1 => {
+                            // Version 1: verify that the function is a valid authenticator
+                            verify_authenticate_func_v1(
+                                module,
+                                Identifier::new(fn_name.clone()).map_err(|err| {
+                                    verification_failure(format!(
+                                        "Failed to read function name: {err}",
+                                    ))
+                                })?,
+                                &type_tag,
+                            )?;
+                        }
+                        _ => {
+                            return Err(verification_failure(format!(
+                                "Unsupported authenticator attribute version {} for function {}",
+                                attr.version, fn_name
+                            )));
+                        }
+                    }
+                }
+            }
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
# Description of change

This PR builds on top of the previous ones in order to make so that the `#[authenticator]` attribute is stored into the compiled module bytes. This allows the verifier to retrieve the attribute and then check the associated function for authentication validity. 

## Links to any relevant issues

Fixes #9189

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
