### PR TITLE
fix: use single requests for aws ec2 commands

### DIFF
--- a/crates/iota-aws-orchestrator/src/client/aws.rs
+++ b/crates/iota-aws-orchestrator/src/client/aws.rs
@@ -368,19 +368,22 @@ impl ServerProviderClient for AwsClient {
     where
         I: Iterator<Item = &'a Instance> + Send,
     {
-        let mut instance_ids = HashMap::new();
-        for instance in instances {
-            instance_ids
-                .entry(&instance.region)
-                .or_insert_with(Vec::new)
-                .push(instance.id.clone());
-        }
-
-        for (region, client) in &self.clients {
-            let ids = instance_ids.remove(&region.to_string());
-            if ids.is_some() {
-                client.stop_instances().set_instance_ids(ids).send().await?;
-            }
+        let map_of_ids_by_region = instances.into_iter().fold(
+            HashMap::new(),
+            |mut acc: HashMap<String, Vec<String>>, i| {
+                acc.entry(i.region.clone()).or_default().push(i.id.clone());
+                acc
+            },
+        );
+        for (region, ids) in map_of_ids_by_region {
+            let client = self.clients.get(&region).ok_or_else(|| {
+                CloudProviderError::Request(format!("Undefined region {:?}", region))
+            })?;
+            client
+                .stop_instances()
+                .set_instance_ids(Some(ids))
+                .send()
+                .await?;
         }
         Ok(())
     }
@@ -389,7 +392,8 @@ impl ServerProviderClient for AwsClient {
         &self,
         region: S,
         role: InstanceRole,
-    ) -> CloudProviderResult<Instance>
+        quantity: usize,
+    ) -> CloudProviderResult<Vec<Instance>>
     where
         S: Into<String> + Serialize + Send,
     {
@@ -434,32 +438,43 @@ impl ServerProviderClient for AwsClient {
             .image_id(image_id)
             .instance_type(instance_type.as_str().into())
             .key_name(testbed_id)
-            .min_count(1)
-            .max_count(1)
+            .min_count(quantity as i32)
+            .max_count(quantity as i32)
             .security_groups(&self.settings.testbed_id)
             .block_device_mappings(storage)
             .tag_specifications(tags);
 
         let response = request.send().await?;
-        let instance = &response
+        let instances = response
             .instances()
-            .first()
-            .expect("AWS instances list should contain instances");
+            .iter()
+            .map(|instance| self.make_instance(region.clone(), instance))
+            .collect::<Vec<_>>();
 
-        Ok(self.make_instance(region, instance))
+        Ok(instances)
     }
 
-    async fn delete_instance(&self, instance: Instance) -> CloudProviderResult<()> {
-        let client = self.clients.get(&instance.region).ok_or_else(|| {
-            CloudProviderError::Request(format!("Undefined region {:?}", instance.region))
-        })?;
-
-        client
-            .terminate_instances()
-            .set_instance_ids(Some(vec![instance.id.clone()]))
-            .send()
-            .await?;
-
+    async fn delete_instances<'a, I>(&self, instances: I) -> CloudProviderResult<()>
+    where
+        I: Iterator<Item = &'a Instance> + Send,
+    {
+        let map_of_ids_by_region = instances.into_iter().fold(
+            HashMap::new(),
+            |mut acc: HashMap<String, Vec<String>>, i| {
+                acc.entry(i.region.clone()).or_default().push(i.id.clone());
+                acc
+            },
+        );
+        for (region, ids) in map_of_ids_by_region {
+            let client = self.clients.get(&region).ok_or_else(|| {
+                CloudProviderError::Request(format!("Undefined region {:?}", region))
+            })?;
+            client
+                .terminate_instances()
+                .set_instance_ids(Some(ids))
+                .send()
+                .await?;
+        }
         Ok(())
     }
 

--- a/crates/iota-aws-orchestrator/src/client/mod.rs
+++ b/crates/iota-aws-orchestrator/src/client/mod.rs
@@ -123,7 +123,7 @@ pub trait ServerProviderClient: Display {
 
     /// Halt/Stop the specified instances. We may still be billed for stopped
     /// instances.
-    async fn stop_instances<'a, I>(&self, instance_ids: I) -> CloudProviderResult<()>
+    async fn stop_instances<'a, I>(&self, instances: I) -> CloudProviderResult<()>
     where
         I: Iterator<Item = &'a Instance> + Send;
 
@@ -132,13 +132,16 @@ pub trait ServerProviderClient: Display {
         &self,
         region: S,
         role: InstanceRole,
-    ) -> CloudProviderResult<Instance>
+        quantity: usize,
+    ) -> CloudProviderResult<Vec<Instance>>
     where
         S: Into<String> + Serialize + Send;
 
     /// Delete a specific instance. Calling this function ensures we are no
     /// longer billed for the specified instance.
-    async fn delete_instance(&self, instance: Instance) -> CloudProviderResult<()>;
+    async fn delete_instances<'a, I>(&self, instances: I) -> CloudProviderResult<()>
+    where
+        I: Iterator<Item = &'a Instance> + Send;
 
     /// Authorize the provided ssh public key to access machines.
     async fn register_ssh_public_key(&self, public_key: String) -> CloudProviderResult<()>;
@@ -231,29 +234,40 @@ pub mod test_client {
             &self,
             region: S,
             role: InstanceRole,
-        ) -> CloudProviderResult<Instance>
+            quantity: usize,
+        ) -> CloudProviderResult<Vec<Instance>>
         where
             S: Into<String> + Serialize + Send,
         {
             let mut guard = self.instances.lock().unwrap();
-            let id = guard.len();
-            let instance = Instance {
-                id: id.to_string(),
-                region: region.into(),
-                main_ip: format!("0.0.0.{id}").parse().unwrap(),
-                private_ip: format!("0.0.0.{id}").parse().unwrap(),
-                tags: Vec::new(),
-                specs: self.settings.node_specs.clone(),
-                status: "running".into(),
-                role,
-            };
-            guard.push(instance.clone());
-            Ok(instance)
+            let mut instances = Vec::new();
+            let region = region.into();
+            for _ in 0..quantity {
+                let id = guard.len();
+                let instance = Instance {
+                    id: id.to_string(),
+                    region: region.clone(),
+                    main_ip: format!("0.0.0.{id}").parse().unwrap(),
+                    private_ip: format!("0.0.0.{id}").parse().unwrap(),
+                    tags: Vec::new(),
+                    specs: self.settings.node_specs.clone(),
+                    status: "running".into(),
+                    role: role.clone(),
+                };
+                guard.push(instance.clone());
+                instances.push(instance);
+            }
+
+            Ok(instances)
         }
 
-        async fn delete_instance(&self, instance: Instance) -> CloudProviderResult<()> {
+        async fn delete_instances<'a, I>(&self, instances: I) -> CloudProviderResult<()>
+        where
+            I: Iterator<Item = &'a Instance> + Send,
+        {
+            let ids_to_delete = instances.map(|x| x.id.clone()).collect::<Vec<_>>();
             let mut guard = self.instances.lock().unwrap();
-            guard.retain(|x| x.id != instance.id);
+            guard.retain(|x| !ids_to_delete.contains(&x.id));
             Ok(())
         }
 

--- a/crates/iota-aws-orchestrator/src/testbed.rs
+++ b/crates/iota-aws-orchestrator/src/testbed.rs
@@ -163,7 +163,7 @@ impl<C: ServerProviderClient> Testbed<C> {
     ) -> TestbedResult<()> {
         display::action(format!("Deploying instances ({quantity} per region)"));
 
-        let mut instances = vec![];
+        let mut instances: Vec<Instance> = vec![];
 
         if !skip_monitoring {
             let metrics_region = match &region {
@@ -177,48 +177,57 @@ impl<C: ServerProviderClient> Testbed<C> {
             };
             let metrics_instance = self
                 .client
-                .create_instance(metrics_region, InstanceRole::Metrics)
+                .create_instance(metrics_region, InstanceRole::Metrics, 1)
                 .await?;
-            instances.push(metrics_instance);
+            instances.extend(metrics_instance);
         }
 
         let node_instances = match &region {
             Some(x) => {
-                try_join_all(
-                    (0..quantity)
-                        .map(|_| self.client.create_instance(x.clone(), InstanceRole::Node)),
-                )
-                .await?
+                self.client
+                    .create_instance(x.clone(), InstanceRole::Node, quantity)
+                    .await?
             }
             None => {
-                try_join_all(self.settings.regions.iter().flat_map(|region| {
-                    (0..quantity).map(|_| {
-                        self.client
-                            .create_instance(region.clone(), InstanceRole::Node)
-                    })
-                }))
-                .await?
+                // Multi-region case — call create_instance per region in parallel
+                let tasks = self.settings.regions.iter().map(|region| {
+                    self.client
+                        .create_instance(region.clone(), InstanceRole::Node, quantity)
+                });
+
+                // Run them all concurrently, flatten Vec<Vec<Instance>> → Vec<Instance>
+                try_join_all(tasks)
+                    .await?
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
             }
         };
         instances.extend(node_instances);
 
         let client_instances = match (&region, dedicated_clients) {
             (_, 0) => vec![],
-            (Some(x), _) => {
-                try_join_all(
-                    (0..dedicated_clients)
-                        .map(|_| self.client.create_instance(x.clone(), InstanceRole::Client)),
-                )
-                .await?
+            (Some(x), instance_quantity) => {
+                self.client
+                    .create_instance(x.clone(), InstanceRole::Client, instance_quantity)
+                    .await?
             }
-            (None, dedicated_clients) => {
-                try_join_all(self.settings.regions.iter().flat_map(|region| {
-                    (0..dedicated_clients).map(|_| {
-                        self.client
-                            .create_instance(region.clone(), InstanceRole::Client)
-                    })
-                }))
-                .await?
+            (None, instance_quantity) => {
+                // Multi-region case — call create_instance per region in parallel
+                let tasks = self.settings.regions.iter().map(|region| {
+                    self.client.create_instance(
+                        region.clone(),
+                        InstanceRole::Client,
+                        instance_quantity,
+                    )
+                });
+
+                // Run them all concurrently, flatten Vec<Vec<Instance>> → Vec<Instance>
+                try_join_all(tasks)
+                    .await?
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
             }
         };
 
@@ -255,14 +264,14 @@ impl<C: ServerProviderClient> Testbed<C> {
     /// Destroy all instances of the testbed.
     pub async fn destroy(&mut self, keep_monitoring: bool) -> TestbedResult<()> {
         display::action("Destroying testbed");
-
-        try_join_all(
-            self.instances()
-                .iter()
-                .filter(|i| !(keep_monitoring && i.role == InstanceRole::Metrics))
-                .map(|instance| self.client.delete_instance(instance.clone())),
-        )
-        .await?;
+        let instances_to_destroy = self
+            .instances()
+            .into_iter()
+            .filter(|i| !(keep_monitoring && i.role == InstanceRole::Metrics))
+            .collect::<Vec<_>>();
+        self.client
+            .delete_instances(instances_to_destroy.iter())
+            .await?;
 
         display::done();
         Ok(())


### PR DESCRIPTION
# Description of change

Previous implementation used request per instance for the aws ec2 commands deploy, destroy, stop, start.
This PR, uses a request per region.

## Links to any relevant issues

fixes #9202 .

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
