### PR TITLE
feat(consensus): refactor of latency commands

### DIFF
--- a/crates/iota-aws-orchestrator/assets/run_command.sh
+++ b/crates/iota-aws-orchestrator/assets/run_command.sh
@@ -1,23 +1,89 @@
 #!/bin/bash
 
-# Script to execute commands on all testbed Node machines
-# Usage: ./run_command.sh <command> [args...]
-# example: run_command.sh \
-# 'ADDR=$(grep -m 1 admin node.log | sed -E "s/.*address=([^ ]+).*/\1/"); \
-# curl -X POST "http://$ADDR/spammer/start?tps=20&mean_size=30000&std_dev_size=3000"'
-# collects the admin address from the node.log and executes the curl admin command
+# Script to execute commands on some or all testbed Node machines
+# Usage:
+#   ./run_command.sh [--restart] <command> [args...]
+#   ./run_command.sh --limit N [--restart] <command> [args...]
+#
+# Examples:
+#   ./run_command.sh apt update -y
+#
+#   ./run_command.sh --limit 3 \
+#     'ADDR=$(grep -m 1 admin node.log | sed -E "s/.*address=([^ ]+).*/\1/"); \
+#      curl -X POST "http://$ADDR/spammer/start?tps=20&mean_size=30000&std_dev_size=3000"'
+#
+#   ./run_command.sh --restart "echo hello && sleep 5"
+#
+# The --limit/-n flag restricts execution to the first N Node machines.
+# The --restart flag wraps the command in a tmux-restart sequence
+# on the remote host.
 
 set -e
 
