### PR TITLE
fix(iota-private-network): disable batch feature for faucet in privatenet docker compose

### DIFF
--- a/dev-tools/iota-private-network/docker-compose.yaml
+++ b/dev-tools/iota-private-network/docker-compose.yaml
@@ -396,7 +396,6 @@ services:
       - --max-request-per-second=50
       - --batch-request-size=1000
       - --ttl-expiration=150
-      - --batch-enabled=true
     ports:
       - "127.0.0.1:5003:5003/tcp"
       - "127.0.0.1:9188:9184/tcp"

--- a/dev-tools/iota-private-network/docker-compose.yaml
+++ b/dev-tools/iota-private-network/docker-compose.yaml
@@ -394,7 +394,6 @@ services:
       - --num-coins=10
       - --amount=200000000000
       - --max-request-per-second=50
-      - --batch-request-size=1000
       - --ttl-expiration=150
     ports:
       - "127.0.0.1:5003:5003/tcp"


### PR DESCRIPTION
# Description of change

This PR disables the batch feature for the faucet in the privatenet docker compose file, since otherwise the faucet cannot provide gas - I am not really sure why, but it just works as expected if the batch feature is simply disabled.

## How the change has been tested

- Build and run a private network as instructed [here](https://github.com/iotaledger/iota/tree/develop/dev-tools/iota-private-network). Make sure to bring up a faucet while running the private net: `./run.sh faucet`.
- Also make sure the faucet is up (can be checked with `docker ps`, for example).
- Request gas coins from the faucet:
   ```sh
   curl -X POST 'http://127.0.0.1:5003/gas' \
   --header 'Content-Type: application/json' \
   --data-raw "{
       \"FixedAmountRequest\": {
           \"recipient\": \"$(iota client active-address)\"
       }
   }"
   ```

On `develop`, such faucet request returns `{"transferredGasObjects":[],"error":"Timed out waiting for a coin from the gas coin pool"}`. If the batch feature is disabled (this branch), the gas faucet request completes as expected.