### PR TITLE
upstream(iota-data-ingestion-core): introduce checkpoint upper limit

### DIFF
--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -7,7 +7,7 @@ use std::{path::PathBuf, pin::Pin, sync::Arc};
 use futures::Future;
 use iota_metrics::spawn_monitored_task;
 use iota_rest_api::CheckpointData;
-use iota_types::messages_checkpoint::CheckpointSequenceNumber;
+use iota_types::{committee::EpochId, messages_checkpoint::CheckpointSequenceNumber};
 use prometheus::Registry;
 use tokio::{
     sync::{mpsc, oneshot},
@@ -20,7 +20,7 @@ use crate::{
     DataIngestionMetrics, IngestionError, IngestionResult, ReaderOptions, Worker,
     progress_store::{ExecutorProgress, ProgressStore, ProgressStoreWrapper, ShimProgressStore},
     reader::{
-        v1::{CheckpointReader as CheckpointReaderV1, IngestionLimit},
+        v1::CheckpointReader as CheckpointReaderV1,
         v2::{CheckpointReader as CheckpointReaderV2, CheckpointReaderConfig},
     },
     worker_pool::{WorkerPool, WorkerPoolStatus},
@@ -31,6 +31,37 @@ pub const MAX_CHECKPOINTS_IN_PROGRESS: usize = 10000;
 /// Callback function that when resolved to `true`, the executor will start the
 /// shutdown process.
 type ShutdownCallback = Box<dyn FnMut(&CheckpointData) -> bool + Send>;
+
+/// Common policies for upper limit checkpoint ingestion by the framework.
+///
+/// Once the limit is reached, the framework will start the graceful
+/// shutdown process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum IngestionLimit {
+    /// Last checkpoint sequence number to process.
+    ///
+    /// After processing this checkpoint the framework will start the graceful
+    /// shutdown process.
+    MaxCheckpoint(CheckpointSequenceNumber),
+    /// Last checkpoint to process based on the given epoch.
+    ///
+    /// After processing this checkpoint the framework will start the graceful
+    /// shutdown process.
+    EndOfEpoch(EpochId),
+}
+
+impl IngestionLimit {
+    /// Returns `true` if the given checkpoint matches the limit.
+    fn matches(&self, checkpoint: &CheckpointData) -> bool {
+        match self {
+            IngestionLimit::MaxCheckpoint(max) => {
+                &checkpoint.checkpoint_summary.sequence_number > max
+            }
+            IngestionLimit::EndOfEpoch(max) => &checkpoint.checkpoint_summary.epoch > max,
+        }
+    }
+}
 
 /// Represents a common interface for checkpoint readers.
 ///
@@ -218,11 +249,38 @@ impl<P: ProgressStore> IndexerExecutor<P> {
     /// *further* new checkpoints to the worker pool and wait for all
     /// previously sent checkpoints to be processed by the workers
     /// before initiating the graceful shutdown sequence.
+    ///
+    /// Note:
+    ///
+    /// Calling this method after
+    /// [`with_ingestion_limit`](Self::with_ingestion_limit) replaces the
+    /// earlier predicate, and vice versa. They are not cumulative.
     pub fn shutdown_when<F>(&mut self, f: F)
     where
         F: FnMut(&CheckpointData) -> bool + Send + 'static,
     {
         self.shutdown_callback = Some(Box::new(f));
+    }
+
+    /// Adds an upper‑limit policy that determines when the ingestion
+    /// process should stop.
+    ///
+    /// This is a convenience method, it internally uses
+    /// [`shutdown_when`](Self::shutdown_when) by registering a predicate
+    /// derived from the provided [`IngestionLimit`].
+    ///
+    /// If the callback resolves to `true`, the **current checkpoint is
+    /// discarded**. The executor will then immediately stop sending any
+    /// *further* new checkpoints to the worker pool and wait for all
+    /// previously sent checkpoints to be processed by the workers
+    /// before initiating the graceful shutdown sequence.
+    ///
+    /// Note:
+    ///
+    /// Calling this method after [`shutdown_when`](Self::shutdown_when)
+    /// replaces the earlier predicate, and vice versa. They are not cumulative.
+    pub fn with_ingestion_limit(&mut self, limit: IngestionLimit) {
+        self.shutdown_when(move |checkpoint| limit.matches(checkpoint));
     }
 
     pub async fn update_watermark(
@@ -253,7 +311,6 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         reader_options: ReaderOptions,
     ) -> IngestionResult<ExecutorProgress> {
         let reader_checkpoint_number = self.progress_store.min_watermark()?;
-        let ingestion_upper_limit = reader_options.ingestion_upper_limit;
         let (checkpoint_reader, checkpoint_recv, gc_sender, exit_sender) =
             CheckpointReaderV1::initialize(
                 path,
@@ -273,7 +330,6 @@ impl<P: ProgressStore> IndexerExecutor<P> {
                 exit_sender,
                 handle,
             },
-            ingestion_upper_limit,
         )
         .await
     }
@@ -291,14 +347,11 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         config: CheckpointReaderConfig,
     ) -> IngestionResult<ExecutorProgress> {
         let reader_checkpoint_number = self.progress_store.min_watermark()?;
-        let ingestion_upper_limit = config.reader_options.ingestion_upper_limit;
-
         let checkpoint_reader = CheckpointReaderV2::new(reader_checkpoint_number, config).await?;
 
         self.run_executor_loop(
             reader_checkpoint_number,
             CheckpointReader::V2(checkpoint_reader),
-            ingestion_upper_limit,
         )
         .await
     }
@@ -308,7 +361,6 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         &mut self,
         mut reader_checkpoint_number: u64,
         mut checkpoint_reader: CheckpointReader,
-        ingestion_upper_limit: Option<IngestionLimit>,
     ) -> IngestionResult<ExecutorProgress> {
         let worker_pools = std::mem::take(&mut self.pools)
             .into_iter()
@@ -357,7 +409,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
                 }
                 Some(checkpoint) = checkpoint_reader.get_checkpoint(), if !self.token.is_cancelled() && checkpoint_limit_reached.is_none() => {
                     // when we reach the upper limit we skip sending new checkpoints to workers.
-                    if self.is_ingestion_upper_limit_reached(ingestion_upper_limit.as_ref(), &checkpoint) {
+                    if self.is_ingestion_upper_limit_reached(&checkpoint) {
                         info!("checkpoint upper limit reached: no further checkpoints will be sent, waiting for workers to process remaining checkpoints");
                         checkpoint_limit_reached.get_or_insert(checkpoint.checkpoint_summary.sequence_number.saturating_sub(1));
                         continue;
@@ -392,22 +444,13 @@ impl<P: ProgressStore> IndexerExecutor<P> {
 
     /// Check if the current ingestion limit has been reached.
     ///
-    /// It checks both the [`IngestionLimit`] and the
-    /// [`IndexerExecutor::shutdown_when`]. If either of them is reached, the
-    /// function returns `true`.
-    ///
-    /// If neither an [`IngestionLimit`] nor [`IndexerExecutor::shutdown_when`]
-    /// is present, the function returns `false`.
-    fn is_ingestion_upper_limit_reached(
-        &mut self,
-        ingestion_upper_limit: Option<&IngestionLimit>,
-        checkpoint: &CheckpointData,
-    ) -> bool {
-        ingestion_upper_limit.is_some_and(|limit| limit.matches(checkpoint))
-            || self
-                .shutdown_callback
-                .as_mut()
-                .is_some_and(|matches| matches(checkpoint))
+    /// Returns `true` if the ingestion limit has been reached.
+    /// If no ingestion limit is present or it has not been reached yet, the
+    /// function returns `false`.
+    fn is_ingestion_upper_limit_reached(&mut self, checkpoint: &CheckpointData) -> bool {
+        self.shutdown_callback
+            .as_mut()
+            .is_some_and(|matches| matches(checkpoint))
     }
 }
 

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -28,9 +28,23 @@ use crate::{
 
 pub const MAX_CHECKPOINTS_IN_PROGRESS: usize = 10000;
 
-/// Callback function that when resolved to `true`, the executor will start the
-/// shutdown process.
-type ShutdownCallback = Box<dyn FnMut(&CheckpointData) -> bool + Send>;
+/// Callback function invoked for each incoming checkpoint to determine the
+/// shutdown action if it exceeds the ingestion limit.
+type ShutdownCallback = Box<dyn Fn(&CheckpointData) -> ShutdownAction + Send>;
+
+/// Determines the shutdown action when a checkpoint reaches the ingestion
+/// limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ShutdownAction {
+    /// Include the current checkpoint in the ingestion process, then initiate
+    /// the graceful shutdown process.
+    IncludeAndShutdown,
+    /// Exclude the current checkpoint from ingestion and immediately initiate
+    /// the graceful shutdown process.
+    ExcludeAndShutdown,
+    /// Continue processing the current checkpoint without shutting down.
+    Continue,
+}
 
 /// Common policies for upper limit checkpoint ingestion by the framework.
 ///
@@ -52,13 +66,22 @@ pub enum IngestionLimit {
 }
 
 impl IngestionLimit {
-    /// Returns `true` if the given checkpoint matches the limit.
-    fn matches(&self, checkpoint: &CheckpointData) -> bool {
+    /// Evaluates whether the given checkpoint triggers a shutdown action based
+    /// on the ingestion limit.
+    fn matches(&self, checkpoint: &CheckpointData) -> ShutdownAction {
         match self {
             IngestionLimit::MaxCheckpoint(max) => {
-                &checkpoint.checkpoint_summary.sequence_number > max
+                if &checkpoint.checkpoint_summary.sequence_number > max {
+                    return ShutdownAction::ExcludeAndShutdown;
+                }
+                ShutdownAction::Continue
             }
-            IngestionLimit::EndOfEpoch(max) => &checkpoint.checkpoint_summary.epoch > max,
+            IngestionLimit::EndOfEpoch(max) => {
+                if &checkpoint.checkpoint_summary.epoch > max {
+                    return ShutdownAction::ExcludeAndShutdown;
+                }
+                ShutdownAction::Continue
+            }
         }
     }
 }
@@ -244,11 +267,13 @@ impl<P: ProgressStore> IndexerExecutor<P> {
     /// This function `f` will be called for every **incoming checkpoint**
     /// before it’s sent to the worker pool.
     ///
-    /// If the callback resolves to `true`, the **current checkpoint is
-    /// discarded**. The executor will then immediately stop sending any
-    /// *further* new checkpoints to the worker pool and wait for all
-    /// previously sent checkpoints to be processed by the workers
-    /// before initiating the graceful shutdown sequence.
+    /// Based on the returned [`ShutdownAction`] the executor will evaluate
+    /// whether to continue or stop the ingestion process by initiating the
+    /// graceful shutdown process.
+    ///
+    /// Once a shutdown action is triggered, the executor will stop sending new
+    /// checkpoints and will wait for all previously sent checkpoints to be
+    /// processed by workers before initiating graceful shutdown process.
     ///
     /// Note:
     ///
@@ -257,7 +282,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
     /// earlier predicate, and vice versa. They are not cumulative.
     pub fn shutdown_when<F>(&mut self, f: F)
     where
-        F: FnMut(&CheckpointData) -> bool + Send + 'static,
+        F: Fn(&CheckpointData) -> ShutdownAction + Send + 'static,
     {
         self.shutdown_callback = Some(Box::new(f));
     }
@@ -268,12 +293,6 @@ impl<P: ProgressStore> IndexerExecutor<P> {
     /// This is a convenience method, it internally uses
     /// [`shutdown_when`](Self::shutdown_when) by registering a predicate
     /// derived from the provided [`IngestionLimit`].
-    ///
-    /// If the callback resolves to `true`, the **current checkpoint is
-    /// discarded**. The executor will then immediately stop sending any
-    /// *further* new checkpoints to the worker pool and wait for all
-    /// previously sent checkpoints to be processed by the workers
-    /// before initiating the graceful shutdown sequence.
     ///
     /// Note:
     ///
@@ -371,7 +390,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         let mut checkpoint_limit_reached = None;
 
         loop {
-            // the min watermark represents the lowest sequence number that
+            // the min watermark represents the lowest watermark that
             // has been processed by any worker pool. This guarantees that
             // all worker pools have processed the checkpoint before the
             // shutdown process starts.
@@ -407,11 +426,9 @@ impl<P: ProgressStore> IndexerExecutor<P> {
                         }
                     }
                 }
-                Some(checkpoint) = checkpoint_reader.get_checkpoint(), if !self.token.is_cancelled() && checkpoint_limit_reached.is_none() => {
-                    // when we reach the upper limit we skip sending new checkpoints to workers.
-                    if self.is_ingestion_upper_limit_reached(&checkpoint) {
-                        info!("checkpoint upper limit reached: no further checkpoints will be sent, waiting for workers to process remaining checkpoints");
-                        checkpoint_limit_reached.get_or_insert(checkpoint.checkpoint_summary.sequence_number.saturating_sub(1));
+                Some(checkpoint) = checkpoint_reader.get_checkpoint(), if !self.token.is_cancelled() => {
+                    // once upper limit reached skip sending new checkpoints to workers.
+                    if self.should_shutdown(&checkpoint, &mut checkpoint_limit_reached) {
                         continue;
                     }
 
@@ -447,10 +464,40 @@ impl<P: ProgressStore> IndexerExecutor<P> {
     /// Returns `true` if the ingestion limit has been reached.
     /// If no ingestion limit is present or it has not been reached yet, the
     /// function returns `false`.
-    fn is_ingestion_upper_limit_reached(&mut self, checkpoint: &CheckpointData) -> bool {
-        self.shutdown_callback
-            .as_mut()
-            .is_some_and(|matches| matches(checkpoint))
+    fn should_shutdown(
+        &mut self,
+        checkpoint: &CheckpointData,
+        checkpoint_limit_reached: &mut Option<CheckpointSequenceNumber>,
+    ) -> bool {
+        if checkpoint_limit_reached.is_some() {
+            return true;
+        }
+
+        let Some(shutdown_action) = self
+            .shutdown_callback
+            .as_ref()
+            .map(|matches| matches(checkpoint))
+        else {
+            return false;
+        };
+
+        match shutdown_action {
+            ShutdownAction::IncludeAndShutdown => {
+                checkpoint_limit_reached
+                    .get_or_insert(checkpoint.checkpoint_summary.sequence_number);
+                false
+            }
+            ShutdownAction::ExcludeAndShutdown => {
+                checkpoint_limit_reached.get_or_insert(
+                    checkpoint
+                        .checkpoint_summary
+                        .sequence_number
+                        .saturating_sub(1),
+                );
+                true
+            }
+            ShutdownAction::Continue => false,
+        }
     }
 }
 

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -14,6 +14,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
+use tracing::info;
 
 use crate::{
     DataIngestionMetrics, IngestionError, IngestionResult, ReaderOptions, Worker,
@@ -219,6 +220,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         reader_options: ReaderOptions,
     ) -> IngestionResult<ExecutorProgress> {
         let reader_checkpoint_number = self.progress_store.min_watermark()?;
+        let checkpoint_upper_limit = reader_options.checkpoint_upper_limit;
         let (checkpoint_reader, checkpoint_recv, gc_sender, exit_sender) =
             CheckpointReaderV1::initialize(
                 path,
@@ -238,6 +240,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
                 exit_sender,
                 handle,
             },
+            checkpoint_upper_limit,
         )
         .await
     }
@@ -255,12 +258,14 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         config: CheckpointReaderConfig,
     ) -> IngestionResult<ExecutorProgress> {
         let reader_checkpoint_number = self.progress_store.min_watermark()?;
+        let checkpoint_upper_limit = config.reader_options.checkpoint_upper_limit;
 
         let checkpoint_reader = CheckpointReaderV2::new(reader_checkpoint_number, config).await?;
 
         self.run_executor_loop(
             reader_checkpoint_number,
             CheckpointReader::V2(checkpoint_reader),
+            checkpoint_upper_limit,
         )
         .await
     }
@@ -270,6 +275,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         &mut self,
         mut reader_checkpoint_number: u64,
         mut checkpoint_reader: CheckpointReader,
+        checkpoint_upper_limit: Option<u64>,
     ) -> IngestionResult<ExecutorProgress> {
         let worker_pools = std::mem::take(&mut self.pools)
             .into_iter()
@@ -277,6 +283,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
             .collect::<Vec<JoinHandle<()>>>();
 
         let mut worker_pools_shutdown_signals = vec![];
+        let mut checkpoint_limit_reached = false;
 
         loop {
             tokio::select! {
@@ -293,13 +300,27 @@ impl<P: ProgressStore> IndexerExecutor<P> {
                             self.metrics.data_ingestion_checkpoint
                                 .with_label_values(&[&task_name])
                                 .set(watermark as i64);
+
+                            // we cancel the token when we're sure that the worker actually processed the checkpoint.
+                            if Self::is_checkpoint_upper_limit_reached(checkpoint_upper_limit.as_ref(), &watermark)
+                            {
+                                info!("checkpoint upper limit reached: last checkpoint was processed, shutdown process started");
+                                self.token.cancel();
+                            }
                         }
                         WorkerPoolStatus::Shutdown(worker_pool_name) => {
                             worker_pools_shutdown_signals.push(worker_pool_name);
                         }
                     }
                 }
-                Some(checkpoint) = checkpoint_reader.get_checkpoint(), if !self.token.is_cancelled() => {
+                Some(checkpoint) = checkpoint_reader.get_checkpoint(), if !self.token.is_cancelled() && !checkpoint_limit_reached => {
+                    // when we reach the upper limit we skip sending new checkpoints to workers.
+                    if Self::is_checkpoint_upper_limit_reached(checkpoint_upper_limit.as_ref(), &checkpoint.checkpoint_summary.sequence_number)
+                    {
+                        info!("checkpoint upper limit reached: no further checkpoints will be sent, waiting for workers to process remaining checkpoints");
+                        checkpoint_limit_reached = true;
+                        continue;
+                    }
                     for sender in &self.pool_senders {
                         sender.send(checkpoint.clone()).await.map_err(|_| {
                             IngestionError::Channel(
@@ -325,6 +346,17 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         }
 
         Ok(self.progress_store.stats())
+    }
+
+    /// Check if the current checkpoint sequence number has reached the upper
+    /// limit.
+    ///
+    /// If no upper limit is present, the function returns `false`.
+    fn is_checkpoint_upper_limit_reached(
+        checkpoint_upper_limit: Option<&CheckpointSequenceNumber>,
+        checkpoint_seq_num: &CheckpointSequenceNumber,
+    ) -> bool {
+        checkpoint_upper_limit.is_some_and(|upper_limit| checkpoint_seq_num > upper_limit)
     }
 }
 

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -20,7 +20,7 @@ use crate::{
     DataIngestionMetrics, IngestionError, IngestionResult, ReaderOptions, Worker,
     progress_store::{ExecutorProgress, ProgressStore, ProgressStoreWrapper, ShimProgressStore},
     reader::{
-        v1::CheckpointReader as CheckpointReaderV1,
+        v1::{CheckpointReader as CheckpointReaderV1, IngestionLimit},
         v2::{CheckpointReader as CheckpointReaderV2, CheckpointReaderConfig},
     },
     worker_pool::{WorkerPool, WorkerPoolStatus},
@@ -28,17 +28,28 @@ use crate::{
 
 pub const MAX_CHECKPOINTS_IN_PROGRESS: usize = 10000;
 
+/// Callback function that when resolved to `true`, the executor will start the
+/// shutdown process.
+type ShutdownCallback = Box<dyn FnMut(&CheckpointData) -> bool + Send>;
+
+/// Represents a common interface for checkpoint readers.
+///
+/// It manages the old checkpoint reader implementation for backwards
+/// compatibility and the new one.
 enum CheckpointReader {
+    /// The old checkpoint reader implementation.
     V1 {
         checkpoint_recv: mpsc::Receiver<Arc<CheckpointData>>,
         gc_sender: mpsc::Sender<CheckpointSequenceNumber>,
         exit_sender: oneshot::Sender<()>,
         handle: JoinHandle<IngestionResult<()>>,
     },
+    /// The new checkpoint reader implementation.
     V2(CheckpointReaderV2),
 }
 
 impl CheckpointReader {
+    /// Gets the next checkpoint from the reader.
     async fn get_checkpoint(&mut self) -> Option<Arc<CheckpointData>> {
         match self {
             Self::V1 {
@@ -48,6 +59,7 @@ impl CheckpointReader {
         }
     }
 
+    /// Sends a GC signal to the reader.
     async fn send_gc_signal(
         &mut self,
         seq_number: CheckpointSequenceNumber,
@@ -62,6 +74,7 @@ impl CheckpointReader {
         }
     }
 
+    /// Shuts down the reader.
     async fn shutdown(self) -> IngestionResult<()> {
         match self {
             Self::V1 {
@@ -153,6 +166,7 @@ pub struct IndexerExecutor<P> {
     pool_status_receiver: mpsc::Receiver<WorkerPoolStatus>,
     metrics: DataIngestionMetrics,
     token: CancellationToken,
+    shutdown_callback: Option<ShutdownCallback>,
 }
 
 impl<P: ProgressStore> IndexerExecutor<P> {
@@ -172,6 +186,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
             pool_status_receiver,
             metrics,
             token,
+            shutdown_callback: None,
         }
     }
 
@@ -190,6 +205,24 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         )));
         self.pool_senders.push(sender);
         Ok(())
+    }
+
+    /// Registers a predicate callback that determines when the ingestion
+    /// process should stop.
+    ///
+    /// This function `f` will be called for every **incoming checkpoint**
+    /// before it’s sent to the worker pool.
+    ///
+    /// If the callback resolves to `true`, the **current checkpoint is
+    /// discarded**. The executor will then immediately stop sending any
+    /// *further* new checkpoints to the worker pool and wait for all
+    /// previously sent checkpoints to be processed by the workers
+    /// before initiating the graceful shutdown sequence.
+    pub fn shutdown_when<F>(&mut self, f: F)
+    where
+        F: FnMut(&CheckpointData) -> bool + Send + 'static,
+    {
+        self.shutdown_callback = Some(Box::new(f));
     }
 
     pub async fn update_watermark(
@@ -220,7 +253,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         reader_options: ReaderOptions,
     ) -> IngestionResult<ExecutorProgress> {
         let reader_checkpoint_number = self.progress_store.min_watermark()?;
-        let checkpoint_upper_limit = reader_options.checkpoint_upper_limit;
+        let ingestion_upper_limit = reader_options.ingestion_upper_limit;
         let (checkpoint_reader, checkpoint_recv, gc_sender, exit_sender) =
             CheckpointReaderV1::initialize(
                 path,
@@ -240,7 +273,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
                 exit_sender,
                 handle,
             },
-            checkpoint_upper_limit,
+            ingestion_upper_limit,
         )
         .await
     }
@@ -258,14 +291,14 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         config: CheckpointReaderConfig,
     ) -> IngestionResult<ExecutorProgress> {
         let reader_checkpoint_number = self.progress_store.min_watermark()?;
-        let checkpoint_upper_limit = config.reader_options.checkpoint_upper_limit;
+        let ingestion_upper_limit = config.reader_options.ingestion_upper_limit;
 
         let checkpoint_reader = CheckpointReaderV2::new(reader_checkpoint_number, config).await?;
 
         self.run_executor_loop(
             reader_checkpoint_number,
             CheckpointReader::V2(checkpoint_reader),
-            checkpoint_upper_limit,
+            ingestion_upper_limit,
         )
         .await
     }
@@ -275,7 +308,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         &mut self,
         mut reader_checkpoint_number: u64,
         mut checkpoint_reader: CheckpointReader,
-        checkpoint_upper_limit: Option<u64>,
+        ingestion_upper_limit: Option<IngestionLimit>,
     ) -> IngestionResult<ExecutorProgress> {
         let worker_pools = std::mem::take(&mut self.pools)
             .into_iter()
@@ -283,9 +316,25 @@ impl<P: ProgressStore> IndexerExecutor<P> {
             .collect::<Vec<JoinHandle<()>>>();
 
         let mut worker_pools_shutdown_signals = vec![];
-        let mut checkpoint_limit_reached = false;
+        let mut checkpoint_limit_reached = None;
 
         loop {
+            // the min watermark represents the lowest sequence number that
+            // has been processed by any worker pool. This guarantees that
+            // all worker pools have processed the checkpoint before the
+            // shutdown process starts.
+            if checkpoint_limit_reached.is_some_and(|ch_seq_num| {
+                self.progress_store
+                    .min_watermark()
+                    .map(|watermark| watermark > ch_seq_num)
+                    .unwrap_or_default()
+            }) {
+                info!(
+                    "checkpoint upper limit reached: last checkpoint was processed, shutdown process started"
+                );
+                self.token.cancel();
+            }
+
             tokio::select! {
                 Some(worker_pool_progress_msg) = self.pool_status_receiver.recv() => {
                     match worker_pool_progress_msg {
@@ -300,27 +349,20 @@ impl<P: ProgressStore> IndexerExecutor<P> {
                             self.metrics.data_ingestion_checkpoint
                                 .with_label_values(&[&task_name])
                                 .set(watermark as i64);
-
-                            // we cancel the token when we're sure that the worker actually processed the checkpoint.
-                            if Self::is_checkpoint_upper_limit_reached(checkpoint_upper_limit.as_ref(), &watermark)
-                            {
-                                info!("checkpoint upper limit reached: last checkpoint was processed, shutdown process started");
-                                self.token.cancel();
-                            }
                         }
                         WorkerPoolStatus::Shutdown(worker_pool_name) => {
                             worker_pools_shutdown_signals.push(worker_pool_name);
                         }
                     }
                 }
-                Some(checkpoint) = checkpoint_reader.get_checkpoint(), if !self.token.is_cancelled() && !checkpoint_limit_reached => {
+                Some(checkpoint) = checkpoint_reader.get_checkpoint(), if !self.token.is_cancelled() && checkpoint_limit_reached.is_none() => {
                     // when we reach the upper limit we skip sending new checkpoints to workers.
-                    if Self::is_checkpoint_upper_limit_reached(checkpoint_upper_limit.as_ref(), &checkpoint.checkpoint_summary.sequence_number)
-                    {
+                    if self.is_ingestion_upper_limit_reached(ingestion_upper_limit.as_ref(), &checkpoint) {
                         info!("checkpoint upper limit reached: no further checkpoints will be sent, waiting for workers to process remaining checkpoints");
-                        checkpoint_limit_reached = true;
+                        checkpoint_limit_reached.get_or_insert(checkpoint.checkpoint_summary.sequence_number.saturating_sub(1));
                         continue;
                     }
+
                     for sender in &self.pool_senders {
                         sender.send(checkpoint.clone()).await.map_err(|_| {
                             IngestionError::Channel(
@@ -348,15 +390,24 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         Ok(self.progress_store.stats())
     }
 
-    /// Check if the current checkpoint sequence number has reached the upper
-    /// limit.
+    /// Check if the current ingestion limit has been reached.
     ///
-    /// If no upper limit is present, the function returns `false`.
-    fn is_checkpoint_upper_limit_reached(
-        checkpoint_upper_limit: Option<&CheckpointSequenceNumber>,
-        checkpoint_seq_num: &CheckpointSequenceNumber,
+    /// It checks both the [`IngestionLimit`] and the
+    /// [`IndexerExecutor::shutdown_when`]. If either of them is reached, the
+    /// function returns `true`.
+    ///
+    /// If neither an [`IngestionLimit`] nor [`IndexerExecutor::shutdown_when`]
+    /// is present, the function returns `false`.
+    fn is_ingestion_upper_limit_reached(
+        &mut self,
+        ingestion_upper_limit: Option<&IngestionLimit>,
+        checkpoint: &CheckpointData,
     ) -> bool {
-        checkpoint_upper_limit.is_some_and(|upper_limit| checkpoint_seq_num > upper_limit)
+        ingestion_upper_limit.is_some_and(|limit| limit.matches(checkpoint))
+            || self
+                .shutdown_callback
+                .as_mut()
+                .is_some_and(|matches| matches(checkpoint))
     }
 }
 

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -47,7 +47,7 @@ pub use executor::{IndexerExecutor, MAX_CHECKPOINTS_IN_PROGRESS, setup_single_wo
 use iota_types::full_checkpoint_content::CheckpointData;
 pub use metrics::DataIngestionMetrics;
 pub use progress_store::{FileProgressStore, ProgressStore, ShimProgressStore};
-pub use reader::v1::ReaderOptions;
+pub use reader::v1::{IngestionLimit, ReaderOptions};
 pub use reducer::Reducer;
 pub use util::{create_remote_store_client, create_remote_store_client_with_ops};
 pub use worker_pool::WorkerPool;

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -43,11 +43,13 @@ use std::{
 
 use async_trait::async_trait;
 pub use errors::{IngestionError, IngestionResult};
-pub use executor::{IndexerExecutor, MAX_CHECKPOINTS_IN_PROGRESS, setup_single_workflow};
+pub use executor::{
+    IndexerExecutor, IngestionLimit, MAX_CHECKPOINTS_IN_PROGRESS, setup_single_workflow,
+};
 use iota_types::full_checkpoint_content::CheckpointData;
 pub use metrics::DataIngestionMetrics;
 pub use progress_store::{FileProgressStore, ProgressStore, ShimProgressStore};
-pub use reader::v1::{IngestionLimit, ReaderOptions};
+pub use reader::v1::ReaderOptions;
 pub use reducer::Reducer;
 pub use util::{create_remote_store_client, create_remote_store_client_with_ops};
 pub use worker_pool::WorkerPool;

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -44,7 +44,8 @@ use std::{
 use async_trait::async_trait;
 pub use errors::{IngestionError, IngestionResult};
 pub use executor::{
-    IndexerExecutor, IngestionLimit, MAX_CHECKPOINTS_IN_PROGRESS, setup_single_workflow,
+    IndexerExecutor, IngestionLimit, MAX_CHECKPOINTS_IN_PROGRESS, ShutdownAction,
+    setup_single_workflow,
 };
 use iota_types::full_checkpoint_content::CheckpointData;
 pub use metrics::DataIngestionMetrics;

--- a/crates/iota-data-ingestion-core/src/reader/v1.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v1.rs
@@ -14,7 +14,8 @@ use backoff::backoff::Backoff;
 use futures::StreamExt;
 use iota_metrics::spawn_monitored_task;
 use iota_types::{
-    full_checkpoint_content::CheckpointData, messages_checkpoint::CheckpointSequenceNumber,
+    committee::EpochId, full_checkpoint_content::CheckpointData,
+    messages_checkpoint::CheckpointSequenceNumber,
 };
 use object_store::ObjectStore;
 use tap::pipe::Pipe;
@@ -72,6 +73,37 @@ impl LocalRead for CheckpointReader {
     }
 }
 
+/// Common policies for upper limit checkpoint ingestion by the framework.
+///
+/// Once the limit is reached, the framework will start the graceful
+/// shutdown process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum IngestionLimit {
+    /// Last checkpoint sequence number to process.
+    ///
+    /// After processing this checkpoint the framework will start the graceful
+    /// shutdown process.
+    MaxCheckpoint(CheckpointSequenceNumber),
+    /// Last checkpoint to process based on the given epoch.
+    ///
+    /// After processing this checkpoint the framework will start the graceful
+    /// shutdown process.
+    EndOfEpoch(EpochId),
+}
+
+impl IngestionLimit {
+    /// Returns `true` if the given checkpoint matches the limit.
+    pub(crate) fn matches(&self, checkpoint: &CheckpointData) -> bool {
+        match self {
+            IngestionLimit::MaxCheckpoint(max) => {
+                &checkpoint.checkpoint_summary.sequence_number > max
+            }
+            IngestionLimit::EndOfEpoch(max) => &checkpoint.checkpoint_summary.epoch > max,
+        }
+    }
+}
+
 /// Options for configuring how the checkpoint reader fetches new checkpoints.
 #[derive(Clone)]
 pub struct ReaderOptions {
@@ -94,11 +126,13 @@ pub struct ReaderOptions {
     ///
     /// Default: 0.
     pub data_limit: usize,
-    /// Last checkpoint sequence number to process.
+    /// Common policies for upper limit checkpoint ingestion by the framework.
     ///
-    /// After processing this checkpoint the framework will start the graceful
+    /// Once the limit is reached, the framework will start the graceful
     /// shutdown process.
-    pub checkpoint_upper_limit: Option<CheckpointSequenceNumber>,
+    ///
+    /// Default: No ingestion limits are enforced.
+    pub ingestion_upper_limit: Option<IngestionLimit>,
 }
 
 impl Default for ReaderOptions {
@@ -108,7 +142,7 @@ impl Default for ReaderOptions {
             timeout_secs: 5,
             batch_size: 10,
             data_limit: 0,
-            checkpoint_upper_limit: None,
+            ingestion_upper_limit: None,
         }
     }
 }

--- a/crates/iota-data-ingestion-core/src/reader/v1.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v1.rs
@@ -14,8 +14,7 @@ use backoff::backoff::Backoff;
 use futures::StreamExt;
 use iota_metrics::spawn_monitored_task;
 use iota_types::{
-    committee::EpochId, full_checkpoint_content::CheckpointData,
-    messages_checkpoint::CheckpointSequenceNumber,
+    full_checkpoint_content::CheckpointData, messages_checkpoint::CheckpointSequenceNumber,
 };
 use object_store::ObjectStore;
 use tap::pipe::Pipe;
@@ -73,37 +72,6 @@ impl LocalRead for CheckpointReader {
     }
 }
 
-/// Common policies for upper limit checkpoint ingestion by the framework.
-///
-/// Once the limit is reached, the framework will start the graceful
-/// shutdown process.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[non_exhaustive]
-pub enum IngestionLimit {
-    /// Last checkpoint sequence number to process.
-    ///
-    /// After processing this checkpoint the framework will start the graceful
-    /// shutdown process.
-    MaxCheckpoint(CheckpointSequenceNumber),
-    /// Last checkpoint to process based on the given epoch.
-    ///
-    /// After processing this checkpoint the framework will start the graceful
-    /// shutdown process.
-    EndOfEpoch(EpochId),
-}
-
-impl IngestionLimit {
-    /// Returns `true` if the given checkpoint matches the limit.
-    pub(crate) fn matches(&self, checkpoint: &CheckpointData) -> bool {
-        match self {
-            IngestionLimit::MaxCheckpoint(max) => {
-                &checkpoint.checkpoint_summary.sequence_number > max
-            }
-            IngestionLimit::EndOfEpoch(max) => &checkpoint.checkpoint_summary.epoch > max,
-        }
-    }
-}
-
 /// Options for configuring how the checkpoint reader fetches new checkpoints.
 #[derive(Clone)]
 pub struct ReaderOptions {
@@ -126,13 +94,6 @@ pub struct ReaderOptions {
     ///
     /// Default: 0.
     pub data_limit: usize,
-    /// Common policies for upper limit checkpoint ingestion by the framework.
-    ///
-    /// Once the limit is reached, the framework will start the graceful
-    /// shutdown process.
-    ///
-    /// Default: No ingestion limits are enforced.
-    pub ingestion_upper_limit: Option<IngestionLimit>,
 }
 
 impl Default for ReaderOptions {
@@ -142,7 +103,6 @@ impl Default for ReaderOptions {
             timeout_secs: 5,
             batch_size: 10,
             data_limit: 0,
-            ingestion_upper_limit: None,
         }
     }
 }

--- a/crates/iota-data-ingestion-core/src/reader/v1.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v1.rs
@@ -94,6 +94,11 @@ pub struct ReaderOptions {
     ///
     /// Default: 0.
     pub data_limit: usize,
+    /// Last checkpoint sequence number to process.
+    ///
+    /// After processing this checkpoint the framework will start the graceful
+    /// shutdown process.
+    pub checkpoint_upper_limit: Option<CheckpointSequenceNumber>,
 }
 
 impl Default for ReaderOptions {
@@ -103,6 +108,7 @@ impl Default for ReaderOptions {
             timeout_secs: 5,
             batch_size: 10,
             data_limit: 0,
+            checkpoint_upper_limit: None,
         }
     }
 }

--- a/crates/iota-data-ingestion-core/src/tests.rs
+++ b/crates/iota-data-ingestion-core/src/tests.rs
@@ -382,9 +382,11 @@ async fn basic_flow_with_custom_callback_epoch_limit() {
 // Scenario:
 // A transaction with a known digest is embedded only in checkpoint 10. The
 // callback `shutdown_when` inspects each processed checkpoint and returns
-// `true` if it contains the target transaction digest. Once the condition is
-// met, the Executor initiates graceful shutdown without handing that checkpoint
-// to workers (i.e. 11.chk is skipped and becomes the upper limit).
+// `ShutdownAction::IncludeAndShutdown` enum variant if it contains the target
+// transaction digest. Once the condition is met, the Executor will stop sending
+// new checkpoints and will wait for all previously sent checkpoints to be
+// processed by workers before initiating graceful shutdown process. 11.chk is
+// skipped and becomes the upper limit.
 //
 // This test verifies that:
 // 1. The framework only processes checkpoints with sequence numbers strictly

--- a/crates/iota-data-ingestion-core/src/tests.rs
+++ b/crates/iota-data-ingestion-core/src/tests.rs
@@ -14,15 +14,21 @@ use std::{
 
 use async_trait::async_trait;
 use iota_protocol_config::ProtocolConfig;
+use iota_rest_api::CheckpointTransaction;
 use iota_storage::blob::{Blob, BlobEncoding};
 use iota_types::{
-    crypto::KeypairTraits,
+    base_types::{IotaAddress, ObjectID, SequenceNumber},
+    committee::EpochId,
+    crypto::{KeypairTraits, RandomnessRound},
+    digests::ObjectDigest,
+    effects::TransactionEffects,
     full_checkpoint_content::CheckpointData,
     gas::GasCostSummary,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
         CheckpointSummary, SignedCheckpointSummary,
     },
+    transaction::{RandomnessStateUpdate, Transaction, TransactionData, TransactionKind},
     utils::make_committee_key,
 };
 use prometheus::Registry;
@@ -32,8 +38,9 @@ use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    DataIngestionMetrics, FileProgressStore, IndexerExecutor, IngestionError, IngestionResult,
-    ProgressStore, ReaderOptions, Reducer, Worker, WorkerPool, progress_store::ExecutorProgress,
+    DataIngestionMetrics, FileProgressStore, IndexerExecutor, IngestionError, IngestionLimit,
+    IngestionResult, ProgressStore, ReaderOptions, Reducer, Worker, WorkerPool,
+    progress_store::ExecutorProgress,
 };
 
 async fn add_worker_pool<W: Worker + 'static>(
@@ -228,10 +235,6 @@ async fn basic_flow() {
 // 3. The graceful shutdown is triggered by the Executor when the Worker reports
 //    the processed checkpoint matching the upper limit one, making sure to not
 //    trigger the shutdown prematurely.
-// 4. The ingestion directory should contain leftover checkpoint files, but
-//    should not contain the checkpoint file provided in the
-//    `ReaderOptions.checkpoint_upper_limit` asserting that the checkpoint file
-//    was indeed processed.
 #[tokio::test]
 async fn basic_flow_with_checkpoint_upper_limit() {
     let mut bundle = create_executor_bundle().await;
@@ -239,6 +242,7 @@ async fn basic_flow_with_checkpoint_upper_limit() {
         .await
         .unwrap();
     let path = temp_dir();
+    // range not inclusive actual chk files generated 0.chk .. 24.chk
     for checkpoint_number in 0..25 {
         let bytes = mock_checkpoint_data_bytes(checkpoint_number);
         std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
@@ -248,7 +252,7 @@ async fn basic_flow_with_checkpoint_upper_limit() {
     let options = ReaderOptions {
         tick_interval_ms: 10,
         batch_size: 1,
-        checkpoint_upper_limit: Some(19),
+        ingestion_upper_limit: Some(IngestionLimit::MaxCheckpoint(19)),
         ..Default::default()
     };
     let result = run_with_reader_options(
@@ -262,16 +266,320 @@ async fn basic_flow_with_checkpoint_upper_limit() {
     assert!(result.is_ok());
     // expect watermark == processed_last_checkpoint + 1 == 20.
     assert_eq!(result.unwrap().get("test"), Some(&20));
-    // assert that 19.chk was consumed (i.e. no longer in directory), while later
-    // unprocessed ones may remain.
-    assert!(
-        !fs::read_dir(path.clone()).unwrap().any(|d| d
-            .unwrap()
-            .file_name()
-            .to_str()
-            .unwrap()
-            .starts_with("19"))
+    // remove leftover checkpoint files.
+    fs::remove_dir_all(path).unwrap();
+}
+
+// Tests the graceful shutdown behavior when a checkpoint upper limit is
+// provided through a custom callback.
+//
+// This test verifies that:
+// 1. The framework process checkpoints not exceeding the upper limit.
+// 2. The Executor handles the upper limit correctly by not sending any more
+//    checkpoints to workers.
+// 3. The graceful shutdown is triggered by the Executor when the Worker reports
+//    the processed checkpoint matching the upper limit one, making sure to not
+//    trigger the shutdown prematurely.
+#[tokio::test]
+async fn basic_flow_with_custom_callback_checkpoint_limit() {
+    let mut bundle = create_executor_bundle().await;
+    add_worker_pool(&mut bundle.executor, TestWorker, 5)
+        .await
+        .unwrap();
+    let path = temp_dir();
+    // range not inclusive actual chk files generated 0.chk .. 24.chk
+    for checkpoint_number in 0..25 {
+        let bytes = mock_checkpoint_data_bytes(checkpoint_number);
+        std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
+    }
+
+    // process until we reach the checkpoint sequence number 19 (inclusive).
+    // Subsequent checkpoints should be skipped.
+    bundle
+        .executor
+        .shutdown_when(|chk| chk.checkpoint_summary.sequence_number > 19);
+
+    let result = run(
+        bundle.executor,
+        Some(path.clone()),
+        Some(Duration::from_secs(3)),
+        bundle.token,
+    )
+    .await;
+    assert!(result.is_ok());
+    // expect watermark == processed_last_checkpoint + 1 == 20.
+    assert_eq!(result.unwrap().get("test"), Some(&20));
+    // remove leftover checkpoint files.
+    fs::remove_dir_all(path).unwrap();
+}
+
+// Tests the graceful shutdown behavior when an epoch upper limit is
+// provided.
+//
+// This test verifies that:
+// 1. The framework process checkpoints not exceeding the epoch upper limit.
+// 2. The Executor handles the upper limit correctly by not sending any more
+//    checkpoints to workers.
+// 3. The graceful shutdown is triggered by the Executor when the Worker reports
+//    the processed checkpoint matching the upper limit one, making sure to not
+//    trigger the shutdown prematurely.
+#[tokio::test]
+async fn basic_flow_with_epoch_upper_limit() {
+    let mut bundle = create_executor_bundle().await;
+    add_worker_pool(&mut bundle.executor, TestWorker, 5)
+        .await
+        .unwrap();
+    let path = temp_dir();
+    // range not inclusive actual chk files generated 0.chk .. 14.chk
+    for checkpoint_number in 0..15 {
+        let bytes = mock_checkpoint_data_bytes(checkpoint_number);
+        std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
+    }
+    // create a single checkpoint with a new epoch to simulate epoch change
+    // this checkpoint should not be processed
+    let bytes = mock_checkpoint_data_bytes_with_opt(15, 1, vec![]);
+    std::fs::write(path.join("15.chk"), bytes).unwrap();
+
+    // process until we reach the epoch upper limit 0, so it should process up to
+    // checkpoint file 14.chk (inclusive). Subsequent checkpoints (15.chk) should be
+    // skipped.
+    let options = ReaderOptions {
+        tick_interval_ms: 10,
+        batch_size: 1,
+        ingestion_upper_limit: Some(IngestionLimit::EndOfEpoch(0)),
+        ..Default::default()
+    };
+    let result = run_with_reader_options(
+        bundle.executor,
+        Some(path.clone()),
+        Some(Duration::from_secs(3)),
+        bundle.token,
+        options,
+    )
+    .await;
+    assert!(result.is_ok());
+    // expect watermark == processed_last_checkpoint + 1 == 15.
+    assert_eq!(result.unwrap().get("test"), Some(&15));
+    // remove leftover checkpoint files.
+    fs::remove_dir_all(path).unwrap();
+}
+
+// Tests the graceful shutdown behavior when an epoch upper limit is
+// provided through a custom callback.
+//
+// This test verifies that:
+// 1. The framework process checkpoints not exceeding the epoch upper limit.
+// 2. The Executor handles the upper limit correctly by not sending any more
+//    checkpoints to workers.
+// 3. The graceful shutdown is triggered by the Executor when the Worker reports
+//    the processed checkpoint matching the upper limit one, making sure to not
+//    trigger the shutdown prematurely.
+#[tokio::test]
+async fn basic_flow_with_custom_callback_epoch_limit() {
+    let mut bundle = create_executor_bundle().await;
+    add_worker_pool(&mut bundle.executor, TestWorker, 5)
+        .await
+        .unwrap();
+    let path = temp_dir();
+    // range not inclusive actual chk files generated 0.chk .. 14.chk
+    for checkpoint_number in 0..15 {
+        let bytes = mock_checkpoint_data_bytes(checkpoint_number);
+        std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
+    }
+    // create a single checkpoint with a new epoch to simulate epoch change
+    // this checkpoint should not be processed
+    let bytes = mock_checkpoint_data_bytes_with_opt(15, 1, vec![]);
+    std::fs::write(path.join("15.chk"), bytes).unwrap();
+
+    // process until we reach the epoch upper limit 0, so it should process up to
+    // checkpoint file 14.chk (inclusive). Subsequent checkpoints (15.chk) should be
+    // skipped.
+    bundle
+        .executor
+        .shutdown_when(|chk| chk.checkpoint_summary.epoch > 0);
+
+    let result = run(
+        bundle.executor,
+        Some(path.clone()),
+        Some(Duration::from_secs(3)),
+        bundle.token,
+    )
+    .await;
+    assert!(result.is_ok());
+    // expect watermark == processed_last_checkpoint + 1 == 15.
+    assert_eq!(result.unwrap().get("test"), Some(&15));
+    // remove leftover checkpoint files.
+    fs::remove_dir_all(path).unwrap();
+}
+
+// Test: graceful shutdown via a custom callback.
+//
+// Scenario:
+// A transaction with a known digest is embedded only in checkpoint 10. The
+// callback `shutdown_when` inspects each processed checkpoint and returns
+// `true` if it contains the target transaction digest. Once the condition is
+// met, the Executor initiates graceful shutdown without handing that checkpoint
+// to workers (i.e. 10.chk is skipped and becomes the upper limit).
+//
+// This test verifies that:
+// 1. The framework only processes checkpoints with sequence numbers strictly
+//    less than the one containing the matching transaction digest (0.chk =>
+//    9.chk).
+// 2. Upon hitting the shutdown condition, the Executor stops dispatching
+//    further checkpoints (10.chk and later are not sent to workers).
+// 3. Graceful shutdown is triggered exactly when the matching digest would be
+//    encountered, never prematurely.
+#[tokio::test]
+async fn basic_flow_with_custom_callback() {
+    let mut bundle = create_executor_bundle().await;
+    add_worker_pool(&mut bundle.executor, TestWorker, 5)
+        .await
+        .unwrap();
+    let path = temp_dir();
+
+    let tx_data = TransactionData::new(
+        TransactionKind::RandomnessStateUpdate(RandomnessStateUpdate {
+            epoch: 0,
+            randomness_round: RandomnessRound::new(0),
+            random_bytes: vec![],
+            randomness_obj_initial_shared_version: SequenceNumber::new(),
+        }),
+        IotaAddress::random_for_testing_only(),
+        (ObjectID::ZERO, SequenceNumber::default(), ObjectDigest::MIN),
+        0,
+        0,
     );
+
+    let ch_tx = CheckpointTransaction {
+        transaction: Transaction::from_data(tx_data, vec![]),
+        effects: TransactionEffects::default(),
+        events: None,
+        input_objects: vec![],
+        output_objects: vec![],
+    };
+
+    let tx_digest = *ch_tx.transaction.digest();
+
+    // range not inclusive actual chk files generated 0.chk .. 14.chk
+    for checkpoint_number in 0..15 {
+        if checkpoint_number == 10 {
+            let bytes =
+                mock_checkpoint_data_bytes_with_opt(checkpoint_number, 0, vec![ch_tx.clone()]);
+            std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
+        } else {
+            let bytes = mock_checkpoint_data_bytes(checkpoint_number);
+            std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
+        }
+    }
+
+    // process until we reach the checkpoint number 9. The checkpoint sequence
+    // number 10 which holds the transaction digest should be skipped.
+    bundle.executor.shutdown_when(move |chk| {
+        chk.transactions
+            .iter()
+            .any(|tx| *tx.transaction.digest() == tx_digest)
+    });
+
+    let result = run(
+        bundle.executor,
+        Some(path.clone()),
+        Some(Duration::from_secs(3)),
+        bundle.token,
+    )
+    .await;
+    assert!(result.is_ok());
+    // expect watermark == processed_last_checkpoint + 1 == 10.
+    assert_eq!(result.unwrap().get("test"), Some(&10));
+    // remove leftover checkpoint files.
+    fs::remove_dir_all(path).unwrap();
+}
+
+// Test: graceful shutdown via custom callback (inclusive variant).
+//
+// Scenario:
+// A transaction with a known digest is embedded only in checkpoint 10. The
+// callback `shutdown_when` inspects each checkpoint. When it encounters the
+// target digest in checkpoint 10, it records that fact (sets
+// `include_matching_checkpoint = true`) but returns `false`, allowing
+// checkpoint 10 to be processed normally. On the next invocation (checkpoint
+// 11), since the flag is set, it returns `true`, triggering graceful
+// shutdown before dispatching checkpoint 11 to workers.
+//
+// This test verifies that:
+// 1. The framework only processes checkpoints with sequence numbers (0.chk =>
+//    10.chk).
+// 2. Upon hitting the shutdown condition, the Executor stops dispatching
+//    further checkpoints (11.chk and later are not sent to workers).
+// 3. Graceful shutdown is triggered after 10.chk was processed by all workers.
+#[tokio::test]
+async fn basic_flow_with_custom_callback_inclusive() {
+    let mut bundle = create_executor_bundle().await;
+    add_worker_pool(&mut bundle.executor, TestWorker, 5)
+        .await
+        .unwrap();
+    let path = temp_dir();
+
+    let tx_data = TransactionData::new(
+        TransactionKind::RandomnessStateUpdate(RandomnessStateUpdate {
+            epoch: 0,
+            randomness_round: RandomnessRound::new(0),
+            random_bytes: vec![],
+            randomness_obj_initial_shared_version: SequenceNumber::new(),
+        }),
+        IotaAddress::random_for_testing_only(),
+        (ObjectID::ZERO, SequenceNumber::default(), ObjectDigest::MIN),
+        0,
+        0,
+    );
+
+    let ch_tx = CheckpointTransaction {
+        transaction: Transaction::from_data(tx_data, vec![]),
+        effects: TransactionEffects::default(),
+        events: None,
+        input_objects: vec![],
+        output_objects: vec![],
+    };
+
+    let tx_digest = *ch_tx.transaction.digest();
+
+    // range not inclusive actual chk files generated 0.chk .. 14.chk
+    for checkpoint_number in 0..15 {
+        if checkpoint_number == 10 {
+            let bytes =
+                mock_checkpoint_data_bytes_with_opt(checkpoint_number, 0, vec![ch_tx.clone()]);
+            std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
+        } else {
+            let bytes = mock_checkpoint_data_bytes(checkpoint_number);
+            std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
+        }
+    }
+
+    let mut include_matching_checkpoint = false;
+    // the checkpoint sequence number 10 which holds the transaction digest should
+    // be included.
+    bundle.executor.shutdown_when(move |chk| {
+        if include_matching_checkpoint {
+            return true;
+        }
+
+        include_matching_checkpoint = chk
+            .transactions
+            .iter()
+            .any(|tx| *tx.transaction.digest() == tx_digest);
+
+        false
+    });
+
+    let result = run(
+        bundle.executor,
+        Some(path.clone()),
+        Some(Duration::from_secs(3)),
+        bundle.token,
+    )
+    .await;
+    assert!(result.is_ok());
+    // expect watermark == processed_last_checkpoint + 1 == 11.
+    assert_eq!(result.unwrap().get("test"), Some(&11));
     // remove leftover checkpoint files.
     fs::remove_dir_all(path).unwrap();
 }
@@ -498,12 +806,20 @@ const RNG_SEED: [u8; 32] = [
 ];
 
 fn mock_checkpoint_data_bytes(seq_number: CheckpointSequenceNumber) -> Vec<u8> {
+    mock_checkpoint_data_bytes_with_opt(seq_number, 0, vec![])
+}
+
+fn mock_checkpoint_data_bytes_with_opt(
+    seq_number: CheckpointSequenceNumber,
+    epoch: EpochId,
+    transactions: Vec<CheckpointTransaction>,
+) -> Vec<u8> {
     let mut rng = StdRng::from_seed(RNG_SEED);
     let (keys, committee) = make_committee_key(&mut rng);
     let contents = CheckpointContents::new_with_digests_only_for_tests(vec![]);
     let summary = CheckpointSummary::new(
         &ProtocolConfig::get_for_max_version_UNSAFE(),
-        0,
+        epoch,
         seq_number,
         0,
         &contents,
@@ -526,7 +842,7 @@ fn mock_checkpoint_data_bytes(seq_number: CheckpointSequenceNumber) -> Vec<u8> {
         checkpoint_summary: CertifiedCheckpointSummary::new(summary, sign_infos, &committee)
             .unwrap(),
         checkpoint_contents: contents,
-        transactions: vec![],
+        transactions,
     };
     Blob::encode(&checkpoint_data, BlobEncoding::Bcs)
         .unwrap()

--- a/crates/iota-data-ingestion-core/src/tests.rs
+++ b/crates/iota-data-ingestion-core/src/tests.rs
@@ -39,7 +39,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     DataIngestionMetrics, FileProgressStore, IndexerExecutor, IngestionError, IngestionLimit,
-    IngestionResult, ProgressStore, ReaderOptions, Reducer, Worker, WorkerPool,
+    IngestionResult, ProgressStore, ReaderOptions, Reducer, ShutdownAction, Worker, WorkerPool,
     progress_store::ExecutorProgress,
 };
 
@@ -275,9 +275,12 @@ async fn basic_flow_with_custom_callback_checkpoint_limit() {
 
     // process until we reach the checkpoint sequence number 19 (inclusive).
     // Subsequent checkpoints should be skipped.
-    bundle
-        .executor
-        .shutdown_when(|chk| chk.checkpoint_summary.sequence_number > 19);
+    bundle.executor.shutdown_when(|chk| {
+        if chk.checkpoint_summary.sequence_number == 19 {
+            return ShutdownAction::IncludeAndShutdown;
+        }
+        ShutdownAction::Continue
+    });
 
     let result = run(bundle.executor, path.clone(), None, bundle.token).await;
     assert!(result.is_ok());
@@ -359,17 +362,14 @@ async fn basic_flow_with_custom_callback_epoch_limit() {
     // process until we reach the epoch upper limit 0, so it should process up to
     // checkpoint file 14.chk (inclusive). Subsequent checkpoints (15.chk) should be
     // skipped.
-    bundle
-        .executor
-        .shutdown_when(|chk| chk.checkpoint_summary.epoch > 0);
+    bundle.executor.shutdown_when(|chk| {
+        if chk.checkpoint_summary.epoch > 0 {
+            return ShutdownAction::ExcludeAndShutdown;
+        }
+        ShutdownAction::Continue
+    });
 
-    let result = run(
-        bundle.executor,
-        path.clone(),
-        Duration::from_secs(3),
-        bundle.token,
-    )
-    .await;
+    let result = run(bundle.executor, path.clone(), None, bundle.token).await;
     assert!(result.is_ok());
     // expect watermark == processed_last_checkpoint + 1 == 15.
     assert_eq!(result.unwrap().get("test"), Some(&15));
@@ -384,14 +384,14 @@ async fn basic_flow_with_custom_callback_epoch_limit() {
 // callback `shutdown_when` inspects each processed checkpoint and returns
 // `true` if it contains the target transaction digest. Once the condition is
 // met, the Executor initiates graceful shutdown without handing that checkpoint
-// to workers (i.e. 10.chk is skipped and becomes the upper limit).
+// to workers (i.e. 11.chk is skipped and becomes the upper limit).
 //
 // This test verifies that:
 // 1. The framework only processes checkpoints with sequence numbers strictly
 //    less than the one containing the matching transaction digest (0.chk =>
-//    9.chk).
+//    10.chk).
 // 2. Upon hitting the shutdown condition, the Executor stops dispatching
-//    further checkpoints (10.chk and later are not sent to workers).
+//    further checkpoints (11.chk and later are not sent to workers).
 // 3. Graceful shutdown is triggered exactly when the matching digest would be
 //    encountered, never prematurely.
 #[tokio::test]
@@ -437,96 +437,17 @@ async fn basic_flow_with_custom_callback() {
         }
     }
 
-    // process until we reach the checkpoint number 9. The checkpoint sequence
-    // number 10 which holds the transaction digest should be skipped.
+    // process until we reach the checkpoint number 10 the one that holds the
+    // transaction digest.
     bundle.executor.shutdown_when(move |chk| {
-        chk.transactions
-            .iter()
-            .any(|tx| *tx.transaction.digest() == tx_digest)
-    });
-
-    let result = run(bundle.executor, path.clone(), None, bundle.token).await;
-    assert!(result.is_ok());
-    // expect watermark == processed_last_checkpoint + 1 == 10.
-    assert_eq!(result.unwrap().get("test"), Some(&10));
-    // remove leftover checkpoint files.
-    fs::remove_dir_all(path).unwrap();
-}
-
-// Test: graceful shutdown via custom callback (inclusive variant).
-//
-// Scenario:
-// A transaction with a known digest is embedded only in checkpoint 10. The
-// callback `shutdown_when` inspects each checkpoint. When it encounters the
-// target digest in checkpoint 10, it records that fact (sets
-// `include_matching_checkpoint = true`) but returns `false`, allowing
-// checkpoint 10 to be processed normally. On the next invocation (checkpoint
-// 11), since the flag is set, it returns `true`, triggering graceful
-// shutdown before dispatching checkpoint 11 to workers.
-//
-// This test verifies that:
-// 1. The framework only processes checkpoints with sequence numbers (0.chk =>
-//    10.chk).
-// 2. Upon hitting the shutdown condition, the Executor stops dispatching
-//    further checkpoints (11.chk and later are not sent to workers).
-// 3. Graceful shutdown is triggered after 10.chk was processed by all workers.
-#[tokio::test]
-async fn basic_flow_with_custom_callback_inclusive() {
-    let mut bundle = create_executor_bundle().await;
-    add_worker_pool(&mut bundle.executor, TestWorker, 5)
-        .await
-        .unwrap();
-    let path = temp_dir();
-
-    let tx_data = TransactionData::new(
-        TransactionKind::RandomnessStateUpdate(RandomnessStateUpdate {
-            epoch: 0,
-            randomness_round: RandomnessRound::new(0),
-            random_bytes: vec![],
-            randomness_obj_initial_shared_version: SequenceNumber::new(),
-        }),
-        IotaAddress::random_for_testing_only(),
-        (ObjectID::ZERO, SequenceNumber::default(), ObjectDigest::MIN),
-        0,
-        0,
-    );
-
-    let ch_tx = CheckpointTransaction {
-        transaction: Transaction::from_data(tx_data, vec![]),
-        effects: TransactionEffects::default(),
-        events: None,
-        input_objects: vec![],
-        output_objects: vec![],
-    };
-
-    let tx_digest = *ch_tx.transaction.digest();
-
-    // range not inclusive actual chk files generated 0.chk .. 14.chk
-    for checkpoint_number in 0..15 {
-        if checkpoint_number == 10 {
-            let bytes =
-                mock_checkpoint_data_bytes_with_opt(checkpoint_number, 0, vec![ch_tx.clone()]);
-            std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
-        } else {
-            let bytes = mock_checkpoint_data_bytes(checkpoint_number);
-            std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
-        }
-    }
-
-    let mut include_matching_checkpoint = false;
-    // the checkpoint sequence number 10 which holds the transaction digest should
-    // be included.
-    bundle.executor.shutdown_when(move |chk| {
-        if include_matching_checkpoint {
-            return true;
-        }
-
-        include_matching_checkpoint = chk
+        if chk
             .transactions
             .iter()
-            .any(|tx| *tx.transaction.digest() == tx_digest);
-
-        false
+            .any(|tx| *tx.transaction.digest() == tx_digest)
+        {
+            return ShutdownAction::IncludeAndShutdown;
+        }
+        ShutdownAction::Continue
     });
 
     let result = run(bundle.executor, path.clone(), None, bundle.token).await;

--- a/crates/iota-data-ingestion-core/src/tests.rs
+++ b/crates/iota-data-ingestion-core/src/tests.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    fs,
     path::PathBuf,
     sync::{
         Arc,
@@ -45,6 +46,36 @@ async fn add_worker_pool<W: Worker + 'static>(
     Ok(())
 }
 
+async fn run_with_reader_options(
+    indexer: IndexerExecutor<FileProgressStore>,
+    path: Option<PathBuf>,
+    duration: Option<Duration>,
+    token: CancellationToken,
+    reader_options: ReaderOptions,
+) -> IngestionResult<ExecutorProgress> {
+    match duration {
+        None => {
+            indexer
+                .run(path.unwrap_or_else(temp_dir), None, vec![], reader_options)
+                .await
+        }
+        Some(duration) => {
+            let handle = tokio::task::spawn(indexer.run(
+                path.unwrap_or_else(temp_dir),
+                None,
+                vec![],
+                reader_options,
+            ));
+            tokio::time::sleep(duration).await;
+            token.cancel();
+            handle.await.map_err(|err| IngestionError::Shutdown {
+                component: "indexer executor".into(),
+                msg: err.to_string(),
+            })?
+        }
+    }
+}
+
 async fn run(
     indexer: IndexerExecutor<FileProgressStore>,
     path: Option<PathBuf>,
@@ -57,27 +88,7 @@ async fn run(
         ..Default::default()
     };
 
-    match duration {
-        None => {
-            indexer
-                .run(path.unwrap_or_else(temp_dir), None, vec![], options)
-                .await
-        }
-        Some(duration) => {
-            let handle = tokio::task::spawn(indexer.run(
-                path.unwrap_or_else(temp_dir),
-                None,
-                vec![],
-                options,
-            ));
-            tokio::time::sleep(duration).await;
-            token.cancel();
-            handle.await.map_err(|err| IngestionError::Shutdown {
-                component: "indexer executor".into(),
-                msg: err.to_string(),
-            })?
-        }
-    }
+    run_with_reader_options(indexer, path, duration, token, options).await
 }
 
 struct ExecutorBundle {
@@ -205,6 +216,64 @@ async fn basic_flow() {
     .await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap().get("test"), Some(&20));
+}
+
+// Tests the graceful shutdown behavior when a checkpoint upper limit is
+// provided.
+//
+// This test verifies that:
+// 1. The framework process checkpoints not exceeding the upper limit.
+// 2. The Executor handles the upper limit correctly by not sending any more
+//    checkpoints to workers.
+// 3. The graceful shutdown is triggered by the Executor when the Worker reports
+//    the processed checkpoint matching the upper limit one, making sure to not
+//    trigger the shutdown prematurely.
+// 4. The ingestion directory should contain leftover checkpoint files, but
+//    should not contain the checkpoint file provided in the
+//    `ReaderOptions.checkpoint_upper_limit` asserting that the checkpoint file
+//    was indeed processed.
+#[tokio::test]
+async fn basic_flow_with_checkpoint_upper_limit() {
+    let mut bundle = create_executor_bundle().await;
+    add_worker_pool(&mut bundle.executor, TestWorker, 5)
+        .await
+        .unwrap();
+    let path = temp_dir();
+    for checkpoint_number in 0..25 {
+        let bytes = mock_checkpoint_data_bytes(checkpoint_number);
+        std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
+    }
+    // process until we reach the checkpoint sequence number 19. Subsequent
+    // checkpoints should be skipped.
+    let options = ReaderOptions {
+        tick_interval_ms: 10,
+        batch_size: 1,
+        checkpoint_upper_limit: Some(19),
+        ..Default::default()
+    };
+    let result = run_with_reader_options(
+        bundle.executor,
+        Some(path.clone()),
+        Some(Duration::from_secs(3)),
+        bundle.token,
+        options,
+    )
+    .await;
+    assert!(result.is_ok());
+    // expect watermark == processed_last_checkpoint + 1 == 20.
+    assert_eq!(result.unwrap().get("test"), Some(&20));
+    // assert that 19.chk was consumed (i.e. no longer in directory), while later
+    // unprocessed ones may remain.
+    assert!(
+        !fs::read_dir(path.clone()).unwrap().any(|d| d
+            .unwrap()
+            .file_name()
+            .to_str()
+            .unwrap()
+            .starts_with("19"))
+    );
+    // remove leftover checkpoint files.
+    fs::remove_dir_all(path).unwrap();
 }
 
 // Tests the graceful shutdown behavior when workers encounter persistent

--- a/crates/iota-data-ingestion-core/src/tests.rs
+++ b/crates/iota-data-ingestion-core/src/tests.rs
@@ -53,22 +53,32 @@ async fn add_worker_pool<W: Worker + 'static>(
     Ok(())
 }
 
-async fn run_with_reader_options(
+async fn run(
     indexer: IndexerExecutor<FileProgressStore>,
-    path: Option<PathBuf>,
-    duration: Option<Duration>,
+    path: impl Into<Option<PathBuf>>,
+    duration: impl Into<Option<Duration>>,
     token: CancellationToken,
-    reader_options: ReaderOptions,
 ) -> IngestionResult<ExecutorProgress> {
-    match duration {
+    let reader_options = ReaderOptions {
+        tick_interval_ms: 10,
+        batch_size: 1,
+        ..Default::default()
+    };
+
+    match duration.into() {
         None => {
             indexer
-                .run(path.unwrap_or_else(temp_dir), None, vec![], reader_options)
+                .run(
+                    path.into().unwrap_or_else(temp_dir),
+                    None,
+                    vec![],
+                    reader_options,
+                )
                 .await
         }
         Some(duration) => {
             let handle = tokio::task::spawn(indexer.run(
-                path.unwrap_or_else(temp_dir),
+                path.into().unwrap_or_else(temp_dir),
                 None,
                 vec![],
                 reader_options,
@@ -81,21 +91,6 @@ async fn run_with_reader_options(
             })?
         }
     }
-}
-
-async fn run(
-    indexer: IndexerExecutor<FileProgressStore>,
-    path: Option<PathBuf>,
-    duration: Option<Duration>,
-    token: CancellationToken,
-) -> IngestionResult<ExecutorProgress> {
-    let options = ReaderOptions {
-        tick_interval_ms: 10,
-        batch_size: 1,
-        ..Default::default()
-    };
-
-    run_with_reader_options(indexer, path, duration, token, options).await
 }
 
 struct ExecutorBundle {
@@ -214,13 +209,7 @@ async fn basic_flow() {
         let bytes = mock_checkpoint_data_bytes(checkpoint_number);
         std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
     }
-    let result = run(
-        bundle.executor,
-        Some(path),
-        Some(Duration::from_secs(3)),
-        bundle.token,
-    )
-    .await;
+    let result = run(bundle.executor, path, Duration::from_secs(3), bundle.token).await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap().get("test"), Some(&20));
 }
@@ -249,20 +238,11 @@ async fn basic_flow_with_checkpoint_upper_limit() {
     }
     // process until we reach the checkpoint sequence number 19. Subsequent
     // checkpoints should be skipped.
-    let options = ReaderOptions {
-        tick_interval_ms: 10,
-        batch_size: 1,
-        ingestion_upper_limit: Some(IngestionLimit::MaxCheckpoint(19)),
-        ..Default::default()
-    };
-    let result = run_with_reader_options(
-        bundle.executor,
-        Some(path.clone()),
-        Some(Duration::from_secs(3)),
-        bundle.token,
-        options,
-    )
-    .await;
+    bundle
+        .executor
+        .with_ingestion_limit(IngestionLimit::MaxCheckpoint(19));
+
+    let result = run(bundle.executor, path.clone(), None, bundle.token).await;
     assert!(result.is_ok());
     // expect watermark == processed_last_checkpoint + 1 == 20.
     assert_eq!(result.unwrap().get("test"), Some(&20));
@@ -299,13 +279,7 @@ async fn basic_flow_with_custom_callback_checkpoint_limit() {
         .executor
         .shutdown_when(|chk| chk.checkpoint_summary.sequence_number > 19);
 
-    let result = run(
-        bundle.executor,
-        Some(path.clone()),
-        Some(Duration::from_secs(3)),
-        bundle.token,
-    )
-    .await;
+    let result = run(bundle.executor, path.clone(), None, bundle.token).await;
     assert!(result.is_ok());
     // expect watermark == processed_last_checkpoint + 1 == 20.
     assert_eq!(result.unwrap().get("test"), Some(&20));
@@ -343,20 +317,11 @@ async fn basic_flow_with_epoch_upper_limit() {
     // process until we reach the epoch upper limit 0, so it should process up to
     // checkpoint file 14.chk (inclusive). Subsequent checkpoints (15.chk) should be
     // skipped.
-    let options = ReaderOptions {
-        tick_interval_ms: 10,
-        batch_size: 1,
-        ingestion_upper_limit: Some(IngestionLimit::EndOfEpoch(0)),
-        ..Default::default()
-    };
-    let result = run_with_reader_options(
-        bundle.executor,
-        Some(path.clone()),
-        Some(Duration::from_secs(3)),
-        bundle.token,
-        options,
-    )
-    .await;
+    bundle
+        .executor
+        .with_ingestion_limit(IngestionLimit::EndOfEpoch(0));
+
+    let result = run(bundle.executor, path.clone(), None, bundle.token).await;
     assert!(result.is_ok());
     // expect watermark == processed_last_checkpoint + 1 == 15.
     assert_eq!(result.unwrap().get("test"), Some(&15));
@@ -400,8 +365,8 @@ async fn basic_flow_with_custom_callback_epoch_limit() {
 
     let result = run(
         bundle.executor,
-        Some(path.clone()),
-        Some(Duration::from_secs(3)),
+        path.clone(),
+        Duration::from_secs(3),
         bundle.token,
     )
     .await;
@@ -480,13 +445,7 @@ async fn basic_flow_with_custom_callback() {
             .any(|tx| *tx.transaction.digest() == tx_digest)
     });
 
-    let result = run(
-        bundle.executor,
-        Some(path.clone()),
-        Some(Duration::from_secs(3)),
-        bundle.token,
-    )
-    .await;
+    let result = run(bundle.executor, path.clone(), None, bundle.token).await;
     assert!(result.is_ok());
     // expect watermark == processed_last_checkpoint + 1 == 10.
     assert_eq!(result.unwrap().get("test"), Some(&10));
@@ -570,13 +529,7 @@ async fn basic_flow_with_custom_callback_inclusive() {
         false
     });
 
-    let result = run(
-        bundle.executor,
-        Some(path.clone()),
-        Some(Duration::from_secs(3)),
-        bundle.token,
-    )
-    .await;
+    let result = run(bundle.executor, path.clone(), None, bundle.token).await;
     assert!(result.is_ok());
     // expect watermark == processed_last_checkpoint + 1 == 11.
     assert_eq!(result.unwrap().get("test"), Some(&11));
@@ -609,13 +562,7 @@ async fn graceful_shutdown_faulty_worker() {
         let bytes = mock_checkpoint_data_bytes(checkpoint_number);
         std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
     }
-    let result = run(
-        bundle.executor,
-        Some(path),
-        Some(Duration::from_secs(1)),
-        bundle.token,
-    )
-    .await;
+    let result = run(bundle.executor, path, Duration::from_secs(1), bundle.token).await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap().get("test"), Some(&0));
 }
@@ -648,13 +595,7 @@ async fn worker_pool_with_reducer() {
         let bytes = mock_checkpoint_data_bytes(checkpoint_number);
         std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
     }
-    let result = run(
-        bundle.executor,
-        Some(path),
-        Some(Duration::from_secs(3)),
-        bundle.token,
-    )
-    .await;
+    let result = run(bundle.executor, path, Duration::from_secs(3), bundle.token).await;
     // 4 commits (batches of 5 checkpoints)
     assert_eq!(commit_count.load(Ordering::SeqCst), 4);
     assert!(result.is_ok());
@@ -695,13 +636,7 @@ async fn graceful_shutdown_faulty_reducer() {
         let bytes = mock_checkpoint_data_bytes(checkpoint_number);
         std::fs::write(path.join(format!("{checkpoint_number}.chk")), bytes).unwrap();
     }
-    let result = run(
-        bundle.executor,
-        Some(path),
-        Some(Duration::from_secs(1)),
-        bundle.token,
-    )
-    .await;
+    let result = run(bundle.executor, path, Duration::from_secs(1), bundle.token).await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap().get("test"), Some(&0));
 }


### PR DESCRIPTION
# Description of change
This PR adds new APIs for the `IndexerExecutor` for managing the ingestion upper limit. Once the ingestion process reaches the upper limit the frameworks will initiate the graceful shutdown process.

This path diverges a bit from the upstream, mostly because of how graceful shutdown is handled and the different guarantees we aim to provide to the library users.

Difference from upstream behavior:

- Upstream: Reaching the limit immediately breaks the executor loop, dropping tasks, and it may exit before the limit checkpoint is actually processed.
- In our implementation, once the upper limit checkpoint is reached, no further checkpoints are sent to workers. The executor does not terminate immediately; it waits until workers advance the watermark past the limit. Only then is the graceful shutdown sequence started.

## Links to any relevant issues

fixes #9251 

## How the change has been tested
- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

- Added a new test case for the checkpoint upper limit feature.
- Ran the tests 10 times 
    ```shell
    cargo test -p iota-data-ingestion-core
    ```
- Modified the `examples/custom-indexer/rust/remote_reader.rs` to sync `testnet` data up to checkpoint using different checkpoint upper limits: 10, 100, 10k. All runs were successful, and the upper limit was respected. Logs from last run:
```log
2025-11-13T09:39:35.978788Z  INFO iota_data_ingestion_core::reader::fetch: cleaning processed files, watermark is 9999
2025-11-13T09:39:35.978810Z  INFO iota_data_ingestion_core::reader::fetch: cleaning processed files, watermark is 10000
2025-11-13T09:39:36.356335Z  INFO iota_data_ingestion_core::worker_pool: received checkpoint for processing 10000 for workflow remote_reader
Processing checkpoint: CheckpointSummary { epoch: 0, seq: 10000, content_digest: CdZuLf2JwogAM2dWzfUtaBecbcBrWZokmg59P2g585nQ,
            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, computation_cost_burned: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }}
2025-11-13T09:39:36.356392Z  INFO iota_data_ingestion_core::worker_pool: finished checkpoint processing 10000 for workflow remote_reader in 37.916µs
2025-11-13T09:39:36.356360Z  INFO iota_data_ingestion_core::executor: checkpoint upper limit reached: no further checkpoints will be sent, waiting for workers to process remaining checkpoints
2025-11-13T09:39:36.356439Z  INFO iota_data_ingestion_core::executor: checkpoint upper limit reached: last checkpoint was processed, shutdown process started
2025-11-13T09:39:36.356561Z  INFO iota_data_ingestion_core::worker_pool: Worker pool `remote_reader` terminated gracefully
2025-11-13T09:39:39.509208Z  INFO iota_data_ingestion_core::reader::v2: Read from remote. Current checkpoint number: 20000, pruning watermark: 10000
2025-11-13T09:39:39.509262Z  INFO iota_data_ingestion_core::reader::fetch: cleaning processed files, watermark is 10001
2025-11-13T09:39:39.509433Z  INFO iota_data_ingestion_core::history::reader: terminating the manifest sync loop
```

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
> [!NOTE]
> The patch does not affect the normal operation of the indexer, this optional APIs are not used by default by the indexer. Thus no further tests were conducted.

### Release Notes
- [x] Indexer: `iota-data-ingestion-core`: Introduced new APIs for managing the ingestion upper limit:
  - `IndexerExecutor::with_ingestion_limit`: offers high level upper limit policies through `IngestionLimit` enum. It provides explicit control to automatically start the graceful shutdown process upon reaching a defined upper limit (e.g., maximum checkpoint number or epoch boundary). 
  - `IndexerExecutor::shutdown_when`: offers the ability to provide a custom callback for defining more complex upper limit scenarios for the ingestion process.