### PR TITLE
fix: check object to authenticate for duplication

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -918,21 +918,17 @@ impl AuthorityState {
         // account object are also checked and must be provided.
         // It is also checked if there is enough gas to execute the transaction and its
         // authenticators.
-        let (
-            gas_status,
-            tx_checked_input_objects,
-            auth_checked_input_objects_union,
-            authenticator_info,
-        ) = self.check_transaction_inputs_for_signing(
-            protocol_config,
-            reference_gas_price,
-            tx_data,
-            tx_input_objects,
-            &tx_receiving_objects,
-            move_authenticator,
-            auth_input_objects,
-            account_object,
-        )?;
+        let (gas_status, tx_checked_input_objects, auth_checked_input_objects, authenticator_info) =
+            self.check_transaction_inputs_for_signing(
+                protocol_config,
+                reference_gas_price,
+                tx_data,
+                tx_input_objects,
+                &tx_receiving_objects,
+                move_authenticator,
+                auth_input_objects,
+                account_object,
+            )?;
 
         check_coin_deny_list_v1_during_signing(
             tx_data.sender(),
@@ -945,7 +941,7 @@ impl AuthorityState {
             // It is supposed that `MoveAuthenticator` availability is checked in
             // `SenderSignedData::validity_check`.
 
-            let auth_checked_input_objects_union = auth_checked_input_objects_union
+            let auth_checked_input_objects = auth_checked_input_objects
                 .expect("MoveAuthenticator input objects must be provided");
             let authenticator_info =
                 authenticator_info.expect("AuthenticatorInfoV1 object must be provided");
@@ -965,7 +961,7 @@ impl AuthorityState {
                 gas_status,
                 move_authenticator.to_owned(),
                 authenticator_info,
-                auth_checked_input_objects_union,
+                auth_checked_input_objects,
                 kind,
                 signer,
                 transaction.digest().to_owned(),
@@ -1734,7 +1730,7 @@ impl AuthorityState {
             // that the account object is loaded.
             let account_object = account_object.expect("Account object must be provided");
 
-            let (checked_account_object, authenticator_info) = self.check_move_account(
+            let authenticator_info = self.check_move_account(
                 auth_account_object_id,
                 auth_account_object_seq_number,
                 auth_account_object_digest,
@@ -1758,7 +1754,6 @@ impl AuthorityState {
             ) = iota_transaction_checks::check_certificate_and_move_authenticator_input(
                 certificate,
                 tx_input_objects,
-                checked_account_object,
                 move_authenticator_input_objects,
                 authenticator_gas_budget,
                 protocol_config,
@@ -5334,24 +5329,24 @@ impl AuthorityState {
         auth_account_object_id: ObjectID,
         auth_account_object_seq_number: Option<SequenceNumber>,
         auth_account_object_digest: Option<ObjectDigest>,
-        account_object_read_result: ObjectReadResult,
+        account_object: ObjectReadResult,
         signer: &IotaAddress,
-    ) -> IotaResult<(CheckedInputObjects, AuthenticatorInfoV1)> {
-        let account_object = match &account_object_read_result.object {
+    ) -> IotaResult<AuthenticatorInfoV1> {
+        let account_object = match account_object.object {
             ObjectReadResultKind::Object(object) => Ok(object),
             ObjectReadResultKind::DeletedSharedObject(version, digest) => {
                 Err(UserInputError::AccountObjectDeleted {
-                    account_id: account_object_read_result.id(),
-                    account_version: version.to_owned(),
-                    transaction_digest: digest.to_owned(),
+                    account_id: account_object.id(),
+                    account_version: version,
+                    transaction_digest: digest,
                 })
             }
             // It is impossible to check the account object because it is used in a canceled
             // transaction and is not loaded.
             ObjectReadResultKind::CancelledTransactionSharedObject(version) => {
                 Err(UserInputError::AccountObjectInCanceledTransaction {
-                    account_id: account_object_read_result.id(),
-                    account_version: version.to_owned(),
+                    account_id: account_object.id(),
+                    account_version: version,
                 })
             }
         }?;
@@ -5435,12 +5430,7 @@ impl AuthorityState {
                     }
                 })?;
 
-            let checked_account_object =
-                CheckedInputObjects::new_with_checked_transaction_inputs(InputObjects::from(vec![
-                    account_object_read_result,
-                ]));
-
-            Ok((checked_account_object, field.value))
+            Ok(field.value)
         } else {
             Err(UserInputError::MoveAuthenticatorNotFound {
                 authenticator_info_id: authenticator_info_field_id,
@@ -5510,7 +5500,7 @@ impl AuthorityState {
                 ) = move_authenticator.object_to_authenticate_components()?;
 
                 // Make sure the sender is a Move account.
-                let (checked_account_object, authenticator_info) = self.check_move_account(
+                let authenticator_info = self.check_move_account(
                     auth_account_object_id,
                     auth_account_object_seq_number,
                     auth_account_object_digest,
@@ -5519,9 +5509,8 @@ impl AuthorityState {
                 )?;
 
                 // Check the MoveAuthenticator input objects.
-                let auth_checked_input_objects_union =
+                let auth_checked_input_objects =
                     iota_transaction_checks::check_move_authenticator_input_for_signing(
-                        checked_account_object,
                         auth_input_objects,
                     )?;
 
@@ -5530,7 +5519,7 @@ impl AuthorityState {
                 let authenticator_gas_budget = protocol_config.max_auth_gas();
 
                 (
-                    Some(auth_checked_input_objects_union),
+                    Some(auth_checked_input_objects),
                     Some(authenticator_info),
                     authenticator_gas_budget,
                 )

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -211,17 +211,11 @@ mod checked {
     /// object.
     #[instrument(level = "trace", skip_all)]
     pub fn check_move_authenticator_input_for_signing(
-        account_object: CheckedInputObjects,
         authenticator_input_objects: InputObjects,
     ) -> IotaResult<CheckedInputObjects> {
         check_move_authenticator_objects(&authenticator_input_objects)?;
 
-        let auth_input_objects_union = checked_input_objects_union(
-            authenticator_input_objects.into_checked(),
-            &account_object,
-        )?;
-
-        Ok(auth_input_objects_union)
+        Ok(authenticator_input_objects.into_checked())
     }
 
     /// A function to check the `MoveAuthenticator` inputs for execution and
@@ -239,7 +233,6 @@ mod checked {
     pub fn check_certificate_and_move_authenticator_input(
         cert: &VerifiedExecutableTransaction,
         tx_input_objects: InputObjects,
-        account_object: CheckedInputObjects,
         authenticator_input_objects: InputObjects,
         authenticator_gas_budget: u64,
         protocol_config: &ProtocolConfig,
@@ -265,8 +258,6 @@ mod checked {
             tx_input_objects.into_checked(),
             &authenticator_input_objects,
         )?;
-        let input_objects_union =
-            checked_input_objects_union(input_objects_union, &account_object)?;
 
         Ok((gas_status, authenticator_input_objects, input_objects_union))
     }

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -121,10 +121,13 @@ impl MoveAuthenticator {
         })
     }
 
+    /// Returns all input objects used by the MoveAuthenticator,
+    /// including those from the object to authenticate.
     pub fn input_objects(&self) -> Vec<InputObjectKind> {
         self.call_args
             .iter()
             .flat_map(|arg| arg.input_objects())
+            .chain(self.object_to_authenticate().input_objects())
             .collect::<Vec<_>>()
     }
 
@@ -135,10 +138,13 @@ impl MoveAuthenticator {
             .collect()
     }
 
+    /// Returns all shared input objects used by the MoveAuthenticator,
+    /// including those from the object to authenticate.
     pub fn shared_objects(&self) -> Vec<SharedInputObject> {
         self.call_args
             .iter()
             .flat_map(|arg| arg.shared_objects())
+            .chain(self.object_to_authenticate().shared_objects())
             .collect()
     }
 
@@ -174,13 +180,6 @@ impl MoveAuthenticator {
         let mut used = HashSet::new();
         fp_ensure!(
             self.input_objects()
-                .iter()
-                .all(|o| used.insert(o.object_id())),
-            UserInputError::DuplicateObjectRefInput
-        );
-        fp_ensure!(
-            self.object_to_authenticate()
-                .input_objects()
                 .iter()
                 .all(|o| used.insert(o.object_id())),
             UserInputError::DuplicateObjectRefInput

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -178,6 +178,13 @@ impl MoveAuthenticator {
                 .all(|o| used.insert(o.object_id())),
             UserInputError::DuplicateObjectRefInput
         );
+        fp_ensure!(
+            self.object_to_authenticate()
+                .input_objects()
+                .iter()
+                .all(|o| used.insert(o.object_id())),
+            UserInputError::DuplicateObjectRefInput
+        );
 
         self.call_args()
             .iter()

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2510,7 +2510,6 @@ impl SenderSignedData {
                 .collect::<HashSet<_>>();
 
             input_objects_set.extend(move_authenticator.input_objects());
-            input_objects_set.extend(move_authenticator.object_to_authenticate().input_objects());
 
             Ok(input_objects_set.into_iter().collect::<Vec<_>>())
         } else {
@@ -2520,9 +2519,9 @@ impl SenderSignedData {
 
     /// Splits the provided input objects into three groups:
     /// 1. Input objects required by the transaction itself.
-    /// 2. Input objects required by the sender `MoveAuthenticator`.
-    /// 3. The object to authenticate from the sender `MoveAuthenticator`, if
-    ///    any.
+    /// 2. Input objects required by the sender `MoveAuthenticator`, including
+    ///    the object to authenticate.
+    /// 3. The object to authenticate from the sender `MoveAuthenticator`.
     pub fn split_inputs_into_groups(
         &self,
         input_objects: InputObjects,
@@ -2597,13 +2596,7 @@ impl SenderSignedData {
         // Add the Move authenticator shared objects if any.
         let authenticator_shared_objects =
             if let Some(move_authenticator) = self.sender_move_authenticator() {
-                move_authenticator
-                    .shared_objects()
-                    .into_iter()
-                    // Add `object_to_authenticate` if it is a shared object.
-                    .chain(move_authenticator.object_to_authenticate().shared_objects())
-                    .collect::<Vec<_>>()
-                    .into_iter()
+                move_authenticator.shared_objects().into_iter()
             } else {
                 Vec::new().into_iter()
             };


### PR DESCRIPTION
# Description of change

Include `object_to_authenticate` in `MoveAuthenticator::input_objects` and `MoveAuthenticator::shared_objects` that fixes the arguments duplication check as well.

