### PR TITLE
feat: add retriers on create instance

### DIFF
--- a/crates/iota-aws-orchestrator/assets/run_command.sh
+++ b/crates/iota-aws-orchestrator/assets/run_command.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Script to execute commands on all testbed Node machines
+# Usage: ./run_command.sh <command> [args...]
+# example: run_command.sh \
+# 'ADDR=$(grep -m 1 admin node.log | sed -E "s/.*address=([^ ]+).*/\1/"); \
+# curl -X POST "http://$ADDR/spammer/start?tps=20&mean_size=30000&std_dev_size=3000"'
+# collects the admin address from the node.log and executes the curl admin command
+
+set -e
+
+# Check if at least one argument is provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <command> [args...]"
+    echo "Example: $0 apt update -y"
+    exit 1
+fi
+
+# Get the command to execute (all script arguments)
+REMOTE_COMMAND="$@"
+
+echo "Getting testbed status..."
+# Run the orchestrator and capture output
+ORCHESTRATOR_OUTPUT=$(cargo run --bin iota-aws-orchestrator -- testbed status 2>&1)
+
+# Extract SSH commands ONLY for [Node   ] lines
+# Then add SSH options to skip host key checking and known_hosts updates
+SSH_COMMANDS=$(
+    echo "$ORCHESTRATOR_OUTPUT" \
+    | grep "\[Node" \
+    | grep -o "ssh -i [^ ]* [^ ]*@[0-9\.]*" \
+    | sed 's/^ssh /ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=\/dev\/null /' \
+    | sort -u
+)
+
+# Count the number of node machines
+MACHINE_COUNT=$(echo "$SSH_COMMANDS" | sed '/^\s*$/d' | wc -l)
+
+if [ "$MACHINE_COUNT" -eq 0 ]; then
+    echo "Error: No Node SSH commands found in orchestrator output"
+    exit 1
+fi
+
+echo "Found $MACHINE_COUNT node machines"
+echo "Executing command: $REMOTE_COMMAND"
+echo "----------------------------------------"
+
+# Create a temporary directory for logs
+LOG_DIR=$(mktemp -d)
+echo "Logs will be stored in: $LOG_DIR"
+
+# Counter for progress
+COUNTER=0
+
+# Execute command on all node machines in parallel
+while IFS= read -r SSH_CMD; do
+    # skip empty lines just in case
+    [ -z "$SSH_CMD" ] && continue
+
+    COUNTER=$((COUNTER + 1))
+    HOST=$(echo "$SSH_CMD" | grep -oP '[^@\s]+@\K[0-9.]+')
+
+    # Execute in background and log output
+    (
+        echo "[$COUNTER/$MACHINE_COUNT] Executing on $HOST..."
+        if $SSH_CMD "$REMOTE_COMMAND" > "$LOG_DIR/$HOST.log" 2>&1; then
+            echo "[$COUNTER/$MACHINE_COUNT] ✓ Success on $HOST"
+        else
+            echo "[$COUNTER/$MACHINE_COUNT] ✗ Failed on $HOST (see $LOG_DIR/$HOST.log)"
+        fi
+    ) &
+done <<< "$SSH_COMMANDS"
+
+# Wait for all background jobs to complete
+wait
+
+echo "----------------------------------------"
+echo "Execution complete!"
+echo "Logs available in: $LOG_DIR"
+echo ""
+echo "To view logs for a specific host:"
+echo "  cat $LOG_DIR/<host-ip>.log"
+echo ""
+echo "To view all logs:"
+echo "  cat $LOG_DIR/*.log"

--- a/crates/iota-aws-orchestrator/src/client/aws.rs
+++ b/crates/iota-aws-orchestrator/src/client/aws.rs
@@ -23,6 +23,7 @@ use serde::Serialize;
 
 use super::{Instance, InstanceLifecycle, InstanceRole, ServerProviderClient};
 use crate::{
+    display,
     error::{CloudProviderError, CloudProviderResult},
     settings::Settings,
 };
