### PR TITLE
chore(homebrew): add protobuf source dependency

### DIFF
--- a/scripts/homebrew/template.rb
+++ b/scripts/homebrew/template.rb
@@ -31,6 +31,7 @@ class Iota < Formula
         depends_on "cmake" => :build
         depends_on "libpq" => :build
         depends_on "rust" => :build
+        depends_on "protobuf" => :build
         on_linux do
             depends_on "llvm" => :build
         end


### PR DESCRIPTION
# Description of change

This should have been done in the template rather than in the homebrew repo directly https://github.com/iotaledger/homebrew-tap/pull/24.