### PR TITLE
feat(consensus): use spot instances

### DIFF
--- a/crates/iota-aws-orchestrator/src/client/aws.rs
+++ b/crates/iota-aws-orchestrator/src/client/aws.rs
@@ -12,14 +12,16 @@ use aws_sdk_ec2::{
     config::Region,
     primitives::Blob,
     types::{
-        BlockDeviceMapping, EbsBlockDevice, EphemeralNvmeSupport, Filter, ResourceType, Tag,
-        TagSpecification, VolumeType, builders::FilterBuilder,
+        BlockDeviceMapping, EbsBlockDevice, EphemeralNvmeSupport, Filter,
+        InstanceInterruptionBehavior, InstanceMarketOptionsRequest, MarketType, ResourceType,
+        SpotInstanceType, SpotMarketOptions, Tag, TagSpecification, VolumeType,
+        builders::FilterBuilder,
     },
 };
 use aws_smithy_runtime_api::client::{behavior_version::BehaviorVersion, result::SdkError};
 use serde::Serialize;
 
-use super::{Instance, InstanceRole, ServerProviderClient};
+use super::{Instance, InstanceLifecycle, InstanceRole, ServerProviderClient};
 use crate::{
     error::{CloudProviderError, CloudProviderResult},
     settings::Settings,
@@ -113,6 +115,14 @@ impl AwsClient {
             .expect("AWS instance should have a role")
             .as_str()
             .into();
+        let lifecycle: InstanceLifecycle =
+            if let Some(aws_sdk_ec2::types::InstanceLifecycleType::Spot) =
+                aws_instance.instance_lifecycle
+            {
+                InstanceLifecycle::Spot
+            } else {
+                InstanceLifecycle::OnDemand
+            };
         Instance {
             id: aws_instance
                 .instance_id()
@@ -145,6 +155,7 @@ impl AwsClient {
                     .expect("AWS status should have a name")
             ),
             role,
+            lifecycle,
         }
     }
 
@@ -268,6 +279,24 @@ impl AwsClient {
         }
         Ok(false)
     }
+    fn spot_options() -> InstanceMarketOptionsRequest {
+        InstanceMarketOptionsRequest::builder()
+            // SPOT vs CAPACITY_BLOCK
+            .market_type(MarketType::Spot)
+            .spot_options(
+                SpotMarketOptions::builder()
+                    // One-off Spot request that ends when the instance ends.
+                    .spot_instance_type(SpotInstanceType::OneTime)
+                    // What to do when AWS reclaims capacity.
+                    // For ephemeral test runs, terminate is usually fine.
+                    .instance_interruption_behavior(InstanceInterruptionBehavior::Terminate)
+                    // Usually DON'T set max_price: if omitted, you just pay current Spot price,
+                    // capped by On-Demand in most regions. Setting it can increase
+                    // interruptions.:contentReference[oaicite:4]{index=4}
+                    .build(),
+            )
+            .build()
+    }
 }
 
 #[async_trait::async_trait]
