### PR TITLE
feat(consensus): add traversed headers tracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13793,6 +13793,7 @@ dependencies = [
  "rstest",
  "rustls 0.23.28",
  "serde",
+ "serial_test",
  "shared-crypto",
  "starfish-config",
  "strum_macros 0.26.4",

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1310,6 +1310,7 @@
                 "congestion_control_gas_price_feedback_mechanism": false,
                 "congestion_control_min_free_execution_slot": false,
                 "consensus_batched_block_sync": false,
+                "consensus_commit_transactions_only_for_traversed_headers": false,
                 "consensus_distributed_vote_scoring_strategy": false,
                 "consensus_linearize_subdag_v2": false,
                 "consensus_median_timestamp_with_checkpoint_enforcement": false,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -89,6 +89,8 @@ pub const MAX_PROTOCOL_VERSION: u64 = 16;
 // Version 16: Enable selecting committee only from active validators that
 //             support the next epoch's version and issued valid
 //             AuthorityCapabilities notification.
+//             Enable committing transactions only for traversed headers in
+//             Starfish.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -2309,6 +2311,9 @@ impl ProtocolConfig {
                     // next epoch's version and issued valid AuthorityCapabilities notification.
                     cfg.feature_flags
                         .select_committee_supporting_next_epoch_version = true;
+                    // Enable committing transactions only for traversed headers in Starfish
+                    cfg.feature_flags
+                        .consensus_commit_transactions_only_for_traversed_headers = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2495,7 +2495,10 @@ impl ProtocolConfig {
         self.feature_flags
             .consensus_median_timestamp_with_checkpoint_enforcement = val;
     }
-    pub fn set_consensus_commit_transactions_only_for_traversed_headers(&mut self, val: bool) {
+    pub fn set_consensus_commit_transactions_only_for_traversed_headers_for_testing(
+        &mut self,
+        val: bool,
+    ) {
         self.feature_flags
             .consensus_commit_transactions_only_for_traversed_headers = val;
     }

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -367,6 +367,9 @@ struct FeatureFlags {
     // leader's ancestors, and (3) enforces checkpoint timestamps are non-decreasing.
     #[serde(skip_serializing_if = "is_false")]
     consensus_median_timestamp_with_checkpoint_enforcement: bool,
+    // If true, then transactions are committed only for traversed headers
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_commit_transactions_only_for_traversed_headers: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1436,6 +1439,10 @@ impl ProtocolConfig {
         );
         res
     }
+    pub fn consensus_commit_transactions_only_for_traversed_headers(&self) -> bool {
+        self.feature_flags
+            .consensus_commit_transactions_only_for_traversed_headers
+    }
 }
 
 #[cfg(not(msim))]
@@ -2482,6 +2489,10 @@ impl ProtocolConfig {
     ) {
         self.feature_flags
             .consensus_median_timestamp_with_checkpoint_enforcement = val;
+    }
+    pub fn set_consensus_commit_transactions_only_for_traversed_headers(&mut self, val: bool) {
+        self.feature_flags
+            .consensus_commit_transactions_only_for_traversed_headers = val;
     }
 }
 

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_16.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_16.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/iota-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 16
 feature_flags:
@@ -30,6 +29,7 @@ feature_flags:
   select_committee_from_eligible_validators: true
   track_non_committee_eligible_validators: true
   select_committee_supporting_next_epoch_version: true
+  consensus_commit_transactions_only_for_traversed_headers: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_16.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_16.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/iota-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 16
 feature_flags:
@@ -31,6 +30,7 @@ feature_flags:
   track_non_committee_eligible_validators: true
   select_committee_supporting_next_epoch_version: true
   consensus_median_timestamp_with_checkpoint_enforcement: true
+  consensus_commit_transactions_only_for_traversed_headers: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_16.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_16.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/iota-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 16
 feature_flags:
@@ -38,6 +37,7 @@ feature_flags:
   track_non_committee_eligible_validators: true
   select_committee_supporting_next_epoch_version: true
   consensus_median_timestamp_with_checkpoint_enforcement: true
+  consensus_commit_transactions_only_for_traversed_headers: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/starfish/core/Cargo.toml
+++ b/crates/starfish/core/Cargo.toml
@@ -64,6 +64,7 @@ typed-store.workspace = true
 [dev-dependencies]
 # external dependencies
 rstest.workspace = true
