### PR TITLE
fix(sdk): Fix client wait in sdk tests

### DIFF
--- a/sdk/graphql-transport/test/compatibility.test.ts
+++ b/sdk/graphql-transport/test/compatibility.test.ts
@@ -57,7 +57,7 @@ describe('GraphQL IotaClient compatibility', () => {
 
         transactionBlockDigest = result.digest;
 
-        await toolbox.client.waitForTransaction({
+        await graphQLClient.waitForTransaction({
             digest: transactionBlockDigest,
             waitMode: 'checkpoint',
         });


### PR DESCRIPTION
# Description of change

Switch from `toolbox.client` to `graphQLClient`

## Links to any relevant issues

fixes #9223 