@@ -314,16 +343,9 @@ impl ServerProviderClient for AwsClient {
 
     async fn list_instances_by_region_and_ids(
         &self,
-        regions_and_ids: Vec<(String, String)>,
+        ids_by_region: &HashMap<String, Vec<String>>,
     ) -> CloudProviderResult<Vec<Instance>> {
         let mut instances = Vec::new();
-        let ids_by_region: HashMap<String, Vec<String>> =
-            regions_and_ids
-                .into_iter()
-                .fold(HashMap::new(), |mut acc, (k, v)| {
-                    acc.entry(k).or_default().push(v);
-                    acc
-                });
         for (region, client) in &self.clients {
             let request = client
                 .describe_instances()
@@ -368,14 +390,18 @@ impl ServerProviderClient for AwsClient {
     where
         I: Iterator<Item = &'a Instance> + Send,
     {
-        let map_of_ids_by_region = instances.into_iter().fold(
-            HashMap::new(),
-            |mut acc: HashMap<String, Vec<String>>, i| {
-                acc.entry(i.region.clone()).or_default().push(i.id.clone());
-                acc
-            },
-        );
-        for (region, ids) in map_of_ids_by_region {
+        let mut instance_ids: HashMap<String, Vec<String>> = HashMap::new();
+        for i in instances {
+            if i.lifecycle == InstanceLifecycle::Spot {
+                return Err(CloudProviderError::FailedToStopSpotInstance(i.id.clone()));
+            }
+            instance_ids
+                .entry(i.region.clone())
+                .or_default()
+                .push(i.id.clone());
+        }
+
+        for (region, ids) in instance_ids {
             let client = self.clients.get(&region).ok_or_else(|| {
                 CloudProviderError::Request(format!("Undefined region {:?}", region))
             })?;
@@ -393,6 +419,7 @@ impl ServerProviderClient for AwsClient {
         region: S,
         role: InstanceRole,
         quantity: usize,
+        use_spot_instances: bool,
     ) -> CloudProviderResult<Vec<Instance>>
     where
         S: Into<String> + Serialize + Send,
@@ -433,25 +460,48 @@ impl ServerProviderClient for AwsClient {
             InstanceRole::Metrics => &self.settings.metrics_specs,
             InstanceRole::Client => &self.settings.client_specs,
         };
-        let request = client
+
+        let base_request = client
             .run_instances()
             .image_id(image_id)
             .instance_type(instance_type.as_str().into())
             .key_name(testbed_id)
-            .min_count(quantity as i32)
-            .max_count(quantity as i32)
             .security_groups(&self.settings.testbed_id)
             .block_device_mappings(storage)
             .tag_specifications(tags);
-
-        let response = request.send().await?;
-        let instances = response
-            .instances()
-            .iter()
-            .map(|instance| self.make_instance(region.clone(), instance))
-            .collect::<Vec<_>>();
-
-        Ok(instances)
+        let mut collected_instances = Vec::new();
+        if use_spot_instances && role == InstanceRole::Node {
+            // first attempt to deploy sport instances
+            let request = base_request
+                .clone()
+                .min_count(1)
+                .max_count(quantity as i32)
+                .instance_market_options(Self::spot_options());
+            let result = request.send().await;
+            let instances = match result {
+                Ok(response) => response
+                    .instances()
+                    .iter()
+                    .map(|i| self.make_instance(region.clone(), i))
+                    .collect(),
+                Err(_) => Vec::new(),
+            };
+            collected_instances.extend(instances);
+        }
+        if collected_instances.len() < quantity {
+            // some instances need to be OnDemand
+            let request = base_request
+                .min_count((quantity - collected_instances.len()) as i32)
+                .max_count((quantity - collected_instances.len()) as i32);
+            let response = request.send().await?;
+            let on_demand_instances = response
+                .instances()
+                .iter()
+                .map(|instance| self.make_instance(region.clone(), instance))
+                .collect::<Vec<_>>();
+            collected_instances.extend(on_demand_instances);
+        }
+        Ok(collected_instances)
     }
 
     async fn delete_instances<'a, I>(&self, instances: I) -> CloudProviderResult<()>

--- a/crates/iota-aws-orchestrator/src/client/mod.rs
+++ b/crates/iota-aws-orchestrator/src/client/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    collections::HashMap,
     fmt::Display,
     net::{Ipv4Addr, SocketAddr},
 };
@@ -36,6 +37,18 @@ impl From<&str> for InstanceRole {
         }
     }
 }
+
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq, Hash)]
+pub enum InstanceLifecycle {
+    Spot,
+    OnDemand,
+}
+
+impl Display for InstanceLifecycle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
 /// Represents a cloud provider instance.
 #[derive(Debug, Deserialize, Clone, Eq, PartialEq, Hash)]
 pub struct Instance {
@@ -55,6 +68,8 @@ pub struct Instance {
     pub status: String,
     // The role of the instance. "Node" | "Client" | "Metrics"
     pub role: InstanceRole,
+    // The lifecycle of the instance. "Spot" | "OnDemand"
+    pub lifecycle: InstanceLifecycle,
 }
 
 impl Instance {
@@ -95,6 +110,7 @@ impl Instance {
             specs: Default::default(),
             status: Default::default(),
             role: InstanceRole::Node,
+            lifecycle: InstanceLifecycle::OnDemand,
         }
     }
 }
@@ -113,7 +129,7 @@ pub trait ServerProviderClient: Display {
 
     async fn list_instances_by_region_and_ids(
         &self,
-        ids: Vec<(String, String)>,
+        ids_by_region: &HashMap<String, Vec<String>>,
     ) -> CloudProviderResult<Vec<Instance>>;
 
     /// Start the specified instances.
@@ -133,6 +149,7 @@ pub trait ServerProviderClient: Display {
         region: S,
         role: InstanceRole,
         quantity: usize,
+        use_spot_instances: bool,
     ) -> CloudProviderResult<Vec<Instance>>
     where
         S: Into<String> + Serialize + Send;
@@ -155,11 +172,11 @@ pub trait ServerProviderClient: Display {
 
 #[cfg(test)]
 pub mod test_client {
-    use std::{fmt::Display, sync::Mutex};
+    use std::{collections::HashMap, fmt::Display, sync::Mutex};
 
     use serde::Serialize;
 
-    use super::{Instance, InstanceRole, ServerProviderClient};
+    use super::{Instance, InstanceLifecycle, InstanceRole, ServerProviderClient};
     use crate::{error::CloudProviderResult, settings::Settings};
 
     pub struct TestClient {
@@ -195,12 +212,18 @@ pub mod test_client {
         }
         async fn list_instances_by_region_and_ids(
             &self,
-            regions_and_ids: Vec<(String, String)>,
+            ids_by_region: &HashMap<String, Vec<String>>,
         ) -> CloudProviderResult<Vec<Instance>> {
             let guard = self.instances.lock().unwrap();
             let instances_by_ids = guard
                 .iter()
-                .filter(|x| regions_and_ids.contains(&(x.region.clone(), x.id.clone())))
+                .filter(|x| {
+                    if let Some(instances) = ids_by_region.get(x.region.as_str()) {
+                        instances.contains(&x.id)
+                    } else {
+                        false
+                    }
+                })
                 .cloned()
                 .collect::<Vec<_>>();
             Ok(instances_by_ids)
@@ -235,6 +258,7 @@ pub mod test_client {
             region: S,
             role: InstanceRole,
             quantity: usize,
+            use_spot_instances: bool,
         ) -> CloudProviderResult<Vec<Instance>>
         where
             S: Into<String> + Serialize + Send,
@@ -253,6 +277,11 @@ pub mod test_client {
                     specs: self.settings.node_specs.clone(),
                     status: "running".into(),
                     role: role.clone(),
+                    lifecycle: if use_spot_instances {
+                        InstanceLifecycle::Spot
+                    } else {
+                        InstanceLifecycle::OnDemand
+                    },
                 };
                 guard.push(instance.clone());
                 instances.push(instance);

--- a/crates/iota-aws-orchestrator/src/error.rs
+++ b/crates/iota-aws-orchestrator/src/error.rs
@@ -47,6 +47,9 @@ pub enum CloudProviderError {
 
     #[error("SSH key \"{0}\" not found")]
     SshKeyNotFound(String),
+
+    #[error("Spot Instances cannot be stopped: Instance Id: {0}")]
+    FailedToStopSpotInstance(String),
 }
 
 pub type SshResult<T> = Result<T, SshError>;

--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -156,7 +156,7 @@ pub enum TestbedAction {
         #[arg(long)]
         instances: usize,
 
-        // Skips deployment of a Metrics instance
+        /// Skips deployment of a Metrics instance
         #[arg(long, action, default_value = "false", global = true)]
         skip_monitoring: bool,
 
@@ -164,11 +164,10 @@ pub enum TestbedAction {
         #[arg(long, value_name = "INT", default_value = "0", global = true)]
         dedicated_clients: usize,
 
-        /// The region where to deploy the instances. If this parameter is not
-        /// specified, the command deploys the specified number of
-        /// instances in all regions listed in the setting file.
-        #[arg(long)]
-        region: Option<String>,
+        /// Attempts to prioritise cheaper spot instances
+        /// Note: stop and start commands are not available for spot instances
+        #[arg(long, action, default_value = "false", global = true)]
+        use_spot_instances: bool,
     },
 
     /// Start at most the specified number of instances per region on an
@@ -268,9 +267,14 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
                 instances,
                 dedicated_clients,
                 skip_monitoring,
-                region,
+                use_spot_instances,
             } => testbed
-                .deploy(instances, region, skip_monitoring, dedicated_clients)
+                .deploy(
+                    instances,
+                    skip_monitoring,
+                    dedicated_clients,
+                    use_spot_instances,
+                )
                 .await
                 .wrap_err("Failed to deploy testbed")?,
 

--- a/crates/iota-aws-orchestrator/src/settings.rs
+++ b/crates/iota-aws-orchestrator/src/settings.rs
@@ -12,10 +12,7 @@ use std::{
 use reqwest::Url;
 use serde::{Deserialize, Deserializer, de::Error};
 
-use crate::{
-    client::{Instance, InstanceRole},
-    error::{SettingsError, SettingsResult},
-};
+use crate::error::{SettingsError, SettingsResult};
 
 /// The git repository holding the codebase.
 #[derive(Deserialize, Clone)]
@@ -165,28 +162,6 @@ impl Settings {
                 file: ssh_public_key_file.display().to_string(),
                 message: e.to_string(),
             }),
-        }
-    }
-
-    /// Check whether the input instance matches the criteria described in the
-    /// settings.
-    pub fn filter_instances(&self, instance: &Instance) -> bool {
-        match &instance.role {
-            InstanceRole::Node => {
-                self.regions.contains(&instance.region)
-                    && instance.specs.to_lowercase().replace('.', "")
-                        == self.node_specs.to_lowercase().replace('.', "")
-            }
-            InstanceRole::Client => {
-                self.regions.contains(&instance.region)
-                    && instance.specs.to_lowercase().replace('.', "")
-                        == self.client_specs.to_lowercase().replace('.', "")
-            }
-            InstanceRole::Metrics => {
-                self.regions.contains(&instance.region)
-                    && instance.specs.to_lowercase().replace('.', "")
-                        == self.metrics_specs.to_lowercase().replace('.', "")
-            }
         }
     }
 

--- a/crates/iota-aws-orchestrator/src/testbed.rs
+++ b/crates/iota-aws-orchestrator/src/testbed.rs
@@ -2,13 +2,13 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use futures::future::try_join_all;
 use prettytable::{Table, row};
 use tokio::time::{self, Instant};
 
-use super::client::{Instance, InstanceRole};
+use super::client::{Instance, InstanceLifecycle, InstanceRole};
 use crate::{
     client::ServerProviderClient,
     display,
@@ -92,31 +92,18 @@ impl<C: ServerProviderClient> Testbed<C> {
 
     /// Print the current status of the testbed.
     pub fn status(&self) {
-        let filtered = self
-            .instances()
-            .into_iter()
-            .filter(|instance| self.settings.filter_instances(instance));
-        let sorted: Vec<(_, Vec<_>)> = self
-            .settings
-            .regions
-            .iter()
-            .map(|region| {
-                (
-                    region,
-                    filtered
-                        .clone()
-                        .filter(|instance| &instance.region == region)
-                        .collect(),
-                )
-            })
-            .collect();
+        let instances_by_region = self.instances().into_iter().fold(
+            HashMap::new(),
+            |mut acc: HashMap<String, Vec<Instance>>, i| {
+                acc.entry(i.region.clone()).or_default().push(i);
+                acc
+            },
+        );
 
         let mut table = Table::new();
         table.set_format(display::default_table_format());
 
-        let active = filtered.filter(|x| x.is_active()).count();
-        table.set_titles(row![bH2->format!("Instances ({active})")]);
-        for (i, (region, instances)) in sorted.iter().enumerate() {
+        for (i, (region, instances)) in instances_by_region.iter().enumerate() {
             table.add_row(row![bH2->region.to_uppercase()]);
             let mut j = 0;
             for instance in instances {
@@ -127,7 +114,10 @@ impl<C: ServerProviderClient> Testbed<C> {
                 let username = C::USERNAME;
                 let ip = instance.main_ip;
                 let role = instance.role.to_string();
-                let connect = format!("[{role:<7}] ssh -i {private_key_file} {username}@{ip}");
+                let lifecycle = instance.lifecycle.to_string();
+                let connect = format!(
+                    "[{role:<7}] [{lifecycle:<8}] ssh -i {private_key_file} {username}@{ip}"
+                );
                 if !instance.is_terminated() {
                     if instance.is_active() {
                         table.add_row(row![bFg->format!("{j}"), connect]);
@@ -137,7 +127,7 @@ impl<C: ServerProviderClient> Testbed<C> {
                     j += 1;
                 }
             }
-            if i != sorted.len() - 1 {
+            if i != instances_by_region.len() - 1 {
                 table.add_row(row![]);
             }
         }
@@ -157,68 +147,58 @@ impl<C: ServerProviderClient> Testbed<C> {
     pub async fn deploy(
         &mut self,
         quantity: usize,
-        region: Option<String>,
         skip_monitoring: bool,
         dedicated_clients: usize,
+        use_spot_instances: bool,
     ) -> TestbedResult<()> {
         display::action(format!("Deploying instances ({quantity} per region)"));
 
         let mut instances: Vec<Instance> = vec![];
 
         if !skip_monitoring {
-            let metrics_region = match &region {
-                Some(region) => region.clone(),
-                None => self
-                    .settings
-                    .regions
-                    .first()
-                    .expect("At least one region must be present")
-                    .clone(),
-            };
+            let metrics_region = self
+                .settings
+                .regions
+                .first()
+                .expect("At least one region must be present")
+                .clone();
             let metrics_instance = self
                 .client
-                .create_instance(metrics_region, InstanceRole::Metrics, 1)
+                .create_instance(metrics_region, InstanceRole::Metrics, 1, false)
                 .await?;
             instances.extend(metrics_instance);
         }
 
-        let node_instances = match &region {
-            Some(x) => {
-                self.client
-                    .create_instance(x.clone(), InstanceRole::Node, quantity)
-                    .await?
-            }
-            None => {
-                // Multi-region case — call create_instance per region in parallel
-                let tasks = self.settings.regions.iter().map(|region| {
-                    self.client
-                        .create_instance(region.clone(), InstanceRole::Node, quantity)
-                });
+        let node_instances = {
+            // Multi-region case — call create_instance per region in parallel
+            let tasks = self.settings.regions.iter().map(|region| {
+                self.client.create_instance(
+                    region.clone(),
+                    InstanceRole::Node,
+                    quantity,
+                    use_spot_instances,
+                )
+            });
 
-                // Run them all concurrently, flatten Vec<Vec<Instance>> → Vec<Instance>
-                try_join_all(tasks)
-                    .await?
-                    .into_iter()
-                    .flatten()
-                    .collect::<Vec<_>>()
-            }
+            // Run them all concurrently, flatten Vec<Vec<Instance>> → Vec<Instance>
+            try_join_all(tasks)
+                .await?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>()
         };
         instances.extend(node_instances);
 
-        let client_instances = match (&region, dedicated_clients) {
-            (_, 0) => vec![],
-            (Some(x), instance_quantity) => {
-                self.client
-                    .create_instance(x.clone(), InstanceRole::Client, instance_quantity)
-                    .await?
-            }
-            (None, instance_quantity) => {
+        let client_instances = match dedicated_clients {
+            0 => vec![],
+            instance_quantity => {
                 // Multi-region case — call create_instance per region in parallel
                 let tasks = self.settings.regions.iter().map(|region| {
                     self.client.create_instance(
                         region.clone(),
                         InstanceRole::Client,
                         instance_quantity,
+                        false,
                     )
                 });
 
@@ -289,56 +269,70 @@ impl<C: ServerProviderClient> Testbed<C> {
 
         // Gather available instances.
         let mut available = Vec::new();
-
-        for region in &self.settings.regions {
-            #[cfg(not(test))]
-            available.extend(
-                self.node_instances
-                    .iter()
-                    .filter(|x| {
-                        x.is_stopped() && &x.region == region && self.settings.filter_instances(x)
-                    })
-                    .take(quantity)
-                    .cloned()
-                    .collect::<Vec<_>>(),
+        #[cfg(not(test))]
+        let stopped_node_instances_by_region = self
+            .node_instances()
+            .into_iter()
+            .filter(|i| i.is_stopped())
+            .fold(
+                HashMap::new(),
+                |mut acc: HashMap<String, Vec<Instance>>, i| {
+                    acc.entry(i.region.clone()).or_default().push(i);
+                    acc
+                },
             );
-            #[cfg(test)]
-            available.extend(
-                self.client
-                    .instances()
-                    .iter()
-                    .filter(|i| i.role == InstanceRole::Node)
-                    .filter(|x| {
-                        x.is_stopped() && &x.region == region && self.settings.filter_instances(x)
-                    })
-                    .take(quantity)
-                    .cloned()
-                    .collect::<Vec<_>>(),
+        #[cfg(test)]
+        let stopped_node_instances_by_region = self
+            .client
+            .instances()
+            .into_iter()
+            .filter(|i| i.role == InstanceRole::Node)
+            .filter(|i| i.is_stopped())
+            .fold(
+                HashMap::new(),
+                |mut acc: HashMap<String, Vec<Instance>>, i| {
+                    acc.entry(i.region.clone()).or_default().push(i);
+                    acc
+                },
             );
+        for (_, instances) in stopped_node_instances_by_region {
+            if instances.len() < quantity {
+                return Err(TestbedError::InsufficientCapacity(
+                    quantity - instances.len(),
+                ));
+            }
+            available.extend(instances.into_iter().take(quantity));
         }
+
         if !skip_monitoring {
             if let Some(metrics_instance) = &self.metrics_instance {
-                if metrics_instance.is_inactive() {
+                if metrics_instance.is_stopped() {
                     available.push(metrics_instance.clone());
+                } else {
+                    return Err(TestbedError::MetricsServerMissing());
                 }
             }
         }
         if dedicated_clients > 0 {
-            for region in &self.settings.regions {
-                available.extend(
-                    self.client_instances
-                        .clone()
-                        .unwrap()
-                        .iter()
-                        .filter(|x| {
-                            x.is_inactive()
-                                && &x.region == region
-                                && self.settings.filter_instances(x)
-                        })
-                        .take(dedicated_clients)
-                        .cloned()
-                        .collect::<Vec<_>>(),
-                );
+            if let Some(dedicated_client_nodes) = &self.client_instances {
+                let stopped_client_instances_by_region = dedicated_client_nodes
+                    .iter()
+                    .filter(|i| i.is_stopped())
+                    .fold(
+                        HashMap::new(),
+                        |mut acc: HashMap<String, Vec<Instance>>, i| {
+                            acc.entry(i.region.clone()).or_default().push(i.clone());
+                            acc
+                        },
+                    );
+                for (_, instances) in stopped_client_instances_by_region {
+                    if instances.len() < dedicated_clients {
+                        return Err(TestbedError::InsufficientDedicatedClientCapacity(
+                            dedicated_clients - instances.len(),
+                        ));
+                    }
+                    available.extend(instances.into_iter().take(dedicated_clients));
+                }
             }
         }
 
@@ -379,11 +373,11 @@ impl<C: ServerProviderClient> Testbed<C> {
 
         // Stop all instances.
         self.client
-            .stop_instances(
-                self.instances().iter().filter(|i| {
-                    i.is_active() && !(i.role == InstanceRole::Metrics && keep_monitoring)
-                }),
-            )
+            .stop_instances(self.instances().iter().filter(|i| {
+                i.is_active()
+                    && !(i.role == InstanceRole::Metrics && keep_monitoring)
+                    && i.lifecycle == InstanceLifecycle::OnDemand
+            }))
             .await?;
 
         // Wait until the instances are stopped.
@@ -419,9 +413,13 @@ impl<C: ServerProviderClient> Testbed<C> {
     where
         I: Iterator<Item = &'a Instance> + Clone,
     {
-        let instance_region_and_ids = instances
-            .map(|x| (x.region.clone(), x.id.clone()))
-            .collect::<Vec<_>>();
+        let instance_region_and_ids = instances.fold(
+            HashMap::new(),
+            |mut acc: HashMap<String, Vec<String>>, i| {
+                acc.entry(i.region.clone()).or_default().push(i.id.clone());
+                acc
+            },
+        );
         let mut interval = time::interval(Duration::from_secs(5));
         interval.tick().await; // The first tick returns immediately.
 
@@ -432,7 +430,7 @@ impl<C: ServerProviderClient> Testbed<C> {
             display::status(format!("{elapsed}s"));
             let instances = self
                 .client
-                .list_instances_by_region_and_ids(instance_region_and_ids.clone())
+                .list_instances_by_region_and_ids(&instance_region_and_ids)
                 .await?;
 
             let futures = instances.iter().map(|instance| {
@@ -467,7 +465,7 @@ mod test {
         let client = TestClient::new(settings.clone());
         let mut testbed = Testbed::new(settings, client).await.unwrap();
 
-        testbed.deploy(5, None, true, 0).await.unwrap();
+        testbed.deploy(5, true, 0, false).await.unwrap();
 
         assert_eq!(
             testbed.node_instances.len(),
@@ -494,10 +492,10 @@ mod test {
         let settings = Settings::new_for_test();
         let client = TestClient::new(settings.clone());
         let mut testbed = Testbed::new(settings, client).await.unwrap();
-        testbed.deploy(5, None, true, 0).await.unwrap();
+        testbed.deploy(5, true, 0, false).await.unwrap();
         testbed.stop(false).await.unwrap();
 
-        let result = testbed.start(2, 0, false).await;
+        let result = testbed.start(2, 0, true).await;
 
         assert!(result.is_ok());
         for region in &testbed.settings.regions {
@@ -526,8 +524,8 @@ mod test {
         let settings = Settings::new_for_test();
         let client = TestClient::new(settings.clone());
         let mut testbed = Testbed::new(settings, client).await.unwrap();
-        testbed.deploy(5, None, true, 0).await.unwrap();
-        testbed.start(2, 0, false).await.unwrap();
+        testbed.deploy(5, true, 0, false).await.unwrap();
+        testbed.start(2, 0, true).await.unwrap();
 
         testbed.stop(false).await.unwrap();
 


### PR DESCRIPTION
# Description of change

Adds the `--use-spot-instances` flag for the `deploy` command. If used attempts to hire spot instances instead of on-demand ones, if less spot instances are available then required, on demand ones will be hired.

Removes the `--region` flag for the `deploy` command, as all the other commands work only with the `settings.json` file `regions` line. If a region is passed to the `--region` flag that is not present in the regions list the other commands will work unreliably.

## Links to any relevant issues

fixes #9205 .

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
