### PR TITLE
upstream(iota-graphql-rpc): document transaction/event filters and underlying schema

### DIFF
--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -1355,8 +1355,18 @@ type EventEdge {
 	cursor: String!
 }
 
+"""
+Represents optional available filters for events.
+"""
 input EventFilter {
+	"""
+	Filter down to events from transactions sent by this address.
+	"""
 	sender: IotaAddress
+	"""
+	Filter down to the events from this transaction (given by its
+	transaction digest).
+	"""
 	transactionDigest: String
 	"""
 	Events emitted by a particular module. An event is emitted by a
@@ -3203,11 +3213,8 @@ resulting set of objects are ones whose
 """
 input ObjectFilter {
 	"""
-	This field is used to specify the type of objects that should be
-	included in the query results.
-	
-	Objects can be filtered by their type's package, package::module, or
-	their fully qualified type name.
+	Filter objects by their type's `package`, `package::module`, or their
+	fully qualified type name.
 	
 	Generic types can be queried by either the generic type name, e.g.
 	`0x2::coin::Coin`, or by the full type name, such as
@@ -4534,21 +4541,57 @@ type TransactionBlockEffects {
 	bcs: Base64!
 }
 
+"""
+Represents optional available filters for transaction blocks.
+"""
 input TransactionBlockFilter {
+	"""
+	Filter transactions by move function called.
+	
+	Calls can be filtered by the `package`, `package::module`, or the
+	`package::module::name` of their function.
+	"""
 	function: String
 	"""
 	An input filter selecting for either system or programmable
 	transactions.
 	"""
 	kind: TransactionBlockKindInput
+	"""
+	Limit to transactions that occurred strictly after the given checkpoint.
+	"""
 	afterCheckpoint: UInt53
+	"""
+	Limit to transactions in the given checkpoint.
+	"""
 	atCheckpoint: UInt53
+	"""
+	Limit to transaction that occurred strictly before the given checkpoint.
+	"""
 	beforeCheckpoint: UInt53
+	"""
+	Limit to transactions that were signed by the given address.
+	"""
 	signAddress: IotaAddress
+	"""
+	Limit to transactions that sent an object to the given address.
+	"""
 	recvAddress: IotaAddress
+	"""
+	Limit to transactions that accepted the given object as an input.
+	"""
 	inputObject: IotaAddress
+	"""
+	Limit to transactions that output a version of this object.
+	"""
 	changedObject: IotaAddress
+	"""
+	Limit to transactions that wrapped or deleted the given object.
+	"""
 	wrappedOrDeletedObject: IotaAddress
+	"""
+	Select transactions by their digest.
+	"""
 	transactionIds: [String!]
 }
 

--- a/crates/iota-graphql-rpc/src/types/event/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/event/filter.rs
@@ -10,12 +10,17 @@ use crate::types::{
     type_filter::{ModuleFilter, TypeFilter},
 };
 
+/// Represents optional available filters for events.
 #[derive(InputObject, Clone, Default)]
 pub(crate) struct EventFilter {
+    /// Filter down to events from transactions sent by this address.
     pub sender: Option<IotaAddress>,
+    /// Filter down to the events from this transaction (given by its
+    /// transaction digest).
     pub transaction_digest: Option<Digest>,
     // Enhancement (post-MVP)
     // after_checkpoint
+    // at_checkpoint
     // before_checkpoint
     /// Events emitted by a particular module. An event is emitted by a
     /// particular module if some function in the module is called by a

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -133,11 +133,8 @@ pub(crate) struct ObjectRef {
 ///   `objectKeys`.
 #[derive(InputObject, Default, Debug, Clone, Eq, PartialEq)]
 pub(crate) struct ObjectFilter {
-    /// This field is used to specify the type of objects that should be
-    /// included in the query results.
-    ///
-    /// Objects can be filtered by their type's package, package::module, or
-    /// their fully qualified type name.
+    /// Filter objects by their type's `package`, `package::module`, or their
+    /// fully qualified type name.
     ///
     /// Generic types can be queried by either the generic type name, e.g.
     /// `0x2::coin::Coin`, or by the full type name, such as

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -12,24 +12,38 @@ use crate::types::{
     transaction_block::TransactionBlockKindInput, type_filter::FqNameFilter, uint53::UInt53,
 };
 
+/// Represents optional available filters for transaction blocks.
 #[derive(InputObject, Debug, Default, Clone)]
 pub(crate) struct TransactionBlockFilter {
+    /// Filter transactions by move function called.
+    ///
+    /// Calls can be filtered by the `package`, `package::module`, or the
+    /// `package::module::name` of their function.
     pub function: Option<FqNameFilter>,
 
     /// An input filter selecting for either system or programmable
     /// transactions.
     pub kind: Option<TransactionBlockKindInput>,
+    /// Limit to transactions that occurred strictly after the given checkpoint.
     pub after_checkpoint: Option<UInt53>,
+    /// Limit to transactions in the given checkpoint.
     pub at_checkpoint: Option<UInt53>,
+    /// Limit to transaction that occurred strictly before the given checkpoint.
     pub before_checkpoint: Option<UInt53>,
 
+    /// Limit to transactions that were signed by the given address.
     pub sign_address: Option<IotaAddress>,
+    /// Limit to transactions that sent an object to the given address.
     pub recv_address: Option<IotaAddress>,
 
+    /// Limit to transactions that accepted the given object as an input.
     pub input_object: Option<IotaAddress>,
+    /// Limit to transactions that output a version of this object.
     pub changed_object: Option<IotaAddress>,
+    /// Limit to transactions that wrapped or deleted the given object.
     pub wrapped_or_deleted_object: Option<IotaAddress>,
 
+    /// Select transactions by their digest.
     pub transaction_ids: Option<Vec<Digest>>,
 }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
@@ -2,6 +2,64 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! # Transaction Filter Lookup Tables
+//!
+//! ## Schemas
+//!
+//! Tables backing Transaction filters in GraphQL all follow the same rough
+//! shape:
+//!
+//! 1. They each get their own table, mapping the filter value to the
+//!    transaction sequence number.
+//!
+//! 2. They also include a `sender` column, and a secondary index over the
+//!    sender, filter values and the transaction sequence number.
+//!
+//! 3. They also include a secondary index over the transaction sequence number.
+//!
+//! This pattern allows us to offer a simple rule for users:
+//! - If you are filtering on a **single value**, you can do so without
+//!   worrying.
+//! - If you want to additionally filter by the sender, that is also possible,
+//!   but if you want to combine any other set of filters, you need to use a
+//!   "scan limit".
+//!
+//! ## Query construction
+//!
+//! Queries that filter transactions work in two phases: Identify the
+//! transaction sequence numbers to fetch, and then fetch their contents.
+//! Filtering all happens in the first phase:
+//!
+//! - Firstly filters are broken down into individual queries targeting the
+//!   appropriate lookup table. Each constituent query is expected to return a
+//!   sorted run of transaction sequence numbers.
+//!
+//! - If a `sender` filter is included, then it is incorporated into each
+//!   constituent query, leveraging their secondary indices (2), otherwise each
+//!   constituent query filters only based on its filter value using the primary
+//!   index (1).
+//!
+//! - The fact that both the primary and secondary indices contain the
+//!   transaction sequence number help to ensure that the output from an index
+//!   scan is already sorted, which avoids a potentially expensive materialize
+//!   and sort operation.
+//!
+//! - If there are multiple constituent queries, they are intersected using
+//!   inner joins. Postgres can occasionally pick a poor query plan for this
+//!   merge, so we require that filters resulting in such merges also use a
+//!   "scan limit" (see below).
+//!
+//! ## Scan limits
+//!
+//! The scan limit restricts the number of transactions considered as candidates
+//! for the results.It is analogous to the page size limit, which restricts the
+//! number of results returned to the user, but it operates at the top of the
+//! funnel rather than the top.
+//!
+//! When postgres picks a poor query plan, it can end up performing a sequential
+//! scan over all candidate transactions. By limiting the size of the candidate
+//! set, we bound the work done in the worse case (whereas otherwise, the worst
+//! case would grow with the history of the chain).
 use std::fmt::Write;
 
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};

--- a/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
@@ -58,7 +58,7 @@
 //!
 //! When postgres picks a poor query plan, it can end up performing a sequential
 //! scan over all candidate transactions. By limiting the size of the candidate
-//! set, we bound the work done in the worse case (whereas otherwise, the worst
+//! set, we bound the work done in the worst case (whereas otherwise, the worst
 //! case would grow with the history of the chain).
 use std::fmt::Write;
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
@@ -54,7 +54,7 @@
 //! The scan limit restricts the number of transactions considered as candidates
 //! for the results.It is analogous to the page size limit, which restricts the
 //! number of results returned to the user, but it operates at the top of the
-//! funnel rather than the top.
+//! funnel rather than the bottom.
 //!
 //! When postgres picks a poor query plan, it can end up performing a sequential
 //! scan over all candidate transactions. By limiting the size of the candidate

--- a/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
@@ -52,7 +52,7 @@
 //! ## Scan limits
 //!
 //! The scan limit restricts the number of transactions considered as candidates
-//! for the results.It is analogous to the page size limit, which restricts the
+//! for the results. It is analogous to the page size limit, which restricts the
 //! number of results returned to the user, but it operates at the top of the
 //! funnel rather than the bottom.
 //!

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1359,8 +1359,18 @@ type EventEdge {
 	cursor: String!
 }
 
+"""
+Represents optional available filters for events.
+"""
 input EventFilter {
+	"""
+	Filter down to events from transactions sent by this address.
+	"""
 	sender: IotaAddress
+	"""
+	Filter down to the events from this transaction (given by its
+	transaction digest).
+	"""
 	transactionDigest: String
 	"""
 	Events emitted by a particular module. An event is emitted by a
@@ -3207,11 +3217,8 @@ resulting set of objects are ones whose
 """
 input ObjectFilter {
 	"""
-	This field is used to specify the type of objects that should be
-	included in the query results.
-	
-	Objects can be filtered by their type's package, package::module, or
-	their fully qualified type name.
+	Filter objects by their type's `package`, `package::module`, or their
+	fully qualified type name.
 	
 	Generic types can be queried by either the generic type name, e.g.
 	`0x2::coin::Coin`, or by the full type name, such as
@@ -4538,21 +4545,57 @@ type TransactionBlockEffects {
 	bcs: Base64!
 }
 
+"""
+Represents optional available filters for transaction blocks.
+"""
 input TransactionBlockFilter {
+	"""
+	Filter transactions by move function called.
+	
+	Calls can be filtered by the `package`, `package::module`, or the
+	`package::module::name` of their function.
+	"""
 	function: String
 	"""
 	An input filter selecting for either system or programmable
 	transactions.
 	"""
 	kind: TransactionBlockKindInput
+	"""
+	Limit to transactions that occurred strictly after the given checkpoint.
+	"""
 	afterCheckpoint: UInt53
+	"""
+	Limit to transactions in the given checkpoint.
+	"""
 	atCheckpoint: UInt53
+	"""
+	Limit to transaction that occurred strictly before the given checkpoint.
+	"""
 	beforeCheckpoint: UInt53
+	"""
+	Limit to transactions that were signed by the given address.
+	"""
 	signAddress: IotaAddress
+	"""
+	Limit to transactions that sent an object to the given address.
+	"""
 	recvAddress: IotaAddress
+	"""
+	Limit to transactions that accepted the given object as an input.
+	"""
 	inputObject: IotaAddress
+	"""
+	Limit to transactions that output a version of this object.
+	"""
 	changedObject: IotaAddress
+	"""
+	Limit to transactions that wrapped or deleted the given object.
+	"""
 	wrappedOrDeletedObject: IotaAddress
+	"""
+	Select transactions by their digest.
+	"""
 	transactionIds: [String!]
 }
 

--- a/sdk/graphql-transport/src/generated/queries.ts
+++ b/sdk/graphql-transport/src/generated/queries.ts
@@ -1603,6 +1603,7 @@ export type EventEdge = {
   node: Event;
 };
 
+/** Represents optional available filters for events. */
 export type EventFilter = {
   /**
    * Events emitted by a particular module. An event is emitted by a
@@ -1626,7 +1627,12 @@ export type EventFilter = {
    * `0x2::coin::Coin<0x2::iota::IOTA>`.
    */
   eventType?: InputMaybe<Scalars['String']['input']>;
+  /** Filter down to events from transactions sent by this address. */
   sender?: InputMaybe<Scalars['IotaAddress']['input']>;
+  /**
+   * Filter down to the events from this transaction (given by its
+   * transaction digest).
+   */
   transactionDigest?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -3861,11 +3867,8 @@ export type ObjectFilter = {
   /** Filter for live objects by their current owners. */
   owner?: InputMaybe<Scalars['IotaAddress']['input']>;
   /**
-   * This field is used to specify the type of objects that should be
-   * included in the query results.
-   *
-   * Objects can be filtered by their type's package, package::module, or
-   * their fully qualified type name.
+   * Filter objects by their type's `package`, `package::module`, or their
+   * fully qualified type name.
    *
    * Generic types can be queried by either the generic type name, e.g.
    * `0x2::coin::Coin`, or by the full type name, such as
@@ -5426,21 +5429,37 @@ export type TransactionBlockEffectsUnchangedSharedObjectsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+/** Represents optional available filters for transaction blocks. */
 export type TransactionBlockFilter = {
+  /** Limit to transactions that occurred strictly after the given checkpoint. */
   afterCheckpoint?: InputMaybe<Scalars['UInt53']['input']>;
+  /** Limit to transactions in the given checkpoint. */
   atCheckpoint?: InputMaybe<Scalars['UInt53']['input']>;
+  /** Limit to transaction that occurred strictly before the given checkpoint. */
   beforeCheckpoint?: InputMaybe<Scalars['UInt53']['input']>;
+  /** Limit to transactions that output a version of this object. */
   changedObject?: InputMaybe<Scalars['IotaAddress']['input']>;
+  /**
+   * Filter transactions by move function called.
+   *
+   * Calls can be filtered by the `package`, `package::module`, or the
+   * `package::module::name` of their function.
+   */
   function?: InputMaybe<Scalars['String']['input']>;
+  /** Limit to transactions that accepted the given object as an input. */
   inputObject?: InputMaybe<Scalars['IotaAddress']['input']>;
   /**
    * An input filter selecting for either system or programmable
    * transactions.
    */
   kind?: InputMaybe<TransactionBlockKindInput>;
+  /** Limit to transactions that sent an object to the given address. */
   recvAddress?: InputMaybe<Scalars['IotaAddress']['input']>;
+  /** Limit to transactions that were signed by the given address. */
   signAddress?: InputMaybe<Scalars['IotaAddress']['input']>;
+  /** Select transactions by their digest. */
   transactionIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** Limit to transactions that wrapped or deleted the given object. */
   wrappedOrDeletedObject?: InputMaybe<Scalars['IotaAddress']['input']>;
 };
 

--- a/sdk/typescript/src/graphql/generated/2025.2/schema.graphql
+++ b/sdk/typescript/src/graphql/generated/2025.2/schema.graphql
@@ -1355,8 +1355,18 @@ type EventEdge {
 	cursor: String!
 }
 
+"""
+Represents optional available filters for events.
+"""
 input EventFilter {
+	"""
+	Filter down to events from transactions sent by this address.
+	"""
 	sender: IotaAddress
+	"""
+	Filter down to the events from this transaction (given by its
+	transaction digest).
+	"""
 	transactionDigest: String
 	"""
 	Events emitted by a particular module. An event is emitted by a
@@ -3203,11 +3213,8 @@ resulting set of objects are ones whose
 """
 input ObjectFilter {
 	"""
-	This field is used to specify the type of objects that should be
-	included in the query results.
-	
-	Objects can be filtered by their type's package, package::module, or
-	their fully qualified type name.
+	Filter objects by their type's `package`, `package::module`, or their
+	fully qualified type name.
 	
 	Generic types can be queried by either the generic type name, e.g.
 	`0x2::coin::Coin`, or by the full type name, such as
@@ -4534,21 +4541,57 @@ type TransactionBlockEffects {
 	bcs: Base64!
 }
 
+"""
+Represents optional available filters for transaction blocks.
+"""
 input TransactionBlockFilter {
+	"""
+	Filter transactions by move function called.
+	
+	Calls can be filtered by the `package`, `package::module`, or the
+	`package::module::name` of their function.
+	"""
 	function: String
 	"""
 	An input filter selecting for either system or programmable
 	transactions.
 	"""
 	kind: TransactionBlockKindInput
+	"""
+	Limit to transactions that occurred strictly after the given checkpoint.
+	"""
 	afterCheckpoint: UInt53
+	"""
+	Limit to transactions in the given checkpoint.
+	"""
 	atCheckpoint: UInt53
+	"""
+	Limit to transaction that occurred strictly before the given checkpoint.
+	"""
 	beforeCheckpoint: UInt53
+	"""
+	Limit to transactions that were signed by the given address.
+	"""
 	signAddress: IotaAddress
+	"""
+	Limit to transactions that sent an object to the given address.
+	"""
 	recvAddress: IotaAddress
+	"""
+	Limit to transactions that accepted the given object as an input.
+	"""
 	inputObject: IotaAddress
+	"""
+	Limit to transactions that output a version of this object.
+	"""
 	changedObject: IotaAddress
+	"""
+	Limit to transactions that wrapped or deleted the given object.
+	"""
 	wrappedOrDeletedObject: IotaAddress
+	"""
+	Select transactions by their digest.
+	"""
 	transactionIds: [String!]
 }
 


### PR DESCRIPTION
# Description of change

This PR introduces an upstream patch mostly focused on documentation for transaction & event filter, and explaining the pattern we use for transaction lookup tables.

## Links to any relevant issues

fixes #9216 

## How the change has been tested

- Ran `cargo insta test` & `cargo insta review` to apply the new changes to the `schema.graphql`.
- Generated TS SDK graphql schema aswell.
```shell
$ pnpm install
$ pnpm codegen
```

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> The path does not affect the normal operation of the indexer, thus no tests were conducted.