### PR TITLE
feat(consensus): add timestamps to consensus spammer

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -285,6 +285,7 @@ pub struct AuthorityMetrics {
 
     /// Consensus handler metrics
     pub consensus_handler_processed: IntCounterVec,
+    pub consensus_handler_random_bytes_latency: Histogram,
     pub consensus_handler_transaction_sizes: HistogramVec,
     pub consensus_handler_num_low_scoring_authorities: IntGauge,
     pub consensus_handler_scores: IntGaugeVec,
@@ -654,6 +655,12 @@ impl AuthorityMetrics {
                 "Number of transactions processed by consensus handler",
                 &["class"],
                 registry
+            ).unwrap(),
+            consensus_handler_random_bytes_latency: register_histogram_with_registry!(
+                "consensus_handler_random_bytes_latency",
+                "The time taken between transaction creation and committing it in the handler",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
             ).unwrap(),
             consensus_handler_transaction_sizes: register_histogram_vec_with_registry!(
                 "consensus_handler_transaction_sizes",

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -7,6 +7,7 @@ use std::{
     hash::Hash,
     num::NonZeroUsize,
     sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use arc_swap::ArcSwap;
@@ -325,6 +326,23 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         self.last_consensus_stats
                             .stats
                             .inc_num_user_transactions(authority_index as usize);
+                    }
+                    if let ConsensusTransactionKind::RandomBytes(bytes) = &transaction.kind {
+                        // Extract only the first 8 bytes to derive the timestamp
+                        let ts = u64::from_be_bytes(bytes[..8].try_into().unwrap());
+
+                        // Get the current moment
+                        let now = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap()
+                            .as_micros() as u64;
+
+                        // Compute latency in seconds
+                        let latency = now.saturating_sub(ts);
+                        let latency_sec = (latency as f64) / 1_000_000.0;
+                        self.metrics
+                            .consensus_handler_random_bytes_latency
+                            .observe(latency_sec);
                     }
                     let transaction = SequencedConsensusTransactionKind::External(transaction);
                     transactions.push((transaction, authority_index));

--- a/crates/iota-node/src/spammer.rs
+++ b/crates/iota-node/src/spammer.rs
@@ -6,7 +6,7 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use iota_core::{
@@ -213,9 +213,22 @@ impl SpammerService {
                             config.mean_size_bytes as f64,
                             config.std_dev_size_bytes as f64,
                         );
-                        let size = size.max(1.0) as usize; // Ensure at least 1 byte
+                         let size = size.max(8.0) as usize; // Ensure at least 8 bytes
 
-                        let bytes = Self::generate_random_bytes(size);
+                        // 1. Generate random bytes of given size
+                        let mut bytes = Self::generate_random_bytes(size);
+
+                        // 2. Generate timestamp
+                        let timestamp = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap()
+                            .as_micros() as u64;
+
+                        // 3. Convert timestamp to 8 bytes
+                        let ts_bytes = timestamp.to_be_bytes();
+
+                        // 4. Overwrite first 8 bytes
+                        bytes[..8].copy_from_slice(&ts_bytes);
 
                         // Create and submit transaction
                         let tx = ConsensusTransaction::new_random_bytes(bytes);


### PR DESCRIPTION
# Description of change

To measure a metric close to e2e latency we append a timestamp to randomly generated consensus transactions. This allows to measure the latency in the consensus handler at the time when processing the consensus output. In particular, this is useful to detect that the consensus input is not overwhelmed

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

