### PR TITLE
feat(core-node): Add allocation metrics to flamegraphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Move.lock
 
 # Flamegraph output
 flamegraph.svg
+flamegraph-mem.svg
 
 # Thumbnails
 ._*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5728,6 +5728,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "regex",
+ "rustc_version_runtime",
  "serde",
  "serde_json",
  "strum 0.26.3",
@@ -7194,6 +7195,7 @@ dependencies = [
  "move-vm-profiler",
  "prometheus",
  "reqwest 0.12.7",
+ "rustc_version_runtime",
  "serde",
  "tap",
  "telemetry-subscribers",
@@ -12722,6 +12724,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14359,6 +14371,7 @@ dependencies = [
  "prometheus",
  "prost 0.13.3",
  "rand 0.8.5",
+ "rustc_version_runtime",
  "serde",
  "thiserror 1.0.64",
  "tokio",

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -612,7 +612,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         if self.settings.enable_flamegraph {
             self.fetch_flamegraphs(
                 parameters,
-                self.node_instances.clone(),
+                self.instances_without_metrics().clone(),
                 &path,
                 "?svg=true",
                 "flamegraph",
@@ -627,7 +627,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             {
                 self.fetch_flamegraphs(
                     parameters,
-                    self.node_instances.clone(),
+                    self.instances_without_metrics().clone(),
                     &path,
                     "?svg=true&mem=true",
                     "flamegraph-alloc",

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -623,9 +623,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
                 .settings
                 .build_configs
                 .get("iota-node")
-                .is_some_and(|config| {
-                    config.features.iter().any(|f| f == "flamegraph-alloc")
-                })
+                .is_some_and(|config| config.features.iter().any(|f| f == "flamegraph-alloc"))
             {
                 self.fetch_flamegraphs(
                     parameters,

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -618,6 +618,24 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
                 "flamegraph",
             )
             .await?;
+
+            if self
+                .settings
+                .build_configs
+                .get("iota-node")
+                .map_or(false, |config| {
+                    config.features.iter().any(|f| f == "flamegraph-alloc")
+                })
+            {
+                self.fetch_flamegraphs(
+                    parameters,
+                    self.node_instances.clone(),
+                    &path,
+                    "?svg=true&mem=true",
+                    "flamegraph-alloc",
+                )
+                .await?;
+            }
         }
 
         display::done();

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -623,7 +623,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
                 .settings
                 .build_configs
                 .get("iota-node")
-                .map_or(false, |config| {
+                .is_some_and(|config| {
                     config.features.iter().any(|f| f == "flamegraph-alloc")
                 })
             {

--- a/crates/iota-aws-orchestrator/src/protocol/mod.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/mod.rs
@@ -103,7 +103,7 @@ pub trait ProtocolMetrics {
         self.nodes_metrics_path(instances, parameters)
             .into_iter()
             .map(|(instance, path)| {
-                let cmd = format!("curl {path}");
+                let cmd = format!("curl '{path}'");
                 display::action(format!("\n{cmd}"));
                 (instance, cmd)
             })
@@ -125,7 +125,7 @@ pub trait ProtocolMetrics {
             .into_iter()
             .map(|instance| {
                 (instance, {
-                    let cmd = format!("curl http://localhost:1337/flamegraph{query}");
+                    let cmd = format!("curl 'http://localhost:1337/flamegraph{query}'");
                     display::action(format!("\n{cmd}"));
                     cmd.to_string()
                 })
@@ -154,7 +154,7 @@ pub trait ProtocolMetrics {
     {
         self.clients_metrics_path(instances, parameters)
             .into_iter()
-            .map(|(instance, path)| (instance, format!("curl {path}")))
+            .map(|(instance, path)| (instance, format!("curl '{path}'")))
             .collect()
     }
 }

--- a/crates/iota-benchmark/Cargo.toml
+++ b/crates/iota-benchmark/Cargo.toml
@@ -62,7 +62,6 @@ iota-surfer.workspace = true
 typed-store.workspace = true
 
 [[bin]]
-
 name = "flamegraph"
 path = "src/bin/flamegraph.rs"
 required-features = ["flamegraph-alloc"]

--- a/crates/iota-benchmark/Cargo.toml
+++ b/crates/iota-benchmark/Cargo.toml
@@ -61,6 +61,9 @@ iota-simulator.workspace = true
 iota-surfer.workspace = true
 typed-store.workspace = true
 
+[build-dependencies]
+rustc_version_runtime = "0.3"
+
 [[bin]]
 name = "flamegraph"
 path = "src/bin/flamegraph.rs"

--- a/crates/iota-benchmark/Cargo.toml
+++ b/crates/iota-benchmark/Cargo.toml
@@ -9,6 +9,9 @@ publish = false
 [lints]
 workspace = true
 
+[features]
+flamegraph-alloc = ["telemetry-subscribers/flamegraph-alloc"]
+
 [dependencies]
 # external dependencies
 anyhow = { workspace = true, features = ["backtrace"] }
@@ -57,3 +60,9 @@ iota-macros.workspace = true
 iota-simulator.workspace = true
 iota-surfer.workspace = true
 typed-store.workspace = true
+
+[[bin]]
+
+name = "flamegraph"
+path = "src/bin/flamegraph.rs"
+required-features = ["flamegraph-alloc"]

--- a/crates/iota-benchmark/build.rs
+++ b/crates/iota-benchmark/build.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    // Declare the custom cfg to avoid warnings
+    println!("cargo::rustc-check-cfg=cfg(nightly)");
+
+    // Detect if we're using nightly Rust
+    let meta = rustc_version_runtime::version_meta();
+    if meta.channel == rustc_version_runtime::Channel::Nightly {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}

--- a/crates/iota-benchmark/src/bin/flamegraph.rs
+++ b/crates/iota-benchmark/src/bin/flamegraph.rs
@@ -1,15 +1,14 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{alloc::System, fs};
-
 use iota_test_transaction_builder::make_transfer_iota_transaction;
-use telemetry_subscribers::flamegraph::CounterAlloc;
 use test_cluster::TestClusterBuilder;
 use tracing::Instrument as _;
 
+#[cfg(all(feature = "flamegraph-alloc", nightly))]
 #[global_allocator]
-static GLOBAL: CounterAlloc<System> = CounterAlloc::new(System);
+static GLOBAL: telemetry_subscribers::flamegraph::CounterAlloc<std::alloc::System> =
+    telemetry_subscribers::flamegraph::CounterAlloc::new(std::alloc::System);
 
 /// This is a binary to generate test flamegraph data in a simple benchmark with
 /// a local test cluster. To run it, use:
@@ -34,7 +33,10 @@ async fn main() {
     println!("{}", serde_json::to_string_pretty(&nested_sets).unwrap());
 
     use std::io::Write as _;
+
+    #[allow(unused_mut)]
     let mut config = Default::default();
+
     std::fs::File::create("flamegraph.svg")
         .unwrap()
         .write_all(
@@ -44,7 +46,7 @@ async fn main() {
                 .as_bytes(),
         )
         .unwrap();
-    #[cfg(feature = "flamegraph-alloc")]
+    #[cfg(all(feature = "flamegraph-alloc", nightly))]
     {
         config.measure_mem = true;
         std::fs::File::create("flamegraph-mem.svg")

--- a/crates/iota-benchmark/src/bin/flamegraph.rs
+++ b/crates/iota-benchmark/src/bin/flamegraph.rs
@@ -2,10 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fs;
+use std::alloc::System;
 
 use iota_test_transaction_builder::make_transfer_iota_transaction;
+use telemetry_subscribers::flamegraph::CounterAlloc;
 use test_cluster::TestClusterBuilder;
 use tracing::Instrument as _;
+
+#[global_allocator]
+static GLOBAL: CounterAlloc<System> = CounterAlloc::new(System);
 
 /// This is a binary to generate test flamegraph data in a simple benchmark with
 /// a local test cluster. To run it, use:

--- a/crates/iota-benchmark/src/bin/flamegraph.rs
+++ b/crates/iota-benchmark/src/bin/flamegraph.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs;
-use std::alloc::System;
+use std::{alloc::System, fs};
 
 use iota_test_transaction_builder::make_transfer_iota_transaction;
 use telemetry_subscribers::flamegraph::CounterAlloc;
@@ -31,26 +30,31 @@ async fn main() {
 
     // follow instructions in telemetry-subscribers README how to setup grafana to
     // visualize the flamegraphs
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&sub.get_nested_sets(
-            "iota-benchmark::flamegraph",
-            true,
-            true
-        ))
-        .unwrap()
-    );
-    println!();
+    let nested_sets = sub.get_nested_sets("iota-benchmark::flamegraph", true, true);
+    println!("{}", serde_json::to_string_pretty(&nested_sets).unwrap());
 
-    let svg = sub
-        .get_combined_svg(
-            "iota-benchmark::flamegraph",
-            true,
-            true,
-            &Default::default(),
-        )
+    use std::io::Write as _;
+    let mut config = Default::default();
+    std::fs::File::create("flamegraph.svg")
         .unwrap()
-        .into_string();
-    fs::write("flamegraph.svg", &svg).expect("Failed to write flamegraph.svg");
-    println!("Flamegraph written to flamegraph.svg");
+        .write_all(
+            sub.get_combined_svg("iota-benchmark::flamegraph", true, true, &config)
+                .unwrap()
+                .into_string()
+                .as_bytes(),
+        )
+        .unwrap();
+    #[cfg(feature = "flamegraph-alloc")]
+    {
+        config.measure_mem = true;
+        std::fs::File::create("flamegraph-mem.svg")
+            .unwrap()
+            .write_all(
+                sub.get_combined_svg("iota-benchmark::flamegraph", true, true, &config)
+                    .unwrap()
+                    .into_string()
+                    .as_bytes(),
+            )
+            .unwrap();
+    }
 }

--- a/crates/iota-build-cache-server/scripts/build.sh
+++ b/crates/iota-build-cache-server/scripts/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Get script directory and source config
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+source "$SCRIPT_DIR/utils.sh"
+
+print_config
+check_availability
+AVAILABILITY_CHECK=$?
+set -e  # Enable exit on error
+
+# If build is not available, start build and wait
+if [ $AVAILABILITY_CHECK -ne 0 ]; then
+    # Build will resolve branch/tag to commit and update COMMIT variable
+    log_info "Starting build for commit/branch/tag: $COMMIT"
+    build
+    
+    log_info "Waiting for build to complete for commit: $COMMIT"
+    wait
+fi
+
+log_info "Build completed for commit: $COMMIT"

--- a/crates/iota-node/Cargo.toml
+++ b/crates/iota-node/Cargo.toml
@@ -9,6 +9,9 @@ publish = false
 [lints]
 workspace = true
 
+[features]
+flamegraph-alloc = ["telemetry-subscribers/flamegraph-alloc"]
+
 [dependencies]
 # external dependencies
 anemo.workspace = true

--- a/crates/iota-node/Cargo.toml
+++ b/crates/iota-node/Cargo.toml
@@ -63,5 +63,8 @@ move-vm-profiler.workspace = true
 telemetry-subscribers.workspace = true
 typed-store.workspace = true
 
+[build-dependencies]
+rustc_version_runtime = "0.3"
+
 [target.'cfg(msim)'.dependencies]
 iota-simulator.workspace = true

--- a/crates/iota-node/build.rs
+++ b/crates/iota-node/build.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    // Declare the custom cfg to avoid warnings
+    println!("cargo::rustc-check-cfg=cfg(nightly)");
+
+    // Detect if we're using nightly Rust
+    let meta = rustc_version_runtime::version_meta();
+    if meta.channel == rustc_version_runtime::Channel::Nightly {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -473,7 +473,7 @@ struct Flamegraph {
     #[serde(default)]
     graph_id: String,
     /// Use memory allocations as span measure rather than duration.
-    #[cfg(feature = "flamegraph-alloc")]
+    #[cfg(all(feature = "flamegraph-alloc", nightly))]
     #[serde(default)]
     mem: bool,
 }
@@ -486,7 +486,7 @@ async fn flamegraph(State(state): State<Arc<AppState>>, query: Query<Flamegraph>
             mut running,
             mut completed,
             graph_id,
-            #[cfg(feature = "flamegraph-alloc")]
+            #[cfg(all(feature = "flamegraph-alloc", nightly))]
             mem,
         }) = query;
         if !running && !completed {
@@ -498,7 +498,7 @@ async fn flamegraph(State(state): State<Arc<AppState>>, query: Query<Flamegraph>
             let width = if width == 0 { Some(3600) } else { Some(width) };
             let config = telemetry_subscribers::flamegraph::SvgConfig {
                 width,
-                #[cfg(feature = "flamegraph-alloc")]
+                #[cfg(all(feature = "flamegraph-alloc", nightly))]
                 measure_mem: mem,
                 ..Default::default()
             };

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -473,7 +473,6 @@ struct Flamegraph {
     #[serde(default)]
     graph_id: String,
     /// Use memory allocations as span measure rather than duration.
-    #[cfg(all(feature = "flamegraph-alloc", nightly))]
     #[serde(default)]
     mem: bool,
 }
@@ -486,7 +485,6 @@ async fn flamegraph(State(state): State<Arc<AppState>>, query: Query<Flamegraph>
             mut running,
             mut completed,
             graph_id,
-            #[cfg(all(feature = "flamegraph-alloc", nightly))]
             mem,
         }) = query;
         if !running && !completed {
@@ -494,8 +492,19 @@ async fn flamegraph(State(state): State<Arc<AppState>>, query: Query<Flamegraph>
             completed = true;
         }
         if svg {
+            #[cfg(not(all(feature = "flamegraph-alloc", nightly)))]
+            {
+                if mem {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        "memory flamegraphs are not supported (re-run iota-node with 'flamegraph-alloc' feature enabled and on nightly Rust toolchain)",
+                    )
+                        .into_response();
+                }
+            }
+
             // draw an svg
-            let width = if width == 0 { Some(3600) } else { Some(width) };
+            let width = if width == 0 { Some(1920) } else { Some(width) };
             let config = telemetry_subscribers::flamegraph::SvgConfig {
                 width,
                 #[cfg(all(feature = "flamegraph-alloc", nightly))]

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -460,7 +460,7 @@ struct Flamegraph {
     /// Toggle SVG response, otherwise return nested set model for Grafana.
     #[serde(default)]
     svg: bool,
-    /// SVG width in pixels (when missing or set to 0 will default to 3600).
+    /// SVG width in pixels (when missing or set to 0 will default to 1920).
     #[serde(default)]
     width: usize,
     /// Select still running call graphs.

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -460,7 +460,7 @@ struct Flamegraph {
     /// Toggle SVG response, otherwise return nested set model for Grafana.
     #[serde(default)]
     svg: bool,
-    /// SVG width in pixels (3600 by default).
+    /// SVG width in pixels (when missing or set to 0 will default to 3600).
     #[serde(default)]
     width: usize,
     /// Select still running call graphs.
@@ -472,6 +472,10 @@ struct Flamegraph {
     /// Select call graph with the given ID.
     #[serde(default)]
     graph_id: String,
+    /// Use memory allocations as span measure rather than duration.
+    #[cfg(feature = "flamegraph-alloc")]
+    #[serde(default)]
+    mem: bool,
 }
 
 async fn flamegraph(State(state): State<Arc<AppState>>, query: Query<Flamegraph>) -> Response {
@@ -482,6 +486,8 @@ async fn flamegraph(State(state): State<Arc<AppState>>, query: Query<Flamegraph>
             mut running,
             mut completed,
             graph_id,
+            #[cfg(feature = "flamegraph-alloc")]
+            mem,
         }) = query;
         if !running && !completed {
             running = true;
@@ -492,6 +498,8 @@ async fn flamegraph(State(state): State<Arc<AppState>>, query: Query<Flamegraph>
             let width = if width == 0 { Some(3600) } else { Some(width) };
             let config = telemetry_subscribers::flamegraph::SvgConfig {
                 width,
+                #[cfg(feature = "flamegraph-alloc")]
+                measure_mem: mem,
                 ..Default::default()
             };
             let svg = if !graph_id.is_empty() {

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -13,12 +13,12 @@ use iota_types::{
     committee::EpochId, messages_checkpoint::CheckpointSequenceNumber, multiaddr::Multiaddr,
     supported_protocol_versions::SupportedProtocolVersions,
 };
-#[cfg(feature = "flamegraph-alloc")]
+#[cfg(all(feature = "flamegraph-alloc", nightly))]
 use telemetry_subscribers::flamegraph::CounterAlloc;
 use tokio::sync::broadcast;
 use tracing::{error, info};
 
-#[cfg(feature = "flamegraph-alloc")]
+#[cfg(all(feature = "flamegraph-alloc", nightly))]
 #[global_allocator]
 static GLOBAL: CounterAlloc<std::alloc::System> = CounterAlloc::new(std::alloc::System);
 

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -13,8 +13,14 @@ use iota_types::{
     committee::EpochId, messages_checkpoint::CheckpointSequenceNumber, multiaddr::Multiaddr,
     supported_protocol_versions::SupportedProtocolVersions,
 };
+#[cfg(feature = "flamegraph-alloc")]
+use telemetry_subscribers::flamegraph::CounterAlloc;
 use tokio::sync::broadcast;
 use tracing::{error, info};
+
+#[cfg(feature = "flamegraph-alloc")]
+#[global_allocator]
+static GLOBAL: CounterAlloc<std::alloc::System> = CounterAlloc::new(std::alloc::System);
 
 // Define the `GIT_REVISION` and `VERSION` consts
 bin_version::bin_version!();

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -301,11 +301,8 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
-    pub fn with_admin_interface_address(
-        mut self,
-        admin_interface_address: Option<SocketAddr>,
-    ) -> Self {
-        self.admin_interface_address = admin_interface_address;
+    pub fn with_admin_interface_address(mut self, admin_interface_address: SocketAddr) -> Self {
+        self.admin_interface_address = Some(admin_interface_address);
         self
     }
 

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -301,8 +301,11 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
-    pub fn with_admin_interface_address(mut self, admin_interface_address: SocketAddr) -> Self {
-        self.admin_interface_address = Some(admin_interface_address);
+    pub fn with_admin_interface_address(
+        mut self,
+        admin_interface_address: Option<SocketAddr>,
+    ) -> Self {
+        self.admin_interface_address = admin_interface_address;
         self
     }
 

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -388,9 +388,9 @@ impl FullnodeConfigBuilder {
 
     pub fn with_admin_interface_address(
         mut self,
-        admin_interface_address: impl Into<SocketAddr>,
+        admin_interface_address: Option<impl Into<SocketAddr>>,
     ) -> Self {
-        self.admin_interface_address = Some(admin_interface_address.into());
+        self.admin_interface_address = admin_interface_address.map(|addr| addr.into());
         self
     }
 

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -1160,26 +1160,26 @@ async fn genesis(
         genesis_conf.parameters.epoch_duration_ms = epoch_duration_ms;
     }
 
-    let admin_interface_address_with_port = match admin_interface_address {
-        Some(input) => {
+    let admin_interface_address_with_port = admin_interface_address
+        .map(|input| {
             let default_port = iota_config::node::default_admin_interface_address().port();
-            Some(
-                parse_host_port(input, default_port)
-                    .map_err(|_| anyhow!("Invalid admin interface host and port"))?,
-            )
-        }
-        None => Some(iota_config::node::default_admin_interface_address()),
-    };
+            parse_host_port(input, default_port)
+                .map_err(|_| anyhow!("Invalid admin interface host and port"))
+        })
+        .transpose()?;
 
     let mut builder = ConfigBuilder::new(iota_config_dir)
         .with_genesis_config(genesis_conf)
-        .with_empty_validator_genesis()
-        .with_admin_interface_address(admin_interface_address_with_port);
+        .with_empty_validator_genesis();
     builder = if let Some(validators) = validator_info {
         builder.with_validators(validators)
     } else {
         builder.committee_size(NonZeroUsize::new(committee_size).unwrap())
     };
+
+    if let Some(address) = admin_interface_address_with_port {
+        builder = builder.with_admin_interface_address(address);
+    }
 
     let network_config = tokio::task::spawn_blocking(move || builder.build()).await?;
     let mut keystore = FileBasedKeystore::new(&keystore_path)?;

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -1159,20 +1159,28 @@ async fn genesis(
     if let Some(epoch_duration_ms) = epoch_duration_ms {
         genesis_conf.parameters.epoch_duration_ms = epoch_duration_ms;
     }
+
+    let admin_interface_address_with_port = match admin_interface_address {
+        Some(input) => {
+            let default_port = iota_config::node::default_admin_interface_address().port();
+            Some(
+                parse_host_port(input, default_port)
+                    .map_err(|_| anyhow!("Invalid admin interface host and port"))?,
+            )
+        }
+        None => Some(iota_config::node::default_admin_interface_address()),
+    };
+
     let mut builder = ConfigBuilder::new(iota_config_dir)
         .with_genesis_config(genesis_conf)
-        .with_empty_validator_genesis();
+        .with_empty_validator_genesis()
+        .with_admin_interface_address(admin_interface_address_with_port);
     builder = if let Some(validators) = validator_info {
         builder.with_validators(validators)
     } else {
         builder.committee_size(NonZeroUsize::new(committee_size).unwrap())
     };
-    if let Some(input) = admin_interface_address {
-        let default_port = iota_config::node::default_admin_interface_address().port();
-        let admin_interface_address = parse_host_port(input, default_port)
-            .map_err(|_| anyhow!("Invalid admin interface host and port"))?;
-        builder = builder.with_admin_interface_address(admin_interface_address);
-    }
+
     let network_config = tokio::task::spawn_blocking(move || builder.build()).await?;
     let mut keystore = FileBasedKeystore::new(&keystore_path)?;
     for key in &network_config.account_keys {
@@ -1202,6 +1210,7 @@ async fn genesis(
         .with_config_directory(FULL_NODE_DB_PATH.into())
         .with_rpc_addr(iota_config::node::default_json_rpc_address())
         .with_genesis(genesis.clone())
+        .with_admin_interface_address(admin_interface_address_with_port)
         .build_from_parts(&mut OsRng, network_config.validator_configs(), genesis);
 
     fullnode_config.save(iota_config_dir.join(IOTA_FULLNODE_CONFIG))?;
@@ -1220,7 +1229,7 @@ async fn genesis(
                 .with_db_path(PathBuf::from("/opt/iota/db/authorities_db/full_node_db"))
                 .with_network_address("/ip4/0.0.0.0/tcp/8080/http".parse()?)
                 .with_metrics_address(([0, 0, 0, 0], 9184))
-                .with_admin_interface_address(([127, 0, 0, 1], 1337))
+                .with_admin_interface_address(admin_interface_address_with_port)
                 .with_json_rpc_address(([0, 0, 0, 0], 9000))
                 .with_genesis(genesis.clone())
                 .build_from_parts(&mut OsRng, network_config.validator_configs(), genesis);

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -10,6 +10,9 @@ description = "Library for common telemetry and observability functionality"
 [lints]
 workspace = true
 
+[features]
+flamegraph-alloc = []
+
 [dependencies]
 atomic_float = "1.0"
 bytes.workspace = true

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -39,5 +39,8 @@ tracing-appender = "0.2.2"
 tracing-opentelemetry = "0.28.0"
 tracing-subscriber.workspace = true
 
+[build-dependencies]
+rustc_version_runtime = "0.3"
+
 [dev-dependencies]
 camino.workspace = true

--- a/crates/telemetry-subscribers/build.rs
+++ b/crates/telemetry-subscribers/build.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    // Declare the custom cfg to avoid warnings
+    println!("cargo::rustc-check-cfg=cfg(nightly)");
+
+    // Detect if we're using nightly Rust
+    let meta = rustc_version_runtime::version_meta();
+    if meta.channel == rustc_version_runtime::Channel::Nightly {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}

--- a/crates/telemetry-subscribers/src/flamegraph.rs
+++ b/crates/telemetry-subscribers/src/flamegraph.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "flamegraph-alloc")]
+mod alloc;
 mod arena;
 mod callgraph;
 mod flame;
@@ -8,6 +10,9 @@ mod grafana;
 mod metric;
 mod svg;
 mod tracing;
+#[cfg(feature = "flamegraph-alloc")]
+pub use alloc::{AllocMetrics, CounterAlloc, get_alloc_metrics};
+
 pub use grafana::NestedSetFrame;
 pub use svg::{Config as SvgConfig, Svg};
 pub use tracing::FlameSub;

--- a/crates/telemetry-subscribers/src/flamegraph.rs
+++ b/crates/telemetry-subscribers/src/flamegraph.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "flamegraph-alloc")]
+#[cfg(all(feature = "flamegraph-alloc", nightly))]
 mod alloc;
 mod arena;
 mod callgraph;
@@ -10,7 +10,7 @@ mod grafana;
 mod metric;
 mod svg;
 mod tracing;
-#[cfg(feature = "flamegraph-alloc")]
+#[cfg(all(feature = "flamegraph-alloc", nightly))]
 pub use alloc::{AllocMetrics, CounterAlloc, get_alloc_metrics};
 
 pub use grafana::NestedSetFrame;

--- a/crates/telemetry-subscribers/src/flamegraph/alloc.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/alloc.rs
@@ -14,7 +14,7 @@ impl<A> CounterAlloc<A> {
     }
 }
 
-#[cfg_attr(feature = "flamegraph-alloc", thread_local)]
+#[thread_local]
 static mut THREAD_METRICS: AllocMetrics = AllocMetrics::new();
 
 pub fn get_alloc_metrics() -> AllocMetrics {

--- a/crates/telemetry-subscribers/src/flamegraph/alloc.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/alloc.rs
@@ -82,12 +82,37 @@ impl AllocMetrics {
         self.peak = self.peak.max(other.peak);
     }
 }
+struct Iec(usize);
+impl fmt::Display for Iec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0 < 1024 {
+            write!(f, "{}B", self.0)
+        } else if self.0 < 1024 * 1024 {
+            write!(f, "{:.2}KiB", self.0 as f64 / 1024.0)
+        } else if self.0 < 1024 * 1024 * 1024 {
+            write!(f, "{:.2}MiB", self.0 as f64 / 1024.0 / 1024.0)
+        } else {
+            write!(f, "{:.2}GiB", self.0 as f64 / 1024.0 / 1024.0 / 1024.0)
+        }
+    }
+}
 impl fmt::Debug for AllocMetrics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "alloc={} dealloc={} peak={}",
             self.alloc, self.dealloc, self.peak
+        )
+    }
+}
+impl fmt::Display for AllocMetrics {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "alloc={} total={} peak={}",
+            Iec(self.alloc.saturating_sub(self.dealloc)),
+            Iec(self.alloc),
+            Iec(self.peak)
         )
     }
 }

--- a/crates/telemetry-subscribers/src/flamegraph/alloc.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/alloc.rs
@@ -1,0 +1,93 @@
+use std::{
+    alloc::{GlobalAlloc, System},
+    fmt,
+};
+
+// #[global_allocator]
+// static GLOBAL: CounterAlloc<System> = CounterAlloc::new(System);
+
+#[derive(Default)]
+pub struct CounterAlloc<A = System>(A);
+impl<A> CounterAlloc<A> {
+    pub const fn new(alloc: A) -> Self {
+        CounterAlloc(alloc)
+    }
+}
+
+#[thread_local]
+static mut THREAD_METRICS: AllocMetrics = AllocMetrics::new();
+
+pub fn get_alloc_metrics() -> AllocMetrics {
+    unsafe { THREAD_METRICS }
+}
+
+fn update_metrics(old: usize, new: usize) {
+    unsafe {
+        THREAD_METRICS.alloc += new;
+    }
+    unsafe {
+        THREAD_METRICS.dealloc += old;
+    }
+    unsafe {
+        THREAD_METRICS.peak = THREAD_METRICS
+            .alloc
+            .abs_diff(THREAD_METRICS.dealloc)
+            .max(THREAD_METRICS.peak);
+    }
+}
+
+unsafe impl<A: GlobalAlloc> GlobalAlloc for CounterAlloc<A> {
+    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+        update_metrics(0, layout.size());
+        unsafe { self.0.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+        update_metrics(layout.size(), 0);
+        unsafe { self.0.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: std::alloc::Layout, new_size: usize) -> *mut u8 {
+        update_metrics(layout.size(), new_size);
+        unsafe { self.0.realloc(ptr, layout, new_size) }
+    }
+    unsafe fn alloc_zeroed(&self, layout: std::alloc::Layout) -> *mut u8 {
+        update_metrics(0, layout.size());
+        unsafe { self.0.alloc_zeroed(layout) }
+    }
+}
+
+#[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
+pub struct AllocMetrics {
+    pub alloc: usize,
+    pub dealloc: usize,
+    pub peak: usize,
+}
+impl AllocMetrics {
+    pub const fn new() -> Self {
+        Self {
+            alloc: 0,
+            dealloc: 0,
+            peak: 0,
+        }
+    }
+    pub fn delta(&self, other: Self) -> Self {
+        Self {
+            alloc: self.alloc.saturating_sub(other.alloc),
+            dealloc: self.dealloc.saturating_sub(other.dealloc),
+            peak: self.peak.saturating_sub(other.peak),
+        }
+    }
+    pub fn merge(&mut self, other: Self) {
+        self.alloc += other.alloc;
+        self.dealloc += other.dealloc;
+        self.peak = self.peak.max(other.peak);
+    }
+}
+impl fmt::Debug for AllocMetrics {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "alloc={} dealloc={} peak={}",
+            self.alloc, self.dealloc, self.peak
+        )
+    }
+}

--- a/crates/telemetry-subscribers/src/flamegraph/alloc.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/alloc.rs
@@ -14,7 +14,7 @@ impl<A> CounterAlloc<A> {
     }
 }
 
-#[thread_local]
+#[cfg_attr(feature = "flamegraph-alloc", thread_local)]
 static mut THREAD_METRICS: AllocMetrics = AllocMetrics::new();
 
 pub fn get_alloc_metrics() -> AllocMetrics {

--- a/crates/telemetry-subscribers/src/flamegraph/alloc.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/alloc.rs
@@ -1,10 +1,10 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{
     alloc::{GlobalAlloc, System},
     fmt,
 };
-
-// #[global_allocator]
-// static GLOBAL: CounterAlloc<System> = CounterAlloc::new(System);
 
 #[derive(Default)]
 pub struct CounterAlloc<A = System>(A);

--- a/crates/telemetry-subscribers/src/flamegraph/callgraph.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/callgraph.rs
@@ -39,7 +39,7 @@ impl PartialEq<str> for FrameLabel {
 }
 
 /// Call graph frame.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub(super) struct Frame<S> {
     /// Frame identifier.
     pub(super) label: FrameLabel,

--- a/crates/telemetry-subscribers/src/flamegraph/metric.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/metric.rs
@@ -3,6 +3,9 @@
 
 use std::{fmt, time::Duration};
 
+#[cfg(feature = "flamegraph-alloc")]
+use super::alloc::{AllocMetrics, get_alloc_metrics};
+
 /// A generic API for internal span metric measuring compatible with
 /// `tracing::Subscriber`.
 pub trait SpanMetrics: fmt::Debug + Default + Sized {
@@ -90,15 +93,28 @@ pub struct FlameMetric {
     /// Stopwatch measuring a task's idle pending time.
     pub pending: Stopwatch,
     pub count: CountMetric,
+    #[cfg(feature = "flamegraph-alloc")]
+    pub alloc_current: AllocMetrics,
+    #[cfg(feature = "flamegraph-alloc")]
+    pub alloc_total: AllocMetrics,
 }
 
 impl fmt::Debug for FlameMetric {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg(not(feature = "flamegraph-alloc"))]
         {
             write!(
                 f,
                 "[run={:?} pend={:?} {:?}]",
                 self.running, self.pending, self.count
+            )
+        }
+        #[cfg(feature = "flamegraph-alloc")]
+        {
+            write!(
+                f,
+                "[run={:?} pend={:?} {:?} {:?}]",
+                self.running, self.pending, self.count, self.alloc_total
             )
         }
     }
@@ -112,12 +128,21 @@ impl SpanMetrics for FlameMetric {
         self.count.enter(());
         self.pending.try_stop(now);
         self.running.start(now);
+        #[cfg(feature = "flamegraph-alloc")]
+        {
+            self.alloc_current = get_alloc_metrics();
+        }
     }
 
     fn exit(&mut self, now: Clock) {
         self.count.exit(());
         self.running.stop(now);
         self.pending.start(now);
+        #[cfg(feature = "flamegraph-alloc")]
+        {
+            self.alloc_total
+                .merge(get_alloc_metrics().delta(self.alloc_current));
+        }
     }
 }
 
@@ -126,6 +151,8 @@ impl MergeMetrics for FlameMetric {
         self.count.merge(other.count);
         self.running.total += other.running.total;
         self.pending.total += other.pending.total;
+        #[cfg(feature = "flamegraph-alloc")]
+        self.alloc_total.merge(other.alloc_total);
     }
 }
 

--- a/crates/telemetry-subscribers/src/flamegraph/metric.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/metric.rs
@@ -3,9 +3,6 @@
 
 use std::{fmt, time::Duration};
 
-#[cfg(feature = "flamegraph-alloc")]
-use super::alloc::{AllocMetrics, get_alloc_metrics};
-
 /// A generic API for internal span metric measuring compatible with
 /// `tracing::Subscriber`.
 pub trait SpanMetrics: fmt::Debug + Default + Sized {
@@ -93,15 +90,15 @@ pub struct FlameMetric {
     /// Stopwatch measuring a task's idle pending time.
     pub pending: Stopwatch,
     pub count: CountMetric,
-    #[cfg(feature = "flamegraph-alloc")]
-    pub alloc_current: AllocMetrics,
-    #[cfg(feature = "flamegraph-alloc")]
-    pub alloc_total: AllocMetrics,
+    #[cfg(all(feature = "flamegraph-alloc", nightly))]
+    pub alloc_current: super::alloc::AllocMetrics,
+    #[cfg(all(feature = "flamegraph-alloc", nightly))]
+    pub alloc_total: super::alloc::AllocMetrics,
 }
 
 impl fmt::Debug for FlameMetric {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        #[cfg(not(feature = "flamegraph-alloc"))]
+        #[cfg(not(all(feature = "flamegraph-alloc", nightly)))]
         {
             write!(
                 f,
@@ -109,7 +106,7 @@ impl fmt::Debug for FlameMetric {
                 self.running, self.pending, self.count
             )
         }
-        #[cfg(feature = "flamegraph-alloc")]
+        #[cfg(all(feature = "flamegraph-alloc", nightly))]
         {
             write!(
                 f,
@@ -128,9 +125,9 @@ impl SpanMetrics for FlameMetric {
         self.count.enter(());
         self.pending.try_stop(now);
         self.running.start(now);
-        #[cfg(feature = "flamegraph-alloc")]
+        #[cfg(all(feature = "flamegraph-alloc", nightly))]
         {
-            self.alloc_current = get_alloc_metrics();
+            self.alloc_current = super::alloc::get_alloc_metrics();
         }
     }
 
@@ -138,10 +135,10 @@ impl SpanMetrics for FlameMetric {
         self.count.exit(());
         self.running.stop(now);
         self.pending.start(now);
-        #[cfg(feature = "flamegraph-alloc")]
+        #[cfg(all(feature = "flamegraph-alloc", nightly))]
         {
             self.alloc_total
-                .merge(get_alloc_metrics().delta(self.alloc_current));
+                .merge(super::alloc::get_alloc_metrics().delta(self.alloc_current));
         }
     }
 }
@@ -151,7 +148,7 @@ impl MergeMetrics for FlameMetric {
         self.count.merge(other.count);
         self.running.total += other.running.total;
         self.pending.total += other.pending.total;
-        #[cfg(feature = "flamegraph-alloc")]
+        #[cfg(all(feature = "flamegraph-alloc", nightly))]
         self.alloc_total.merge(other.alloc_total);
     }
 }

--- a/crates/telemetry-subscribers/src/flamegraph/svg.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/svg.rs
@@ -309,6 +309,22 @@ impl CallGraph<FlameMetric> {
     }
 }
 
+fn append_type_suffix(label: &str, config: &Config) -> String {
+    #[cfg(all(feature = "flamegraph-alloc", nightly))]
+    {
+        if config.measure_mem {
+            format!("{label} (memory)")
+        } else {
+            format!("{label} (time)")
+        }
+    }
+    #[cfg(not(all(feature = "flamegraph-alloc", nightly)))]
+    {
+        let _ = config;
+        format!("{label} (time)")
+    }
+}
+
 impl Flames<FlameMetric> {
     pub fn render_svg(
         &self,
@@ -317,8 +333,10 @@ impl Flames<FlameMetric> {
         completed: bool,
         config: &Config,
     ) -> Option<Svg> {
+        let caption = &append_type_suffix(graph_id.caption, config);
+
         self.get_callgraph(graph_id, running, completed)
-            .map(|callgraph| callgraph.render_svg(graph_id.caption, config))
+            .map(|callgraph| callgraph.render_svg(caption, config))
     }
     fn render_combined_svg_with_measure<M>(
         &self,
@@ -363,6 +381,8 @@ impl Flames<FlameMetric> {
         completed: bool,
         config: &Config,
     ) -> Option<Svg> {
+        let caption = &append_type_suffix(caption, config);
+
         #[cfg(all(feature = "flamegraph-alloc", nightly))]
         {
             if config.measure_mem {

--- a/crates/telemetry-subscribers/src/flamegraph/svg.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/svg.rs
@@ -21,8 +21,8 @@ struct Node {
 
 #[derive(Clone, Copy, Debug)]
 pub struct Config {
-    /// Desired resolution in nanoseconds per pixel.
-    pub resolution_nanos_per_px: Option<u128>,
+    /// Desired resolution in units (nanoseconds, bytes) per pixel.
+    pub resolution_units_per_px: Option<usize>,
     /// Desired width of the SVG in pixels.
     pub width: Option<usize>,
     /// Desired aspect ratio (width, height) of the SVG.
@@ -30,14 +30,19 @@ pub struct Config {
     /// Seed value for random color generation to ensure reproducible flamegraph
     /// colors.
     pub seed: u64,
+    #[cfg(feature = "flamegraph-alloc")]
+    /// Use memory allocations span measure instead of total duration.
+    pub measure_mem: bool,
 }
 impl Default for Config {
     fn default() -> Config {
         Config {
-            resolution_nanos_per_px: None,
+            resolution_units_per_px: None,
             width: Some(1920),
             aspect_ratio: None,
             seed: 1,
+            #[cfg(feature = "flamegraph-alloc")]
+            measure_mem: false,
         }
     }
 }
@@ -54,66 +59,148 @@ impl Svg {
     }
 }
 
-pub trait Renderer {
-    fn raw_svg(&self, raw: &mut Raw, indent: bool);
-    fn render_svg(&self, caption: &str, config: &Config) -> Svg {
-        let mut raw = Raw::default();
-        self.raw_svg(&mut raw, false);
-        raw.render(caption, config)
-    }
-}
-
 use super::{
     callgraph::{CallGraph, Frame, NodeId},
     flame::{Flames, FrameLabel, Metadata},
-    metric::{FlameMetric, MergeMetrics, SpanMetrics},
+    metric::FlameMetric,
 };
+
+trait FromSpanMetrics<S>:
+    for<'a> std::ops::Add<&'a S, Output = Self> + for<'a> std::ops::AddAssign<&'a S>
+{
+}
+
+// Helper trait to abstract over span measure (eg. duration or allocations).
+trait Measure: Clone + Copy + Default + Eq + for<'a> From<&'a RawNode> + Into<f64> + Sized {}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct TotalTime(Duration);
+impl std::ops::Add<&FlameMetric> for TotalTime {
+    type Output = Self;
+    fn add(mut self, rhs: &FlameMetric) -> Self {
+        self += rhs;
+        self
+    }
+}
+impl std::ops::AddAssign<&FlameMetric> for TotalTime {
+    fn add_assign(&mut self, rhs: &FlameMetric) {
+        self.0 += rhs.running.total;
+    }
+}
+impl FromSpanMetrics<FlameMetric> for TotalTime {}
+impl From<&RawNode> for TotalTime {
+    fn from(raw: &RawNode) -> Self {
+        TotalTime(raw.total)
+    }
+}
+impl From<TotalTime> for f64 {
+    fn from(t: TotalTime) -> f64 {
+        t.0.as_nanos() as f64
+    }
+}
+impl Measure for TotalTime {}
+
+#[cfg(feature = "flamegraph-alloc")]
+#[derive(Clone, Copy, Debug, Default)]
+struct TotalMem(usize);
+#[cfg(feature = "flamegraph-alloc")]
+impl std::ops::Add<&FlameMetric> for TotalMem {
+    type Output = Self;
+    fn add(mut self, rhs: &FlameMetric) -> Self {
+        self += rhs;
+        self
+    }
+}
+#[cfg(feature = "flamegraph-alloc")]
+impl std::ops::AddAssign<&FlameMetric> for TotalMem {
+    fn add_assign(&mut self, rhs: &FlameMetric) {
+        self.0 += rhs.alloc_total.alloc;
+    }
+}
+#[cfg(feature = "flamegraph-alloc")]
+impl FromSpanMetrics<FlameMetric> for TotalMem {}
+#[cfg(feature = "flamegraph-alloc")]
+impl From<&RawNode> for TotalMem {
+    fn from(raw: &RawNode) -> Self {
+        TotalMem(raw.alloc.alloc)
+    }
+}
+#[cfg(feature = "flamegraph-alloc")]
+impl From<TotalMem> for f64 {
+    fn from(t: TotalMem) -> f64 {
+        t.0 as f64
+    }
+}
+#[cfg(feature = "flamegraph-alloc")]
+impl Measure for TotalMem {}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct RawNode {
     label: FrameLabel,
     samples: usize,
-    start: Duration,
     total: Duration,
     #[cfg(feature = "flamegraph-alloc")]
     alloc: AllocMetrics,
 }
+impl From<&Frame<FlameMetric>> for RawNode {
+    fn from(frame: &Frame<FlameMetric>) -> Self {
+        RawNode {
+            label: frame.label,
+            samples: frame.metrics.count.entered,
+            total: frame.metrics.running.total,
+            #[cfg(feature = "flamegraph-alloc")]
+            alloc: frame.metrics.alloc_total,
+        }
+    }
+}
 impl RawNode {
-    fn into_node<R: rand::Rng>(
+    fn into_node<M: Measure, R: rand::Rng>(
         self,
-        overall: Duration,
+        start: M,
+        overall: M,
         x_scale: f64,
         y: usize,
         rng: &mut R,
     ) -> Node {
+        // start represents an absolute unscaled x coordinate of the span node in svg
+        let x = start.into() * x_scale + 10.0;
+        // width is the span node measure, ie. width in svg
+        let width = M::from(&self);
+        // overall is the measure of the whole flamegraph, represents 100%
+        let percent = width.into() * 100.0 / overall.into();
+        // scale width into pixels
+        let width = width.into() * x_scale;
+        // svg node height is fixed
+        let height = 15;
+
         let RawNode {
             label,
             samples,
-            start,
             total,
             #[cfg(feature = "flamegraph-alloc")]
             alloc,
         } = self;
+
         let rgb = random_rgb(rng);
         let dur = total.as_nanos() as f64 / 1_000_000.0;
         let avg = dur / samples as f64;
-        let percent = total.as_nanos() as f64 * 100.0 / overall.as_nanos() as f64;
         #[cfg(not(feature = "flamegraph-alloc"))]
         let title = format!(
-            "{} (#{samples}, tot={dur:.2}ms, avg={avg:.2}ms, {percent:.2}%)",
+            "{} (#{samples}, dur={dur:.2}ms, avg={avg:.2}ms, {percent:.2}%)",
             label.name
         );
         #[cfg(feature = "flamegraph-alloc")]
         let title = format!(
-            "{} (#{samples}, tot={dur:.2}ms, avg={avg:.2}ms, {percent:.2}%, {alloc})",
+            "{} (#{samples}, dur={dur:.2}ms, avg={avg:.2}ms, {percent:.2}%, {alloc})",
             label.name,
         );
+
         Node {
             title,
-            x: start.as_nanos() as f64 * x_scale + 10.0,
+            x,
             y,
-            width: total.as_nanos() as f64 * x_scale,
-            height: 15,
+            width,
+            height,
             rgb,
         }
     }
@@ -126,23 +213,19 @@ fn random_rgb<R: rand::Rng>(rng: &mut R) -> (u8, u8, u8) {
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct Raw {
-    total: Duration,
-    running: Vec<Vec<RawNode>>,
+struct Raw<M> {
+    total: M,
+    running: Vec<Vec<(M, RawNode)>>,
 }
-impl Raw {
-    fn add_node(&mut self, frame: &Frame<FlameMetric>, start: Duration, level: usize) -> Duration {
+impl<M: Measure> Raw<M> {
+    fn add_node<S>(&mut self, frame: &Frame<S>, start: M, level: usize) -> M
+    where
+        for<'a> &'a Frame<S>: Into<RawNode>,
+    {
         if self.running.len() <= level {
             self.running.resize(level + 1, Vec::new());
         }
-        self.running[level].push(RawNode {
-            label: frame.label,
-            samples: frame.metrics.count.entered,
-            start,
-            total: frame.metrics.running.total,
-            #[cfg(feature = "flamegraph-alloc")]
-            alloc: frame.metrics.alloc_total,
-        });
+        self.running[level].push((start, frame.into()));
         start
     }
     fn render(self, caption: &str, config: &Config) -> Svg {
@@ -152,9 +235,9 @@ impl Raw {
         let height = 33 + num_levels * 16 + 33;
 
         let (x_scale, width) = config
-            .resolution_nanos_per_px // try resolution first
+            .resolution_units_per_px // try resolution first
             .and_then(|r| (r > 0).then_some(r))
-            .map(|r| (1.0 / r as f64, (total.as_nanos() / r) as usize + 20))
+            .map(|r| (1.0 / r as f64, total.into() as usize / r + 20))
             .unwrap_or_else(|| {
                 let w = config
                     .width // try width next
@@ -165,10 +248,10 @@ impl Raw {
                     })
                     .max(100); // minimum width
                 // 10px margin on each side
-                if total.is_zero() {
+                if total == M::default() {
                     (1.0, w)
                 } else {
-                    ((w - 20) as f64 / total.as_nanos() as f64, w)
+                    ((w - 20) as f64 / total.into(), w)
                 }
             });
 
@@ -179,41 +262,63 @@ impl Raw {
             .into_iter()
             .enumerate()
             .flat_map(|(i, row)| row.into_iter().map(move |raw| (raw, i)))
-            .map(|(raw, level)| {
+            .map(|((start, raw), level)| {
                 let y = (num_levels - 1 - level) * 16 + 33;
-                raw.into_node(total, x_scale, y, &mut rng)
+                raw.into_node(start, total, x_scale, y, &mut rng)
             });
 
         render(caption, width, height, nodes)
     }
 }
 
-impl Renderer for CallGraph<FlameMetric> {
-    fn raw_svg(&self, raw: &mut Raw, indent: bool) {
+impl CallGraph<FlameMetric> {
+    fn raw_svg<M>(&self, raw: &mut Raw<M>)
+    where
+        M: Measure + FromSpanMetrics<FlameMetric>,
+    {
         if !self.graph.is_empty() {
             let start = raw.total;
-            let root_metrics = self.graph[NodeId::default()].value.metrics;
-            raw.total += root_metrics.running.total;
+            let root_metrics = &self.graph[NodeId::default()].value.metrics;
+            raw.total += root_metrics;
 
             self.graph.dfs_fold2(
                 raw,
                 || start,
                 |svg_raw, start, node_id, level| {
-                    svg_raw.add_node(&self.graph[node_id].value, start, level + indent as usize)
+                    svg_raw.add_node(&self.graph[node_id].value, start, level)
                 },
                 |_, start, node_id| {
-                    let metrics = self.graph[node_id].value.metrics;
-                    *start + metrics.running.total
+                    let metrics = &self.graph[node_id].value.metrics;
+                    *start + metrics
                 },
             );
         }
     }
+    fn render_svg_with_measure<M>(&self, caption: &str, config: &Config) -> Svg
+    where
+        M: Measure + FromSpanMetrics<FlameMetric>,
+    {
+        let mut raw = Raw::<M>::default();
+        self.raw_svg(&mut raw);
+        raw.render(caption, config)
+    }
+    fn render_svg(&self, caption: &str, config: &Config) -> Svg where {
+        #[cfg(feature = "flamegraph-alloc")]
+        {
+            if config.measure_mem {
+                self.render_svg_with_measure::<TotalMem>(caption, config)
+            } else {
+                self.render_svg_with_measure::<TotalTime>(caption, config)
+            }
+        }
+        #[cfg(not(feature = "flamegraph-alloc"))]
+        {
+            self.render_svg_with_measure::<TotalTime>(caption, config)
+        }
+    }
 }
 
-impl<S: Clone + Default + MergeMetrics + SpanMetrics> Flames<S>
-where
-    CallGraph<S>: Renderer,
-{
+impl Flames<FlameMetric> {
     pub fn render_svg(
         &self,
         graph_id: &Metadata<'_>,
@@ -224,6 +329,46 @@ where
         self.get_callgraph(graph_id, running, completed)
             .map(|callgraph| callgraph.render_svg(graph_id.caption, config))
     }
+    fn render_combined_svg_with_measure<M>(
+        &self,
+        caption: &str,
+        running: bool,
+        completed: bool,
+        config: &Config,
+    ) -> Option<Svg>
+    where
+        M: Measure + FromSpanMetrics<FlameMetric>,
+    {
+        let mut raw = self.get_callgraphs(running, completed).values().fold(
+            Raw::<M>::default(),
+            |mut raw, callgraph| {
+                callgraph.raw_svg(&mut raw);
+                raw
+            },
+        );
+        if raw.running.is_empty() {
+            // no data at all
+            None
+        } else {
+            // aggregate level 0 nodes into one
+            let mut root = RawNode {
+                label: FrameLabel { name: "all" },
+                samples: 1,
+                total: Duration::default(),
+                #[cfg(feature = "flamegraph-alloc")]
+                alloc: AllocMetrics::new(),
+            };
+            let level0 = raw.running.first().unwrap();
+            for (_, node) in level0 {
+                root.total += node.total;
+                #[cfg(feature = "flamegraph-alloc")]
+                root.alloc.merge(node.alloc);
+            }
+            // insert the root node at level 0 and shift other nodes 1 level up
+            raw.running.insert(0, vec![(Default::default(), root)]);
+            Some(raw.render(caption, config))
+        }
+    }
     pub fn render_combined_svg(
         &self,
         caption: &str,
@@ -231,25 +376,21 @@ where
         completed: bool,
         config: &Config,
     ) -> Option<Svg> {
-        let mut raw = self.get_callgraphs(running, completed).values().fold(
-            Raw::default(),
-            |mut raw, callgraph| {
-                callgraph.raw_svg(&mut raw, true);
-                raw
-            },
-        );
-        if raw.total.is_zero() || raw.running.is_empty() {
-            None
-        } else {
-            raw.running[0].push(RawNode {
-                label: FrameLabel { name: "all" },
-                samples: 1,
-                start: Default::default(),
-                total: raw.total,
-                #[cfg(feature = "flamegraph-alloc")]
-                alloc: AllocMetrics::new(),
-            });
-            Some(raw.render(caption, config))
+        #[cfg(feature = "flamegraph-alloc")]
+        {
+            if config.measure_mem {
+                self.render_combined_svg_with_measure::<TotalMem>(
+                    caption, running, completed, config,
+                )
+            } else {
+                self.render_combined_svg_with_measure::<TotalTime>(
+                    caption, running, completed, config,
+                )
+            }
+        }
+        #[cfg(not(feature = "flamegraph-alloc"))]
+        {
+            self.render_combined_svg_with_measure::<TotalTime>(caption, running, completed, config)
         }
     }
 }

--- a/crates/telemetry-subscribers/src/flamegraph/svg.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/svg.rs
@@ -96,16 +96,17 @@ impl RawNode {
         } = self;
         let rgb = random_rgb(rng);
         let dur = total.as_nanos() as f64 / 1_000_000.0;
+        let avg = dur / samples as f64;
         let percent = total.as_nanos() as f64 * 100.0 / overall.as_nanos() as f64;
         #[cfg(not(feature = "flamegraph-alloc"))]
-        let title = format!("{} (#{samples}, {dur:.2}ms, {percent:.2}%)", label.name);
+        let title = format!(
+            "{} (#{samples}, tot={dur:.2}ms, avg={avg:.2}ms, {percent:.2}%)",
+            label.name
+        );
         #[cfg(feature = "flamegraph-alloc")]
         let title = format!(
-            "{} (#{samples}, {dur:.2}ms, {percent:.2}%, alloc={} total={} peak={})",
+            "{} (#{samples}, tot={dur:.2}ms, avg={avg:.2}ms, {percent:.2}%, {alloc})",
             label.name,
-            alloc.alloc.saturating_sub(alloc.dealloc),
-            alloc.alloc,
-            alloc.peak
         );
         Node {
             title,

--- a/crates/telemetry-subscribers/src/flamegraph/svg.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/svg.rs
@@ -293,7 +293,7 @@ impl CallGraph<FlameMetric> {
         self.raw_svg(&mut raw);
         raw.render(caption, config)
     }
-    fn render_svg(&self, caption: &str, config: &Config) -> Svg where {
+    fn render_svg(&self, caption: &str, config: &Config) -> Svg {
         #[cfg(feature = "flamegraph-alloc")]
         {
             if config.measure_mem {

--- a/crates/telemetry-subscribers/src/flamegraph/svg.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/svg.rs
@@ -3,15 +3,15 @@
 
 use std::time::Duration;
 
+#[cfg(feature = "flamegraph-alloc")]
+use super::alloc::AllocMetrics;
+
 #[path = "svg_template.rs"]
 mod svg_template;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct Node {
-    title: &'static str,
-    samples: usize,
-    dur: Duration,
-    percent: f64,
+    title: String,
     x: f64,
     y: usize,
     width: f64,
@@ -75,9 +75,11 @@ struct RawNode {
     samples: usize,
     start: Duration,
     total: Duration,
+    #[cfg(feature = "flamegraph-alloc")]
+    alloc: AllocMetrics,
 }
 impl RawNode {
-    fn into_svg<R: rand::Rng>(
+    fn into_node<R: rand::Rng>(
         self,
         overall: Duration,
         x_scale: f64,
@@ -89,13 +91,24 @@ impl RawNode {
             samples,
             start,
             total,
+            #[cfg(feature = "flamegraph-alloc")]
+            alloc,
         } = self;
         let rgb = random_rgb(rng);
+        let dur = total.as_nanos() as f64 / 1_000_000.0;
+        let percent = total.as_nanos() as f64 * 100.0 / overall.as_nanos() as f64;
+        #[cfg(not(feature = "flamegraph-alloc"))]
+        let title = format!("{} (#{samples}, {dur:.2}ms, {percent:.2}%)", label.name);
+        #[cfg(feature = "flamegraph-alloc")]
+        let title = format!(
+            "{} (#{samples}, {dur:.2}ms, {percent:.2}%, alloc={} total={} peak={})",
+            label.name,
+            alloc.alloc.saturating_sub(alloc.dealloc),
+            alloc.alloc,
+            alloc.peak
+        );
         Node {
-            title: label.name,
-            samples,
-            dur: total,
-            percent: total.as_nanos() as f64 * 100.0 / overall.as_nanos() as f64,
+            title,
             x: start.as_nanos() as f64 * x_scale + 10.0,
             y,
             width: total.as_nanos() as f64 * x_scale,
@@ -126,6 +139,8 @@ impl Raw {
             samples: frame.metrics.count.entered,
             start,
             total: frame.metrics.running.total,
+            #[cfg(feature = "flamegraph-alloc")]
+            alloc: frame.metrics.alloc_total,
         });
         start
     }
@@ -165,7 +180,7 @@ impl Raw {
             .flat_map(|(i, row)| row.into_iter().map(move |raw| (raw, i)))
             .map(|(raw, level)| {
                 let y = (num_levels - 1 - level) * 16 + 33;
-                raw.into_svg(total, x_scale, y, &mut rng)
+                raw.into_node(total, x_scale, y, &mut rng)
             });
 
         render(caption, width, height, nodes)
@@ -230,6 +245,8 @@ where
                 samples: 1,
                 start: Default::default(),
                 total: raw.total,
+                #[cfg(feature = "flamegraph-alloc")]
+                alloc: AllocMetrics::new(),
             });
             Some(raw.render(caption, config))
         }
@@ -273,9 +290,6 @@ fn render(caption: &str, width: usize, height: usize, nodes: impl Iterator<Item 
     nodes.for_each(|n| {
         let Node {
             title,
-            samples,
-            dur,
-            percent,
             x,
             y,
             width: node_width,
@@ -283,7 +297,7 @@ fn render(caption: &str, width: usize, height: usize, nodes: impl Iterator<Item 
             rgb,
         } = n;
         svg.push_str(&svg_template::svg_node(
-            title, samples, dur, percent, x, y, node_width, height, rgb,
+            &title, x, y, node_width, height, rgb,
         ));
     });
     svg.push_str("</g>\n");

--- a/crates/telemetry-subscribers/src/flamegraph/svg.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/svg.rs
@@ -3,8 +3,11 @@
 
 use std::time::Duration;
 
-#[cfg(feature = "flamegraph-alloc")]
-use super::alloc::AllocMetrics;
+use super::{
+    callgraph::{CallGraph, Frame, NodeId},
+    flame::{Flames, FrameLabel, Metadata},
+    metric::{CountMetric, FlameMetric, MergeMetrics, Stopwatch},
+};
 
 #[path = "svg_template.rs"]
 mod svg_template;
@@ -59,19 +62,16 @@ impl Svg {
     }
 }
 
-use super::{
-    callgraph::{CallGraph, Frame, NodeId},
-    flame::{Flames, FrameLabel, Metadata},
-    metric::FlameMetric,
-};
-
 trait FromSpanMetrics<S>:
     for<'a> std::ops::Add<&'a S, Output = Self> + for<'a> std::ops::AddAssign<&'a S>
 {
 }
 
 // Helper trait to abstract over span measure (eg. duration or allocations).
-trait Measure: Clone + Copy + Default + Eq + for<'a> From<&'a RawNode> + Into<f64> + Sized {}
+trait Measure:
+    Clone + Copy + Default + Eq + for<'a> From<&'a Frame<FlameMetric>> + Into<f64> + Sized
+{
+}
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct TotalTime(Duration);
@@ -88,9 +88,9 @@ impl std::ops::AddAssign<&FlameMetric> for TotalTime {
     }
 }
 impl FromSpanMetrics<FlameMetric> for TotalTime {}
-impl From<&RawNode> for TotalTime {
-    fn from(raw: &RawNode) -> Self {
-        TotalTime(raw.total)
+impl From<&Frame<FlameMetric>> for TotalTime {
+    fn from(raw: &Frame<FlameMetric>) -> Self {
+        TotalTime(raw.metrics.running.total)
     }
 }
 impl From<TotalTime> for f64 {
@@ -120,9 +120,9 @@ impl std::ops::AddAssign<&FlameMetric> for TotalMem {
 #[cfg(feature = "flamegraph-alloc")]
 impl FromSpanMetrics<FlameMetric> for TotalMem {}
 #[cfg(feature = "flamegraph-alloc")]
-impl From<&RawNode> for TotalMem {
-    fn from(raw: &RawNode) -> Self {
-        TotalMem(raw.alloc.alloc)
+impl From<&Frame<FlameMetric>> for TotalMem {
+    fn from(frame: &Frame<FlameMetric>) -> Self {
+        TotalMem(frame.metrics.alloc_total.alloc)
     }
 }
 #[cfg(feature = "flamegraph-alloc")]
@@ -134,26 +134,7 @@ impl From<TotalMem> for f64 {
 #[cfg(feature = "flamegraph-alloc")]
 impl Measure for TotalMem {}
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct RawNode {
-    label: FrameLabel,
-    samples: usize,
-    total: Duration,
-    #[cfg(feature = "flamegraph-alloc")]
-    alloc: AllocMetrics,
-}
-impl From<&Frame<FlameMetric>> for RawNode {
-    fn from(frame: &Frame<FlameMetric>) -> Self {
-        RawNode {
-            label: frame.label,
-            samples: frame.metrics.count.entered,
-            total: frame.metrics.running.total,
-            #[cfg(feature = "flamegraph-alloc")]
-            alloc: frame.metrics.alloc_total,
-        }
-    }
-}
-impl RawNode {
+impl Frame<FlameMetric> {
     fn into_node<M: Measure, R: rand::Rng>(
         self,
         start: M,
@@ -173,12 +154,25 @@ impl RawNode {
         // svg node height is fixed
         let height = 15;
 
-        let RawNode {
+        let Frame {
             label,
-            samples,
-            total,
-            #[cfg(feature = "flamegraph-alloc")]
-            alloc,
+            metrics: FlameMetric {
+                count: CountMetric {
+                    // the number of span samples is the number the span was entered
+                    entered: samples,
+                    ..
+                },
+                running: Stopwatch {
+                    // the total duration span was in active/running state
+                    total,
+                    ..
+                },
+                #[cfg(feature = "flamegraph-alloc")]
+                // allocation metrics are accumulated metrics per all span entries
+                alloc_total: alloc,
+                // we do not need the rest of the metrics
+                ..
+            },
         } = self;
 
         let rgb = random_rgb(rng);
@@ -212,20 +206,17 @@ fn random_rgb<R: rand::Rng>(rng: &mut R) -> (u8, u8, u8) {
     (r, g, b)
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default)]
 struct Raw<M> {
     total: M,
-    running: Vec<Vec<(M, RawNode)>>,
+    running: Vec<Vec<(M, Frame<FlameMetric>)>>,
 }
 impl<M: Measure> Raw<M> {
-    fn add_node<S>(&mut self, frame: &Frame<S>, start: M, level: usize) -> M
-    where
-        for<'a> &'a Frame<S>: Into<RawNode>,
-    {
+    fn add_node(&mut self, frame: Frame<FlameMetric>, start: M, level: usize) -> M {
         if self.running.len() <= level {
             self.running.resize(level + 1, Vec::new());
         }
-        self.running[level].push((start, frame.into()));
+        self.running[level].push((start, frame));
         start
     }
     fn render(self, caption: &str, config: &Config) -> Svg {
@@ -285,7 +276,7 @@ impl CallGraph<FlameMetric> {
                 raw,
                 || start,
                 |svg_raw, start, node_id, level| {
-                    svg_raw.add_node(&self.graph[node_id].value, start, level)
+                    svg_raw.add_node(self.graph[node_id].value, start, level)
                 },
                 |_, start, node_id| {
                     let metrics = &self.graph[node_id].value.metrics;
@@ -351,18 +342,14 @@ impl Flames<FlameMetric> {
             None
         } else {
             // aggregate level 0 nodes into one
-            let mut root = RawNode {
+            let mut root: Frame<FlameMetric> = Frame {
                 label: FrameLabel { name: "all" },
-                samples: 1,
-                total: Duration::default(),
-                #[cfg(feature = "flamegraph-alloc")]
-                alloc: AllocMetrics::new(),
+                ..Default::default()
             };
+            root.metrics.count.entered += 1;
             let level0 = raw.running.first().unwrap();
             for (_, node) in level0 {
-                root.total += node.total;
-                #[cfg(feature = "flamegraph-alloc")]
-                root.alloc.merge(node.alloc);
+                root.metrics.merge(node.metrics);
             }
             // insert the root node at level 0 and shift other nodes 1 level up
             raw.running.insert(0, vec![(Default::default(), root)]);

--- a/crates/telemetry-subscribers/src/flamegraph/svg.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/svg.rs
@@ -101,7 +101,7 @@ impl From<TotalTime> for f64 {
 impl Measure for TotalTime {}
 
 #[cfg(feature = "flamegraph-alloc")]
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct TotalMem(usize);
 #[cfg(feature = "flamegraph-alloc")]
 impl std::ops::Add<&FlameMetric> for TotalMem {

--- a/crates/telemetry-subscribers/src/flamegraph/svg.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/svg.rs
@@ -33,7 +33,7 @@ pub struct Config {
     /// Seed value for random color generation to ensure reproducible flamegraph
     /// colors.
     pub seed: u64,
-    #[cfg(feature = "flamegraph-alloc")]
+    #[cfg(all(feature = "flamegraph-alloc", nightly))]
     /// Use memory allocations span measure instead of total duration.
     pub measure_mem: bool,
 }
@@ -44,7 +44,7 @@ impl Default for Config {
             width: Some(1920),
             aspect_ratio: None,
             seed: 1,
-            #[cfg(feature = "flamegraph-alloc")]
+            #[cfg(all(feature = "flamegraph-alloc", nightly))]
             measure_mem: false,
         }
     }
@@ -100,10 +100,10 @@ impl From<TotalTime> for f64 {
 }
 impl Measure for TotalTime {}
 
-#[cfg(feature = "flamegraph-alloc")]
+#[cfg(all(feature = "flamegraph-alloc", nightly))]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct TotalMem(usize);
-#[cfg(feature = "flamegraph-alloc")]
+#[cfg(all(feature = "flamegraph-alloc", nightly))]
 impl std::ops::Add<&FlameMetric> for TotalMem {
     type Output = Self;
     fn add(mut self, rhs: &FlameMetric) -> Self {
@@ -111,27 +111,27 @@ impl std::ops::Add<&FlameMetric> for TotalMem {
         self
     }
 }
-#[cfg(feature = "flamegraph-alloc")]
+#[cfg(all(feature = "flamegraph-alloc", nightly))]
 impl std::ops::AddAssign<&FlameMetric> for TotalMem {
     fn add_assign(&mut self, rhs: &FlameMetric) {
         self.0 += rhs.alloc_total.alloc;
     }
 }
-#[cfg(feature = "flamegraph-alloc")]
+#[cfg(all(feature = "flamegraph-alloc", nightly))]
 impl FromSpanMetrics<FlameMetric> for TotalMem {}
-#[cfg(feature = "flamegraph-alloc")]
+#[cfg(all(feature = "flamegraph-alloc", nightly))]
 impl From<&Frame<FlameMetric>> for TotalMem {
     fn from(frame: &Frame<FlameMetric>) -> Self {
         TotalMem(frame.metrics.alloc_total.alloc)
     }
 }
-#[cfg(feature = "flamegraph-alloc")]
+#[cfg(all(feature = "flamegraph-alloc", nightly))]
 impl From<TotalMem> for f64 {
     fn from(t: TotalMem) -> f64 {
         t.0 as f64
     }
 }
-#[cfg(feature = "flamegraph-alloc")]
+#[cfg(all(feature = "flamegraph-alloc", nightly))]
 impl Measure for TotalMem {}
 
 impl Frame<FlameMetric> {
@@ -167,7 +167,7 @@ impl Frame<FlameMetric> {
                     total,
                     ..
                 },
-                #[cfg(feature = "flamegraph-alloc")]
+                #[cfg(all(feature = "flamegraph-alloc", nightly))]
                 // allocation metrics are accumulated metrics per all span entries
                 alloc_total: alloc,
                 // we do not need the rest of the metrics
@@ -178,12 +178,12 @@ impl Frame<FlameMetric> {
         let rgb = random_rgb(rng);
         let dur = total.as_nanos() as f64 / 1_000_000.0;
         let avg = dur / samples as f64;
-        #[cfg(not(feature = "flamegraph-alloc"))]
+        #[cfg(not(all(feature = "flamegraph-alloc", nightly)))]
         let title = format!(
             "{} (#{samples}, dur={dur:.2}ms, avg={avg:.2}ms, {percent:.2}%)",
             label.name
         );
-        #[cfg(feature = "flamegraph-alloc")]
+        #[cfg(all(feature = "flamegraph-alloc", nightly))]
         let title = format!(
             "{} (#{samples}, dur={dur:.2}ms, avg={avg:.2}ms, {percent:.2}%, {alloc})",
             label.name,
@@ -294,7 +294,7 @@ impl CallGraph<FlameMetric> {
         raw.render(caption, config)
     }
     fn render_svg(&self, caption: &str, config: &Config) -> Svg {
-        #[cfg(feature = "flamegraph-alloc")]
+        #[cfg(all(feature = "flamegraph-alloc", nightly))]
         {
             if config.measure_mem {
                 self.render_svg_with_measure::<TotalMem>(caption, config)
@@ -302,7 +302,7 @@ impl CallGraph<FlameMetric> {
                 self.render_svg_with_measure::<TotalTime>(caption, config)
             }
         }
-        #[cfg(not(feature = "flamegraph-alloc"))]
+        #[cfg(not(all(feature = "flamegraph-alloc", nightly)))]
         {
             self.render_svg_with_measure::<TotalTime>(caption, config)
         }
@@ -363,7 +363,7 @@ impl Flames<FlameMetric> {
         completed: bool,
         config: &Config,
     ) -> Option<Svg> {
-        #[cfg(feature = "flamegraph-alloc")]
+        #[cfg(all(feature = "flamegraph-alloc", nightly))]
         {
             if config.measure_mem {
                 self.render_combined_svg_with_measure::<TotalMem>(
@@ -375,7 +375,7 @@ impl Flames<FlameMetric> {
                 )
             }
         }
-        #[cfg(not(feature = "flamegraph-alloc"))]
+        #[cfg(not(all(feature = "flamegraph-alloc", nightly)))]
         {
             self.render_combined_svg_with_measure::<TotalTime>(caption, running, completed, config)
         }

--- a/crates/telemetry-subscribers/src/flamegraph/svg_template.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/svg_template.rs
@@ -613,9 +613,6 @@ pub(super) fn svg_controls(
 
 pub(super) fn svg_node(
     title: &str,
-    samples: usize,
-    dur: std::time::Duration,
-    percent: f64,
     x: f64,
     y: usize,
     width: f64,
@@ -625,18 +622,12 @@ pub(super) fn svg_node(
     let (fill_r, fill_g, fill_b) = rgb;
     let text_x = x + 3.0;
     let text_y = (y as f64) + (height as f64 / 2.0) + 3.0;
-    let dur = dur.as_nanos() as f64 / 1_000_000.0;
-    let avg = if samples > 0 {
-        dur / samples as f64
-    } else {
-        0.0
-    };
 
     let escaped_title = escape_xml(title);
 
     format!(
         r###"<g class="func_g">
-<title>{escaped_title} (#{samples}, tot={dur:.2}ms, avg={avg:.2}ms, {percent:.2}%)</title>
+<title>{escaped_title}</title>
 <rect x="{x:.1}" y="{y}" width="{width:.1}" height="{height}" fill="rgb({fill_r},{fill_g},{fill_b})" rx="2" ry="2" />
 <text x="{text_x:.2}" y="{text_y:.0}"></text>
 </g>

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-#![cfg_attr(feature = "flamegraph-alloc", feature(thread_local))]
+#![cfg_attr(all(feature = "flamegraph-alloc", nightly), feature(thread_local))]
 
 use std::{
     env,

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+#![cfg_attr(feature = "flamegraph-alloc", feature(thread_local))]
+
 use std::{
     env,
     io::{Write, stderr},

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-#![cfg_attr(feature = "flamegraph-alloc", feature(thread_local))]
-
 use std::{
     env,
     io::{Write, stderr},

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+#![cfg_attr(feature = "flamegraph-alloc", feature(thread_local))]
 
 use std::{
     env,


### PR DESCRIPTION
# Description of change

This PR adds global allocator wrapper counting allocation metrics (alloc, dealloc, peak) per thread. It uses unstable feature `thread_local` (it's the only reasonable way, `thread_local!` macro can't be used) which is guarded behind feature `"flamegraph-alloc"`. The allocation stats are shown in rendered SVG.

## Links to any relevant issues

Part of #8694.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Extend telemetry subscribers with allocations per thread metrics.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: