### PR TITLE
refactor(starfish): updates for pending and solid subdags

### DIFF
--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -18,9 +18,9 @@ use crate::{
     BlockRef, CommitConsumer, CommittedSubDag,
     block_header::{BlockHeaderAPI, VerifiedBlockHeader},
     commit::{CommitAPI, CommitIndex, PendingSubDag, load_pending_subdag_from_store},
+    commit_solidifier::CommitSolidifier,
     context::Context,
     dag_state::DagState,
-    data_manager::DataManager,
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
     linearizer::Linearizer,
@@ -45,9 +45,9 @@ use crate::{
 pub(crate) struct CommitObserver {
     context: Arc<Context>,
     /// Component to deterministically collect subdags for committed leaders.
-    commit_interpreter: Linearizer,
+    linearizer: Linearizer,
     /// Component to deterministically collect subdags for committed leaders.
-    commit_solidifier: DataManager,
+    commit_solidifier: CommitSolidifier,
     /// An unbounded channel to send committed sub-dags to the consumer of
     /// consensus output.
     sender: UnboundedSender<CommittedSubDag>,
@@ -72,12 +72,12 @@ impl CommitObserver {
     ) -> Self {
         let last_processed_commit_index = commit_consumer.last_processed_commit_index;
         let mut observer = Self {
-            commit_interpreter: Linearizer::new(
+            linearizer: Linearizer::new(
                 context.clone(),
                 dag_state.clone(),
                 leader_schedule.clone(),
             ),
-            commit_solidifier: DataManager::new(dag_state.clone()),
+            commit_solidifier: CommitSolidifier::new(dag_state.clone()),
             context,
             sender: commit_consumer.sender,
             store,
@@ -100,7 +100,7 @@ impl CommitObserver {
     /// - A vector of block references to transactions that were missing during
     ///   the commit.
     #[instrument(level = "trace", skip_all)]
-    pub(crate) fn handle_commit(
+    pub(crate) fn handle_committed_leaders(
         &mut self,
         committed_leaders: Vec<VerifiedBlockHeader>,
     ) -> ConsensusResult<(
@@ -112,16 +112,23 @@ impl CommitObserver {
             .metrics
             .node_metrics
             .scope_processing_time
-            .with_label_values(&["CommitObserver::handle_commit"])
+            .with_label_values(&["CommitObserver::handle_committed_leaders"])
             .start_timer();
 
-        let pending_sub_dags = self.commit_interpreter.handle_commit(committed_leaders);
+        let pending_sub_dags = self.linearizer.get_pending_sub_dags(committed_leaders);
 
         // First, add the commits to the commit solidifier to make sure that the data is
         // available. This function returns not only the just-created commits but also
         // any pending ones that'd become solid since the last commit.
-        let (solid_sub_dags, missing_transactions) =
-            self.commit_solidifier.try_commit(&pending_sub_dags);
+        let (solid_sub_dags, missing_transactions) = self
+            .commit_solidifier
+            .try_get_solid_sub_dags(&pending_sub_dags);
+
+        // Committed headers and sequenced transactions must be persisted to storage
+        // before sending them outside consensus.
+        if !pending_sub_dags.is_empty() || !solid_sub_dags.is_empty() {
+            self.dag_state.write().flush();
+        }
 
         tracing::trace!("Missing committed transactions {missing_transactions:#?}");
 
@@ -130,7 +137,7 @@ impl CommitObserver {
         // fetch the missing transactions from the authorities that acknowledged
         // them.
         let missing_transaction_acknowledgers = self
-            .commit_interpreter
+            .linearizer
             .get_transaction_ack_authors(missing_transactions);
 
         let mut sent_sub_dags = Vec::with_capacity(solid_sub_dags.len());
@@ -175,7 +182,7 @@ impl CommitObserver {
                 .expect("There should be at least one solid subdag")
                 .leader
                 .round;
-            self.commit_interpreter
+            self.linearizer
                 .evict_old_acknowledgments(max_solid_commit_leader_round);
         }
         tracing::trace!("Committed & sent {sent_sub_dags:#?}");
@@ -261,7 +268,7 @@ impl CommitObserver {
             for ((round, authority_idx), transaction_acknowledgments) in
                 pending_sub_dag.transaction_acknowledgments().into_iter()
             {
-                self.commit_interpreter.add_committed_transaction_acks(
+                self.linearizer.add_committed_transaction_acks(
                     round,
                     authority_idx,
                     transaction_acknowledgments,
@@ -271,7 +278,9 @@ impl CommitObserver {
             // they are tracked there. The commit will be sent to IOTA here if all the
             // transactions are available or will be kept in the buffer and sent later when
             // the transactions become available.
-            let (solid_sub_dags, _missing) = self.commit_solidifier.try_commit(&[pending_sub_dag]);
+            let (solid_sub_dags, _missing) = self
+                .commit_solidifier
+                .try_get_solid_sub_dags(&[pending_sub_dag]);
             // Only submit unprocessed commits to IOTA
             for solid_sub_dag in solid_sub_dags {
                 if solid_sub_dag.commit_ref.index > last_processed_commit_index {
@@ -315,7 +324,7 @@ impl CommitObserver {
         &self,
     ) -> BTreeMap<BlockRef, BTreeSet<AuthorityIndex>> {
         let missing_refs = self.commit_solidifier.get_missing_transaction_data();
-        self.commit_interpreter
+        self.linearizer
             .get_transaction_ack_authors(missing_refs.into_iter().collect())
     }
 
@@ -356,11 +365,13 @@ impl CommitObserver {
             }
         }
 
-        self.context
-            .metrics
-            .node_metrics
-            .sub_dags_per_commit_count
-            .observe(pending_sub_dags.len() as f64);
+        if !pending_sub_dags.is_empty() {
+            self.context
+                .metrics
+                .node_metrics
+                .sub_dags_per_commit_count
+                .observe(pending_sub_dags.len() as f64);
+        }
 
         // Now report transaction-related metrics for committed subdags
         for commit in committed_sub_dags {
@@ -475,7 +486,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let (commits, _missing_transactions_refs) =
-            observer.handle_commit(leaders.clone()).unwrap();
+            observer.handle_committed_leaders(leaders.clone()).unwrap();
 
         // Check commits are returned by CommitObserver::handle_commit is accurate
         let mut expected_stored_refs: Vec<BlockRef> = vec![];
@@ -594,7 +605,7 @@ mod tests {
         // consumer of the consensus output channel.
         let expected_last_processed_index: usize = 2;
         let (mut created_commits, _missing_transactions_refs) = observer
-            .handle_commit(
+            .handle_committed_leaders(
                 leaders
                     .clone()
                     .into_iter()
@@ -630,7 +641,7 @@ mod tests {
         // the consumer side where the commits were not persisted.
         created_commits.append(
             &mut observer
-                .handle_commit(
+                .handle_committed_leaders(
                     leaders
                         .clone()
                         .into_iter()
@@ -732,7 +743,7 @@ mod tests {
         // the consensus output channel.
         let expected_last_processed_index: usize = 10;
         let (created_commits, _missing_transactions_refs) =
-            observer.handle_commit(leaders.clone()).unwrap();
+            observer.handle_committed_leaders(leaders.clone()).unwrap();
 
         // Check commits sent over consensus output channel is accurate
         let mut processed_subdag_index = 0;

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -11,13 +11,14 @@ use tracing::debug;
 
 use crate::{BlockRef, CommitIndex, CommittedSubDag, commit::PendingSubDag, dag_state::DagState};
 
-/// The `DataManager` is responsible for managing and handling
-/// the commit process for newly committed sub-dags. It ensures that sub-dags
-/// are committed after transactions included in the commit are available and
-/// that sub-dags are committed in order. The `DataManager` also tracks the
-/// highest committed index and maintains a buffer for pending sub-dags for
-/// which either the transactions are not yet available or the previous sub-dags
-/// are missing transactions and have not been output yet.
+/// The `CommitSolidifier` is responsible for managing and handling
+/// the commit process for newly committed pending sub-dags. It ensures that
+/// sub-dags that are sent for execution are solid, i.e. all transactions
+/// included in the pending sub_dags are locally available and sub-dags are
+/// committed in order. The `CommitSolidifier` also tracks the highest committed
+/// index and maintains a buffer for pending sub-dags for which either the
+/// transactions are not yet available or the previous sub-dags are missing
+/// transactions and have not been output yet.
 ///
 /// # Fields
 /// - `dag_state`: Shared state of the DAG.
@@ -25,37 +26,30 @@ use crate::{BlockRef, CommitIndex, CommittedSubDag, commit::PendingSubDag, dag_s
 /// - `last_committed_index`: Tracks the highest committed sub-dag index.
 ///
 /// # Usage
-/// The `DataManager` is used to process newly committed sub-dags by retrieving
-/// information about potentially missing blocks.
-pub(crate) struct DataManager {
+/// The `CommitSolidifier` is used to process newly committed sub-dags by
+/// retrieving information about potentially missing transactions.
+pub(crate) struct CommitSolidifier {
     dag_state: Arc<RwLock<DagState>>,
     // Buffer for pending subdags, keyed by commit_ref.index for order
     pending_subdags: BTreeMap<u32, PendingSubDag>,
-    // The highest committed commit_ref.index
-    last_committed_index: CommitIndex,
+    // The highest solid commit_ref.index
+    last_solid_committed_index: CommitIndex,
 }
 
-impl DataManager {
-    /// Creates a new instance of `DataManager`.
-    ///
-    /// # Arguments
-    /// - `dag_state`: Shared state of the DAG.
-    ///
-    /// # Returns
-    /// A new `DataManager` instance.
+impl CommitSolidifier {
     pub(crate) fn new(dag_state: Arc<RwLock<DagState>>) -> Self {
-        // the last_committed_index is set non-trivially during a recovery process
+        // the last_solid_committed_index is set non-trivially during a recovery process
         // before the first usage of try_commit method.
-        let last_committed_index = 0;
+        let last_solid_committed_index = 0;
         Self {
             dag_state,
             pending_subdags: BTreeMap::new(),
-            last_committed_index,
+            last_solid_committed_index,
         }
     }
 
     pub(crate) fn set_last_committed_index(&mut self, index: CommitIndex) {
-        self.last_committed_index = index;
+        self.last_solid_committed_index = index;
     }
 
     /// Gets all missing transactions from pending subdags.
@@ -90,7 +84,7 @@ impl DataManager {
     /// - `Vec<CommittedSubDag>`: Successfully committed sub-dags.
     /// - `Vec<BlockRef>`: References to blocks with missing transactions
     ///   preventing further commits.
-    pub(crate) fn try_commit(
+    pub(crate) fn try_get_solid_sub_dags(
         &mut self,
         subdags: &[PendingSubDag],
     ) -> (Vec<CommittedSubDag>, Vec<BlockRef>) {
@@ -101,7 +95,7 @@ impl DataManager {
                 .or_insert_with(|| subdag.clone());
         }
         let mut committed = Vec::new();
-        let mut last_committed = self.last_committed_index;
+        let mut last_committed = self.last_solid_committed_index;
         let mut missing = BTreeSet::new();
 
         // Try to commit in order
@@ -109,10 +103,10 @@ impl DataManager {
             let next_index = last_committed + 1;
             // If the next expected subdag is not in the buffer, we cannot commit anything
             // further
-            let Some(subdag) = self.pending_subdags.get(&next_index) else {
+            let Some(pending_subdag) = self.pending_subdags.get(&next_index) else {
                 break;
             };
-            match self.try_commit_one_internal(subdag) {
+            match self.try_get_one_solid_sub_dag_internal(pending_subdag) {
                 Ok(committed_subdag) => {
                     committed.push(committed_subdag);
                     self.pending_subdags.remove(&next_index);
@@ -145,12 +139,12 @@ impl DataManager {
         }
 
         // Update last_committed_index
-        self.last_committed_index = last_committed;
+        self.last_solid_committed_index = last_committed;
 
         // Only check for missing refs in the newly passed subdags that weren't
         // processed yet
         for subdag in subdags {
-            if subdag.commit_ref.index > self.last_committed_index {
+            if subdag.commit_ref.index > self.last_solid_committed_index {
                 // Query dag_state directly for missing transactions
                 let dag_state_guard = self.dag_state.read();
                 let exists = dag_state_guard
@@ -172,16 +166,16 @@ impl DataManager {
         (committed, missing.into_iter().collect())
     }
 
-    /// Internal method to retrieve all committed transactions and checks if all
-    /// previous commits have been committed.
+    /// Internal method to retrieve all transactions commited to PendingSubDag
+    /// and form CommittedSubDAG if all of them are locally available
     ///
     /// # Arguments
     /// - `subdag`: A reference to the `PendingSubDag` to be committed.
     ///
     /// # Returns
-    /// - `Ok(CommittedSubDag)`: If all required blocks exist.
-    /// - `Err(Vec<BlockRef>)`: If some blocks are missing.
-    fn try_commit_one_internal(
+    /// - `Ok(CommittedSubDag)`: If all required transactions are in DagState
+    /// - `Err(Vec<BlockRef>)`: If some transactions are missing.
+    fn try_get_one_solid_sub_dag_internal(
         &self,
         subdag: &PendingSubDag,
     ) -> Result<CommittedSubDag, Vec<BlockRef>> {
@@ -322,10 +316,10 @@ mod tests {
             &self,
             included_rounds: Vec<u32>,
             excluded_blocks: Vec<(u32, usize)>,
-        ) -> (DataManager, Arc<RwLock<DagState>>) {
+        ) -> (CommitSolidifier, Arc<RwLock<DagState>>) {
             let selective_dag_state =
                 self.create_selective_dag_state(included_rounds, excluded_blocks);
-            let manager = DataManager::new(selective_dag_state.clone());
+            let manager = CommitSolidifier::new(selective_dag_state.clone());
             (manager, selective_dag_state)
         }
 
@@ -521,7 +515,7 @@ mod tests {
     #[tokio::test]
     async fn test_happy_path_commit() {
         let setup = Arc::new(TestSetup::new(3));
-        let mut manager = DataManager::new(setup.dag_state.clone());
+        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -533,10 +527,10 @@ mod tests {
             .with_committed_refs_from_round(1)
             .build();
 
-        let (committed, missing) = manager.try_commit(&[subdag]);
+        let (committed, missing) = manager.try_get_solid_sub_dags(&[subdag]);
         assert_eq!(committed.len(), 1);
         assert!(missing.is_empty());
-        assert_eq!(manager.last_committed_index, 1);
+        assert_eq!(manager.last_solid_committed_index, 1);
         assert!(manager.pending_subdags.is_empty());
     }
 
@@ -558,7 +552,7 @@ mod tests {
             .with_committed_refs(vec![setup.dag_builder.block_headers(1..=1)[0].reference()]) // Commit
             .build();
 
-        let (committed, missing) = manager.try_commit(&[subdag]);
+        let (committed, missing) = manager.try_get_solid_sub_dags(&[subdag]);
         assert!(committed.is_empty());
         assert_eq!(missing.len(), 1);
         assert_eq!(
@@ -566,7 +560,7 @@ mod tests {
             setup.dag_builder.block_headers(1..=1)[0].reference()
         );
         assert_eq!(manager.pending_subdags.len(), 1);
-        assert_eq!(manager.last_committed_index, 0);
+        assert_eq!(manager.last_solid_committed_index, 0);
     }
 
     #[tokio::test]
@@ -588,7 +582,7 @@ mod tests {
             .build();
 
         // The first attempt should fail due to a missing block
-        let (committed, missing) = manager.try_commit(std::slice::from_ref(&subdag));
+        let (committed, missing) = manager.try_get_solid_sub_dags(std::slice::from_ref(&subdag));
         assert!(committed.is_empty());
         assert_eq!(missing.len(), 1);
 
@@ -596,17 +590,17 @@ mod tests {
         setup.add_missing_transactions(&selective_dag_state, &[(1, 0)]);
 
         // The second attempt should succeed
-        let (committed, missing) = manager.try_commit(&[]);
+        let (committed, missing) = manager.try_get_solid_sub_dags(&[]);
         assert_eq!(committed.len(), 1);
         assert!(missing.is_empty());
         assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_committed_index, 1);
+        assert_eq!(manager.last_solid_committed_index, 1);
     }
 
     #[tokio::test]
     async fn test_multiple_subdags_in_order() {
         let setup = Arc::new(TestSetup::new(4));
-        let mut manager = DataManager::new(setup.dag_state.clone());
+        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -624,17 +618,17 @@ mod tests {
             .with_committed_refs_from_round(2)
             .build();
 
-        let (committed, missing) = manager.try_commit(&[subdag1, subdag2]);
+        let (committed, missing) = manager.try_get_solid_sub_dags(&[subdag1, subdag2]);
         assert_eq!(committed.len(), 2);
         assert!(missing.is_empty());
         assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_committed_index, 2);
+        assert_eq!(manager.last_solid_committed_index, 2);
     }
 
     #[tokio::test]
     async fn test_out_of_order_subdags() {
         let setup = Arc::new(TestSetup::new(4));
-        let mut manager = DataManager::new(setup.dag_state.clone());
+        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -653,36 +647,37 @@ mod tests {
             .build();
 
         // Submit out of order
-        let (committed, missing) = manager.try_commit(&[subdag2.clone(), subdag1.clone()]);
+        let (committed, missing) =
+            manager.try_get_solid_sub_dags(&[subdag2.clone(), subdag1.clone()]);
         assert_eq!(committed.len(), 2);
         assert!(missing.is_empty());
         assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_committed_index, 2);
+        assert_eq!(manager.last_solid_committed_index, 2);
 
         // The second call should be no-op
-        let (committed, missing) = manager.try_commit(&[]);
+        let (committed, missing) = manager.try_get_solid_sub_dags(&[]);
         assert!(committed.is_empty());
         assert!(missing.is_empty());
         assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_committed_index, 2);
+        assert_eq!(manager.last_solid_committed_index, 2);
     }
 
     #[tokio::test]
     async fn test_empty_subdag_commit() {
         let setup = Arc::new(TestSetup::new(2));
-        let mut manager = DataManager::new(setup.dag_state.clone());
+        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
 
-        let (committed, missing) = manager.try_commit(&[]);
+        let (committed, missing) = manager.try_get_solid_sub_dags(&[]);
         assert!(committed.is_empty());
         assert!(missing.is_empty());
         assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_committed_index, 0);
+        assert_eq!(manager.last_solid_committed_index, 0);
     }
 
     #[tokio::test]
     async fn test_duplicate_subdag_commit() {
         let setup = Arc::new(TestSetup::new(3));
-        let mut manager = DataManager::new(setup.dag_state.clone());
+        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -694,17 +689,18 @@ mod tests {
             .with_committed_refs_from_round(1)
             .build();
 
-        let (committed, missing) = manager.try_commit(&[subdag1.clone(), subdag1.clone()]);
+        let (committed, missing) =
+            manager.try_get_solid_sub_dags(&[subdag1.clone(), subdag1.clone()]);
         assert_eq!(committed.len(), 1);
         assert!(missing.is_empty());
         assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_committed_index, 1);
+        assert_eq!(manager.last_solid_committed_index, 1);
     }
 
     #[tokio::test]
     async fn test_out_of_order_commit_calls() {
         let setup = Arc::new(TestSetup::new(4));
-        let mut manager = DataManager::new(setup.dag_state.clone());
+        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -723,18 +719,18 @@ mod tests {
             .build();
 
         // First submit subdag2 (index 2)
-        let (committed, missing) = manager.try_commit(std::slice::from_ref(&subdag2));
+        let (committed, missing) = manager.try_get_solid_sub_dags(std::slice::from_ref(&subdag2));
         assert!(committed.is_empty());
         assert!(missing.is_empty());
         assert!(manager.pending_subdags.contains_key(&2));
-        assert_eq!(manager.last_committed_index, 0);
+        assert_eq!(manager.last_solid_committed_index, 0);
 
         // Then submit subdag1 (index 1) - should commit both
-        let (committed, missing) = manager.try_commit(std::slice::from_ref(&subdag1));
+        let (committed, missing) = manager.try_get_solid_sub_dags(std::slice::from_ref(&subdag1));
         assert_eq!(committed.len(), 2);
         assert!(missing.is_empty());
         assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_committed_index, 2);
+        assert_eq!(manager.last_solid_committed_index, 2);
     }
 
     #[tokio::test]
@@ -769,17 +765,17 @@ mod tests {
             .build();
 
         // Initial commit attempts
-        let (committed, missing) = manager.try_commit(std::slice::from_ref(&subdag3));
+        let (committed, missing) = manager.try_get_solid_sub_dags(std::slice::from_ref(&subdag3));
         assert!(committed.is_empty());
         assert_eq!(missing.len(), 1);
         assert_eq!(manager.pending_subdags.len(), 1);
 
-        let (committed, missing) = manager.try_commit(std::slice::from_ref(&subdag2));
+        let (committed, missing) = manager.try_get_solid_sub_dags(std::slice::from_ref(&subdag2));
         assert!(committed.is_empty());
         assert_eq!(missing.len(), 1);
         assert_eq!(manager.pending_subdags.len(), 2);
 
-        let (committed, missing) = manager.try_commit(std::slice::from_ref(&subdag1));
+        let (committed, missing) = manager.try_get_solid_sub_dags(std::slice::from_ref(&subdag1));
         assert!(missing.is_empty());
         assert_eq!(committed.len(), 1); // subdag1 can commit
         assert_eq!(committed[0].commit_ref, subdag1.commit_ref);
@@ -787,17 +783,17 @@ mod tests {
 
         // Add missing block from round 1
         setup.add_missing_transactions(&selective_dag_state, &[(1, 0)]);
-        let (committed, _missing) = manager.try_commit(&[]);
+        let (committed, _missing) = manager.try_get_solid_sub_dags(&[]);
         assert_eq!(committed.len(), 1); // subdag2 commits
         assert_eq!(committed[0].commit_ref, subdag2.commit_ref);
-        assert_eq!(manager.last_committed_index, 2);
+        assert_eq!(manager.last_solid_committed_index, 2);
 
         // Add missing block from round 2
         setup.add_missing_transactions(&selective_dag_state, &[(2, 0)]);
-        let (committed, _missing) = manager.try_commit(&[]);
+        let (committed, _missing) = manager.try_get_solid_sub_dags(&[]);
         assert_eq!(committed.len(), 1); // subdag3 commits
         assert_eq!(committed[0].commit_ref, subdag3.commit_ref);
-        assert_eq!(manager.last_committed_index, 3);
+        assert_eq!(manager.last_solid_committed_index, 3);
         assert!(manager.pending_subdags.is_empty());
     }
 
@@ -835,7 +831,7 @@ mod tests {
             .build();
 
         // This should panic due to a duplicate missing block ref
-        manager.try_commit(&[subdag1, subdag2, subdag3]);
+        manager.try_get_solid_sub_dags(&[subdag1, subdag2, subdag3]);
     }
 
     #[tokio::test]
@@ -874,7 +870,7 @@ mod tests {
             .build();
 
         // Initial commit - should commit first two, buffer the rest
-        let (committed, missing) = manager.try_commit(&[
+        let (committed, missing) = manager.try_get_solid_sub_dags(&[
             subdag1.clone(),
             subdag2.clone(),
             subdag3.clone(),
@@ -883,41 +879,41 @@ mod tests {
         assert_eq!(committed.len(), 2);
         assert_eq!(missing.len(), 2);
         assert_eq!(manager.pending_subdags.len(), 2);
-        assert_eq!(manager.last_committed_index, 2);
+        assert_eq!(manager.last_solid_committed_index, 2);
 
         // Add missing transaction for subdag3
         setup.add_missing_transactions(&selective_dag_state, &[(1, 0)]);
-        let (committed, _missing) = manager.try_commit(&[]);
+        let (committed, _missing) = manager.try_get_solid_sub_dags(&[]);
         assert_eq!(committed.len(), 1); // subdag3 commits
-        assert_eq!(manager.last_committed_index, 3);
+        assert_eq!(manager.last_solid_committed_index, 3);
 
         // Add missing transaction for subdag5
         setup.add_missing_transactions(&selective_dag_state, &[(3, 0)]);
-        let (committed, _missing) = manager.try_commit(&[]);
+        let (committed, _missing) = manager.try_get_solid_sub_dags(&[]);
         assert!(committed.is_empty()); // subdag5 can't commit due to a gap (missing index 4)
         assert_eq!(manager.pending_subdags.len(), 1); // subdag5 still pending
-        assert_eq!(manager.last_committed_index, 3); // Unchanged
+        assert_eq!(manager.last_solid_committed_index, 3); // Unchanged
     }
 
     #[tokio::test]
     async fn test_set_last_committed_index() {
         let setup = Arc::new(TestSetup::new(3));
-        let mut manager = DataManager::new(setup.dag_state.clone());
+        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
 
         // Initially should be 0
-        assert_eq!(manager.last_committed_index, 0);
+        assert_eq!(manager.last_solid_committed_index, 0);
 
         // Set to a new value
         manager.set_last_committed_index(5);
-        assert_eq!(manager.last_committed_index, 5);
+        assert_eq!(manager.last_solid_committed_index, 5);
 
         // Can set to a lower value
         manager.set_last_committed_index(3);
-        assert_eq!(manager.last_committed_index, 3);
+        assert_eq!(manager.last_solid_committed_index, 3);
 
         // Can set to 0
         manager.set_last_committed_index(0);
-        assert_eq!(manager.last_committed_index, 0);
+        assert_eq!(manager.last_solid_committed_index, 0);
     }
 
     #[tokio::test]
@@ -942,7 +938,7 @@ mod tests {
             .build();
 
         // Add subdags to manager
-        manager.try_commit(&[subdag1, subdag2]);
+        manager.try_get_solid_sub_dags(&[subdag1, subdag2]);
 
         // Get missing transactions
         let missing = manager.get_missing_transaction_data();

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -94,7 +94,7 @@ impl CommitSolidifier {
                 .entry(subdag.commit_ref.index)
                 .or_insert_with(|| subdag.clone());
         }
-        let mut committed = Vec::new();
+        let mut committed_subdags = Vec::new();
         let mut last_committed = self.last_solid_committed_index;
         let mut missing = BTreeSet::new();
 
@@ -108,7 +108,7 @@ impl CommitSolidifier {
             };
             match self.try_get_one_solid_sub_dag_internal(pending_subdag) {
                 Ok(committed_subdag) => {
-                    committed.push(committed_subdag);
+                    committed_subdags.push(committed_subdag);
                     self.pending_subdags.remove(&next_index);
                     last_committed = next_index;
                 }
@@ -126,16 +126,21 @@ impl CommitSolidifier {
 
         // Update dag state with the round of the leader in the last committed subdag
         // This will allow to evict transactions from the DAG state
-        if !committed.is_empty() {
-            let mut dag_state_guard = self.dag_state.write();
-
-            dag_state_guard.update_last_solid_commit_leader_round(
-                committed
+        // In addition, update with the latest solid_commit_refs which are used for
+        // commit syncer
+        if !committed_subdags.is_empty() {
+            let solid_commit_refs = committed_subdags
+                .iter()
+                .map(|subdag| subdag.commit_ref)
+                .collect();
+            let mut dag_state = self.dag_state.write();
+            dag_state.update_last_solid_commit_leader_round(
+                committed_subdags
                     .last()
                     .expect("We should expect at least one committed subdag")
                     .leader_round(),
             );
-            drop(dag_state_guard);
+            dag_state.update_pending_commit_votes(solid_commit_refs);
         }
 
         // Update last_committed_index
@@ -163,7 +168,7 @@ impl CommitSolidifier {
             }
         }
 
-        (committed, missing.into_iter().collect())
+        (committed_subdags, missing.into_iter().collect())
     }
 
     /// Internal method to retrieve all transactions commited to PendingSubDag

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -171,7 +171,7 @@ impl CommitSolidifier {
         (committed_subdags, missing.into_iter().collect())
     }
 
-    /// Internal method to retrieve all transactions commited to PendingSubDag
+    /// Internal method to retrieve all transactions committed to PendingSubDag
     /// and form CommittedSubDAG if all of them are locally available
     ///
     /// # Arguments
@@ -316,16 +316,16 @@ mod tests {
             selective_dag_state
         }
 
-        /// Creates a DataManager with a selective DAG state
-        fn create_selective_manager(
+        /// Creates a CommitSolidifier with a selective DAG state
+        fn create_selective_commit_solidifier(
             &self,
             included_rounds: Vec<u32>,
             excluded_blocks: Vec<(u32, usize)>,
         ) -> (CommitSolidifier, Arc<RwLock<DagState>>) {
             let selective_dag_state =
                 self.create_selective_dag_state(included_rounds, excluded_blocks);
-            let manager = CommitSolidifier::new(selective_dag_state.clone());
-            (manager, selective_dag_state)
+            let commit_solidifier = CommitSolidifier::new(selective_dag_state.clone());
+            (commit_solidifier, selective_dag_state)
         }
 
         /// Adds missing transactions for specific blocks back to the DAG state
@@ -520,7 +520,7 @@ mod tests {
     #[tokio::test]
     async fn test_happy_path_commit() {
         let setup = Arc::new(TestSetup::new(3));
-        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
+        let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -532,20 +532,21 @@ mod tests {
             .with_committed_refs_from_round(1)
             .build();
 
-        let (committed, missing) = manager.try_get_solid_sub_dags(&[subdag]);
+        let (committed, missing) = commit_solidifier.try_get_solid_sub_dags(&[subdag]);
         assert_eq!(committed.len(), 1);
         assert!(missing.is_empty());
-        assert_eq!(manager.last_solid_committed_index, 1);
-        assert!(manager.pending_subdags.is_empty());
+        assert_eq!(commit_solidifier.last_solid_committed_index, 1);
+        assert!(commit_solidifier.pending_subdags.is_empty());
     }
 
     #[tokio::test]
     async fn test_missing_blocks() {
         let setup = Arc::new(TestSetup::new(3));
-        let (mut manager, _selective_dag_state) = setup.create_selective_manager(
-            vec![1, 2, 3],
-            vec![(1, 0)], // Exclude the first transaction from round 1
-        );
+        let (mut commit_solidifier, _selective_dag_state) = setup
+            .create_selective_commit_solidifier(
+                vec![1, 2, 3],
+                vec![(1, 0)], // Exclude the first transaction from round 1
+            );
 
         let subdag = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -557,24 +558,25 @@ mod tests {
             .with_committed_refs(vec![setup.dag_builder.block_headers(1..=1)[0].reference()]) // Commit
             .build();
 
-        let (committed, missing) = manager.try_get_solid_sub_dags(&[subdag]);
+        let (committed, missing) = commit_solidifier.try_get_solid_sub_dags(&[subdag]);
         assert!(committed.is_empty());
         assert_eq!(missing.len(), 1);
         assert_eq!(
             missing[0],
             setup.dag_builder.block_headers(1..=1)[0].reference()
         );
-        assert_eq!(manager.pending_subdags.len(), 1);
-        assert_eq!(manager.last_solid_committed_index, 0);
+        assert_eq!(commit_solidifier.pending_subdags.len(), 1);
+        assert_eq!(commit_solidifier.last_solid_committed_index, 0);
     }
 
     #[tokio::test]
     async fn test_commit_after_missing_blocks_arrive() {
         let setup = Arc::new(TestSetup::new(3));
-        let (mut manager, selective_dag_state) = setup.create_selective_manager(
-            vec![1, 2, 3],
-            vec![(1, 0)], // Exclude the first transactions from round 1
-        );
+        let (mut commit_solidifier, selective_dag_state) = setup
+            .create_selective_commit_solidifier(
+                vec![1, 2, 3],
+                vec![(1, 0)], // Exclude the first transactions from round 1
+            );
 
         let subdag = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -587,7 +589,8 @@ mod tests {
             .build();
 
         // The first attempt should fail due to a missing block
-        let (committed, missing) = manager.try_get_solid_sub_dags(std::slice::from_ref(&subdag));
+        let (committed, missing) =
+            commit_solidifier.try_get_solid_sub_dags(std::slice::from_ref(&subdag));
         assert!(committed.is_empty());
         assert_eq!(missing.len(), 1);
 
@@ -595,17 +598,17 @@ mod tests {
         setup.add_missing_transactions(&selective_dag_state, &[(1, 0)]);
 
         // The second attempt should succeed
-        let (committed, missing) = manager.try_get_solid_sub_dags(&[]);
+        let (committed, missing) = commit_solidifier.try_get_solid_sub_dags(&[]);
         assert_eq!(committed.len(), 1);
         assert!(missing.is_empty());
-        assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_solid_committed_index, 1);
+        assert!(commit_solidifier.pending_subdags.is_empty());
+        assert_eq!(commit_solidifier.last_solid_committed_index, 1);
     }
 
     #[tokio::test]
     async fn test_multiple_subdags_in_order() {
         let setup = Arc::new(TestSetup::new(4));
-        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
+        let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -623,17 +626,17 @@ mod tests {
             .with_committed_refs_from_round(2)
             .build();
 
-        let (committed, missing) = manager.try_get_solid_sub_dags(&[subdag1, subdag2]);
+        let (committed, missing) = commit_solidifier.try_get_solid_sub_dags(&[subdag1, subdag2]);
         assert_eq!(committed.len(), 2);
         assert!(missing.is_empty());
-        assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_solid_committed_index, 2);
+        assert!(commit_solidifier.pending_subdags.is_empty());
+        assert_eq!(commit_solidifier.last_solid_committed_index, 2);
     }
 
     #[tokio::test]
     async fn test_out_of_order_subdags() {
         let setup = Arc::new(TestSetup::new(4));
-        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
+        let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -653,36 +656,36 @@ mod tests {
 
         // Submit out of order
         let (committed, missing) =
-            manager.try_get_solid_sub_dags(&[subdag2.clone(), subdag1.clone()]);
+            commit_solidifier.try_get_solid_sub_dags(&[subdag2.clone(), subdag1.clone()]);
         assert_eq!(committed.len(), 2);
         assert!(missing.is_empty());
-        assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_solid_committed_index, 2);
+        assert!(commit_solidifier.pending_subdags.is_empty());
+        assert_eq!(commit_solidifier.last_solid_committed_index, 2);
 
         // The second call should be no-op
-        let (committed, missing) = manager.try_get_solid_sub_dags(&[]);
+        let (committed, missing) = commit_solidifier.try_get_solid_sub_dags(&[]);
         assert!(committed.is_empty());
         assert!(missing.is_empty());
-        assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_solid_committed_index, 2);
+        assert!(commit_solidifier.pending_subdags.is_empty());
+        assert_eq!(commit_solidifier.last_solid_committed_index, 2);
     }
 
     #[tokio::test]
     async fn test_empty_subdag_commit() {
         let setup = Arc::new(TestSetup::new(2));
-        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
+        let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
-        let (committed, missing) = manager.try_get_solid_sub_dags(&[]);
+        let (committed, missing) = commit_solidifier.try_get_solid_sub_dags(&[]);
         assert!(committed.is_empty());
         assert!(missing.is_empty());
-        assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_solid_committed_index, 0);
+        assert!(commit_solidifier.pending_subdags.is_empty());
+        assert_eq!(commit_solidifier.last_solid_committed_index, 0);
     }
 
     #[tokio::test]
     async fn test_duplicate_subdag_commit() {
         let setup = Arc::new(TestSetup::new(3));
-        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
+        let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -695,17 +698,17 @@ mod tests {
             .build();
 
         let (committed, missing) =
-            manager.try_get_solid_sub_dags(&[subdag1.clone(), subdag1.clone()]);
+            commit_solidifier.try_get_solid_sub_dags(&[subdag1.clone(), subdag1.clone()]);
         assert_eq!(committed.len(), 1);
         assert!(missing.is_empty());
-        assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_solid_committed_index, 1);
+        assert!(commit_solidifier.pending_subdags.is_empty());
+        assert_eq!(commit_solidifier.last_solid_committed_index, 1);
     }
 
     #[tokio::test]
     async fn test_out_of_order_commit_calls() {
         let setup = Arc::new(TestSetup::new(4));
-        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
+        let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -724,18 +727,20 @@ mod tests {
             .build();
 
         // First submit subdag2 (index 2)
-        let (committed, missing) = manager.try_get_solid_sub_dags(std::slice::from_ref(&subdag2));
+        let (committed, missing) =
+            commit_solidifier.try_get_solid_sub_dags(std::slice::from_ref(&subdag2));
         assert!(committed.is_empty());
         assert!(missing.is_empty());
-        assert!(manager.pending_subdags.contains_key(&2));
-        assert_eq!(manager.last_solid_committed_index, 0);
+        assert!(commit_solidifier.pending_subdags.contains_key(&2));
+        assert_eq!(commit_solidifier.last_solid_committed_index, 0);
 
         // Then submit subdag1 (index 1) - should commit both
-        let (committed, missing) = manager.try_get_solid_sub_dags(std::slice::from_ref(&subdag1));
+        let (committed, missing) =
+            commit_solidifier.try_get_solid_sub_dags(std::slice::from_ref(&subdag1));
         assert_eq!(committed.len(), 2);
         assert!(missing.is_empty());
-        assert!(manager.pending_subdags.is_empty());
-        assert_eq!(manager.last_solid_committed_index, 2);
+        assert!(commit_solidifier.pending_subdags.is_empty());
+        assert_eq!(commit_solidifier.last_solid_committed_index, 2);
     }
 
     #[tokio::test]
@@ -743,10 +748,11 @@ mod tests {
         telemetry_subscribers::init_for_testing();
 
         let setup = Arc::new(TestSetup::new(4));
-        let (mut manager, selective_dag_state) = setup.create_selective_manager(
-            vec![1, 2, 3, 4],
-            vec![(1, 0), (2, 0)], // Exclude the first transactions from rounds 1 and 2
-        );
+        let (mut commit_solidifier, selective_dag_state) = setup
+            .create_selective_commit_solidifier(
+                vec![1, 2, 3, 4],
+                vec![(1, 0), (2, 0)], // Exclude the first transactions from rounds 1 and 2
+            );
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
             .leader(2, 0)
@@ -770,46 +776,50 @@ mod tests {
             .build();
 
         // Initial commit attempts
-        let (committed, missing) = manager.try_get_solid_sub_dags(std::slice::from_ref(&subdag3));
+        let (committed, missing) =
+            commit_solidifier.try_get_solid_sub_dags(std::slice::from_ref(&subdag3));
         assert!(committed.is_empty());
         assert_eq!(missing.len(), 1);
-        assert_eq!(manager.pending_subdags.len(), 1);
+        assert_eq!(commit_solidifier.pending_subdags.len(), 1);
 
-        let (committed, missing) = manager.try_get_solid_sub_dags(std::slice::from_ref(&subdag2));
+        let (committed, missing) =
+            commit_solidifier.try_get_solid_sub_dags(std::slice::from_ref(&subdag2));
         assert!(committed.is_empty());
         assert_eq!(missing.len(), 1);
-        assert_eq!(manager.pending_subdags.len(), 2);
+        assert_eq!(commit_solidifier.pending_subdags.len(), 2);
 
-        let (committed, missing) = manager.try_get_solid_sub_dags(std::slice::from_ref(&subdag1));
+        let (committed, missing) =
+            commit_solidifier.try_get_solid_sub_dags(std::slice::from_ref(&subdag1));
         assert!(missing.is_empty());
         assert_eq!(committed.len(), 1); // subdag1 can commit
         assert_eq!(committed[0].commit_ref, subdag1.commit_ref);
-        assert_eq!(manager.pending_subdags.len(), 2);
+        assert_eq!(commit_solidifier.pending_subdags.len(), 2);
 
         // Add missing block from round 1
         setup.add_missing_transactions(&selective_dag_state, &[(1, 0)]);
-        let (committed, _missing) = manager.try_get_solid_sub_dags(&[]);
+        let (committed, _missing) = commit_solidifier.try_get_solid_sub_dags(&[]);
         assert_eq!(committed.len(), 1); // subdag2 commits
         assert_eq!(committed[0].commit_ref, subdag2.commit_ref);
-        assert_eq!(manager.last_solid_committed_index, 2);
+        assert_eq!(commit_solidifier.last_solid_committed_index, 2);
 
         // Add missing block from round 2
         setup.add_missing_transactions(&selective_dag_state, &[(2, 0)]);
-        let (committed, _missing) = manager.try_get_solid_sub_dags(&[]);
+        let (committed, _missing) = commit_solidifier.try_get_solid_sub_dags(&[]);
         assert_eq!(committed.len(), 1); // subdag3 commits
         assert_eq!(committed[0].commit_ref, subdag3.commit_ref);
-        assert_eq!(manager.last_solid_committed_index, 3);
-        assert!(manager.pending_subdags.is_empty());
+        assert_eq!(commit_solidifier.last_solid_committed_index, 3);
+        assert!(commit_solidifier.pending_subdags.is_empty());
     }
 
     #[tokio::test]
     #[should_panic(expected = "Duplicate missing blockref detected")]
     async fn test_duplicate_missing_refs_panic() {
         let setup = Arc::new(TestSetup::new(4));
-        let (mut manager, _selective_dag_state) = setup.create_selective_manager(
-            vec![1, 2, 3, 4],
-            vec![(1, 0)], // Exclude the first transactions from round 1
-        );
+        let (mut commit_solidifier, _selective_dag_state) = setup
+            .create_selective_commit_solidifier(
+                vec![1, 2, 3, 4],
+                vec![(1, 0)], // Exclude the first transactions from round 1
+            );
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
             .leader(2, 0)
@@ -836,16 +846,17 @@ mod tests {
             .build();
 
         // This should panic due to a duplicate missing block ref
-        manager.try_get_solid_sub_dags(&[subdag1, subdag2, subdag3]);
+        commit_solidifier.try_get_solid_sub_dags(&[subdag1, subdag2, subdag3]);
     }
 
     #[tokio::test]
     async fn test_gaps_in_subdags_sequence() {
         let setup = Arc::new(TestSetup::new(5));
-        let (mut manager, selective_dag_state) = setup.create_selective_manager(
-            vec![1, 2, 3, 4, 5],
-            vec![(1, 0), (3, 0)], // Exclude first transactions from rounds 1 and 3
-        );
+        let (mut commit_solidifier, selective_dag_state) = setup
+            .create_selective_commit_solidifier(
+                vec![1, 2, 3, 4, 5],
+                vec![(1, 0), (3, 0)], // Exclude first transactions from rounds 1 and 3
+            );
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
             .leader(1, 0)
@@ -875,7 +886,7 @@ mod tests {
             .build();
 
         // Initial commit - should commit first two, buffer the rest
-        let (committed, missing) = manager.try_get_solid_sub_dags(&[
+        let (committed, missing) = commit_solidifier.try_get_solid_sub_dags(&[
             subdag1.clone(),
             subdag2.clone(),
             subdag3.clone(),
@@ -883,51 +894,53 @@ mod tests {
         ]);
         assert_eq!(committed.len(), 2);
         assert_eq!(missing.len(), 2);
-        assert_eq!(manager.pending_subdags.len(), 2);
-        assert_eq!(manager.last_solid_committed_index, 2);
+        assert_eq!(commit_solidifier.pending_subdags.len(), 2);
+        assert_eq!(commit_solidifier.last_solid_committed_index, 2);
 
         // Add missing transaction for subdag3
         setup.add_missing_transactions(&selective_dag_state, &[(1, 0)]);
-        let (committed, _missing) = manager.try_get_solid_sub_dags(&[]);
+        let (committed, _missing) = commit_solidifier.try_get_solid_sub_dags(&[]);
         assert_eq!(committed.len(), 1); // subdag3 commits
-        assert_eq!(manager.last_solid_committed_index, 3);
+        assert_eq!(commit_solidifier.last_solid_committed_index, 3);
 
         // Add missing transaction for subdag5
         setup.add_missing_transactions(&selective_dag_state, &[(3, 0)]);
-        let (committed, _missing) = manager.try_get_solid_sub_dags(&[]);
+        let (committed, _missing) = commit_solidifier.try_get_solid_sub_dags(&[]);
         assert!(committed.is_empty()); // subdag5 can't commit due to a gap (missing index 4)
-        assert_eq!(manager.pending_subdags.len(), 1); // subdag5 still pending
-        assert_eq!(manager.last_solid_committed_index, 3); // Unchanged
+        assert_eq!(commit_solidifier.pending_subdags.len(), 1); // subdag5 still pending
+        assert_eq!(commit_solidifier.last_solid_committed_index, 3); // Unchanged
     }
 
     #[tokio::test]
     async fn test_set_last_committed_index() {
         let setup = Arc::new(TestSetup::new(3));
-        let mut manager = CommitSolidifier::new(setup.dag_state.clone());
+        let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
         // Initially should be 0
-        assert_eq!(manager.last_solid_committed_index, 0);
+        assert_eq!(commit_solidifier.last_solid_committed_index, 0);
 
         // Set to a new value
-        manager.set_last_committed_index(5);
-        assert_eq!(manager.last_solid_committed_index, 5);
+        commit_solidifier.set_last_committed_index(5);
+        assert_eq!(commit_solidifier.last_solid_committed_index, 5);
 
         // Can set to a lower value
-        manager.set_last_committed_index(3);
-        assert_eq!(manager.last_solid_committed_index, 3);
+        commit_solidifier.set_last_committed_index(3);
+        assert_eq!(commit_solidifier.last_solid_committed_index, 3);
 
         // Can set to 0
-        manager.set_last_committed_index(0);
-        assert_eq!(manager.last_solid_committed_index, 0);
+        commit_solidifier.set_last_committed_index(0);
+        assert_eq!(commit_solidifier.last_solid_committed_index, 0);
     }
 
     #[tokio::test]
     async fn test_get_missing_transaction_data() {
         let setup = Arc::new(TestSetup::new(4));
-        let (mut manager, selective_dag_state) = setup.create_selective_manager(
-            vec![1, 2, 3, 4],
-            vec![(1, 0), (2, 1)], // Exclude transactions from round 1 block 0 and round 2 block 1
-        );
+        let (mut commit_solidifier, selective_dag_state) = setup
+            .create_selective_commit_solidifier(
+                vec![1, 2, 3, 4],
+                vec![(1, 0), (2, 1)], /* Exclude transactions from round 1 block 0 and round 2
+                                       * block 1 */
+            );
 
         // Create subdags that reference the missing transactions
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
@@ -942,11 +955,11 @@ mod tests {
             .with_committed_refs(vec![setup.dag_builder.block_headers(2..=2)[1].reference()])
             .build();
 
-        // Add subdags to manager
-        manager.try_get_solid_sub_dags(&[subdag1, subdag2]);
+        // Add subdags to commit_solidifier
+        commit_solidifier.try_get_solid_sub_dags(&[subdag1, subdag2]);
 
         // Get missing transactions
-        let missing = manager.get_missing_transaction_data();
+        let missing = commit_solidifier.get_missing_transaction_data();
         assert_eq!(missing.len(), 2);
         assert!(missing.contains(&setup.dag_builder.block_headers(1..=1)[0].reference()));
         assert!(missing.contains(&setup.dag_builder.block_headers(2..=2)[1].reference()));
@@ -955,7 +968,7 @@ mod tests {
         setup.add_missing_transactions(&selective_dag_state, &[(1, 0)]);
 
         // Check missing transactions again
-        let missing = manager.get_missing_transaction_data();
+        let missing = commit_solidifier.get_missing_transaction_data();
         assert_eq!(missing.len(), 1);
         assert!(missing.contains(&setup.dag_builder.block_headers(2..=2)[1].reference()));
 
@@ -963,7 +976,7 @@ mod tests {
         setup.add_missing_transactions(&selective_dag_state, &[(2, 1)]);
 
         // Should now have no missing transactions
-        let missing = manager.get_missing_transaction_data();
+        let missing = commit_solidifier.get_missing_transaction_data();
         assert!(missing.is_empty());
     }
 }

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -441,7 +441,7 @@ impl Core {
         // Commit observer is called with an empty vector of new leaders to check if all
         // transactions are available for any currently pending subdags, without
         // creating any new commits.
-        self.commit_observer.handle_commit(Vec::new())?;
+        self.commit_observer.handle_committed_leaders(Vec::new())?;
 
         Ok(())
     }
@@ -910,8 +910,9 @@ impl Core {
             );
 
             // TODO: refcount subdags
-            let (subdags, missing_transactions_refs) =
-                self.commit_observer.handle_commit(sequenced_leaders)?;
+            let (subdags, missing_transactions_refs) = self
+                .commit_observer
+                .handle_committed_leaders(sequenced_leaders)?;
 
             // Check for duplicates before extending
             assert!(

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -451,6 +451,9 @@ impl DagState {
             .gap_to_available_commit
             .set(gap as i64);
     }
+    pub(crate) fn update_pending_commit_votes(&mut self, solid_commit_refs: Vec<CommitRef>) {
+        self.pending_commit_votes.extend(solid_commit_refs);
+    }
 
     /// Updates internal metadata for accepted block header.
     fn update_block_header_metadata(&mut self, block_header: &VerifiedBlockHeader) {
@@ -1345,7 +1348,6 @@ impl DagState {
                 .set((*round).into());
         }
 
-        self.pending_commit_votes.push_back(commit.reference());
         self.commits_to_write.push(commit);
     }
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -148,7 +148,6 @@ pub(crate) struct DagState {
     scoring_subdag: ScoringSubdag,
 
     /// Commit votes pending to be included in new blocks.
-    // TODO: limit to 1st commit per round with multi-leader.
     pending_commit_votes: VecDeque<CommitVote>,
 
     /// Acknowledgments pending to be included in new blocks. These represent

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -97,7 +97,6 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
         tokio::pin!(max_leader_timeout);
 
         loop {
-            debug!("Loop is running");
             tokio::select! {
                 // When the min block delay timer expires, then we attempt to trigger the creation of a new block.
                 // If we already timed out before then, the branch gets disabled so we don't attempt

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -45,8 +45,8 @@ mod universal_committer;
 #[path = "tests/randomized_tests.rs"]
 mod randomized_tests;
 
+mod commit_solidifier;
 mod cordial_knowledge;
-mod data_manager;
 mod decoder;
 mod encoder;
 mod shard_reconstructor;

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -211,7 +211,7 @@ impl Linearizer {
     // Leaders in `committed_leaders` are assumed to be ordered in increasing
     // rounds.
     #[instrument(level = "trace", skip_all)]
-    pub(crate) fn handle_commit(
+    pub(crate) fn get_pending_sub_dags(
         &mut self,
         committed_leaders: Vec<VerifiedBlockHeader>,
     ) -> Vec<PendingSubDag> {
@@ -249,16 +249,6 @@ impl Linearizer {
 
             pending_sub_dags.push(sub_dag);
         }
-
-        // Committed blocks must be persisted to storage before sending them to IOTA and
-        // executing their transactions.
-        // Commit metadata can be persisted more lazily because they are recoverable.
-        // Uncommitted blocks can wait to persist too.
-        // But for simplicity, all unpersisted blocks and commits are flushed to
-        // storage.
-        let mut dag_state_guard = self.dag_state.write();
-        dag_state_guard.flush();
-        drop(dag_state_guard);
 
         pending_sub_dags
     }
@@ -451,7 +441,7 @@ mod tests {
             .map(Option::unwrap)
             .collect::<Vec<_>>();
 
-        let commits = linearizer.handle_commit(leaders.clone());
+        let commits = linearizer.get_pending_sub_dags(leaders.clone());
         for (idx, subdag) in commits.into_iter().enumerate() {
             tracing::info!("{subdag:?}");
             assert_eq!(subdag.leader, leaders[idx].reference());
@@ -533,7 +523,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Create some commits
-        let commits = linearizer.handle_commit(leaders.clone());
+        let commits = linearizer.get_pending_sub_dags(leaders.clone());
 
         // Write them in DagState
         dag_state
@@ -555,7 +545,7 @@ mod tests {
 
         // Now on the commits only the first one should contain the updated scores, the
         // other should be empty
-        let commits = linearizer.handle_commit(leaders.clone());
+        let commits = linearizer.get_pending_sub_dags(leaders.clone());
         assert_eq!(commits.len(), 10);
         let scores = vec![
             (AuthorityIndex::new_for_test(1), 29),
@@ -666,7 +656,7 @@ mod tests {
             vec![],
         );
 
-        let commit = linearizer.handle_commit(vec![leader.clone()]);
+        let commit = linearizer.get_pending_sub_dags(vec![leader.clone()]);
         assert_eq!(commit.len(), 1);
 
         let subdag = &commit[0];
@@ -768,7 +758,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         for (idx, leader) in leaders.iter().enumerate() {
-            let subdags = linearizer.handle_commit(vec![leader.clone()]);
+            let subdags = linearizer.get_pending_sub_dags(vec![leader.clone()]);
             assert_eq!(subdags.len(), 1);
             let subdag = &subdags[0];
 
@@ -887,7 +877,7 @@ mod tests {
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();
-        linearizer.handle_commit(leaders.clone());
+        linearizer.get_pending_sub_dags(leaders.clone());
         // Check that before eviction acknowledgements for all rounds up to num_rounds-2
         // are stored
         for round in 1..=num_rounds - 2 {


### PR DESCRIPTION
# Description of change

Commit handling contains several small inconsistencies which are fixed in this PR:
1. Computing `subdags_per_commit_count` was not correctly represented
2. `dag_state.flush()` should be called in case we have at least one pending or solid subdag (not necessarily pending)
3. `pending_commit_votes` should be updated when a new solid commit is produced (not pending). This is a prerequisite for commit syncer which allows for fetching transactions along with headers #9180
4. several renames for functions and fields

## Links to any relevant issues

Fixes #9222 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
