### PR TITLE
fix(wallet): fix accountsFinder start account index

### DIFF
--- a/apps/wallet/src/ui/app/accounts-finder/accountsFinder.ts
+++ b/apps/wallet/src/ui/app/accounts-finder/accountsFinder.ts
@@ -185,10 +185,15 @@ export class AccountsFinder {
 
     async runBreadthSearch() {
         // during breadth search we always start by searching for new account indexes
-        const initialAccountIndex = this.accounts?.length ? this.accounts.length : 0; // next index or start from 0;
+        let initialAccountIndex = 0;
+        const existingIndices = new Set(this.accounts?.map((a) => a.index) || []);
+        // Get the first missing account index
+        while (existingIndices.has(initialAccountIndex)) {
+            initialAccountIndex++;
+        }
 
         const foundAccounts = await recoverAccounts({
-            accountStartIndex: initialAccountIndex, // we start from the last existing account index
+            accountStartIndex: initialAccountIndex, // we start from the first missing account index
             accountGapLimit: this.accountGapLimit, // we search for the full account gap limit
             addressStartIndex: 0, // we start from the first address index
             addressGapLimit: 0, // we only search for 1 address


### PR DESCRIPTION
# Description of change

If there are accounts with index 0 and 2, the account finder would start with index 2 (length accounts). So if one deleted an account by accident or received funds to an account with lower account index than one still has in the wallet, then it's impossible to find this account using the balance finder. One would need to recreate the whole profile.
This PR fixes this by setting the account start index to the first account index that is missing. This can potentially check existing accounts again, but that should still be better and seems to be not create any duplicated entries/issues.
