### PR TITLE
feat(gRPC): add `GetTransactions` implementation in gRPC

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_transactions.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_transactions.rs
@@ -1,0 +1,531 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::StreamExt;
+use iota_grpc_types::{
+    field::FieldMaskUtil,
+    v0::ledger_service::{
+        GetTransactionsRequest, GetTransactionsResponse, TransactionRequest, TransactionRequests,
+        ledger_service_client::LedgerServiceClient,
+    },
+};
+use iota_macros::sim_test;
+use iota_test_transaction_builder::TestTransactionBuilder;
+use iota_types::digests::TransactionDigest;
+use prost_types::FieldMask;
+use test_cluster::{TestCluster, TestClusterBuilder};
+
+use crate::utils::assert_field_presence;
+
+// Note: impl_field_presence_checker! for ExecutedTransaction is already defined
+
+/// Helper to create a test transaction and return its digest
+async fn create_test_transaction(test_cluster: &TestCluster) -> TransactionDigest {
+    let (sender, gas) = test_cluster
+        .wallet
+        .get_one_gas_object()
+        .await
+        .unwrap()
+        .unwrap();
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let transaction_data = TestTransactionBuilder::new(sender, gas, rgp)
+        .transfer_iota(None, sender)
+        .build();
+    let signed_transaction = test_cluster.wallet.sign_transaction(&transaction_data);
+    let transaction_digest = *signed_transaction.digest();
+    test_cluster
+        .wallet
+        .execute_transaction_may_fail(signed_transaction)
+        .await
+        .unwrap();
+    transaction_digest
+}
+
+/// Helper function to make GetTransactions requests and validate responses..
+async fn assert_get_transactions_request(
+    client: &mut LedgerServiceClient<tonic::transport::Channel>,
+    digests: Vec<TransactionDigest>,
+    read_mask: Option<FieldMask>,
+    max_message_size_bytes: Option<u32>,
+    expected_field_mask_paths: &[&str],
+    scenario: &str,
+) -> Vec<GetTransactionsResponse> {
+    let request = GetTransactionsRequest {
+        requests: Some(TransactionRequests {
+            requests: digests
+                .iter()
+                .map(|d| TransactionRequest {
+                    digest: Some(iota_grpc_types::v0::types::Digest {
+                        digest: d.inner().to_vec().into(),
+                    }),
+                })
+                .collect(),
+        }),
+        read_mask,
+        max_message_size_bytes,
+    };
+
+    let mut stream = client.get_transactions(request).await.unwrap().into_inner();
+
+    let mut responses = Vec::new();
+    let mut response_count = 0;
+
+    // Loop through all responses until has_next is false
+    while let Some(response) = stream.next().await {
+        let response = response.unwrap();
+        response_count += 1;
+
+        // Assert all returned transactions have the expected fields
+        for (idx, tx_result) in response.transactions.iter().enumerate() {
+            if let Some(transaction) = tx_result.transaction_opt() {
+                assert_field_presence(
+                    transaction,
+                    expected_field_mask_paths,
+                    &format!("{scenario} (response {response_count}, transaction {idx})"),
+                );
+            }
+        }
+
+        let has_next = response.has_next;
+        responses.push(response);
+
+        // If has_next is false, this should be the last response
+        if !has_next {
+            break;
+        }
+    }
+
+    // Validate has_next values: all intermediate messages should have has_next=true
+    for (idx, response) in responses[..responses.len() - 1].iter().enumerate() {
+        assert!(
+            response.has_next,
+            "Intermediate stream message #{} should have has_next=true, but got false",
+            idx + 1
+        );
+    }
+
+    // Verify the last response has has_next=false
+    assert!(
+        !responses.last().unwrap().has_next,
+        "{scenario}: last response should have has_next=false"
+    );
+
+    // Verify stream is exhausted
+    assert!(
+        stream.next().await.is_none(),
+        "{scenario}: stream should be exhausted after has_next=false"
+    );
+    responses
+}
+
+#[sim_test]
+async fn get_transactions_readmask_scenarios() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .build()
+        .await;
+
+    test_cluster.wait_for_checkpoint(1, None).await;
+
+    // Create a test transaction
+    let transaction_digest = create_test_transaction(&test_cluster).await;
+
+    let mut client = LedgerServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    // Tests for single-transaction readmask scenarios
+    // Note: When a parent field is specified without nested paths (e.g.,
+    // "effects"), FieldMaskTree treats it as a wildcard and includes all nested
+    // fields. So "effects" means "effects.digest" AND "effects.bcs".
+    type TestCase<'a> = (&'a str, Option<FieldMask>, &'a [&'a str]);
+    let test_cases: Vec<TestCase> = vec![
+        // Default readmask (None) - returns only digest
+        ("default readmask", None, &["digest"]),
+        // Empty readmask - returns no fields
+        (
+            "empty readmask",
+            Some(FieldMask::from_paths(&[] as &[&str])),
+            &[],
+        ),
+        // Full readmask - returns all implemented fields with explicit nested paths
+        // Note: events may be None if transaction doesn't emit events
+        // Note: signatures, input_objects, output_objects are leaf fields (not
+        // nested) because their inner fields are Vec, not Option
+        (
+            "full readmask",
+            Some(FieldMask::from_paths([
+                "digest",
+                "transaction.digest",
+                "transaction.bcs",
+                "signatures",
+                "effects.digest",
+                "effects.bcs",
+                "events",
+                "checkpoint",
+                "timestamp",
+            ])),
+            &[
+                "digest",
+                "transaction.digest",
+                "transaction.bcs",
+                "signatures",
+                "effects.digest",
+                "effects.bcs",
+                // Note: events is intentionally excluded from expected because
+                // simple transfers don't emit events
+                "checkpoint",
+                "timestamp",
+            ],
+        ),
+        // Partial readmask: digest only
+        (
+            "partial readmask (digest only)",
+            Some(FieldMask::from_paths(["digest"])),
+            &["digest"],
+        ),
+        // Partial readmask: effects.digest only (specific nested field)
+        (
+            "partial readmask (effects.digest only)",
+            Some(FieldMask::from_paths(["effects.digest"])),
+            &["effects.digest"],
+        ),
+        // Partial readmask: effects wildcard (all nested fields)
+        (
+            "partial readmask (effects wildcard)",
+            Some(FieldMask::from_paths(["effects"])),
+            &["effects.digest", "effects.bcs"],
+        ),
+        // Partial readmask: transaction + signatures
+        // Note: signatures is a leaf field, transaction has nested paths
+        (
+            "partial readmask (transaction + signatures)",
+            Some(FieldMask::from_paths(["transaction.digest", "signatures"])),
+            &["transaction.digest", "signatures"],
+        ),
+        // Partial readmask: checkpoint + timestamp (metadata only)
+        (
+            "partial readmask (checkpoint + timestamp)",
+            Some(FieldMask::from_paths(["checkpoint", "timestamp"])),
+            &["checkpoint", "timestamp"],
+        ),
+    ];
+
+    for (scenario, mask, expected_paths) in test_cases {
+        let responses = assert_get_transactions_request(
+            &mut client,
+            vec![transaction_digest],
+            mask,
+            None,
+            expected_paths,
+            scenario,
+        )
+        .await;
+
+        let total_transactions: usize = responses.iter().map(|r| r.transactions.len()).sum();
+        assert_eq!(total_transactions, 1, "{scenario}: expected 1 transaction");
+    }
+}
+
+#[sim_test]
+async fn get_transactions_batch() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .build()
+        .await;
+
+    test_cluster.wait_for_checkpoint(1, None).await;
+
+    // Create multiple test transactions
+    let mut digests = Vec::new();
+    for _ in 0..3 {
+        let digest = create_test_transaction(&test_cluster).await;
+        digests.push(digest);
+    }
+
+    let mut client = LedgerServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    // Test batch request with partial readmask
+    // Note: "effects" without nested paths means all nested fields are included
+    let responses = assert_get_transactions_request(
+        &mut client,
+        digests.clone(),
+        Some(FieldMask::from_paths(["digest", "effects"])),
+        None,
+        &["digest", "effects.digest", "effects.bcs"],
+        "batch with 3 transactions",
+    )
+    .await;
+
+    let total_transactions: usize = responses.iter().map(|r| r.transactions.len()).sum();
+    assert_eq!(
+        total_transactions, 3,
+        "Should have received 3 transactions in batch"
+    );
+}
+
+#[sim_test]
+async fn get_transactions_streaming() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .build()
+        .await;
+
+    test_cluster.wait_for_checkpoint(1, None).await;
+
+    // Create multiple test transactions to have enough data for streaming
+    let mut digests = Vec::new();
+    for _ in 0..10 {
+        let digest = create_test_transaction(&test_cluster).await;
+        digests.push(digest);
+    }
+
+    let mut client = LedgerServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    // Request each transaction multiple times to create larger payload
+    let mut all_digests = Vec::new();
+    for _ in 0..100 {
+        all_digests.extend(digests.iter().cloned());
+    }
+
+    // Test streaming by requesting many transactions with full readmask
+    // Use minimum allowed message size to maximize chance of multi-message
+    // streaming
+    // Note: Parent fields without nested paths are wildcards that include all
+    // nested fields
+    let responses = assert_get_transactions_request(
+        &mut client,
+        all_digests,
+        Some(FieldMask::from_paths([
+            "digest",
+            "transaction",
+            "signatures",
+            "effects",
+            "checkpoint",
+            "timestamp",
+            "input_objects",
+            "output_objects",
+        ])),
+        Some(1024 * 1024_u32), // 1MB (minimum allowed)
+        &[
+            "digest",
+            "transaction.digest",
+            "transaction.bcs",
+            "signatures",
+            "effects.digest",
+            "effects.bcs",
+            "checkpoint",
+            "timestamp",
+            "input_objects",
+            "output_objects",
+        ],
+        "streaming with 1000 transactions",
+    )
+    .await;
+
+    // Verify we got all 1000 results
+    let total_transactions: usize = responses.iter().map(|r| r.transactions.len()).sum();
+    assert_eq!(
+        total_transactions, 1000,
+        "Should have received 1000 transactions"
+    );
+
+    // Verify the number of response messages is greater than 1 (i.e., streaming
+    // occurred)
+    assert!(
+        responses.len() > 1,
+        "Should have received multiple response messages for streaming"
+    );
+}
+
+#[sim_test]
+async fn get_transactions_empty_request() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .build()
+        .await;
+
+    let mut client = LedgerServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    // Test empty request list
+    let responses =
+        assert_get_transactions_request(&mut client, vec![], None, None, &[], "empty request")
+            .await;
+
+    // Should return single response with 0 transactions
+    assert_eq!(responses.len(), 1, "Should have 1 response");
+    assert_eq!(
+        responses[0].transactions.len(),
+        0,
+        "Should have 0 transactions"
+    );
+    assert!(
+        !responses[0].has_next,
+        "has_next should be false for empty request"
+    );
+}
+
+#[sim_test]
+async fn get_transactions_nonexistent() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .build()
+        .await;
+
+    let mut client = LedgerServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    // Request non-existent transactions
+    let fake_digest1 = TransactionDigest::new([0u8; 32]);
+    let fake_digest2 = TransactionDigest::new([1u8; 32]);
+
+    let request = GetTransactionsRequest {
+        requests: Some(TransactionRequests {
+            requests: vec![
+                TransactionRequest {
+                    digest: Some(iota_grpc_types::v0::types::Digest {
+                        digest: fake_digest1.inner().to_vec().into(),
+                    }),
+                },
+                TransactionRequest {
+                    digest: Some(iota_grpc_types::v0::types::Digest {
+                        digest: fake_digest2.inner().to_vec().into(),
+                    }),
+                },
+            ],
+        }),
+        read_mask: None,
+        max_message_size_bytes: None,
+    };
+
+    let mut stream = client.get_transactions(request).await.unwrap().into_inner();
+
+    let mut responses = Vec::new();
+    while let Some(response) = stream.next().await {
+        let response = response.unwrap();
+        let has_next = response.has_next;
+        responses.push(response);
+        if !has_next {
+            break;
+        }
+    }
+
+    // Verify all results contain errors (not transactions)
+    let mut error_count = 0;
+    for response in &responses {
+        for tx_result in &response.transactions {
+            assert!(
+                tx_result.error_opt().is_some(),
+                "Expected error for non-existent transaction"
+            );
+            assert!(
+                tx_result.transaction_opt().is_none(),
+                "Expected no transaction for non-existent digest"
+            );
+
+            let error = tx_result.error_opt().unwrap();
+            // Verify error code is NOT_FOUND (5)
+            assert_eq!(
+                error.code, 5,
+                "Error code should be NOT_FOUND (5), got: {}",
+                error.code
+            );
+            error_count += 1;
+        }
+    }
+
+    assert_eq!(error_count, 2, "Should receive 2 errors");
+}
+
+#[sim_test]
+async fn get_transactions_mixed_valid_invalid() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .build()
+        .await;
+
+    test_cluster.wait_for_checkpoint(1, None).await;
+
+    // Create a real transaction
+    let real_digest = create_test_transaction(&test_cluster).await;
+
+    let mut client = LedgerServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    // Request mix of valid and invalid digests
+    let fake_digest = TransactionDigest::new([0u8; 32]);
+
+    let request = GetTransactionsRequest {
+        requests: Some(TransactionRequests {
+            requests: vec![
+                // Valid digest first
+                TransactionRequest {
+                    digest: Some(iota_grpc_types::v0::types::Digest {
+                        digest: real_digest.inner().to_vec().into(),
+                    }),
+                },
+                // Invalid digest
+                TransactionRequest {
+                    digest: Some(iota_grpc_types::v0::types::Digest {
+                        digest: fake_digest.inner().to_vec().into(),
+                    }),
+                },
+            ],
+        }),
+        read_mask: Some(FieldMask::from_paths(["digest"])),
+        max_message_size_bytes: None,
+    };
+
+    let mut stream = client.get_transactions(request).await.unwrap().into_inner();
+
+    let mut all_results = Vec::new();
+    while let Some(response) = stream.next().await {
+        let response = response.unwrap();
+        let has_next = response.has_next;
+        for tx_result in response.transactions {
+            all_results.push(tx_result);
+        }
+        if !has_next {
+            break;
+        }
+    }
+
+    // Should have exactly 2 results
+    assert_eq!(all_results.len(), 2, "Should have 2 results total");
+
+    // First result should be a transaction (valid digest)
+    assert!(
+        all_results[0].transaction_opt().is_some(),
+        "First result should be a valid transaction"
+    );
+    assert!(
+        all_results[0].error_opt().is_none(),
+        "First result should not have an error"
+    );
+
+    // Second result should be an error (invalid digest)
+    assert!(
+        all_results[1].error_opt().is_some(),
+        "Second result should be an error"
+    );
+    assert!(
+        all_results[1].transaction_opt().is_none(),
+        "Second result should not have a transaction"
+    );
+
+    // Verify error code is NOT_FOUND
+    let error = all_results[1].error_opt().unwrap();
+    assert_eq!(
+        error.code, 5,
+        "Error code should be NOT_FOUND (5), got: {}",
+        error.code
+    );
+}

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_transactions.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_transactions.rs
@@ -141,7 +141,7 @@ async fn get_transactions_readmask_scenarios() {
     type TestCase<'a> = (&'a str, Option<FieldMask>, &'a [&'a str]);
     let test_cases: Vec<TestCase> = vec![
         // Default readmask (None) - returns only digest
-        ("default readmask", None, &["digest"]),
+        ("default readmask", None, &["transaction.digest"]),
         // Empty readmask - returns no fields
         (
             "empty readmask",
@@ -155,7 +155,6 @@ async fn get_transactions_readmask_scenarios() {
         (
             "full readmask",
             Some(FieldMask::from_paths([
-                "digest",
                 "transaction.digest",
                 "transaction.bcs",
                 "signatures",
@@ -166,14 +165,12 @@ async fn get_transactions_readmask_scenarios() {
                 "timestamp",
             ])),
             &[
-                "digest",
                 "transaction.digest",
                 "transaction.bcs",
                 "signatures",
                 "effects.digest",
                 "effects.bcs",
-                // Note: events is intentionally excluded from expected because
-                // simple transfers don't emit events
+                "events",
                 "checkpoint",
                 "timestamp",
             ],
@@ -181,8 +178,8 @@ async fn get_transactions_readmask_scenarios() {
         // Partial readmask: digest only
         (
             "partial readmask (digest only)",
-            Some(FieldMask::from_paths(["digest"])),
-            &["digest"],
+            Some(FieldMask::from_paths(["transaction.digest"])),
+            &["transaction.digest"],
         ),
         // Partial readmask: effects.digest only (specific nested field)
         (
@@ -252,9 +249,9 @@ async fn get_transactions_batch() {
     let responses = assert_get_transactions_request(
         &mut client,
         digests.clone(),
-        Some(FieldMask::from_paths(["digest", "effects"])),
+        Some(FieldMask::from_paths(["transaction.digest", "effects"])),
         None,
-        &["digest", "effects.digest", "effects.bcs"],
+        &["transaction.digest", "effects.digest", "effects.bcs"],
         "batch with 3 transactions",
     )
     .await;
@@ -301,7 +298,6 @@ async fn get_transactions_streaming() {
         &mut client,
         all_digests,
         Some(FieldMask::from_paths([
-            "digest",
             "transaction",
             "signatures",
             "effects",
@@ -312,7 +308,6 @@ async fn get_transactions_streaming() {
         ])),
         Some(1024 * 1024_u32), // 1MB (minimum allowed)
         &[
-            "digest",
             "transaction.digest",
             "transaction.bcs",
             "signatures",
@@ -480,7 +475,7 @@ async fn get_transactions_mixed_valid_invalid() {
                 },
             ],
         }),
-        read_mask: Some(FieldMask::from_paths(["digest"])),
+        read_mask: Some(FieldMask::from_paths(["transaction.digest"])),
         max_message_size_bytes: None,
     };
 

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/mod.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/mod.rs
@@ -4,3 +4,4 @@
 mod get_epoch;
 mod get_objects;
 mod get_service_info;
+mod get_transactions;

--- a/crates/iota-grpc-server/src/error.rs
+++ b/crates/iota-grpc-server/src/error.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_grpc_types::google::rpc::{BadRequest, ErrorInfo, RetryInfo};
-use iota_types::base_types::ObjectID;
+use iota_types::{base_types::ObjectID, digests::TransactionDigest};
 use tonic::{Code, Status};
 
 /// Main RPC error type
@@ -181,6 +181,23 @@ impl std::error::Error for ObjectNotFoundError {}
 
 impl From<ObjectNotFoundError> for RpcError {
     fn from(value: ObjectNotFoundError) -> Self {
+        Self::new(tonic::Code::NotFound, value.to_string())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TransactionNotFoundError(pub TransactionDigest);
+
+impl std::fmt::Display for TransactionNotFoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Transaction {} not found", self.0)
+    }
+}
+
+impl std::error::Error for TransactionNotFoundError {}
+
+impl From<TransactionNotFoundError> for RpcError {
+    fn from(value: TransactionNotFoundError) -> Self {
         Self::new(tonic::Code::NotFound, value.to_string())
     }
 }

--- a/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
@@ -1,0 +1,217 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::Stream;
+use iota_grpc_types::{
+    field::{FieldMaskTree, FieldMaskUtil},
+    google::rpc::bad_request::FieldViolation,
+    merge::Merge,
+    v0::{
+        error_reason::ErrorReason,
+        ledger_service::{
+            GetTransactionsRequest, GetTransactionsResponse, TransactionResult, transaction_result,
+        },
+        object::Objects,
+        transaction::{ExecutedTransaction, TransactionEvents, TransactionReadSource},
+    },
+};
+use iota_types::{digests::TransactionDigest, iota_sdk_types_conversions::SdkTypeConversionError};
+use prost::Message;
+use prost_types::FieldMask;
+
+use crate::{
+    constants::validate_max_message_size,
+    error::RpcError,
+    types::{GrpcReader, TransactionsStreamResult},
+};
+
+pub const READ_MASK_DEFAULT: &str = crate::field_mask!("digest");
+
+type ValidationResult = Result<(Vec<TransactionDigest>, FieldMaskTree), RpcError>;
+
+pub fn validate_get_transaction_requests(
+    requests: Vec<Option<Vec<u8>>>,
+    read_mask: Option<FieldMask>,
+) -> ValidationResult {
+    let read_mask = {
+        let read_mask = read_mask.unwrap_or_else(|| FieldMask::from_str(READ_MASK_DEFAULT));
+        read_mask
+            .validate::<ExecutedTransaction>()
+            .map_err(|path| {
+                FieldViolation::new("read_mask")
+                    .with_description(format!("invalid read_mask path: {path}"))
+                    .with_reason(ErrorReason::FieldInvalid)
+            })?;
+        FieldMaskTree::from(read_mask)
+    };
+
+    let requests = requests
+        .into_iter()
+        .enumerate()
+        .map(|(idx, digest_bytes)| {
+            let digest_bytes = digest_bytes.ok_or_else(|| {
+                FieldViolation::new("digest")
+                    .with_reason(ErrorReason::FieldMissing)
+                    .nested_at("requests", idx)
+            })?;
+
+            TransactionDigest::try_from(digest_bytes.as_slice()).map_err(|e| {
+                FieldViolation::new("digest")
+                    .with_description(format!("invalid digest: {e}"))
+                    .with_reason(ErrorReason::FieldInvalid)
+                    .nested_at("requests", idx)
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok((requests, read_mask))
+}
+
+#[tracing::instrument(skip(reader))]
+pub(crate) fn get_transactions(
+    reader: GrpcReader,
+    GetTransactionsRequest {
+        requests,
+        read_mask,
+        max_message_size_bytes,
+    }: GetTransactionsRequest,
+) -> Result<impl Stream<Item = TransactionsStreamResult> + Send, RpcError> {
+    let requests = requests
+        .map(|r| r.requests)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|req| req.digest.map(|d| d.digest.to_vec()))
+        .collect();
+
+    let (digests, read_mask) = validate_get_transaction_requests(requests, read_mask)?;
+    let max_message_size = validate_max_message_size(max_message_size_bytes.map(|v| v as u64))?;
+
+    Ok(crate::create_batching_stream!(
+        digests.into_iter(),
+        digest,
+        {
+            let tx_result = match get_transaction_impl(&reader, digest, &read_mask) {
+                Ok(tx) => TransactionResult {
+                    result: Some(transaction_result::Result::Transaction(Box::new(tx))),
+                },
+                Err(error) => TransactionResult {
+                    result: Some(transaction_result::Result::Error(error.into_status_proto())),
+                },
+            };
+
+            let tx_size = tx_result.encoded_len();
+            (tx_result, tx_size)
+        },
+        max_message_size,
+        GetTransactionsResponse,
+        transactions,
+        has_next
+    ))
+}
+
+#[tracing::instrument(skip(reader))]
+fn get_transaction_impl(
+    reader: &GrpcReader,
+    digest: TransactionDigest,
+    read_mask: &FieldMaskTree,
+) -> Result<ExecutedTransaction, RpcError> {
+    // Get transaction data from storage
+    let tx_read = reader.get_transaction_read(&digest)?;
+
+    // Convert to iota_sdk2 types - create owned data in local scope
+    // Clone the inner transaction from Arc and convert to SDK type
+    let sdk_transaction: iota_sdk2::types::SignedTransaction = (*tx_read.transaction)
+        .clone()
+        .into_inner()
+        .try_into()
+        .map_err(|e: SdkTypeConversionError| anyhow::Error::msg(e.to_string()))?;
+
+    let sdk_effects: iota_sdk2::types::TransactionEffects = tx_read
+        .effects
+        .clone()
+        .try_into()
+        .map_err(|e: SdkTypeConversionError| anyhow::Error::msg(e.to_string()))?;
+
+    let sdk_events: Option<iota_sdk2::types::TransactionEvents> = tx_read
+        .events
+        .as_ref()
+        .map(|events| {
+            events
+                .clone()
+                .try_into()
+                .map_err(|e: SdkTypeConversionError| anyhow::Error::msg(e.to_string()))
+        })
+        .transpose()?;
+
+    let sdk_digest: iota_sdk2::types::TransactionDigest = tx_read.digest.into();
+
+    // Create TransactionReadSource with references to local owned data
+    let sdk_source = TransactionReadSource {
+        digest: sdk_digest,
+        transaction: &sdk_transaction,
+        effects: &sdk_effects,
+        events: sdk_events.as_ref(),
+        checkpoint: tx_read.checkpoint,
+        timestamp_ms: tx_read.timestamp_ms,
+    };
+
+    // Build response using Merge trait
+    let mut message = ExecutedTransaction::default();
+    Merge::merge(&mut message, &sdk_source, read_mask);
+
+    // Handle events separately (as noted in TransactionReadSource impl)
+    // Events are handled here because they need the events_digest from effects
+    if let Some(events_mask) = read_mask.subtree(ExecutedTransaction::EVENTS_FIELD.name) {
+        if let Some(ref sdk_events) = sdk_events {
+            let mut proto_events = TransactionEvents::default();
+            Merge::merge(&mut proto_events, sdk_events, &events_mask);
+            message.events = Some(proto_events);
+        }
+    }
+
+    // Handle input_objects separately
+    if let Some(input_objects_mask) =
+        read_mask.subtree(ExecutedTransaction::INPUT_OBJECTS_FIELD.name)
+    {
+        // Convert input objects to SDK types
+        let sdk_input_objects: Vec<iota_sdk2::types::Object> = tx_read
+            .input_objects
+            .into_iter()
+            .filter_map(|obj| obj.try_into().ok())
+            .collect();
+
+        if !sdk_input_objects.is_empty() {
+            let mut proto_objects = Objects::default();
+            Merge::merge(
+                &mut proto_objects,
+                sdk_input_objects.as_slice(),
+                &input_objects_mask,
+            );
+            message.input_objects = Some(proto_objects);
+        }
+    }
+
+    // Handle output_objects separately
+    if let Some(output_objects_mask) =
+        read_mask.subtree(ExecutedTransaction::OUTPUT_OBJECTS_FIELD.name)
+    {
+        // Convert output objects to SDK types
+        let sdk_output_objects: Vec<iota_sdk2::types::Object> = tx_read
+            .output_objects
+            .into_iter()
+            .filter_map(|obj| obj.try_into().ok())
+            .collect();
+
+        if !sdk_output_objects.is_empty() {
+            let mut proto_objects = Objects::default();
+            Merge::merge(
+                &mut proto_objects,
+                sdk_output_objects.as_slice(),
+                &output_objects_mask,
+            );
+            message.output_objects = Some(proto_objects);
+        }
+    }
+
+    Ok(message)
+}

--- a/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use futures::Stream;
 use iota_grpc_types::{
     field::{FieldMaskTree, FieldMaskUtil},
@@ -11,21 +13,21 @@ use iota_grpc_types::{
         ledger_service::{
             GetTransactionsRequest, GetTransactionsResponse, TransactionResult, transaction_result,
         },
-        object::Objects,
-        transaction::{ExecutedTransaction, TransactionEvents, TransactionReadSource},
+        transaction::ExecutedTransaction,
     },
 };
-use iota_types::{digests::TransactionDigest, iota_sdk_types_conversions::SdkTypeConversionError};
+use iota_types::digests::TransactionDigest;
 use prost::Message;
 use prost_types::FieldMask;
 
 use crate::{
     constants::validate_max_message_size,
     error::RpcError,
+    transaction_execution_service::TransactionReadSource,
     types::{GrpcReader, TransactionsStreamResult},
 };
 
-pub const READ_MASK_DEFAULT: &str = crate::field_mask!("digest");
+pub const READ_MASK_DEFAULT: &str = crate::field_mask!("transaction.digest");
 
 type ValidationResult = Result<(Vec<TransactionDigest>, FieldMaskTree), RpcError>;
 
@@ -69,7 +71,8 @@ pub fn validate_get_transaction_requests(
 
 #[tracing::instrument(skip(reader))]
 pub(crate) fn get_transactions(
-    reader: GrpcReader,
+    reader: Arc<GrpcReader>,
+    config: iota_config::node::GrpcApiConfig,
     GetTransactionsRequest {
         requests,
         read_mask,
@@ -90,7 +93,7 @@ pub(crate) fn get_transactions(
         digests.into_iter(),
         digest,
         {
-            let tx_result = match get_transaction_impl(&reader, digest, &read_mask) {
+            let tx_result = match get_transaction_impl(&reader, &config, digest, &read_mask) {
                 Ok(tx) => TransactionResult {
                     result: Some(transaction_result::Result::Transaction(Box::new(tx))),
                 },
@@ -111,107 +114,35 @@ pub(crate) fn get_transactions(
 
 #[tracing::instrument(skip(reader))]
 fn get_transaction_impl(
-    reader: &GrpcReader,
+    reader: &Arc<GrpcReader>,
+    config: &iota_config::node::GrpcApiConfig,
     digest: TransactionDigest,
     read_mask: &FieldMaskTree,
 ) -> Result<ExecutedTransaction, RpcError> {
     // Get transaction data from storage
     let tx_read = reader.get_transaction_read(&digest)?;
 
-    // Convert to iota_sdk2 types - create owned data in local scope
-    // Clone the inner transaction from Arc and convert to SDK type
-    let sdk_transaction: iota_sdk2::types::SignedTransaction = (*tx_read.transaction)
-        .clone()
-        .into_inner()
-        .try_into()
-        .map_err(|e: SdkTypeConversionError| anyhow::Error::msg(e.to_string()))?;
+    let transaction_data = tx_read.transaction.transaction_data().clone();
+    let signatures = tx_read.transaction.tx_signatures().to_owned();
 
-    let sdk_effects: iota_sdk2::types::TransactionEffects = tx_read
-        .effects
-        .clone()
-        .try_into()
-        .map_err(|e: SdkTypeConversionError| anyhow::Error::msg(e.to_string()))?;
-
-    let sdk_events: Option<iota_sdk2::types::TransactionEvents> = tx_read
-        .events
-        .as_ref()
-        .map(|events| {
-            events
-                .clone()
-                .try_into()
-                .map_err(|e: SdkTypeConversionError| anyhow::Error::msg(e.to_string()))
-        })
-        .transpose()?;
-
-    let sdk_digest: iota_sdk2::types::TransactionDigest = tx_read.digest.into();
-
-    // Create TransactionReadSource with references to local owned data
-    let sdk_source = TransactionReadSource {
-        digest: sdk_digest,
-        transaction: &sdk_transaction,
-        effects: &sdk_effects,
-        events: sdk_events.as_ref(),
+    // Create a source for the merge
+    let source = TransactionReadSource {
+        reader: reader.clone(),
+        config,
+        transaction_data,
+        signatures: Some(signatures),
+        effects: Some(tx_read.effects),
+        events: tx_read.events,
         checkpoint: tx_read.checkpoint,
         timestamp_ms: tx_read.timestamp_ms,
+        input_objects: Some(tx_read.input_objects),
+        output_objects: Some(tx_read.output_objects),
     };
 
-    // Build response using Merge trait
-    let mut message = ExecutedTransaction::default();
-    Merge::merge(&mut message, &sdk_source, read_mask);
-
-    // Handle events separately (as noted in TransactionReadSource impl)
-    // Events are handled here because they need the events_digest from effects
-    if let Some(events_mask) = read_mask.subtree(ExecutedTransaction::EVENTS_FIELD.name) {
-        if let Some(ref sdk_events) = sdk_events {
-            let mut proto_events = TransactionEvents::default();
-            Merge::merge(&mut proto_events, sdk_events, &events_mask);
-            message.events = Some(proto_events);
-        }
-    }
-
-    // Handle input_objects separately
-    if let Some(input_objects_mask) =
-        read_mask.subtree(ExecutedTransaction::INPUT_OBJECTS_FIELD.name)
-    {
-        // Convert input objects to SDK types
-        let sdk_input_objects: Vec<iota_sdk2::types::Object> = tx_read
-            .input_objects
-            .into_iter()
-            .filter_map(|obj| obj.try_into().ok())
-            .collect();
-
-        if !sdk_input_objects.is_empty() {
-            let mut proto_objects = Objects::default();
-            Merge::merge(
-                &mut proto_objects,
-                sdk_input_objects.as_slice(),
-                &input_objects_mask,
-            );
-            message.input_objects = Some(proto_objects);
-        }
-    }
-
-    // Handle output_objects separately
-    if let Some(output_objects_mask) =
-        read_mask.subtree(ExecutedTransaction::OUTPUT_OBJECTS_FIELD.name)
-    {
-        // Convert output objects to SDK types
-        let sdk_output_objects: Vec<iota_sdk2::types::Object> = tx_read
-            .output_objects
-            .into_iter()
-            .filter_map(|obj| obj.try_into().ok())
-            .collect();
-
-        if !sdk_output_objects.is_empty() {
-            let mut proto_objects = Objects::default();
-            Merge::merge(
-                &mut proto_objects,
-                sdk_output_objects.as_slice(),
-                &output_objects_mask,
-            );
-            message.output_objects = Some(proto_objects);
-        }
-    }
-
-    Ok(message)
+    ExecutedTransaction::merge_from(&source, read_mask).map_err(|e| {
+        RpcError::new(
+            tonic::Code::Internal,
+            format!("failed to build executed transaction in get_transaction response: {e}"),
+        )
+    })
 }

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -4,6 +4,7 @@
 mod get_epoch;
 mod get_objects;
 mod get_service_info;
+mod get_transactions;
 
 use std::{pin::Pin, sync::Arc};
 
@@ -96,12 +97,11 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
 
     async fn get_transactions(
         &self,
-        _request: tonic::Request<grpc_ledger_service::GetTransactionsRequest>,
+        request: tonic::Request<grpc_ledger_service::GetTransactionsRequest>,
     ) -> std::result::Result<tonic::Response<Self::GetTransactionsStream>, tonic::Status> {
-        // not implemented - return empty stream
-        let stream = futures::stream::empty();
-        let stream: Self::GetTransactionsStream = Box::pin(stream);
-        Ok(Response::new(stream))
+        get_transactions::get_transactions((*self.reader).clone(), request.into_inner())
+            .map(|stream| Response::new(Box::pin(stream) as Self::GetTransactionsStream))
+            .map_err(Into::into)
     }
 
     /// Checkpoint operations

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -18,6 +18,7 @@ use crate::types::*;
 
 pub struct LedgerGrpcService {
     pub reader: Arc<GrpcReader>,
+    pub config: iota_config::node::GrpcApiConfig,
     pub checkpoint_summary_broadcaster: GrpcCheckpointSummaryBroadcaster,
     pub checkpoint_data_broadcaster: GrpcCheckpointDataBroadcaster,
     pub cancellation_token: CancellationToken,
@@ -29,6 +30,7 @@ pub struct LedgerGrpcService {
 impl LedgerGrpcService {
     pub fn new(
         reader: Arc<GrpcReader>,
+        config: iota_config::node::GrpcApiConfig,
         checkpoint_summary_broadcaster: GrpcCheckpointSummaryBroadcaster,
         checkpoint_data_broadcaster: GrpcCheckpointDataBroadcaster,
         cancellation_token: CancellationToken,
@@ -37,6 +39,7 @@ impl LedgerGrpcService {
     ) -> Self {
         Self {
             reader,
+            config,
             checkpoint_summary_broadcaster,
             checkpoint_data_broadcaster,
             cancellation_token,
@@ -99,9 +102,13 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
         &self,
         request: tonic::Request<grpc_ledger_service::GetTransactionsRequest>,
     ) -> std::result::Result<tonic::Response<Self::GetTransactionsStream>, tonic::Status> {
-        get_transactions::get_transactions((*self.reader).clone(), request.into_inner())
-            .map(|stream| Response::new(Box::pin(stream) as Self::GetTransactionsStream))
-            .map_err(Into::into)
+        get_transactions::get_transactions(
+            self.reader.clone(),
+            self.config.clone(),
+            request.into_inner(),
+        )
+        .map(|stream| Response::new(Box::pin(stream) as Self::GetTransactionsStream))
+        .map_err(Into::into)
     }
 
     /// Checkpoint operations

--- a/crates/iota-grpc-server/src/server.rs
+++ b/crates/iota-grpc-server/src/server.rs
@@ -88,6 +88,7 @@ pub async fn start_grpc_server(
     // server level
     let ledger_service = LedgerGrpcService::new(
         grpc_reader.clone(),
+        config.clone(),
         checkpoint_summary_broadcaster.clone(),
         checkpoint_data_broadcaster.clone(),
         shutdown_token.clone(),

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -15,10 +15,13 @@ use iota_grpc_types::v0::{
 use iota_json_rpc_types::{EventFilter, IotaEvent};
 use iota_types::{
     base_types::{ObjectID, VersionNumber},
+    digests::{TransactionDigest, TransactionEventsDigest},
+    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     full_checkpoint_content::CheckpointData,
     messages_checkpoint::CertifiedCheckpointSummary,
     object::Object,
     storage::{ObjectStore, ReadStore, RestStateReader, error::Kind},
+    transaction::VerifiedTransaction,
 };
 use serde::Serialize;
 use tokio::sync::broadcast::{Receiver, Sender, error::RecvError};
@@ -260,6 +263,19 @@ pub trait GrpcStateReader: Send + Sync + 'static {
         &self,
         type_tag: &iota_types::TypeTag,
     ) -> Result<Option<move_core_types::annotated_value::MoveTypeLayout>>;
+
+    /// Get a transaction by its digest
+    fn get_transaction(&self, digest: &TransactionDigest) -> Option<Arc<VerifiedTransaction>>;
+
+    /// Get transaction effects by digest
+    fn get_transaction_effects(&self, digest: &TransactionDigest) -> Option<TransactionEffects>;
+
+    /// Get transaction events by event digest
+    fn get_transaction_events(&self, digest: &TransactionEventsDigest)
+    -> Option<TransactionEvents>;
+
+    /// Get checkpoint sequence number for a transaction
+    fn get_transaction_checkpoint(&self, digest: &TransactionDigest) -> Option<u64>;
 }
 
 /// Adapter that implements GrpcStateReader for RestStateReader
@@ -353,6 +369,31 @@ impl GrpcStateReader for RestStateReaderAdapter {
         type_tag: &iota_types::TypeTag,
     ) -> Result<Option<move_core_types::annotated_value::MoveTypeLayout>> {
         Ok(self.inner.get_type_layout(type_tag)?)
+    }
+
+    fn get_transaction(&self, digest: &TransactionDigest) -> Option<Arc<VerifiedTransaction>> {
+        self.inner.get_transaction(digest)
+    }
+
+    fn get_transaction_effects(&self, digest: &TransactionDigest) -> Option<TransactionEffects> {
+        self.inner.get_transaction_effects(digest)
+    }
+
+    fn get_transaction_events(
+        &self,
+        digest: &TransactionEventsDigest,
+    ) -> Option<TransactionEvents> {
+        self.inner.get_events(digest)
+    }
+
+    fn get_transaction_checkpoint(&self, digest: &TransactionDigest) -> Option<u64> {
+        self.inner.indexes().and_then(|indexes| {
+            indexes
+                .get_transaction_info(digest)
+                .ok()
+                .flatten()
+                .map(|info| info.checkpoint)
+        })
     }
 }
 
@@ -596,4 +637,91 @@ impl GrpcReader {
             |item| item.sequence_number(),
         )
     }
+
+    /// Get transaction data for a single transaction digest.
+    ///
+    /// Returns all transaction-related data needed to build a gRPC response.
+    #[tracing::instrument(skip(self))]
+    pub fn get_transaction_read(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Result<TransactionReadData, crate::error::RpcError> {
+        // Get the transaction
+        let transaction = self
+            .state_reader
+            .get_transaction(digest)
+            .ok_or(crate::error::TransactionNotFoundError(*digest))?;
+
+        // Get the effects - required
+        let effects = self
+            .state_reader
+            .get_transaction_effects(digest)
+            .ok_or(crate::error::TransactionNotFoundError(*digest))?;
+
+        // Get events if they exist
+        let events = effects
+            .events_digest()
+            .and_then(|event_digest| self.state_reader.get_transaction_events(event_digest));
+
+        // Get checkpoint from indexes if available
+        let checkpoint = self.state_reader.get_transaction_checkpoint(digest);
+
+        // Get timestamp from checkpoint if we have it
+        let timestamp_ms = checkpoint.and_then(|checkpoint_seq| {
+            self.state_reader
+                .get_checkpoint_summary(checkpoint_seq)
+                .map(|summary| summary.data().timestamp_ms)
+        });
+
+        // Get input objects (objects at their state before the transaction)
+        // modified_at_versions() returns the object IDs and their versions before
+        // modification
+        let input_objects: Vec<Object> = effects
+            .modified_at_versions()
+            .into_iter()
+            .filter_map(|(object_id, version)| {
+                self.state_reader.get_object_by_key(&object_id, version)
+            })
+            .collect();
+
+        // Get output objects (created, mutated, unwrapped objects at their state after
+        // the transaction)
+        let output_objects: Vec<Object> = effects
+            .created()
+            .into_iter()
+            .chain(effects.mutated())
+            .chain(effects.unwrapped())
+            .filter_map(|((object_id, version, _digest), _owner)| {
+                self.state_reader.get_object_by_key(&object_id, version)
+            })
+            .collect();
+
+        Ok(TransactionReadData {
+            digest: *digest,
+            transaction,
+            effects,
+            events,
+            checkpoint,
+            timestamp_ms,
+            input_objects,
+            output_objects,
+        })
+    }
+}
+
+/// Internal struct to hold all transaction-related data fetched from storage.
+///
+/// This struct holds owned data from storage, which is then converted to
+/// `iota-sdk-types` types and used with `Merge` trait to populate gRPC
+/// responses.
+#[derive(Debug)]
+pub struct TransactionReadData {
+    pub digest: TransactionDigest,
+    pub transaction: Arc<VerifiedTransaction>,
+    pub effects: TransactionEffects,
+    pub events: Option<TransactionEvents>,
+    pub checkpoint: Option<u64>,
+    pub timestamp_ms: Option<u64>,
+    pub input_objects: Vec<Object>,
+    pub output_objects: Vec<Object>,
 }

--- a/crates/iota-grpc-types/proto/iota/grpc/v0/ledger_service.proto
+++ b/crates/iota-grpc-types/proto/iota/grpc/v0/ledger_service.proto
@@ -118,7 +118,7 @@ message GetTransactionsRequest {
   optional TransactionRequests requests = 1;
 
   // Mask specifying which fields to read.
-  // If no mask is specified, defaults to `digest`.
+  // If no mask is specified, defaults to `transaction.digest`.
   optional google.protobuf.FieldMask read_mask = 2;
 
   // Optional maximum message size the client can receive (1MB - 128MB)

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.rs
@@ -106,7 +106,7 @@ pub struct GetTransactionsRequest {
     #[prost(message, optional, tag = "1")]
     pub requests: ::core::option::Option<TransactionRequests>,
     /// Mask specifying which fields to read.
-    /// If no mask is specified, defaults to `digest`.
+    /// If no mask is specified, defaults to `transaction.digest`.
     #[prost(message, optional, tag = "2")]
     pub read_mask: ::core::option::Option<::prost_types::FieldMask>,
     /// Optional maximum message size the client can receive (1MB - 128MB)


### PR DESCRIPTION
# Description of change

- Implemented`GetTransactions` in the gRPC API.
- Verified the `get_transactions` simtest by using `cargo simtest --package iota-e2e-tests --test grpc -- get_transactions`
- Note that #9437 should be merged before this PR.
  
## Links to any relevant issues

Closes #9391 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
