### PR TITLE
feat: use `SenderSignedData::input_objects` instead of `TransactionData::input_objects`

### DIFF
--- a/crates/iota-analytics-indexer/src/handlers/mod.rs
+++ b/crates/iota-analytics-indexer/src/handlers/mod.rs
@@ -93,6 +93,7 @@ impl InputObjectTracker {
     fn new(txn: &SenderSignedData) -> Self {
         let shared: BTreeSet<ObjectID> = txn
             .shared_input_objects()
+            .into_iter()
             .map(|shared_io| shared_io.id())
             .collect();
         let tx_data = txn.transaction_data();
@@ -102,6 +103,7 @@ impl InputObjectTracker {
         let input: BTreeSet<ObjectID> = txn
             .input_objects()
             .expect("Input objects must be valid")
+            .into_iter()
             .map(|io_kind| io_kind.object_id())
             .collect();
         Self {

--- a/crates/iota-analytics-indexer/src/handlers/mod.rs
+++ b/crates/iota-analytics-indexer/src/handlers/mod.rs
@@ -97,10 +97,11 @@ impl InputObjectTracker {
             .collect();
         let tx_data = txn.transaction_data();
         let coins: BTreeSet<ObjectID> = tx_data.gas().iter().map(|obj_ref| obj_ref.0).collect();
-        let input: BTreeSet<ObjectID> = tx_data
+        // All input objects (transaction + authenticators) are collected here, just
+        // like the shared objects previously.
+        let input: BTreeSet<ObjectID> = txn
             .input_objects()
             .expect("Input objects must be valid")
-            .iter()
             .map(|io_kind| io_kind.object_id())
             .collect();
         Self {

--- a/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
@@ -154,10 +154,11 @@ impl TransactionHandler {
             is_sponsored_tx,
             transaction_count: txn_data.kind().num_commands() as u64,
             execution_success: effects.status().is_ok(),
-            input: txn_data
+            // Calculate all objects(transaction + authenticators) amount.
+            input: transaction
                 .input_objects()
                 .expect("Input objects must be valid")
-                .len() as u64,
+                .count() as u64,
             shared_input: transaction.shared_input_objects().count() as u64,
             gas_coins: txn_data.gas().len() as u64,
             created: effects.created().len() as u64,

--- a/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
@@ -158,8 +158,8 @@ impl TransactionHandler {
             input: transaction
                 .input_objects()
                 .expect("Input objects must be valid")
-                .count() as u64,
-            shared_input: transaction.shared_input_objects().count() as u64,
+                .len() as u64,
+            shared_input: transaction.shared_input_objects().len() as u64,
             gas_coins: txn_data.gas().len() as u64,
             created: effects.created().len() as u64,
             mutated: (effects.mutated().len() + effects.unwrapped().len()) as u64,

--- a/crates/iota-analytics-indexer/src/handlers/transaction_objects_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_objects_handler.rs
@@ -104,6 +104,7 @@ impl TransactionObjectsHandler {
         transaction
             .input_objects()
             .expect("Input objects must be valid")
+            .into_iter()
             .map(|object| (object.object_id(), object.version().map(|v| v.value())))
             .for_each(|(object_id, version)| {
                 self.process_transaction_object(

--- a/crates/iota-analytics-indexer/src/handlers/transaction_objects_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_objects_handler.rs
@@ -10,7 +10,6 @@ use iota_types::{
     base_types::ObjectID,
     effects::TransactionEffects,
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
-    transaction::TransactionDataAPI,
 };
 use tokio::sync::Mutex;
 
@@ -97,13 +96,14 @@ impl TransactionObjectsHandler {
         let object_status_tracker = ObjectStatusTracker::new(effects);
 
         let transaction_digest = transaction.digest().base58_encode();
-        let txn_data = transaction.transaction_data();
 
         // input
-        txn_data
+        //
+        // Process all objects associated with the transaction, including authenticator
+        // inputs.
+        transaction
             .input_objects()
             .expect("Input objects must be valid")
-            .iter()
             .map(|object| (object.object_id(), object.version().map(|v| v.value())))
             .for_each(|(object_id, version)| {
                 self.process_transaction_object(

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -889,17 +889,14 @@ impl AuthorityState {
 
         let tx_data = transaction.data().transaction_data();
 
-        let tx_and_auth_input_objects = transaction.input_objects()?.collect::<Vec<_>>();
-        let tx_receiving_objects = tx_data.receiving_objects();
-
         // Note: the deny checks may do redundant package loads but:
         // - they only load packages when there is an active package deny map
         // - the loads are cached anyway
         iota_transaction_checks::deny::check_transaction_for_signing(
             tx_data,
             transaction.tx_signatures(),
-            &tx_and_auth_input_objects,
-            &tx_receiving_objects,
+            &tx_data.input_objects()?,
+            &tx_data.receiving_objects(),
             &self.config.transaction_deny_config,
             self.get_backing_package_store().as_ref(),
         )?;
@@ -908,13 +905,8 @@ impl AuthorityState {
         // Authenticator input objects and the account object are loaded in the same
         // call if there is a sender `MoveAuthenticator` signature present in the
         // transaction.
-        let (tx_input_objects, tx_receiving_objects, auth_input_objects, account_object) = self
-            .read_objects_for_signing(
-                &transaction,
-                &tx_and_auth_input_objects,
-                &tx_receiving_objects,
-                epoch,
-            )?;
+        let (tx_input_objects, tx_receiving_objects, auth_input_objects, account_object) =
+            self.read_objects_for_signing(&transaction, epoch)?;
 
         // Get the sender `MoveAuthenticator`, if any.
         // Only one `MoveAuthenticator` signature is possible, since it is not
@@ -1321,7 +1313,7 @@ impl AuthorityState {
             .execution_load_input_objects_latency
             .start_timer();
 
-        let input_objects = certificate.input_objects()?.collect::<Vec<_>>();
+        let input_objects = certificate.collect_all_inputs_for_reading()?;
 
         let input_objects = self.input_loader.read_objects_for_execution(
             epoch_store,
@@ -1331,7 +1323,7 @@ impl AuthorityState {
             epoch_store.epoch(),
         )?;
 
-        certificate.split_inputs_into_groups(input_objects)
+        certificate.split_inputs_into_groups_for_reading(input_objects)
     }
 
     /// Test only wrapper for `try_execute_immediately()` above, useful for
@@ -5455,8 +5447,6 @@ impl AuthorityState {
     fn read_objects_for_signing(
         &self,
         transaction: &VerifiedTransaction,
-        input_object_kinds: &[InputObjectKind],
-        receiving_objects: &[ObjectRef],
         epoch: u64,
     ) -> IotaResult<(
         InputObjects,
@@ -5466,21 +5456,21 @@ impl AuthorityState {
     )> {
         let (input_objects, tx_receiving_objects) = self.input_loader.read_objects_for_signing(
             Some(transaction.digest()),
-            input_object_kinds,
-            receiving_objects,
+            &transaction.collect_all_inputs_for_reading()?,
+            &transaction.data().transaction_data().receiving_objects(),
             epoch,
         )?;
 
-        transaction.split_inputs_into_groups(input_objects).map(
-            |(tx_input_objects, auth_input_objects, account_object)| {
+        transaction
+            .split_inputs_into_groups_for_reading(input_objects)
+            .map(|(tx_input_objects, auth_input_objects, account_object)| {
                 (
                     tx_input_objects,
                     tx_receiving_objects,
                     auth_input_objects,
                     account_object,
                 )
-            },
-        )
+            })
     }
 
     fn check_transaction_inputs_for_signing(

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -889,14 +889,17 @@ impl AuthorityState {
 
         let tx_data = transaction.data().transaction_data();
 
+        let tx_and_auth_input_objects = transaction.input_objects()?.collect::<Vec<_>>();
+        let tx_receiving_objects = tx_data.receiving_objects();
+
         // Note: the deny checks may do redundant package loads but:
         // - they only load packages when there is an active package deny map
         // - the loads are cached anyway
         iota_transaction_checks::deny::check_transaction_for_signing(
             tx_data,
             transaction.tx_signatures(),
-            &tx_data.input_objects()?,
-            &tx_data.receiving_objects(),
+            &tx_and_auth_input_objects,
+            &tx_receiving_objects,
             &self.config.transaction_deny_config,
             self.get_backing_package_store().as_ref(),
         )?;
@@ -905,8 +908,13 @@ impl AuthorityState {
         // Authenticator input objects and the account object are loaded in the same
         // call if there is a sender `MoveAuthenticator` signature present in the
         // transaction.
-        let (tx_input_objects, tx_receiving_objects, auth_input_objects, account_object) =
-            self.read_objects_for_signing(&transaction, epoch)?;
+        let (tx_input_objects, tx_receiving_objects, auth_input_objects, account_object) = self
+            .read_objects_for_signing(
+                &transaction,
+                &tx_and_auth_input_objects,
+                &tx_receiving_objects,
+                epoch,
+            )?;
 
         // Get the sender `MoveAuthenticator`, if any.
         // Only one `MoveAuthenticator` signature is possible, since it is not
@@ -1182,12 +1190,15 @@ impl AuthorityState {
         let observed_effects_digest = observed_effects.digest();
         if &observed_effects_digest != expected_effects_digest {
             panic!(
-                "Locally executed effects do not match canonical effects! expected_effects_digest={:?} observed_effects_digest={:?} expected_effects={:?} observed_effects={:?} input_objects={:?}",
+                "Locally executed effects do not match canonical effects! expected_effects_digest={:?} observed_effects_digest={:?} expected_effects={:?} observed_effects={:?} transaction_input_objects={:?} authenticator_input_objects={:?}",
                 expected_effects_digest,
                 observed_effects_digest,
                 effects.data(),
                 observed_effects,
-                transaction.data().transaction_data().input_objects()
+                transaction.data().transaction_data().input_objects(),
+                transaction
+                    .sender_move_authenticator()
+                    .map(|a| a.input_objects())
             );
         }
         Ok(())
@@ -1314,7 +1325,7 @@ impl AuthorityState {
             .execution_load_input_objects_latency
             .start_timer();
 
-        let input_objects = certificate.collect_all_inputs()?;
+        let input_objects = certificate.input_objects()?.collect::<Vec<_>>();
 
         let input_objects = self.input_loader.read_objects_for_execution(
             epoch_store,
@@ -5454,6 +5465,8 @@ impl AuthorityState {
     fn read_objects_for_signing(
         &self,
         transaction: &VerifiedTransaction,
+        input_object_kinds: &[InputObjectKind],
+        receiving_objects: &[ObjectRef],
         epoch: u64,
     ) -> IotaResult<(
         InputObjects,
@@ -5463,8 +5476,8 @@ impl AuthorityState {
     )> {
         let (input_objects, tx_receiving_objects) = self.input_loader.read_objects_for_signing(
             Some(transaction.digest()),
-            &transaction.collect_all_inputs()?,
-            &transaction.data().transaction_data().receiving_objects(),
+            input_object_kinds,
+            receiving_objects,
             epoch,
         )?;
 

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1313,7 +1313,7 @@ impl AuthorityState {
             .execution_load_input_objects_latency
             .start_timer();
 
-        let input_objects = certificate.collect_all_inputs_for_reading()?;
+        let input_objects = certificate.collect_all_input_object_kind_for_reading()?;
 
         let input_objects = self.input_loader.read_objects_for_execution(
             epoch_store,
@@ -1323,7 +1323,7 @@ impl AuthorityState {
             epoch_store.epoch(),
         )?;
 
-        certificate.split_inputs_into_groups_for_reading(input_objects)
+        certificate.split_input_objects_into_groups_for_reading(input_objects)
     }
 
     /// Test only wrapper for `try_execute_immediately()` above, useful for
@@ -5456,13 +5456,13 @@ impl AuthorityState {
     )> {
         let (input_objects, tx_receiving_objects) = self.input_loader.read_objects_for_signing(
             Some(transaction.digest()),
-            &transaction.collect_all_inputs_for_reading()?,
+            &transaction.collect_all_input_object_kind_for_reading()?,
             &transaction.data().transaction_data().receiving_objects(),
             epoch,
         )?;
 
         transaction
-            .split_inputs_into_groups_for_reading(input_objects)
+            .split_input_objects_into_groups_for_reading(input_objects)
             .map(|(tx_input_objects, auth_input_objects, account_object)| {
                 (
                     tx_input_objects,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1959,7 +1959,7 @@ impl AuthorityPerEpochStore {
         {
             // Initialise the free execution slots for the objects that are not in the
             // tracker.
-            let shared_input_objects: Vec<_> = cert.shared_input_objects().collect();
+            let shared_input_objects = cert.shared_input_objects();
             shared_object_congestion_tracker
                 .initialize_object_execution_slots(&shared_input_objects);
             // Defer transaction if it uses shared objects that are congested.

--- a/crates/iota-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/iota-core/src/authority/shared_object_congestion_tracker.rs
@@ -391,7 +391,7 @@ impl SharedObjectCongestionTracker {
             return SequencingResult::Schedule(0);
         }
 
-        let shared_input_objects = cert.shared_input_objects().collect::<Vec<_>>();
+        let shared_input_objects = cert.shared_input_objects();
         if shared_input_objects.is_empty() {
             // This is an owned object only transaction. No need to defer.
             return SequencingResult::Schedule(0);
@@ -468,7 +468,11 @@ impl SharedObjectCongestionTracker {
         }
         let end_time = start_time.saturating_add(tx_duration);
         let occupied_slot = ExecutionSlot::new(start_time, end_time);
-        for obj in cert.shared_input_objects().filter(|obj| obj.mutable) {
+        for obj in cert
+            .shared_input_objects()
+            .into_iter()
+            .filter(|obj| obj.mutable)
+        {
             self.object_execution_slots
                 .get_mut(&obj.id)
                 .expect("object execution slot should have been initialized before.")
@@ -679,7 +683,7 @@ pub mod shared_object_test_utils {
         previously_deferred_tx_digests: &PreviouslyDeferredTransactions,
         commit_round: CommitRound,
     ) -> SequencingResult {
-        let shared_input_objects = cert.shared_input_objects().collect::<Vec<_>>();
+        let shared_input_objects = cert.shared_input_objects();
         shared_object_congestion_tracker.initialize_object_execution_slots(&shared_input_objects);
         shared_object_congestion_tracker.try_schedule(
             cert,
@@ -703,8 +707,7 @@ pub mod shared_object_test_utils {
                 PerObjectCongestionControlMode::TotalGasBudget => {
                     let transaction =
                         build_transaction(&[(*object_id, true)], *duration, TEST_ONLY_GAS_PRICE);
-                    let shared_input_objects =
-                        transaction.shared_input_objects().collect::<Vec<_>>();
+                    let shared_input_objects = transaction.shared_input_objects();
                     let start_time = initialize_tracker_and_compute_tx_start_time(
                         &mut shared_object_congestion_tracker,
                         &shared_input_objects,
@@ -721,8 +724,7 @@ pub mod shared_object_test_utils {
                     for _ in 0..*duration {
                         let transaction =
                             build_transaction(&[(*object_id, true)], 1, TEST_ONLY_GAS_PRICE);
-                        let shared_input_objects =
-                            transaction.shared_input_objects().collect::<Vec<_>>();
+                        let shared_input_objects = transaction.shared_input_objects();
                         let start_time = initialize_tracker_and_compute_tx_start_time(
                             &mut shared_object_congestion_tracker,
                             &shared_input_objects,
@@ -1232,7 +1234,7 @@ mod object_cost_tests {
         );
         let cert_duration =
             shared_object_congestion_tracker.get_estimated_execution_duration(&cert);
-        let shared_input_objects = cert.shared_input_objects().collect::<Vec<_>>();
+        let shared_input_objects = cert.shared_input_objects();
         let start_time = initialize_tracker_and_compute_tx_start_time(
             &mut shared_object_congestion_tracker,
             &shared_input_objects,
@@ -1263,7 +1265,7 @@ mod object_cost_tests {
         );
         let cert_duration =
             shared_object_congestion_tracker.get_estimated_execution_duration(&cert);
-        let shared_input_objects = cert.shared_input_objects().collect::<Vec<_>>();
+        let shared_input_objects = cert.shared_input_objects();
         let start_time = initialize_tracker_and_compute_tx_start_time(
             &mut shared_object_congestion_tracker,
             &shared_input_objects,
@@ -1315,7 +1317,7 @@ mod object_cost_tests {
         };
         let cert_duration =
             shared_object_congestion_tracker.get_estimated_execution_duration(&cert);
-        let shared_input_objects = cert.shared_input_objects().collect::<Vec<_>>();
+        let shared_input_objects = cert.shared_input_objects();
         let start_time = initialize_tracker_and_compute_tx_start_time(
             &mut shared_object_congestion_tracker,
             &shared_input_objects,
@@ -1439,7 +1441,7 @@ mod object_cost_tests {
         }
 
         let cert_duration = shared_object_congestion_tracker.get_estimated_execution_duration(&tx);
-        let shared_input_objects = tx.shared_input_objects().collect::<Vec<_>>();
+        let shared_input_objects = tx.shared_input_objects();
         assert!(
             initialize_tracker_and_compute_tx_start_time(
                 &mut shared_object_congestion_tracker,
@@ -1494,7 +1496,7 @@ mod object_cost_tests {
         }
 
         let cert_duration = shared_object_congestion_tracker.get_estimated_execution_duration(&tx);
-        let shared_input_objects = tx.shared_input_objects().collect::<Vec<_>>();
+        let shared_input_objects = tx.shared_input_objects();
         assert!(
             initialize_tracker_and_compute_tx_start_time(
                 &mut shared_object_congestion_tracker,
@@ -1533,7 +1535,7 @@ mod object_cost_tests {
         }
 
         let cert_duration = shared_object_congestion_tracker.get_estimated_execution_duration(&tx);
-        let shared_input_objects = tx.shared_input_objects().collect::<Vec<_>>();
+        let shared_input_objects = tx.shared_input_objects();
         assert!(
             initialize_tracker_and_compute_tx_start_time(
                 &mut shared_object_congestion_tracker,

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -152,7 +152,7 @@ impl SharedObjVerManager {
         let txn_cancelled = cancellation_info.is_some();
 
         // Make an iterator to update the locks of the transaction's shared objects.
-        let shared_input_objects: Vec<_> = cert.shared_input_objects().collect();
+        let shared_input_objects = cert.shared_input_objects();
 
         let mut input_object_keys = transaction_non_shared_input_object_keys(cert)
             .expect("Transaction input should have been verified");
@@ -267,7 +267,11 @@ fn get_or_init_versions<'a>(
     generate_randomness: bool,
 ) -> IotaResult<HashMap<ObjectID, SequenceNumber>> {
     let mut shared_input_objects: Vec<_> = transactions
-        .flat_map(|tx| tx.shared_input_objects().map(|so| so.into_id_and_version()))
+        .flat_map(|tx| {
+            tx.shared_input_objects()
+                .into_iter()
+                .map(|so| so.into_id_and_version())
+        })
         .collect();
 
     if generate_randomness {

--- a/crates/iota-core/src/authority/suggested_gas_price_calculator.rs
+++ b/crates/iota-core/src/authority/suggested_gas_price_calculator.rs
@@ -131,6 +131,7 @@ impl SuggestedGasPriceCalculator {
 
         certificate
             .shared_input_objects()
+            .into_iter()
             // Only consider shared objects accessed mutably as objects accessed immutably
             // do not change object's execution slots in the sequencer.
             .filter(|object| object.mutable)
@@ -200,6 +201,7 @@ impl SuggestedGasPriceCalculator {
 
         certificate
             .shared_input_objects()
+            .into_iter()
             .filter_map(|object| {
                 self.congestion_info
                     .get(&object.id)
@@ -276,7 +278,7 @@ pub mod suggested_gas_price_calculator_test_utils {
 
                     let execution_start_time = initialize_tracker_and_compute_tx_start_time(
                         &mut shared_object_congestion_tracker,
-                        &certificate.shared_input_objects().collect::<Vec<_>>(),
+                        &certificate.shared_input_objects(),
                         *duration,
                     )
                     .expect(
@@ -299,7 +301,7 @@ pub mod suggested_gas_price_calculator_test_utils {
 
                         let execution_start_time = initialize_tracker_and_compute_tx_start_time(
                             &mut shared_object_congestion_tracker,
-                            &certificate.shared_input_objects().collect::<Vec<_>>(),
+                            &certificate.shared_input_objects(),
                             *duration,
                         )
                         .expect(
@@ -363,7 +365,7 @@ mod tests {
             tx_gas_data.gas_budget,
             tx_gas_data.gas_price,
         );
-        let shared_input_objects: Vec<_> = certificate.shared_input_objects().collect();
+        let shared_input_objects = certificate.shared_input_objects();
         shared_object_congestion_tracker.initialize_object_execution_slots(&shared_input_objects);
 
         let sequencing_result = shared_object_congestion_tracker.try_schedule(

--- a/crates/iota-core/src/transaction_manager.rs
+++ b/crates/iota-core/src/transaction_manager.rs
@@ -449,12 +449,12 @@ impl TransactionManager {
             certs
                 .into_iter()
                 .filter_map(|(cert, fx_digest)| {
+                    // Check availability of all transaction associated input objects(transaction +
+                    // authenticators).
                     let input_object_kinds = cert
-                        .data()
-                        .intent_message()
-                        .value
                         .input_objects()
-                        .expect("input_objects() cannot fail");
+                        .expect("input_objects() cannot fail")
+                        .collect::<Vec<_>>();
                     let mut input_object_keys = match epoch_store
                         .get_input_object_keys(&cert.key(), &input_object_kinds)
                     {

--- a/crates/iota-core/src/transaction_manager.rs
+++ b/crates/iota-core/src/transaction_manager.rs
@@ -451,10 +451,8 @@ impl TransactionManager {
                 .filter_map(|(cert, fx_digest)| {
                     // Check availability of all transaction associated input objects(transaction +
                     // authenticators).
-                    let input_object_kinds = cert
-                        .input_objects()
-                        .expect("input_objects() cannot fail")
-                        .collect::<Vec<_>>();
+                    let input_object_kinds =
+                        cert.input_objects().expect("input_objects() cannot fail");
                     let mut input_object_keys = match epoch_store
                         .get_input_object_keys(&cert.key(), &input_object_kinds)
                     {
@@ -870,6 +868,7 @@ impl TransactionManager {
         for (object_id, queue_len, txn_age) in self.objects_queue_len_and_age(
             tx_data
                 .shared_input_objects()
+                .into_iter()
                 .filter_map(|r| r.mutable.then_some(r.id))
                 .collect(),
         ) {

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -6330,6 +6330,7 @@ async fn test_consensus_handler_per_object_congestion_control(
             cert.data().transaction_data().gas_price() >= 4000
                 || cert
                     .shared_input_objects()
+                    .into_iter()
                     .any(|obj| { obj.id() == shared_objects[1].id() })
         );
     }
@@ -6387,6 +6388,7 @@ async fn test_consensus_handler_per_object_congestion_control(
             cert.data().transaction_data().gas_price() >= 2000
                 || cert
                     .shared_input_objects()
+                    .into_iter()
                     .any(|obj| { obj.id() == shared_objects[1].id() })
         );
     }

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -788,54 +788,9 @@ mod checked {
                 // In the case of an alive object, check that the object kind matches exactly,
                 // or that, if it is a shared object, only the mutability changes
                 if let ObjectReadResultKind::Object(_) = &other_object.object {
-                    match base_object.input_object_kind {
-                        // If immutable or owned object or package, the kinds must match exactly
-                        InputObjectKind::ImmOrOwnedMoveObject(_)
-                        | InputObjectKind::MovePackage(_) => {
-                            // This is an invariant
-                            assert_eq!(
-                                base_object.input_object_kind, other_object.input_object_kind,
-                                "The object kind for input objects with the same id must be equal"
-                            );
-                        }
-                        // else, if shared object, only mutability can differ
-                        InputObjectKind::SharedMoveObject {
-                            id: input_id,
-                            initial_shared_version: base_initial_shared_version,
-                            mutable: base_is_mutable,
-                            ..
-                        } => {
-                            match other_object.input_object_kind {
-                                InputObjectKind::ImmOrOwnedMoveObject(_)
-                                | InputObjectKind::MovePackage(_) => {
-                                    // The object owner for objects with the same id must be equal
-                                    fp_bail!(UserInputError::NotSharedObject.into())
-                                }
-                                InputObjectKind::SharedMoveObject {
-                                    id: additional_id,
-                                    initial_shared_version: other_initial_shared_version,
-                                    mutable: other_is_mutable,
-                                } => {
-                                    fp_ensure!(
-                                        input_id == additional_id
-                                            && base_initial_shared_version
-                                                == other_initial_shared_version,
-                                        UserInputError::SharedObjectStartingVersionMismatch.into()
-                                    );
-                                    // if other_is_mutable is true and base_is_mutable is false,
-                                    // then swap
-                                    if other_is_mutable && !base_is_mutable {
-                                        base_object.input_object_kind =
-                                            InputObjectKind::SharedMoveObject {
-                                                id: input_id,
-                                                initial_shared_version: base_initial_shared_version,
-                                                mutable: true,
-                                            };
-                                    }
-                                }
-                            }
-                        }
-                    };
+                    base_object
+                        .input_object_kind
+                        .union(&other_object.input_object_kind)?;
                 }
             } else {
                 base_set.push(other_object.clone());

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -790,7 +790,7 @@ mod checked {
                 if let ObjectReadResultKind::Object(_) = &other_object.object {
                     base_object
                         .input_object_kind
-                        .union(&other_object.input_object_kind)?;
+                        .left_union_with_checks(&other_object.input_object_kind)?;
                 }
             } else {
                 base_set.push(other_object.clone());

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -219,6 +219,9 @@ pub enum UserInputError {
     #[error("Wrong initial version given for shared object")]
     SharedObjectStartingVersionMismatch,
 
+    #[error("Wrong id given for shared object")]
+    SharedObjectIdMismatch,
+
     #[error(
         "Attempt to transfer object {object_id} that does not have public transfer. Object transfer must be done instead using a distinct Move function call"
     )]

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -529,10 +529,7 @@ pub fn transaction_non_shared_input_object_keys(
 ) -> IotaResult<Vec<ObjectKey>> {
     use crate::transaction::InputObjectKind as I;
     Ok(tx
-        .intent_message()
-        .value
         .input_objects()?
-        .into_iter()
         .filter_map(|object| match object {
             I::MovePackage(_) | I::SharedMoveObject { .. } => None,
             I::ImmOrOwnedMoveObject(obj) => Some(obj.into()),

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -530,6 +530,7 @@ pub fn transaction_non_shared_input_object_keys(
     use crate::transaction::InputObjectKind as I;
     Ok(tx
         .input_objects()?
+        .into_iter()
         .filter_map(|object| match object {
             I::MovePackage(_) | I::SharedMoveObject { .. } => None,
             I::ImmOrOwnedMoveObject(obj) => Some(obj.into()),

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -1294,7 +1294,7 @@ impl SharedInputObject {
     /// Merges another SharedInputObject into self.
     /// If there is a conflict in mutability, the resulting object will be
     /// mutable. Errors if the id or initial_shared_version do not match.
-    pub fn union(&mut self, other: &SharedInputObject) -> UserInputResult<()> {
+    pub fn left_union(&mut self, other: &SharedInputObject) -> UserInputResult<()> {
         fp_ensure!(self.id == other.id, UserInputError::SharedObjectIdMismatch);
         fp_ensure!(
             self.initial_shared_version == other.initial_shared_version,
@@ -2523,7 +2523,7 @@ impl SenderSignedData {
     /// example) can be duplicated in the transaction and authenticator
     /// object lists, we load them independently to make it possible to
     /// analyze the inputs in the transaction checkers.
-    pub fn collect_all_inputs_for_reading(&self) -> IotaResult<Vec<InputObjectKind>> {
+    pub fn collect_all_input_object_kind_for_reading(&self) -> IotaResult<Vec<InputObjectKind>> {
         let mut input_objects_set = self
             .transaction_data()
             .input_objects()?
@@ -2543,7 +2543,7 @@ impl SenderSignedData {
     /// 2. Input objects required by the sender `MoveAuthenticator`, including
     ///    the object to authenticate.
     /// 3. The object to authenticate from the sender `MoveAuthenticator`.
-    pub fn split_inputs_into_groups_for_reading(
+    pub fn split_input_objects_into_groups_for_reading(
         &self,
         input_objects: InputObjects,
     ) -> IotaResult<(InputObjects, Option<InputObjects>, Option<ObjectReadResult>)> {
@@ -2633,7 +2633,7 @@ impl SenderSignedData {
                 match entry {
                     None => input_objects.push(auth_shared_object),
                     Some(existing) => existing
-                        .union(&auth_shared_object)
+                        .left_union(&auth_shared_object)
                         .expect("union of shared objects should not fail"),
                 }
             }
@@ -2667,7 +2667,7 @@ impl SenderSignedData {
 
                 match entry {
                     None => input_objects.push(auth_object),
-                    Some(existing) => existing.union(&auth_object)?,
+                    Some(existing) => existing.left_union_with_checks(&auth_object)?,
                 }
             }
         }
@@ -3118,7 +3118,7 @@ impl InputObjectKind {
     /// For shared objects, if either is mutable, the result is mutable.
     /// Fails if either is not a shared object, or if the IDs or initial
     /// versions do not match.
-    pub fn union(&mut self, other: &InputObjectKind) -> UserInputResult<()> {
+    pub fn left_union_with_checks(&mut self, other: &InputObjectKind) -> UserInputResult<()> {
         match self {
             InputObjectKind::MovePackage(_) | InputObjectKind::ImmOrOwnedMoveObject(_) => {
                 fp_bail!(UserInputError::NotSharedObject)

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet, hash_map::Entry},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt::{Debug, Display, Formatter, Write},
     hash::Hash,
     iter::{self, once},
@@ -2507,19 +2507,17 @@ impl SenderSignedData {
     /// them independently to make it possible to analyze the inputs in the
     /// transaction checkers.
     pub fn collect_all_inputs_for_reading(&self) -> IotaResult<Vec<InputObjectKind>> {
+        let mut input_objects_set = self
+            .transaction_data()
+            .input_objects()?
+            .into_iter()
+            .collect::<HashSet<_>>();
+
         if let Some(move_authenticator) = self.sender_move_authenticator() {
-            let mut input_objects_set = self
-                .transaction_data()
-                .input_objects()?
-                .into_iter()
-                .collect::<HashSet<_>>();
-
             input_objects_set.extend(move_authenticator.input_objects());
-
-            Ok(input_objects_set.into_iter().collect::<Vec<_>>())
-        } else {
-            Ok(self.transaction_data().input_objects()?)
         }
+
+        Ok(input_objects_set.into_iter().collect::<Vec<_>>())
     }
 
     /// Splits the provided input objects into three groups:
@@ -2532,62 +2530,61 @@ impl SenderSignedData {
         &self,
         input_objects: InputObjects,
     ) -> IotaResult<(InputObjects, Option<InputObjects>, Option<ObjectReadResult>)> {
-        if let Some(move_authenticator) = self.sender_move_authenticator() {
-            let input_objects_map = input_objects
-                .iter()
-                .map(|o| (&o.input_object_kind, o))
-                .collect::<HashMap<_, _>>();
+        let input_objects_map = input_objects
+            .iter()
+            .map(|o| (&o.input_object_kind, o))
+            .collect::<HashMap<_, _>>();
 
-            let tx_input_objects = self
-                .transaction_data()
-                .input_objects()?
-                .iter()
-                .map(|k| {
-                    input_objects_map
-                        .get(k)
-                        .map(|&r| r.clone())
-                        .expect("All transaction input objects are expected to be present")
-                })
-                .collect::<Vec<_>>()
-                .into();
+        let tx_input_objects = self
+            .transaction_data()
+            .input_objects()?
+            .iter()
+            .map(|k| {
+                input_objects_map
+                    .get(k)
+                    .map(|&r| r.clone())
+                    .expect("All transaction input objects are expected to be present")
+            })
+            .collect::<Vec<_>>()
+            .into();
 
-            let auth_input_objects = move_authenticator
-                .input_objects()
-                .iter()
-                .map(|k| {
-                    input_objects_map
-                        .get(k)
-                        .map(|&r| r.clone())
-                        .expect("All authenticator input objects are expected to be present")
-                })
-                .collect::<Vec<_>>()
-                .into();
+        let (auth_input_objects, account_object) =
+            if let Some(move_authenticator) = self.sender_move_authenticator() {
+                let auth_input_objects = move_authenticator
+                    .input_objects()
+                    .iter()
+                    .map(|k| {
+                        input_objects_map
+                            .get(k)
+                            .map(|&r| r.clone())
+                            .expect("All authenticator input objects are expected to be present")
+                    })
+                    .collect::<Vec<_>>()
+                    .into();
 
-            let account_objects = move_authenticator
-                .object_to_authenticate()
-                .input_objects()
-                .iter()
-                .map(|k| {
-                    input_objects_map
-                        .get(k)
-                        .map(|&r| r.clone())
-                        .expect("Account object is expected to be present")
-                })
-                .collect::<Vec<_>>();
+                let account_objects = move_authenticator
+                    .object_to_authenticate()
+                    .input_objects()
+                    .iter()
+                    .map(|k| {
+                        input_objects_map
+                            .get(k)
+                            .map(|&r| r.clone())
+                            .expect("Account object is expected to be present")
+                    })
+                    .collect::<Vec<_>>();
 
-            debug_assert!(
-                account_objects.len() == 1,
-                "Only one account object must be loaded"
-            );
+                debug_assert!(
+                    account_objects.len() == 1,
+                    "Only one account object must be loaded"
+                );
 
-            Ok((
-                tx_input_objects,
-                Some(auth_input_objects),
-                account_objects.into_iter().next(),
-            ))
-        } else {
-            Ok((input_objects, None, None))
-        }
+                (Some(auth_input_objects), account_objects.into_iter().next())
+            } else {
+                (None, None)
+            };
+
+        Ok((tx_input_objects, auth_input_objects, account_object))
     }
 
     /// Checks if `SenderSignedData` contains at least one shared object.
@@ -2603,38 +2600,36 @@ impl SenderSignedData {
     /// with different mutability, only one instance which is mutable is
     /// returned.
     pub fn shared_input_objects(&self) -> impl Iterator<Item = SharedInputObject> + '_ {
-        let mut shared_objects_map = self
-            .transaction_data()
-            .shared_input_objects()
-            .into_iter()
-            .map(|o| (o.id(), o))
-            .collect::<HashMap<_, _>>();
+        // Vector is used to preserve the order of input objects.
+        let mut input_objects = self.transaction_data().shared_input_objects();
 
         // Add the Move authenticator shared objects if any.
         if let Some(move_authenticator) = self.sender_move_authenticator() {
             for auth_shared_object in move_authenticator.shared_objects() {
-                let entry = shared_objects_map.entry(auth_shared_object.id());
+                let entry = input_objects
+                    .iter_mut()
+                    .find(|o| o.id() == auth_shared_object.id());
 
                 match entry {
-                    Entry::Vacant(vacant) => {
-                        vacant.insert(auth_shared_object);
+                    None => {
+                        input_objects.push(auth_shared_object);
                     }
-                    Entry::Occupied(occupied) => {
+                    Some(existing) => {
                         assert_eq!(
-                            occupied.get().initial_shared_version,
+                            existing.initial_shared_version,
                             auth_shared_object.initial_shared_version,
                             "The `initial_shared_version` field for shared input objects with the same id must be equal"
                         );
 
-                        if !occupied.get().mutable && auth_shared_object.mutable {
-                            *occupied.into_mut() = auth_shared_object;
+                        if !existing.mutable && auth_shared_object.mutable {
+                            existing.mutable = auth_shared_object.mutable;
                         }
                     }
                 }
             }
         }
 
-        shared_objects_map.into_values()
+        input_objects.into_iter()
     }
 
     /// Returns an iterator over all input objects related to this

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2528,25 +2528,6 @@ impl SenderSignedData {
             })
     }
 
-    /// Returns all input objects including those from the sender
-    /// `MoveAuthenticator` if any.
-    pub fn collect_all_inputs(&self) -> IotaResult<Vec<InputObjectKind>> {
-        if let Some(move_authenticator) = self.sender_move_authenticator() {
-            let mut input_objects_set = self
-                .transaction_data()
-                .input_objects()?
-                .into_iter()
-                .collect::<HashSet<_>>();
-
-            input_objects_set.extend(move_authenticator.input_objects());
-            input_objects_set.extend(move_authenticator.object_to_authenticate().input_objects());
-
-            Ok(input_objects_set.into_iter().collect::<Vec<_>>())
-        } else {
-            Ok(self.transaction_data().input_objects()?)
-        }
-    }
-
     /// Splits the provided input objects into three groups:
     /// 1. Input objects required by the transaction itself.
     /// 2. Input objects required by the sender `MoveAuthenticator`.
@@ -2644,6 +2625,33 @@ impl SenderSignedData {
             .into_iter()
             .chain(authenticator_shared_objects)
             .unique()
+    }
+
+    /// Returns an iterator over all input objects related to this
+    /// transaction, including those from the `MoveAuthenticator` if any.
+    pub fn input_objects(&self) -> IotaResult<impl Iterator<Item = InputObjectKind> + '_> {
+        // Add the Move authenticator input objects if any.
+        let authenticator_input_objects =
+            if let Some(move_authenticator) = self.sender_move_authenticator() {
+                move_authenticator
+                    .input_objects()
+                    .into_iter()
+                    // Add `object_to_authenticate` input object.
+                    .chain(move_authenticator.object_to_authenticate().input_objects())
+                    .collect::<Vec<_>>()
+                    .into_iter()
+            } else {
+                Vec::new().into_iter()
+            };
+
+        Ok(self
+            .inner()
+            .intent_message
+            .value
+            .input_objects()?
+            .into_iter()
+            .chain(authenticator_input_objects)
+            .unique())
     }
 
     /// Checks if `SenderSignedData` contains the `Random` object as an

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, hash_map::Entry},
     fmt::{Debug, Display, Formatter, Write},
     hash::Hash,
     iter::{self, once},
@@ -15,7 +15,7 @@ use anyhow::bail;
 use enum_dispatch::enum_dispatch;
 use fastcrypto::{encoding::Base64, hash::HashFunction};
 use iota_protocol_config::ProtocolConfig;
-use itertools::{Either, Itertools};
+use itertools::Either;
 use move_core_types::{
     ident_str,
     identifier::{self, Identifier},
@@ -2499,12 +2499,36 @@ impl SenderSignedData {
             })
     }
 
+    /// Returns all unique input objects including those from the sender
+    /// `MoveAuthenticator` if any for reading.
+    ///
+    /// Although some shared objects(with a different mutability flag) can be
+    /// duplicated in the transaction and authenticator object lists, we load
+    /// them independently to make it possible to analyze the inputs in the
+    /// transaction checkers.
+    pub fn collect_all_inputs_for_reading(&self) -> IotaResult<Vec<InputObjectKind>> {
+        if let Some(move_authenticator) = self.sender_move_authenticator() {
+            let mut input_objects_set = self
+                .transaction_data()
+                .input_objects()?
+                .into_iter()
+                .collect::<HashSet<_>>();
+
+            input_objects_set.extend(move_authenticator.input_objects());
+
+            Ok(input_objects_set.into_iter().collect::<Vec<_>>())
+        } else {
+            Ok(self.transaction_data().input_objects()?)
+        }
+    }
+
     /// Splits the provided input objects into three groups:
-    /// 1. Input objects required by the transaction itself.
+    /// 1. Input objects required by the transaction itself; may contain
+    ///    duplicates if an IOTA coin is used both as an input and a gas coin.
     /// 2. Input objects required by the sender `MoveAuthenticator`, including
     ///    the object to authenticate.
     /// 3. The object to authenticate from the sender `MoveAuthenticator`.
-    pub fn split_inputs_into_groups(
+    pub fn split_inputs_into_groups_for_reading(
         &self,
         input_objects: InputObjects,
     ) -> IotaResult<(InputObjects, Option<InputObjects>, Option<ObjectReadResult>)> {
@@ -2574,43 +2598,109 @@ impl SenderSignedData {
 
     /// Returns an iterator over all shared input objects related to this
     /// transaction, including those from the `MoveAuthenticator` if any.
+    ///
+    /// If a shared object appears both in the transaction and authenticator
+    /// with different mutability, only one instance which is mutable is
+    /// returned.
     pub fn shared_input_objects(&self) -> impl Iterator<Item = SharedInputObject> + '_ {
-        // Add the Move authenticator shared objects if any.
-        let authenticator_shared_objects =
-            if let Some(move_authenticator) = self.sender_move_authenticator() {
-                move_authenticator.shared_objects().into_iter()
-            } else {
-                Vec::new().into_iter()
-            };
-
-        self.inner()
-            .intent_message
-            .value
+        let mut shared_objects_map = self
+            .transaction_data()
             .shared_input_objects()
             .into_iter()
-            .chain(authenticator_shared_objects)
-            .unique()
+            .map(|o| (o.id(), o))
+            .collect::<HashMap<_, _>>();
+
+        // Add the Move authenticator shared objects if any.
+        if let Some(move_authenticator) = self.sender_move_authenticator() {
+            for auth_shared_object in move_authenticator.shared_objects() {
+                let entry = shared_objects_map.entry(auth_shared_object.id());
+
+                match entry {
+                    Entry::Vacant(vacant) => {
+                        vacant.insert(auth_shared_object);
+                    }
+                    Entry::Occupied(occupied) => {
+                        assert_eq!(
+                            occupied.get().initial_shared_version,
+                            auth_shared_object.initial_shared_version,
+                            "The `initial_shared_version` field for shared input objects with the same id must be equal"
+                        );
+
+                        if !occupied.get().mutable && auth_shared_object.mutable {
+                            *occupied.into_mut() = auth_shared_object;
+                        }
+                    }
+                }
+            }
+        }
+
+        shared_objects_map.into_values()
     }
 
     /// Returns an iterator over all input objects related to this
     /// transaction, including those from the `MoveAuthenticator` if any.
+    ///
+    /// If an IOTA coin is used both as an input and as a gas coin, it will
+    /// appear two times in the returned iterator.
+    ///
+    /// If a shared object appears both in the transaction and authenticator
+    /// with different mutability, only one instance which is mutable is
+    /// returned.
     pub fn input_objects(&self) -> IotaResult<impl Iterator<Item = InputObjectKind> + '_> {
-        // Add the Move authenticator input objects if any.
-        let authenticator_input_objects =
-            if let Some(move_authenticator) = self.sender_move_authenticator() {
-                move_authenticator.input_objects().into_iter()
-            } else {
-                Vec::new().into_iter()
-            };
+        // Can contain duplicates in case of using the same IOTA coin as an input and as
+        // a gas coin.
+        let mut input_objects = self.transaction_data().input_objects()?;
 
-        Ok(self
-            .inner()
-            .intent_message
-            .value
-            .input_objects()?
-            .into_iter()
-            .chain(authenticator_input_objects)
-            .unique())
+        // Add the Move authenticator shared objects if any.
+        if let Some(move_authenticator) = self.sender_move_authenticator() {
+            for auth_shared_object in move_authenticator.input_objects() {
+                let auth_shared_object_id = auth_shared_object.object_id();
+                let entry = input_objects
+                    .iter_mut()
+                    .find(|o| o.object_id() == auth_shared_object_id);
+
+                match entry {
+                    None => {
+                        input_objects.push(auth_shared_object);
+                    }
+                    Some(existing) => match existing {
+                        InputObjectKind::MovePackage(_)
+                        | InputObjectKind::ImmOrOwnedMoveObject(_) => {
+                            assert_eq!(
+                                existing, &auth_shared_object,
+                                "The input object kinds is expected to be equal or the same object id {auth_shared_object_id}",
+                            );
+                        }
+                        InputObjectKind::SharedMoveObject {
+                            id,
+                            initial_shared_version,
+                            mutable,
+                        } => match auth_shared_object {
+                            InputObjectKind::MovePackage(_)
+                            | InputObjectKind::ImmOrOwnedMoveObject(_) => {
+                                panic!("Mismatched input object kinds for the same object id {id}");
+                            }
+                            InputObjectKind::SharedMoveObject {
+                                id: _,
+                                initial_shared_version: auth_initial_shared_version,
+                                mutable: auth_mutable,
+                            } => {
+                                assert_eq!(
+                                    initial_shared_version, &auth_initial_shared_version,
+                                    "The `initial_shared_version` field must be equal for shared input objects with the same id {id}"
+                                );
+
+                                if !*mutable && auth_mutable {
+                                    *mutable = auth_mutable;
+                                }
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+        Ok(input_objects.into_iter())
     }
 
     /// Checks if `SenderSignedData` contains the `Random` object as an

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2607,7 +2607,7 @@ impl SenderSignedData {
     /// Checks if `SenderSignedData` contains at least one shared object.
     /// This function checks shared objects from the `MoveAuthenticator` if any.
     pub fn contains_shared_object(&self) -> bool {
-        self.shared_input_objects().next().is_some()
+        !self.shared_input_objects().is_empty()
     }
 
     /// Returns an iterator over all shared input objects related to this
@@ -2619,7 +2619,7 @@ impl SenderSignedData {
     ///
     /// Shared objects with the same ID but different versions are returned
     /// separately.
-    pub fn shared_input_objects(&self) -> impl Iterator<Item = SharedInputObject> + '_ {
+    pub fn shared_input_objects(&self) -> Vec<SharedInputObject> {
         // Vector is used to preserve the order of input objects.
         let mut input_objects = self.transaction_data().shared_input_objects();
 
@@ -2640,7 +2640,7 @@ impl SenderSignedData {
             }
         }
 
-        input_objects.into_iter()
+        input_objects
     }
 
     /// Returns an iterator over all input objects related to this
@@ -2654,7 +2654,7 @@ impl SenderSignedData {
     /// returned.
     ///
     /// Shared objects with the same ID but different versions are not allowed.
-    pub fn input_objects(&self) -> IotaResult<impl Iterator<Item = InputObjectKind> + '_> {
+    pub fn input_objects(&self) -> IotaResult<Vec<InputObjectKind>> {
         // Can contain duplicates in case of using the same IOTA coin as an input and as
         // a gas coin.
         let mut input_objects = self.transaction_data().input_objects()?;
@@ -2673,7 +2673,7 @@ impl SenderSignedData {
             }
         }
 
-        Ok(input_objects.into_iter())
+        Ok(input_objects)
     }
 
     /// Checks if `SenderSignedData` contains the `Random` object as an
@@ -2681,6 +2681,7 @@ impl SenderSignedData {
     /// This function checks shared objects from the `MoveAuthenticator` if any.
     pub fn uses_randomness(&self) -> bool {
         self.shared_input_objects()
+            .iter()
             .any(|obj| obj.id() == IOTA_RANDOMNESS_STATE_OBJECT_ID)
     }
 

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2617,8 +2617,8 @@ impl SenderSignedData {
     /// with the same version but different mutability, only one instance which
     /// is mutable is returned.
     ///
-    /// Shared objects with the same ID but different versions are returned
-    /// separately.
+    /// Panics if there are shared objects with the same ID but different
+    /// initial versions.
     pub fn shared_input_objects(&self) -> Vec<SharedInputObject> {
         // Vector is used to preserve the order of input objects.
         let mut input_objects = self.transaction_data().shared_input_objects();
@@ -2626,10 +2626,9 @@ impl SenderSignedData {
         // Add the Move authenticator shared objects if any.
         if let Some(move_authenticator) = self.sender_move_authenticator() {
             for auth_shared_object in move_authenticator.shared_objects() {
-                let entry = input_objects.iter_mut().find(|o| {
-                    o.id == auth_shared_object.id
-                        && o.initial_shared_version == auth_shared_object.initial_shared_version
-                });
+                let entry = input_objects
+                    .iter_mut()
+                    .find(|o| o.id == auth_shared_object.id);
 
                 match entry {
                     None => input_objects.push(auth_shared_object),

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -1290,6 +1290,23 @@ impl SharedInputObject {
     pub fn into_id_and_version(self) -> (ObjectID, SequenceNumber) {
         (self.id, self.initial_shared_version)
     }
+
+    /// Merges another SharedInputObject into self.
+    /// If there is a conflict in mutability, the resulting object will be
+    /// mutable. Errors if the id or initial_shared_version do not match.
+    pub fn union(&mut self, other: &SharedInputObject) -> UserInputResult<()> {
+        fp_ensure!(self.id == other.id, UserInputError::SharedObjectIdMismatch);
+        fp_ensure!(
+            self.initial_shared_version == other.initial_shared_version,
+            UserInputError::SharedObjectStartingVersionMismatch
+        );
+
+        if !self.mutable && other.mutable {
+            self.mutable = other.mutable;
+        }
+
+        Ok(())
+    }
 }
 
 impl TransactionKind {
@@ -2502,10 +2519,10 @@ impl SenderSignedData {
     /// Returns all unique input objects including those from the sender
     /// `MoveAuthenticator` if any for reading.
     ///
-    /// Although some shared objects(with a different mutability flag) can be
-    /// duplicated in the transaction and authenticator object lists, we load
-    /// them independently to make it possible to analyze the inputs in the
-    /// transaction checkers.
+    /// Although some shared objects(with a different mutability flag, for
+    /// example) can be duplicated in the transaction and authenticator
+    /// object lists, we load them independently to make it possible to
+    /// analyze the inputs in the transaction checkers.
     pub fn collect_all_inputs_for_reading(&self) -> IotaResult<Vec<InputObjectKind>> {
         let mut input_objects_set = self
             .transaction_data()
@@ -2597,8 +2614,11 @@ impl SenderSignedData {
     /// transaction, including those from the `MoveAuthenticator` if any.
     ///
     /// If a shared object appears both in the transaction and authenticator
-    /// with different mutability, only one instance which is mutable is
-    /// returned.
+    /// with the same version but different mutability, only one instance which
+    /// is mutable is returned.
+    ///
+    /// Shared objects with the same ID but different versions are returned
+    /// separately.
     pub fn shared_input_objects(&self) -> impl Iterator<Item = SharedInputObject> + '_ {
         // Vector is used to preserve the order of input objects.
         let mut input_objects = self.transaction_data().shared_input_objects();
@@ -2606,25 +2626,16 @@ impl SenderSignedData {
         // Add the Move authenticator shared objects if any.
         if let Some(move_authenticator) = self.sender_move_authenticator() {
             for auth_shared_object in move_authenticator.shared_objects() {
-                let entry = input_objects
-                    .iter_mut()
-                    .find(|o| o.id() == auth_shared_object.id());
+                let entry = input_objects.iter_mut().find(|o| {
+                    o.id == auth_shared_object.id
+                        && o.initial_shared_version == auth_shared_object.initial_shared_version
+                });
 
                 match entry {
-                    None => {
-                        input_objects.push(auth_shared_object);
-                    }
-                    Some(existing) => {
-                        assert_eq!(
-                            existing.initial_shared_version,
-                            auth_shared_object.initial_shared_version,
-                            "The `initial_shared_version` field for shared input objects with the same id must be equal"
-                        );
-
-                        if !existing.mutable && auth_shared_object.mutable {
-                            existing.mutable = auth_shared_object.mutable;
-                        }
-                    }
+                    None => input_objects.push(auth_shared_object),
+                    Some(existing) => existing
+                        .union(&auth_shared_object)
+                        .expect("union of shared objects should not fail"),
                 }
             }
         }
@@ -2641,6 +2652,8 @@ impl SenderSignedData {
     /// If a shared object appears both in the transaction and authenticator
     /// with different mutability, only one instance which is mutable is
     /// returned.
+    ///
+    /// Shared objects with the same ID but different versions are not allowed.
     pub fn input_objects(&self) -> IotaResult<impl Iterator<Item = InputObjectKind> + '_> {
         // Can contain duplicates in case of using the same IOTA coin as an input and as
         // a gas coin.
@@ -2648,49 +2661,14 @@ impl SenderSignedData {
 
         // Add the Move authenticator shared objects if any.
         if let Some(move_authenticator) = self.sender_move_authenticator() {
-            for auth_shared_object in move_authenticator.input_objects() {
-                let auth_shared_object_id = auth_shared_object.object_id();
+            for auth_object in move_authenticator.input_objects() {
                 let entry = input_objects
                     .iter_mut()
-                    .find(|o| o.object_id() == auth_shared_object_id);
+                    .find(|o| o.object_id() == auth_object.object_id());
 
                 match entry {
-                    None => {
-                        input_objects.push(auth_shared_object);
-                    }
-                    Some(existing) => match existing {
-                        InputObjectKind::MovePackage(_)
-                        | InputObjectKind::ImmOrOwnedMoveObject(_) => {
-                            assert_eq!(
-                                existing, &auth_shared_object,
-                                "The input object kinds is expected to be equal or the same object id {auth_shared_object_id}",
-                            );
-                        }
-                        InputObjectKind::SharedMoveObject {
-                            id,
-                            initial_shared_version,
-                            mutable,
-                        } => match auth_shared_object {
-                            InputObjectKind::MovePackage(_)
-                            | InputObjectKind::ImmOrOwnedMoveObject(_) => {
-                                panic!("Mismatched input object kinds for the same object id {id}");
-                            }
-                            InputObjectKind::SharedMoveObject {
-                                id: _,
-                                initial_shared_version: auth_initial_shared_version,
-                                mutable: auth_mutable,
-                            } => {
-                                assert_eq!(
-                                    initial_shared_version, &auth_initial_shared_version,
-                                    "The `initial_shared_version` field must be equal for shared input objects with the same id {id}"
-                                );
-
-                                if !*mutable && auth_mutable {
-                                    *mutable = auth_mutable;
-                                }
-                            }
-                        },
-                    },
+                    None => input_objects.push(auth_object),
+                    Some(existing) => existing.union(&auth_object)?,
                 }
             }
         }
@@ -3134,6 +3112,44 @@ impl InputObjectKind {
             Self::ImmOrOwnedMoveObject((_, _, _)) => true,
             Self::SharedMoveObject { mutable, .. } => *mutable,
         }
+    }
+
+    /// Merges another InputObjectKind into self.
+    /// For shared objects, if either is mutable, the result is mutable.
+    /// Fails if either is not a shared object, or if the IDs or initial
+    /// versions do not match.
+    pub fn union(&mut self, other: &InputObjectKind) -> UserInputResult<()> {
+        match self {
+            InputObjectKind::MovePackage(_) | InputObjectKind::ImmOrOwnedMoveObject(_) => {
+                fp_bail!(UserInputError::NotSharedObject)
+            }
+            InputObjectKind::SharedMoveObject {
+                id,
+                initial_shared_version,
+                mutable,
+            } => match other {
+                InputObjectKind::MovePackage(_) | InputObjectKind::ImmOrOwnedMoveObject(_) => {
+                    fp_bail!(UserInputError::NotSharedObject)
+                }
+                InputObjectKind::SharedMoveObject {
+                    id: other_id,
+                    initial_shared_version: other_initial_shared_version,
+                    mutable: other_mutable,
+                } => {
+                    fp_ensure!(id == other_id, UserInputError::SharedObjectIdMismatch);
+                    fp_ensure!(
+                        initial_shared_version == other_initial_shared_version,
+                        UserInputError::SharedObjectStartingVersionMismatch
+                    );
+
+                    if !*mutable && *other_mutable {
+                        *mutable = *other_mutable;
+                    }
+                }
+            },
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/iota-types/src/unit_tests/messages_tests.rs
+++ b/crates/iota-types/src/unit_tests/messages_tests.rs
@@ -1077,7 +1077,7 @@ fn test_consensus_commit_prologue_v1_transaction() {
     );
     assert!(tx.contains_shared_object());
     assert_eq!(
-        tx.shared_input_objects().next().unwrap(),
+        tx.shared_input_objects().into_iter().next().unwrap(),
         SharedInputObject {
             id: IOTA_CLOCK_OBJECT_ID,
             initial_shared_version: IOTA_CLOCK_OBJECT_SHARED_VERSION,


### PR DESCRIPTION
# Description of change

Replace the function usage in several places, but there are some that still need to be checked:
1. Indexing.
2. Replays.

## Links to any relevant issues

fixes #9278 

