### PR TITLE
refactor(iota-graphql-rpc): change log level for Subscription responses

### DIFF
--- a/crates/iota-graphql-rpc/src/extensions/logger.rs
+++ b/crates/iota-graphql-rpc/src/extensions/logger.rs
@@ -2,17 +2,25 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt::Write, net::SocketAddr, sync::Arc};
+use std::{
+    fmt::Write,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use async_graphql::{
     PathSegment, Response, ServerError, ServerResult, ValidationResult, Variables,
     extensions::{
         Extension, ExtensionContext, ExtensionFactory, NextExecute, NextParseQuery, NextResolve,
-        NextValidation, ResolveInfo,
+        NextSubscribe, NextValidation, ResolveInfo,
     },
     parser::types::{ExecutableDocument, OperationType, Selection},
 };
 use async_graphql_value::ConstValue;
+use futures::stream::BoxStream;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
@@ -44,16 +52,31 @@ impl ExtensionFactory for Logger {
     fn create(&self) -> Arc<dyn Extension> {
         Arc::new(LoggerExtension {
             config: self.config.clone(),
+            is_subscription: AtomicBool::default(),
         })
     }
 }
 
 struct LoggerExtension {
     config: LoggerConfig,
+    /// Marks if the current request is a subscription.
+    is_subscription: AtomicBool,
 }
 
 #[async_trait::async_trait]
 impl Extension for LoggerExtension {
+    fn subscribe<'s>(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        stream: BoxStream<'s, Response>,
+        next: NextSubscribe<'_>,
+    ) -> BoxStream<'s, Response> {
+        // flag this operation as a subscription so later hooks (execute) can
+        // adjust logging.
+        self.is_subscription.store(true, Ordering::Relaxed);
+        next.run(ctx, stream)
+    }
+
     // This hook is used to get the top level node name for recording in the metrics
     // which top level nodes are being called.
     async fn resolve(
@@ -199,10 +222,19 @@ impl Extension for LoggerExtension {
                         "[Schema] {}", resp.data
                     );
                 }
-                _ => info!(
+                _ if self.is_subscription.load(Ordering::Relaxed) => {
+                    // a subscription can emit many payloads; to avoid flooding normal response
+                    // logs we log subscription payloads at debug level.
+                    debug!(
                         %query_id,
                         %session_id,
-                        "[Response] {}", resp.data
+                        "[Subscription] {}", resp.data
+                    );
+                }
+                _ => info!(
+                    %query_id,
+                    %session_id,
+                    "[Response] {}", resp.data
                 ),
             }
         }


### PR DESCRIPTION
# Description of change

This PR modifies the log level from `INFO` to `DEBUG` for Subscription Responses in the Logger extension to avoid log pollution. 
Since every item received from the Subscription stream is treated as a GraphQL Response. With multiple subscribers at the same time, the logs become too polluted and hard to read.

## Links to any relevant issues

fixes #9114 

## How the change has been tested
- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Ran the GraphQL server by using the iota cli
```shell
RUST_LOG=off,iota_graphql_rpc=info cargo r --features indexer -- start --force-regenesis   --with-indexer --with-graphql
```
When making Subscription requests, the logs were no longer present. If enabling `RUST_LOG=off,iota_graphql_rpc=debug`, the logs were visible.

```shell
2025-11-14T14:58:14.201495Z  INFO iota_graphql_rpc::extensions::logger: [Validation] query_id=9eef57e6-edf0-42cd-829b-6e4b469b8919 session_id=127.0.0.1:52594 complexity=3 depth=2
2025-11-14T14:58:14.456023Z DEBUG iota_graphql_rpc::extensions::logger: [Subscription] {transactions: {__typename: "TransactionBlock", digest: "4aQ17xRBjo9bCgQLcKUdqatUjm7Yck2kUtbJTfwDfj4c"}} query_id=9eef57e6-edf0-42cd-829b-6e4b469b8919 session_id=127.0.0.1:52594
```

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch does not affect the normal operations of the indexer; thus, no tests were conducted.
