### PR TITLE
upstream(graphql): deduplicate configs and clap args, add flag to skip db compatibility

### DIFF
--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -275,6 +275,7 @@ impl Cluster for LocalNewCluster {
                 None,
                 None,
                 None,
+                None,
             );
 
             start_graphql_server_with_fn_rpc(

--- a/crates/iota-graphql-rpc/src/commands.rs
+++ b/crates/iota-graphql-rpc/src/commands.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 
 use clap::*;
 
+use crate::config::{ConnectionConfig, Ide, TxExecFullNodeConfig};
+
 #[derive(Parser)]
 #[command(name = "iota-graphql-rpc", about = "IOTA GraphQL RPC", author)]
 pub enum Command {
@@ -21,34 +23,17 @@ pub enum Command {
         file: Option<PathBuf>,
     },
     StartServer {
-        /// The title to display at the top of the page
-        #[arg(short, long)]
-        ide_title: Option<String>,
-        /// DB URL for data fetching
-        #[arg(short, long)]
-        db_url: Option<String>,
-        /// Pool size for DB connections
-        #[arg(long)]
-        db_pool_size: Option<u32>,
-        /// Port to bind the server to
-        #[arg(short, long)]
-        port: Option<u16>,
-        /// Host to bind the server to
-        #[arg(long)]
-        host: Option<String>,
-        /// Port to bind the prom server to
-        #[arg(long)]
-        prom_port: Option<u16>,
-        /// Host to bind the prom server to
-        #[arg(long)]
-        prom_host: Option<String>,
+        #[clap(flatten)]
+        ide: Ide,
+
+        #[clap(flatten)]
+        connection: ConnectionConfig,
 
         /// Path to TOML file containing configuration for service.
         #[arg(short, long)]
         config: Option<PathBuf>,
 
-        /// RPC url to the Node for tx execution
-        #[arg(long)]
-        node_rpc_url: Option<String>,
+        #[clap(flatten)]
+        tx_exec_full_node: TxExecFullNodeConfig,
     },
 }

--- a/crates/iota-graphql-rpc/src/commands.rs
+++ b/crates/iota-graphql-rpc/src/commands.rs
@@ -23,17 +23,17 @@ pub enum Command {
         file: Option<PathBuf>,
     },
     StartServer {
-        #[clap(flatten)]
+        #[command(flatten)]
         ide: Ide,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         connection: ConnectionConfig,
 
         /// Path to TOML file containing configuration for service.
         #[arg(short, long)]
         config: Option<PathBuf>,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         tx_exec_full_node: TxExecFullNodeConfig,
     },
 }