-# Check if at least one argument is provided
+LIMIT=""
+WITH_TMUX_RESTART=0
+
+print_usage() {
+    echo "Usage: $0 [--limit N] [--restart] <command> [args...]"
+    echo ""
+    echo "Examples:"
+    echo "  $0 apt update -y"
+    echo "  $0 --limit 5 'echo hello from limited nodes'"
+    echo "  $0 --restart \"echo hello && sleep 5\""
+}
+
+# --- Parse optional flags -----------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -n|--limit)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --limit/-n requires a numeric argument"
+                print_usage
+                exit 1
+            fi
+            LIMIT="$2"
+            shift 2
+            ;;
+        --restart)
+            WITH_TMUX_RESTART=1
+            shift
+            ;;
+        --help|-h)
+            print_usage
+            exit 0
+            ;;
+        --) # end of flags
+            shift
+            break
+            ;;
+        *)  # first non-flag argument = start of command
+            break
+            ;;
+    esac
+done
+
+# Check that there is at least one argument left for the command
 if [ $# -eq 0 ]; then
-    echo "Usage: $0 <command> [args...]"
-    echo "Example: $0 apt update -y"
+    print_usage
     exit 1
 fi
 
-# Get the command to execute (all script arguments)
+# Get the command to execute (all remaining script arguments)
 REMOTE_COMMAND="$@"
+
+# Wrap command if we are doing the tmux restart dance
+if [[ "$WITH_TMUX_RESTART" -eq 1 ]]; then
+    # This builds a single remote shell command that will:
+    #  1) Grab pane PID of node:0.0
+    #  2) Extract its command
+    #  3) Kill tmux session "node"
+    #  4) Run the user command
+    #  5) Start a new tmux session "node" with the previous command
+    REMOTE_EFFECTIVE_COMMAND='set -x;PID=$(tmux display-message -p -t node:0.0 "#{pane_pid}") && CMD=$(ps -p "$PID" -o cmd= | cut -d " " -f6-) && tmux kill-session -t node && '"$REMOTE_COMMAND"' && tmux new -d -s node bash -lc "cd iota && $CMD"'
+else
+    REMOTE_EFFECTIVE_COMMAND="$REMOTE_COMMAND"
+fi
 
 echo "Getting testbed status..."
 # Run the orchestrator and capture output
@@ -33,16 +99,40 @@ SSH_COMMANDS=$(
     | sort -u
 )
 
-# Count the number of node machines
-MACHINE_COUNT=$(echo "$SSH_COMMANDS" | sed '/^\s*$/d' | wc -l)
+# Total machines before limiting
+TOTAL_COUNT=$(echo "$SSH_COMMANDS" | sed '/^\s*$/d' | wc -l)
 
-if [ "$MACHINE_COUNT" -eq 0 ]; then
+if [ "$TOTAL_COUNT" -eq 0 ]; then
     echo "Error: No Node SSH commands found in orchestrator output"
     exit 1
 fi
 
-echo "Found $MACHINE_COUNT node machines"
-echo "Executing command: $REMOTE_COMMAND"
+# Apply limit if requested
+if [[ -n "$LIMIT" ]]; then
+    if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+        echo "Error: --limit must be an integer"
+        exit 1
+    fi
+
+    if [ "$LIMIT" -le 0 ]; then
+        echo "Error: --limit must be > 0"
+        exit 1
+    fi
+
+    if [ "$LIMIT" -gt "$TOTAL_COUNT" ]; then
+        echo "Warning: --limit ($LIMIT) is greater than available nodes ($TOTAL_COUNT), using all $TOTAL_COUNT nodes."
+    else
+        SSH_COMMANDS=$(echo "$SSH_COMMANDS" | sed '/^\s*$/d' | head -n "$LIMIT")
+        echo "Limiting execution to $LIMIT node(s) out of $TOTAL_COUNT."
+    fi
+fi
+
+# Count the number of *selected* node machines
+MACHINE_COUNT=$(echo "$SSH_COMMANDS" | sed '/^\s*$/d' | wc -l)
+
+echo "Found $TOTAL_COUNT node machines in total"
+echo "Running on $MACHINE_COUNT node machine(s)"
+echo "Executing command: $REMOTE_EFFECTIVE_COMMAND"
 echo "----------------------------------------"
 
 # Create a temporary directory for logs
@@ -52,7 +142,7 @@ echo "Logs will be stored in: $LOG_DIR"
 # Counter for progress
 COUNTER=0
 
-# Execute command on all node machines in parallel
+# Execute command on selected node machines in parallel
 while IFS= read -r SSH_CMD; do
     # skip empty lines just in case
     [ -z "$SSH_CMD" ] && continue
@@ -63,7 +153,7 @@ while IFS= read -r SSH_CMD; do
     # Execute in background and log output
     (
         echo "[$COUNTER/$MACHINE_COUNT] Executing on $HOST..."
-        if $SSH_CMD "$REMOTE_COMMAND" > "$LOG_DIR/$HOST.log" 2>&1; then
+        if $SSH_CMD "$REMOTE_EFFECTIVE_COMMAND" > "$LOG_DIR/$HOST.log" 2>&1; then
             echo "[$COUNTER/$MACHINE_COUNT] ✓ Success on $HOST"
         else
             echo "[$COUNTER/$MACHINE_COUNT] ✗ Failed on $HOST (see $LOG_DIR/$HOST.log)"

--- a/crates/iota-aws-orchestrator/src/benchmark.rs
+++ b/crates/iota-aws-orchestrator/src/benchmark.rs
@@ -55,13 +55,15 @@ pub struct BenchmarkParameters<T> {
     /// the nodes.
     pub use_internal_ip_address: bool,
     /// The topology of private network latencies, Geographical or Clustered
-    pub latency_topology: TopologyLayout,
+    pub latency_topology: Option<TopologyLayout>,
     /// Maximum latency between two nodes in the private network.
     pub maximum_latency: u16,
     /// Specification of Perturbation imposed on the private network latencies.
     pub perturbation_spec: PerturbationSpec,
     /// Flag used to switch between mysticety and starfish every epoch.
     pub protocol_switch_each_epoch: bool,
+    /// Flag to skip generation of the latency matrix in private networks.
+    pub keep_latencies: bool,
 }
 
 impl<T: BenchmarkType> Default for BenchmarkParameters<T> {
@@ -73,10 +75,11 @@ impl<T: BenchmarkType> Default for BenchmarkParameters<T> {
             load: 500,
             duration: Duration::from_secs(60),
             use_internal_ip_address: true,
-            latency_topology: TopologyLayout::Geographical,
+            latency_topology: Some(TopologyLayout::Geographical),
             perturbation_spec: PerturbationSpec::None,
             protocol_switch_each_epoch: false,
             maximum_latency: 400,
+            keep_latencies: false,
         }
     }
 }
@@ -110,10 +113,11 @@ impl<T> BenchmarkParameters<T> {
         load: usize,
         duration: Duration,
         use_internal_ip_address: bool,
-        latency_topology: TopologyLayout,
+        latency_topology: Option<TopologyLayout>,
         perturbation_spec: PerturbationSpec,
         protocol_switch_each_epoch: bool,
         maximum_latency: u16,
+        keep_latencies: bool,
     ) -> Self {
         Self {
             benchmark_type,
@@ -126,6 +130,7 @@ impl<T> BenchmarkParameters<T> {
             perturbation_spec,
             protocol_switch_each_epoch,
             maximum_latency,
+            keep_latencies,
         }
     }
 }
@@ -171,13 +176,15 @@ pub struct BenchmarkParametersGenerator<T> {
     /// IP address for inter-node communication.
     use_internal_ip_address: bool,
     /// The topology of private network latencies, Geographical or Clustered
-    pub latency_topology: TopologyLayout,
+    pub latency_topology: Option<TopologyLayout>,
     /// Maximum latency between two nodes in the private network.
     pub maximum_latency: u16,
     /// Specification of Perturbation imposed on the private network latencies.
     pub perturbation_spec: PerturbationSpec,
     /// Flag used to switch between mysticety and starfish every epoch.
     pub protocol_switch_each_epoch: bool,
+    /// Flag to skip generation of the latency matrix in private networks.
+    pub keep_latencies: bool,
 }
 
 impl<T: BenchmarkType> Iterator for BenchmarkParametersGenerator<T> {
@@ -197,6 +204,7 @@ impl<T: BenchmarkType> Iterator for BenchmarkParametersGenerator<T> {
                 self.perturbation_spec.clone(),
                 self.protocol_switch_each_epoch,
                 self.maximum_latency,
+                self.keep_latencies,
             )
         })
     }
