### PR TITLE
refactor(iota-graphql-rpc): restrict subscriptions feature for `testnet` & `mainnet` networks

### DIFF
--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -655,6 +655,8 @@ async fn subscription_handler(
         .on_upgrade(move |stream| async move {
             // create connection data with per-connection values
             let mut connection_data = Data::default();
+            // axum discards body on GET requests, being always 0
+            connection_data.insert(PayloadSize(0));
             connection_data.insert(Uuid::new_v4());
             if headers_contains_show_usage {
                 connection_data.insert(ShowUsage)

--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -3,11 +3,12 @@
 
 use std::sync::Arc;
 
-use async_graphql::{Context, OutputType, SimpleObject, Subscription, Union};
+use async_graphql::{Context, OutputType, ResultExt, SimpleObject, Subscription, Union};
 use futures::{Stream, StreamExt, TryStreamExt, future};
 use iota_indexer::read::IndexerReader;
 use iota_indexer_streaming::{memory::InMemory, metrics::InMemoryStreamMetrics};
 use iota_json_rpc_types::Filter;
+use iota_types::supported_protocol_versions::Chain;
 use prometheus::Registry;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tracing::warn;
@@ -15,6 +16,7 @@ use tracing::warn;
 use crate::{
     error::Error,
     types::{
+        chain_identifier::ChainIdentifierCache,
         event::Event,
         subscription::filter::{SubscriptionEventFilter, SubscriptionTransactionFilter},
         transaction_block::{TransactionBlock, TransactionBlockInner},
@@ -59,9 +61,29 @@ impl Subscription {
         &self,
         ctx: &Context<'_>,
         filter: Option<SubscriptionTransactionFilter>,
-    ) -> impl Stream<Item = Result<SubscriptionItem<TransactionBlock>, Error>> {
-        let streams = ctx.data_unchecked::<GraphQLStream>().clone();
-        streams.subscribe_transactions(filter)
+    ) -> async_graphql::Result<impl Stream<Item = Result<SubscriptionItem<TransactionBlock>, Error>>>
+    {
+        let chain_id_cache: &ChainIdentifierCache = ctx.data_unchecked();
+
+        let db = ctx.data_unchecked();
+        let metrics = ctx.data_unchecked();
+        let chain = chain_id_cache
+            .read(db, metrics)
+            .await
+            .extend()?
+            .into_inner()
+            .chain();
+
+        if !matches!(chain, Chain::Unknown) {
+            return Err(Error::UnsupportedFeature(format!(
+                "Subscriptions are not yet supported on {}",
+                chain.as_str()
+            )))
+            .extend();
+        }
+
+        let streams = ctx.data_unchecked::<GraphQLStream>();
+        Ok(streams.subscribe_transactions(filter))
     }
 
     /// Subscribe to incoming events from the IOTA network.
@@ -71,9 +93,28 @@ impl Subscription {
         &self,
         ctx: &Context<'_>,
         filter: Option<SubscriptionEventFilter>,
-    ) -> impl Stream<Item = Result<SubscriptionItem<Event>, Error>> {
-        let streams = ctx.data_unchecked::<GraphQLStream>().clone();
-        streams.subscribe_events(filter)
+    ) -> async_graphql::Result<impl Stream<Item = Result<SubscriptionItem<Event>, Error>>> {
+        let chain_id_cache: &ChainIdentifierCache = ctx.data_unchecked();
+
+        let db = ctx.data_unchecked();
+        let metrics = ctx.data_unchecked();
+        let chain = chain_id_cache
+            .read(db, metrics)
+            .await
+            .extend()?
+            .into_inner()
+            .chain();
+
+        if !matches!(chain, Chain::Unknown) {
+            return Err(Error::UnsupportedFeature(format!(
+                "Subscriptions are not yet supported on {}",
+                chain.as_str()
+            )))
+            .extend();
+        }
+
+        let streams = ctx.data_unchecked::<GraphQLStream>();
+        Ok(streams.subscribe_events(filter))
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
 use async_graphql::{Context, OutputType, ResultExt, SimpleObject, Subscription, Union};
 use futures::{Stream, StreamExt, TryStreamExt, future};
 use iota_indexer::read::IndexerReader;
@@ -126,9 +124,8 @@ impl Subscription {
 ///
 /// It ensures that when a critical data error occurs during item conversion,
 /// the resulting stream is gracefully terminated by the server.
-#[derive(Clone)]
 pub(crate) struct GraphQLStream {
-    streamer: Arc<InMemory>,
+    streamer: InMemory,
 }
 
 impl GraphQLStream {
@@ -145,9 +142,7 @@ impl GraphQLStream {
         )
         .await
         .map_err(|e| Error::Internal(format!("failed to connect to postgres: {e}")))?;
-        Ok(Self {
-            streamer: Arc::new(streamer),
-        })
+        Ok(Self { streamer })
     }
 
     /// Checks if the provided filter matches the item.


### PR DESCRIPTION
# Description of change

This PR restricts the usage of the GraphQL Subscription feature only for `testnet` & `mainnet` networks.

## Links to any relevant issues

fixes #9208 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> The path does not affect the normal operation of the indexer, thus no tests were conducted.

### Release Notes
- [x] GraphQL: Usage of the Subscription feature is only supported on `devnet` and local netwroks, as the feature is still in alpha.