+serial_test = "2.0.0"
 tempfile.workspace = true
 
 # internal dependencies

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -183,7 +183,7 @@ impl CommitObserver {
                 .leader
                 .round;
             self.linearizer
-                .evict_old_acknowledgments(max_solid_commit_leader_round);
+                .evict_old_acknowledgments_and_headers(max_solid_commit_leader_round);
         }
         tracing::trace!("Committed & sent {sent_sub_dags:#?}");
 

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -183,7 +183,7 @@ impl CommitObserver {
                 .leader
                 .round;
             self.linearizer
-                .evict_old_acknowledgments_and_headers(max_solid_commit_leader_round);
+                .evict_linearizer(max_solid_commit_leader_round);
         }
         tracing::trace!("Committed & sent {sent_sub_dags:#?}");
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1340,6 +1340,7 @@ mod test {
     use iota_metrics::monitored_mpsc::unbounded_channel;
     use iota_protocol_config::ProtocolConfig;
     use rstest::rstest;
+    use serial_test::serial;
     use starfish_config::{AuthorityIndex, Parameters};
     use tokio::time::sleep;
 
@@ -2260,11 +2261,20 @@ mod test {
         }
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_sequenced_transactions_no_headers() {
+    #[serial]
+    async fn test_sequenced_transactions_no_headers(
+        #[values(true, false)] commit_only_for_traversed_headers: bool,
+    ) {
         telemetry_subscribers::init_for_testing();
         let committee_size = 10;
-        let (context, _key_pairs) = Context::new_for_test(committee_size);
+        let (mut context, _key_pairs) = Context::new_for_test(committee_size);
+        context
+            .protocol_config
+            .set_consensus_commit_transactions_only_for_traversed_headers_for_testing(
+                commit_only_for_traversed_headers,
+            );
         let own_index = AuthorityIndex::new_for_test(0);
         let core_fixture_own = CoreTextFixture::new(
             context.clone(),
@@ -2342,7 +2352,8 @@ mod test {
                     );
                 } else {
                     assert!(
-                        !existing_headers.contains(&transaction.block_ref()),
+                        !existing_headers.contains(&transaction.block_ref())
+                            && !commit_only_for_traversed_headers,
                         "{}",
                         transaction.block_ref()
                     );
@@ -2354,7 +2365,7 @@ mod test {
             }
         }
         // Now the node that tries to catch up will sync the certified commits
-        // The commits contains only the headers
+        // The commits contain only the headers
         let certified_commits = sub_dags_and_commits
             .iter()
             .map(|(_, c)| c.clone())
@@ -2369,14 +2380,24 @@ mod test {
             .find(|(a, _)| a.author == authority_to_skip)
             .unwrap()
             .0;
+        if commit_only_for_traversed_headers {
+            assert_eq!(
+                first_missing_transaction_from_skipped.round,
+                num_rounds_with_skip_ancestors
+            );
+        } else {
+            assert_eq!(first_missing_transaction_from_skipped.round, 1);
+        }
         // Ensure that the block header corresponding to the
         // first_missing_transaction_from_skipped is not in dag_state
-        assert!(
+        // if commit_only_for_traversed_headers=false and in dag_state otherwise
+        assert_eq!(
             core_catch_up
                 .dag_state
                 .read()
                 .get_verified_block_headers(&[first_missing_transaction_from_skipped])[0]
-                .is_none()
+                .is_some(),
+            commit_only_for_traversed_headers
         );
         let last_solid_commit_round = core_catch_up
             .dag_state
@@ -2412,15 +2433,19 @@ mod test {
         // Flush to evict verified transactions from first rounds;
         core_catch_up.dag_state.write().flush();
         // Try to get a verified transaction from skipped authority. It should be
-        // impossible with get_verified_transactions() method since the header
-        // is not available
+        // impossible if commit_only_for_traversed_headers = false with
+        // get_verified_transactions() method since the header is not available;
+        // should be possible with commit_only_for_traversed_headers = true
         let opt_verified_transaction = core_catch_up
             .dag_state
             .read()
             .get_verified_transactions(&[first_missing_transaction_from_skipped]);
-        assert!(opt_verified_transaction[0].is_none());
+        assert_eq!(
+            opt_verified_transaction[0].is_some(),
+            commit_only_for_traversed_headers
+        );
         // Try to get a serialized transaction from skipped authority. It should now be
-        // impossible with get_serialized_transactions() method since it just
+        // possible with get_serialized_transactions() method since it just
         // reads bytes from storage
         let opt_serialized_transaction = core_catch_up
             .dag_state
@@ -2846,7 +2871,6 @@ mod test {
         *receiver.borrow_and_update()
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_commit_and_notify_for_block_status() {
         telemetry_subscribers::init_for_testing();

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -263,10 +263,7 @@ impl Linearizer {
     /// This function evicts old acknowledgments and traversed headers from the
     /// tracker. Should be called for solid committed leader round since we
     /// rely on the ack tracker in transaction synchronizer.
-    pub(crate) fn evict_old_acknowledgments_and_headers(
-        &mut self,
-        solid_commit_leader_round: Round,
-    ) {
+    pub(crate) fn evict_linearizer(&mut self, solid_commit_leader_round: Round) {
         let lower_bound_round =
             solid_commit_leader_round.saturating_sub(self.context.protocol_config.gc_depth() * 2);
         let lower_bound = BlockRef::new(
@@ -905,7 +902,7 @@ mod tests {
             assert_eq!(ack_authors.len(), 4);
         }
 
-        linearizer.evict_old_acknowledgments_and_headers(num_rounds);
+        linearizer.evict_linearizer(num_rounds);
         // Check that acknowledgements for the first num_rounds_to_evict rounds are
         // evicted and the rest are still stored
         for round in 1..=num_rounds - 2 {

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -102,10 +102,15 @@ impl Linearizer {
         );
 
         drop(dag_state_guard);
-
-        for block_header in &to_commit {
-            self.traversed_headers_tracker
-                .insert(block_header.reference());
+        if self
+            .context
+            .protocol_config
+            .consensus_commit_transactions_only_for_traversed_headers()
+        {
+            for block_header in &to_commit {
+                self.traversed_headers_tracker
+                    .insert(block_header.reference());
+            }
         }
 
         // Collect all block references for transactions that reached quorum after
@@ -272,7 +277,13 @@ impl Linearizer {
             BlockHeaderDigest::MIN,
         );
         self.transactions_ack_tracker = self.transactions_ack_tracker.split_off(&lower_bound);
-        self.traversed_headers_tracker = self.traversed_headers_tracker.split_off(&lower_bound);
+        if self
+            .context
+            .protocol_config
+            .consensus_commit_transactions_only_for_traversed_headers()
+        {
+            self.traversed_headers_tracker = self.traversed_headers_tracker.split_off(&lower_bound);
+        }
     }
 
     /// This function is called to add the transaction acknowledgments to the
@@ -297,9 +308,14 @@ impl Linearizer {
             let was_below_threshold = !votes_collector.reached_threshold(&self.context.committee);
 
             if votes_collector.add(authority, &self.context.committee) && was_below_threshold {
-                // We commit transactions only if the moment of reaching the quorum the
+                // We commit transactions only if at the moment of reaching the quorum the
                 // corresponding header is traversed
-                if self.traversed_headers_tracker.contains(&block_ref) {
+                if !self
+                    .context
+                    .protocol_config
+                    .consensus_commit_transactions_only_for_traversed_headers()
+                    || self.traversed_headers_tracker.contains(&block_ref)
+                {
                     transactions_to_commit.push(block_ref);
                 }
             }

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -45,6 +45,7 @@ pub(crate) struct Linearizer {
     dag_state: Arc<RwLock<DagState>>,
     leader_schedule: Arc<LeaderSchedule>,
     transactions_ack_tracker: BTreeMap<BlockRef, StakeAggregator<QuorumThreshold>>,
+    traversed_headers_tracker: BTreeSet<BlockRef>,
 }
 
 impl Linearizer {
@@ -58,6 +59,7 @@ impl Linearizer {
             leader_schedule,
             context,
             transactions_ack_tracker: BTreeMap::new(),
+            traversed_headers_tracker: BTreeSet::new(),
         }
     }
 
@@ -100,6 +102,11 @@ impl Linearizer {
         );
 
         drop(dag_state_guard);
+
+        for block_header in &to_commit {
+            self.traversed_headers_tracker
+                .insert(block_header.reference());
+        }
 
         // Collect all block references for transactions that reached quorum after
         // adding acknowledgments
@@ -165,8 +172,8 @@ impl Linearizer {
 
         let mut to_commit = Vec::new();
 
-        let mut committed = HashSet::new();
-        assert!(committed.insert(leader_block_ref));
+        let mut traversed_headers = HashSet::new();
+        assert!(traversed_headers.insert(leader_block_ref));
 
         while let Some(x) = buffer.pop() {
             to_commit.push(x.clone());
@@ -180,7 +187,7 @@ impl Linearizer {
                             // We skip the block if we already committed it or
                             // we reached a round that we already committed or
                             // we traverse too far back in the past
-                            !committed.contains(ancestor)
+                            !traversed_headers.contains(ancestor)
                                 && last_committed_rounds[ancestor.author] < ancestor.round
                                 && ancestor.round
                                     >= leader_round.saturating_sub(max_linearizer_depth)
@@ -195,7 +202,7 @@ impl Linearizer {
 
             for ancestor in ancestors {
                 buffer.push(ancestor.clone());
-                assert!(committed.insert(ancestor.reference()));
+                assert!(traversed_headers.insert(ancestor.reference()));
             }
         }
 
@@ -253,10 +260,13 @@ impl Linearizer {
         pending_sub_dags
     }
 
-    /// This function evicts old acknowledgments from the tracker. Should be
-    /// called for solid committed leader round since we rely on the ack
-    /// tracker in transaction synchronizer.
-    pub(crate) fn evict_old_acknowledgments(&mut self, solid_commit_leader_round: Round) {
+    /// This function evicts old acknowledgments and traversed headers from the
+    /// tracker. Should be called for solid committed leader round since we
+    /// rely on the ack tracker in transaction synchronizer.
+    pub(crate) fn evict_old_acknowledgments_and_headers(
+        &mut self,
+        solid_commit_leader_round: Round,
+    ) {
         let lower_bound_round =
             solid_commit_leader_round.saturating_sub(self.context.protocol_config.gc_depth() * 2);
         let lower_bound = BlockRef::new(
@@ -265,6 +275,7 @@ impl Linearizer {
             BlockHeaderDigest::MIN,
         );
         self.transactions_ack_tracker = self.transactions_ack_tracker.split_off(&lower_bound);
+        self.traversed_headers_tracker = self.traversed_headers_tracker.split_off(&lower_bound);
     }
 
     /// This function is called to add the transaction acknowledgments to the
@@ -276,7 +287,7 @@ impl Linearizer {
         authority: AuthorityIndex,
         acknowledgments: Vec<BlockRef>,
     ) -> Vec<BlockRef> {
-        let mut acknowledged_data = Vec::new();
+        let mut transactions_to_commit = Vec::new();
         for block_ref in acknowledgments {
             if block_ref.round < round.saturating_sub(self.context.protocol_config.gc_depth()) {
                 continue; // Ignore acknowledgments for blocks that are too old
@@ -289,10 +300,14 @@ impl Linearizer {
             let was_below_threshold = !votes_collector.reached_threshold(&self.context.committee);
 
             if votes_collector.add(authority, &self.context.committee) && was_below_threshold {
-                acknowledged_data.push(block_ref);
+                // We commit transactions only if the moment of reaching the quorum the
+                // corresponding header is traversed
+                if self.traversed_headers_tracker.contains(&block_ref) {
+                    transactions_to_commit.push(block_ref);
+                }
             }
         }
-        acknowledged_data
+        transactions_to_commit
     }
 
     /// This method accepts a vector of missing transaction references and
@@ -890,7 +905,7 @@ mod tests {
             assert_eq!(ack_authors.len(), 4);
         }
 
-        linearizer.evict_old_acknowledgments(num_rounds);
+        linearizer.evict_old_acknowledgments_and_headers(num_rounds);
         // Check that acknowledgements for the first num_rounds_to_evict rounds are
         // evicted and the rest are still stored
         for round in 1..=num_rounds - 2 {

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -300,9 +300,9 @@ impl DagBuilder {
             );
 
             // Update the last committed rounds
-            for block in &to_commit {
-                self.last_committed_rounds[block.author()] =
-                    self.last_committed_rounds[block.author()].max(block.round());
+            for block_header in &to_commit {
+                self.last_committed_rounds[block_header.author()] =
+                    self.last_committed_rounds[block_header.author()].max(block_header.round());
             }
 
             let commit = TrustedCommit::new_for_test(


### PR DESCRIPTION
# Description of change

PR adds traversed headers tracker in Linearizer. Now, when we are trying to commit transactions, we are checking that the corresponding header was actually traversed. It guarantees us that if for some block transactions are committed, then the corresponding header is also committed.

A protocol parameter was added for this change. It is enabled since version 16 in all networks (but it affects only Starfish which is run only on Devnet now).

## Links to any relevant issues

fixes #9302 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: logic for committing transactions in Starfish was changed
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