@@ -471,28 +472,38 @@ impl ServerProviderClient for AwsClient {
             .tag_specifications(tags);
         let mut collected_instances = Vec::new();
         if use_spot_instances && role == InstanceRole::Node {
-            // first attempt to deploy sport instances
-            let request = base_request
-                .clone()
-                .min_count(1)
-                .max_count(quantity as i32)
-                .instance_market_options(Self::spot_options());
-            let result = request.send().await;
-            let instances = match result {
-                Ok(response) => response
-                    .instances()
-                    .iter()
-                    .map(|i| self.make_instance(region.clone(), i))
-                    .collect(),
-                Err(_) => Vec::new(),
-            };
-            collected_instances.extend(instances);
+            let start = tokio::time::Instant::now();
+            // 5min try for spot instances
+            let total_runtime = tokio::time::Duration::from_secs(300);
+            while start.elapsed() < total_runtime && collected_instances.len() < quantity {
+                display::status(format!(
+                    "{}s/{}s: {}",
+                    start.elapsed().as_secs(),
+                    total_runtime.as_secs(),
+                    collected_instances.len()
+                ));
+                let needed = (quantity - collected_instances.len()) as i32;
+                let request = base_request
+                    .clone()
+                    .min_count(1)
+                    .max_count(needed)
+                    .instance_market_options(Self::spot_options());
+                let result = request.send().await;
+                let instances = match result {
+                    Ok(response) => response
+                        .instances()
+                        .iter()
+                        .map(|i| self.make_instance(region.clone(), i))
+                        .collect(),
+                    Err(_) => Vec::new(),
+                };
+                collected_instances.extend(instances);
+            }
         }
-        if collected_instances.len() < quantity {
+        while collected_instances.len() < quantity {
             // some instances need to be OnDemand
-            let request = base_request
-                .min_count((quantity - collected_instances.len()) as i32)
-                .max_count((quantity - collected_instances.len()) as i32);
+            let needed = (quantity - collected_instances.len()) as i32;
+            let request = base_request.clone().min_count(1).max_count(needed);
             let response = request.send().await?;
             let on_demand_instances = response
                 .instances()
@@ -500,6 +511,10 @@ impl ServerProviderClient for AwsClient {
                 .map(|instance| self.make_instance(region.clone(), instance))
                 .collect::<Vec<_>>();
             collected_instances.extend(on_demand_instances);
+            display::status(format!(
+                "collected instances: {}",
+                collected_instances.len()
+            ));
         }
         Ok(collected_instances)
     }

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -408,6 +408,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         // to avoid keeping alive many ssh connections for too long.
         let build_command = [
             "source \"$HOME/.cargo/env\"".to_string(),
+            "export RUSTFLAGS='-C target-cpu=native'".to_string(),
             "cargo build --release --bin iota --bin iota-node --bin stress".to_string(),
         ]
         .join(" && ");

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -105,6 +105,7 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
         [
             &format!("mkdir -p {working_dir}"),
             "source $HOME/.cargo/env",
+            "export RUSTFLAGS='-C target-cpu=native'",
             &genesis,
         ]
         .join(" && ")
@@ -154,7 +155,12 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                     ),
                 ]
                 .join(" ");
-                let command = ["source $HOME/.cargo/env", &run].join(" && ");
+                let command = [
+                    "source $HOME/.cargo/env",
+                    "export RUSTFLAGS='-C target-cpu=native'",
+                    &run,
+                ]
+                .join(" && ");
 
                 display::action(format!("\n Command ({i}): {command}"));
 
@@ -216,7 +222,12 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                     &format!("--client-metric-host 0.0.0.0 --client-metric-port {metrics_port}"),
                 ]
                 .join(" ");
-                let command = ["source $HOME/.cargo/env", &run].join(" && ");
+                let command = [
+                    "source $HOME/.cargo/env",
+                    "export RUSTFLAGS='-C target-cpu=native'",
+                    &run,
+                ]
+                .join(" && ");
 
                 (instance, command)
             })


### PR DESCRIPTION
# Description of change

The `run_instances` aws command fails to return the minimum number of instances for both spot and on-demand. It needs to be retried a few times to collect the appropriate amount.

- requests spot instances in a loop for 5 minutes attempting to collect as many available ones as needed.
- requests on-demand instances in a loop until the full quantity of required instances is not collected.
- displays a status of the time left in the spot instance loop as well as the number of instances collected.
- added the `assets/run_command.sh` script to execute a command on every Node instance. 
- adds `RUSTFLAGS=-Ctarget-cpu=native` build flag to optimize for CPU in test available instructions.

## Links to any relevant issues

fixes #9274.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

