### PR TITLE
feat(gRPC): add `GetObjects` implementation in gRPC

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/utils.rs
+++ b/crates/iota-e2e-tests/tests/grpc/utils.rs
@@ -3,8 +3,32 @@
 
 /// Trait for types that can provide field presence information
 pub(crate) trait FieldPresenceChecker {
-    /// Check if a field with the given name is present (not None)
-    fn is_field_present(&self, field_name: &str) -> Option<bool>;
+    /// Check a field at the current level
+    /// Returns: Some((is_present, nested_checker)) if field exists in the
+    /// schema          
+    ///          None if field doesn't exist in the schema
+    /// Field name must be a single field, not a path (no dots)
+    fn check_field(&self, field_name: &str) -> Option<(bool, Option<&dyn FieldPresenceChecker>)>;
+
+    /// Check if a field path is present, supporting nested paths like
+    /// "reference.object_id"
+    fn is_field_present(&self, field_path: &str) -> Option<bool> {
+        match field_path.split_once('.') {
+            Some((field, rest)) => {
+                // Nested path - check this level and recurse
+                let (is_present, nested) = self.check_field(field)?;
+                if !is_present {
+                    return Some(false);
+                }
+                nested?.is_field_present(rest)
+            }
+            None => {
+                // Single field, no nesting
+                let (is_present, _) = self.check_field(field_path)?;
+                Some(is_present)
+            }
+        }
+    }
 }
 
 /// Macro to automatically implement FieldPresenceChecker for protobuf response