@@ -230,9 +238,10 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
             iterations: 0,
             use_internal_ip_address,
             perturbation_spec: PerturbationSpec::None,
-            latency_topology: TopologyLayout::Geographical,
+            latency_topology: Some(TopologyLayout::Geographical),
             protocol_switch_each_epoch: false,
             maximum_latency: 400,
+            keep_latencies: false,
         }
     }
 
@@ -259,7 +268,7 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
         self
     }
 
-    pub fn with_latency_topology(mut self, latency_topology: TopologyLayout) -> Self {
+    pub fn with_latency_topology(mut self, latency_topology: Option<TopologyLayout>) -> Self {
         self.latency_topology = latency_topology;
         self
     }
@@ -271,6 +280,11 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
 
     pub fn with_max_latency(mut self, max_latency: u16) -> Self {
         self.maximum_latency = max_latency;
+        self
+    }
+
+    pub fn with_keep_latencies(mut self, keep_latencies: bool) -> Self {
+        self.keep_latencies = keep_latencies;
         self
     }
 

--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -138,16 +138,19 @@ pub enum Operation {
         #[clap(long, action, default_value_t = false, global = true)]
         use_internal_ip_addresses: bool,
 
+        /// Optional Latency Topology. if omitted => None -> skips latency
+        /// matrix generation
+        #[arg(long, global = true)]
+        latency_topology: Option<LatencyTopology>,
         /// Optional perturbation spec. If omitted => None
-        #[arg(long = "latency-perturbation-spec")]
+        #[arg(long = "latency-perturbation-spec", global = true)]
         latency_perturbation_spec: Option<PerturbationSpec>,
 
-        /// Optional how many clusters to use in the latency topology, if None
-        /// number of nodes is the number of latency clusters
-        #[arg(long, value_name = "INT")]
-        number_of_clusters: Option<usize>,
+        /// How many clusters to use in the latency topology
+        #[arg(long, value_name = "INT", default_value = "10", global = true)]
+        number_of_clusters: usize,
 
-        /// Optional number-of-triangles parameter for broken-topologies
+        /// Number-of-triangles parameter for broken-topologies
         #[arg(long, value_name = "INT", default_value = "5", global = true)]
         number_of_triangles: u16,
 
@@ -261,6 +264,18 @@ pub enum PerturbationSpec {
     // potentially other options later
 }
 
+#[derive(ValueEnum, Clone, Debug)]
+pub enum LatencyTopology {
+    /// Generates a latency matrix for each node, randomly positioned on a
+    /// cylinder.
+    Geographical,
+    /// Generates a latency matrix by clustering nodes into clusters and
+    /// randomly positioning clusters on a cylinder.
+    Clustered,
+    /// Uses a hardcoded clustered matrix 10x10 in the net_latency module.
+    HardCoded,
+}
+
 fn parse_duration(arg: &str) -> Result<Duration, std::num::ParseIntError> {
     let seconds = arg.parse()?;
     Ok(Duration::from_secs(seconds))
@@ -354,6 +369,7 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
             load_type,
             use_internal_ip_addresses,
             latency_perturbation_spec,
+            latency_topology,
             added_latency,
             number_of_triangles,
             number_of_clusters,
@@ -412,10 +428,13 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
                 None => net_latency::PerturbationSpec::None,
             };
 
-            let latency_topology = if let Some(number_of_clusters) = number_of_clusters {
-                TopologyLayout::Clustered { number_of_clusters }
-            } else {
-                TopologyLayout::Geographical
+            let latency_topology = match latency_topology {
+                Some(LatencyTopology::Geographical) => Some(TopologyLayout::Geographical),
+                Some(LatencyTopology::Clustered) => {
+                    Some(TopologyLayout::Clustered { number_of_clusters })
+                }
+                Some(LatencyTopology::HardCoded) => Some(TopologyLayout::HardCoded),
+                None => None,
             };
 
             let generator =

--- a/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
@@ -2,6 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{PerturbationSpec, TopologyLayout};
+
+// RTT table for 10 AWS regions, in milliseconds.
+// Strict triangle inequality: d(i,j) + 1 <= d(i,k) + d(k,j) for all distinct
+// i,j,k.
+const RTT_LATENCY_TABLE: [[u16; 10]; 10] = [
+    [1, 14, 96, 112, 198, 65, 68, 105, 192, 146],
+    [14, 1, 95, 122, 196, 78, 67, 103, 189, 142],
+    [96, 95, 1, 204, 281, 155, 29, 50, 143, 227],
+    [112, 122, 204, 1, 309, 175, 176, 213, 299, 254],
+    [198, 196, 281, 309, 1, 137, 254, 268, 150, 101],
+    [65, 78, 155, 175, 137, 1, 127, 164, 226, 108],
+    [68, 67, 29, 176, 254, 127, 1, 38, 125, 199],
+    [105, 103, 50, 213, 268, 164, 38, 1, 148, 236],
+    [192, 189, 143, 299, 150, 226, 125, 148, 1, 140],
+    [146, 142, 227, 254, 101, 108, 199, 236, 140, 1],
+];
+
 pub struct LatencyMatrixBuilder {
     number_of_instances: usize,
     max_latency: u16,
@@ -127,7 +144,15 @@ impl LatencyMatrixBuilder {
     }
 
     pub fn build(mut self) -> Vec<Vec<u16>> {
-        self.fill_geographical();
+        match self.topology_layout {
+            TopologyLayout::HardCoded => {
+                self.matrix = RTT_LATENCY_TABLE
+                    .map(|row| row.map(|x| x / 2))
+                    .map(|row| row.to_vec())
+                    .to_vec();
+            }
+            _ => self.fill_geographical(),
+        };
         match self.perturbation_spec {
             PerturbationSpec::BrokenTriangle {
                 number_of_triangles,

--- a/crates/iota-aws-orchestrator/src/net_latency/mod.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/mod.rs
@@ -15,6 +15,8 @@ pub enum TopologyLayout {
     Geographical,
     /// Nodes are distributed in number_of_clusters clusters
     Clustered { number_of_clusters: usize },
+    /// Use the hardcoded 10x10 clustered matrix
+    HardCoded,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -277,15 +277,17 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             .with_log_file("~/node.log".into())
             .with_execute_from_path(repo.into());
         if parameters.use_internal_ip_address {
-            let latency_context = CommandContext::default();
-            let latency_commands = NetworkLatencyCommandBuilder::new(&instances)
-                .with_perturbation_spec(parameters.perturbation_spec.clone())
-                .with_topology_layout(parameters.latency_topology.clone())
-                .with_max_latency(parameters.maximum_latency)
-                .build_network_latency_matrix();
-            self.ssh_manager
-                .execute_per_instance(latency_commands, latency_context)
-                .await?;
+            if let Some(latency_topology) = parameters.latency_topology.clone() {
+                let latency_context = CommandContext::default();
+                let latency_commands = NetworkLatencyCommandBuilder::new(&instances)
+                    .with_perturbation_spec(parameters.perturbation_spec.clone())
+                    .with_topology_layout(latency_topology)
+                    .with_max_latency(parameters.maximum_latency)
+                    .build_network_latency_matrix();
+                self.ssh_manager
+                    .execute_per_instance(latency_commands, latency_context)
+                    .await?;
+            }
         }
         self.ssh_manager
             .execute_per_instance(targets, context)


### PR DESCRIPTION
# Description of change

- adds the `latency-topology` optional parameter for the `benchmark` command
  - `if omitted` no latency matrix will be generated on the private network, no changes to the network will be made in this run.
  - `geographical`: Generates a latency matrix for each node, randomly positioned on a cylinder.
  - `clustered:`    Generates a latency matrix by clustering nodes into clusters and randomly positioning clusters on a cylinder.
  - `hard-coded`:   Uses a hardcoded clustered matrix 10x10 in the `net_latency` module.

-- adds an option to `run_command.sh` script called `--limit N` which executes the given command on N nodes instead of all of them,
- adds an option to `run_command.sh` script called  `--restart` which:
  - stores current running tmux command
  - kills the existing tmux with the node running
  - executes the given command
  - restarts tmux

## Links to any relevant issues

fixes #9336 .
fixes #9209 .

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes