### PR TITLE
feat(indexer): Merge pruning watermarks feature branch

### DIFF
--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -410,9 +410,10 @@ impl ExecutorCluster {
                 tokio::time::sleep(Duration::from_secs(1)).await;
                 latest_snapshot_cp = self
                     .indexer_store
-                    .get_latest_object_snapshot_checkpoint_sequence_number()
+                    .get_latest_object_snapshot_watermark()
                     .await
                     .unwrap()
+                    .map(|watermark| watermark.cp)
                     .unwrap_or_default();
             }
         })

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -413,7 +413,7 @@ impl ExecutorCluster {
                     .get_latest_object_snapshot_watermark()
                     .await
                     .unwrap()
-                    .map(|watermark| watermark.cp)
+                    .map(|watermark| watermark.checkpoint_hi_inclusive)
                     .unwrap_or_default();
             }
         })

--- a/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS watermarks;

--- a/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/up.sql
@@ -1,0 +1,29 @@
+CREATE TABLE watermarks
+(
+    -- The table governed by this watermark, i.e `epochs`, `checkpoints`, `transactions`.
+    entity                      TEXT          NOT NULL,
+    -- Inclusive upper epoch bound for this entity's data. Committer updates this field. Pruner uses
+    -- this to determine if pruning is necessary based on the retention policy.
+    epoch_hi_inclusive          BIGINT        NOT NULL,
+    -- Inclusive lower epoch bound for this entity's data. Pruner updates this field when the epoch range exceeds the retention policy.
+    epoch_lo                    BIGINT        NOT NULL,
+    -- Inclusive upper checkpoint bound for this entity's data. Committer updates this field. All
+    -- data of this entity in the checkpoint must be persisted before advancing this watermark. The
+    -- committer refers to this on disaster recovery to resume writing.
+    checkpoint_hi_inclusive     BIGINT        NOT NULL,
+    -- Inclusive upper transaction sequence number bound for this entity's data. Committer updates
+    -- this field.
+    tx_hi_inclusive             BIGINT        NOT NULL,
+    -- Inclusive low watermark that the pruner advances. Corresponds to the epoch id, checkpoint
+    -- sequence number, or tx sequence number depending on the entity. Data before this watermark is
+    -- considered pruned by a reader. The underlying data may still exist in the db instance.
+    reader_lo                   BIGINT        NOT NULL,
+    -- Updated using the database's current timestamp when the pruner sees that some data needs to
+    -- be dropped. The pruner uses this column to determine whether to prune or wait long enough
+    -- that all in-flight reads complete or timeout before it acts on an updated watermark.
+    timestamp_ms                BIGINT        NOT NULL,
+    -- Column used by the pruner to track its true progress. Data at and below this watermark can
+    -- be immediately pruned.
+    pruner_lo                   BIGINT,
+    PRIMARY KEY (entity)
+);

--- a/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-10-01-090835_watermarks/up.sql
@@ -1,29 +1,33 @@
-CREATE TABLE watermarks
+CREATE TABLE IF NOT EXISTS watermarks
 (
     -- The table governed by this watermark, i.e `epochs`, `checkpoints`, `transactions`.
-    entity                      TEXT          NOT NULL,
-    -- Inclusive upper epoch bound for this entity's data. Committer updates this field. Pruner uses
-    -- this to determine if pruning is necessary based on the retention policy.
+    entity                      TEXT          PRIMARY KEY,
+    -- Inclusive upper epoch bound for this entity's data. Committer updates
+    -- this field. Pruner uses this to determine if pruning is necessary based
+    -- on the retention policy.
     epoch_hi_inclusive          BIGINT        NOT NULL,
-    -- Inclusive lower epoch bound for this entity's data. Pruner updates this field when the epoch range exceeds the retention policy.
-    epoch_lo                    BIGINT        NOT NULL,
-    -- Inclusive upper checkpoint bound for this entity's data. Committer updates this field. All
-    -- data of this entity in the checkpoint must be persisted before advancing this watermark. The
-    -- committer refers to this on disaster recovery to resume writing.
+    -- Inclusive upper checkpoint bound for this entity's data. Committer
+    -- updates this field. All data of this entity in the checkpoint must be
+    -- persisted before advancing this watermark. The committer refers to this
+    -- on disaster recovery to resume writing.
     checkpoint_hi_inclusive     BIGINT        NOT NULL,
-    -- Inclusive upper transaction sequence number bound for this entity's data. Committer updates
-    -- this field.
-    tx_hi_inclusive             BIGINT        NOT NULL,
-    -- Inclusive low watermark that the pruner advances. Corresponds to the epoch id, checkpoint
-    -- sequence number, or tx sequence number depending on the entity. Data before this watermark is
-    -- considered pruned by a reader. The underlying data may still exist in the db instance.
+    -- Exclusive upper transaction sequence number bound for this entity's
+    -- data. Committer updates this field.
+    tx_hi                       BIGINT        NOT NULL,
+    -- Inclusive lower epoch bound for this entity's data. Pruner updates this
+    -- field when the epoch range exceeds the retention policy.
+    epoch_lo                    BIGINT        NOT NULL,
+    -- Inclusive low watermark that the pruner advances. Corresponds to the
+    -- epoch id, checkpoint sequence number, or tx sequence number depending on
+    -- the entity. Data before this watermark is considered pruned by a reader.
+    -- The underlying data may still exist in the db instance.
     reader_lo                   BIGINT        NOT NULL,
-    -- Updated using the database's current timestamp when the pruner sees that some data needs to
-    -- be dropped. The pruner uses this column to determine whether to prune or wait long enough
-    -- that all in-flight reads complete or timeout before it acts on an updated watermark.
+    -- Updated using the database's current timestamp when the pruner sees that
+    -- some data needs to be dropped. The pruner uses this column to determine
+    -- whether to prune or wait long enough that all in-flight reads complete
+    -- or timeout before it acts on an updated watermark.
     timestamp_ms                BIGINT        NOT NULL,
-    -- Column used by the pruner to track its true progress. Data at and below this watermark can
-    -- be immediately pruned.
-    pruner_lo                   BIGINT,
-    PRIMARY KEY (entity)
+    -- Column used by the pruner to track its true progress. Data below this
+    -- watermark can be immediately pruned.
+    pruner_hi                   BIGINT        NOT NULL
 );

--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
 use iota_rest_api::CheckpointData;
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -33,7 +34,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
     async fn persist(&self, batch: Vec<T>) -> IndexerResult<()>;
 
     /// Reads high watermark of the table DB.
-    async fn get_watermark_hi(&self) -> IndexerResult<Option<CommitterWatermark>>;
+    async fn get_watermark_hi(&self) -> IndexerResult<Option<CheckpointSequenceNumber>>;
 
     /// Sets high watermark of the table DB, also update metrics.
     async fn set_watermark_hi(&self, watermark_hi: CommitterWatermark) -> IndexerResult<()>;
@@ -85,7 +86,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
         let mut next_cp_to_process = self
             .get_watermark_hi()
             .await?
-            .map(|watermark| watermark.cp.saturating_add(1))
+            .map(|watermark| watermark.saturating_add(1))
             .unwrap_or_default();
 
         loop {
@@ -108,7 +109,8 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
                             return Ok(());
                         }
                         for (watermark, data) in tuple_chunk {
-                            unprocessed.insert(watermark.cp, (watermark, data));
+                            unprocessed
+                                .insert(watermark.checkpoint_hi_inclusive, (watermark, data));
                         }
                     }
                     Some(None) => break, // Stream has ended
@@ -152,32 +154,38 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
 }
 
 /// The indexer writer operates on checkpoint data, which contains information
-/// on the current epoch, checkpoint, and transaction. These three numbers form
-/// the watermark upper bound for each committed table.
+/// on the current epoch, checkpoint, and transaction.
+///
+/// These three numbers form the watermark upper bound for each committed table.
+/// The reader and pruner are responsible for determining which of the three
+/// units will be used for a particular table.
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub struct CommitterWatermark {
-    pub epoch: u64,
-    pub cp: u64,
-    pub tx: u64,
+    /// Highest epoch written for given table. Doesn't mean that data for the
+    /// whole epoch is persisted as it still may be in progress.
+    pub epoch_hi_inclusive: u64,
+    /// Highest checkpoint for which all data is already written for given
+    /// table.
+    pub checkpoint_hi_inclusive: u64,
+    /// Exclusive upper transaction sequence number bound for this table's
+    /// data.
+    pub tx_hi: u64,
 }
 impl From<&IndexedCheckpoint> for CommitterWatermark {
     fn from(checkpoint: &IndexedCheckpoint) -> Self {
         Self {
-            epoch: checkpoint.epoch,
-            cp: checkpoint.sequence_number,
-            tx: checkpoint.network_total_transactions.saturating_sub(1),
+            epoch_hi_inclusive: checkpoint.epoch,
+            checkpoint_hi_inclusive: checkpoint.sequence_number,
+            tx_hi: checkpoint.network_total_transactions,
         }
     }
 }
 impl From<&CheckpointData> for CommitterWatermark {
     fn from(checkpoint: &CheckpointData) -> Self {
         Self {
-            epoch: checkpoint.checkpoint_summary.epoch,
-            cp: checkpoint.checkpoint_summary.sequence_number,
-            tx: checkpoint
-                .checkpoint_summary
-                .network_total_transactions
-                .saturating_sub(1),
+            epoch_hi_inclusive: checkpoint.checkpoint_summary.epoch,
+            checkpoint_hi_inclusive: checkpoint.checkpoint_summary.sequence_number,
+            tx_hi: checkpoint.checkpoint_summary.network_total_transactions,
         }
     }
 }

--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -8,10 +8,15 @@ use std::collections::BTreeMap;
 
 use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
+use iota_rest_api::CheckpointData;
+use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use crate::{errors::IndexerError, types::IndexerResult};
+use crate::{
+    errors::IndexerError,
+    types::{IndexedCheckpoint, IndexerResult},
+};
 
 pub(crate) const CHECKPOINT_COMMIT_BATCH_SIZE: usize = 100;
 pub(crate) const UNPROCESSED_CHECKPOINT_SIZE_LIMIT: usize = 1000;
@@ -28,10 +33,10 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
     async fn persist(&self, batch: Vec<T>) -> IndexerResult<()>;
 
     /// Reads high watermark of the table DB.
-    async fn get_watermark_hi(&self) -> IndexerResult<Option<u64>>;
+    async fn get_watermark_hi(&self) -> IndexerResult<Option<CommitterWatermark>>;
 
     /// Sets high watermark of the table DB, also update metrics.
-    async fn set_watermark_hi(&self, watermark_hi: u64) -> IndexerResult<()>;
+    async fn set_watermark_hi(&self, watermark_hi: CommitterWatermark) -> IndexerResult<()>;
 
     /// Gets the current max checkpoint that can be committed by the writer.
     ///
@@ -62,7 +67,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
     /// is persisted to.
     async fn persist_sequentially(
         &self,
-        cp_receiver: iota_metrics::metered_channel::Receiver<(u64, T)>,
+        cp_receiver: iota_metrics::metered_channel::Receiver<(CommitterWatermark, T)>,
         cancel: CancellationToken,
     ) -> IndexerResult<()> {
         let checkpoint_commit_batch_size = std::env::var("CHECKPOINT_COMMIT_BATCH_SIZE")
@@ -72,12 +77,15 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
         let mut stream = iota_metrics::metered_channel::ReceiverStream::new(cp_receiver)
             .ready_chunks(checkpoint_commit_batch_size);
 
-        let mut unprocessed = BTreeMap::new();
+        // Mapping of ordered checkpoint data to ensure that we process them in order.
+        // The key is just the checkpoint sequence number, and the tuple is
+        // (CommitterWatermark, T).
+        let mut unprocessed: BTreeMap<u64, (CommitterWatermark, _)> = BTreeMap::new();
         let mut tuple_batch = vec![];
         let mut next_cp_to_process = self
             .get_watermark_hi()
             .await?
-            .map(|n| n.saturating_add(1))
+            .map(|watermark| watermark.cp.saturating_add(1))
             .unwrap_or_default();
 
         loop {
@@ -99,8 +107,8 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
                             info!("transform and load task terminating gracefully");
                             return Ok(());
                         }
-                        for (cp_seq, data) in tuple_chunk {
-                            unprocessed.insert(cp_seq, (cp_seq, data));
+                        for (watermark, data) in tuple_chunk {
+                            unprocessed.insert(watermark.cp, (watermark, data));
                         }
                     }
                     Some(None) => break, // Stream has ended
@@ -121,8 +129,8 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
 
             if !tuple_batch.is_empty() && checkpoint_lag_limiter != 0 {
                 let tuple_batch = std::mem::take(&mut tuple_batch);
-                let (last_checkpoint_seq, _data) = tuple_batch.last().unwrap();
-                let last_checkpoint_seq = last_checkpoint_seq.to_owned();
+                let (committer_watermark, _data) = tuple_batch.last().unwrap();
+                let committer_watermark = committer_watermark.to_owned();
                 let batch = tuple_batch
                     .into_iter()
                     .map(|(_cp_seq, data)| data)
@@ -133,7 +141,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
                         self.name()
                     ))
                 })?;
-                self.set_watermark_hi(last_checkpoint_seq).await?;
+                self.set_watermark_hi(committer_watermark).await?;
             }
         }
         Err(IndexerError::ChannelClosed(format!(
@@ -141,4 +149,103 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
             self.name()
         )))
     }
+}
+
+/// The indexer writer operates on checkpoint data, which contains information
+/// on the current epoch, checkpoint, and transaction. These three numbers form
+/// the watermark upper bound for each committed table.
+#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
+pub struct CommitterWatermark {
+    pub epoch: u64,
+    pub cp: u64,
+    pub tx: u64,
+}
+impl From<&IndexedCheckpoint> for CommitterWatermark {
+    fn from(checkpoint: &IndexedCheckpoint) -> Self {
+        Self {
+            epoch: checkpoint.epoch,
+            cp: checkpoint.sequence_number,
+            tx: checkpoint.network_total_transactions.saturating_sub(1),
+        }
+    }
+}
+impl From<&CheckpointData> for CommitterWatermark {
+    fn from(checkpoint: &CheckpointData) -> Self {
+        Self {
+            epoch: checkpoint.checkpoint_summary.epoch,
+            cp: checkpoint.checkpoint_summary.sequence_number,
+            tx: checkpoint
+                .checkpoint_summary
+                .network_total_transactions
+                .saturating_sub(1),
+        }
+    }
+}
+/// Enum representing tables that a committer updates.
+#[derive(
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::EnumIter,
+    strum_macros::AsRefStr,
+    Hash,
+    Serialize,
+    Deserialize,
+    Clone,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum CommitterTables {
+    // Unpruned tables
+    ChainIdentifier,
+    Display,
+    Epochs,
+    FeatureFlags,
+    Objects,
+    ObjectsVersion,
+    Packages,
+    ProtocolConfigs,
+    // Prunable tables
+    ObjectsHistory,
+    Transactions,
+    Events,
+    EventEmitPackage,
+    EventEmitModule,
+    EventSenders,
+    EventStructInstantiation,
+    EventStructModule,
+    EventStructName,
+    EventStructPackage,
+    TxCallsPkg,
+    TxCallsMod,
+    TxCallsFun,
+    TxChangedObjects,
+    TxDigests,
+    TxInputObjects,
+    TxKinds,
+    TxRecipients,
+    TxSenders,
+    Checkpoints,
+    PrunerCpWatermark,
+}
+/// Enum representing tables that the objects snapshot processor updates.
+#[derive(
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::EnumIter,
+    strum_macros::AsRefStr,
+    Hash,
+    Serialize,
+    Deserialize,
+    Clone,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectsSnapshotHandlerTables {
+    ObjectsSnapshot,
 }

--- a/crates/iota-indexer/src/ingestion/primary/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/primary/orchestration.rs
@@ -148,6 +148,8 @@ async fn start_writer_task(
             let epoch = checkpoint.epoch.clone();
             batch.push(checkpoint);
             next_checkpoint_sequence_number += 1;
+            // The batch will consist of contiguous checkpoints and at most one epoch
+            // boundary at the end.
             if batch.len() == writer.checkpoint_commit_batch_size || epoch.is_some() {
                 writer.commit_checkpoints(batch, epoch).await;
                 batch = vec![];

--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -264,21 +264,22 @@ impl PrimaryWriter {
             elapsed,
             "Checkpoint {}-{} committed with {} transactions.",
             first_checkpoint_seq,
-            committer_watermark.cp,
+            committer_watermark.checkpoint_hi_inclusive,
             tx_count,
         );
         self.metrics
             .latest_tx_checkpoint_sequence_number
-            .set(committer_watermark.cp as i64);
+            .set(committer_watermark.checkpoint_hi_inclusive as i64);
         self.metrics
             .total_tx_checkpoint_committed
             .inc_by(checkpoint_num as u64);
         self.metrics
             .total_transaction_committed
             .inc_by(tx_count as u64);
-        self.metrics
-            .transaction_per_checkpoint
-            .observe(tx_count as f64 / (committer_watermark.cp - first_checkpoint_seq + 1) as f64);
+        self.metrics.transaction_per_checkpoint.observe(
+            tx_count as f64
+                / (committer_watermark.checkpoint_hi_inclusive - first_checkpoint_seq + 1) as f64,
+        );
         // 1000.0 is not necessarily the batch size, it's to roughly map average tx
         // commit latency to [0.1, 1] seconds, which is well covered by
         // DB_COMMIT_LATENCY_SEC_BUCKETS.

--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -8,7 +8,10 @@ use tap::tap::TapFallible;
 use tracing::{error, info, instrument};
 
 use crate::{
-    ingestion::common::{persist::CHECKPOINT_COMMIT_BATCH_SIZE, prepare::CheckpointObjectChanges},
+    ingestion::common::{
+        persist::{CHECKPOINT_COMMIT_BATCH_SIZE, CommitterTables, CommitterWatermark},
+        prepare::CheckpointObjectChanges,
+    },
     metrics::IndexerMetrics,
     models::{
         display::StoredDisplay,
@@ -78,6 +81,12 @@ impl PrimaryWriter {
         }
     }
 
+    /// Writes indexed checkpoint data to the database, and then update
+    /// watermark upper bounds and metrics. Expects
+    /// `indexed_checkpoint_batch` to be non-empty, and contain contiguous
+    /// checkpoints. There can be at most one epoch boundary at the end. If
+    /// an epoch boundary is detected, epoch-partitioned tables must be
+    /// advanced.
     // Unwrap: Caller needs to make sure indexed_checkpoint_batch is not empty
     #[instrument(skip_all, fields(
         first = indexed_checkpoint_batch.first().as_ref().unwrap().checkpoint.sequence_number,
@@ -127,7 +136,7 @@ impl PrimaryWriter {
         }
 
         let first_checkpoint_seq = checkpoint_batch.first().as_ref().unwrap().sequence_number;
-        let last_checkpoint_seq = checkpoint_batch.last().as_ref().unwrap().sequence_number;
+        let committer_watermark = CommitterWatermark::from(checkpoint_batch.last().unwrap());
 
         let guard = self.metrics.checkpoint_db_commit_latency.start_timer();
         let tx_batch = tx_batch.into_iter().flatten().collect::<Vec<_>>();
@@ -193,7 +202,8 @@ impl PrimaryWriter {
 
         let is_epoch_end = epoch.is_some();
 
-        // handle partitioning on epoch boundary
+        // On epoch boundary, we need to modify the existing partitions' upper bound,
+        // and introduce a new partition for incoming data for the upcoming epoch.
         if let Some(epoch_data) = epoch {
             self.state
                 .advance_epoch(epoch_data)
@@ -237,18 +247,29 @@ impl PrimaryWriter {
                 .persist_protocol_configs_and_feature_flags(chain_id);
         }
 
+        self.state
+            .update_watermarks_upper_bound::<CommitterTables>(committer_watermark)
+            .await
+            .tap_err(|e| {
+                error!(
+                    "Failed to update watermark upper bound with error: {}",
+                    e.to_string()
+                );
+            })
+            .expect("Updating watermark upper bound in DB should not fail.");
+
         let elapsed = guard.stop_and_record();
 
         info!(
             elapsed,
             "Checkpoint {}-{} committed with {} transactions.",
             first_checkpoint_seq,
-            last_checkpoint_seq,
+            committer_watermark.cp,
             tx_count,
         );
         self.metrics
             .latest_tx_checkpoint_sequence_number
-            .set(last_checkpoint_seq as i64);
+            .set(committer_watermark.cp as i64);
         self.metrics
             .total_tx_checkpoint_committed
             .inc_by(checkpoint_num as u64);
@@ -257,7 +278,7 @@ impl PrimaryWriter {
             .inc_by(tx_count as u64);
         self.metrics
             .transaction_per_checkpoint
-            .observe(tx_count as f64 / (last_checkpoint_seq - first_checkpoint_seq + 1) as f64);
+            .observe(tx_count as f64 / (committer_watermark.cp - first_checkpoint_seq + 1) as f64);
         // 1000.0 is not necessarily the batch size, it's to roughly map average tx
         // commit latency to [0.1, 1] seconds, which is well covered by
         // DB_COMMIT_LATENCY_SEC_BUCKETS.

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -18,7 +18,7 @@ use crate::{
     ingestion::{
         common::{
             orchestration::{ShimIndexerProgressStore, new_executor},
-            persist::Writer,
+            persist::{CommitterWatermark, Writer},
         },
         primary::persist::TransactionObjectChangesToCommit,
         snapshot::{persist::ObjectSnapshotWriter, prepare::ObjectsSnapshotWorker},
@@ -48,7 +48,11 @@ impl SnapshotPipelineBuilder {
         cancel: CancellationToken,
     ) -> IndexerResult<SnapshotPipelineBuilder> {
         let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone(), lag_config);
-        let watermark = writer.get_watermark_hi().await?.unwrap_or_default();
+        let watermark = writer
+            .get_watermark_hi()
+            .await?
+            .map(|w| w.cp)
+            .unwrap_or_default();
         Ok(SnapshotPipelineBuilder {
             writer,
             checkpoint_download_queue_size,
@@ -93,7 +97,10 @@ impl SnapshotPipelineBuilder {
         &self,
         executor: &mut IndexerExecutor<ShimIndexerProgressStore>,
     ) -> IndexerResult<
-        iota_metrics::metered_channel::Receiver<(u64, TransactionObjectChangesToCommit)>,
+        iota_metrics::metered_channel::Receiver<(
+            CommitterWatermark,
+            TransactionObjectChangesToCommit,
+        )>,
     > {
         let global_metrics = get_metrics().unwrap();
         let (sender, receiver) = iota_metrics::metered_channel::channel(
@@ -117,14 +124,20 @@ impl SnapshotPipelineBuilder {
 pub(crate) struct SnapshotPipeline {
     executor: Option<IndexerExecutor<ShimIndexerProgressStore>>,
     writer: ObjectSnapshotWriter,
-    receiver: iota_metrics::metered_channel::Receiver<(u64, TransactionObjectChangesToCommit)>,
+    receiver: iota_metrics::metered_channel::Receiver<(
+        CommitterWatermark,
+        TransactionObjectChangesToCommit,
+    )>,
     cancel: CancellationToken,
 }
 
 impl SnapshotPipeline {
     fn spawn_writer_task(
         writer: ObjectSnapshotWriter,
-        receiver: iota_metrics::metered_channel::Receiver<(u64, TransactionObjectChangesToCommit)>,
+        receiver: iota_metrics::metered_channel::Receiver<(
+            CommitterWatermark,
+            TransactionObjectChangesToCommit,
+        )>,
         cancel: CancellationToken,
     ) -> JoinHandle<IndexerResult<()>> {
         spawn_monitored_task!(writer.persist_sequentially(receiver, cancel))

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -48,11 +48,7 @@ impl SnapshotPipelineBuilder {
         cancel: CancellationToken,
     ) -> IndexerResult<SnapshotPipelineBuilder> {
         let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone(), lag_config);
-        let watermark = writer
-            .get_watermark_hi()
-            .await?
-            .map(|w| w.cp)
-            .unwrap_or_default();
+        let watermark = writer.get_watermark_hi().await?.unwrap_or_default();
         Ok(SnapshotPipelineBuilder {
             writer,
             checkpoint_download_queue_size,

--- a/crates/iota-indexer/src/ingestion/snapshot/persist.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/persist.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 
 use crate::{
     config::SnapshotLagConfig,
@@ -52,8 +53,10 @@ impl Writer<TransactionObjectChangesToCommit> for ObjectSnapshotWriter {
         Ok(())
     }
 
-    async fn get_watermark_hi(&self) -> IndexerResult<Option<CommitterWatermark>> {
-        self.store.get_latest_object_snapshot_watermark().await
+    async fn get_watermark_hi(&self) -> IndexerResult<Option<CheckpointSequenceNumber>> {
+        self.store
+            .get_latest_object_snapshot_checkpoint_sequence_number()
+            .await
     }
 
     async fn set_watermark_hi(&self, watermark: CommitterWatermark) -> IndexerResult<()> {
@@ -62,7 +65,7 @@ impl Writer<TransactionObjectChangesToCommit> for ObjectSnapshotWriter {
             .await?;
         self.metrics
             .latest_object_snapshot_sequence_number
-            .set(watermark.cp as i64);
+            .set(watermark.checkpoint_hi_inclusive as i64);
         Ok(())
     }
 

--- a/crates/iota-indexer/src/ingestion/snapshot/persist.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/persist.rs
@@ -6,7 +6,10 @@ use async_trait::async_trait;
 
 use crate::{
     config::SnapshotLagConfig,
-    ingestion::{common::persist::Writer, primary::persist::TransactionObjectChangesToCommit},
+    ingestion::{
+        common::persist::{CommitterWatermark, ObjectsSnapshotHandlerTables, Writer},
+        primary::persist::TransactionObjectChangesToCommit,
+    },
     metrics::IndexerMetrics,
     store::{IndexerStore, PgIndexerStore},
     types::IndexerResult,
@@ -49,18 +52,17 @@ impl Writer<TransactionObjectChangesToCommit> for ObjectSnapshotWriter {
         Ok(())
     }
 
-    // TODO: read watermark table when it's ready.
-    async fn get_watermark_hi(&self) -> IndexerResult<Option<u64>> {
-        self.store
-            .get_latest_object_snapshot_checkpoint_sequence_number()
-            .await
+    async fn get_watermark_hi(&self) -> IndexerResult<Option<CommitterWatermark>> {
+        self.store.get_latest_object_snapshot_watermark().await
     }
 
-    // TODO: update watermark table when it's ready.
-    async fn set_watermark_hi(&self, watermark_hi: u64) -> IndexerResult<()> {
+    async fn set_watermark_hi(&self, watermark: CommitterWatermark) -> IndexerResult<()> {
+        self.store
+            .update_watermarks_upper_bound::<ObjectsSnapshotHandlerTables>(watermark)
+            .await?;
         self.metrics
             .latest_object_snapshot_sequence_number
-            .set(watermark_hi as i64);
+            .set(watermark.cp as i64);
         Ok(())
     }
 

--- a/crates/iota-indexer/src/ingestion/snapshot/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/prepare.rs
@@ -11,19 +11,22 @@ use iota_types::full_checkpoint_content::CheckpointData;
 
 use crate::{
     errors::IndexerError,
-    ingestion::primary::{persist::TransactionObjectChangesToCommit, prepare::PrimaryWorker},
+    ingestion::{
+        common::persist::CommitterWatermark,
+        primary::{persist::TransactionObjectChangesToCommit, prepare::PrimaryWorker},
+    },
     metrics::IndexerMetrics,
 };
 
 #[derive(Clone)]
 pub struct ObjectsSnapshotWorker {
-    pub sender: Sender<(u64, TransactionObjectChangesToCommit)>,
+    pub sender: Sender<(CommitterWatermark, TransactionObjectChangesToCommit)>,
     pub(crate) metrics: IndexerMetrics,
 }
 
 impl ObjectsSnapshotWorker {
     pub fn new(
-        sender: Sender<(u64, TransactionObjectChangesToCommit)>,
+        sender: Sender<(CommitterWatermark, TransactionObjectChangesToCommit)>,
         metrics: IndexerMetrics,
     ) -> ObjectsSnapshotWorker {
         Self { sender, metrics }
@@ -42,7 +45,7 @@ impl Worker for ObjectsSnapshotWorker {
         let transformed_data = PrimaryWorker::index_objects(&checkpoint, &self.metrics).await?;
         self.sender
             .send((
-                checkpoint.checkpoint_summary.sequence_number,
+                CommitterWatermark::from(checkpoint.as_ref()),
                 transformed_data,
             ))
             .await

--- a/crates/iota-indexer/src/metrics.rs
+++ b/crates/iota-indexer/src/metrics.rs
@@ -138,6 +138,7 @@ pub struct IndexerMetrics {
     pub checkpoint_db_commit_latency_tx_indices_chunks: Histogram,
     pub checkpoint_db_commit_latency_checkpoints: Histogram,
     pub checkpoint_db_commit_latency_epoch: Histogram,
+    pub checkpoint_db_commit_latency_watermarks: Histogram,
     pub thousand_transaction_avg_db_commit_latency: Histogram,
     pub object_db_commit_latency: Histogram, // not used
     pub object_mutation_db_commit_latency: Histogram, // not used
@@ -588,6 +589,13 @@ impl IndexerMetrics {
             checkpoint_db_commit_latency_epoch: register_histogram_with_registry!(
                 "checkpoint_db_commit_latency_epochs",
                 "Time spent committing epochs",
+                DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            checkpoint_db_commit_latency_watermarks: register_histogram_with_registry!(
+                "checkpoint_db_commit_latency_watermarks",
+                "Time spent committing watermarks",
                 DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )

--- a/crates/iota-indexer/src/models/mod.rs
+++ b/crates/iota-indexer/src/models/mod.rs
@@ -17,3 +17,4 @@ pub mod participation_metrics;
 pub mod transactions;
 pub mod tx_count_metrics;
 pub mod tx_indices;
+pub mod watermarks;

--- a/crates/iota-indexer/src/models/watermarks.rs
+++ b/crates/iota-indexer/src/models/watermarks.rs
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+//
+use diesel::prelude::*;
+
+use crate::{
+    ingestion::common::persist::CommitterWatermark,
+    schema::watermarks::{self},
+};
+
+/// Represents a row in the `watermarks` table.
+#[derive(Queryable, Insertable, Default, QueryableByName)]
+#[diesel(table_name = watermarks, primary_key(entity))]
+pub struct StoredWatermark {
+    /// The table governed by this watermark, i.e `epochs`, `checkpoints`,
+    /// `transactions`.
+    pub entity: String,
+    /// Inclusive upper epoch bound for this entity's data. Committer updates
+    /// this field. Pruner uses this to determine if pruning is necessary
+    /// based on the retention policy.
+    pub epoch_hi_inclusive: i64,
+    /// Inclusive lower epoch bound for this entity's data. Pruner updates this
+    /// field when the epoch range exceeds the retention policy.
+    pub epoch_lo: i64,
+    /// Inclusive upper checkpoint bound for this entity's data. Committer
+    /// updates this field. All data of this entity in the checkpoint must
+    /// be persisted before advancing this watermark. The committer refers
+    /// to this on disaster recovery to resume writing.
+    pub checkpoint_hi_inclusive: i64,
+    /// Inclusive upper transaction sequence number bound for this entity's
+    /// data. Committer updates this field.
+    pub tx_hi_inclusive: i64,
+    /// Inclusive low watermark that the pruner advances. Corresponds to the
+    /// epoch id, checkpoint sequence number, or tx sequence number
+    /// depending on the entity. Data before this watermark is considered
+    /// pruned by a reader. The underlying data may still exist in the db
+    /// instance.
+    pub reader_lo: i64,
+    /// Updated using the database's current timestamp when the pruner sees that
+    /// some data needs to be dropped. The pruner uses this column to
+    /// determine whether to prune or wait long enough that all in-flight
+    /// reads complete or timeout before it acts on an updated watermark.
+    pub timestamp_ms: i64,
+    /// Column used by the pruner to track its true progress. Data at and below
+    /// this watermark can be immediately pruned.
+    pub pruner_lo: Option<i64>,
+}
+
+impl StoredWatermark {
+    pub fn from_upper_bound_update(entity: &str, watermark: CommitterWatermark) -> Self {
+        StoredWatermark {
+            entity: entity.to_string(),
+            epoch_hi_inclusive: watermark.epoch as i64,
+            checkpoint_hi_inclusive: watermark.cp as i64,
+            tx_hi_inclusive: watermark.tx as i64,
+            ..StoredWatermark::default()
+        }
+    }
+}

--- a/crates/iota-indexer/src/models/watermarks.rs
+++ b/crates/iota-indexer/src/models/watermarks.rs
@@ -2,15 +2,18 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 //
+use std::str::FromStr;
+
 use diesel::prelude::*;
 
 use crate::{
     ingestion::common::persist::CommitterWatermark,
+    pruning::pruner::PrunableTable,
     schema::watermarks::{self},
 };
 
 /// Represents a row in the `watermarks` table.
-#[derive(Queryable, Insertable, Default, QueryableByName)]
+#[derive(Queryable, Insertable, Default, QueryableByName, Clone)]
 #[diesel(table_name = watermarks, primary_key(entity))]
 pub struct StoredWatermark {
     /// The table governed by this watermark, i.e `epochs`, `checkpoints`,
@@ -20,17 +23,17 @@ pub struct StoredWatermark {
     /// this field. Pruner uses this to determine if pruning is necessary
     /// based on the retention policy.
     pub epoch_hi_inclusive: i64,
-    /// Inclusive lower epoch bound for this entity's data. Pruner updates this
-    /// field when the epoch range exceeds the retention policy.
-    pub epoch_lo: i64,
     /// Inclusive upper checkpoint bound for this entity's data. Committer
     /// updates this field. All data of this entity in the checkpoint must
     /// be persisted before advancing this watermark. The committer refers
     /// to this on disaster recovery to resume writing.
     pub checkpoint_hi_inclusive: i64,
-    /// Inclusive upper transaction sequence number bound for this entity's
+    /// Exclusive upper transaction sequence number bound for this entity's
     /// data. Committer updates this field.
-    pub tx_hi_inclusive: i64,
+    pub tx_hi: i64,
+    /// Inclusive lower epoch bound for this entity's data. Pruner updates this
+    /// field when the epoch range exceeds the retention policy.
+    pub epoch_lo: i64,
     /// Inclusive low watermark that the pruner advances. Corresponds to the
     /// epoch id, checkpoint sequence number, or tx sequence number
     /// depending on the entity. Data before this watermark is considered
@@ -42,19 +45,42 @@ pub struct StoredWatermark {
     /// determine whether to prune or wait long enough that all in-flight
     /// reads complete or timeout before it acts on an updated watermark.
     pub timestamp_ms: i64,
-    /// Column used by the pruner to track its true progress. Data at and below
-    /// this watermark can be immediately pruned.
-    pub pruner_lo: Option<i64>,
+    /// Column used by the pruner to track its true progress. Data below this
+    /// watermark can be immediately pruned.
+    pub pruner_hi: i64,
 }
 
 impl StoredWatermark {
     pub fn from_upper_bound_update(entity: &str, watermark: CommitterWatermark) -> Self {
         StoredWatermark {
             entity: entity.to_string(),
-            epoch_hi_inclusive: watermark.epoch as i64,
-            checkpoint_hi_inclusive: watermark.cp as i64,
-            tx_hi_inclusive: watermark.tx as i64,
+            epoch_hi_inclusive: watermark.epoch_hi_inclusive as i64,
+            checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive as i64,
+            tx_hi: watermark.tx_hi as i64,
             ..StoredWatermark::default()
+        }
+    }
+
+    pub fn from_lower_bound_update(entity: &str, epoch_lo: u64, reader_lo: u64) -> Self {
+        StoredWatermark {
+            entity: entity.to_string(),
+            epoch_lo: epoch_lo as i64,
+            reader_lo: reader_lo as i64,
+            ..StoredWatermark::default()
+        }
+    }
+
+    pub fn entity(&self) -> Option<PrunableTable> {
+        PrunableTable::from_str(&self.entity).ok()
+    }
+
+    /// Determine whether to set a new epoch lower bound based on the retention
+    /// policy.
+    pub fn new_epoch_lo(&self, retention: u64) -> Option<u64> {
+        if self.epoch_lo as u64 + retention <= self.epoch_hi_inclusive as u64 {
+            Some((self.epoch_hi_inclusive as u64).saturating_sub(retention - 1))
+        } else {
+            None
         }
     }
 }

--- a/crates/iota-indexer/src/pruning/pruner.rs
+++ b/crates/iota-indexer/src/pruning/pruner.rs
@@ -13,9 +13,12 @@ use crate::{
     errors::IndexerError,
     ingestion::primary::prepare::PrimaryWorker,
     metrics::IndexerMetrics,
+    spawn_monitored_task,
     store::{IndexerStore, PgIndexerStore, pg_partition_manager::PgPartitionManager},
     types::IndexerResult,
 };
+
+const UPDATE_WATERMARKS_LOWER_BOUNDS_TASK_INTERVAL: Duration = Duration::from_secs(5);
 
 pub struct Pruner {
     pub store: PgIndexerStore,
@@ -26,8 +29,11 @@ pub struct Pruner {
     pub metrics: IndexerMetrics,
 }
 
-/// Enum representing tables that the pruner is allowed to prune. The pruner
-/// will ignore any table that is not listed here.
+/// Enum representing tables that the pruner is allowed to prune. This
+/// corresponds to table names in the database, and should be used in lieu of
+/// string literals. This enum is also meant to facilitate the process of
+/// determining which unit (epoch, cp, or tx) should be used for the
+/// table's range. Pruner will ignore any table that is not listed here.
 #[derive(
     Debug,
     Eq,
@@ -73,6 +79,37 @@ pub enum PrunableTable {
     PrunerCpWatermark,
 }
 
+impl PrunableTable {
+    pub fn select_reader_lo(&self, cp: u64, tx: u64) -> u64 {
+        match self {
+            PrunableTable::ObjectsHistory
+            | PrunableTable::Checkpoints
+            | PrunableTable::PrunerCpWatermark => cp,
+
+            PrunableTable::Transactions
+            | PrunableTable::Events
+            | PrunableTable::EventEmitPackage
+            | PrunableTable::EventEmitModule
+            | PrunableTable::EventSenders
+            | PrunableTable::EventStructInstantiation
+            | PrunableTable::EventStructModule
+            | PrunableTable::EventStructName
+            | PrunableTable::EventStructPackage
+            | PrunableTable::TxAffectedAddresses
+            | PrunableTable::TxAffectedObjects
+            | PrunableTable::TxCallsPkg
+            | PrunableTable::TxCallsMod
+            | PrunableTable::TxCallsFun
+            | PrunableTable::TxChangedObjects
+            | PrunableTable::TxDigests
+            | PrunableTable::TxInputObjects
+            | PrunableTable::TxKinds
+            | PrunableTable::TxRecipients
+            | PrunableTable::TxSenders => tx,
+        }
+    }
+}
+
 impl Pruner {
     /// Instantiates a pruner with default retention and overrides. Pruner will
     /// finalize the retention policies so there is a value for every
@@ -107,6 +144,15 @@ impl Pruner {
     }
 
     pub async fn start(&self, cancel: CancellationToken) -> IndexerResult<()> {
+        let store_clone = self.store.clone();
+        let retention_policies = self.retention_policies.clone();
+        let cancel_clone = cancel.clone();
+        spawn_monitored_task!(update_watermarks_lower_bounds_task(
+            store_clone,
+            retention_policies,
+            cancel_clone
+        ));
+
         let mut last_seen_max_epoch = 0;
         // The first epoch that has not yet been pruned.
         let mut next_prune_epoch = None;
@@ -178,4 +224,62 @@ impl Pruner {
         info!("Pruner task cancelled.");
         Ok(())
     }
+}
+
+/// Task to periodically query the `watermarks` table and update the lower
+/// bounds for all watermarks if the entry exceeds epoch-level retention policy.
+async fn update_watermarks_lower_bounds_task(
+    store: PgIndexerStore,
+    retention_policies: HashMap<PrunableTable, u64>,
+    cancel: CancellationToken,
+) -> IndexerResult<()> {
+    let mut interval = tokio::time::interval(UPDATE_WATERMARKS_LOWER_BOUNDS_TASK_INTERVAL);
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("Pruner watermark lower bound update task cancelled.");
+                return Ok(());
+            }
+            _ = interval.tick() => {
+                update_watermarks_lower_bounds(&store, &retention_policies, &cancel).await?;
+            }
+        }
+    }
+}
+
+/// Fetches all entries from the `watermarks` table, and updates the `reader_lo`
+/// for each entry if its epoch range exceeds the respective retention policy.
+async fn update_watermarks_lower_bounds(
+    store: &PgIndexerStore,
+    retention_policies: &HashMap<PrunableTable, u64>,
+    cancel: &CancellationToken,
+) -> IndexerResult<()> {
+    let (watermarks, _) = store.get_watermarks().await?;
+
+    if cancel.is_cancelled() {
+        info!("Pruner watermark lower bound update task cancelled.");
+        return Ok(());
+    }
+
+    let mut lower_bound_updates = vec![];
+    for watermark in watermarks.iter() {
+        let Some(prunable_table) = watermark.entity() else {
+            continue;
+        };
+        let Some(epochs_to_keep) = retention_policies.get(&prunable_table) else {
+            error!("no retention policy found for prunable table {prunable_table}");
+            continue;
+        };
+        if let Some(new_epoch_lo) = watermark.new_epoch_lo(*epochs_to_keep) {
+            lower_bound_updates.push((prunable_table, new_epoch_lo));
+        };
+    }
+    if !lower_bound_updates.is_empty() {
+        store
+            .update_watermarks_lower_bound(lower_bound_updates)
+            .await?;
+        info!("Finished updating lower bounds for watermarks");
+    }
+
+    Ok(())
 }

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -445,12 +445,12 @@ diesel::table! {
     watermarks (entity) {
         entity -> Text,
         epoch_hi_inclusive -> Int8,
-        epoch_lo -> Int8,
         checkpoint_hi_inclusive -> Int8,
-        tx_hi_inclusive -> Int8,
+        tx_hi -> Int8,
+        epoch_lo -> Int8,
         reader_lo -> Int8,
         timestamp_ms -> Int8,
-        pruner_lo -> Nullable<Int8>,
+        pruner_hi -> Int8,
     }
 }
 

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -441,6 +441,19 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    watermarks (entity) {
+        entity -> Text,
+        epoch_hi_inclusive -> Int8,
+        epoch_lo -> Int8,
+        checkpoint_hi_inclusive -> Int8,
+        tx_hi_inclusive -> Int8,
+        reader_lo -> Int8,
+        timestamp_ms -> Int8,
+        pruner_lo -> Nullable<Int8>,
+    }
+}
+
 #[macro_export]
 macro_rules! for_all_tables {
     ($action:path) => {
@@ -484,7 +497,8 @@ macro_rules! for_all_tables {
             tx_kinds,
             tx_recipients,
             tx_senders,
-            tx_wrapped_or_deleted_objects
+            tx_wrapped_or_deleted_objects,
+            watermarks
         );
     };
 }

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -6,11 +6,12 @@ use std::{any::Any, collections::BTreeMap};
 
 use async_trait::async_trait;
 use diesel::PgConnection;
+use strum::IntoEnumIterator;
 
 use crate::{
     errors::IndexerError,
     ingestion::{
-        common::prepare::CheckpointObjectChanges,
+        common::{persist::CommitterWatermark, prepare::CheckpointObjectChanges},
         primary::persist::{EpochToCommit, TransactionObjectChangesToCommit},
     },
     models::{
@@ -31,9 +32,9 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
 
     async fn get_available_checkpoint_range(&self) -> Result<(u64, u64), IndexerError>;
 
-    async fn get_latest_object_snapshot_checkpoint_sequence_number(
+    async fn get_latest_object_snapshot_watermark(
         &self,
-    ) -> Result<Option<u64>, IndexerError>;
+    ) -> Result<Option<CommitterWatermark>, IndexerError>;
 
     async fn get_chain_identifier(&self) -> Result<Option<Vec<u8>>, IndexerError>;
 
@@ -113,6 +114,14 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         conn: &mut PgConnection,
         object_changes: Vec<TransactionObjectChangesToCommit>,
     ) -> Result<(), IndexerError>;
+
+    /// Update the upper bound of the watermarks for the given tables.
+    async fn update_watermarks_upper_bound<E: IntoEnumIterator>(
+        &self,
+        watermark: CommitterWatermark,
+    ) -> Result<(), IndexerError>
+    where
+        E::Iterator: Iterator<Item: AsRef<str>>;
 
     async fn persist_checkpoint_objects(
         &self,

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -18,7 +18,9 @@ use crate::{
         display::StoredDisplay,
         obj_indices::StoredObjectVersion,
         transactions::{CheckpointTxGlobalOrder, OptimisticTransaction},
+        watermarks::StoredWatermark,
     },
+    pruning::pruner::PrunableTable,
     types::{
         EventIndex, IndexedCheckpoint, IndexedEvent, IndexedPackage, IndexedTransaction, TxIndex,
     },
@@ -35,6 +37,10 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     async fn get_latest_object_snapshot_watermark(
         &self,
     ) -> Result<Option<CommitterWatermark>, IndexerError>;
+
+    async fn get_latest_object_snapshot_checkpoint_sequence_number(
+        &self,
+    ) -> Result<Option<u64>, IndexerError>;
 
     async fn get_chain_identifier(&self) -> Result<Option<Vec<u8>>, IndexerError>;
 
@@ -122,6 +128,17 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     ) -> Result<(), IndexerError>
     where
         E::Iterator: Iterator<Item: AsRef<str>>;
+
+    /// Updates each watermark entry's lower bounds per the list of tables and
+    /// their new epoch lower bounds.
+    async fn update_watermarks_lower_bound(
+        &self,
+        watermarks: Vec<(PrunableTable, u64)>,
+    ) -> Result<(), IndexerError>;
+
+    /// Load all watermark entries from the store, and the latest timestamp from
+    /// the db.
+    async fn get_watermarks(&self) -> Result<(Vec<StoredWatermark>, i64), IndexerError>;
 
     async fn persist_checkpoint_objects(
         &self,

--- a/crates/iota-indexer/src/store/mod.rs
+++ b/crates/iota-indexer/src/store/mod.rs
@@ -241,6 +241,30 @@ pub mod diesel_macro {
     }
 
     #[macro_export]
+    macro_rules! run_query_with_retry {
+        ($pool:expr, $query:expr, $max_elapsed:expr) => {{
+            blocking_call_is_ok_or_panic!();
+            let mut backoff = backoff::ExponentialBackoff::default();
+            backoff.max_elapsed_time = Some($max_elapsed);
+            let result = match backoff::retry(backoff, || {
+                read_only_blocking!($pool, $query).map_err(|e| {
+                    tracing::error!("error with reading data from DB: {e:?}, retrying...");
+                    backoff::Error::Transient {
+                        err: e,
+                        retry_after: None,
+                    }
+                })
+            }) {
+                Ok(v) => Ok(v),
+                Err(backoff::Error::Transient { err, .. }) => Err(err),
+                Err(backoff::Error::Permanent(err)) => Err(err),
+            };
+
+            result
+        }};
+    }
+
+    #[macro_export]
     macro_rules! run_query_async {
         ($pool:expr, $query:expr) => {{ spawn_read_only_blocking!($pool, $query, false) }};
     }

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-
 use core::result::Result::Ok;
 use std::{any::Any as StdAny, collections::BTreeMap, time::Duration};
 
@@ -19,6 +18,7 @@ use iota_types::{
     digests::{ChainIdentifier, CheckpointDigest},
 };
 use itertools::Itertools;
+use strum::IntoEnumIterator;
 use tap::TapFallible;
 use tracing::info;
 
@@ -27,9 +27,12 @@ use crate::{
     db::ConnectionPool,
     errors::{Context, IndexerError, IndexerResult},
     ingestion::{
-        common::prepare::{
-            CheckpointObjectChanges, LiveObject, RemovedObject,
-            retain_latest_objects_from_checkpoint_batch,
+        common::{
+            persist::{CommitterWatermark, ObjectsSnapshotHandlerTables},
+            prepare::{
+                CheckpointObjectChanges, LiveObject, RemovedObject,
+                retain_latest_objects_from_checkpoint_batch,
+            },
         },
         primary::persist::{EpochToCommit, TransactionObjectChangesToCommit},
     },
@@ -50,6 +53,7 @@ use crate::{
             CheckpointTxGlobalOrder, IndexStatus, OptimisticTransaction, StoredTransaction,
         },
         tx_indices::TxIndexSplit,
+        watermarks::StoredWatermark,
     },
     on_conflict_do_update, on_conflict_do_update_with_condition, persist_chunk_into_table,
     persist_chunk_into_table_in_existing_connection, read_only_blocking,
@@ -60,7 +64,7 @@ use crate::{
         objects_version, optimistic_transactions, packages, protocol_configs, pruner_cp_watermark,
         transactions, tx_calls_fun, tx_calls_mod, tx_calls_pkg, tx_changed_objects, tx_digests,
         tx_global_order, tx_input_objects, tx_kinds, tx_recipients, tx_senders,
-        tx_wrapped_or_deleted_objects,
+        tx_wrapped_or_deleted_objects, watermarks,
     },
     store::IndexerStore,
     transactional_blocking_with_retry,
@@ -386,16 +390,32 @@ impl PgIndexerStore {
         )
     }
 
-    fn get_latest_object_snapshot_checkpoint_sequence_number(
+    fn get_latest_object_snapshot_watermark(
         &self,
-    ) -> Result<Option<u64>, IndexerError> {
+    ) -> Result<Option<CommitterWatermark>, IndexerError> {
         read_only_blocking!(&self.blocking_cp, |conn| {
-            objects_snapshot::dsl::objects_snapshot
-                .select(max(objects_snapshot::checkpoint_sequence_number))
-                .first::<Option<i64>>(conn)
-                .map(|v| v.map(|v| v as u64))
+            watermarks::table
+                .select((
+                    watermarks::epoch_hi_inclusive,
+                    watermarks::checkpoint_hi_inclusive,
+                    watermarks::tx_hi_inclusive,
+                ))
+                .filter(
+                    watermarks::entity
+                        .eq(ObjectsSnapshotHandlerTables::ObjectsSnapshot.to_string()),
+                )
+                .first::<(i64, i64, i64)>(conn)
+                // Handle case where the watermark is not set yet
+                .optional()
+                .map(|v| {
+                    v.map(|(epoch, cp, tx)| CommitterWatermark {
+                        epoch: epoch as u64,
+                        cp: cp as u64,
+                        tx: tx as u64,
+                    })
+                })
         })
-        .context("Failed reading latest object snapshot checkpoint sequence number from PostgresDB")
+        .context("Failed reading latest object snapshot watermark from PostgresDB")
     }
 
     fn persist_display_updates(
@@ -1542,6 +1562,51 @@ impl PgIndexerStore {
         })
     }
 
+    fn update_watermarks_upper_bound<E: IntoEnumIterator>(
+        &self,
+        watermark: CommitterWatermark,
+    ) -> Result<(), IndexerError>
+    where
+        E::Iterator: Iterator<Item: AsRef<str>>,
+    {
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_watermarks
+            .start_timer();
+
+        let upper_bound_updates = E::iter()
+            .map(|table| StoredWatermark::from_upper_bound_update(table.as_ref(), watermark))
+            .collect::<Vec<_>>();
+
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                diesel::insert_into(watermarks::table)
+                    .values(&upper_bound_updates)
+                    .on_conflict(watermarks::entity)
+                    .do_update()
+                    .set((
+                        watermarks::epoch_hi_inclusive.eq(excluded(watermarks::epoch_hi_inclusive)),
+                        watermarks::checkpoint_hi_inclusive
+                            .eq(excluded(watermarks::checkpoint_hi_inclusive)),
+                        watermarks::tx_hi_inclusive.eq(excluded(watermarks::tx_hi_inclusive)),
+                    ))
+                    .execute(conn)
+                    .map_err(IndexerError::from)
+                    .context("Failed to update watermarks upper bound")?;
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+        .tap_ok(|_| {
+            let elapsed = guard.stop_and_record();
+            info!(elapsed, "Persisted watermarks");
+        })
+        .tap_err(|e| {
+            tracing::error!("Failed to persist watermarks with error: {}", e);
+        })
+    }
+
     async fn execute_in_blocking_worker<F, R>(&self, f: F) -> Result<R, IndexerError>
     where
         F: FnOnce(Self) -> Result<R, IndexerError> + Send + 'static,
@@ -1609,13 +1674,11 @@ impl IndexerStore for PgIndexerStore {
             .await
     }
 
-    async fn get_latest_object_snapshot_checkpoint_sequence_number(
+    async fn get_latest_object_snapshot_watermark(
         &self,
-    ) -> Result<Option<u64>, IndexerError> {
-        self.execute_in_blocking_worker(|this| {
-            this.get_latest_object_snapshot_checkpoint_sequence_number()
-        })
-        .await
+    ) -> Result<Option<CommitterWatermark>, IndexerError> {
+        self.execute_in_blocking_worker(|this| this.get_latest_object_snapshot_watermark())
+            .await
     }
 
     fn persist_objects_in_existing_transaction(
@@ -2027,6 +2090,19 @@ impl IndexerStore for PgIndexerStore {
     async fn refresh_participation_metrics(&self) -> Result<(), IndexerError> {
         self.execute_in_blocking_worker(move |this| this.refresh_participation_metrics())
             .await
+    }
+
+    async fn update_watermarks_upper_bound<E: IntoEnumIterator>(
+        &self,
+        watermark: CommitterWatermark,
+    ) -> Result<(), IndexerError>
+    where
+        E::Iterator: Iterator<Item: AsRef<str>>,
+    {
+        self.execute_in_blocking_worker(move |this| {
+            this.update_watermarks_upper_bound::<E>(watermark)
+        })
+        .await
     }
 
     fn as_any(&self) -> &dyn StdAny {

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -2,12 +2,16 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 use core::result::Result::Ok;
-use std::{any::Any as StdAny, collections::BTreeMap, time::Duration};
+use std::{
+    any::Any as StdAny,
+    collections::{BTreeMap, HashMap},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use diesel::{
     ExpressionMethods, OptionalExtension, PgConnection, QueryDsl, RunQueryDsl,
-    dsl::{max, min},
+    dsl::{max, min, sql},
     sql_types::{Array, BigInt, Bytea, Nullable, SmallInt, Text},
     upsert::excluded,
 };
@@ -16,6 +20,7 @@ use iota_protocol_config::ProtocolConfig;
 use iota_types::{
     base_types::ObjectID,
     digests::{ChainIdentifier, CheckpointDigest},
+    messages_checkpoint::CheckpointSequenceNumber,
 };
 use itertools::Itertools;
 use strum::IntoEnumIterator;
@@ -24,6 +29,7 @@ use tracing::info;
 
 use super::pg_partition_manager::{EpochPartitionData, PgPartitionManager};
 use crate::{
+    blocking_call_is_ok_or_panic,
     db::ConnectionPool,
     errors::{Context, IndexerError, IndexerResult},
     ingestion::{
@@ -56,7 +62,9 @@ use crate::{
         watermarks::StoredWatermark,
     },
     on_conflict_do_update, on_conflict_do_update_with_condition, persist_chunk_into_table,
-    persist_chunk_into_table_in_existing_connection, read_only_blocking,
+    persist_chunk_into_table_in_existing_connection,
+    pruning::pruner::PrunableTable,
+    read_only_blocking, run_query, run_query_with_retry,
     schema::{
         chain_identifier, checkpoints, display, epochs, event_emit_module, event_emit_package,
         event_senders, event_struct_instantiation, event_struct_module, event_struct_name,
@@ -398,7 +406,7 @@ impl PgIndexerStore {
                 .select((
                     watermarks::epoch_hi_inclusive,
                     watermarks::checkpoint_hi_inclusive,
-                    watermarks::tx_hi_inclusive,
+                    watermarks::tx_hi,
                 ))
                 .filter(
                     watermarks::entity
@@ -409,13 +417,25 @@ impl PgIndexerStore {
                 .optional()
                 .map(|v| {
                     v.map(|(epoch, cp, tx)| CommitterWatermark {
-                        epoch: epoch as u64,
-                        cp: cp as u64,
-                        tx: tx as u64,
+                        epoch_hi_inclusive: epoch as u64,
+                        checkpoint_hi_inclusive: cp as u64,
+                        tx_hi: tx as u64,
                     })
                 })
         })
         .context("Failed reading latest object snapshot watermark from PostgresDB")
+    }
+
+    fn get_latest_object_snapshot_checkpoint_sequence_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>, IndexerError> {
+        read_only_blocking!(&self.blocking_cp, |conn| {
+            objects_snapshot::table
+                .select(max(objects_snapshot::checkpoint_sequence_number))
+                .first::<Option<i64>>(conn)
+                .map(|v| v.map(|v| v as CheckpointSequenceNumber))
+        })
+        .context("Failed reading latest object snapshot checkpoint sequence number from PostgresDB")
     }
 
     fn persist_display_updates(
@@ -1589,7 +1609,7 @@ impl PgIndexerStore {
                         watermarks::epoch_hi_inclusive.eq(excluded(watermarks::epoch_hi_inclusive)),
                         watermarks::checkpoint_hi_inclusive
                             .eq(excluded(watermarks::checkpoint_hi_inclusive)),
-                        watermarks::tx_hi_inclusive.eq(excluded(watermarks::tx_hi_inclusive)),
+                        watermarks::tx_hi.eq(excluded(watermarks::tx_hi)),
                     ))
                     .execute(conn)
                     .map_err(IndexerError::from)
@@ -1605,6 +1625,115 @@ impl PgIndexerStore {
         .tap_err(|e| {
             tracing::error!("Failed to persist watermarks with error: {}", e);
         })
+    }
+
+    fn map_epochs_to_cp_tx(
+        &self,
+        epochs: &[u64],
+    ) -> Result<HashMap<u64, (u64, u64)>, IndexerError> {
+        let pool = &self.blocking_cp;
+        let results: Vec<(i64, i64, i64)> = run_query!(pool, move |conn| {
+            epochs::table
+                .filter(epochs::epoch.eq_any(epochs.iter().map(|&e| e as i64)))
+                .select((
+                    epochs::epoch,
+                    epochs::first_checkpoint_id,
+                    epochs::first_tx_sequence_number,
+                ))
+                .load::<(i64, i64, i64)>(conn)
+        })
+        .context("Failed to fetch first checkpoint and tx seq num for epochs")?;
+
+        Ok(results
+            .into_iter()
+            .map(|(epoch, checkpoint, tx)| (epoch as u64, (checkpoint as u64, tx as u64)))
+            .collect())
+    }
+
+    fn update_watermarks_lower_bound(
+        &self,
+        watermarks: Vec<(PrunableTable, u64)>,
+    ) -> Result<(), IndexerError> {
+        use diesel::query_dsl::methods::FilterDsl;
+
+        let epochs: Vec<u64> = watermarks.iter().map(|(_table, epoch)| *epoch).collect();
+        let epoch_mapping = self.map_epochs_to_cp_tx(&epochs)?;
+        let lookups: Result<Vec<StoredWatermark>, IndexerError> = watermarks
+            .into_iter()
+            .map(|(table, epoch)| {
+                let (checkpoint, tx) = epoch_mapping.get(&epoch).ok_or_else(|| {
+                    IndexerError::PersistentStorageDataCorruption(format!(
+                        "epoch {epoch} not found in epoch mapping",
+                    ))
+                })?;
+                Ok(StoredWatermark::from_lower_bound_update(
+                    table.as_ref(),
+                    epoch,
+                    table.select_reader_lo(*checkpoint, *tx),
+                ))
+            })
+            .collect();
+        let lower_bound_updates = lookups?;
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_watermarks
+            .start_timer();
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                diesel::insert_into(watermarks::table)
+                    .values(&lower_bound_updates)
+                    .on_conflict(watermarks::entity)
+                    .do_update()
+                    .set((
+                        watermarks::reader_lo.eq(excluded(watermarks::reader_lo)),
+                        watermarks::epoch_lo.eq(excluded(watermarks::epoch_lo)),
+                        watermarks::timestamp_ms.eq(sql::<diesel::sql_types::BigInt>(
+                            "(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000)::bigint",
+                        )),
+                    ))
+                    .filter(excluded(watermarks::reader_lo).gt(watermarks::reader_lo))
+                    .filter(excluded(watermarks::epoch_lo).gt(watermarks::epoch_lo))
+                    .filter(
+                        diesel::dsl::sql::<diesel::sql_types::BigInt>(
+                            "(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000)::bigint",
+                        )
+                        .gt(watermarks::timestamp_ms),
+                    )
+                    .execute(conn)
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+        .tap_ok(|_| {
+            let elapsed = guard.stop_and_record();
+            info!(elapsed, "Persisted watermarks");
+        })
+        .tap_err(|e| {
+            tracing::error!("Failed to persist watermarks with error: {}", e);
+        })?;
+        Ok(())
+    }
+
+    fn get_watermarks(&self) -> Result<(Vec<StoredWatermark>, i64), IndexerError> {
+        // read_only transaction, otherwise this will block and get blocked by write
+        // transactions to the same table.
+        run_query_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                let stored = watermarks::table
+                    .load::<StoredWatermark>(conn)
+                    .map_err(Into::into)
+                    .context("Failed reading watermarks from PostgresDB")?;
+                let timestamp = diesel::select(diesel::dsl::sql::<diesel::sql_types::BigInt>(
+                    "(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000)::bigint",
+                ))
+                .get_result(conn)
+                .map_err(Into::into)
+                .context("Failed reading current timestamp from PostgresDB")?;
+                Ok::<_, IndexerError>((stored, timestamp))
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
     }
 
     async fn execute_in_blocking_worker<F, R>(&self, f: F) -> Result<R, IndexerError>
@@ -1679,6 +1808,15 @@ impl IndexerStore for PgIndexerStore {
     ) -> Result<Option<CommitterWatermark>, IndexerError> {
         self.execute_in_blocking_worker(|this| this.get_latest_object_snapshot_watermark())
             .await
+    }
+
+    async fn get_latest_object_snapshot_checkpoint_sequence_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>, IndexerError> {
+        self.execute_in_blocking_worker(|this| {
+            this.get_latest_object_snapshot_checkpoint_sequence_number()
+        })
+        .await
     }
 
     fn persist_objects_in_existing_transaction(
@@ -2328,6 +2466,19 @@ impl IndexerStore for PgIndexerStore {
         let elapsed = guard.stop_and_record();
         info!(elapsed, "Persisted {len} txs insertion orders");
         Ok(())
+    }
+
+    async fn update_watermarks_lower_bound(
+        &self,
+        watermarks: Vec<(PrunableTable, u64)>,
+    ) -> Result<(), IndexerError> {
+        self.execute_in_blocking_worker(move |this| this.update_watermarks_lower_bound(watermarks))
+            .await
+    }
+
+    async fn get_watermarks(&self) -> Result<(Vec<StoredWatermark>, i64), IndexerError> {
+        self.execute_in_blocking_worker(move |this| this.get_watermarks())
+            .await
     }
 }
 

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -495,9 +495,10 @@ pub async fn wait_for_objects_snapshot(
     tokio::time::timeout(Duration::from_secs(30), async {
         while {
             let cp_opt = pg_store
-                .get_latest_object_snapshot_checkpoint_sequence_number()
+                .get_latest_object_snapshot_watermark()
                 .await
-                .unwrap();
+                .unwrap()
+                .map(|watermark| watermark.cp);
             cp_opt.is_none() || (cp_opt.unwrap() < checkpoint_sequence_number)
         } {
             tokio::time::sleep(Duration::from_millis(100)).await;

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -498,7 +498,7 @@ pub async fn wait_for_objects_snapshot(
                 .get_latest_object_snapshot_watermark()
                 .await
                 .unwrap()
-                .map(|watermark| watermark.cp);
+                .map(|watermark| watermark.checkpoint_hi_inclusive);
             cp_opt.is_none() || (cp_opt.unwrap() < checkpoint_sequence_number)
         } {
             tokio::time::sleep(Duration::from_millis(100)).await;


### PR DESCRIPTION
# Description of change

This introduces the watermarks table that stores current committer and pruner progress for every indexer table.
This is for future use, the table is not currently used for pruning.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/7538

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [x] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