@@ -13,17 +37,79 @@ pub(crate) trait FieldPresenceChecker {
 /// Example: To add support for another protobuf response type, just add:
 /// impl_field_presence_checker!(AnotherResponse, {
 ///     "field1" => field1,
-///     "field2" => field2,
+///     "field2" => field2 [nested],
 ///     // ... other fields
 /// });
 #[macro_export]
 macro_rules! impl_field_presence_checker {
-    ($type:ty, { $( $field_name:literal => $field_ident:ident ),* $(,)? }) => {
+    ($type:ty, {
+        $( $tokens:tt )*
+    }) => {
+        $crate::impl_field_presence_checker!(@parse $type, [], [], [ $( $tokens )* ]);
+    };
+
+    // TT muncher: parse nested field
+    (@parse $type:ty, [ $( $non_nested_parsed:tt )* ], [ $( $nested_parsed:tt )* ],
+     [ $field_name:literal => $field_ident:ident [nested] , $( $rest:tt )* ]) => {
+        $crate::impl_field_presence_checker!(@parse $type,
+            [ $( $non_nested_parsed )* ],
+            [ $( $nested_parsed )* ($field_name, $field_ident), ],
+            [ $( $rest )* ]
+        );
+    };
+
+    // TT muncher: parse nested field (no trailing comma)
+    (@parse $type:ty, [ $( $non_nested_parsed:tt )* ], [ $( $nested_parsed:tt )* ],
+     [ $field_name:literal => $field_ident:ident [nested] ]) => {
+        $crate::impl_field_presence_checker!(@impl $type,
+            [ $( $non_nested_parsed )* ],
+            [ $( $nested_parsed )* ($field_name, $field_ident), ]
+        );
+    };
+
+    // TT muncher: parse non-nested field
+    (@parse $type:ty, [ $( $non_nested_parsed:tt )* ], [ $( $nested_parsed:tt )* ],
+     [ $field_name:literal => $field_ident:ident , $( $rest:tt )* ]) => {
+        $crate::impl_field_presence_checker!(@parse $type,
+            [ $( $non_nested_parsed )* ($field_name, $field_ident), ],
+            [ $( $nested_parsed )* ],
+            [ $( $rest )* ]
+        );
+    };
+
+    // TT muncher: parse non-nested field (no trailing comma)
+    (@parse $type:ty, [ $( $non_nested_parsed:tt )* ], [ $( $nested_parsed:tt )* ],
+     [ $field_name:literal => $field_ident:ident ]) => {
+        $crate::impl_field_presence_checker!(@impl $type,
+            [ $( $non_nested_parsed )* ($field_name, $field_ident), ],
+            [ $( $nested_parsed )* ]
+        );
+    };
+
+    // TT muncher: done parsing (empty input)
+    (@parse $type:ty, [ $( $non_nested_parsed:tt )* ], [ $( $nested_parsed:tt )* ], []) => {
+        $crate::impl_field_presence_checker!(@impl $type,
+            [ $( $non_nested_parsed )* ],
+            [ $( $nested_parsed )* ]
+        );
+    };
+
+    // Generate the implementation
+    (@impl $type:ty, [ $(  ($non_nested_name:literal, $non_nested_ident:ident), )* ], [ $(  ($nested_name:literal, $nested_ident:ident), )* ]) => {
         impl $crate::utils::FieldPresenceChecker for $type {
-            fn is_field_present(&self, field_name: &str) -> Option<bool> {
+            fn check_field(&self, field_name: &str) -> Option<(bool, Option<&dyn $crate::utils::FieldPresenceChecker>)> {
                 match field_name {
-                    $( $field_name => Some(self.$field_ident.is_some()), )*
-                    _ => None, // Unknown field
+                    $(
+                        $nested_name => {
+                            let is_present = self.$nested_ident.is_some();
+                            let nested = self.$nested_ident.as_ref().map(|f| f as &dyn $crate::utils::FieldPresenceChecker);
+                            Some((is_present, nested))
+                        }
+                    )*
+                    $(
+                        $non_nested_name => Some((self.$non_nested_ident.is_some(), None)),
+                    )*
+                    _ => None,
                 }
             }
         }
@@ -42,8 +128,8 @@ where
         let field_name = field.name;
         let should_be_present = expected_set.contains(field_name);
 
-        match response.is_field_present(field_name) {
-            Some(is_present) => {
+        match response.check_field(field_name) {
+            Some((is_present, _)) => {
                 assert_eq!(
                     is_present, should_be_present,
                     "{field_name} presence mismatch in {scenario}: expected {should_be_present}, got {is_present}",
@@ -53,6 +139,44 @@ where
                 "Unknown field '{field_name}' in {}, scenario {scenario}",
                 std::any::type_name::<T>(),
             ),
+        }
+    }
+}
+
+/// Assert nested field masks on any type implementing MessageFields +
+/// FieldPresenceChecker. This function validates that an object contains
+/// exactly the fields specified.
+/// # Example
+/// ```ignore
+/// assert_nested_field_masks(
+///     &my_object,
+///     &["reference.object_id", "reference.version", "bcs"],
+///     "test scenario"
+/// );
+/// ```
+pub(crate) fn assert_nested_field_masks<T>(object: &T, field_mask_paths: &[&str], scenario: &str)
+where
+    T: iota_grpc_types::field::MessageFields + FieldPresenceChecker,
+{
+    use std::collections::HashSet;
+
+    // Extract top-level field names (everything before first '.', if any)
+    let top_level_fields: Vec<&str> = field_mask_paths
+        .iter()
+        .map(|path| path.split('.').next().unwrap())
+        .collect::<HashSet<_>>() // Deduplicate in the same level
+        .into_iter()
+        .collect();
+
+    // Validate all top-level fields
+    assert_field_presence(object, &top_level_fields, scenario);
+
+    // Validate each path depth by depth
+    for path in field_mask_paths {
+        match object.is_field_present(path) {
+            Some(true) => {}
+            Some(false) => panic!("Expected field '{path}' in {scenario}, but it was None"),
+            None => panic!("Unknown field '{path}' in {scenario}"),
         }
     }
 }

--- a/crates/iota-e2e-tests/tests/grpc/utils.rs
+++ b/crates/iota-e2e-tests/tests/grpc/utils.rs
@@ -1,27 +1,24 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-/// Trait for checking if fields are present in protobuf messages
-///
-/// This lets us check which optional fields have values (Some) vs are empty
-/// (None)
-pub(crate) trait FieldPresenceChecker {
-    /// Returns a list of all possible field names for this type
-    /// Example: For a message with fields "id" and "name", returns ["id",
-    /// "name"]
-    fn all_fields(&self) -> &[&'static str];
+use std::collections::{HashMap, HashSet};
 
-    /// Check if a single field is present
+/// Trait for checking field presence/absence
+pub(crate) trait FieldPresenceChecker {
+    /// Returns a list of all top-level field names for this type.
+    fn top_level_fields(&self) -> &[&'static str];
+
+    /// Check if a specific top-level field is present (no dots allowed).
     ///
-    /// Input: field name like "reference" (no dots allowed)
     /// Returns:
     ///   - None: field name is invalid (doesn't exist on this type)
     ///   - Some((true, Some(checker))): field is present and has nested fields
-    ///     we can check
-    ///   - Some((true, None)): field is present but is a simple value (no
-    ///     nesting)
-    ///   - Some((false, _)): field is absent (None)
-    fn check_field(&self, field: &str) -> Option<(bool, Option<&dyn FieldPresenceChecker>)>;
+    ///   - Some((true, None)): field is present without nested fields
+    ///   - Some((false, _)): field exists but is absent (None)
+    fn check_field_presence(
+        &self,
+        field: &str,
+    ) -> Option<(bool, Option<&dyn FieldPresenceChecker>)>;
 }
 
 /// Macro to automatically implement FieldPresenceChecker for a protobuf message
@@ -37,24 +34,17 @@ pub(crate) trait FieldPresenceChecker {
 ///     nested: NestedType,   // nested message that can be recursed into
 /// });
 /// ```
-///
-/// # What it generates
-/// For each field, it checks if `self.field.is_some()` (protobuf optional
-/// fields are Option<T>) For nested fields with `: Type`, it also provides the
-/// nested checker so you can recurse
 #[macro_export]
 macro_rules! impl_field_presence_checker {
     // Main rule: matches the syntax `Type { field1, field2: NestedType, ... }`
     ($type:ty { $( $field:ident $( : $nested_type:ty )? ),* $(,)? }) => {
         // Generate the trait implementation for the given type
         impl $crate::utils::FieldPresenceChecker for $type {
-            // Return all field names as a static array
-            fn all_fields(&self) -> &[&'static str] {
+            fn top_level_fields(&self) -> &[&'static str] {
                 &[ $( stringify!($field) ),* ]  // stringify! turns `field1` into "field1"
             }
 
-            // Check a single field by name
-            fn check_field(&self, field: &str) -> Option<(bool, Option<&dyn $crate::utils::FieldPresenceChecker>)> {
+            fn check_field_presence(&self, field: &str) -> Option<(bool, Option<&dyn $crate::utils::FieldPresenceChecker>)> {
                 match field {
                     // For each field in the macro input, generate a match arm
                     $(
@@ -72,36 +62,27 @@ macro_rules! impl_field_presence_checker {
     };
 
     // Helper rule for nested fields (when `: Type` is specified)
-    // This rule matches when $nested_type is present
     (@field_check $self:ident, $field:ident, $nested_type:ty) => {{
         // Check if the field is Some (present) or None (absent)
         let present = $self.$field.is_some();
 
-        // If present, provide a reference to it as a FieldPresenceChecker
-        // This allows recursion into nested fields
+        // If nested field is present, provide a reference to it as a FieldPresenceChecker
         let nested = $self.$field.as_ref().map(|f| f as &dyn $crate::utils::FieldPresenceChecker);
 
         Some((present, nested))
     }};
 
     // Helper rule for simple fields (when no `: Type` is specified)
-    // This rule matches when $nested_type is NOT present
     (@field_check $self:ident, $field:ident) => {
         // Just check if the field is present; no nested checker needed
         Some(($self.$field.is_some(), None))
     };
 }
 
-/// Assert nested field masks - validate presence and absence of nested fields
-///
-/// This validates field masks that can include nested paths like
-/// "reference.object_id"
-///
-/// # Arguments
-/// * `object` - The protobuf message to check
-/// * `field_paths` - List of field paths that should be present (can include
-///   dots)
-/// * `scenario` - Test scenario name (for error messages)
+/// Assert field presence/absence for any type implementing
+/// FieldPresenceChecker. This function validates that an object contains
+/// exactly the fields specified (or their absence). It also supports nested
+/// field paths using dot notation (e.g., "reference.object_id").
 ///
 /// # Example
 /// ```ignore
@@ -118,124 +99,82 @@ macro_rules! impl_field_presence_checker {
 /// - `bcs` is present
 /// - All other fields at the top level are absent
 /// - All other fields inside `reference` are absent (like `reference.digest`)
-pub(crate) fn assert_field_presence<T>(object: &T, field_paths: &[&str], scenario: &str)
-where
-    T: iota_grpc_types::field::MessageFields + FieldPresenceChecker,
-{
-    // Start checking from the top level
-    check_level(object, object.all_fields(), field_paths, scenario);
-}
-
-/// Internal recursive function to check field presence at each nesting level
-///
-/// This is called recursively for each level of nesting.
-///
-/// # How it works
-/// 1. Extract field names expected at THIS level (before the first dot)
-/// 2. Check that all fields at this level are present/absent as expected
-/// 3. Group remaining paths by their parent field
-/// 4. Recursively check nested levels
-///
-/// # Example
-/// If field_paths is ["reference.object_id", "reference.version", "bcs"]:
-/// 1. At top level: expects "reference" and "bcs" present, all others absent
-/// 2. Recurses into "reference" with paths ["object_id", "version"]
-/// 3. Inside "reference": expects "object_id" and "version" present, all others
-///    absent
-fn check_level(
+pub(crate) fn assert_field_presence(
     checker: &dyn FieldPresenceChecker,
-    all_fields: &[&'static str],
-    paths: &[&str],
+    expected_field_paths: &[&str],
     scenario: &str,
 ) {
-    use std::collections::{HashMap, HashSet};
+    let mut expected_nested_field_paths: HashMap<&str, Vec<&str>> = HashMap::new();
+    let mut expected_non_nested_field_paths: HashSet<&str> = HashSet::new();
+    let mut expected_top_level_fields: HashSet<&str> = HashSet::new();
 
-    // Extract field names expected at THIS level (before first '.')
-    // Example: ["reference.object_id", "bcs"] -> {"reference", "bcs"}
-    let expected_this_level: HashSet<&str> = paths
-        .iter()
-        .map(|path| path.split('.').next().unwrap())
-        .collect();
+    for expected_field_path in expected_field_paths {
+        if let Some((top_level_field, remaining_path)) = expected_field_path.split_once('.') {
+            expected_nested_field_paths
+                .entry(top_level_field)
+                .or_default()
+                .push(remaining_path);
+            expected_top_level_fields.insert(top_level_field);
+        } else {
+            expected_non_nested_field_paths.insert(expected_field_path);
+            expected_top_level_fields.insert(expected_field_path);
+        }
+    }
 
-    // Validate that all expected fields are valid (exist in all_fields)
-    let valid_fields: HashSet<&str> = all_fields.iter().copied().collect();
-    for expected_field in &expected_this_level {
+    let actual_top_level_fields: HashSet<&str> =
+        checker.top_level_fields().iter().copied().collect();
+
+    // Validate that all expected fields exist on this type
+    for expected_top_level_field in &expected_top_level_fields {
         assert!(
-            valid_fields.contains(expected_field),
+            actual_top_level_fields.contains(expected_top_level_field),
             "Invalid field '{}' in {scenario}: field does not exist on this type",
-            expected_field
+            expected_top_level_field
         );
     }
 
     // Check each field at this level for correct presence/absence
-    for field in all_fields {
-        // Should this field be present?
-        let should_be_present = expected_this_level.contains(field);
+    for top_level_field in actual_top_level_fields.clone() {
+        let should_be_present = expected_top_level_fields.contains(top_level_field);
 
-        // Is this field actually present?
         let (is_present, _) = checker
-            .check_field(field)
-            .unwrap_or_else(|| panic!("Invalid field '{field}' in {scenario}"));
+            .check_field_presence(top_level_field)
+            .unwrap_or_else(|| panic!("Invalid field '{top_level_field}' in {scenario}"));
 
-        // Verify expectation matches reality
         assert_eq!(
             is_present, should_be_present,
-            "Field '{field}' in {scenario}: expected {should_be_present}, got {is_present}"
+            "Field '{top_level_field}' in {scenario}: expected {should_be_present}, got {is_present}"
         );
     }
 
-    // Group nested paths by their parent field
-    // Example: ["reference.object_id", "reference.version"]
-    //       -> {"reference": ["object_id", "version"]}
-    let mut nested: HashMap<&str, Vec<&str>> = HashMap::new();
-    let mut standalone_fields: HashSet<&str> = HashSet::new();
-
-    for path in paths {
-        if let Some((field, rest)) = path.split_once('.') {
-            // This path has nesting - add the remaining part to the group
-            nested.entry(field).or_default().push(rest);
-        } else {
-            // This is a standalone field (no dot) - track it
-            standalone_fields.insert(path);
-        }
-    }
-
-    // Validate no contradictory paths
-    // A field cannot be specified both standalone AND with nested paths
-    // Example: ["reference", "reference.object_id"] is contradictory because:
-    //   - "reference" alone means: all nested fields should be absent
-    //   - "reference.object_id" means: object_id should be present
-    for field in &standalone_fields {
-        if nested.contains_key(field) {
+    // Check that no field is specified both as nested and non-nested
+    for non_nested_field in &expected_non_nested_field_paths {
+        if expected_nested_field_paths.contains_key(non_nested_field) {
             panic!(
-                "Contradictory field paths in {scenario}: '{}' specified both standalone (implying no nested fields) and with nested paths ({})",
-                field,
-                nested[field]
+                "Contradictory field paths in {scenario}: '{non_nested_field}' specified both as non-nested (implying no nested fields) and with nested fields ({})",
+                expected_nested_field_paths[non_nested_field]
                     .iter()
-                    .map(|s| format!("{}.{}", field, s))
+                    .map(|s| format!("{}.{}", non_nested_field, s))
                     .collect::<Vec<_>>()
                     .join(", ")
             );
         }
     }
 
-    // Recursively check nested fields
-    // IMPORTANT: We must recurse into ALL present fields (not just those with
-    // nested paths) to verify their nested children are absent when not
-    // specified
-    for field in &expected_this_level {
-        // Get the nested checker for this field
-        if let Some((_, Some(nested_checker))) = checker.check_field(field) {
-            // Get sub-paths for this field, or empty slice if none specified
-            // Empty slice means ALL nested fields should be absent
-            let sub_paths = nested.get(field).map(|v| v.as_slice()).unwrap_or(&[]);
+    // Recurse into nested fields
+    for top_level_field in &actual_top_level_fields {
+        // Recurse only if there is a nested checker for this field
+        if let Some((_, Some(nested_checker))) = checker.check_field_presence(top_level_field) {
+            let expected_field_paths_nested = expected_nested_field_paths
+                .get(top_level_field)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
 
             // Recurse into this nested field
-            check_level(
+            assert_field_presence(
                 nested_checker,
-                nested_checker.all_fields(),
-                sub_paths,
-                &format!("{scenario}.{field}"), // Update scenario for better error messages
+                expected_field_paths_nested,
+                &format!("{scenario}.{top_level_field}"),
             );
         }
     }

--- a/crates/iota-e2e-tests/tests/grpc/utils.rs
+++ b/crates/iota-e2e-tests/tests/grpc/utils.rs
@@ -1,182 +1,242 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-/// Trait for types that can provide field presence information
+/// Trait for checking if fields are present in protobuf messages
+///
+/// This lets us check which optional fields have values (Some) vs are empty
+/// (None)
 pub(crate) trait FieldPresenceChecker {
-    /// Check a field at the current level
-    /// Returns: Some((is_present, nested_checker)) if field exists in the
-    /// schema          
-    ///          None if field doesn't exist in the schema
-    /// Field name must be a single field, not a path (no dots)
-    fn check_field(&self, field_name: &str) -> Option<(bool, Option<&dyn FieldPresenceChecker>)>;
+    /// Returns a list of all possible field names for this type
+    /// Example: For a message with fields "id" and "name", returns ["id",
+    /// "name"]
+    fn all_fields(&self) -> &[&'static str];
 
-    /// Check if a field path is present, supporting nested paths like
-    /// "reference.object_id"
-    fn is_field_present(&self, field_path: &str) -> Option<bool> {
-        match field_path.split_once('.') {
-            Some((field, rest)) => {
-                // Nested path - check this level and recurse
-                let (is_present, nested) = self.check_field(field)?;
-                if !is_present {
-                    return Some(false);
-                }
-                nested?.is_field_present(rest)
-            }
-            None => {
-                // Single field, no nesting
-                let (is_present, _) = self.check_field(field_path)?;
-                Some(is_present)
-            }
-        }
-    }
+    /// Check if a single field is present
+    ///
+    /// Input: field name like "reference" (no dots allowed)
+    /// Returns:
+    ///   - None: field name is invalid (doesn't exist on this type)
+    ///   - Some((true, Some(checker))): field is present and has nested fields
+    ///     we can check
+    ///   - Some((true, None)): field is present but is a simple value (no
+    ///     nesting)
+    ///   - Some((false, _)): field is absent (None)
+    fn check_field(&self, field: &str) -> Option<(bool, Option<&dyn FieldPresenceChecker>)>;
 }
 
-/// Macro to automatically implement FieldPresenceChecker for protobuf response
-/// types.
+/// Macro to automatically implement FieldPresenceChecker for a protobuf message
+/// type
 ///
-/// Example: To add support for another protobuf response type, just add:
-/// impl_field_presence_checker!(AnotherResponse, {
-///     "field1" => field1,
-///     "field2" => field2 [nested],
-///     // ... other fields
+/// This macro generates code that can check which fields are present/absent.
+///
+/// # Usage
+/// ```ignore
+/// impl_field_presence_checker!(MyMessage {
+///     field1,               // simple field (string, int, etc.)
+///     field2,               // another simple field
+///     nested: NestedType,   // nested message that can be recursed into
 /// });
+/// ```
+///
+/// # What it generates
+/// For each field, it checks if `self.field.is_some()` (protobuf optional
+/// fields are Option<T>) For nested fields with `: Type`, it also provides the
+/// nested checker so you can recurse
 #[macro_export]
 macro_rules! impl_field_presence_checker {
-    ($type:ty, {
-        $( $tokens:tt )*
-    }) => {
-        $crate::impl_field_presence_checker!(@parse $type, [], [], [ $( $tokens )* ]);
-    };
-
-    // TT muncher: parse nested field
-    (@parse $type:ty, [ $( $non_nested_parsed:tt )* ], [ $( $nested_parsed:tt )* ],
-     [ $field_name:literal => $field_ident:ident [nested] , $( $rest:tt )* ]) => {
-        $crate::impl_field_presence_checker!(@parse $type,
-            [ $( $non_nested_parsed )* ],
-            [ $( $nested_parsed )* ($field_name, $field_ident), ],
-            [ $( $rest )* ]
-        );
-    };
-
-    // TT muncher: parse nested field (no trailing comma)
-    (@parse $type:ty, [ $( $non_nested_parsed:tt )* ], [ $( $nested_parsed:tt )* ],
-     [ $field_name:literal => $field_ident:ident [nested] ]) => {
-        $crate::impl_field_presence_checker!(@impl $type,
-            [ $( $non_nested_parsed )* ],
-            [ $( $nested_parsed )* ($field_name, $field_ident), ]
-        );
-    };
-
-    // TT muncher: parse non-nested field
-    (@parse $type:ty, [ $( $non_nested_parsed:tt )* ], [ $( $nested_parsed:tt )* ],
-     [ $field_name:literal => $field_ident:ident , $( $rest:tt )* ]) => {
-        $crate::impl_field_presence_checker!(@parse $type,
-            [ $( $non_nested_parsed )* ($field_name, $field_ident), ],
-            [ $( $nested_parsed )* ],
-            [ $( $rest )* ]
-        );
-    };
-
-    // TT muncher: parse non-nested field (no trailing comma)
-    (@parse $type:ty, [ $( $non_nested_parsed:tt )* ], [ $( $nested_parsed:tt )* ],
-     [ $field_name:literal => $field_ident:ident ]) => {
-        $crate::impl_field_presence_checker!(@impl $type,
-            [ $( $non_nested_parsed )* ($field_name, $field_ident), ],
-            [ $( $nested_parsed )* ]
-        );
-    };
-
-    // TT muncher: done parsing (empty input)
-    (@parse $type:ty, [ $( $non_nested_parsed:tt )* ], [ $( $nested_parsed:tt )* ], []) => {
-        $crate::impl_field_presence_checker!(@impl $type,
-            [ $( $non_nested_parsed )* ],
-            [ $( $nested_parsed )* ]
-        );
-    };
-
-    // Generate the implementation
-    (@impl $type:ty, [ $(  ($non_nested_name:literal, $non_nested_ident:ident), )* ], [ $(  ($nested_name:literal, $nested_ident:ident), )* ]) => {
+    // Main rule: matches the syntax `Type { field1, field2: NestedType, ... }`
+    ($type:ty { $( $field:ident $( : $nested_type:ty )? ),* $(,)? }) => {
+        // Generate the trait implementation for the given type
         impl $crate::utils::FieldPresenceChecker for $type {
-            fn check_field(&self, field_name: &str) -> Option<(bool, Option<&dyn $crate::utils::FieldPresenceChecker>)> {
-                match field_name {
+            // Return all field names as a static array
+            fn all_fields(&self) -> &[&'static str] {
+                &[ $( stringify!($field) ),* ]  // stringify! turns `field1` into "field1"
+            }
+
+            // Check a single field by name
+            fn check_field(&self, field: &str) -> Option<(bool, Option<&dyn $crate::utils::FieldPresenceChecker>)> {
+                match field {
+                    // For each field in the macro input, generate a match arm
                     $(
-                        $nested_name => {
-                            let is_present = self.$nested_ident.is_some();
-                            let nested = self.$nested_ident.as_ref().map(|f| f as &dyn $crate::utils::FieldPresenceChecker);
-                            Some((is_present, nested))
+                        stringify!($field) => {
+                            // Call the helper rule to check this field
+                            // If $nested_type is present, it passes it; otherwise doesn't
+                            $crate::impl_field_presence_checker!(@field_check self, $field $(, $nested_type)?)
                         }
                     )*
-                    $(
-                        $non_nested_name => Some((self.$non_nested_ident.is_some(), None)),
-                    )*
+                    // Field name doesn't match any known field
                     _ => None,
                 }
             }
         }
     };
+
+    // Helper rule for nested fields (when `: Type` is specified)
+    // This rule matches when $nested_type is present
+    (@field_check $self:ident, $field:ident, $nested_type:ty) => {{
+        // Check if the field is Some (present) or None (absent)
+        let present = $self.$field.is_some();
+
+        // If present, provide a reference to it as a FieldPresenceChecker
+        // This allows recursion into nested fields
+        let nested = $self.$field.as_ref().map(|f| f as &dyn $crate::utils::FieldPresenceChecker);
+
+        Some((present, nested))
+    }};
+
+    // Helper rule for simple fields (when no `: Type` is specified)
+    // This rule matches when $nested_type is NOT present
+    (@field_check $self:ident, $field:ident) => {
+        // Just check if the field is present; no nested checker needed
+        Some(($self.$field.is_some(), None))
+    };
 }
 
-/// Assert field presence for any type implementing MessageFields +
-/// FieldPresenceChecker
-pub(crate) fn assert_field_presence<T>(response: &T, expected_fields: &[&str], scenario: &str)
-where
-    T: iota_grpc_types::field::MessageFields + FieldPresenceChecker,
-{
-    let expected_set: std::collections::HashSet<_> = expected_fields.iter().copied().collect();
-
-    for field in T::FIELDS {
-        let field_name = field.name;
-        let should_be_present = expected_set.contains(field_name);
-
-        match response.check_field(field_name) {
-            Some((is_present, _)) => {
-                assert_eq!(
-                    is_present, should_be_present,
-                    "{field_name} presence mismatch in {scenario}: expected {should_be_present}, got {is_present}",
-                );
-            }
-            None => panic!(
-                "Unknown field '{field_name}' in {}, scenario {scenario}",
-                std::any::type_name::<T>(),
-            ),
-        }
-    }
-}
-
-/// Assert nested field masks on any type implementing MessageFields +
-/// FieldPresenceChecker. This function validates that an object contains
-/// exactly the fields specified.
+/// Assert nested field masks - validate presence and absence of nested fields
+///
+/// This validates field masks that can include nested paths like
+/// "reference.object_id"
+///
+/// # Arguments
+/// * `object` - The protobuf message to check
+/// * `field_paths` - List of field paths that should be present (can include
+///   dots)
+/// * `scenario` - Test scenario name (for error messages)
+///
 /// # Example
 /// ```ignore
-/// assert_nested_field_masks(
-///     &my_object,
+/// assert_field_presence(
+///     &object,
 ///     &["reference.object_id", "reference.version", "bcs"],
 ///     "test scenario"
 /// );
 /// ```
-pub(crate) fn assert_nested_field_masks<T>(object: &T, field_mask_paths: &[&str], scenario: &str)
+/// This checks:
+/// - `reference` is present (inferred because reference.* are listed)
+/// - `reference.object_id` is present
+/// - `reference.version` is present
+/// - `bcs` is present
+/// - All other fields at the top level are absent
+/// - All other fields inside `reference` are absent (like `reference.digest`)
+pub(crate) fn assert_field_presence<T>(object: &T, field_paths: &[&str], scenario: &str)
 where
     T: iota_grpc_types::field::MessageFields + FieldPresenceChecker,
 {
-    use std::collections::HashSet;
+    // Start checking from the top level
+    check_level(object, object.all_fields(), field_paths, scenario);
+}
 
-    // Extract top-level field names (everything before first '.', if any)
-    let top_level_fields: Vec<&str> = field_mask_paths
+/// Internal recursive function to check field presence at each nesting level
+///
+/// This is called recursively for each level of nesting.
+///
+/// # How it works
+/// 1. Extract field names expected at THIS level (before the first dot)
+/// 2. Check that all fields at this level are present/absent as expected
+/// 3. Group remaining paths by their parent field
+/// 4. Recursively check nested levels
+///
+/// # Example
+/// If field_paths is ["reference.object_id", "reference.version", "bcs"]:
+/// 1. At top level: expects "reference" and "bcs" present, all others absent
+/// 2. Recurses into "reference" with paths ["object_id", "version"]
+/// 3. Inside "reference": expects "object_id" and "version" present, all others
+///    absent
+fn check_level(
+    checker: &dyn FieldPresenceChecker,
+    all_fields: &[&'static str],
+    paths: &[&str],
+    scenario: &str,
+) {
+    use std::collections::{HashMap, HashSet};
+
+    // Extract field names expected at THIS level (before first '.')
+    // Example: ["reference.object_id", "bcs"] -> {"reference", "bcs"}
+    let expected_this_level: HashSet<&str> = paths
         .iter()
         .map(|path| path.split('.').next().unwrap())
-        .collect::<HashSet<_>>() // Deduplicate in the same level
-        .into_iter()
         .collect();
 
-    // Validate all top-level fields
-    assert_field_presence(object, &top_level_fields, scenario);
+    // Validate that all expected fields are valid (exist in all_fields)
+    let valid_fields: HashSet<&str> = all_fields.iter().copied().collect();
+    for expected_field in &expected_this_level {
+        assert!(
+            valid_fields.contains(expected_field),
+            "Invalid field '{}' in {scenario}: field does not exist on this type",
+            expected_field
+        );
+    }
 
-    // Validate each path depth by depth
-    for path in field_mask_paths {
-        match object.is_field_present(path) {
-            Some(true) => {}
-            Some(false) => panic!("Expected field '{path}' in {scenario}, but it was None"),
-            None => panic!("Unknown field '{path}' in {scenario}"),
+    // Check each field at this level for correct presence/absence
+    for field in all_fields {
+        // Should this field be present?
+        let should_be_present = expected_this_level.contains(field);
+
+        // Is this field actually present?
+        let (is_present, _) = checker
+            .check_field(field)
+            .unwrap_or_else(|| panic!("Invalid field '{field}' in {scenario}"));
+
+        // Verify expectation matches reality
+        assert_eq!(
+            is_present, should_be_present,
+            "Field '{field}' in {scenario}: expected {should_be_present}, got {is_present}"
+        );
+    }
+
+    // Group nested paths by their parent field
+    // Example: ["reference.object_id", "reference.version"]
+    //       -> {"reference": ["object_id", "version"]}
+    let mut nested: HashMap<&str, Vec<&str>> = HashMap::new();
+    let mut standalone_fields: HashSet<&str> = HashSet::new();
+
+    for path in paths {
+        if let Some((field, rest)) = path.split_once('.') {
+            // This path has nesting - add the remaining part to the group
+            nested.entry(field).or_default().push(rest);
+        } else {
+            // This is a standalone field (no dot) - track it
+            standalone_fields.insert(path);
+        }
+    }
+
+    // Validate no contradictory paths
+    // A field cannot be specified both standalone AND with nested paths
+    // Example: ["reference", "reference.object_id"] is contradictory because:
+    //   - "reference" alone means: all nested fields should be absent
+    //   - "reference.object_id" means: object_id should be present
+    for field in &standalone_fields {
+        if nested.contains_key(field) {
+            panic!(
+                "Contradictory field paths in {scenario}: '{}' specified both standalone (implying no nested fields) and with nested paths ({})",
+                field,
+                nested[field]
+                    .iter()
+                    .map(|s| format!("{}.{}", field, s))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+    }
+
+    // Recursively check nested fields
+    // IMPORTANT: We must recurse into ALL present fields (not just those with
+    // nested paths) to verify their nested children are absent when not
+    // specified
+    for field in &expected_this_level {
+        // Get the nested checker for this field
+        if let Some((_, Some(nested_checker))) = checker.check_field(field) {
+            // Get sub-paths for this field, or empty slice if none specified
+            // Empty slice means ALL nested fields should be absent
+            let sub_paths = nested.get(field).map(|v| v.as_slice()).unwrap_or(&[]);
+
+            // Recurse into this nested field
+            check_level(
+                nested_checker,
+                nested_checker.all_fields(),
+                sub_paths,
+                &format!("{scenario}.{field}"), // Update scenario for better error messages
+            );
         }
     }
 }

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
@@ -391,3 +391,67 @@ async fn get_objects_empty_request() {
         "has_next should be false for empty request"
     );
 }
+
+#[sim_test]
+async fn get_objects_nonexistent() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .build()
+        .await;
+
+    let mut grpc_client = LedgerServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    // Request objects that don't exist
+    let responses = assert_get_objects_request(
+        &mut grpc_client,
+        vec![
+            ObjectRequest {
+                object_ref: Some(ObjectReference {
+                    object_id: Some("0xdead".to_string()),
+                    version: None,
+                    digest: None,
+                }),
+            },
+            ObjectRequest {
+                object_ref: Some(ObjectReference {
+                    object_id: Some("0xbeef".to_string()),
+                    version: None,
+                    digest: None,
+                }),
+            },
+        ],
+        None,
+        None,
+        &[], // Skip field mask validation for error responses
+        "non-existent objects",
+    )
+    .await;
+
+    // Verify all results contain errors (not objects)
+    let mut error_count = 0;
+    for response in &responses {
+        for obj_result in &response.objects {
+            assert!(
+                obj_result.error_opt().is_some(),
+                "Expected error for non-existent object"
+            );
+            assert!(
+                obj_result.object_opt().is_none(),
+                "Expected no object for non-existent object"
+            );
+
+            let error = obj_result.error_opt().unwrap();
+            // Verify error has a non-zero code (indicating an actual error)
+            assert!(
+                error.code != 0,
+                "Error should have non-zero code, got: {}",
+                error.code
+            );
+            error_count += 1;
+        }
+    }
+
+    assert_eq!(error_count, 2, "Should receive 2 errors");
+}

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
@@ -19,11 +19,11 @@ use iota_types::base_types::ObjectID;
 use prost_types::FieldMask;
 use test_cluster::TestClusterBuilder;
 
-use crate::{impl_field_presence_checker, utils::assert_field_presence};
+use crate::{impl_field_presence_checker, utils::assert_nested_field_masks};
 
 // Generate the FieldPresenceChecker implementation for Object
 impl_field_presence_checker!(Object, {
-    "reference" => reference,
+    "reference" => reference [nested],
     "bcs" => bcs,
 });
 
@@ -34,33 +34,12 @@ impl_field_presence_checker!(ObjectReference, {
     "digest" => digest,
 });
 
-/// Helper function to assert object fields based on expected fields
-fn assert_object_fields(
-    object: &Object,
-    expected_top_level: &[&str],
-    expected_reference: &[&str],
-    scenario: &str,
-) {
-    // Check top-level fields
-    assert_field_presence(object, expected_top_level, scenario);
-
-    // If reference is expected, check nested fields
-    if expected_top_level.contains(&"reference") {
-        if let Some(ref reference) = object.reference {
-            assert_field_presence(reference, expected_reference, scenario);
-        } else {
-            panic!("Expected reference field in {scenario}, but it was None");
-        }
-    }
-}
-
 async fn assert_get_objects_request(
     client: &mut LedgerServiceClient<tonic::transport::Channel>,
     requests: Vec<ObjectRequest>,
     read_mask: Option<FieldMask>,
     max_message_size_bytes: Option<u32>,
-    expected_top_level: &[&str],
-    expected_reference: &[&str],
+    expected_field_mask_paths: &[&str],
     scenario: &str,
 ) -> Vec<GetObjectsResponse> {
     let request = GetObjectsRequest {
@@ -82,10 +61,9 @@ async fn assert_get_objects_request(
         // Assert all returned objects have the expected fields
         for (idx, obj_result) in response.objects.iter().enumerate() {
             let object = obj_result.object();
-            assert_object_fields(
+            assert_nested_field_masks(
                 object,
-                expected_top_level,
-                expected_reference,
+                expected_field_mask_paths,
                 &format!("{scenario} (response {response_count}, object {idx})"),
             );
         }
@@ -134,18 +112,20 @@ async fn get_objects_readmask_scenarios() {
     let object_id = ObjectID::from_hex_literal("0x5").unwrap().to_string();
 
     // Table-driven tests for single-object readmask scenarios
-    type TestCase<'a> = (&'a str, Option<FieldMask>, &'a [&'a str], &'a [&'a str]);
+    type TestCase<'a> = (&'a str, Option<FieldMask>, &'a [&'a str]);
     let test_cases: Vec<TestCase> = vec![
         (
             "default readmask",
             None,
-            &["reference"],
-            &["object_id", "version", "digest"],
+            &[
+                "reference.object_id",
+                "reference.version",
+                "reference.digest",
+            ],
         ),
         (
             "empty readmask",
             Some(FieldMask::from_paths(&[] as &[&str])),
-            &[],
             &[],
         ),
         (
@@ -156,8 +136,12 @@ async fn get_objects_readmask_scenarios() {
                 "reference.digest",
                 "bcs",
             ])),
-            &["reference", "bcs"],
-            &["object_id", "version", "digest"],
+            &[
+                "reference.object_id",
+                "reference.version",
+                "reference.digest",
+                "bcs",
+            ],
         ),
         (
             "partial readmask (reference fields only)",
@@ -165,18 +149,16 @@ async fn get_objects_readmask_scenarios() {
                 "reference.object_id",
                 "reference.version",
             ])),
-            &["reference"],
-            &["object_id", "version"],
+            &["reference.object_id", "reference.version"],
         ),
         (
             "partial readmask (bcs only)",
             Some(FieldMask::from_paths(["bcs"])),
             &["bcs"],
-            &[],
         ),
     ];
 
-    for (scenario, mask, expected_top, expected_ref) in test_cases {
+    for (scenario, mask, expected_paths) in test_cases {
         let responses = assert_get_objects_request(
             &mut grpc_client,
             vec![ObjectRequest {
@@ -188,8 +170,7 @@ async fn get_objects_readmask_scenarios() {
             }],
             mask,
             None,
-            expected_top,
-            expected_ref,
+            expected_paths,
             scenario,
         )
         .await;
@@ -245,8 +226,7 @@ async fn get_objects_batch() {
         ],
         Some(FieldMask::from_paths(["reference.object_id", "bcs"])),
         None,
-        &["reference", "bcs"],
-        &["object_id"],
+        &["reference.object_id", "bcs"],
         "batch with 4 objects",
     )
     .await;
@@ -283,8 +263,7 @@ async fn get_objects_with_version() {
             "reference.version",
         ])),
         None,
-        &["reference"],
-        &["object_id", "version"],
+        &["reference.object_id", "reference.version"],
         "specific version query",
     )
     .await;
@@ -339,8 +318,12 @@ async fn get_objects_streaming() {
         ])),
         // Use minimum allowed message size to maximize chance of streaming
         Some(1024 * 1024_u32), // 1MB (minimum allowed)
-        &["reference", "bcs"],
-        &["object_id", "version", "digest"],
+        &[
+            "reference.object_id",
+            "reference.version",
+            "reference.digest",
+            "bcs",
+        ],
         "streaming with 100 objects",
     )
     .await;
@@ -396,16 +379,9 @@ async fn get_objects_empty_request() {
         .unwrap();
 
     // Test empty request list
-    let responses = assert_get_objects_request(
-        &mut grpc_client,
-        vec![],
-        None,
-        None,
-        &[],
-        &[],
-        "empty request",
-    )
-    .await;
+    let responses =
+        assert_get_objects_request(&mut grpc_client, vec![], None, None, &[], "empty request")
+            .await;
 
     // Should return single response with 0 objects
     assert_eq!(responses.len(), 1, "Should have 1 response");

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
@@ -1,0 +1,436 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::StreamExt;
+use iota_grpc_types::{
+    field::FieldMaskUtil,
+    v0::{
+        ledger_service::{
+            GetObjectsRequest, GetObjectsResponse, ObjectRequest, ObjectRequests,
+            ledger_service_client::LedgerServiceClient,
+        },
+        object::Object,
+        types::ObjectReference,
+    },
+};
+use iota_macros::sim_test;
+use iota_types::base_types::ObjectID;
+use prost_types::FieldMask;
+use test_cluster::TestClusterBuilder;
+
+use crate::{impl_field_presence_checker, utils::assert_field_presence};
+
+// Generate the FieldPresenceChecker implementation for Object
+impl_field_presence_checker!(Object, {
+    "reference" => reference,
+    "bcs" => bcs,
+});
+
+// Generate the FieldPresenceChecker implementation for ObjectReference
+impl_field_presence_checker!(ObjectReference, {
+    "object_id" => object_id,
+    "version" => version,
+    "digest" => digest,
+});
+
+/// Helper function to assert object fields based on expected fields
+fn assert_object_fields(
+    object: &Object,
+    expected_top_level: &[&str],
+    expected_reference: &[&str],
+    scenario: &str,
+) {
+    // Check top-level fields
+    assert_field_presence(object, expected_top_level, scenario);
+
+    // If reference is expected, check nested fields
+    if expected_top_level.contains(&"reference") {
+        if let Some(ref reference) = object.reference {
+            assert_field_presence(reference, expected_reference, scenario);
+        } else {
+            panic!("Expected reference field in {scenario}, but it was None");
+        }
+    }
+}
+
+async fn assert_get_objects_request(
+    client: &mut LedgerServiceClient<tonic::transport::Channel>,
+    requests: Vec<ObjectRequest>,
+    read_mask: Option<FieldMask>,
+    max_message_size_bytes: Option<u32>,
+    expected_top_level: &[&str],
+    expected_reference: &[&str],
+    expected_has_next: bool,
+    scenario: &str,
+) -> GetObjectsResponse {
+    let request = GetObjectsRequest {
+        requests: Some(ObjectRequests { requests }),
+        read_mask,
+        max_message_size_bytes,
+    };
+
+    let mut stream = client.get_objects(request).await.unwrap().into_inner();
+
+    let response = stream.next().await.unwrap().unwrap();
+
+    // Assert all returned objects have the expected fields
+    for (idx, obj_result) in response.objects.iter().enumerate() {
+        let object = obj_result.object();
+        assert_object_fields(
+            object,
+            expected_top_level,
+            expected_reference,
+            &format!("{scenario} (object {idx})"),
+        );
+    }
+
+    // Verify has_next value
+    assert_eq!(
+        response.has_next, expected_has_next,
+        "{scenario}: has_next should be {expected_has_next}"
+    );
+
+    // If has_next is false, verify stream is exhausted
+    if !expected_has_next {
+        assert!(
+            stream.next().await.is_none(),
+            "{scenario}: stream should be exhausted when has_next is false"
+        );
+    }
+
+    response
+}
+
+#[sim_test]
+async fn get_objects_readmask_scenarios() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .build()
+        .await;
+
+    let mut grpc_client = LedgerServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    let object_id = ObjectID::from_hex_literal("0x5").unwrap().to_string();
+
+    // Table-driven tests for single-object readmask scenarios
+    type TestCase<'a> = (&'a str, Option<FieldMask>, &'a [&'a str], &'a [&'a str]);
+    let test_cases: Vec<TestCase> = vec![
+        (
+            "default readmask",
+            None,
+            &["reference"],
+            &["object_id", "version", "digest"],
+        ),
+        (
+            "empty readmask",
+            Some(FieldMask::from_paths(&[] as &[&str])),
+            &[],
+            &[],
+        ),
+        (
+            "full readmask",
+            Some(FieldMask::from_paths([
+                "reference.object_id",
+                "reference.version",
+                "reference.digest",
+                "bcs",
+            ])),
+            &["reference", "bcs"],
+            &["object_id", "version", "digest"],
+        ),
+        (
+            "partial readmask (reference fields only)",
+            Some(FieldMask::from_paths([
+                "reference.object_id",
+                "reference.version",
+            ])),
+            &["reference"],
+            &["object_id", "version"],
+        ),
+        (
+            "partial readmask (bcs only)",
+            Some(FieldMask::from_paths(["bcs"])),
+            &["bcs"],
+            &[],
+        ),
+    ];
+
+    for (scenario, mask, expected_top, expected_ref) in test_cases {
+        let response = assert_get_objects_request(
+            &mut grpc_client,
+            vec![ObjectRequest {
+                object_ref: Some(ObjectReference {
+                    object_id: Some(object_id.clone()),
+                    version: None,
+                    digest: None,
+                }),
+            }],
+            mask,
+            None,
+            expected_top,
+            expected_ref,
+            false,
+            scenario,
+        )
+        .await;
+
+        assert_eq!(response.objects.len(), 1, "{scenario}: expected 1 object");
+    }
+}
+
+#[sim_test]
+async fn get_objects_batch() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .build()
+        .await;
+
+    let mut grpc_client = LedgerServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    // Test batch request with multiple objects and partial readmask
+    let response = assert_get_objects_request(
+        &mut grpc_client,
+        vec![
+            ObjectRequest {
+                object_ref: Some(ObjectReference {
+                    object_id: Some("0x1".to_string()),
+                    version: None,
+                    digest: None,
+                }),
+            },
+            ObjectRequest {
+                object_ref: Some(ObjectReference {
+                    object_id: Some("0x2".to_string()),
+                    version: None,
+                    digest: None,
+                }),
+            },
+            ObjectRequest {
+                object_ref: Some(ObjectReference {
+                    object_id: Some("0x3".to_string()),
+                    version: None,
+                    digest: None,
+                }),
+            },
+            ObjectRequest {
+                object_ref: Some(ObjectReference {
+                    object_id: Some("0x5".to_string()),
+                    version: None,
+                    digest: None,
+                }),
+            },
+        ],
+        Some(FieldMask::from_paths(["reference.object_id", "bcs"])),
+        None,
+        &["reference", "bcs"],
+        &["object_id"],
+        false,
+        "batch with 4 objects",
+    )
+    .await;
+
+    assert_eq!(response.objects.len(), 4);
+}
+
+#[sim_test]
+async fn get_objects_with_version() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .build()
+        .await;
+
+    let mut grpc_client = LedgerServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    let object_id = ObjectID::from_hex_literal("0x5").unwrap().to_string();
+
+    // Request specific version
+    assert_get_objects_request(
+        &mut grpc_client,
+        vec![ObjectRequest {
+            object_ref: Some(ObjectReference {
+                object_id: Some(object_id),
+                version: Some(1),
+                digest: None,
+            }),
+        }],
+        Some(FieldMask::from_paths([
+            "reference.object_id",
+            "reference.version",
+        ])),
+        None,
+        &["reference"],
+        &["object_id", "version"],
+        false,
+        "specific version query",
+    )
+    .await;
+}
+
+#[sim_test]
+async fn get_objects_streaming() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .build()
+        .await;
+
+    let mut grpc_client = LedgerServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    // Test streaming by requesting many objects with full readmask
+    // Use only known-to-exist objects (0x1-0x6 commonly exist in test cluster)
+    // but repeat them multiple times to ensure we have enough data for potential
+    // multi-message streaming
+    let mut requests = Vec::new();
+    let known_objects = ["0x1", "0x2", "0x3", "0x5", "0x6"];
+
+    // Request each object 20 times to create a larger payload (100 total objects,
+    // around 2-3 MB)
+    for _ in 0..20 {
+        for obj_id in &known_objects {
+            requests.push(ObjectRequest {
+                object_ref: Some(ObjectReference {
+                    object_id: Some(obj_id.to_string()),
+                    version: None,
+                    digest: None,
+                }),
+            });
+        }
+    }
+
+    let request = GetObjectsRequest {
+        requests: Some(ObjectRequests { requests }),
+        read_mask: Some(FieldMask::from_paths([
+            "reference.object_id",
+            "reference.version",
+            "reference.digest",
+            "bcs",
+        ])),
+        // Use minimum allowed message size to maximize chance of streaming
+        max_message_size_bytes: Some(1024 * 1024_u32), // 1MB (minimum allowed)
+    };
+
+    let mut stream = grpc_client.get_objects(request).await.unwrap().into_inner();
+
+    let mut total_results = 0;
+    let mut successful_objects = 0;
+    let mut response_count = 0;
+    let mut last_has_next = false;
+    let mut has_next_values = Vec::new();
+
+    while let Some(response) = stream.next().await {
+        let response = response.unwrap();
+        response_count += 1;
+        total_results += response.objects.len();
+        last_has_next = response.has_next;
+        has_next_values.push(response.has_next);
+
+        // Each response should have at least one result
+        assert!(
+            !response.objects.is_empty(),
+            "Each stream message should contain at least one result"
+        );
+
+        // Validate that each successful object has the expected fields
+        for obj_result in &response.objects {
+            // Only validate successful objects (skip errors for non-existent objects)
+            if let Some(iota_grpc_types::v0::ledger_service::object_result::Result::Object(
+                object,
+            )) = obj_result.result.as_ref()
+            {
+                successful_objects += 1;
+                assert!(object.reference.is_some(), "object should have reference");
+                assert!(object.bcs.is_some(), "object should have bcs");
+                let reference = object.reference.as_ref().unwrap();
+                assert!(
+                    reference.object_id.is_some(),
+                    "object should have object_id"
+                );
+                assert!(reference.version.is_some(), "object should have version");
+                assert!(reference.digest.is_some(), "object should have digest");
+            }
+        }
+    }
+
+    // Validate has_next values: all intermediate messages should have has_next=true
+    if response_count > 1 {
+        for (idx, &has_next) in has_next_values[..has_next_values.len() - 1]
+            .iter()
+            .enumerate()
+        {
+            assert!(
+                has_next,
+                "Intermediate stream message #{} should have has_next=true, but got false",
+                idx + 1
+            );
+        }
+    }
+
+    // Verify we got all 100 results (even if some are errors)
+    assert_eq!(
+        total_results, 100,
+        "Should have received 100 results (objects or errors)"
+    );
+
+    // Verify we got at least some successful objects
+    assert!(
+        successful_objects > 0,
+        "Should have at least some successful objects"
+    );
+
+    // Verify multi-message streaming occurred (more than 1 stream message)
+    assert!(
+        response_count > 1,
+        "Expected multi-message streaming (>1 message), but got only {} message(s)",
+        response_count
+    );
+
+    // Verify the last response had has_next=false
+    assert!(
+        !last_has_next,
+        "Last stream message should have has_next=false"
+    );
+}
+
+#[sim_test]
+async fn get_objects_empty_request() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .build()
+        .await;
+
+    let mut grpc_client = LedgerServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    // Test empty request list
+    let request = GetObjectsRequest {
+        requests: Some(ObjectRequests { requests: vec![] }),
+        read_mask: None,
+        max_message_size_bytes: None,
+    };
+
+    let mut stream = grpc_client.get_objects(request).await.unwrap().into_inner();
+
+    let response = stream.next().await.unwrap().unwrap();
+
+    // Should return empty response with has_next=false
+    assert_eq!(response.objects.len(), 0, "Should have 0 objects");
+    assert!(
+        !response.has_next,
+        "has_next should be false for empty request"
+    );
+
+    // Stream should be exhausted
+    assert!(
+        stream.next().await.is_none(),
+        "Stream should be exhausted after empty response"
+    );
+}

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
@@ -77,11 +77,14 @@ async fn assert_get_objects_request(
         }
     }
 
-    // Verify we got at least one response
-    assert!(
-        !responses.is_empty(),
-        "{scenario}: should receive at least one response"
-    );
+    // Validate has_next values: all intermediate messages should have has_next=true
+    for (idx, response) in responses[..responses.len() - 1].iter().enumerate() {
+        assert!(
+            response.has_next,
+            "Intermediate stream message #{} should have has_next=true, but got false",
+            idx + 1
+        );
+    }
 
     // Verify the last response has has_next=false
     assert!(
@@ -335,36 +338,12 @@ async fn get_objects_streaming() {
         responses.len()
     );
 
-    // Validate has_next values: all intermediate messages should have has_next=true
-    for (idx, response) in responses[..responses.len() - 1].iter().enumerate() {
-        assert!(
-            response.has_next,
-            "Intermediate stream message #{} should have has_next=true, but got false",
-            idx + 1
-        );
-    }
-
-    // Verify the last response has has_next=false
-    assert!(
-        !responses.last().unwrap().has_next,
-        "Last stream message should have has_next=false"
-    );
-
     // Verify we got all 100 results
     let total_objects: usize = responses.iter().map(|r| r.objects.len()).sum();
     assert_eq!(
         total_objects, 100,
         "Should have received 100 results (objects or errors)"
     );
-
-    // Each response should have at least one result
-    for (idx, response) in responses.iter().enumerate() {
-        assert!(
-            !response.objects.is_empty(),
-            "Response #{} should contain at least one result",
-            idx + 1
-        );
-    }
 }
 
 #[sim_test]

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
@@ -61,9 +61,8 @@ async fn assert_get_objects_request(
     max_message_size_bytes: Option<u32>,
     expected_top_level: &[&str],
     expected_reference: &[&str],
-    expected_has_next: bool,
     scenario: &str,
-) -> GetObjectsResponse {
+) -> Vec<GetObjectsResponse> {
     let request = GetObjectsRequest {
         requests: Some(ObjectRequests { requests }),
         read_mask,
@@ -72,34 +71,53 @@ async fn assert_get_objects_request(
 
     let mut stream = client.get_objects(request).await.unwrap().into_inner();
 
-    let response = stream.next().await.unwrap().unwrap();
+    let mut responses = Vec::new();
+    let mut response_count = 0;
 
-    // Assert all returned objects have the expected fields
-    for (idx, obj_result) in response.objects.iter().enumerate() {
-        let object = obj_result.object();
-        assert_object_fields(
-            object,
-            expected_top_level,
-            expected_reference,
-            &format!("{scenario} (object {idx})"),
-        );
+    // Loop through all responses until has_next is false
+    while let Some(response) = stream.next().await {
+        let response = response.unwrap();
+        response_count += 1;
+
+        // Assert all returned objects have the expected fields
+        for (idx, obj_result) in response.objects.iter().enumerate() {
+            let object = obj_result.object();
+            assert_object_fields(
+                object,
+                expected_top_level,
+                expected_reference,
+                &format!("{scenario} (response {response_count}, object {idx})"),
+            );
+        }
+
+        let has_next = response.has_next;
+        responses.push(response);
+
+        // If has_next is false, this should be the last response
+        if !has_next {
+            break;
+        }
     }
 
-    // Verify has_next value
-    assert_eq!(
-        response.has_next, expected_has_next,
-        "{scenario}: has_next should be {expected_has_next}"
+    // Verify we got at least one response
+    assert!(
+        !responses.is_empty(),
+        "{scenario}: should receive at least one response"
     );
 
-    // If has_next is false, verify stream is exhausted
-    if !expected_has_next {
-        assert!(
-            stream.next().await.is_none(),
-            "{scenario}: stream should be exhausted when has_next is false"
-        );
-    }
+    // Verify the last response has has_next=false
+    assert!(
+        !responses.last().unwrap().has_next,
+        "{scenario}: last response should have has_next=false"
+    );
 
-    response
+    // Verify stream is exhausted
+    assert!(
+        stream.next().await.is_none(),
+        "{scenario}: stream should be exhausted after has_next=false"
+    );
+
+    responses
 }
 
 #[sim_test]
@@ -159,7 +177,7 @@ async fn get_objects_readmask_scenarios() {
     ];
 
     for (scenario, mask, expected_top, expected_ref) in test_cases {
-        let response = assert_get_objects_request(
+        let responses = assert_get_objects_request(
             &mut grpc_client,
             vec![ObjectRequest {
                 object_ref: Some(ObjectReference {
@@ -172,12 +190,12 @@ async fn get_objects_readmask_scenarios() {
             None,
             expected_top,
             expected_ref,
-            false,
             scenario,
         )
         .await;
 
-        assert_eq!(response.objects.len(), 1, "{scenario}: expected 1 object");
+        let total_objects: usize = responses.iter().map(|r| r.objects.len()).sum();
+        assert_eq!(total_objects, 1, "{scenario}: expected 1 object");
     }
 }
 
@@ -193,7 +211,7 @@ async fn get_objects_batch() {
         .unwrap();
 
     // Test batch request with multiple objects and partial readmask
-    let response = assert_get_objects_request(
+    let responses = assert_get_objects_request(
         &mut grpc_client,
         vec![
             ObjectRequest {
@@ -229,12 +247,12 @@ async fn get_objects_batch() {
         None,
         &["reference", "bcs"],
         &["object_id"],
-        false,
         "batch with 4 objects",
     )
     .await;
 
-    assert_eq!(response.objects.len(), 4);
+    let total_objects: usize = responses.iter().map(|r| r.objects.len()).sum();
+    assert_eq!(total_objects, 4);
 }
 
 #[sim_test]
@@ -251,7 +269,7 @@ async fn get_objects_with_version() {
     let object_id = ObjectID::from_hex_literal("0x5").unwrap().to_string();
 
     // Request specific version
-    assert_get_objects_request(
+    let responses = assert_get_objects_request(
         &mut grpc_client,
         vec![ObjectRequest {
             object_ref: Some(ObjectReference {
@@ -267,10 +285,15 @@ async fn get_objects_with_version() {
         None,
         &["reference"],
         &["object_id", "version"],
-        false,
         "specific version query",
     )
     .await;
+
+    let total_objects: usize = responses.iter().map(|r| r.objects.len()).sum();
+    assert_eq!(
+        total_objects, 1,
+        "specific version query: expected 1 object"
+    );
 }
 
 #[sim_test]
@@ -305,98 +328,60 @@ async fn get_objects_streaming() {
         }
     }
 
-    let request = GetObjectsRequest {
-        requests: Some(ObjectRequests { requests }),
-        read_mask: Some(FieldMask::from_paths([
+    let responses = assert_get_objects_request(
+        &mut grpc_client,
+        requests,
+        Some(FieldMask::from_paths([
             "reference.object_id",
             "reference.version",
             "reference.digest",
             "bcs",
         ])),
         // Use minimum allowed message size to maximize chance of streaming
-        max_message_size_bytes: Some(1024 * 1024_u32), // 1MB (minimum allowed)
-    };
-
-    let mut stream = grpc_client.get_objects(request).await.unwrap().into_inner();
-
-    let mut total_results = 0;
-    let mut successful_objects = 0;
-    let mut response_count = 0;
-    let mut last_has_next = false;
-    let mut has_next_values = Vec::new();
-
-    while let Some(response) = stream.next().await {
-        let response = response.unwrap();
-        response_count += 1;
-        total_results += response.objects.len();
-        last_has_next = response.has_next;
-        has_next_values.push(response.has_next);
-
-        // Each response should have at least one result
-        assert!(
-            !response.objects.is_empty(),
-            "Each stream message should contain at least one result"
-        );
-
-        // Validate that each successful object has the expected fields
-        for obj_result in &response.objects {
-            // Only validate successful objects (skip errors for non-existent objects)
-            if let Some(iota_grpc_types::v0::ledger_service::object_result::Result::Object(
-                object,
-            )) = obj_result.result.as_ref()
-            {
-                successful_objects += 1;
-                assert!(object.reference.is_some(), "object should have reference");
-                assert!(object.bcs.is_some(), "object should have bcs");
-                let reference = object.reference.as_ref().unwrap();
-                assert!(
-                    reference.object_id.is_some(),
-                    "object should have object_id"
-                );
-                assert!(reference.version.is_some(), "object should have version");
-                assert!(reference.digest.is_some(), "object should have digest");
-            }
-        }
-    }
-
-    // Validate has_next values: all intermediate messages should have has_next=true
-    if response_count > 1 {
-        for (idx, &has_next) in has_next_values[..has_next_values.len() - 1]
-            .iter()
-            .enumerate()
-        {
-            assert!(
-                has_next,
-                "Intermediate stream message #{} should have has_next=true, but got false",
-                idx + 1
-            );
-        }
-    }
-
-    // Verify we got all 100 results (even if some are errors)
-    assert_eq!(
-        total_results, 100,
-        "Should have received 100 results (objects or errors)"
-    );
-
-    // Verify we got at least some successful objects
-    assert!(
-        successful_objects > 0,
-        "Should have at least some successful objects"
-    );
+        Some(1024 * 1024_u32), // 1MB (minimum allowed)
+        &["reference", "bcs"],
+        &["object_id", "version", "digest"],
+        "streaming with 100 objects",
+    )
+    .await;
 
     // Verify multi-message streaming occurred (more than 1 stream message)
     assert!(
-        response_count > 1,
+        responses.len() > 1,
         "Expected multi-message streaming (>1 message), but got only {} message(s)",
-        response_count
+        responses.len()
     );
 
-    // Verify the last response had has_next=false
+    // Validate has_next values: all intermediate messages should have has_next=true
+    for (idx, response) in responses[..responses.len() - 1].iter().enumerate() {
+        assert!(
+            response.has_next,
+            "Intermediate stream message #{} should have has_next=true, but got false",
+            idx + 1
+        );
+    }
+
+    // Verify the last response has has_next=false
     assert!(
-        !last_has_next,
+        !responses.last().unwrap().has_next,
         "Last stream message should have has_next=false"
     );
+
+    // Verify we got all 100 results
+    let total_objects: usize = responses.iter().map(|r| r.objects.len()).sum();
+    assert_eq!(
+        total_objects, 100,
+        "Should have received 100 results (objects or errors)"
+    );
+
+    // Each response should have at least one result
+    for (idx, response) in responses.iter().enumerate() {
+        assert!(
+            !response.objects.is_empty(),
+            "Response #{} should contain at least one result",
+            idx + 1
+        );
+    }
 }
 
 #[sim_test]
@@ -411,26 +396,22 @@ async fn get_objects_empty_request() {
         .unwrap();
 
     // Test empty request list
-    let request = GetObjectsRequest {
-        requests: Some(ObjectRequests { requests: vec![] }),
-        read_mask: None,
-        max_message_size_bytes: None,
-    };
+    let responses = assert_get_objects_request(
+        &mut grpc_client,
+        vec![],
+        None,
+        None,
+        &[],
+        &[],
+        "empty request",
+    )
+    .await;
 
-    let mut stream = grpc_client.get_objects(request).await.unwrap().into_inner();
-
-    let response = stream.next().await.unwrap().unwrap();
-
-    // Should return empty response with has_next=false
-    assert_eq!(response.objects.len(), 0, "Should have 0 objects");
+    // Should return single response with 0 objects
+    assert_eq!(responses.len(), 1, "Should have 1 response");
+    assert_eq!(responses[0].objects.len(), 0, "Should have 0 objects");
     assert!(
-        !response.has_next,
+        !responses[0].has_next,
         "has_next should be false for empty request"
-    );
-
-    // Stream should be exhausted
-    assert!(
-        stream.next().await.is_none(),
-        "Stream should be exhausted after empty response"
     );
 }

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
@@ -111,7 +111,7 @@ async fn get_objects_readmask_scenarios() {
 
     let object_id = ObjectID::from_hex_literal("0x5").unwrap().to_string();
 
-    // Table-driven tests for single-object readmask scenarios
+    // Tests for single-object readmask scenarios
     type TestCase<'a> = (&'a str, Option<FieldMask>, &'a [&'a str]);
     let test_cases: Vec<TestCase> = vec![
         (

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
@@ -19,19 +19,19 @@ use iota_types::base_types::ObjectID;
 use prost_types::FieldMask;
 use test_cluster::TestClusterBuilder;
 
-use crate::{impl_field_presence_checker, utils::assert_nested_field_masks};
+use crate::{impl_field_presence_checker, utils::assert_field_presence};
 
 // Generate the FieldPresenceChecker implementation for Object
-impl_field_presence_checker!(Object, {
-    "reference" => reference [nested],
-    "bcs" => bcs,
+impl_field_presence_checker!(Object {
+    reference: ObjectReference,
+    bcs,
 });
 
 // Generate the FieldPresenceChecker implementation for ObjectReference
-impl_field_presence_checker!(ObjectReference, {
-    "object_id" => object_id,
-    "version" => version,
-    "digest" => digest,
+impl_field_presence_checker!(ObjectReference {
+    object_id,
+    version,
+    digest,
 });
 
 async fn assert_get_objects_request(
@@ -61,7 +61,7 @@ async fn assert_get_objects_request(
         // Assert all returned objects have the expected fields
         for (idx, obj_result) in response.objects.iter().enumerate() {
             let object = obj_result.object();
-            assert_nested_field_masks(
+            assert_field_presence(
                 object,
                 expected_field_mask_paths,
                 &format!("{scenario} (response {response_count}, object {idx})"),
@@ -141,9 +141,11 @@ async fn get_objects_readmask_scenarios() {
             ])),
             &[
                 "reference.object_id",
-                "reference.version",
+                "reference.version", // comment out to check absence of nested field
                 "reference.digest",
-                "bcs",
+                "bcs", /* comment out to check absence of bcs field
+                        * "reference", // Remove comment to check existence of reference field
+                        * "reference.id", // Remove comment to check existence of nested field */
             ],
         ),
         (

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_service_info.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_service_info.rs
@@ -15,15 +15,15 @@ use test_cluster::TestClusterBuilder;
 use crate::{impl_field_presence_checker, utils::assert_field_presence};
 
 // Generate the FieldPresenceChecker implementation for GetServiceInfoResponse
-impl_field_presence_checker!(GetServiceInfoResponse, {
-    "chain_id" => chain_id,
-    "chain" => chain,
-    "epoch" => epoch,
-    "executed_checkpoint_height" => executed_checkpoint_height,
-    "executed_checkpoint_timestamp" => executed_checkpoint_timestamp,
-    "lowest_available_checkpoint" => lowest_available_checkpoint,
-    "lowest_available_checkpoint_objects" => lowest_available_checkpoint_objects,
-    "server" => server,
+impl_field_presence_checker!(GetServiceInfoResponse {
+    chain_id,
+    chain,
+    epoch,
+    executed_checkpoint_height,
+    executed_checkpoint_timestamp,
+    lowest_available_checkpoint,
+    lowest_available_checkpoint_objects,
+    server,
 });
 
 async fn assert_service_info_request(

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/mod.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/mod.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod get_epoch;
+mod get_objects;
 mod get_service_info;

--- a/crates/iota-grpc-server/src/constants.rs
+++ b/crates/iota-grpc-server/src/constants.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_grpc_types::{google::rpc::bad_request::FieldViolation, v0::error_reason::ErrorReason};
+
+use crate::error::RpcError;
+
+/// Default maximum message size for chunked responses (4MB)
+pub const DEFAULT_MAX_MESSAGE_SIZE_BYTES: usize = 4 * 1024 * 1024;
+
+/// Minimum allowed message size (1MB)
+pub const MIN_MESSAGE_SIZE_BYTES: usize = 1024 * 1024;
+
+/// Maximum allowed message size (128MB)
+pub const MAX_MESSAGE_SIZE_BYTES: usize = 128 * 1024 * 1024;
+
+/// Validates and converts the max_message_size_bytes parameter.
+pub fn validate_max_message_size(max_message_size_bytes: Option<u64>) -> Result<usize, RpcError> {
+    match max_message_size_bytes {
+        Some(size) => {
+            let size = usize::try_from(size).map_err(|_| {
+                FieldViolation::new("max_message_size_bytes")
+                    .with_description("must be a valid positive integer")
+                    .with_reason(ErrorReason::FieldInvalid)
+            })?;
+
+            match size {
+                s if s < MIN_MESSAGE_SIZE_BYTES => {
+                    Err(FieldViolation::new("max_message_size_bytes")
+                        .with_description(format!(
+                            "must be at least {MIN_MESSAGE_SIZE_BYTES} bytes"
+                        ))
+                        .with_reason(ErrorReason::FieldInvalid)
+                        .into())
+                }
+                s if s > MAX_MESSAGE_SIZE_BYTES => {
+                    Err(FieldViolation::new("max_message_size_bytes")
+                        .with_description(format!("must be at most {MAX_MESSAGE_SIZE_BYTES} bytes"))
+                        .with_reason(ErrorReason::FieldInvalid)
+                        .into())
+                }
+                s => Ok(s),
+            }
+        }
+        None => Ok(DEFAULT_MAX_MESSAGE_SIZE_BYTES),
+    }
+}

--- a/crates/iota-grpc-server/src/error.rs
+++ b/crates/iota-grpc-server/src/error.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_grpc_types::google::rpc::{BadRequest, ErrorInfo, RetryInfo};
+use iota_types::base_types::ObjectID;
 use tonic::{Code, Status};
 
 /// Main RPC error type
@@ -131,5 +132,55 @@ impl ErrorDetails {
             );
         }
         details
+    }
+}
+
+// NOTE: Similar errors exist in iota-rest-api, but are intentionally duplicated
+// here. The REST API will be deprecated soon, so we avoid creating a shared
+// dependency. This keeps the gRPC server independent and allows the REST API to
+// be removed cleanly without impacting gRPC error handling.
+// TODO: Remove the above comments when the REST API is removed.
+#[derive(Debug, Clone)]
+pub struct ObjectNotFoundError {
+    object_id: ObjectID,
+    version: Option<u64>,
+}
+
+impl ObjectNotFoundError {
+    pub fn new(object_id: ObjectID) -> Self {
+        Self {
+            object_id,
+            version: None,
+        }
+    }
+
+    pub fn new_with_version(object_id: ObjectID, version: u64) -> Self {
+        Self {
+            object_id,
+            version: Some(version),
+        }
+    }
+}
+
+impl std::fmt::Display for ObjectNotFoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.version {
+            Some(version) => {
+                write!(
+                    f,
+                    "Object {} at version {} not found",
+                    self.object_id, version
+                )
+            }
+            None => write!(f, "Object {} not found", self.object_id),
+        }
+    }
+}
+
+impl std::error::Error for ObjectNotFoundError {}
+
+impl From<ObjectNotFoundError> for RpcError {
+    fn from(value: ObjectNotFoundError) -> Self {
+        Self::new(tonic::Code::NotFound, value.to_string())
     }
 }

--- a/crates/iota-grpc-server/src/ledger_service/get_objects.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_objects.rs
@@ -1,0 +1,148 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::Stream;
+use iota_grpc_types::{
+    field::{FieldMaskTree, FieldMaskUtil},
+    google::rpc::bad_request::FieldViolation,
+    merge::Merge,
+    v0::{
+        error_reason::ErrorReason,
+        ledger_service::{GetObjectsRequest, GetObjectsResponse, ObjectResult, object_result},
+        object::Object,
+    },
+};
+use iota_types::{base_types::ObjectID, iota_sdk_types_conversions::SdkTypeConversionError};
+use prost::Message;
+use prost_types::FieldMask;
+
+use crate::{
+    constants::validate_max_message_size,
+    error::{ObjectNotFoundError, RpcError},
+    types::{GrpcReader, ObjectsStreamResult},
+};
+
+pub const READ_MASK_DEFAULT: &str = "reference.object_id,reference.version,reference.digest";
+
+type ValidationResult = Result<(Vec<(ObjectID, Option<u64>)>, FieldMaskTree), RpcError>;
+
+pub fn validate_get_object_requests(
+    requests: Vec<(Option<String>, Option<u64>)>,
+    read_mask: Option<FieldMask>,
+) -> ValidationResult {
+    let read_mask = {
+        let read_mask = read_mask.unwrap_or_else(|| FieldMask::from_str(READ_MASK_DEFAULT));
+        read_mask.validate::<Object>().map_err(|path| {
+            FieldViolation::new("read_mask")
+                .with_description(format!("invalid read_mask path: {path}"))
+                .with_reason(ErrorReason::FieldInvalid)
+        })?;
+        FieldMaskTree::from(read_mask)
+    };
+    let requests = requests
+        .into_iter()
+        .enumerate()
+        .map(|(idx, (object_id, version))| {
+            let object_id = object_id
+                .as_ref()
+                .ok_or_else(|| {
+                    FieldViolation::new("object_id")
+                        .with_reason(ErrorReason::FieldMissing)
+                        .nested_at("requests", idx)
+                })?
+                .parse()
+                .map_err(|e| {
+                    FieldViolation::new("object_id")
+                        .with_description(format!("invalid object_id: {e}"))
+                        .with_reason(ErrorReason::FieldInvalid)
+                        .nested_at("requests", idx)
+                })?;
+            Ok((object_id, version))
+        })
+        .collect::<Result<_, RpcError>>()?;
+    Ok((requests, read_mask))
+}
+
+#[tracing::instrument(skip(reader))]
+pub(crate) fn get_objects(
+    reader: GrpcReader,
+    GetObjectsRequest {
+        requests,
+        read_mask,
+        max_message_size_bytes,
+        ..
+    }: GetObjectsRequest,
+) -> Result<impl Stream<Item = ObjectsStreamResult> + Send, RpcError> {
+    let requests = requests
+        .map(|r| r.requests)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|req| {
+            let object_ref = req.object_ref;
+            (
+                object_ref.as_ref().and_then(|r| r.object_id.clone()),
+                object_ref.and_then(|r| r.version),
+            )
+        })
+        .collect();
+    let (requests, read_mask) = validate_get_object_requests(requests, read_mask)?;
+
+    // Validate and set max_message_size
+    let max_message_size = validate_max_message_size(max_message_size_bytes.map(|v| v as u64))?;
+
+    // Create lazy stream that fetches and batches objects on-demand
+    Ok(crate::create_batching_stream!(
+        requests.into_iter(),
+        (object_id, version),
+        {
+            // Lazily fetch the object only when needed
+            let object_result = match get_object_impl(&reader, object_id, version, &read_mask) {
+                Ok(object) => ObjectResult {
+                    result: Some(object_result::Result::Object(object)),
+                },
+                Err(error) => ObjectResult {
+                    result: Some(object_result::Result::Error(error.into_status_proto())),
+                },
+            };
+
+            let object_size = object_result.encoded_len();
+            (object_result, object_size)
+        },
+        max_message_size,
+        GetObjectsResponse,
+        objects,
+        has_next
+    ))
+}
+
+#[tracing::instrument(skip(reader))]
+fn get_object_impl(
+    reader: &GrpcReader,
+    object_id: ObjectID,
+    version: Option<u64>,
+    read_mask: &FieldMaskTree,
+) -> Result<Object, RpcError> {
+    // Get object from storage (returns iota_types::object::Object)
+    let object = if let Some(version) = version {
+        reader
+            .get_object_by_key(&object_id, version.into())
+            .ok_or_else(|| ObjectNotFoundError::new_with_version(object_id, version))?
+    } else {
+        reader
+            .get_object(&object_id)
+            .ok_or_else(|| ObjectNotFoundError::new(object_id))?
+    };
+
+    // Convert to iota_sdk2 type
+    // TODO: Remove this conversion when we migrate iota-types to iota_sdk2 types
+    let sdk_object = object
+        .try_into()
+        .map_err(|e: SdkTypeConversionError| anyhow::Error::msg(e.to_string()))?;
+
+    let mut message = Object::default();
+
+    Merge::merge(&mut message, &sdk_object, read_mask);
+
+    Ok(message)
+}

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -89,7 +89,6 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
         &self,
         request: tonic::Request<grpc_ledger_service::GetObjectsRequest>,
     ) -> std::result::Result<tonic::Response<Self::GetObjectsStream>, tonic::Status> {
-        // Get the lazy stream
         get_objects::get_objects((*self.reader).clone(), request.into_inner())
             .map(|stream| Response::new(Box::pin(stream) as Self::GetObjectsStream))
             .map_err(Into::into)

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod get_epoch;
+mod get_objects;
 mod get_service_info;
 
 use std::{pin::Pin, sync::Arc};
@@ -86,12 +87,12 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
 
     async fn get_objects(
         &self,
-        _request: tonic::Request<grpc_ledger_service::GetObjectsRequest>,
+        request: tonic::Request<grpc_ledger_service::GetObjectsRequest>,
     ) -> std::result::Result<tonic::Response<Self::GetObjectsStream>, tonic::Status> {
-        // not implemented - return empty stream
-        let stream = futures::stream::empty();
-        let stream: Self::GetObjectsStream = Box::pin(stream);
-        Ok(Response::new(stream))
+        // Get the lazy stream
+        get_objects::get_objects((*self.reader).clone(), request.into_inner())
+            .map(|stream| Response::new(Box::pin(stream) as Self::GetObjectsStream))
+            .map_err(Into::into)
     }
 
     async fn get_transactions(

--- a/crates/iota-grpc-server/src/lib.rs
+++ b/crates/iota-grpc-server/src/lib.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Modules
+pub mod constants;
 mod error;
 pub mod ledger_service;
 pub mod server;
 pub mod types;
+pub mod utils;
 
 // Re-export commonly used types and traits
 pub use ledger_service::LedgerGrpcService;

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -14,9 +14,11 @@ use iota_grpc_types::v0::{
 };
 use iota_json_rpc_types::{EventFilter, IotaEvent};
 use iota_types::{
+    base_types::{ObjectID, VersionNumber},
     full_checkpoint_content::CheckpointData,
     messages_checkpoint::CertifiedCheckpointSummary,
-    storage::{RestStateReader, error::Kind},
+    object::Object,
+    storage::{ObjectStore, ReadStore, RestStateReader, error::Kind},
 };
 use serde::Serialize;
 use tokio::sync::broadcast::{Receiver, Sender, error::RecvError};
@@ -231,6 +233,12 @@ pub trait GrpcStateReader: Send + Sync + 'static {
     /// Get the lowest available checkpoint for which object data is available
     fn get_lowest_available_checkpoint_objects(&self) -> anyhow::Result<u64>;
 
+    /// Get an object by its ObjectID
+    fn get_object(&self, object_id: &ObjectID) -> Option<Object>;
+
+    /// Get an object by its ObjectID and version
+    fn get_object_by_key(&self, object_id: &ObjectID, version: VersionNumber) -> Option<Object>;
+
     /// Get committee for a specific epoch
     fn get_committee(
         &self,
@@ -297,6 +305,14 @@ impl GrpcStateReader for RestStateReaderAdapter {
         self.inner
             .get_lowest_available_checkpoint_objects()
             .map_err(Into::into)
+    }
+
+    fn get_object(&self, object_id: &ObjectID) -> Option<Object> {
+        self.inner.get_object(object_id)
+    }
+
+    fn get_object_by_key(&self, object_id: &ObjectID, version: VersionNumber) -> Option<Object> {
+        self.inner.get_object_by_key(object_id, version)
     }
 
     fn get_committee(
@@ -380,6 +396,18 @@ impl GrpcReader {
 
     pub fn get_lowest_available_checkpoint_objects(&self) -> anyhow::Result<u64> {
         self.state_reader.get_lowest_available_checkpoint_objects()
+    }
+
+    pub fn get_object(&self, object_id: &ObjectID) -> Option<Object> {
+        self.state_reader.get_object(object_id)
+    }
+
+    pub fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Option<Object> {
+        self.state_reader.get_object_by_key(object_id, version)
     }
 
     pub fn get_committee(

--- a/crates/iota-grpc-server/src/utils.rs
+++ b/crates/iota-grpc-server/src/utils.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+/// Creates a lazy batching stream that fetches and batches items on-demand
+/// based on message size limits.
+///
+/// # Example
+/// ```ignore
+/// create_batching_stream!(
+///     requests.into_iter(),
+///     (object_id, version),
+///     {
+///         let result = process(object_id, version);
+///         let size = result.encoded_len();
+///         (result, size)
+///     },
+///     max_message_size,
+///     GetObjectsResponse,
+///     objects,
+///     has_next
+/// )
+/// ```
+#[macro_export]
+macro_rules! create_batching_stream {
+    (
+        $requests_iter:expr,
+        $item_pattern:pat,
+        $process_block:block,
+        $max_message_size:expr,
+        $response_type:ty,
+        $items_field:ident,
+        $has_next_field:ident
+    ) => {
+        async_stream::try_stream! {
+            let mut requests_iter = $requests_iter;
+            let mut current_batch = Vec::new();
+            let mut current_size = 0;
+            let mut has_yielded = false;
+
+            loop {
+                // Try to get the next item
+                match requests_iter.next() {
+                    Some($item_pattern) => {
+                        // Process the item using the provided block
+                        let (result_item, item_size) = $process_block;
+
+                        // Check if adding this item would exceed the limit
+                        if current_size + item_size > $max_message_size && !current_batch.is_empty() {
+                            // Current batch is full, yield it
+                            has_yielded = true;
+                            yield $response_type {
+                                $items_field: current_batch,
+                                $has_next_field: true,
+                            };
+                            // Start new batch with current item
+                            current_batch = vec![result_item];
+                            current_size = item_size;
+                        } else {
+                            // Item fits, add to current batch
+                            current_batch.push(result_item);
+                            current_size += item_size;
+                        }
+                    }
+                    None => {
+                        // No more items
+                        if !current_batch.is_empty() {
+                            yield $response_type {
+                                $items_field: current_batch,
+                                $has_next_field: false,
+                            };
+                        } else if !has_yielded {
+                            // Return empty response if we haven't yielded anything yet
+                            yield $response_type {
+                                $items_field: vec![],
+                                $has_next_field: false,
+                            };
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    };
+}

--- a/crates/iota-grpc-server/src/utils.rs
+++ b/crates/iota-grpc-server/src/utils.rs
@@ -44,6 +44,15 @@ macro_rules! create_batching_stream {
                         // Process the item using the provided block
                         let (result_item, item_size) = $process_block;
 
+                        // Check if a single item exceeds the message size limit
+                        if item_size > $max_message_size {
+                            Err($crate::error::RpcError::new(
+                                tonic::Code::InvalidArgument,
+                                format!("Single item size ({} bytes) exceeds max message size ({} bytes)",
+                                    item_size, $max_message_size)
+                            ))?;
+                        }
+
                         // Check if adding this item would exceed the limit
                         if current_size + item_size > $max_message_size && !current_batch.is_empty() {
                             // Current batch is full, yield it

--- a/crates/iota-grpc-types/src/field/field_mask_util.rs
+++ b/crates/iota-grpc-types/src/field/field_mask_util.rs
@@ -185,12 +185,14 @@ mod tests {
                     name: "a",
                     json_name: "a",
                     number: 1,
+                    is_optional: false,
                     message_fields: None,
                 },
                 &MessageField {
                     name: "b",
                     json_name: "b",
                     number: 2,
+                    is_optional: false,
                     message_fields: None,
                 },
             ];

--- a/crates/iota-grpc-types/src/field/mod.rs
+++ b/crates/iota-grpc-types/src/field/mod.rs
@@ -77,11 +77,9 @@ impl MessageField {
                     names.push(format!("{}.{}", self.name, nested_name));
                 }
             }
-        } else {
-            if self.is_optional {
-                // No nested fields, just return the field name if it's optional
-                names.push(self.name.to_string());
-            }
+        } else if self.is_optional {
+            // No nested fields, just return the field name if it's optional
+            names.push(self.name.to_string());
         }
 
         names

--- a/crates/iota-grpc-types/src/field/mod.rs
+++ b/crates/iota-grpc-types/src/field/mod.rs
@@ -61,7 +61,31 @@ pub struct MessageField {
     pub name: &'static str,
     pub json_name: &'static str,
     pub number: i32,
+    pub is_optional: bool,
     pub message_fields: Option<&'static [&'static MessageField]>,
+}
+
+impl MessageField {
+    // Returns the field name and all nested field names
+    pub fn get_optional_message_field_names(&self) -> Vec<String> {
+        let mut names = Vec::new();
+
+        // Recursively get nested field names and prefix them with the parent field name
+        if let Some(nested_fields) = self.message_fields {
+            for field in nested_fields {
+                for nested_name in field.get_optional_message_field_names() {
+                    names.push(format!("{}.{}", self.name, nested_name));
+                }
+            }
+        } else {
+            if self.is_optional {
+                // No nested fields, just return the field name if it's optional
+                names.push(self.name.to_string());
+            }
+        }
+
+        names
+    }
 }
 
 impl AsRef<str> for MessageField {
@@ -77,6 +101,7 @@ impl MessageField {
             name,
             json_name: "",
             number: 0,
+            is_optional: false,
             message_fields: None,
         }
     }
@@ -86,6 +111,11 @@ impl MessageField {
         message_fields: &'static [&'static MessageField],
     ) -> Self {
         self.message_fields = Some(message_fields);
+        self
+    }
+
+    pub const fn with_optional(mut self, is_optional: bool) -> Self {
+        self.is_optional = is_optional;
         self
     }
 }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.bcs.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.bcs.field_info.rs
@@ -12,6 +12,7 @@ mod _field_impls {
             name: "data",
             json_name: "data",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.checkpoint.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.checkpoint.field_info.rs
@@ -24,12 +24,14 @@ mod _field_impls {
             name: "digest",
             json_name: "digest",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(Digest::FIELDS),
         };
         pub const BCS_FIELD: &'static MessageField = &MessageField {
             name: "bcs",
             json_name: "bcs",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(BcsData::FIELDS),
         };
     }
@@ -73,12 +75,14 @@ mod _field_impls {
             name: "digest",
             json_name: "digest",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(Digest::FIELDS),
         };
         pub const BCS_FIELD: &'static MessageField = &MessageField {
             name: "bcs",
             json_name: "bcs",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(BcsData::FIELDS),
         };
     }
@@ -122,24 +126,28 @@ mod _field_impls {
             name: "sequence_number",
             json_name: "sequenceNumber",
             number: 1i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const SUMMARY_FIELD: &'static MessageField = &MessageField {
             name: "summary",
             json_name: "summary",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(CheckpointSummary::FIELDS),
         };
         pub const CONTENTS_FIELD: &'static MessageField = &MessageField {
             name: "contents",
             json_name: "contents",
             number: 3i32,
+            is_optional: true,
             message_fields: Some(CheckpointContents::FIELDS),
         };
         pub const SIGNATURE_FIELD: &'static MessageField = &MessageField {
             name: "signature",
             json_name: "signature",
             number: 4i32,
+            is_optional: true,
             message_fields: Some(ValidatorAggregatedSignature::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.command.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.command.field_info.rs
@@ -80,6 +80,7 @@ mod _field_impls {
                 name: "index",
                 json_name: "index",
                 number: 1i32,
+                is_optional: true,
                 message_fields: None,
             };
         }
@@ -116,12 +117,14 @@ mod _field_impls {
                 name: "index",
                 json_name: "index",
                 number: 1i32,
+                is_optional: true,
                 message_fields: None,
             };
             pub const NESTED_RESULT_INDEX_FIELD: &'static MessageField = &MessageField {
                 name: "nested_result_index",
                 json_name: "nestedResultIndex",
                 number: 2i32,
+                is_optional: true,
                 message_fields: None,
             };
         }
@@ -166,24 +169,28 @@ mod _field_impls {
             name: "unknown",
             json_name: "unknown",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(Unknown::FIELDS),
         };
         pub const GAS_COIN_FIELD: &'static MessageField = &MessageField {
             name: "gas_coin",
             json_name: "gasCoin",
             number: 2i32,
+            is_optional: false,
             message_fields: Some(GasCoin::FIELDS),
         };
         pub const INPUT_FIELD: &'static MessageField = &MessageField {
             name: "input",
             json_name: "input",
             number: 3i32,
+            is_optional: false,
             message_fields: Some(Input::FIELDS),
         };
         pub const RESULT_FIELD: &'static MessageField = &MessageField {
             name: "result",
             json_name: "result",
             number: 4i32,
+            is_optional: false,
             message_fields: Some(Result::FIELDS),
         };
     }
@@ -237,18 +244,21 @@ mod _field_impls {
             name: "argument",
             json_name: "argument",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(Argument::FIELDS),
         };
         pub const TYPE_TAG_FIELD: &'static MessageField = &MessageField {
             name: "type_tag",
             json_name: "typeTag",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(TypeTag::FIELDS),
         };
         pub const BCS_FIELD: &'static MessageField = &MessageField {
             name: "bcs",
             json_name: "bcs",
             number: 3i32,
+            is_optional: true,
             message_fields: Some(BcsData::FIELDS),
         };
     }
@@ -297,6 +307,7 @@ mod _field_impls {
             name: "outputs",
             json_name: "outputs",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(CommandOutput::FIELDS),
         };
     }
@@ -333,12 +344,14 @@ mod _field_impls {
             name: "return_values",
             json_name: "returnValues",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(CommandOutputs::FIELDS),
         };
         pub const MUTATED_BY_REF_FIELD: &'static MessageField = &MessageField {
             name: "mutated_by_ref",
             json_name: "mutatedByRef",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(CommandOutputs::FIELDS),
         };
     }
@@ -382,6 +395,7 @@ mod _field_impls {
             name: "results",
             json_name: "results",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(CommandResult::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.epoch.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.epoch.field_info.rs
@@ -16,12 +16,14 @@ mod _field_impls {
             name: "public_key",
             json_name: "publicKey",
             number: 1i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const WEIGHT_FIELD: &'static MessageField = &MessageField {
             name: "weight",
             json_name: "weight",
             number: 2i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -65,6 +67,7 @@ mod _field_impls {
             name: "members",
             json_name: "members",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(ValidatorCommitteeMember::FIELDS),
         };
     }
@@ -101,12 +104,14 @@ mod _field_impls {
             name: "epoch",
             json_name: "epoch",
             number: 1i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const MEMBERS_FIELD: &'static MessageField = &MessageField {
             name: "members",
             json_name: "members",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(ValidatorCommitteeMembers::FIELDS),
         };
     }
@@ -150,6 +155,7 @@ mod _field_impls {
             name: "flags",
             json_name: "flags",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -186,6 +192,7 @@ mod _field_impls {
             name: "attributes",
             json_name: "attributes",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -222,18 +229,21 @@ mod _field_impls {
             name: "protocol_version",
             json_name: "protocolVersion",
             number: 1i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const FEATURE_FLAGS_FIELD: &'static MessageField = &MessageField {
             name: "feature_flags",
             json_name: "featureFlags",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(ProtocolFeatureFlags::FIELDS),
         };
         pub const ATTRIBUTES_FIELD: &'static MessageField = &MessageField {
             name: "attributes",
             json_name: "attributes",
             number: 3i32,
+            is_optional: true,
             message_fields: Some(ProtocolAttributes::FIELDS),
         };
     }
@@ -282,54 +292,63 @@ mod _field_impls {
             name: "epoch",
             json_name: "epoch",
             number: 1i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const COMMITTEE_FIELD: &'static MessageField = &MessageField {
             name: "committee",
             json_name: "committee",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(ValidatorCommittee::FIELDS),
         };
         pub const BCS_SYSTEM_STATE_FIELD: &'static MessageField = &MessageField {
             name: "bcs_system_state",
             json_name: "bcsSystemState",
             number: 3i32,
+            is_optional: true,
             message_fields: Some(BcsData::FIELDS),
         };
         pub const FIRST_CHECKPOINT_FIELD: &'static MessageField = &MessageField {
             name: "first_checkpoint",
             json_name: "firstCheckpoint",
             number: 4i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const LAST_CHECKPOINT_FIELD: &'static MessageField = &MessageField {
             name: "last_checkpoint",
             json_name: "lastCheckpoint",
             number: 5i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const START_FIELD: &'static MessageField = &MessageField {
             name: "start",
             json_name: "start",
             number: 6i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const END_FIELD: &'static MessageField = &MessageField {
             name: "end",
             json_name: "end",
             number: 7i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const REFERENCE_GAS_PRICE_FIELD: &'static MessageField = &MessageField {
             name: "reference_gas_price",
             json_name: "referenceGasPrice",
             number: 8i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const PROTOCOL_CONFIG_FIELD: &'static MessageField = &MessageField {
             name: "protocol_config",
             json_name: "protocolConfig",
             number: 9i32,
+            is_optional: true,
             message_fields: Some(ProtocolConfig::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.event.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.event.field_info.rs
@@ -20,42 +20,49 @@ mod _field_impls {
             name: "bcs",
             json_name: "bcs",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(BcsData::FIELDS),
         };
         pub const PACKAGE_ID_FIELD: &'static MessageField = &MessageField {
             name: "package_id",
             json_name: "packageId",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(Address::FIELDS),
         };
         pub const MODULE_FIELD: &'static MessageField = &MessageField {
             name: "module",
             json_name: "module",
             number: 3i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const SENDER_FIELD: &'static MessageField = &MessageField {
             name: "sender",
             json_name: "sender",
             number: 4i32,
+            is_optional: true,
             message_fields: Some(Address::FIELDS),
         };
         pub const EVENT_TYPE_FIELD: &'static MessageField = &MessageField {
             name: "event_type",
             json_name: "eventType",
             number: 5i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const BCS_CONTENTS_FIELD: &'static MessageField = &MessageField {
             name: "bcs_contents",
             json_name: "bcsContents",
             number: 6i32,
+            is_optional: true,
             message_fields: Some(BcsData::FIELDS),
         };
         pub const JSON_CONTENTS_FIELD: &'static MessageField = &MessageField {
             name: "json_contents",
             json_name: "jsonContents",
             number: 7i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -124,6 +131,7 @@ mod _field_impls {
             name: "events",
             json_name: "events",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(Event::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.filter.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.filter.field_info.rs
@@ -20,6 +20,7 @@ mod _field_impls {
             name: "filters",
             json_name: "filters",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -56,6 +57,7 @@ mod _field_impls {
             name: "filters",
             json_name: "filters",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -92,6 +94,7 @@ mod _field_impls {
             name: "filter",
             json_name: "filter",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -128,6 +131,7 @@ mod _field_impls {
             name: "address",
             json_name: "address",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(Address::FIELDS),
         };
     }
@@ -164,12 +168,14 @@ mod _field_impls {
             name: "package_id",
             json_name: "packageId",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(Address::FIELDS),
         };
         pub const MODULE_FIELD: &'static MessageField = &MessageField {
             name: "module",
             json_name: "module",
             number: 2i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -213,6 +219,7 @@ mod _field_impls {
             name: "struct_tag",
             json_name: "structTag",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -249,12 +256,14 @@ mod _field_impls {
             name: "json_pointer",
             json_name: "jsonPointer",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
         pub const VALUE_FIELD: &'static MessageField = &MessageField {
             name: "value",
             json_name: "value",
             number: 2i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -298,48 +307,56 @@ mod _field_impls {
             name: "all",
             json_name: "all",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(AllEventFilter::FIELDS),
         };
         pub const ANY_FIELD: &'static MessageField = &MessageField {
             name: "any",
             json_name: "any",
             number: 2i32,
+            is_optional: false,
             message_fields: Some(AnyEventFilter::FIELDS),
         };
         pub const NEGATION_FIELD: &'static MessageField = &MessageField {
             name: "negation",
             json_name: "negation",
             number: 3i32,
+            is_optional: false,
             message_fields: Some(NotEventFilter::FIELDS),
         };
         pub const SENDER_FIELD: &'static MessageField = &MessageField {
             name: "sender",
             json_name: "sender",
             number: 4i32,
+            is_optional: false,
             message_fields: Some(AddressFilter::FIELDS),
         };
         pub const MOVE_PACKAGE_AND_MODULE_FIELD: &'static MessageField = &MessageField {
             name: "move_package_and_module",
             json_name: "movePackageAndModule",
             number: 5i32,
+            is_optional: false,
             message_fields: Some(MovePackageAndModuleFilter::FIELDS),
         };
         pub const MOVE_EVENT_PACKAGE_AND_MODULE_FIELD: &'static MessageField = &MessageField {
             name: "move_event_package_and_module",
             json_name: "moveEventPackageAndModule",
             number: 6i32,
+            is_optional: false,
             message_fields: Some(MovePackageAndModuleFilter::FIELDS),
         };
         pub const MOVE_EVENT_TYPE_FIELD: &'static MessageField = &MessageField {
             name: "move_event_type",
             json_name: "moveEventType",
             number: 7i32,
+            is_optional: false,
             message_fields: Some(MoveEventTypeFilter::FIELDS),
         };
         pub const MOVE_EVENT_FIELD_FIELD: &'static MessageField = &MessageField {
             name: "move_event_field",
             json_name: "moveEventField",
             number: 8i32,
+            is_optional: false,
             message_fields: Some(MoveEventFieldFilter::FIELDS),
         };
     }
@@ -417,6 +434,7 @@ mod _field_impls {
             name: "filters",
             json_name: "filters",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -453,6 +471,7 @@ mod _field_impls {
             name: "filters",
             json_name: "filters",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -489,6 +508,7 @@ mod _field_impls {
             name: "filter",
             json_name: "filter",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -525,6 +545,7 @@ mod _field_impls {
             name: "kinds",
             json_name: "kinds",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -561,6 +582,7 @@ mod _field_impls {
             name: "object_ref",
             json_name: "objectRef",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(ObjectReference::FIELDS),
         };
     }
@@ -597,18 +619,21 @@ mod _field_impls {
             name: "package_id",
             json_name: "packageId",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(Address::FIELDS),
         };
         pub const MODULE_FIELD: &'static MessageField = &MessageField {
             name: "module",
             json_name: "module",
             number: 2i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const FUNCTION_FIELD: &'static MessageField = &MessageField {
             name: "function",
             json_name: "function",
             number: 3i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -657,72 +682,84 @@ mod _field_impls {
             name: "all",
             json_name: "all",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(AllTransactionFilter::FIELDS),
         };
         pub const ANY_FIELD: &'static MessageField = &MessageField {
             name: "any",
             json_name: "any",
             number: 2i32,
+            is_optional: false,
             message_fields: Some(AnyTransactionFilter::FIELDS),
         };
         pub const NEGATION_FIELD: &'static MessageField = &MessageField {
             name: "negation",
             json_name: "negation",
             number: 3i32,
+            is_optional: false,
             message_fields: Some(NotTransactionFilter::FIELDS),
         };
         pub const TRANSACTION_KINDS_FIELD: &'static MessageField = &MessageField {
             name: "transaction_kinds",
             json_name: "transactionKinds",
             number: 4i32,
+            is_optional: false,
             message_fields: Some(TransactionKindsFilter::FIELDS),
         };
         pub const SENDER_FIELD: &'static MessageField = &MessageField {
             name: "sender",
             json_name: "sender",
             number: 5i32,
+            is_optional: false,
             message_fields: Some(AddressFilter::FIELDS),
         };
         pub const RECEIVER_FIELD: &'static MessageField = &MessageField {
             name: "receiver",
             json_name: "receiver",
             number: 6i32,
+            is_optional: false,
             message_fields: Some(AddressFilter::FIELDS),
         };
         pub const INPUT_OBJECT_FIELD: &'static MessageField = &MessageField {
             name: "input_object",
             json_name: "inputObject",
             number: 7i32,
+            is_optional: false,
             message_fields: Some(ObjectIdFilter::FIELDS),
         };
         pub const CHANGED_OBJECT_FIELD: &'static MessageField = &MessageField {
             name: "changed_object",
             json_name: "changedObject",
             number: 8i32,
+            is_optional: false,
             message_fields: Some(ObjectIdFilter::FIELDS),
         };
         pub const WRAPPED_OR_DELETED_OBJECT_FIELD: &'static MessageField = &MessageField {
             name: "wrapped_or_deleted_object",
             json_name: "wrappedOrDeletedObject",
             number: 9i32,
+            is_optional: false,
             message_fields: Some(ObjectIdFilter::FIELDS),
         };
         pub const AFFECTED_OBJECT_FIELD: &'static MessageField = &MessageField {
             name: "affected_object",
             json_name: "affectedObject",
             number: 10i32,
+            is_optional: false,
             message_fields: Some(ObjectIdFilter::FIELDS),
         };
         pub const MOVE_CALL_FIELD: &'static MessageField = &MessageField {
             name: "move_call",
             json_name: "moveCall",
             number: 11i32,
+            is_optional: false,
             message_fields: Some(MoveCallFilter::FIELDS),
         };
         pub const EVENT_FIELD: &'static MessageField = &MessageField {
             name: "event",
             json_name: "event",
             number: 12i32,
+            is_optional: false,
             message_fields: Some(EventFilter::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.field_info.rs
@@ -52,6 +52,7 @@ mod _field_impls {
                 name: "sequence_number",
                 json_name: "sequenceNumber",
                 number: 1i32,
+                is_optional: true,
                 message_fields: None,
             };
         }
@@ -91,6 +92,7 @@ mod _field_impls {
             name: "read_mask",
             json_name: "readMask",
             number: 1i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -127,48 +129,56 @@ mod _field_impls {
             name: "chain_id",
             json_name: "chainId",
             number: 1i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const CHAIN_FIELD: &'static MessageField = &MessageField {
             name: "chain",
             json_name: "chain",
             number: 2i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const EPOCH_FIELD: &'static MessageField = &MessageField {
             name: "epoch",
             json_name: "epoch",
             number: 3i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const EXECUTED_CHECKPOINT_HEIGHT_FIELD: &'static MessageField = &MessageField {
             name: "executed_checkpoint_height",
             json_name: "executedCheckpointHeight",
             number: 4i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const EXECUTED_CHECKPOINT_TIMESTAMP_FIELD: &'static MessageField = &MessageField {
             name: "executed_checkpoint_timestamp",
             json_name: "executedCheckpointTimestamp",
             number: 5i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const LOWEST_AVAILABLE_CHECKPOINT_FIELD: &'static MessageField = &MessageField {
             name: "lowest_available_checkpoint",
             json_name: "lowestAvailableCheckpoint",
             number: 6i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const LOWEST_AVAILABLE_CHECKPOINT_OBJECTS_FIELD: &'static MessageField = &MessageField {
             name: "lowest_available_checkpoint_objects",
             json_name: "lowestAvailableCheckpointObjects",
             number: 7i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const SERVER_FIELD: &'static MessageField = &MessageField {
             name: "server",
             json_name: "server",
             number: 8i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -249,6 +259,7 @@ mod _field_impls {
             name: "object_ref",
             json_name: "objectRef",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(ObjectReference::FIELDS),
         };
     }
@@ -285,6 +296,7 @@ mod _field_impls {
             name: "requests",
             json_name: "requests",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(ObjectRequest::FIELDS),
         };
     }
@@ -321,18 +333,21 @@ mod _field_impls {
             name: "requests",
             json_name: "requests",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(ObjectRequests::FIELDS),
         };
         pub const READ_MASK_FIELD: &'static MessageField = &MessageField {
             name: "read_mask",
             json_name: "readMask",
             number: 2i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const MAX_MESSAGE_SIZE_BYTES_FIELD: &'static MessageField = &MessageField {
             name: "max_message_size_bytes",
             json_name: "maxMessageSizeBytes",
             number: 3i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -381,12 +396,14 @@ mod _field_impls {
             name: "object",
             json_name: "object",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(Object::FIELDS),
         };
         pub const ERROR_FIELD: &'static MessageField = &MessageField {
             name: "error",
             json_name: "error",
             number: 2i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -430,12 +447,14 @@ mod _field_impls {
             name: "objects",
             json_name: "objects",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(ObjectResult::FIELDS),
         };
         pub const HAS_NEXT_FIELD: &'static MessageField = &MessageField {
             name: "has_next",
             json_name: "hasNext",
             number: 2i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -479,6 +498,7 @@ mod _field_impls {
             name: "digest",
             json_name: "digest",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(Digest::FIELDS),
         };
     }
@@ -515,6 +535,7 @@ mod _field_impls {
             name: "requests",
             json_name: "requests",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(TransactionRequest::FIELDS),
         };
     }
@@ -551,18 +572,21 @@ mod _field_impls {
             name: "requests",
             json_name: "requests",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(TransactionRequests::FIELDS),
         };
         pub const READ_MASK_FIELD: &'static MessageField = &MessageField {
             name: "read_mask",
             json_name: "readMask",
             number: 2i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const MAX_MESSAGE_SIZE_BYTES_FIELD: &'static MessageField = &MessageField {
             name: "max_message_size_bytes",
             json_name: "maxMessageSizeBytes",
             number: 3i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -611,12 +635,14 @@ mod _field_impls {
             name: "transaction",
             json_name: "transaction",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(ExecutedTransaction::FIELDS),
         };
         pub const ERROR_FIELD: &'static MessageField = &MessageField {
             name: "error",
             json_name: "error",
             number: 2i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -660,12 +686,14 @@ mod _field_impls {
             name: "transactions",
             json_name: "transactions",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(TransactionResult::FIELDS),
         };
         pub const HAS_NEXT_FIELD: &'static MessageField = &MessageField {
             name: "has_next",
             json_name: "hasNext",
             number: 2i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -709,54 +737,63 @@ mod _field_impls {
             name: "latest",
             json_name: "latest",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
         pub const SEQUENCE_NUMBER_FIELD: &'static MessageField = &MessageField {
             name: "sequence_number",
             json_name: "sequenceNumber",
             number: 2i32,
+            is_optional: false,
             message_fields: None,
         };
         pub const DIGEST_FIELD: &'static MessageField = &MessageField {
             name: "digest",
             json_name: "digest",
             number: 3i32,
+            is_optional: false,
             message_fields: Some(Digest::FIELDS),
         };
         pub const CHECKPOINT_READ_MASK_FIELD: &'static MessageField = &MessageField {
             name: "checkpoint_read_mask",
             json_name: "checkpointReadMask",
             number: 4i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const TRANSACTIONS_FILTER_FIELD: &'static MessageField = &MessageField {
             name: "transactions_filter",
             json_name: "transactionsFilter",
             number: 5i32,
+            is_optional: true,
             message_fields: Some(TransactionFilter::FIELDS),
         };
         pub const TRANSACTION_READ_MASK_FIELD: &'static MessageField = &MessageField {
             name: "transaction_read_mask",
             json_name: "transactionReadMask",
             number: 6i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const EVENTS_FILTER_FIELD: &'static MessageField = &MessageField {
             name: "events_filter",
             json_name: "eventsFilter",
             number: 7i32,
+            is_optional: true,
             message_fields: Some(EventFilter::FIELDS),
         };
         pub const EVENT_READ_MASK_FIELD: &'static MessageField = &MessageField {
             name: "event_read_mask",
             json_name: "eventReadMask",
             number: 8i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const MAX_MESSAGE_SIZE_BYTES_FIELD: &'static MessageField = &MessageField {
             name: "max_message_size_bytes",
             json_name: "maxMessageSizeBytes",
             number: 9i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -835,48 +872,56 @@ mod _field_impls {
             name: "start_sequence_number",
             json_name: "startSequenceNumber",
             number: 1i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const END_SEQUENCE_NUMBER_FIELD: &'static MessageField = &MessageField {
             name: "end_sequence_number",
             json_name: "endSequenceNumber",
             number: 2i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const CHECKPOINT_READ_MASK_FIELD: &'static MessageField = &MessageField {
             name: "checkpoint_read_mask",
             json_name: "checkpointReadMask",
             number: 3i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const TRANSACTIONS_FILTER_FIELD: &'static MessageField = &MessageField {
             name: "transactions_filter",
             json_name: "transactionsFilter",
             number: 4i32,
+            is_optional: true,
             message_fields: Some(TransactionFilter::FIELDS),
         };
         pub const TRANSACTION_READ_MASK_FIELD: &'static MessageField = &MessageField {
             name: "transaction_read_mask",
             json_name: "transactionReadMask",
             number: 5i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const EVENTS_FILTER_FIELD: &'static MessageField = &MessageField {
             name: "events_filter",
             json_name: "eventsFilter",
             number: 6i32,
+            is_optional: true,
             message_fields: Some(EventFilter::FIELDS),
         };
         pub const EVENT_READ_MASK_FIELD: &'static MessageField = &MessageField {
             name: "event_read_mask",
             json_name: "eventReadMask",
             number: 7i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const MAX_MESSAGE_SIZE_BYTES_FIELD: &'static MessageField = &MessageField {
             name: "max_message_size_bytes",
             json_name: "maxMessageSizeBytes",
             number: 8i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -953,24 +998,28 @@ mod _field_impls {
             name: "checkpoint",
             json_name: "checkpoint",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(Checkpoint::FIELDS),
         };
         pub const TRANSACTIONS_FIELD: &'static MessageField = &MessageField {
             name: "transactions",
             json_name: "transactions",
             number: 2i32,
+            is_optional: false,
             message_fields: Some(ExecutedTransaction::FIELDS),
         };
         pub const EVENTS_FIELD: &'static MessageField = &MessageField {
             name: "events",
             json_name: "events",
             number: 3i32,
+            is_optional: false,
             message_fields: Some(Events::FIELDS),
         };
         pub const END_MARKER_FIELD: &'static MessageField = &MessageField {
             name: "end_marker",
             json_name: "endMarker",
             number: 4i32,
+            is_optional: false,
             message_fields: Some(EndMarker::FIELDS),
         };
     }
@@ -1024,12 +1073,14 @@ mod _field_impls {
             name: "epoch",
             json_name: "epoch",
             number: 1i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const READ_MASK_FIELD: &'static MessageField = &MessageField {
             name: "read_mask",
             json_name: "readMask",
             number: 2i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -1073,6 +1124,7 @@ mod _field_impls {
             name: "epoch",
             json_name: "epoch",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(Epoch::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.object.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.object.field_info.rs
@@ -20,12 +20,14 @@ mod _field_impls {
             name: "reference",
             json_name: "reference",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(ObjectReference::FIELDS),
         };
         pub const BCS_FIELD: &'static MessageField = &MessageField {
             name: "bcs",
             json_name: "bcs",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(BcsData::FIELDS),
         };
     }
@@ -69,6 +71,7 @@ mod _field_impls {
             name: "objects",
             json_name: "objects",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(Object::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.signatures.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.signatures.field_info.rs
@@ -16,6 +16,7 @@ mod _field_impls {
             name: "bcs",
             json_name: "bcs",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(BcsData::FIELDS),
         };
     }
@@ -52,6 +53,7 @@ mod _field_impls {
             name: "signatures",
             json_name: "signatures",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(UserSignature::FIELDS),
         };
     }
@@ -88,6 +90,7 @@ mod _field_impls {
             name: "bcs",
             json_name: "bcs",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(BcsData::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.transaction.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.transaction.field_info.rs
@@ -32,12 +32,14 @@ mod _field_impls {
             name: "digest",
             json_name: "digest",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(Digest::FIELDS),
         };
         pub const BCS_FIELD: &'static MessageField = &MessageField {
             name: "bcs",
             json_name: "bcs",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(BcsData::FIELDS),
         };
     }
@@ -81,12 +83,14 @@ mod _field_impls {
             name: "digest",
             json_name: "digest",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(Digest::FIELDS),
         };
         pub const BCS_FIELD: &'static MessageField = &MessageField {
             name: "bcs",
             json_name: "bcs",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(BcsData::FIELDS),
         };
     }
@@ -130,12 +134,14 @@ mod _field_impls {
             name: "digest",
             json_name: "digest",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(Digest::FIELDS),
         };
         pub const EVENTS_FIELD: &'static MessageField = &MessageField {
             name: "events",
             json_name: "events",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(Events::FIELDS),
         };
     }
@@ -179,54 +185,63 @@ mod _field_impls {
             name: "digest",
             json_name: "digest",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(Digest::FIELDS),
         };
         pub const TRANSACTION_FIELD: &'static MessageField = &MessageField {
             name: "transaction",
             json_name: "transaction",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(Transaction::FIELDS),
         };
         pub const SIGNATURES_FIELD: &'static MessageField = &MessageField {
             name: "signatures",
             json_name: "signatures",
             number: 3i32,
+            is_optional: true,
             message_fields: Some(UserSignatures::FIELDS),
         };
         pub const EFFECTS_FIELD: &'static MessageField = &MessageField {
             name: "effects",
             json_name: "effects",
             number: 4i32,
+            is_optional: true,
             message_fields: Some(TransactionEffects::FIELDS),
         };
         pub const EVENTS_FIELD: &'static MessageField = &MessageField {
             name: "events",
             json_name: "events",
             number: 5i32,
+            is_optional: true,
             message_fields: Some(TransactionEvents::FIELDS),
         };
         pub const CHECKPOINT_FIELD: &'static MessageField = &MessageField {
             name: "checkpoint",
             json_name: "checkpoint",
             number: 6i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const TIMESTAMP_FIELD: &'static MessageField = &MessageField {
             name: "timestamp",
             json_name: "timestamp",
             number: 7i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const INPUT_OBJECTS_FIELD: &'static MessageField = &MessageField {
             name: "input_objects",
             json_name: "inputObjects",
             number: 9i32,
+            is_optional: true,
             message_fields: Some(Objects::FIELDS),
         };
         pub const OUTPUT_OBJECTS_FIELD: &'static MessageField = &MessageField {
             name: "output_objects",
             json_name: "outputObjects",
             number: 10i32,
+            is_optional: true,
             message_fields: Some(Objects::FIELDS),
         };
     }
@@ -305,6 +320,7 @@ mod _field_impls {
             name: "transactions",
             json_name: "transactions",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(ExecutedTransaction::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.transaction_execution_service.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.transaction_execution_service.field_info.rs
@@ -28,18 +28,21 @@ mod _field_impls {
             name: "transaction",
             json_name: "transaction",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(Transaction::FIELDS),
         };
         pub const SIGNATURES_FIELD: &'static MessageField = &MessageField {
             name: "signatures",
             json_name: "signatures",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(UserSignatures::FIELDS),
         };
         pub const READ_MASK_FIELD: &'static MessageField = &MessageField {
             name: "read_mask",
             json_name: "readMask",
             number: 3i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -88,6 +91,7 @@ mod _field_impls {
             name: "transaction",
             json_name: "transaction",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(ExecutedTransaction::FIELDS),
         };
     }
@@ -124,24 +128,28 @@ mod _field_impls {
             name: "transaction",
             json_name: "transaction",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(Transaction::FIELDS),
         };
         pub const TX_CHECKS_FIELD: &'static MessageField = &MessageField {
             name: "tx_checks",
             json_name: "txChecks",
             number: 2i32,
+            is_optional: false,
             message_fields: None,
         };
         pub const ESTIMATE_GAS_BUDGET_FIELD: &'static MessageField = &MessageField {
             name: "estimate_gas_budget",
             json_name: "estimateGasBudget",
             number: 3i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const READ_MASK_FIELD: &'static MessageField = &MessageField {
             name: "read_mask",
             json_name: "readMask",
             number: 4i32,
+            is_optional: true,
             message_fields: None,
         };
     }
@@ -195,12 +203,14 @@ mod _field_impls {
             name: "transaction",
             json_name: "transaction",
             number: 1i32,
+            is_optional: true,
             message_fields: Some(ExecutedTransaction::FIELDS),
         };
         pub const COMMAND_RESULTS_FIELD: &'static MessageField = &MessageField {
             name: "command_results",
             json_name: "commandResults",
             number: 2i32,
+            is_optional: true,
             message_fields: Some(CommandResults::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.types.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.types.field_info.rs
@@ -12,6 +12,7 @@ mod _field_impls {
             name: "address",
             json_name: "address",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -48,6 +49,7 @@ mod _field_impls {
             name: "digest",
             json_name: "digest",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -84,18 +86,21 @@ mod _field_impls {
             name: "object_id",
             json_name: "objectId",
             number: 1i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const VERSION_FIELD: &'static MessageField = &MessageField {
             name: "version",
             json_name: "version",
             number: 2i32,
+            is_optional: true,
             message_fields: None,
         };
         pub const DIGEST_FIELD: &'static MessageField = &MessageField {
             name: "digest",
             json_name: "digest",
             number: 3i32,
+            is_optional: true,
             message_fields: Some(Digest::FIELDS),
         };
     }
@@ -144,6 +149,7 @@ mod _field_impls {
             name: "inner_type",
             json_name: "innerType",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -180,6 +186,7 @@ mod _field_impls {
             name: "struct_tag",
             json_name: "structTag",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
     }
@@ -216,66 +223,77 @@ mod _field_impls {
             name: "bool_tag",
             json_name: "boolTag",
             number: 1i32,
+            is_optional: false,
             message_fields: None,
         };
         pub const U8_TAG_FIELD: &'static MessageField = &MessageField {
             name: "u8_tag",
             json_name: "u8Tag",
             number: 2i32,
+            is_optional: false,
             message_fields: None,
         };
         pub const U16_TAG_FIELD: &'static MessageField = &MessageField {
             name: "u16_tag",
             json_name: "u16Tag",
             number: 3i32,
+            is_optional: false,
             message_fields: None,
         };
         pub const U32_TAG_FIELD: &'static MessageField = &MessageField {
             name: "u32_tag",
             json_name: "u32Tag",
             number: 4i32,
+            is_optional: false,
             message_fields: None,
         };
         pub const U64_TAG_FIELD: &'static MessageField = &MessageField {
             name: "u64_tag",
             json_name: "u64Tag",
             number: 5i32,
