### PR TITLE
feat(core-node): Allow iota-aws-orchestrator clients to start and use fullnodes for JSON RPC

### DIFF
--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -411,16 +411,13 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
 
     /// Deploy the load generators.
     pub async fn run_clients(&self, parameters: &BenchmarkParameters<T>) -> TestbedResult<()> {
-        // Select the instances to run.
-        let (clients, _, _) = self.select_instances(parameters)?;
-
         if self.settings.use_fullnode_for_execution {
             display::action("Setting up full nodes");
 
             // Deploy the fullnodes.
             let targets = self
                 .protocol_commands
-                .fullnode_command(clients.clone(), parameters);
+                .fullnode_command(self.client_instances.clone(), parameters);
 
             let repo = self.settings.repository_name();
             let context = CommandContext::new()
@@ -430,6 +427,14 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             self.ssh_manager
                 .execute_per_instance(targets, context)
                 .await?;
+
+            // Wait until all fullnodes are reachable (otherwise clients might fail when a
+            // fullnode is not listening yet).
+            let commands = self.client_instances
+                .iter()
+                .cloned()
+                .map(|i| (i, "curl http://127.0.0.1:9000".to_owned())); // fullnodes default json RPC address
+            self.ssh_manager.wait_for_success(commands).await;
 
             display::done();
         }

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -430,7 +430,8 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
 
             // Wait until all fullnodes are reachable (otherwise clients might fail when a
             // fullnode is not listening yet).
-            let commands = self.client_instances
+            let commands = self
+                .client_instances
                 .iter()
                 .cloned()
                 .map(|i| (i, "curl http://127.0.0.1:9000".to_owned())); // fullnodes default json RPC address

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -411,6 +411,29 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
 
     /// Deploy the load generators.
     pub async fn run_clients(&self, parameters: &BenchmarkParameters<T>) -> TestbedResult<()> {
+        // Select the instances to run.
+        let (clients, _, _) = self.select_instances(parameters)?;
+
+        if self.settings.use_fullnode_for_execution {
+            display::action("Setting up full nodes");
+
+            // Deploy the fullnodes.
+            let targets = self
+                .protocol_commands
+                .fullnode_command(clients.clone(), parameters);
+
+            let repo = self.settings.repository_name();
+            let context = CommandContext::new()
+                .run_background("fullnode".into())
+                .with_log_file("~/fullnode.log".into())
+                .with_execute_from_path(repo.into());
+            self.ssh_manager
+                .execute_per_instance(targets, context)
+                .await?;
+
+            display::done();
+        }
+
         display::action("Setting up load generators");
 
         // Deploy the load generators.

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -54,6 +54,7 @@ impl BenchmarkType for IotaBenchmarkType {}
 /// All configurations information to run an IOTA client or validator.
 pub struct IotaProtocol {
     working_dir: PathBuf,
+    use_fullnode_for_execution: bool,
 }
 
 impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
@@ -179,6 +180,41 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
             .collect()
     }
 
+    fn fullnode_command<I>(
+        &self,
+        instances: I,
+        _parameters: &BenchmarkParameters<IotaBenchmarkType>,
+    ) -> Vec<(Instance, String)>
+    where
+        I: IntoIterator<Item = Instance>,
+    {
+        let working_dir = self.working_dir.clone();
+
+        instances
+            .into_iter()
+            .enumerate()
+            .map(|(i, instance)| {
+                let config_path: PathBuf = working_dir.join(iota_config::IOTA_FULLNODE_CONFIG);
+
+                let run = [
+                    "cargo run --release --bin iota-node --",
+                    &format!("--config-path {}", config_path.display(),),
+                ]
+                .join(" ");
+                let command = [
+                    "source $HOME/.cargo/env",
+                    "export RUSTFLAGS='-C target-cpu=native'",
+                    &run,
+                ]
+                .join(" && ");
+
+                display::action(format!("\n Command ({i}): {command}"));
+
+                (instance, command)
+            })
+            .collect()
+    }
+
     fn client_command<I>(
         &self,
         instances: I,
@@ -217,7 +253,7 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                 let gas_key = &gas_keys[i % committee_size];
                 let gas_address = IotaAddress::from(&gas_key.public());
 
-                let run = [
+                let mut run = [
                     "cargo run --release --bin stress --",
                     "--num-client-threads 24 --num-server-threads 1",
                     "--local false --num-transfer-accounts 2",
@@ -232,6 +268,10 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                     &format!("--client-metric-host 0.0.0.0 --client-metric-port {metrics_port}"),
                 ]
                 .join(" ");
+                if self.use_fullnode_for_execution {
+                    run.push_str(" --use-fullnode-for-execution true");
+                    run.push_str(" --fullnode-rpc-addresses http://127.0.0.1:9000");
+                }
                 let command = [
                     "source $HOME/.cargo/env",
                     "export RUSTFLAGS='-C target-cpu=native'",
@@ -254,6 +294,7 @@ impl IotaProtocol {
             working_dir: [&settings.working_dir, &iota_config::IOTA_CONFIG_DIR.into()]
                 .iter()
                 .collect(),
+            use_fullnode_for_execution: settings.use_fullnode_for_execution,
         }
     }
 

--- a/crates/iota-aws-orchestrator/src/protocol/mod.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/mod.rs
@@ -38,6 +38,16 @@ pub trait ProtocolCommands<T: BenchmarkType> {
     where
         I: IntoIterator<Item = Instance>;
 
+    /// The command to run a fullnode. The function returns a vector of commands
+    /// along with the associated instance on which to run the command.
+    fn fullnode_command<I>(
+        &self,
+        instances: I,
+        parameters: &BenchmarkParameters<T>,
+    ) -> Vec<(Instance, String)>
+    where
+        I: IntoIterator<Item = Instance>;
+
     fn monitor_command<I>(&self, instances: I) -> Vec<(Instance, String)>
     where
         I: IntoIterator<Item = Instance>;

--- a/crates/iota-aws-orchestrator/src/settings.rs
+++ b/crates/iota-aws-orchestrator/src/settings.rs
@@ -80,6 +80,10 @@ pub struct Settings {
     /// configuration files).
     #[serde(default = "default_working_dir")]
     pub working_dir: PathBuf,
+    /// Pass '--use-fullnode-for-execution' and '--fullnode-rpc-addresses' to
+    /// stress binary.
+    #[serde(default)]
+    pub use_fullnode_for_execution: bool,
     /// The directory (on the local machine) where to save benchmarks
     /// measurements.
     #[serde(default = "default_results_dir")]
@@ -196,6 +200,7 @@ impl Settings {
                 commit: "main".into(),
             },
             working_dir: "/path/to/working_dir".into(),
+            use_fullnode_for_execution: false,
             results_dir: "results".into(),
             logs_dir: "logs".into(),
         }


### PR DESCRIPTION
# Description of change

The title says it all.

## Links to any relevant issues

Fixes #9244.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
