### PR TITLE
feat(authority): make simulate_transaction work with both dry_run and dev_inspect

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -110,7 +110,7 @@ use iota_types::{
         ProtocolConfig, SupportedProtocolVersions, SupportedProtocolVersionsWithHashes,
     },
     transaction::*,
-    transaction_executor::SimulateTransactionResult,
+    transaction_executor::{SimulateTransactionResult, VmChecks},
 };
 use itertools::Itertools;
 use move_binary_format::{CompiledModule, binary_config::BinaryConfig};
@@ -1619,6 +1619,8 @@ impl AuthorityState {
         self.prepare_certificate(&execution_guard, certificate, input_objects, epoch_store)
     }
 
+    /// TO BE DEPRECATED SOON: Use `simulate_transaction` with
+    /// `VmChecks::Enabled` instead.
     #[instrument("dry_exec_tx", level = "trace", skip_all)]
     #[allow(clippy::type_complexity)]
     pub fn dry_exec_transaction(
@@ -1845,7 +1847,8 @@ impl AuthorityState {
 
     pub fn simulate_transaction(
         &self,
-        transaction: TransactionData,
+        mut transaction: TransactionData,
+        checks: VmChecks,
     ) -> IotaResult<SimulateTransactionResult> {
         if transaction.kind().is_system_tx() {
             return Err(IotaError::UnsupportedFeature {
@@ -1860,20 +1863,16 @@ impl AuthorityState {
             });
         }
 
-        self.simulate_transaction_impl(&epoch_store, transaction)
-    }
-
-    fn simulate_transaction_impl(
-        &self,
-        epoch_store: &AuthorityPerEpochStore,
-        transaction: TransactionData,
-    ) -> IotaResult<SimulateTransactionResult> {
         // Cheap validity checks for a transaction, including input size limits.
+        // This does not check if gas objects are missing since we may create a
+        // mock gas object. It checks for other transaction input validity.
         transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
 
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 
+        // Since we need to simulate a validator signing the transaction, the first step
+        // is to check if some transaction elements are denied.
         iota_transaction_checks::deny::check_transaction_for_signing(
             &transaction,
             &[],
@@ -1883,100 +1882,111 @@ impl AuthorityState {
             self.get_backing_package_store().as_ref(),
         )?;
 
-        let (input_objects, receiving_objects) = self.input_loader.read_objects_for_signing(
-            // We don't want to cache this transaction since it's a dry run.
+        // Load input and receiving objects
+        let (mut input_objects, receiving_objects) = self.input_loader.read_objects_for_signing(
+            // We don't want to cache this transaction since it's a simulation.
             None,
             &input_object_kinds,
             &receiving_object_refs,
             epoch_store.epoch(),
         )?;
-        // make a gas object if one was not provided
-        let mut transaction = transaction;
-        let mut gas_object_refs = transaction.gas().to_vec();
-        let ((gas_status, checked_input_objects), mock_gas) = if transaction.gas().is_empty() {
-            let sender = transaction.gas_owner();
-            let gas_object_id = ObjectID::MAX;
-            let gas_object = Object::new_move(
+
+        // Create a mock gas object if one was not provided
+        let mock_gas_id = if transaction.gas().is_empty() {
+            let mock_gas_object = Object::new_move(
                 MoveObject::new_gas_coin(
                     OBJECT_START_VERSION,
-                    gas_object_id,
+                    ObjectID::MAX,
                     SIMULATION_GAS_COIN_VALUE,
                 ),
-                Owner::AddressOwner(sender),
+                Owner::AddressOwner(transaction.gas_data().owner),
                 TransactionDigest::genesis_marker(),
             );
-            let gas_object_ref = gas_object.compute_object_reference();
-            gas_object_refs = vec![gas_object_ref];
-
-            // Add the gas object to the transaction payment.
-            transaction.gas_data_mut().payment = gas_object_refs.clone();
-            (
-                iota_transaction_checks::check_transaction_input_with_given_gas(
-                    epoch_store.protocol_config(),
-                    epoch_store.reference_gas_price(),
-                    &transaction,
-                    input_objects,
-                    receiving_objects,
-                    gas_object,
-                    &self.metrics.bytecode_verifier_metrics,
-                    &self.config.verifier_signing_config,
-                )?,
-                Some(gas_object_id),
-            )
+            let mock_gas_object_ref = mock_gas_object.compute_object_reference();
+            transaction.gas_data_mut().payment = vec![mock_gas_object_ref];
+            input_objects.push(ObjectReadResult::new_from_gas_object(&mock_gas_object));
+            Some(mock_gas_object.id())
         } else {
-            (
-                iota_transaction_checks::check_transaction_input(
-                    epoch_store.protocol_config(),
-                    epoch_store.reference_gas_price(),
-                    &transaction,
-                    input_objects,
-                    &receiving_objects,
-                    &self.metrics.bytecode_verifier_metrics,
-                    &self.config.verifier_signing_config,
-                )?,
-                None,
-            )
+            None
         };
 
         let protocol_config = epoch_store.protocol_config();
-        let (kind, signer, _) = transaction.execution_parts();
 
-        let silent = true;
-        let executor = iota_execution::executor(protocol_config, silent, None)
-            .expect("Creating an executor should not fail here");
-
-        let expensive_checks = false;
-        let (inner_temp_store, _, effects, _execution_error) = executor
-            .execute_transaction_to_effects(
-                self.get_backing_store().as_ref(),
+        // Checks enabled -> DRY-RUN, it means we are simulating a real TX
+        // Checks disabled -> DEV-INSPECT, more relaxed Move VM checks
+        let (gas_status, checked_input_objects) = if checks.enabled() {
+            iota_transaction_checks::check_transaction_input(
                 protocol_config,
-                self.metrics.limits_metrics.clone(),
-                expensive_checks,
-                self.config.certificate_deny_config.certificate_deny_set(),
-                &epoch_store.epoch_start_config().epoch_data().epoch_id(),
-                epoch_store
-                    .epoch_start_config()
-                    .epoch_data()
-                    .epoch_start_timestamp(),
-                checked_input_objects,
-                gas_object_refs,
-                gas_status,
-                kind,
-                signer,
-                transaction.digest(),
-                &mut None,
-            );
+                epoch_store.reference_gas_price(),
+                &transaction,
+                input_objects,
+                &receiving_objects,
+                &self.metrics.bytecode_verifier_metrics,
+                &self.config.verifier_signing_config,
+            )?
+        } else {
+            let checked_input_objects = iota_transaction_checks::check_dev_inspect_input(
+                protocol_config,
+                transaction.kind(),
+                input_objects,
+                receiving_objects,
+            )?;
+            let gas_status = IotaGasStatus::new(
+                transaction.gas_budget(),
+                transaction.gas_price(),
+                epoch_store.reference_gas_price(),
+                protocol_config,
+            )?;
 
+            (gas_status, checked_input_objects)
+        };
+
+        // Create a new executor for the simulation
+        let executor = iota_execution::executor(
+            protocol_config,
+            true, // silent
+            None,
+        )
+        .expect("Creating an executor should not fail here");
+
+        // Execute the simulation
+        let (kind, signer, gas_coins) = transaction.execution_parts();
+        let (inner_temp_store, _, effects, execution_result) = executor.dev_inspect_transaction(
+            self.get_backing_store().as_ref(),
+            protocol_config,
+            self.metrics.limits_metrics.clone(),
+            false, // expensive_checks
+            self.config.certificate_deny_config.certificate_deny_set(),
+            &epoch_store.epoch_start_config().epoch_data().epoch_id(),
+            epoch_store
+                .epoch_start_config()
+                .epoch_data()
+                .epoch_start_timestamp(),
+            checked_input_objects,
+            gas_coins,
+            gas_status,
+            kind,
+            signer,
+            transaction.digest(),
+            checks.disabled(),
+        );
+
+        // In the case of a dev inspect, the execution_result could be filled with some
+        // values. Else, execution_result is empty in the case of a dry run.
         Ok(SimulateTransactionResult {
             input_objects: inner_temp_store.input_objects,
             output_objects: inner_temp_store.written,
             events: effects.events_digest().map(|_| inner_temp_store.events),
             effects,
-            mock_gas_id: mock_gas,
+            execution_result,
+            mock_gas_id,
         })
     }
 
-    /// The object ID for gas can be any object ID, even for an uncreated object
+    /// TO BE DEPRECATED SOON: Use `simulate_transaction` with
+    /// `VmChecks::DISABLED` instead.
+    /// The object ID for gas can be any
+    /// object ID, even for an uncreated object
     #[instrument("dev_inspect_tx", level = "trace", skip_all)]
     pub async fn dev_inspect_transaction_block(
         &self,

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -28,7 +28,7 @@ use iota_types::{
         QuorumDriverError, QuorumDriverResponse, QuorumDriverResult,
     },
     transaction::{TransactionData, VerifiedTransaction},
-    transaction_executor::SimulateTransactionResult,
+    transaction_executor::{SimulateTransactionResult, VmChecks},
 };
 use prometheus::{
     Histogram, Registry,
@@ -726,7 +726,9 @@ where
     fn simulate_transaction(
         &self,
         transaction: TransactionData,
+        checks: VmChecks,
     ) -> Result<SimulateTransactionResult, IotaError> {
-        self.validator_state.simulate_transaction(transaction)
+        self.validator_state
+            .simulate_transaction(transaction, checks)
     }
 }

--- a/crates/iota-rest-api/src/transactions/execution.rs
+++ b/crates/iota-rest-api/src/transactions/execution.rs
@@ -10,7 +10,7 @@ use iota_sdk2::types::{
     Transaction, TransactionEffects, TransactionEvents, ValidatorAggregatedSignature,
     framework::Coin,
 };
-use iota_types::transaction_executor::{SimulateTransactionResult, TransactionExecutor};
+use iota_types::transaction_executor::{SimulateTransactionResult, TransactionExecutor, VmChecks};
 use schemars::JsonSchema;
 use tap::Pipe;
 
@@ -420,14 +420,17 @@ pub(super) fn simulate_transaction_impl(
         ));
     }
 
+    // Hardcoded dry run simulation
+    let dry_run_checks = VmChecks::Enabled;
     let SimulateTransactionResult {
         input_objects,
         output_objects,
         events,
         effects,
+        execution_result: _,
         mock_gas_id,
     } = executor
-        .simulate_transaction(transaction.try_into()?)
+        .simulate_transaction(transaction.try_into()?, dry_run_checks)
         .map_err(anyhow::Error::from)?;
 
     if mock_gas_id.is_some() {

--- a/crates/iota-rest-api/src/transactions/resolve.rs
+++ b/crates/iota-rest-api/src/transactions/resolve.rs
@@ -22,6 +22,7 @@ use iota_types::{
     transaction::{
         CallArg, GasData, ObjectArg, ProgrammableTransaction, TransactionData, TransactionDataAPI,
     },
+    transaction_executor::VmChecks,
 };
 use itertools::Itertools;
 use move_binary_format::normalized;
@@ -128,8 +129,10 @@ async fn resolve_transaction(
     let budget = if let Some(user_provided_budget) = user_provided_budget {
         user_provided_budget
     } else {
+        // Hardcoded dry run simulation
+        let dry_run_checks = VmChecks::Enabled;
         let simulation_result = executor
-            .simulate_transaction(resolved_transaction.clone())
+            .simulate_transaction(resolved_transaction.clone(), dry_run_checks)
             .map_err(anyhow::Error::from)?;
 
         let estimate = estimate_gas_budget_from_gas_cost(

--- a/crates/iota-types/src/transaction_executor.rs
+++ b/crates/iota-types/src/transaction_executor.rs
@@ -7,7 +7,8 @@ use std::collections::BTreeMap;
 use crate::{
     base_types::ObjectID,
     effects::{TransactionEffects, TransactionEvents},
-    error::IotaError,
+    error::{ExecutionError, IotaError},
+    execution::ExecutionResult,
     object::Object,
     quorum_driver_types::{
         ExecuteTransactionRequestV1, ExecuteTransactionResponseV1, QuorumDriverError,
@@ -28,6 +29,7 @@ pub trait TransactionExecutor: Send + Sync {
     fn simulate_transaction(
         &self,
         transaction: TransactionData,
+        checks: VmChecks,
     ) -> Result<SimulateTransactionResult, IotaError>;
 }
 
@@ -36,5 +38,23 @@ pub struct SimulateTransactionResult {
     pub events: Option<TransactionEvents>,
     pub input_objects: BTreeMap<ObjectID, Object>,
     pub output_objects: BTreeMap<ObjectID, Object>,
+    pub execution_result: Result<Vec<ExecutionResult>, ExecutionError>,
     pub mock_gas_id: Option<ObjectID>,
+}
+
+#[derive(Default, Debug, Copy, Clone)]
+pub enum VmChecks {
+    #[default]
+    Enabled,
+    Disabled,
+}
+
+impl VmChecks {
+    pub fn disabled(self) -> bool {
+        matches!(self, Self::Disabled)
+    }
+
+    pub fn enabled(self) -> bool {
+        matches!(self, Self::Enabled)
+    }
 }


### PR DESCRIPTION
# Description of change

Changed the implementation of `simulate_transaction` in the authority. Now it supports the execution of both DRY RUN (when passing `VmChecks::ENABLED`) and DEV INSPECT (when passing `VmChecks::DISABLED`).

The REST API was not changed and a dry run was hardcoded for the `simulate_transaction` API (as it was working before). Not sure if this is needed to be changed as well. If yes, `TransactionSimulationResponse` should be changed to include `execution_result` and `SimulateTransactionQueryParameters` should be changed to include the `VmChecks` param.

The current tests should check that the `authority::simulate_transaction` dry run path works correctly. No new tests were added for the dev inspect path. If we don't change the REST API now, these new tests could be written once the gRPC is ready.

## Links to any relevant issues

Fixes #9323 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

