### PR TITLE
upstream(ts-sdk): generate graphql schema

### DIFF
--- a/sdk/graphql-transport/src/generated/queries.ts
+++ b/sdk/graphql-transport/src/generated/queries.ts
@@ -1603,6 +1603,7 @@ export type EventEdge = {
   node: Event;
 };
 
+/** Represents optional available filters for events. */
 export type EventFilter = {
   /**
    * Events emitted by a particular module. An event is emitted by a
@@ -1626,7 +1627,12 @@ export type EventFilter = {
    * `0x2::coin::Coin<0x2::iota::IOTA>`.
    */
   eventType?: InputMaybe<Scalars['String']['input']>;
+  /** Filter down to events from transactions sent by this address. */
   sender?: InputMaybe<Scalars['IotaAddress']['input']>;
+  /**
+   * Filter down to the events from this transaction (given by its
+   * transaction digest).
+   */
   transactionDigest?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -3861,11 +3867,8 @@ export type ObjectFilter = {
   /** Filter for live objects by their current owners. */
   owner?: InputMaybe<Scalars['IotaAddress']['input']>;
   /**
-   * This field is used to specify the type of objects that should be
-   * included in the query results.
-   *
-   * Objects can be filtered by their type's package, package::module, or
-   * their fully qualified type name.
+   * Filter objects by their type's `package`, `package::module`, or their
+   * fully qualified type name.
    *
    * Generic types can be queried by either the generic type name, e.g.
    * `0x2::coin::Coin`, or by the full type name, such as
@@ -5426,21 +5429,37 @@ export type TransactionBlockEffectsUnchangedSharedObjectsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+/** Represents optional available filters for transaction blocks. */
 export type TransactionBlockFilter = {
+  /** Limit to transactions that occurred strictly after the given checkpoint. */
   afterCheckpoint?: InputMaybe<Scalars['UInt53']['input']>;
+  /** Limit to transactions in the given checkpoint. */
   atCheckpoint?: InputMaybe<Scalars['UInt53']['input']>;
+  /** Limit to transaction that occurred strictly before the given checkpoint. */
   beforeCheckpoint?: InputMaybe<Scalars['UInt53']['input']>;
+  /** Limit to transactions that output a version of this object. */
   changedObject?: InputMaybe<Scalars['IotaAddress']['input']>;
+  /**
+   * Filter transactions by move function called.
+   *
+   * Calls can be filtered by the `package`, `package::module`, or the
+   * `package::module::name` of their function.
+   */
   function?: InputMaybe<Scalars['String']['input']>;
+  /** Limit to transactions that accepted the given object as an input. */
   inputObject?: InputMaybe<Scalars['IotaAddress']['input']>;
   /**
    * An input filter selecting for either system or programmable
    * transactions.
    */
   kind?: InputMaybe<TransactionBlockKindInput>;
+  /** Limit to transactions that sent an object to the given address. */
   recvAddress?: InputMaybe<Scalars['IotaAddress']['input']>;
+  /** Limit to transactions that were signed by the given address. */
   signAddress?: InputMaybe<Scalars['IotaAddress']['input']>;
+  /** Select transactions by their digest. */
   transactionIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** Limit to transactions that wrapped or deleted the given object. */
   wrappedOrDeletedObject?: InputMaybe<Scalars['IotaAddress']['input']>;
 };
 

--- a/sdk/typescript/src/graphql/generated/2025.2/schema.graphql
+++ b/sdk/typescript/src/graphql/generated/2025.2/schema.graphql
@@ -1355,8 +1355,18 @@ type EventEdge {
 	cursor: String!
 }
 
+"""
+Represents optional available filters for events.
+"""
 input EventFilter {
+	"""
+	Filter down to events from transactions sent by this address.
+	"""
 	sender: IotaAddress
+	"""
+	Filter down to the events from this transaction (given by its
+	transaction digest).
+	"""
 	transactionDigest: String
 	"""
 	Events emitted by a particular module. An event is emitted by a
@@ -3203,11 +3213,8 @@ resulting set of objects are ones whose
 """
 input ObjectFilter {
 	"""
-	This field is used to specify the type of objects that should be
-	included in the query results.
-	
-	Objects can be filtered by their type's package, package::module, or
-	their fully qualified type name.
+	Filter objects by their type's `package`, `package::module`, or their
+	fully qualified type name.
 	
 	Generic types can be queried by either the generic type name, e.g.
 	`0x2::coin::Coin`, or by the full type name, such as
@@ -4534,21 +4541,57 @@ type TransactionBlockEffects {
 	bcs: Base64!
 }
 
+"""
+Represents optional available filters for transaction blocks.
+"""
 input TransactionBlockFilter {
+	"""
+	Filter transactions by move function called.
+	
+	Calls can be filtered by the `package`, `package::module`, or the
+	`package::module::name` of their function.
+	"""
 	function: String
 	"""
 	An input filter selecting for either system or programmable
 	transactions.
 	"""
 	kind: TransactionBlockKindInput
+	"""
+	Limit to transactions that occurred strictly after the given checkpoint.
+	"""
 	afterCheckpoint: UInt53
+	"""
+	Limit to transactions in the given checkpoint.
+	"""
 	atCheckpoint: UInt53
+	"""
+	Limit to transaction that occurred strictly before the given checkpoint.
+	"""
 	beforeCheckpoint: UInt53
+	"""
+	Limit to transactions that were signed by the given address.
+	"""
 	signAddress: IotaAddress
+	"""
+	Limit to transactions that sent an object to the given address.
+	"""
 	recvAddress: IotaAddress
+	"""
+	Limit to transactions that accepted the given object as an input.
+	"""
 	inputObject: IotaAddress
+	"""
+	Limit to transactions that output a version of this object.
+	"""
 	changedObject: IotaAddress
+	"""
+	Limit to transactions that wrapped or deleted the given object.
+	"""
 	wrappedOrDeletedObject: IotaAddress
+	"""
+	Select transactions by their digest.
+	"""
 	transactionIds: [String!]
 }
 


### PR DESCRIPTION
# Description of change

This PR introduces an upstream patch mostly focused on documentation for transaction & event filter, and explaining the pattern we use for transaction lookup tables.

## Links to any relevant issues

fixes #9216 

## How the change has been tested

```shell
$ pnpm install
$ pnpm codegen
```

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> The path does not affect the normal operation of the indexer, thus no tests were conducted.