--- a/crates/iota-graphql-rpc/src/config.rs
+++ b/crates/iota-graphql-rpc/src/config.rs
@@ -34,26 +34,26 @@ pub struct ServerConfig {
 #[derive(clap::Args, Clone, Eq, PartialEq)]
 pub struct ConnectionConfig {
     /// Port to bind the server to
-    #[clap(short, long, default_value_t = ConnectionConfig::default().port)]
+    #[arg(short, long, default_value_t = ConnectionConfig::default().port)]
     pub port: u16,
     /// Host to bind the server to
-    #[clap(long, default_value_t = ConnectionConfig::default().host)]
+    #[arg(long, default_value_t = ConnectionConfig::default().host)]
     pub host: String,
     /// DB URL for data fetching
-    #[clap(short, long, default_value_t = ConnectionConfig::default().db_url)]
+    #[arg(short, long, default_value_t = ConnectionConfig::default().db_url)]
     pub db_url: String,
     /// Pool size for DB connections
-    #[clap(long, default_value_t = ConnectionConfig::default().db_pool_size)]
+    #[arg(long, default_value_t = ConnectionConfig::default().db_pool_size)]
     pub db_pool_size: u32,
     /// Host to bind the prom server to
-    #[clap(long, default_value_t = ConnectionConfig::default().prom_host)]
+    #[arg(long, default_value_t = ConnectionConfig::default().prom_host)]
     pub prom_host: String,
     /// Port to bind the prom server to
-    #[clap(long, default_value_t = ConnectionConfig::default().prom_port)]
+    #[arg(long, default_value_t = ConnectionConfig::default().prom_port)]
     pub prom_port: u16,
     /// Skip checking whether the service is compatible with the DB it is about
     /// to connect to, on start-up.
-    #[clap(long, default_value_t = ConnectionConfig::default().skip_migration_consistency_check)]
+    #[arg(long, default_value_t = ConnectionConfig::default().skip_migration_consistency_check)]
     pub skip_migration_consistency_check: bool,
 }
 
@@ -179,7 +179,7 @@ impl Version {
 #[derive(clap::Args)]
 pub struct Ide {
     /// The title to display at the top of the web-based GraphiQL IDE.
-    #[clap(short, long, default_value_t = Ide::default().ide_title)]
+    #[arg(short, long, default_value_t = Ide::default().ide_title)]
     pub(crate) ide_title: String,
 }
 
@@ -209,7 +209,7 @@ pub struct InternalFeatureConfig {
 #[derive(clap::Args, Default)]
 pub struct TxExecFullNodeConfig {
     /// RPC URL for the fullnode to send transactions to execute and dry-run.
-    #[clap(long)]
+    #[arg(long)]
     pub(crate) node_rpc_url: Option<String>,
 }
 

--- a/crates/iota-graphql-rpc/src/config.rs
+++ b/crates/iota-graphql-rpc/src/config.rs
@@ -31,16 +31,26 @@ pub struct ServerConfig {
 /// other services, and might differ from instance to instance of the GraphQL
 /// service.
 #[GraphQLConfig]
-#[derive(Clone, Eq, PartialEq)]
+#[derive(clap::Args, Clone, Eq, PartialEq)]
 pub struct ConnectionConfig {
     /// Port to bind the server to
-    pub(crate) port: u16,
+    #[clap(short, long, default_value_t = ConnectionConfig::default().port)]
+    pub port: u16,
     /// Host to bind the server to
-    pub(crate) host: String,
-    pub(crate) db_url: String,
-    pub(crate) db_pool_size: u32,
-    pub(crate) prom_url: String,
-    pub(crate) prom_port: u16,
+    #[clap(long, default_value_t = ConnectionConfig::default().host)]
+    pub host: String,
+    /// DB URL for data fetching
+    #[clap(short, long, default_value_t = ConnectionConfig::default().db_url)]
+    pub db_url: String,
+    /// Pool size for DB connections
+    #[clap(long, default_value_t = ConnectionConfig::default().db_pool_size)]
+    pub db_pool_size: u32,
+    /// Host to bind the prom server to
+    #[clap(long, default_value_t = ConnectionConfig::default().prom_host)]
+    pub prom_host: String,
+    /// Port to bind the prom server to
+    #[clap(long, default_value_t = ConnectionConfig::default().prom_port)]
+    pub prom_port: u16,
 }
 
 /// Configuration on features supported by the GraphQL service, passed in a
@@ -162,7 +172,10 @@ impl Version {
 }
 
 #[GraphQLConfig]
+#[derive(clap::Args)]
 pub struct Ide {
+    /// The title to display at the top of the web-based GraphiQL IDE.
+    #[clap(short, long, default_value_t = Ide::default().ide_title)]
     pub(crate) ide_title: String,
 }
 
@@ -189,8 +202,10 @@ pub struct InternalFeatureConfig {
 }
 
 #[GraphQLConfig]
-#[derive(Default)]
+#[derive(clap::Args, Default)]
 pub struct TxExecFullNodeConfig {
+    /// RPC URL for the fullnode to send transactions to execute and dry-run.
+    #[clap(long)]
     pub(crate) node_rpc_url: Option<String>,
 }
 
@@ -339,19 +354,13 @@ impl ServiceConfig {
     }
 }
 
-impl TxExecFullNodeConfig {
-    pub fn new(node_rpc_url: Option<String>) -> Self {
-        Self { node_rpc_url }
-    }
-}
-
 impl ConnectionConfig {
     pub fn new(
         port: Option<u16>,
         host: Option<String>,
         db_url: Option<String>,
         db_pool_size: Option<u32>,
-        prom_url: Option<String>,
+        prom_host: Option<String>,
         prom_port: Option<u16>,
     ) -> Self {
         let default = Self::default();
@@ -360,7 +369,7 @@ impl ConnectionConfig {
             host: host.unwrap_or(default.host),
             db_url: db_url.unwrap_or(default.db_url),
             db_pool_size: db_pool_size.unwrap_or(default.db_pool_size),
-            prom_url: prom_url.unwrap_or(default.prom_url),
+            prom_host: prom_host.unwrap_or(default.prom_host),
             prom_port: prom_port.unwrap_or(default.prom_port),
         }
     }
@@ -431,14 +440,6 @@ impl Limits {
     }
 }
 
-impl Ide {
-    pub fn new(ide_title: Option<String>) -> Self {
-        ide_title
-            .map(|ide_title| Ide { ide_title })
-            .unwrap_or_default()
-    }
-}
-
 impl BackgroundTasksConfig {
     pub fn test_defaults() -> Self {
         Self {
@@ -474,7 +475,7 @@ impl Default for ConnectionConfig {
             host: "127.0.0.1".to_string(),
             db_url: "postgres://postgres:postgrespw@localhost:5432/iota_indexer".to_string(),
             db_pool_size: 10,
-            prom_url: "0.0.0.0".to_string(),
+            prom_host: "0.0.0.0".to_string(),
             prom_port: 9184,
         }
     }

--- a/crates/iota-graphql-rpc/src/config.rs
+++ b/crates/iota-graphql-rpc/src/config.rs
@@ -51,6 +51,10 @@ pub struct ConnectionConfig {
     /// Port to bind the prom server to
     #[clap(long, default_value_t = ConnectionConfig::default().prom_port)]
     pub prom_port: u16,
+    /// Skip checking whether the service is compatible with the DB it is about
+    /// to connect to, on start-up.
+    #[clap(long, default_value_t = ConnectionConfig::default().skip_migration_consistency_check)]
+    pub skip_migration_consistency_check: bool,
 }
 
 /// Configuration on features supported by the GraphQL service, passed in a
@@ -362,6 +366,7 @@ impl ConnectionConfig {
         db_pool_size: Option<u32>,
         prom_host: Option<String>,
         prom_port: Option<u16>,
+        skip_migration_consistency_check: Option<bool>,
     ) -> Self {
         let default = Self::default();
         Self {
@@ -371,6 +376,8 @@ impl ConnectionConfig {
             db_pool_size: db_pool_size.unwrap_or(default.db_pool_size),
             prom_host: prom_host.unwrap_or(default.prom_host),
             prom_port: prom_port.unwrap_or(default.prom_port),
+            skip_migration_consistency_check: skip_migration_consistency_check
+                .unwrap_or(default.skip_migration_consistency_check),
         }
     }
 
@@ -477,6 +484,7 @@ impl Default for ConnectionConfig {
             db_pool_size: 10,
             prom_host: "0.0.0.0".to_string(),
             prom_port: 9184,
+            skip_migration_consistency_check: false,
         }
     }
 }

--- a/crates/iota-graphql-rpc/src/main.rs
+++ b/crates/iota-graphql-rpc/src/main.rs
@@ -7,7 +7,7 @@ use std::{fs, path::PathBuf};
 use clap::{CommandFactory, FromArgMatches};
 use iota_graphql_rpc::{
     commands::Command,
-    config::{ConnectionConfig, Ide, ServerConfig, ServiceConfig, TxExecFullNodeConfig, Version},
+    config::{ServerConfig, ServiceConfig, Version},
     server::{builder::export_schema, graphiql_server::start_graphiql_server},
 };
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
@@ -51,18 +51,11 @@ async fn main() {
             }
         }
         Command::StartServer {
-            ide_title,
-            db_url,
-            db_pool_size,
-            port,
-            host,
+            ide,
+            connection,
             config,
-            node_rpc_url,
-            prom_host,
-            prom_port,
+            tx_exec_full_node,
         } => {
-            let connection =
-                ConnectionConfig::new(port, host, db_url, db_pool_size, prom_host, prom_port);
             let service_config = service_config(config);
             let _guard = telemetry_subscribers::TelemetryConfig::new()
                 .with_env()
@@ -74,8 +67,8 @@ async fn main() {
             let server_config = ServerConfig {
                 connection,
                 service: service_config,
-                ide: Ide::new(ide_title),
-                tx_exec_full_node: TxExecFullNodeConfig::new(node_rpc_url),
+                ide,
+                tx_exec_full_node,
                 ..ServerConfig::default()
             };
 

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -94,7 +94,6 @@ pub(crate) struct Server {
     system_package_task: SystemPackageTask,
     trigger_exchange_rates_task: TriggerExchangeRatesTask,
     state: AppState,
-    db_reader: Db,
 }
 
 impl Server {
@@ -103,14 +102,6 @@ impl Server {
     /// tasks to complete before returning.
     pub async fn run(mut self) -> Result<(), Error> {
         get_or_init_server_start_time().await;
-
-        {
-            // Compatibility check
-            info!("Starting compatibility check");
-            let mut connection = get_pool_connection(&self.db_reader.inner.get_pool())?;
-            check_db_migration_consistency(&mut connection)?;
-            info!("Compatibility check passed");
-        }
 
         // A handle that spawns a background task to periodically update the
         // `Watermark`, which consists of the checkpoint upper bound and current
@@ -364,7 +355,7 @@ impl ServerBuilder {
         );
 
         let trigger_exchange_rates_task = TriggerExchangeRatesTask::new(
-            db_reader.clone(),
+            db_reader,
             watermark_task.epoch_receiver(),
             state.cancellation_token.clone(),
         );
@@ -391,7 +382,6 @@ impl ServerBuilder {
             system_package_task,
             trigger_exchange_rates_task,
             state,
-            db_reader,
         })
     }
 
@@ -449,6 +439,14 @@ impl ServerBuilder {
             config.service.limits.request_timeout_ms.into(),
         )
         .map_err(|e| Error::ServerInit(format!("Failed to create pg connection pool: {e}")))?;
+
+        {
+            // Compatibility check
+            info!("Starting compatibility check");
+            let mut connection = get_pool_connection(&reader.get_pool())?;
+            check_db_migration_consistency(&mut connection)?;
+            info!("Compatibility check passed");
+        }
 
         // DB
         let db = Db::new(

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -405,13 +405,13 @@ impl ServerBuilder {
         // PROMETHEUS
         let prom_addr: SocketAddr = format!(
             "{}:{}",
-            config.connection.prom_url, config.connection.prom_port
+            config.connection.prom_host, config.connection.prom_port
         )
         .parse()
         .map_err(|_| {
             Error::Internal(format!(
                 "Failed to parse url {}, port {} into socket address",
-                config.connection.prom_url, config.connection.prom_port
+                config.connection.prom_host, config.connection.prom_port
             ))
         })?;
 

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -440,7 +440,7 @@ impl ServerBuilder {
         )
         .map_err(|e| Error::ServerInit(format!("Failed to create pg connection pool: {e}")))?;
 
-        {
+        if !config.connection.skip_migration_consistency_check {
             // Compatibility check
             info!("Starting compatibility check");
             let mut connection = get_pool_connection(&reader.get_pool())?;

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -906,14 +906,12 @@ async fn start(
         let graphql_address = parse_host_port(input, DEFAULT_GRAPHQL_PORT)
             .map_err(|_| anyhow!("Invalid graphql host and port"))?;
         tracing::info!("Starting the GraphQL service at {graphql_address}");
-        let graphql_connection_config = ConnectionConfig::new(
-            Some(graphql_address.port()),
-            Some(graphql_address.ip().to_string()),
-            Some(pg_address),
-            None,
-            None,
-            None,
-        );
+        let graphql_connection_config = ConnectionConfig {
+            port: graphql_address.port(),
+            host: graphql_address.ip().to_string(),
+            db_url: pg_address,
+            ..Default::default()
+        };
         start_graphql_server_with_fn_rpc(
             graphql_connection_config,
             Some(fullnode_url.clone()),


### PR DESCRIPTION
# Description of change

Original descriptions:

> Avoid duplicating fields for configs that are accepted as flags from the command-line and can also be read from TOML file. Use the same struct for both purposes but deocrate it with both clap and serde (or GraphQLConfig) annotations so that it can serve both purposes.

> Add a flag to optionally skip database migration compatibility checks.
This is helpful when trying to connect a local build up to a production
database to test a specific change, even if you are aware that other
queries may not be compatible.
To accommodate this change, the compatibility check was also moved into
`ServerBuilder` where the config is readily available. This also
slightly simplifies the `Server` itself, which no longer needs to hold
onto its own instance of the `Db`.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9217

## How the change has been tested

Comparing `cargo run --bin iota-graphql-rpc -- start-server --help` before and after the change.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [x] Deployment of services using Docker. - Tested if graphql starts up successfully with `pg-services-local`
- [ ] Verification of API backward compatibility.
