### PR TITLE
fix(node): IOTA-Names config defaults to chain ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7115,6 +7115,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-macros",
  "iota-metrics",
+ "iota-names",
  "iota-network",
  "iota-network-stack",
  "iota-protocol-config",

--- a/crates/iota-names/src/config.rs
+++ b/crates/iota-names/src/config.rs
@@ -63,7 +63,8 @@ impl IotaNamesConfig {
 
     pub fn from_chain(chain: &Chain) -> Self {
         match chain {
-            Chain::Mainnet => todo!("https://github.com/iotaledger/iota/issues/6532"),
+            // TODO switch to mainnet https://github.com/iotaledger/iota/issues/6532
+            Chain::Mainnet => IotaNamesConfig::testnet(),
             Chain::Testnet => IotaNamesConfig::testnet(),
             Chain::Unknown => IotaNamesConfig::devnet(),
         }

--- a/crates/iota-node/Cargo.toml
+++ b/crates/iota-node/Cargo.toml
@@ -46,6 +46,7 @@ iota-json-rpc.workspace = true
 iota-json-rpc-api.workspace = true
 iota-macros.workspace = true
 iota-metrics.workspace = true
+iota-names.workspace = true
 iota-network.workspace = true
 iota-network-stack.workspace = true
 iota-protocol-config.workspace = true

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -108,6 +108,7 @@ use iota_storage::{
     key_value_store::{FallbackTransactionKVStore, TransactionKeyValueStore},
     key_value_store_metrics::KeyValueStoreMetrics,
 };
+use iota_names::config::IotaNamesConfig;
 use iota_types::{
     base_types::{AuthorityName, ConciseableName, EpochId},
     committee::Committee,
@@ -2521,9 +2522,9 @@ pub async fn build_http_server(
             ))?;
         }
 
-        // TODO: Init from chain if config is not set once `IotaNamesConfig::from_chain`
-        // is implemented
-        let iota_names_config = config.iota_names_config.clone().unwrap_or_default();
+        let iota_names_config = config.iota_names_config.clone().unwrap_or_else(|| {
+            IotaNamesConfig::from_chain(&state.get_chain_identifier().chain())
+        });
 
         server.register_module(IndexerApi::new(
             state.clone(),

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -95,6 +95,7 @@ use iota_metrics::{
     metrics_network::{MetricsMakeCallbackHandler, NetworkConnectionMetrics, NetworkMetrics},
     server_timing_middleware, spawn_monitored_task,
 };
+use iota_names::config::IotaNamesConfig;
 use iota_network::{
     api::ValidatorServer, discovery, discovery::TrustedPeerChangeEvent, randomness, state_sync,
 };
@@ -108,7 +109,6 @@ use iota_storage::{
     key_value_store::{FallbackTransactionKVStore, TransactionKeyValueStore},
     key_value_store_metrics::KeyValueStoreMetrics,
 };
-use iota_names::config::IotaNamesConfig;
 use iota_types::{
     base_types::{AuthorityName, ConciseableName, EpochId},
     committee::Committee,
@@ -2522,9 +2522,10 @@ pub async fn build_http_server(
             ))?;
         }
 
-        let iota_names_config = config.iota_names_config.clone().unwrap_or_else(|| {
-            IotaNamesConfig::from_chain(&state.get_chain_identifier().chain())
-        });
+        let iota_names_config = config
+            .iota_names_config
+            .clone()
+            .unwrap_or_else(|| IotaNamesConfig::from_chain(&state.get_chain_identifier().chain()));
 
         server.register_module(IndexerApi::new(
             state.clone(),


### PR DESCRIPTION
# Description of change

The IOTA-Names config was currently defaulting to Testnet if not provided, which made Devnet nodes to default to Testnet config. This PR changes to default to a config determined by the chain identifier.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [X] Nodes (Validators and Full nodes): IOTA-Names config defaults to the chain identifier instead of Testnet
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