+            is_optional: false,
             message_fields: None,
         };
         pub const U128_TAG_FIELD: &'static MessageField = &MessageField {
             name: "u128_tag",
             json_name: "u128Tag",
             number: 6i32,
+            is_optional: false,
             message_fields: None,
         };
         pub const U256_TAG_FIELD: &'static MessageField = &MessageField {
             name: "u256_tag",
             json_name: "u256Tag",
             number: 7i32,
+            is_optional: false,
             message_fields: None,
         };
         pub const ADDRESS_TAG_FIELD: &'static MessageField = &MessageField {
             name: "address_tag",
             json_name: "addressTag",
             number: 8i32,
+            is_optional: false,
             message_fields: None,
         };
         pub const SIGNER_TAG_FIELD: &'static MessageField = &MessageField {
             name: "signer_tag",
             json_name: "signerTag",
             number: 9i32,
+            is_optional: false,
             message_fields: None,
         };
         pub const VECTOR_TAG_FIELD: &'static MessageField = &MessageField {
             name: "vector_tag",
             json_name: "vectorTag",
             number: 10i32,
+            is_optional: false,
             message_fields: Some(TypeTagVector::FIELDS),
         };
         pub const STRUCT_TAG_FIELD: &'static MessageField = &MessageField {
             name: "struct_tag",
             json_name: "structTag",
             number: 11i32,
