### PR TITLE
feat: bump iota to v1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,7 +1841,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "const-str",
  "git-version",
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "iota"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5470,7 +5470,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-simulator",
  "iota-source-validation",
  "iota-swarm",
@@ -5543,7 +5543,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "arrow-array 53.1.0",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5602,7 +5602,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5633,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5674,7 +5674,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5695,7 +5695,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -5738,7 +5738,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5756,7 +5756,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-move-build",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -5778,7 +5778,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5981,7 +5981,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6014,7 +6014,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6077,7 +6077,7 @@ dependencies = [
  "iota-protocol-config",
  "iota-rest-api",
  "iota-rust-sdk",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-simulator",
  "iota-storage",
  "iota-swarm",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "serde_yaml",
 ]
@@ -6147,7 +6147,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6163,7 +6163,7 @@ dependencies = [
  "iota-keys",
  "iota-metrics",
  "iota-network-stack",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-types",
  "parking_lot 0.12.3",
  "prometheus",
@@ -6187,7 +6187,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6207,7 +6207,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6225,7 +6225,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6246,7 +6246,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6296,7 +6296,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6306,7 +6306,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6314,7 +6314,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6327,7 +6327,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6413,14 +6413,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "axum 0.8.4",
 ]
 
 [[package]]
 name = "iota-grpc-client"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -6434,7 +6434,7 @@ dependencies = [
 
 [[package]]
 name = "iota-grpc-server"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6457,7 +6457,7 @@ dependencies = [
 
 [[package]]
 name = "iota-grpc-types"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "bcs",
  "iota-json-rpc-types",
@@ -6471,7 +6471,7 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "axum 0.8.4",
  "bytes",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6557,7 +6557,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6573,7 +6573,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6592,7 +6592,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6648,7 +6648,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6667,7 +6667,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6686,7 +6686,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6705,7 +6705,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6739,7 +6739,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "bip32",
@@ -6760,7 +6760,7 @@ dependencies = [
 
 [[package]]
 name = "iota-kvstore"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6778,7 +6778,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger-signer"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6807,7 +6807,7 @@ dependencies = [
  "bip32",
  "clap",
  "iota-ledger",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "shared-crypto",
  "thiserror 1.0.64",
  "tokio",
@@ -6816,7 +6816,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6830,7 +6830,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-types",
  "move-core-types",
  "object_store 0.10.2",
@@ -6849,7 +6849,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -6859,7 +6859,7 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6871,7 +6871,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "backoff",
@@ -6892,7 +6892,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6917,7 +6917,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -6956,7 +6956,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6977,7 +6977,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "bin-version",
  "clap",
@@ -7010,7 +7010,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7022,7 +7022,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -7061,7 +7061,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anemo",
  "bcs",
@@ -7090,7 +7090,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7142,7 +7142,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7166,7 +7166,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7178,7 +7178,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-alt"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "move-package-alt",
  "serde",
@@ -7186,7 +7186,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7202,13 +7202,13 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -7218,7 +7218,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7239,7 +7239,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -7249,7 +7249,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "clap",
  "insta",
@@ -7264,7 +7264,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7273,7 +7273,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7288,7 +7288,7 @@ dependencies = [
  "hex",
  "hyper 1.4.1",
  "iota-metrics",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-tls",
  "iota-types",
  "itertools 0.13.0",
@@ -7316,7 +7316,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7332,7 +7332,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-transaction-checks",
  "iota-types",
  "jsonrpsee",
@@ -7361,7 +7361,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7390,7 +7390,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-kv"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7417,7 +7417,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7434,7 +7434,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-swarm-config",
  "iota-types",
  "move-core-types",
@@ -7458,7 +7458,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7468,7 +7468,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-types",
  "itertools 0.13.0",
  "serde",
@@ -7543,7 +7543,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7582,7 +7582,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7604,7 +7604,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7638,7 +7638,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7665,7 +7665,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -7675,7 +7675,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -7697,7 +7697,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7712,7 +7712,7 @@ dependencies = [
  "iota-move",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-source-validation",
  "move-core-types",
  "move-package",
@@ -7733,7 +7733,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7784,7 +7784,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "bcs",
  "clap",
@@ -7812,7 +7812,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -7839,7 +7839,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anemo",
  "anyhow",
@@ -7867,7 +7867,7 @@ dependencies = [
 
 [[package]]
 name = "iota-synthetic-ingestion"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7884,12 +7884,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -7897,7 +7897,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7919,7 +7919,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -7941,7 +7941,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -7964,7 +7964,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7980,7 +7980,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -7993,7 +7993,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8038,7 +8038,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8113,7 +8113,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8141,7 +8141,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11449,7 +11449,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13317,7 +13317,7 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "bcs",
  "eyre",
@@ -13442,7 +13442,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14220,7 +14220,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -14307,7 +14307,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -14325,7 +14325,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.11.0-rc",
+ "iota-sdk 1.11.0",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -15201,7 +15201,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -15273,7 +15273,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "bcs",
  "bincode",
@@ -15302,7 +15302,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -15312,7 +15312,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "serde",
  "thiserror 1.0.64",
@@ -15320,7 +15320,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "1.11.0-rc"
+version = "1.11.0"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "1.11.0-rc"
+version = "1.11.0"
 
 [workspace.metadata.cargo-udeps.ignore]
 normal = ["move-package-alt"]

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "1.11.0-rc"
+    "version": "1.11.0"
   },
   "methods": [
     {


### PR DESCRIPTION
# Description of change

Bump `iota` to `v1.11.0` in preparation for `Mainnet` release.
