### PR TITLE
upstream(graphql-rpc): deprecate sign address transaction filters

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/sent.move
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/sent.move
@@ -1,0 +1,78 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+
+//# init --protocol-version 15 --addresses Test=0x0 --accounts A B --simulator
+
+// Confirm that the new `sentAddress` behaves like `signAddress`, and how the
+// two filters interact with each other.
+
+//# programmable --sender A --inputs 1000000 @B
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender B --inputs 2000000 @A
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+query {
+  bySentAddress: transactionBlocks(filter: { sentAddress: "@{A}" }) {
+    nodes { ...CoinBalances }
+  }
+  bySignAddress: transactionBlocks(filter: { signAddress: "@{A}" }) {
+    nodes { ...CoinBalances }
+  }
+  bothAddresses: transactionBlocks(filter: { sentAddress: "@{A}", signAddress: "@{A}" }) {
+    nodes { ...CoinBalances }
+  }
+  differentAddresses: transactionBlocks(filter: { sentAddress: "@{A}", signAddress: "@{B}" }) {
+    nodes { ...CoinBalances }
+  }
+  compoundBySentAddress: transactionBlocks(filter: { sentAddress: "@{A}", kind: PROGRAMMABLE_TX }) {
+    nodes { ...CoinBalances }
+  }
+  compoundBySignAddress: transactionBlocks(filter: { signAddress: "@{A}", kind: PROGRAMMABLE_TX }) {
+    nodes { ...CoinBalances }
+  }
+  compoundBothAddresses: transactionBlocks(filter: {
+    sentAddress: "@{A}",
+    signAddress: "@{A}",
+    kind: PROGRAMMABLE_TX,
+  }) {
+    nodes { ...CoinBalances }
+  }
+  compoundDifferentAddresses: transactionBlocks(filter: {
+    sentAddress: "@{A}",
+    signAddress: "@{B}",
+    kind: PROGRAMMABLE_TX,
+  }) {
+    nodes { ...CoinBalances }
+  }
+  sentViaAddress: address(address: "@{A}") {
+    transactionBlocks(relation: SENT) {
+      nodes { ...CoinBalances }
+    }
+  }
+  signViaAddress: address(address: "@{A}") {
+    transactionBlocks(relation: SIGN) {
+      nodes { ...CoinBalances }
+    }
+  }
+}
+fragment CoinBalances on TransactionBlock {
+  effects {
+    objectChanges {
+      nodes {
+        inputState { ...CoinBalance }
+        outputState { ...CoinBalance }
+      }
+    }
+  }
+}
+fragment CoinBalance on Object {
+  asMoveObject { asCoin { coinBalance } }
+}