+            is_optional: false,
             message_fields: Some(TypeTagStruct::FIELDS),
         };
     }
@@ -364,6 +382,7 @@ mod _field_impls {
             name: "type_tags",
             json_name: "typeTags",
             number: 1i32,
+            is_optional: false,
             message_fields: Some(TypeTag::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/object.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/object.rs
@@ -12,6 +12,7 @@ use crate::{
     v0::{bcs::BcsData, types::ObjectReference},
 };
 
+// TODO: Wrap Object into a type with a version
 impl Merge<&iota_sdk2::types::object::Object> for Object {
     fn merge(&mut self, source: &iota_sdk2::types::object::Object, mask: &FieldMaskTree) {
         if mask.contains("bcs") {

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/object.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/object.rs
@@ -5,3 +5,47 @@
 include!("../../../generated/iota.grpc.v0.object.rs");
 include!("../../../generated/iota.grpc.v0.object.field_info.rs");
 include!("../../../generated/iota.grpc.v0.object.accessors.rs");
+
+use crate::{
+    field::FieldMaskTree,
+    merge::Merge,
+    v0::{bcs::BcsData, types::ObjectReference},
+};
+
+impl Merge<&iota_sdk2::types::object::Object> for Object {
+    fn merge(&mut self, source: &iota_sdk2::types::object::Object, mask: &FieldMaskTree) {
+        if mask.contains("bcs") {
+            if let Ok(bcs_bytes) = bcs::to_bytes(source) {
+                self.bcs = Some(BcsData {
+                    data: bcs_bytes.into(),
+                });
+            }
+        }
+
+        if mask.contains("reference") {
+            let mut reference = ObjectReference::default();
+
+            // Check for nested fields within reference
+            if let Some(reference_mask) = mask.subtree("reference") {
+                if reference_mask.contains("object_id") {
+                    reference.object_id = Some(source.object_id().to_string());
+                }
+
+                if reference_mask.contains("version") {
+                    reference.version = Some(source.version());
+                }
+
+                if reference_mask.contains("digest") {
+                    reference.digest = Some(source.digest().into());
+                }
+            } else {
+                // If no subtree, include all reference fields
+                reference.object_id = Some(source.object_id().to_string());
+                reference.version = Some(source.version());
+                reference.digest = Some(source.digest().into());
+            }
+
+            self.reference = Some(reference);
+        }
+    }
+}

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/types.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/types.rs
@@ -29,3 +29,11 @@ impl From<iota_sdk2::types::CheckpointContentsDigest> for Digest {
         }
     }
 }
+
+impl From<iota_sdk2::types::ObjectDigest> for Digest {
+    fn from(value: iota_sdk2::types::ObjectDigest) -> Self {
+        Self {
+            digest: value.into_inner().to_vec().into(),
+        }
+    }
+}

--- a/crates/iota-proto-build/src/generate_fields.rs
+++ b/crates/iota-proto-build/src/generate_fields.rs
@@ -444,6 +444,9 @@ fn generate_field_constant(
     let json_name = field.json_name();
     let number = field.number();
 
+    // Check if the field is optional in the proto definition
+    let is_proto3_optional = field.proto3_optional.unwrap_or(false);
+
     let message_fields =
         if matches!(field.r#type(), Type::Message) && !field.type_name().contains("google") {
             let field_message_name = field.type_name().split('.').next_back().unwrap();
@@ -483,6 +486,7 @@ fn generate_field_constant(
             name: #name,
             json_name: #json_name,
             number: #number,
+            is_optional: #is_proto3_optional,
             message_fields: #message_fields,
         };
     }


### PR DESCRIPTION
# Description of change

- Implemented `GetObjects` in the gRPC API.
- Verified the `get_objects` simtest by using `cargo simtest --package iota-e2e-tests --test grpc -- get_objects`
  
## Links to any relevant issues

Closes #9390 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