--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/sent.snap
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/sent.snap
@@ -1,0 +1,348 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 11-13:
+//# programmable --sender A --inputs 1000000 @B
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 15-17:
+//# programmable --sender B --inputs 2000000 @A
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 19:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 21-78:
+//# run-graphql
+Response: {
+  "data": {
+    "bySentAddress": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": {
+              "nodes": [
+                {
+                  "inputState": null,
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "1000000"
+                      }
+                    }
+                  }
+                },
+                {
+                  "inputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "300000000000000"
+                      }
+                    }
+                  },
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "299999996039200"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "bySignAddress": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": {
+              "nodes": [
+                {
+                  "inputState": null,
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "1000000"
+                      }
+                    }
+                  }
+                },
+                {
+                  "inputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "300000000000000"
+                      }
+                    }
+                  },
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "299999996039200"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "bothAddresses": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": {
+              "nodes": [
+                {
+                  "inputState": null,
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "1000000"
+                      }
+                    }
+                  }
+                },
+                {
+                  "inputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "300000000000000"
+                      }
+                    }
+                  },
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "299999996039200"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "differentAddresses": {
+      "nodes": []
+    },
+    "compoundBySentAddress": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": {
+              "nodes": [
+                {
+                  "inputState": null,
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "1000000"
+                      }
+                    }
+                  }
+                },
+                {
+                  "inputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "300000000000000"
+                      }
+                    }
+                  },
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "299999996039200"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "compoundBySignAddress": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": {
+              "nodes": [
+                {
+                  "inputState": null,
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "1000000"
+                      }
+                    }
+                  }
+                },
+                {
+                  "inputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "300000000000000"
+                      }
+                    }
+                  },
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "299999996039200"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "compoundBothAddresses": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": {
+              "nodes": [
+                {
+                  "inputState": null,
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "1000000"
+                      }
+                    }
+                  }
+                },
+                {
+                  "inputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "300000000000000"
+                      }
+                    }
+                  },
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "299999996039200"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "compoundDifferentAddresses": {
+      "nodes": []
+    },
+    "sentViaAddress": {
+      "transactionBlocks": {
+        "nodes": [
+          {
+            "effects": {
+              "objectChanges": {
+                "nodes": [
+                  {
+                    "inputState": null,
+                    "outputState": {
+                      "asMoveObject": {
+                        "asCoin": {
+                          "coinBalance": "1000000"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "inputState": {
+                      "asMoveObject": {
+                        "asCoin": {
+                          "coinBalance": "300000000000000"
+                        }
+                      }
+                    },
+                    "outputState": {
+                      "asMoveObject": {
+                        "asCoin": {
+                          "coinBalance": "299999996039200"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "signViaAddress": {
+      "transactionBlocks": {
+        "nodes": [
+          {
+            "effects": {
+              "objectChanges": {
+                "nodes": [
+                  {
+                    "inputState": null,
+                    "outputState": {
+                      "asMoveObject": {
+                        "asCoin": {
+                          "coinBalance": "1000000"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "inputState": {
+                      "asMoveObject": {
+                        "asCoin": {
+                          "coinBalance": "300000000000000"
+                        }
+                      }
+                    },
+                    "outputState": {
+                      "asMoveObject": {
+                        "asCoin": {
+                          "coinBalance": "299999996039200"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-rpc/examples/address/transaction_block_connection.graphql
+++ b/crates/iota-graphql-rpc/examples/address/transaction_block_connection.graphql
@@ -7,7 +7,7 @@
 # and budget.
 query transaction_block_with_relation_filter {
   address(address: "0x2") {
-    transactionBlocks(relation: SIGN, filter: { function: "0x2" }) {
+    transactionBlocks(relation: SENT, filter: { function: "0x2" }) {
       nodes {
         sender {
           address

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -4566,7 +4566,7 @@ input TransactionBlockFilter {
 	"""
 	kind: TransactionBlockKindInput
 	"""
-	Limit to transactions that occured strictly after the given checkpoint.
+	Limit to transactions that occurred strictly after the given checkpoint.
 	"""
 	afterCheckpoint: UInt53
 	"""
@@ -4574,7 +4574,7 @@ input TransactionBlockFilter {
 	"""
 	atCheckpoint: UInt53
 	"""
-	Limit to transaction that occured strictly before the given checkpoint.
+	Limit to transaction that occurred strictly before the given checkpoint.
 	"""
 	beforeCheckpoint: UInt53
 	"""

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -102,7 +102,7 @@ type Address implements IOwner {
 	"""
 	Similar behavior to the `transactionBlocks` in Query but supporting the
 	additional `AddressTransactionBlockRelationship` filter, which
-	defaults to `SIGN`.
+	defaults to `SENT`.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply
@@ -171,14 +171,22 @@ type AddressOwner {
 }
 
 """
-The possible relationship types for a transaction block: sign, sent,
-received, or paid.
+The possible relationship types for a transaction block: sent or received.
 """
 enum AddressTransactionBlockRelationship {
 	"""
-	Transactions this address has signed either as a sender or as a sponsor.
+	Transactions this address has sent. NOTE: this input filter has been
+	deprecated in favor of `SENT` which behaves identically but is named
+	more clearly. Both filters restrict transactions by their sender,
+	only, not signers in general.
+	
+	This filter will be removed after 6 months with the 1.24.0 release.
 	"""
-	SIGN
+	SIGN @deprecated(reason: "Misleading semantics. Use `SENT` instead. This will be removed with the 1.24.0 release.")
+	"""
+	Transactions this address has sent.
+	"""
+	SENT
 	"""
 	Transactions that sent objects to this address.
 	"""
@@ -4558,7 +4566,7 @@ input TransactionBlockFilter {
 	"""
 	kind: TransactionBlockKindInput
 	"""
-	Limit to transactions that occurred strictly after the given checkpoint.
+	Limit to transactions that occured strictly after the given checkpoint.
 	"""
 	afterCheckpoint: UInt53
 	"""
@@ -4566,13 +4574,22 @@ input TransactionBlockFilter {
 	"""
 	atCheckpoint: UInt53
 	"""
-	Limit to transaction that occurred strictly before the given checkpoint.
+	Limit to transaction that occured strictly before the given checkpoint.
 	"""
 	beforeCheckpoint: UInt53
 	"""
-	Limit to transactions that were signed by the given address.
+	Limit to transactions that were sent by the given address. NOTE: this
+	input filter has been deprecated in favor of `sentAddress` which has
+	clearer semantics. Both filters restrict transactions by their sender,
+	only, not signers in general.
+	
+	This filter will be removed after 6 months with the 1.24.0 release.
 	"""
-	signAddress: IotaAddress
+	signAddress: IotaAddress @deprecated(reason: "Misleading semantics. Use `sentAddress` instead. This will be removed with the 1.24.0 release.")
+	"""
+	Limit to transactions that were sent by the given address.
+	"""
+	sentAddress: IotaAddress
 	"""
 	Limit to transactions that sent an object to the given address.
 	"""

--- a/crates/iota-graphql-rpc/src/types/address.rs
+++ b/crates/iota-graphql-rpc/src/types/address.rs
@@ -28,12 +28,21 @@ pub(crate) struct Address {
     pub checkpoint_viewed_at: u64,
 }
 
-/// The possible relationship types for a transaction block: sign, sent,
-/// received, or paid.
+/// The possible relationship types for a transaction block: sent or received.
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum AddressTransactionBlockRelationship {
-    /// Transactions this address has signed either as a sender or as a sponsor.
+    /// Transactions this address has sent. NOTE: this input filter has been
+    /// deprecated in favor of `SENT` which behaves identically but is named
+    /// more clearly. Both filters restrict transactions by their sender,
+    /// only, not signers in general.
+    ///
+    /// This filter will be removed after 6 months with the 1.24.0 release.
+    #[graphql(
+        deprecation = "Misleading semantics. Use `SENT` instead. This will be removed with the 1.24.0 release."
+    )]
     Sign,
+    /// Transactions this address has sent.
+    Sent,
     /// Transactions that sent objects to this address.
     Recv,
 }
@@ -146,7 +155,7 @@ impl Address {
 
     /// Similar behavior to the `transactionBlocks` in Query but supporting the
     /// additional `AddressTransactionBlockRelationship` filter, which
-    /// defaults to `SIGN`.
+    /// defaults to `SENT`.
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
     /// gathering a page of results. It is required for queries that apply
@@ -187,8 +196,8 @@ impl Address {
 
         let Some(filter) = filter.unwrap_or_default().intersect(match relation {
             // Relationship defaults to "signer" if none is supplied.
-            Some(R::Sign) | None => TransactionBlockFilter {
-                sign_address: Some(self.address),
+            Some(R::Sign) | Some(R::Sent) | None => TransactionBlockFilter {
+                sent_address: Some(self.address),
                 ..Default::default()
             },
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -24,25 +24,32 @@ pub(crate) struct TransactionBlockFilter {
     /// An input filter selecting for either system or programmable
     /// transactions.
     pub kind: Option<TransactionBlockKindInput>,
-    /// Limit to transactions that occurred strictly after the given checkpoint.
+    /// Limit to transactions that occured strictly after the given checkpoint.
     pub after_checkpoint: Option<UInt53>,
     /// Limit to transactions in the given checkpoint.
     pub at_checkpoint: Option<UInt53>,
-    /// Limit to transaction that occurred strictly before the given checkpoint.
+    /// Limit to transaction that occured strictly before the given checkpoint.
     pub before_checkpoint: Option<UInt53>,
-
-    /// Limit to transactions that were signed by the given address.
+    /// Limit to transactions that were sent by the given address. NOTE: this
+    /// input filter has been deprecated in favor of `sentAddress` which has
+    /// clearer semantics. Both filters restrict transactions by their sender,
+    /// only, not signers in general.
+    ///
+    /// This filter will be removed after 6 months with the 1.24.0 release.
+    #[graphql(
+        deprecation = "Misleading semantics. Use `sentAddress` instead. This will be removed with the 1.24.0 release."
+    )]
     pub sign_address: Option<IotaAddress>,
+    /// Limit to transactions that were sent by the given address.
+    pub sent_address: Option<IotaAddress>,
     /// Limit to transactions that sent an object to the given address.
     pub recv_address: Option<IotaAddress>,
-
     /// Limit to transactions that accepted the given object as an input.
     pub input_object: Option<IotaAddress>,
     /// Limit to transactions that output a version of this object.
     pub changed_object: Option<IotaAddress>,
     /// Limit to transactions that wrapped or deleted the given object.
     pub wrapped_or_deleted_object: Option<IotaAddress>,
-
     /// Select transactions by their digest.
     pub transaction_ids: Option<Vec<Digest>>,
 }
@@ -69,6 +76,7 @@ impl TransactionBlockFilter {
             before_checkpoint: intersect!(before_checkpoint, intersect::by_min)?,
 
             sign_address: intersect!(sign_address, intersect::by_eq)?,
+            sent_address: intersect!(sent_address, intersect::by_eq)?,
             recv_address: intersect!(recv_address, intersect::by_eq)?,
             input_object: intersect!(input_object, intersect::by_eq)?,
             changed_object: intersect!(changed_object, intersect::by_eq)?,
@@ -102,8 +110,10 @@ impl TransactionBlockFilter {
             > 1
     }
 
-    /// If we don't query a lookup table that has a denormalized sender column,
-    /// we need to explicitly sp
+    /// Returns the transaction sender to query `tx_sender`.
+    ///
+    /// If there are other filters set that would query tables with a `sender`
+    /// column, then this returns `None`.
     pub(crate) fn explicit_sender(&self) -> Option<IotaAddress> {
         if self.function.is_none()
             && self.kind.is_none()
@@ -112,7 +122,7 @@ impl TransactionBlockFilter {
             && self.changed_object.is_none()
             && self.wrapped_or_deleted_object.is_none()
         {
-            self.sign_address
+            self.sent_address.or(self.sign_address)
         } else {
             None
         }
@@ -124,6 +134,7 @@ impl TransactionBlockFilter {
         self.function.is_some()
             || self.kind.is_some()
             || self.sign_address.is_some()
+            || self.sent_address.is_some()
             || self.recv_address.is_some()
             || self.input_object.is_some()
             || self.changed_object.is_some()
@@ -147,10 +158,16 @@ impl TransactionBlockFilter {
             )
             // If SystemTx, sender if specified must be 0x0. Conversely, if sender is 0x0, kind must be SystemTx.
             || matches!(
-                (self.kind, self.sign_address),
+                (self.kind, self.sent_address),
                 (Some(kind), Some(signer))
                     if (kind == TransactionBlockKindInput::SystemTx)
                         != (signer == IotaAddress::from(NativeIotaAddress::ZERO))
+            )
+            // Temporary while we deprecate `sign_address` in favor of `sent_address`.
+            || matches!(
+                (self.sign_address, self.sent_address),
+                (Some(signer), Some(sent))
+                    if signer != sent
             )
     }
 }

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -158,7 +158,7 @@ impl TransactionBlockFilter {
             )
             // If SystemTx, sender if specified must be 0x0. Conversely, if sender is 0x0, kind must be SystemTx.
             || matches!(
-                (self.kind, self.sent_address),
+                (self.kind, self.sent_address.or(self.sign_address)),
                 (Some(kind), Some(signer))
                     if (kind == TransactionBlockKindInput::SystemTx)
                         != (signer == IotaAddress::from(NativeIotaAddress::ZERO))

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -24,11 +24,11 @@ pub(crate) struct TransactionBlockFilter {
     /// An input filter selecting for either system or programmable
     /// transactions.
     pub kind: Option<TransactionBlockKindInput>,
-    /// Limit to transactions that occured strictly after the given checkpoint.
+    /// Limit to transactions that occurred strictly after the given checkpoint.
     pub after_checkpoint: Option<UInt53>,
     /// Limit to transactions in the given checkpoint.
     pub at_checkpoint: Option<UInt53>,
-    /// Limit to transaction that occured strictly before the given checkpoint.
+    /// Limit to transaction that occurred strictly before the given checkpoint.
     pub before_checkpoint: Option<UInt53>,
     /// Limit to transactions that were sent by the given address. NOTE: this
     /// input filter has been deprecated in favor of `sentAddress` which has

--- a/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
@@ -325,7 +325,7 @@ fn min_option<T: Ord>(xs: impl IntoIterator<Item = Option<T>>) -> Option<T> {
 /// their own filter condition, plus optionally a sender, plus optionally tx/cp
 /// bounds.
 pub(crate) fn subqueries(filter: &TransactionBlockFilter, tx_bounds: TxBounds) -> Option<RawQuery> {
-    let sender = filter.sign_address;
+    let sender = filter.sent_address.or(filter.sign_address);
 
     let mut subqueries = vec![];
 

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -106,7 +106,7 @@ type Address implements IOwner {
 	"""
 	Similar behavior to the `transactionBlocks` in Query but supporting the
 	additional `AddressTransactionBlockRelationship` filter, which
-	defaults to `SIGN`.
+	defaults to `SENT`.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply
@@ -175,14 +175,22 @@ type AddressOwner {
 }
 
 """
-The possible relationship types for a transaction block: sign, sent,
-received, or paid.
+The possible relationship types for a transaction block: sent or received.
 """
 enum AddressTransactionBlockRelationship {
 	"""
-	Transactions this address has signed either as a sender or as a sponsor.
+	Transactions this address has sent. NOTE: this input filter has been
+	deprecated in favor of `SENT` which behaves identically but is named
+	more clearly. Both filters restrict transactions by their sender,
+	only, not signers in general.
+	
+	This filter will be removed after 6 months with the 1.24.0 release.
 	"""
-	SIGN
+	SIGN @deprecated(reason: "Misleading semantics. Use `SENT` instead. This will be removed with the 1.24.0 release.")
+	"""
+	Transactions this address has sent.
+	"""
+	SENT
 	"""
 	Transactions that sent objects to this address.
 	"""
@@ -4562,7 +4570,7 @@ input TransactionBlockFilter {
 	"""
 	kind: TransactionBlockKindInput
 	"""
-	Limit to transactions that occurred strictly after the given checkpoint.
+	Limit to transactions that occured strictly after the given checkpoint.
 	"""
 	afterCheckpoint: UInt53
 	"""
@@ -4570,13 +4578,22 @@ input TransactionBlockFilter {
 	"""
 	atCheckpoint: UInt53
 	"""
-	Limit to transaction that occurred strictly before the given checkpoint.
+	Limit to transaction that occured strictly before the given checkpoint.
 	"""
 	beforeCheckpoint: UInt53
 	"""
-	Limit to transactions that were signed by the given address.
+	Limit to transactions that were sent by the given address. NOTE: this
+	input filter has been deprecated in favor of `sentAddress` which has
+	clearer semantics. Both filters restrict transactions by their sender,
+	only, not signers in general.
+	
+	This filter will be removed after 6 months with the 1.24.0 release.
 	"""
-	signAddress: IotaAddress
+	signAddress: IotaAddress @deprecated(reason: "Misleading semantics. Use `sentAddress` instead. This will be removed with the 1.24.0 release.")
+	"""
+	Limit to transactions that were sent by the given address.
+	"""
+	sentAddress: IotaAddress
 	"""
 	Limit to transactions that sent an object to the given address.
 	"""

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -4570,7 +4570,7 @@ input TransactionBlockFilter {
 	"""
 	kind: TransactionBlockKindInput
 	"""
-	Limit to transactions that occured strictly after the given checkpoint.
+	Limit to transactions that occurred strictly after the given checkpoint.
 	"""
 	afterCheckpoint: UInt53
 	"""
@@ -4578,7 +4578,7 @@ input TransactionBlockFilter {
 	"""
 	atCheckpoint: UInt53
 	"""
-	Limit to transaction that occured strictly before the given checkpoint.
+	Limit to transaction that occurred strictly before the given checkpoint.
 	"""
 	beforeCheckpoint: UInt53
 	"""


### PR DESCRIPTION
# Description of change

This patch follows the respective upstream changes to deprecate tx signers filters on GraphQL.

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

### Release Notes

- [x] GraphQL: :warning:  Deprecates `TransactionBlockFilter.signAddress`, replacing it with `TransactionBlockFilter.sentAddress` which behaves identically. Similarly `AddressTransactionBlockRelationship.SIGN` is deprecated and replaced by `AddressTransactionBlockRelationship.SENT`. The deprecated filter will be removed after more than six months, with the `1.24.0` mainnet release. 
