### PR TITLE
feat(iota-core, iota-types): Add scoring function

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4763,6 +4763,7 @@ impl AuthorityState {
         gas_cost_summary: &GasCostSummary,
         checkpoint: CheckpointSequenceNumber,
         epoch_start_timestamp_ms: CheckpointTimestamp,
+        scores: Vec<u64>,
     ) -> anyhow::Result<(
         IotaSystemState,
         Option<SystemEpochInfoEvent>,
@@ -4817,9 +4818,8 @@ impl AuthorityState {
             bail!("missing system packages: cannot form ChangeEpochTx");
         };
 
-        // Use ChangeEpochV3 when the feature flag is enabled and ChangeEpochV2
-        // requirements are met
-
+        // Use ChangeEpochV3 or ChangeEpochV4 when the feature flags are enabled and
+        // ChangeEpochV2 requirements are met
         if config.select_committee_from_eligible_validators() {
             // Get the list of eligible validators that support the target protocol version
             let active_validators = epoch_store.epoch_start_state().get_active_validators();
@@ -4861,18 +4861,35 @@ impl AuthorityState {
                 }
             }
 
-            txns.push(EndOfEpochTransactionKind::new_change_epoch_v3(
-                next_epoch,
-                next_epoch_protocol_version,
-                gas_cost_summary.storage_cost,
-                gas_cost_summary.computation_cost,
-                gas_cost_summary.computation_cost_burned,
-                gas_cost_summary.storage_rebate,
-                gas_cost_summary.non_refundable_storage_fee,
-                epoch_start_timestamp_ms,
-                next_epoch_system_package_bytes,
-                eligible_active_validators,
-            ));
+            // Use ChangeEpochV4 when the feature flag is enabled
+            if config.score_based_rewards() {
+                txns.push(EndOfEpochTransactionKind::new_change_epoch_v4(
+                    next_epoch,
+                    next_epoch_protocol_version,
+                    gas_cost_summary.storage_cost,
+                    gas_cost_summary.computation_cost,
+                    gas_cost_summary.computation_cost_burned,
+                    gas_cost_summary.storage_rebate,
+                    gas_cost_summary.non_refundable_storage_fee,
+                    epoch_start_timestamp_ms,
+                    next_epoch_system_package_bytes,
+                    eligible_active_validators,
+                    scores,
+                ));
+            } else {
+                txns.push(EndOfEpochTransactionKind::new_change_epoch_v3(
+                    next_epoch,
+                    next_epoch_protocol_version,
+                    gas_cost_summary.storage_cost,
+                    gas_cost_summary.computation_cost,
+                    gas_cost_summary.computation_cost_burned,
+                    gas_cost_summary.storage_rebate,
+                    gas_cost_summary.non_refundable_storage_fee,
+                    epoch_start_timestamp_ms,
+                    next_epoch_system_package_bytes,
+                    eligible_active_validators,
+                ));
+            }
         } else if config.protocol_defined_base_fee()
             && config.max_committee_members_count_as_option().is_some()
         {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3946,7 +3946,7 @@ impl AuthorityPerEpochStore {
                     // Since this verification happens after consensus, all authorities already
                     // agreed on the set of messages that would be verified by this method. Then, we
                     // can update scores according to the validation result directly, without the
-                    // need of any aditional step (as propagating opinions about validity).
+                    // need of any additional step (as propagating opinions about validity).
                     self.scorer.update_invalid_reports_count(authority_index);
                     warn!(
                         "Received invalid misbehavior report from {:?}",

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3934,10 +3934,28 @@ impl AuthorityPerEpochStore {
                 panic!("process_consensus_transaction called with end-of-publish transaction");
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::MisbehaviorReport(_authority, _report, _),
+                kind: ConsensusTransactionKind::MisbehaviorReport(authority, report, _),
                 ..
             }) => {
-                // Validate report
+                let authority_index = self
+                    .committee
+                    .authority_index(authority)
+                    .expect("authority in committee");
+                // Check validity of the report
+                if !report.verify(self.committee.num_members()) {
+                    // Since this verification happens after consensus, all authorities already
+                    // agreed on the set of messages that would be verified by this method. Then, we
+                    // can update scores according to the validation result directly, without the
+                    // need of any aditional step (as propagating opinions about validity).
+                    self.scorer.update_invalid_reports_count(authority_index);
+                    warn!(
+                        "Received invalid misbehavior report from {:?}",
+                        authority.concise()
+                    );
+                } else {
+                    // Here we update all counts related to the information in the reports.
+                    self.scorer.update_received_reports(authority_index, report);
+                }
                 Ok(ConsensusCertificateResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -12,6 +12,9 @@ use iota_types::{
     scoring_metrics::VersionedScoringMetrics,
 };
 
+const MAX_SCORE: u64 = 2_u64.pow(16); // Note: must be consistent with MAX_SCORE in validator_set.move in iota-framework.
+const SCALE_FACTOR: u64 = 2_u64.pow(16);
+
 /// Holds all information related to scoring of authorities in the committee.
 pub struct Scorer {
     // The current metrics counts collected by the authority, i.e., the local view of the node
@@ -49,8 +52,6 @@ impl Scorer {
                     committee_size,
                     protocol_config,
                 ));
-
-                let max_score = 2_u64.pow(16);
                 let (received_metrics, has_not_sent_report, current_scores, invalid_reports_count) =
                     (0..committee_size)
                         .map(|_| {
@@ -60,7 +61,7 @@ impl Scorer {
                                 // Initially, none of the authorities had sent any valid report.
                                 AtomicBool::new(true),
                                 // Current scores initialized to max score.
-                                AtomicU64::new(max_score),
+                                AtomicU64::new(MAX_SCORE),
                                 // Invalid reports count initialized to zero.
                                 AtomicU64::new(0),
                             )
@@ -68,26 +69,15 @@ impl Scorer {
                         .collect();
                 let scale_factor = 2_u64.pow(16);
                 let parameters = ParametersV1 {
-                    max_score,
-                    scale_factor,
-                    allowances: MisbehaviorsV1 {
-                        faulty_blocks_provable: 2,
-                        faulty_blocks_unprovable: 1,
-                        missing_proposals: 1000,
-                        equivocations: 0,
-                    },
-                    maximums: MisbehaviorsV1 {
-                        faulty_blocks_provable: 10,
-                        faulty_blocks_unprovable: 5,
-                        missing_proposals: 5000,
-                        equivocations: 1,
-                    },
-                    weights: MisbehaviorsV1 {
-                        faulty_blocks_provable: scale_factor * 30 / 100,
-                        faulty_blocks_unprovable: scale_factor * 10 / 100,
-                        missing_proposals: scale_factor * 35 / 100,
-                        equivocations: 1,
-                    },
+                    max_score: MAX_SCORE,
+                    scale_factor: SCALE_FACTOR,
+                    allowances: vec![1, 2, 1000, 0],
+                    maximums: vec![5, 10, 5000, 1],
+                    weights: vec![
+                        SCALE_FACTOR * 30 / 100,
+                        SCALE_FACTOR * 10 / 100,
+                        SCALE_FACTOR * 35 / 100,
+                    ],
                 };
                 // Assert that the allowance for major misbehaviors is 0,
                 // maximum is 1 and weight is 1. This is because major misbehaviors should
@@ -433,7 +423,7 @@ mod tests {
     use iota_types::messages_consensus::{MisbehaviorsV1, VersionedMisbehaviorReport};
 
     use crate::authority::authority_per_epoch_store::scorer::{
-        ParametersV1, Scorer, calculate_median_report, calculate_scores_v1,
+        MAX_SCORE, ParametersV1, SCALE_FACTOR, Scorer, calculate_median_report, calculate_scores_v1,
     };
 
     fn mock_protocol_config(consensus_choice: ConsensusChoice) -> ProtocolConfig {
@@ -681,26 +671,15 @@ mod tests {
     #[test]
     fn test_calculate_scores_v1() {
         let parameters = ParametersV1 {
-            max_score: 2_u64.pow(16),
-            scale_factor: 2_u64.pow(16),
-            allowances: MisbehaviorsV1 {
-                faulty_blocks_provable: 1,
-                faulty_blocks_unprovable: 2,
-                missing_proposals: 1000,
-                equivocations: 0,
-            },
-            maximums: MisbehaviorsV1 {
-                faulty_blocks_provable: 5,
-                faulty_blocks_unprovable: 10,
-                missing_proposals: 5000,
-                equivocations: 1,
-            },
-            weights: MisbehaviorsV1 {
-                faulty_blocks_provable: 2_u64.pow(16) * 30 / 100,
-                faulty_blocks_unprovable: 2_u64.pow(16) * 10 / 100,
-                missing_proposals: 2_u64.pow(16) * 35 / 100,
-                equivocations: 1,
-            },
+            max_score: MAX_SCORE,
+            scale_factor: SCALE_FACTOR,
+            allowances: vec![1, 2, 1000, 0],
+            maximums: vec![5, 10, 5000, 1],
+            weights: vec![
+                SCALE_FACTOR * 30 / 100,
+                SCALE_FACTOR * 10 / 100,
+                SCALE_FACTOR * 35 / 100,
+            ],
         };
 
         let median_reports = MisbehaviorsV1 {

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -91,7 +91,7 @@ impl Scorer {
                 };
                 // Assert that the allowance for major misbehaviors is 0,
                 // maximum is 1 and weight is 1. This is because major misbehaviors should
-                // reduce the score to 0 is there are any occurences.
+                // reduce the score to 0 is there are any occurrences.
                 // Only equivocation is considered a major misbehavior in this version.
                 assert!(
                     parameters
@@ -373,7 +373,7 @@ fn metrics_scores_to_final_scores(
 ) -> Vec<u64> {
     // Initialise the final scores with the baseline score whose value is between 0
     // and max_score * scale_factor.
-    let committee_size = minor_metric_scores.iter().next().unwrap().len();
+    let committee_size = minor_metric_scores.first().unwrap().len();
     let mut final_scores = vec![baseline_score * max_score; committee_size];
     // First, calculate the weights sum of minor misbehavior scores vector. The
     // values in final_scores will still be between 0 and max_score * scale_factor
@@ -394,7 +394,7 @@ fn metrics_scores_to_final_scores(
     });
     // Finally, divide by the scale factor and scale to max_score
     for score in final_scores.iter_mut() {
-        *score = *score / scale_factor;
+        *score /= scale_factor;
     }
     final_scores
 }
@@ -704,7 +704,7 @@ mod tests {
         };
 
         let median_reports = MisbehaviorsV1 {
-            faulty_blocks_provable: vec![4, 5, 6],
+            faulty_blocks_provable: vec![6, 7, 8],
             faulty_blocks_unprovable: vec![9, 10, 11],
             missing_proposals: vec![3, 4, 5],
             equivocations: vec![0, 1, 2],

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -8,7 +8,8 @@ use std::sync::{
 
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
-    messages_consensus::VersionedMisbehaviorReport, scoring_metrics::VersionedScoringMetrics,
+    messages_consensus::{MisbehaviorsV1, VersionedMisbehaviorReport},
+    scoring_metrics::VersionedScoringMetrics,
 };
 
 /// Holds all information related to scoring of authorities in the committee.
@@ -18,7 +19,7 @@ pub struct Scorer {
     pub(crate) current_local_metrics_count: Arc<VersionedScoringMetrics>,
     // The metrics counts received from other authorities, i.e., the information contained in the
     // MisbehaviourReports received by the authority. If an authority has not sent a report, its
-    // received_metrics will be all zeroed.
+    // entry in this vector will be all zeroed.
     received_metrics: Vec<VersionedScoringMetrics>,
     // Indicates whether an authority did not send any misbehavior reports in the epoch. We use
     // this to differentiate an authority that did not send a report from another one who sent
@@ -65,17 +66,47 @@ impl Scorer {
                             )
                         })
                         .collect();
+                let scale_factor = 2_u64.pow(16);
                 let parameters = ParametersV1 {
                     max_score,
-                    scale_factor: 2_u64.pow(16),
-                    allowances: vec![1, 2, 1000, 0],
-                    maximums: vec![5, 10, 5000, 1],
-                    weights: vec![
-                        2_u64.pow(16) * 30 / 100,
-                        2_u64.pow(16) * 10 / 100,
-                        2_u64.pow(16) * 35 / 100,
-                    ],
+                    scale_factor,
+                    allowances: MisbehaviorsV1 {
+                        faulty_blocks_provable: 2,
+                        faulty_blocks_unprovable: 1,
+                        missing_proposals: 1000,
+                        equivocations: 0,
+                    },
+                    maximums: MisbehaviorsV1 {
+                        faulty_blocks_provable: 10,
+                        faulty_blocks_unprovable: 5,
+                        missing_proposals: 5000,
+                        equivocations: 1,
+                    },
+                    weights: MisbehaviorsV1 {
+                        faulty_blocks_provable: scale_factor * 30 / 100,
+                        faulty_blocks_unprovable: scale_factor * 10 / 100,
+                        missing_proposals: scale_factor * 35 / 100,
+                        equivocations: 1,
+                    },
                 };
+                // Assert that the allowance for major misbehaviors is 0,
+                // maximum is 1 and weight is 1. This is because major misbehaviors should
+                // reduce the score to 0 is there are any occurences.
+                // Only equivocation is considered a major misbehavior in this version.
+                assert!(
+                    parameters
+                        .allowances
+                        .iter_major_misbehaviors()
+                        .all(|&a| a == 0)
+                        && parameters
+                            .maximums
+                            .iter_major_misbehaviors()
+                            .all(|&m| m == 1)
+                        && parameters
+                            .weights
+                            .iter_major_misbehaviors()
+                            .all(|&w| w == 1)
+                );
 
                 Self {
                     current_local_metrics_count,
@@ -174,7 +205,7 @@ impl Scorer {
 /// VersionedMisbehaviorReport
 fn calculate_median_report(
     reports_and_voting_power: &[(VersionedMisbehaviorReport, VotingPower)],
-) -> Vec<MedianMetricVec> {
+) -> MisbehaviorsV1<MedianMetricVec> {
     // Calls to this method should ensure that we have at least one report to
     // process.
     assert!(!reports_and_voting_power.is_empty());
@@ -199,7 +230,7 @@ fn calculate_median_report(
     let median_report = reports_and_voting_power_per_metric
         .iter_mut()
         .map(|vec| calculate_weighted_median(vec.as_mut_slice()))
-        .collect::<Vec<MetricVec>>();
+        .collect::<MisbehaviorsV1<MedianMetricVec>>();
     median_report
 }
 
@@ -251,11 +282,12 @@ struct ParametersV1 {
     max_score: u64,
     scale_factor: u64,
     // Allowed misbehaviors without any punishment
-    allowances: Vec<u64>,
+    allowances: MisbehaviorsV1<u64>,
     // Number of misbehaviors that lead to zero score
-    maximums: Vec<u64>,
-    // Weights for each non-equivocation metric. Their sum + baseline_score = scale_factor
-    weights: Vec<u64>,
+    maximums: MisbehaviorsV1<u64>,
+    // Weights for each metric. The sum of minor misbehavior weights + baseline_score =
+    // scale_factor. Major misbehavior weights are either 0 or 1.
+    weights: MisbehaviorsV1<u64>,
 }
 
 // Aliases for better readability.
@@ -270,25 +302,26 @@ type MetricVec = Vec<u64>;
 // (allowed misbehaviors without any punishment) and a maximum (number of
 // misbehaviors that lead to zero score). Based on those values, we calculate a
 // score per metric, and then combine them into a final score. Each individual
-// score is also  an integer between 0 and max_score, and the weights used for
-// the combination are such that sum(weights) + baseline_score = scale_factor.
-// Thus, we need max_score*scale_factor < 2^64 to avoid overflows.
-fn calculate_scores_v1(median_reports: Vec<MedianMetricVec>, parameters: ParametersV1) -> Vec<u64> {
-    // Ensure we have 4 median reports: faulty blocks provable, faulty blocks
-    // unprovable, missing blocks, equivocations. This is naturally guaranteed when
-    // these data come from MisbehaviorReports, since they would been considered
-    // invalid otherwise.
-    assert_eq!(median_reports.len(), 4);
+// score for minor misbeahviors (non-equivocation) is also  an integer between 0
+// and max_score, and the weights used for the combination are such that
+// sum(weights) + baseline_score = scale_factor. Thus, we need
+// max_score*scale_factor < 2^64 to avoid overflows.
+// Major misbehaviors (equivocations) are treated differently, as they
+// multiplicatively impact the final score. Their value is either 0 or 1.
+fn calculate_scores_v1(
+    median_reports: MisbehaviorsV1<MedianMetricVec>,
+    parameters: ParametersV1,
+) -> Vec<u64> {
+    let baseline_score =
+        parameters.scale_factor - parameters.weights.iter_minor_misbehaviors().sum::<u64>();
 
-    let baseline_score = parameters.scale_factor - parameters.weights.iter().sum::<u64>();
+    let median_minor_reports_and_parameters = median_reports
+        .iter_minor_misbehaviors()
+        .zip(parameters.allowances.iter_minor_misbehaviors())
+        .zip(parameters.maximums.iter_minor_misbehaviors());
 
-    let median_reports_and_parameters = median_reports
-        .iter()
-        .zip(parameters.allowances.iter())
-        .zip(parameters.maximums.iter());
-
-    // Calculate metric scores for all metrics except equivocations
-    let non_equivocation_metrics_scores = median_reports_and_parameters
+    // Calculate individual metric scores
+    let minor_metric_scores = median_minor_reports_and_parameters
         .map(
             |((median_report_for_a_single_metric, metric_allowance), metric_maximum)| {
                 median_report_single_metric_to_score(
@@ -301,18 +334,29 @@ fn calculate_scores_v1(median_reports: Vec<MedianMetricVec>, parameters: Paramet
         )
         .collect::<Vec<Vec<u64>>>();
 
-    // Calculate metric scores for equivocations
-    let equivocation_score = median_report_single_metric_to_score(
-        &median_reports[3],
-        parameters.allowances[3],
-        parameters.maximums[3],
-        parameters.max_score,
-    );
+    let median_major_reports_and_parameters = median_reports
+        .iter_major_misbehaviors()
+        .zip(parameters.allowances.iter_major_misbehaviors())
+        .zip(parameters.maximums.iter_major_misbehaviors());
+
+    // Calculate individual metric scores
+    let major_metric_scores = median_major_reports_and_parameters
+        .map(
+            |((median_report_for_a_single_metric, metric_allowance), metric_maximum)| {
+                median_report_single_metric_to_score(
+                    median_report_for_a_single_metric,
+                    *metric_allowance,
+                    *metric_maximum,
+                    1,
+                )
+            },
+        )
+        .collect::<Vec<Vec<u64>>>();
 
     metrics_scores_to_final_scores(
-        &non_equivocation_metrics_scores,
+        minor_metric_scores,
+        major_metric_scores,
         parameters.weights,
-        equivocation_score,
         baseline_score,
         parameters.scale_factor,
         parameters.max_score,
@@ -320,51 +364,52 @@ fn calculate_scores_v1(median_reports: Vec<MedianMetricVec>, parameters: Paramet
 }
 
 fn metrics_scores_to_final_scores(
-    non_eq_metrics_scores: &[Vec<u64>],
-    weights: Vec<u64>,
-    eq_scores: Vec<u64>,
+    minor_metric_scores: Vec<Vec<u64>>,
+    major_metric_scores: Vec<Vec<u64>>,
+    weights: MisbehaviorsV1<u64>,
     baseline_score: u64,
     scale_factor: u64,
     max_score: u64,
 ) -> Vec<u64> {
-    // Initialize final scores with a value smaller or equal than max_score *
-    // scale_factor
-    let mut final_scores = vec![baseline_score * max_score; non_eq_metrics_scores[0].len()];
-    // Combine non-equivocation metric scores into that final scores vector. The
+    // Initialise the final scores with the baseline score whose value is between 0
+    // and max_score * scale_factor.
+    let committee_size = minor_metric_scores.iter().next().unwrap().len();
+    let mut final_scores = vec![baseline_score * max_score; committee_size];
+    // First, calculate the weights sum of minor misbehavior scores vector. The
     // values in final_scores will still be between 0 and max_score * scale_factor
-    non_eq_metrics_scores
+    minor_metric_scores
         .iter()
-        .zip(weights.iter())
-        .for_each(|(metric_score, weight)| {
-            let to_add = metric_score
-                .iter()
-                .map(|x| x * weight)
-                .collect::<Vec<u64>>();
-            final_scores
-                .iter_mut()
-                .zip(to_add.iter())
-                .for_each(|(a, b)| *a += *b);
+        .zip(weights.iter_minor_misbehaviors())
+        .for_each(|(scores, weight)| {
+            for (i, &score) in scores.iter().enumerate() {
+                final_scores[i] += score * weight;
+            }
         });
-    // Combine equivocation scores into final scores, and scale down. The final
-    // scores will be values between 0 and max_score.
+    // Then, multiply by each major misbehavior score which is a value of either 0
+    // or 1.
+    major_metric_scores.iter().for_each(|scores| {
+        for (i, &score) in scores.iter().enumerate() {
+            final_scores[i] *= score;
+        }
+    });
+    // Finally, divide by the scale factor and scale to max_score
+    for score in final_scores.iter_mut() {
+        *score = *score / scale_factor;
+    }
     final_scores
-        .iter()
-        .zip(eq_scores.iter())
-        .map(|(score, eq_score)| score * eq_score / scale_factor / max_score)
-        .collect()
 }
 
 // Calculate the metric scores for a single metric's median report vector. It
-// returns a vector of values between 0 and max_score
+// returns a vector of values between 0 and the max score for that metric.
 fn median_report_single_metric_to_score(
     median_report_for_metric: &MedianMetricVec,
     metric_allowance: u64,
     metric_max: u64,
-    max_score: u64,
+    max_metric_score: u64,
 ) -> Vec<u64> {
     median_report_for_metric
         .iter()
-        .map(|&report| metric_to_score(report, metric_allowance, metric_max, max_score))
+        .map(|&report| metric_to_score(report, metric_allowance, metric_max, max_metric_score))
         .collect()
 }
 
@@ -385,7 +430,7 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     use iota_protocol_config::{ConsensusChoice, ProtocolConfig};
-    use iota_types::messages_consensus::{MisbehaviorReportV1, VersionedMisbehaviorReport};
+    use iota_types::messages_consensus::{MisbehaviorsV1, VersionedMisbehaviorReport};
 
     use crate::authority::authority_per_epoch_store::scorer::{
         ParametersV1, Scorer, calculate_median_report, calculate_scores_v1,
@@ -491,7 +536,7 @@ mod tests {
         // Set some reports for testing
         let reports_and_authorities = vec![
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![5, 0, 0],
                     faulty_blocks_unprovable: vec![0, 0, 0],
                     missing_proposals: vec![0, 0, 0],
@@ -500,7 +545,7 @@ mod tests {
                 0_u32,
             ),
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![0, 10, 0],
                     faulty_blocks_unprovable: vec![0, 0, 0],
                     missing_proposals: vec![0, 0, 0],
@@ -509,7 +554,7 @@ mod tests {
                 1_u32,
             ),
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![0, 0, 15],
                     faulty_blocks_unprovable: vec![0, 0, 0],
                     missing_proposals: vec![0, 0, 0],
@@ -537,7 +582,7 @@ mod tests {
     #[test]
     fn test_calculate_median_report() {
         let reports_and_voting_power = vec![(
-            VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+            VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
                 faulty_blocks_provable: vec![7, 8, 9],
                 faulty_blocks_unprovable: vec![10, 11, 12],
                 missing_proposals: vec![4, 5, 6],
@@ -549,17 +594,17 @@ mod tests {
 
         assert_eq!(
             median_report,
-            vec![
-                vec![7, 8, 9],
-                vec![10, 11, 12],
-                vec![4, 5, 6],
-                vec![1, 2, 3]
-            ]
+            MisbehaviorsV1 {
+                faulty_blocks_provable: vec![7, 8, 9],
+                faulty_blocks_unprovable: vec![10, 11, 12],
+                missing_proposals: vec![4, 5, 6],
+                equivocations: vec![1, 2, 3]
+            }
         );
 
         let reports_and_voting_power = vec![
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![7, 8, 9],
                     faulty_blocks_unprovable: vec![10, 11, 12],
                     missing_proposals: vec![4, 5, 6],
@@ -568,7 +613,7 @@ mod tests {
                 20_u64,
             ),
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![70, 80, 90],
                     faulty_blocks_unprovable: vec![100, 110, 120],
                     missing_proposals: vec![40, 50, 60],
@@ -582,17 +627,17 @@ mod tests {
 
         assert_eq!(
             median_report,
-            vec![
-                vec![7, 8, 9],
-                vec![10, 11, 12],
-                vec![4, 5, 6],
-                vec![1, 2, 3]
-            ]
+            MisbehaviorsV1 {
+                faulty_blocks_provable: vec![7, 8, 9],
+                faulty_blocks_unprovable: vec![10, 11, 12],
+                missing_proposals: vec![4, 5, 6],
+                equivocations: vec![1, 2, 3]
+            }
         );
 
         let reports_and_voting_power = vec![
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![1, 8, 9],
                     faulty_blocks_unprovable: vec![10, 15, 12],
                     missing_proposals: vec![4, 5, 6],
@@ -601,7 +646,7 @@ mod tests {
                 10_u64,
             ),
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![7, 8, 9],
                     faulty_blocks_unprovable: vec![10, 11, 12],
                     missing_proposals: vec![4, 5, 6],
@@ -610,7 +655,7 @@ mod tests {
                 10_u64,
             ),
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![6, 8, 9],
                     faulty_blocks_unprovable: vec![10, 11, 12],
                     missing_proposals: vec![4, 22, 6],
@@ -624,12 +669,12 @@ mod tests {
 
         assert_eq!(
             median_report,
-            vec![
-                vec![6, 8, 9],
-                vec![10, 11, 12],
-                vec![4, 5, 6],
-                vec![1, 2, 3]
-            ]
+            MisbehaviorsV1 {
+                faulty_blocks_provable: vec![6, 8, 9],
+                faulty_blocks_unprovable: vec![10, 11, 12],
+                missing_proposals: vec![4, 5, 6],
+                equivocations: vec![1, 2, 3]
+            }
         );
     }
 
@@ -638,21 +683,32 @@ mod tests {
         let parameters = ParametersV1 {
             max_score: 2_u64.pow(16),
             scale_factor: 2_u64.pow(16),
-            allowances: vec![1, 2, 1000, 0],
-            maximums: vec![5, 10, 5000, 1],
-            weights: vec![
-                2_u64.pow(16) * 30 / 100,
-                2_u64.pow(16) * 10 / 100,
-                2_u64.pow(16) * 35 / 100,
-            ],
+            allowances: MisbehaviorsV1 {
+                faulty_blocks_provable: 1,
+                faulty_blocks_unprovable: 2,
+                missing_proposals: 1000,
+                equivocations: 0,
+            },
+            maximums: MisbehaviorsV1 {
+                faulty_blocks_provable: 5,
+                faulty_blocks_unprovable: 10,
+                missing_proposals: 5000,
+                equivocations: 1,
+            },
+            weights: MisbehaviorsV1 {
+                faulty_blocks_provable: 2_u64.pow(16) * 30 / 100,
+                faulty_blocks_unprovable: 2_u64.pow(16) * 10 / 100,
+                missing_proposals: 2_u64.pow(16) * 35 / 100,
+                equivocations: 1,
+            },
         };
 
-        let median_reports = vec![
-            vec![6, 7, 8],   // faulty blocks provable
-            vec![9, 10, 11], // faulty blocks unprovable
-            vec![3, 4, 5],   // missing proposals
-            vec![0, 1, 2],   // equivocations
-        ];
+        let median_reports = MisbehaviorsV1 {
+            faulty_blocks_provable: vec![4, 5, 6],
+            faulty_blocks_unprovable: vec![9, 10, 11],
+            missing_proposals: vec![3, 4, 5],
+            equivocations: vec![0, 1, 2],
+        };
 
         let scores = calculate_scores_v1(median_reports, parameters);
 

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -67,17 +67,25 @@ impl Scorer {
                             )
                         })
                         .collect();
-                let scale_factor = 2_u64.pow(16);
                 let parameters = ParametersV1 {
-                    max_score: MAX_SCORE,
-                    scale_factor: SCALE_FACTOR,
-                    allowances: vec![1, 2, 1000, 0],
-                    maximums: vec![5, 10, 5000, 1],
-                    weights: vec![
-                        SCALE_FACTOR * 30 / 100,
-                        SCALE_FACTOR * 10 / 100,
-                        SCALE_FACTOR * 35 / 100,
-                    ],
+                    allowances: MisbehaviorsV1 {
+                        faulty_blocks_provable: 1,
+                        faulty_blocks_unprovable: 2,
+                        missing_proposals: 48_000, // roughly 3% of consensus rounds in an epoch
+                        equivocations: 0,
+                    },
+                    maximums: MisbehaviorsV1 {
+                        faulty_blocks_provable: 5,
+                        faulty_blocks_unprovable: 10,
+                        missing_proposals: 160_000, // roughly 10% of consensus rounds in an epoch
+                        equivocations: 1,
+                    },
+                    weights: MisbehaviorsV1 {
+                        faulty_blocks_provable: SCALE_FACTOR * 30 / 100,
+                        faulty_blocks_unprovable: SCALE_FACTOR * 10 / 100,
+                        missing_proposals: SCALE_FACTOR * 35 / 100,
+                        equivocations: 1,
+                    },
                 };
                 // Assert that the allowance for major misbehaviors is 0,
                 // maximum is 1 and weight is 1. This is because major misbehaviors should
@@ -269,8 +277,6 @@ enum ScorerVersion {
 // Parameters for ScorerVersion::V1
 #[derive(Clone)]
 struct ParametersV1 {
-    max_score: u64,
-    scale_factor: u64,
     // Allowed misbehaviors without any punishment
     allowances: MisbehaviorsV1<u64>,
     // Number of misbehaviors that lead to zero score
@@ -302,8 +308,7 @@ fn calculate_scores_v1(
     median_reports: MisbehaviorsV1<MedianMetricVec>,
     parameters: ParametersV1,
 ) -> Vec<u64> {
-    let baseline_score =
-        parameters.scale_factor - parameters.weights.iter_minor_misbehaviors().sum::<u64>();
+    let baseline_score = SCALE_FACTOR - parameters.weights.iter_minor_misbehaviors().sum::<u64>();
 
     let median_minor_reports_and_parameters = median_reports
         .iter_minor_misbehaviors()
@@ -318,7 +323,7 @@ fn calculate_scores_v1(
                     median_report_for_a_single_metric,
                     *metric_allowance,
                     *metric_maximum,
-                    parameters.max_score,
+                    MAX_SCORE,
                 )
             },
         )
@@ -348,8 +353,8 @@ fn calculate_scores_v1(
         major_metric_scores,
         parameters.weights,
         baseline_score,
-        parameters.scale_factor,
-        parameters.max_score,
+        SCALE_FACTOR,
+        MAX_SCORE,
     )
 }
 
@@ -409,7 +414,7 @@ fn metric_to_score(value: u64, allowance: u64, max: u64, max_score: u64) -> u64 
     } else if value >= max {
         0
     } else {
-        // Add overflow checks
+        // TODO: add overflow checks
         (max - value) * max_score / (max - allowance)
     }
 }
@@ -517,10 +522,7 @@ mod tests {
 
         // Before calling update_scores, all scores should be MAX_SCORE
         for score in scorer.current_scores.iter() {
-            assert_eq!(
-                score.load(Ordering::Relaxed),
-                scorer.get_parameters_v1().max_score
-            );
+            assert_eq!(score.load(Ordering::Relaxed), MAX_SCORE,);
         }
 
         // Set some reports for testing
@@ -671,15 +673,24 @@ mod tests {
     #[test]
     fn test_calculate_scores_v1() {
         let parameters = ParametersV1 {
-            max_score: MAX_SCORE,
-            scale_factor: SCALE_FACTOR,
-            allowances: vec![1, 2, 1000, 0],
-            maximums: vec![5, 10, 5000, 1],
-            weights: vec![
-                SCALE_FACTOR * 30 / 100,
-                SCALE_FACTOR * 10 / 100,
-                SCALE_FACTOR * 35 / 100,
-            ],
+            allowances: MisbehaviorsV1 {
+                faulty_blocks_provable: 1,
+                faulty_blocks_unprovable: 2,
+                missing_proposals: 1000,
+                equivocations: 0,
+            },
+            maximums: MisbehaviorsV1 {
+                faulty_blocks_provable: 5,
+                faulty_blocks_unprovable: 10,
+                missing_proposals: 5000,
+                equivocations: 1,
+            },
+            weights: MisbehaviorsV1 {
+                faulty_blocks_provable: SCALE_FACTOR * 30 / 100,
+                faulty_blocks_unprovable: SCALE_FACTOR * 10 / 100,
+                missing_proposals: SCALE_FACTOR * 35 / 100,
+                equivocations: 1,
+            },
         };
 
         let median_reports = MisbehaviorsV1 {

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -65,21 +65,20 @@ impl Scorer {
         self.invalid_reports_count[authority as usize].fetch_add(1, Ordering::Relaxed);
     }
 
+    #[expect(dead_code)]
     pub(crate) fn update_scores(&self) {
         match self.version {
             ScorerVersion::V1 => self.update_scores_v1(),
         };
     }
 
-    #[expect(dead_code)]
-    pub(crate) fn update_received_reports_and_score(
+    pub(crate) fn update_received_reports(
         &self,
         authority: u32,
         report: &VersionedMisbehaviorReport,
     ) {
         self.received_metrics[authority as usize].update_from_report(report);
         self.metrics_missing_from[authority as usize].store(false, Ordering::Relaxed);
-        self.update_scores();
     }
 
     fn update_scores_v1(&self) {
@@ -94,6 +93,7 @@ pub(crate) enum ScorerVersion {
 pub(crate) type Scores = Vec<Score>;
 pub(crate) type Score = AtomicU64;
 
+// NOTE: the tests below are going to be finalized in a different PR
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::Ordering;

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -11,17 +11,30 @@ use iota_types::{
     messages_consensus::VersionedMisbehaviorReport, scoring_metrics::VersionedScoringMetrics,
 };
 
-#[allow(unused)]
-const MAX_SCORE: u64 = u64::MAX;
-
-#[expect(dead_code)]
+/// Holds all information related to scoring of authorities in the committee.
 pub struct Scorer {
+    // The current metrics counts collected by the authority, i.e., the local view of the node
+    // about the behaviour of the rest of the committee, according to the blocks received.
     pub(crate) current_local_metrics_count: Arc<VersionedScoringMetrics>,
+    // The metrics counts received from other authorities, i.e., the information contained in the
+    // MisbehaviourReports received by the authority. If an authority has not sent a report, its
+    // received_metrics will be all zeroed.
     received_metrics: Vec<VersionedScoringMetrics>,
-    metrics_missing_from: Vec<AtomicBool>,
+    // Indicates whether an authority did not send any misbehavior reports in the epoch. We use
+    // this to differentiate an authority that did not send a report from another one who sent
+    // zeroed reports.
+    has_not_sent_report: Vec<AtomicBool>,
+    // The current scores of the authorities, updated after each received report. This score is
+    // calculated based on the information in the received reports and the validity of the reports
+    // themselves.
     pub(crate) current_scores: Scores,
+    // The count of invalid reports received from each authority. Validity here must be checked in
+    // a deterministic way, since this information will not be propagated again to the rest of the
+    // committee.
     invalid_reports_count: Vec<AtomicU64>,
+    // The voting power of each authority in the committee.
     voting_power: Vec<u64>,
+    // The version of the scorer being used with its parameters.
     version: ScorerVersion,
 }
 
@@ -30,34 +43,57 @@ impl Scorer {
         let committee_size = voting_power.len();
         match protocol_config.scorer_version_as_option() {
             None | Some(1) => {
+                // Local metrics count are always initialized as zero.
                 let current_local_metrics_count = Arc::new(VersionedScoringMetrics::new(
                     committee_size,
                     protocol_config,
                 ));
 
-                let (received_metrics, metrics_missing_from, current_scores, invalid_reports_count) =
+                let max_score = 2_u64.pow(16);
+                let (received_metrics, has_not_sent_report, current_scores, invalid_reports_count) =
                     (0..committee_size)
                         .map(|_| {
                             (
+                                // Received metrics initialized to zero.
                                 VersionedScoringMetrics::new(committee_size, protocol_config),
+                                // Initially, none of the authorities had sent any valid report.
                                 AtomicBool::new(true),
-                                AtomicU64::new(0),
+                                // Current scores initialized to max score.
+                                AtomicU64::new(max_score),
+                                // Invalid reports count initialized to zero.
                                 AtomicU64::new(0),
                             )
                         })
                         .collect();
+                let parameters = ParametersV1 {
+                    max_score,
+                    scale_factor: 2_u64.pow(16),
+                    allowances: vec![1, 2, 1000, 0],
+                    maximums: vec![5, 10, 5000, 1],
+                    weights: vec![
+                        2_u64.pow(16) * 30 / 100,
+                        2_u64.pow(16) * 10 / 100,
+                        2_u64.pow(16) * 35 / 100,
+                    ],
+                };
 
                 Self {
                     current_local_metrics_count,
                     received_metrics,
-                    metrics_missing_from,
+                    has_not_sent_report,
                     current_scores,
                     invalid_reports_count,
                     voting_power,
-                    version: ScorerVersion::V1,
+                    version: ScorerVersion::V1(parameters),
                 }
             }
             _ => panic!("Unsupported scorer version"),
+        }
+    }
+
+    fn get_parameters_v1(&self) -> ParametersV1 {
+        match &self.version {
+            ScorerVersion::V1(params) => params.clone(),
         }
     }
 
@@ -65,10 +101,9 @@ impl Scorer {
         self.invalid_reports_count[authority as usize].fetch_add(1, Ordering::Relaxed);
     }
 
-    #[expect(dead_code)]
     pub(crate) fn update_scores(&self) {
         match self.version {
-            ScorerVersion::V1 => self.update_scores_v1(),
+            ScorerVersion::V1(_) => self.update_scores_v1(),
         };
     }
 
@@ -77,21 +112,272 @@ impl Scorer {
         authority: u32,
         report: &VersionedMisbehaviorReport,
     ) {
+        // Update the received metrics for the authority, and mark that we have received
+        // metrics from them. Then, update the scores accordingly.
         self.received_metrics[authority as usize].update_from_report(report);
-        self.metrics_missing_from[authority as usize].store(false, Ordering::Relaxed);
+        self.has_not_sent_report[authority as usize].store(false, Ordering::Relaxed);
     }
+}
 
+// Methods for ScorerVersion::V1
+impl Scorer {
     fn update_scores_v1(&self) {
-        // Placeholder
+        // Vector with the highest received reports from each authority and their voting
+        // power. Authorities that did not send reports are filtered out.
+        let highest_received_reports_from_authority = self
+            .received_metrics
+            .iter()
+            .zip(self.voting_power.iter())
+            .zip(self.has_not_sent_report.iter())
+            .filter(|((_, _), is_missing)| !is_missing.load(Ordering::Relaxed))
+            .map(|((metrics, voting_power), _)| (metrics.to_report(), *voting_power))
+            .collect::<Vec<(VersionedMisbehaviorReport, VotingPower)>>();
+        // Ensure that we have at least one report to calculate the scores, otherwise we
+        // do nothing.
+        if highest_received_reports_from_authority.is_empty() {
+        } else {
+            let median_report = calculate_median_report(&highest_received_reports_from_authority);
+            let scores = calculate_scores_v1(median_report, self.get_parameters_v1());
+            for (i, &score) in scores.iter().enumerate() {
+                self.current_scores[i].store(score, Ordering::Relaxed);
+            }
+        }
     }
 }
 
-pub(crate) enum ScorerVersion {
-    V1,
+/// Given a vector of pairs (VersionedMisbehaviorReport, VotingPower), calculate
+/// the medians for all metrics in VersionedMisbehaviorReport and authorities:
+///
+/// - Assume we have N authorities in the committee, but n<=N reports R_1, R_2,
+///   ..., R_n from authorities with voting powers VP_1, VP_2, ..., VP_n.
+/// - For each metric M in VersionedMisbehaviorReport, we'll have n vectors of
+///   metric values: M_1, M_2, ..., M_n, where M_i is the vector of metric
+///   values for report R_i.
+/// - Each M_i is a vector of length N, where the j-th value corresponds to the
+///   metric value for authority j.
+///
+/// Example: If we have 4 authorities in the committee, and we receive 3
+/// reports:
+/// - Report R_1 from authority A_1 with voting power VP_1 = 1:
+///     - Metric M1: [0, 0, 0, 0] (values for authorities A_1, A_2, A_3, A_4)
+///     - Metric M2: [0, 0, 0, 0] (values for authorities A_1, A_2, A_3, A_4)
+/// - Report R_2 from authority A_2 with voting power VP_2 = 1:
+///     - Metric M1: [1, 1, 1, 1] (values for authorities A_1, A_2, A_3, A_4)
+///     - Metric M2: [2, 2, 2, 2] (values for authorities A_1, A_2, A_3, A_4)
+/// - Report R_3 from authority A_3 with voting power VP_3 = 1:
+///     - Metric M1: [2, 2, 2, 2] (values for authorities A_1, A_2, A_3, A_4)
+///     - Metric M2: [1, 1, 1, 1] (values for authorities A_1, A_2, A_3, A_4)
+///
+/// For Metric M1, we have that the median metric vector is [1, 1, 1, 1].
+///
+/// This method returns a vector of MedianMetricVec, one per metric in
+/// VersionedMisbehaviorReport
+fn calculate_median_report(
+    reports_and_voting_power: &[(VersionedMisbehaviorReport, VotingPower)],
+) -> Vec<MedianMetricVec> {
+    // Calls to this method should ensure that we have at least one report to
+    // process.
+    assert!(!reports_and_voting_power.is_empty());
+
+    let number_of_metrics = reports_and_voting_power[0].0.iterate_over_metrics().len();
+
+    // In the case of the example in the method documentation,
+    // reports_and_voting_power_per_metric should be
+    // vec![
+    //      vec![([0, 0, 0, 0],VP_1),([1, 1, 1, 1],VP_2),([2, 2, 2, 2],VP_3)],
+    //      vec![([0, 0, 0, 0],VP_1),([2, 2, 2, 2],VP_2),([1, 1, 1, 1],VP_3)]
+    //      ]
+    let mut reports_and_voting_power_per_metric: Vec<Vec<(MetricVec, VotingPower)>> =
+        vec![vec![]; number_of_metrics];
+    for (versioned_report, voting_power) in reports_and_voting_power.iter() {
+        for (i, metric) in versioned_report.iterate_over_metrics().enumerate() {
+            reports_and_voting_power_per_metric[i].push((metric.clone(), *voting_power));
+        }
+    }
+
+    // Calculate and return the weighted median for each metric
+    let median_report = reports_and_voting_power_per_metric
+        .iter_mut()
+        .map(|vec| calculate_weighted_median(vec.as_mut_slice()))
+        .collect::<Vec<MetricVec>>();
+    median_report
 }
 
+// Given a vector of pairs (MetricVec, VotingPower), calculate the weighted
+// median of each entry of MetricVec and returns a MedianMetricVec. Each entry
+// of reports corresponds to a single authority i who sent the report. MetricVec
+// always corresponds to a single metric, and each of its entries corresponds to
+// the number of misbehaviors that i claims to have detected from each authority
+// in the committee.
+fn calculate_weighted_median(reports: &mut [(MetricVec, VotingPower)]) -> MedianMetricVec {
+    // Calls to this method should ensure that we have at least one pair (MetricVec,
+    // VotingPower) to process.
+    assert!(!reports.is_empty());
+
+    // We calculate the weighted median relative to the voting power of the
+    // authorities who actually sent a report.
+    let voting_power_used = reports.iter().map(|(_, vp)| *vp).sum::<VotingPower>();
+    // The caller should also guarantee that the MetricVec in all reports have the
+    // same length (committee_size). This is naturally guaranteed when these data
+    // come from MisbehaviorReports, since they would been considered invalid
+    // otherwise.
+    let committee_size = reports[0].0.len();
+    let mut median_per_validator_being_scored = Vec::new();
+
+    for validator_being_scored in 0..committee_size {
+        let mut accumulated_voting_power = 0;
+        reports.sort_by_key(|(reported_counts, _)| reported_counts[validator_being_scored]);
+        for (reported_counts, voting_power) in reports.iter() {
+            accumulated_voting_power += *voting_power;
+            if accumulated_voting_power * 2 >= voting_power_used {
+                median_per_validator_being_scored.push(reported_counts[validator_being_scored]);
+                break;
+            }
+        }
+    }
+
+    median_per_validator_being_scored
+}
+
+// Scorer version. Currently, only V1 is implemented, relative to both
+// protocol_config.scorer_version = None or Some(1).
+enum ScorerVersion {
+    V1(ParametersV1),
+}
+
+// Parameters for ScorerVersion::V1
+#[derive(Clone)]
+struct ParametersV1 {
+    max_score: u64,
+    scale_factor: u64,
+    // Allowed misbehaviors without any punishment
+    allowances: Vec<u64>,
+    // Number of misbehaviors that lead to zero score
+    maximums: Vec<u64>,
+    // Weights for each non-equivocation metric. Their sum + baseline_score = scale_factor
+    weights: Vec<u64>,
+}
+
+// Aliases for better readability.
 pub(crate) type Scores = Vec<Score>;
 pub(crate) type Score = AtomicU64;
+type VotingPower = u64;
+type MedianMetricVec = Vec<u64>;
+type MetricVec = Vec<u64>;
+
+// Given the median reports for all metrics, calculate the final scores. A score
+// is an integer between 0 and max_score. For each metrics, we have an allowance
+// (allowed misbehaviors without any punishment) and a maximum (number of
+// misbehaviors that lead to zero score). Based on those values, we calculate a
+// score per metric, and then combine them into a final score. Each individual
+// score is also  an integer between 0 and max_score, and the weights used for
+// the combination are such that sum(weights) + baseline_score = scale_factor.
+// Thus, we need max_score*scale_factor < 2^64 to avoid overflows.
+fn calculate_scores_v1(median_reports: Vec<MedianMetricVec>, parameters: ParametersV1) -> Vec<u64> {
+    // Ensure we have 4 median reports: faulty blocks provable, faulty blocks
+    // unprovable, missing blocks, equivocations. This is naturally guaranteed when
+    // these data come from MisbehaviorReports, since they would been considered
+    // invalid otherwise.
+    assert_eq!(median_reports.len(), 4);
+
+    let baseline_score = parameters.scale_factor - parameters.weights.iter().sum::<u64>();
+
+    let median_reports_and_parameters = median_reports
+        .iter()
+        .zip(parameters.allowances.iter())
+        .zip(parameters.maximums.iter());
+
+    // Calculate metric scores for all metrics except equivocations
+    let non_equivocation_metrics_scores = median_reports_and_parameters
+        .map(
+            |((median_report_for_a_single_metric, metric_allowance), metric_maximum)| {
+                median_report_single_metric_to_score(
+                    median_report_for_a_single_metric,
+                    *metric_allowance,
+                    *metric_maximum,
+                    parameters.max_score,
+                )
+            },
+        )
+        .collect::<Vec<Vec<u64>>>();
+
+    // Calculate metric scores for equivocations
+    let equivocation_score = median_report_single_metric_to_score(
+        &median_reports[3],
+        parameters.allowances[3],
+        parameters.maximums[3],
+        parameters.max_score,
+    );
+
+    metrics_scores_to_final_scores(
+        &non_equivocation_metrics_scores,
+        parameters.weights,
+        equivocation_score,
+        baseline_score,
+        parameters.scale_factor,
+        parameters.max_score,
+    )
+}
+
+fn metrics_scores_to_final_scores(
+    non_eq_metrics_scores: &[Vec<u64>],
+    weights: Vec<u64>,
+    eq_scores: Vec<u64>,
+    baseline_score: u64,
+    scale_factor: u64,
+    max_score: u64,
+) -> Vec<u64> {
+    // Initialize final scores with a value smaller or equal than max_score *
+    // scale_factor
+    let mut final_scores = vec![baseline_score * max_score; non_eq_metrics_scores[0].len()];
+    // Combine non-equivocation metric scores into that final scores vector. The
+    // values in final_scores will still be between 0 and max_score * scale_factor
+    non_eq_metrics_scores
+        .iter()
+        .zip(weights.iter())
+        .for_each(|(metric_score, weight)| {
+            let to_add = metric_score
+                .iter()
+                .map(|x| x * weight)
+                .collect::<Vec<u64>>();
+            final_scores
+                .iter_mut()
+                .zip(to_add.iter())
+                .for_each(|(a, b)| *a += *b);
+        });
+    // Combine equivocation scores into final scores, and scale down. The final
+    // scores will be values between 0 and max_score.
+    final_scores
+        .iter()
+        .zip(eq_scores.iter())
+        .map(|(score, eq_score)| score * eq_score / scale_factor / max_score)
+        .collect()
+}
+
+// Calculate the metric scores for a single metric's median report vector. It
+// returns a vector of values between 0 and max_score
+fn median_report_single_metric_to_score(
+    median_report_for_metric: &MedianMetricVec,
+    metric_allowance: u64,
+    metric_max: u64,
+    max_score: u64,
+) -> Vec<u64> {
+    median_report_for_metric
+        .iter()
+        .map(|&report| metric_to_score(report, metric_allowance, metric_max, max_score))
+        .collect()
+}
+
+fn metric_to_score(value: u64, allowance: u64, max: u64, max_score: u64) -> u64 {
+    if value <= allowance {
+        max_score
+    } else if value >= max {
+        0
+    } else {
+        // Add overflow checks
+        (max - value) * max_score / (max - allowance)
+    }
+}
 
 // NOTE: the tests below are going to be finalized in a different PR
 #[cfg(test)]
@@ -99,8 +385,11 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     use iota_protocol_config::{ConsensusChoice, ProtocolConfig};
+    use iota_types::messages_consensus::{MisbehaviorReportV1, VersionedMisbehaviorReport};
 
-    use super::*;
+    use crate::authority::authority_per_epoch_store::scorer::{
+        ParametersV1, Scorer, calculate_median_report, calculate_scores_v1,
+    };
 
     fn mock_protocol_config(consensus_choice: ConsensusChoice) -> ProtocolConfig {
         let mut config = ProtocolConfig::get_for_max_version_UNSAFE();
@@ -108,6 +397,16 @@ mod tests {
         config
     }
 
+    impl Scorer {
+        fn set_reports_for_tests(
+            &self,
+            reports_and_authorities: &[(VersionedMisbehaviorReport, u32)],
+        ) {
+            for (report, authority) in reports_and_authorities.iter() {
+                self.update_received_reports(*authority, report);
+            }
+        }
+    }
     #[test]
     fn test_scorer_initialization() {
         let voting_power = vec![10, 20, 30];
@@ -118,8 +417,8 @@ mod tests {
 
         assert_eq!(scorer.current_scores.len(), committee_size);
         assert_eq!(scorer.invalid_reports_count.len(), committee_size);
-
-        // Add more
+        assert_eq!(scorer.received_metrics.len(), committee_size);
+        assert_eq!(scorer.has_not_sent_report.len(), committee_size);
     }
 
     #[test]
@@ -143,24 +442,221 @@ mod tests {
 
         // After update
         assert_eq!(
-            scorer.invalid_reports_count[authority_index as usize].load(Ordering::Relaxed),
+            scorer.invalid_reports_count[0_usize].load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            scorer.invalid_reports_count[1_usize].load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            scorer.invalid_reports_count[2_usize].load(Ordering::Relaxed),
+            1
+        );
+
+        let authority_index = 1;
+        // Call the method twice
+        scorer.update_invalid_reports_count(authority_index);
+        scorer.update_invalid_reports_count(authority_index);
+
+        // After update
+        assert_eq!(
+            scorer.invalid_reports_count[0_usize].load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            scorer.invalid_reports_count[1_usize].load(Ordering::Relaxed),
+            2
+        );
+        assert_eq!(
+            scorer.invalid_reports_count[2_usize].load(Ordering::Relaxed),
             1
         );
     }
 
     #[test]
     fn test_update_scores() {
-        let voting_power = vec![10, 20, 30];
-
+        let voting_power = vec![2, 5, 20];
         let protocol_config = mock_protocol_config(ConsensusChoice::Mysticeti);
-
         let scorer = Scorer::new(voting_power, &protocol_config);
 
-        // Before calling update_scores, all scores should be 0
+        // Before calling update_scores, all scores should be MAX_SCORE
         for score in scorer.current_scores.iter() {
-            assert_eq!(score.load(Ordering::Relaxed), 0);
+            assert_eq!(
+                score.load(Ordering::Relaxed),
+                scorer.get_parameters_v1().max_score
+            );
         }
 
-        // Add logic
+        // Set some reports for testing
+        let reports_and_authorities = vec![
+            (
+                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                    faulty_blocks_provable: vec![5, 0, 0],
+                    faulty_blocks_unprovable: vec![0, 0, 0],
+                    missing_proposals: vec![0, 0, 0],
+                    equivocations: vec![0, 0, 0],
+                }),
+                0_u32,
+            ),
+            (
+                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                    faulty_blocks_provable: vec![0, 10, 0],
+                    faulty_blocks_unprovable: vec![0, 0, 0],
+                    missing_proposals: vec![0, 0, 0],
+                    equivocations: vec![0, 0, 0],
+                }),
+                1_u32,
+            ),
+            (
+                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                    faulty_blocks_provable: vec![0, 0, 15],
+                    faulty_blocks_unprovable: vec![0, 0, 0],
+                    missing_proposals: vec![0, 0, 0],
+                    equivocations: vec![5, 0, 0],
+                }),
+                2_u32,
+            ),
+        ];
+
+        scorer.set_reports_for_tests(&reports_and_authorities);
+
+        // Call the method
+        scorer.update_scores();
+
+        let expected_score = vec![0, 65536, 45876];
+        // After calling update_scores, scores should be updated
+        let actual_score = scorer
+            .current_scores
+            .iter()
+            .map(|value| value.load(Ordering::Relaxed))
+            .collect::<Vec<u64>>();
+        assert_eq!(actual_score, expected_score);
+    }
+
+    #[test]
+    fn test_calculate_median_report() {
+        let reports_and_voting_power = vec![(
+            VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                faulty_blocks_provable: vec![7, 8, 9],
+                faulty_blocks_unprovable: vec![10, 11, 12],
+                missing_proposals: vec![4, 5, 6],
+                equivocations: vec![1, 2, 3],
+            }),
+            10_u64,
+        )];
+        let median_report = calculate_median_report(&reports_and_voting_power);
+
+        assert_eq!(
+            median_report,
+            vec![
+                vec![7, 8, 9],
+                vec![10, 11, 12],
+                vec![4, 5, 6],
+                vec![1, 2, 3]
+            ]
+        );
+
+        let reports_and_voting_power = vec![
+            (
+                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                    faulty_blocks_provable: vec![7, 8, 9],
+                    faulty_blocks_unprovable: vec![10, 11, 12],
+                    missing_proposals: vec![4, 5, 6],
+                    equivocations: vec![1, 2, 3],
+                }),
+                20_u64,
+            ),
+            (
+                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                    faulty_blocks_provable: vec![70, 80, 90],
+                    faulty_blocks_unprovable: vec![100, 110, 120],
+                    missing_proposals: vec![40, 50, 60],
+                    equivocations: vec![10, 20, 30],
+                }),
+                10_u64,
+            ),
+        ];
+
+        let median_report = calculate_median_report(&reports_and_voting_power);
+
+        assert_eq!(
+            median_report,
+            vec![
+                vec![7, 8, 9],
+                vec![10, 11, 12],
+                vec![4, 5, 6],
+                vec![1, 2, 3]
+            ]
+        );
+
+        let reports_and_voting_power = vec![
+            (
+                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                    faulty_blocks_provable: vec![1, 8, 9],
+                    faulty_blocks_unprovable: vec![10, 15, 12],
+                    missing_proposals: vec![4, 5, 6],
+                    equivocations: vec![1, 20, 3],
+                }),
+                10_u64,
+            ),
+            (
+                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                    faulty_blocks_provable: vec![7, 8, 9],
+                    faulty_blocks_unprovable: vec![10, 11, 12],
+                    missing_proposals: vec![4, 5, 6],
+                    equivocations: vec![1, 2, 0],
+                }),
+                10_u64,
+            ),
+            (
+                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                    faulty_blocks_provable: vec![6, 8, 9],
+                    faulty_blocks_unprovable: vec![10, 11, 12],
+                    missing_proposals: vec![4, 22, 6],
+                    equivocations: vec![1, 2, 30],
+                }),
+                10_u64,
+            ),
+        ];
+
+        let median_report = calculate_median_report(&reports_and_voting_power);
+
+        assert_eq!(
+            median_report,
+            vec![
+                vec![6, 8, 9],
+                vec![10, 11, 12],
+                vec![4, 5, 6],
+                vec![1, 2, 3]
+            ]
+        );
+    }
+
+    #[test]
+    fn test_calculate_scores_v1() {
+        let parameters = ParametersV1 {
+            max_score: 2_u64.pow(16),
+            scale_factor: 2_u64.pow(16),
+            allowances: vec![1, 2, 1000, 0],
+            maximums: vec![5, 10, 5000, 1],
+            weights: vec![
+                2_u64.pow(16) * 30 / 100,
+                2_u64.pow(16) * 10 / 100,
+                2_u64.pow(16) * 35 / 100,
+            ],
+        };
+
+        let median_reports = vec![
+            vec![6, 7, 8],   // faulty blocks provable
+            vec![9, 10, 11], // faulty blocks unprovable
+            vec![3, 4, 5],   // missing proposals
+            vec![0, 1, 2],   // equivocations
+        ];
+
+        let scores = calculate_scores_v1(median_reports, parameters);
+
+        // Check that scores are calculated correctly
+        assert_eq!(scores, vec![40142, 0, 0]);
     }
 }

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -467,7 +467,8 @@ async fn sync_end_of_epoch_checkpoint(
             &authority_state.epoch_store_for_testing().clone(),
             &GasCostSummary::new(0, 0, 0, 0, 0),
             *checkpoint.sequence_number(),
-            0, // epoch_start_timestamp_ms
+            0,      // epoch_start_timestamp_ms
+            vec![], // scores
         )
         .await
         .expect("Failed to create and execute advance epoch tx");

--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -123,6 +123,20 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
                 .set(checkpoint_seq as i64);
         }
 
+        // We also send misbehavior reports to consensus at this point. Misbehavior
+        // reports containing proofs of misbehaviour can be send whenever the
+        // misbehavior is detected, but we choose to send the ones that include only
+        // unprovable counts at this point, due to periodicity reasons and to ensure a
+        // (approximate) synchronization with the score updates.
+        let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
+        let transaction = ConsensusTransaction::new_misbehavior_report(
+            epoch_store.name,
+            &misbehavior_report,
+            checkpoint_seq,
+        );
+        self.sender
+            .submit_to_consensus(&vec![transaction], epoch_store)?;
+
         if checkpoint_timestamp >= self.next_reconfiguration_timestamp_ms {
             // close_epoch is ok if called multiple times
             self.sender.close_epoch(epoch_store);

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1381,7 +1381,8 @@ impl CheckpointBuilder {
 
         batch.write()?;
 
-        // Send all checkpoint sigs to consensus.
+        // Send all checkpoint sigs to consensus. The messages including
+        // MisbehaviorReports are also sent in this step.
         for (summary, contents) in &new_checkpoints {
             self.output
                 .checkpoint_created(summary, contents, &self.epoch_store, &self.store)

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1615,6 +1615,14 @@ impl CheckpointBuilder {
                 }
             }
 
+            // We update the validator scores based on the information contained in the
+            // Scorer. We choose this point in time to do so because we must guarantee that
+            // scores are up to date right before the epoch changes. It also provides a good
+            // update periodicity: updating scores each time a report is received could be
+            // too frequent and not needed, since scores are not used during the epoch
+            // (except for monitoring purposes, which does not need to be 100% exact)
+            self.epoch_store.scorer.update_scores();
+
             let (mut effects, mut signatures): (Vec<_>, Vec<_>) = transactions.into_iter().unzip();
             let epoch_rolling_gas_cost_summary =
                 self.get_epoch_total_gas_cost(last_checkpoint.as_ref().map(|(_, c)| c), &effects);

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1623,6 +1623,13 @@ impl CheckpointBuilder {
             // too frequent and not needed, since scores are not used during the epoch
             // (except for monitoring purposes, which does not need to be 100% exact)
             self.epoch_store.scorer.update_scores();
+            let scores: Vec<u64> = self
+                .epoch_store
+                .scorer
+                .current_scores
+                .iter()
+                .map(|x| x.load(std::sync::atomic::Ordering::Relaxed))
+                .collect();
 
             let (mut effects, mut signatures): (Vec<_>, Vec<_>) = transactions.into_iter().unzip();
             let epoch_rolling_gas_cost_summary =
@@ -1636,6 +1643,7 @@ impl CheckpointBuilder {
                         &mut effects,
                         &mut signatures,
                         sequence_number,
+                        scores,
                     )
                     .await?;
 
@@ -1781,6 +1789,7 @@ impl CheckpointBuilder {
         checkpoint_effects: &mut Vec<TransactionEffects>,
         signatures: &mut Vec<Vec<GenericSignature>>,
         checkpoint: CheckpointSequenceNumber,
+        scores: Vec<u64>,
     ) -> anyhow::Result<(IotaSystemState, Option<SystemEpochInfoEvent>)> {
         let (system_state, system_epoch_info_event, effects) = self
             .state
@@ -1789,6 +1798,7 @@ impl CheckpointBuilder {
                 epoch_total_gas_cost,
                 checkpoint,
                 epoch_start_timestamp_ms,
+                scores,
             )
             .await?;
         checkpoint_effects.push(effects);

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -62,8 +62,9 @@ async fn advance_epoch_tx_test() {
                 .create_and_execute_advance_epoch_tx(
                     &state.epoch_store_for_testing(),
                     &GasCostSummary::new(0, 0, 0, 0, 0),
-                    0, // checkpoint
-                    0, // epoch_start_timestamp_ms
+                    0,      // checkpoint
+                    0,      // epoch_start_timestamp_ms
+                    vec![], // scores
                 )
                 .await
                 .unwrap();

--- a/crates/iota-framework/packages/iota-system/sources/iota_system.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system.move
@@ -532,6 +532,7 @@ fun advance_epoch(
     epoch_start_timestamp_ms: u64, // Timestamp of the epoch start
     max_committee_members_count: u64,
     eligible_active_validators: vector<u64>,
+    scores : vector<u64>,
     ctx: &mut TxContext,
 ): Balance<IOTA> {
     let self = load_system_state_mut(wrapper);
@@ -550,6 +551,7 @@ fun advance_epoch(
         epoch_start_timestamp_ms,
         max_committee_members_count,
         eligible_active_validators,
+        scores,
         ctx,
     );
 
@@ -765,6 +767,7 @@ public(package) fun advance_epoch_for_testing(
     epoch_start_timestamp_ms: u64,
     max_committee_members_count: u64,
     eligible_active_validators: vector<u64>,
+    scores : vector<u64>,
     ctx: &mut TxContext,
 ): Balance<IOTA> {
     let storage_charge = balance::create_for_testing(storage_charge);
@@ -783,6 +786,7 @@ public(package) fun advance_epoch_for_testing(
         epoch_start_timestamp_ms,
         max_committee_members_count,
         eligible_active_validators,
+        scores,
         ctx,
     );
     storage_rebate

--- a/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
@@ -735,6 +735,7 @@ public(package) fun advance_epoch(
     epoch_start_timestamp_ms: u64, // Timestamp of the epoch start
     max_committee_members_count: u64,
     eligible_active_validators: vector<u64>,
+    scores: vector<u64>,
     ctx: &mut TxContext,
 ): Balance<IOTA> {
     self.epoch_start_timestamp_ms = epoch_start_timestamp_ms;
@@ -792,6 +793,7 @@ public(package) fun advance_epoch(
             self.parameters.validator_low_stake_grace_period,
             max_committee_members_count,
             eligible_active_validators,
+            scores,
             ctx,
         );
 

--- a/crates/iota-framework/packages/iota-system/sources/validator_set.move
+++ b/crates/iota-framework/packages/iota-system/sources/validator_set.move
@@ -140,6 +140,7 @@ const ACTIVE_OR_PENDING_VALIDATOR: u8 = 2;
 const ANY_VALIDATOR: u8 = 3;
 
 const BASIS_POINT_DENOMINATOR: u128 = 10000;
+const MAX_SCORE: u128 = 65536; // Note: must be consistent with max score used in iota-core.
 const MIN_STAKING_THRESHOLD: u64 = 1_000_000_000; // 1 IOTA
 
 // Errors
@@ -161,6 +162,7 @@ const EValidatorSetEmpty: u64 = 13;
 const ENotACommitteeValidator: u64 = 14;
 const EInvalidStakeAmount: u64 = 15;
 const EInvalidEligibleValidatorIndex: u64 = 16;
+const EInvalidRewardAdjustmentData: u64 = 19;
 
 const EInvalidCap: u64 = 101;
 
@@ -457,12 +459,13 @@ public(package) fun advance_epoch(
     low_stake_grace_period: u64,
     committee_size: u64,
     eligible_active_validators: vector<u64>,
+    scores: vector<u64>,
     ctx: &mut TxContext,
 ) {
     let new_epoch = ctx.epoch() + 1;
     let total_voting_power = voting_power::total_voting_power();
 
-    // Compute the reward distribution without taking into account the tallying rule slashing.
+    // Compute the reward distribution without taking into account the scores or reporting.
     let unadjusted_staking_reward_amounts = compute_unadjusted_reward_distribution(
         &self.active_validators,
         &self.committee_members,
@@ -482,6 +485,7 @@ public(package) fun advance_epoch(
         unadjusted_staking_reward_amounts,
         get_validator_indices_set(&self.active_validators, &slashed_validators),
         reward_slashing_rate,
+        scores,
     );
 
     // Distribute the rewards before adjusting stake so that we immediately start compounding
@@ -506,6 +510,7 @@ public(package) fun advance_epoch(
         &adjusted_staking_reward_amounts,
         validator_report_records,
         &slashed_validators,
+        scores,
     );
 
     // Collect committee validator addresses before modifying the `active_validators`.
@@ -1326,14 +1331,22 @@ fun compute_adjusted_reward_distribution(
     unadjusted_staking_reward_amounts: vector<u64>,
     slashed_validator_indices_set: VecSet<u64>,
     reward_slashing_rate: u64,
+    scores: vector<u64>,
 ): vector<u64> {
     let mut adjusted_staking_reward_amounts = vector[];
 
     // Loop through each validator and adjust rewards as necessary
     let length = committee_members.length();
+    assert!(unadjusted_staking_reward_amounts.length() == scores.length(), EInvalidRewardAdjustmentData);
+    assert!(length == unadjusted_staking_reward_amounts.length(), EInvalidRewardAdjustmentData);
+
     let mut i = 0;
     while (i < length) {
         let unadjusted_staking_reward_amount = unadjusted_staking_reward_amounts[i];
+
+        // Calculate staking reward amount adjusted for the validator's score
+        let score_adjusted_staking_reward_amount = scores[i] as u128 * (unadjusted_staking_reward_amount as u128)
+            / MAX_SCORE;
 
         // Check if the validator is slashed
         let adjusted_staking_reward_amount = if (
@@ -1342,15 +1355,14 @@ fun compute_adjusted_reward_distribution(
             // Use the slashing rate to compute the amount of staking rewards slashed from this punished validator.
             // Use u128 to avoid multiplication overflow.
             let staking_reward_adjustment_u128 =
-                ((unadjusted_staking_reward_amount as u128) * (reward_slashing_rate as u128)) / BASIS_POINT_DENOMINATOR;
-            unadjusted_staking_reward_amount - (staking_reward_adjustment_u128 as u64)
+                (score_adjusted_staking_reward_amount * (reward_slashing_rate as u128)) / BASIS_POINT_DENOMINATOR;
+            score_adjusted_staking_reward_amount - staking_reward_adjustment_u128
         } else {
             // Otherwise, unadjusted staking reward amount is assigned to the unslashed validators
-            unadjusted_staking_reward_amount
+            score_adjusted_staking_reward_amount
         };
 
-        adjusted_staking_reward_amounts.push_back(adjusted_staking_reward_amount);
-
+        adjusted_staking_reward_amounts.push_back(adjusted_staking_reward_amount as u64);
         // Move to the next validator
         i = i + 1;
     };
@@ -1408,6 +1420,7 @@ fun emit_validator_epoch_events(
     pool_staking_reward_amounts: &vector<u64>,
     report_records: &VecMap<address, VecSet<address>>,
     slashed_validators: &vector<address>,
+    scores: vector<u64>,
 ) {
     assert!(committee_members.length() == pool_staking_reward_amounts.length());
     let mut i = 0;
@@ -1418,9 +1431,9 @@ fun emit_validator_epoch_events(
         } else {
             vector[]
         };
-        let tallying_rule_global_score = if (slashed_validators.contains(&validator_address)) 0
-        else 1;
         let mut committee_member_index = committee_members.find_index!(|c| c == i);
+        let tallying_rule_global_score = if (slashed_validators.contains(&validator_address) || !committee_member_index.is_some()) 0
+        else scores[committee_member_index.extract()];
         let pool_staking_reward = if (committee_member_index.is_some()) {
             // prepare event for a committee validator
             pool_staking_reward_amounts[committee_member_index.extract()]

--- a/crates/iota-framework/packages/iota-system/tests/governance_test_utils.move
+++ b/crates/iota-framework/packages/iota-system/tests/governance_test_utils.move
@@ -190,6 +190,11 @@ public fun advance_epoch_with_reward_amounts_return_rebate_and_max_committee_mem
         |i| i,
     );
 
+    let scores = vector::tabulate!(
+        system_state.committee_validator_addresses().length(),
+        |_| 65536u64,    
+    );
+
     let storage_rebate = system_state.advance_epoch_for_testing(
         new_epoch,
         1,
@@ -203,6 +208,7 @@ public fun advance_epoch_with_reward_amounts_return_rebate_and_max_committee_mem
         0,
         max_committee_members_count,
         eligible_active_validators,
+        scores,
         ctx,
     );
     test_scenario::return_shared(system_state);
@@ -285,6 +291,11 @@ public fun advance_epoch_with_reward_amounts_and_slashing_rates(
         |i| i,
     );
 
+    let scores = vector::tabulate!(
+        system_state.committee_validator_addresses().length(),
+        |_| 65536u64,    
+    );
+
     // Use the same value as the default value of max_active_validators.
     let max_committee_members_count = 150;
 
@@ -301,6 +312,47 @@ public fun advance_epoch_with_reward_amounts_and_slashing_rates(
         0,
         max_committee_members_count,
         eligible_active_validators,
+        scores,
+        ctx,
+    );
+    test_utils::destroy(storage_rebate);
+    test_scenario::return_shared(system_state);
+    scenario.next_epoch(@0x0);
+}
+
+public fun advance_epoch_with_subsidy_and_scores(
+    validator_subsidy: u64,
+    scores: vector<u64>,
+    scenario: &mut Scenario,
+) {
+    scenario.next_tx(@0x0);
+    let new_epoch = scenario.ctx().epoch() + 1;
+    let mut system_state = scenario.take_shared<IotaSystemState>();
+
+    let ctx = scenario.ctx();
+
+    let eligible_active_validators = vector::tabulate!(
+        system_state.validators().active_validators_inner().length(),
+        |i| i,
+    );
+
+    // Use the same value as the default value of max_active_validators.
+    let max_committee_members_count = 150;
+
+    let storage_rebate = system_state.advance_epoch_for_testing(
+        new_epoch,
+        1,
+        validator_subsidy * NANOS_PER_IOTA,
+        0,
+        0,
+        0,
+        0,
+        0,
+        10000, // 100% slashing
+        0,
+        max_committee_members_count,
+        eligible_active_validators,
+        scores,
         ctx,
     );
     test_utils::destroy(storage_rebate);

--- a/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
+++ b/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
@@ -16,6 +16,7 @@ use iota_system::governance_test_utils::{
     advance_epoch_with_reward_amounts_return_rebate,
     advance_epoch_with_reward_amounts_and_slashing_rates,
     advance_epoch_with_amounts,
+    advance_epoch_with_subsidy_and_scores,
     assert_validator_total_stake_amounts,
     assert_validator_non_self_stake_amounts,
     assert_validator_self_stake_amounts,
@@ -1455,6 +1456,92 @@ fun test_pool_tokens_minted() {
     assert!(pool_token_amount_epoch_5 == pool_token_amount_epoch_6, 0);
 
     test_scenario::return_shared(system_state);
+    scenario_val.end();
+}
+
+#[test]
+fun test_rewards_with_scores() {
+    set_up_iota_system_state();
+    let mut scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+    let scenario = &mut scenario_val;
+
+    // Need to advance epoch so validator's staking starts counting.
+    advance_epoch(scenario);
+
+    // Set validator scores.
+    let system_state = scenario.take_shared<IotaSystemState>();
+    let max_score = 65_536u64;
+    let scores = vector[
+        max_score / 4,    // Validator 1
+        max_score / 2,    // Validator 2
+        (max_score * 3) / 4,  // Validator 3
+        max_score,        // Validator 4
+    ];
+    test_scenario::return_shared(system_state);
+
+    // Advance epoch with 800 IOTA of subsidy and the above scores.
+    advance_epoch_with_subsidy_and_scores(800, scores, scenario);
+
+    // Check that the rewards were distributed according to the scores.
+    // Each pool gets +200 IOTA. 
+    assert_validator_self_stake_amounts(
+        validator_addrs(),
+        vector[ 
+            (100 + 50) * NANOS_PER_IOTA, // 200 * 1/4 = 50
+            (200 + 100) * NANOS_PER_IOTA, // 200 * 1/2 = 100
+            (300 + 150) * NANOS_PER_IOTA, // 200 * 3/4 = 150
+            (400 + 200) * NANOS_PER_IOTA, // 200 * 1 = 200
+        ],
+        scenario,
+    );
+
+    scenario_val.end();
+}
+
+#[test]
+fun test_rewards_with_scores_and_slashing() {
+    set_up_iota_system_state();
+    let mut scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+    let scenario = &mut scenario_val;
+
+    // Need to advance epoch so validator's staking starts counting.
+    advance_epoch(scenario);
+
+    // Set validator scores.
+    let system_state = scenario.take_shared<IotaSystemState>();
+    let max_score = 65_536u64;
+    let scores = vector[
+        max_score / 4,    // Validator 1
+        max_score / 2,    // Validator 2
+        (max_score * 3) / 4,  // Validator 3
+        max_score,        // Validator 4
+    ];
+    test_scenario::return_shared(system_state);
+
+    // validators 2 and 4 reported by all others, so they get slashed.
+    report_validator(VALIDATOR_ADDR_1, VALIDATOR_ADDR_2, scenario);
+    report_validator(VALIDATOR_ADDR_3, VALIDATOR_ADDR_2, scenario);
+    report_validator(VALIDATOR_ADDR_4, VALIDATOR_ADDR_2, scenario);
+    report_validator(VALIDATOR_ADDR_1, VALIDATOR_ADDR_4, scenario);
+    report_validator(VALIDATOR_ADDR_2, VALIDATOR_ADDR_4, scenario);
+    report_validator(VALIDATOR_ADDR_3, VALIDATOR_ADDR_4, scenario);
+
+    // Advance epoch with 800 IOTA of subsidy and the above scores.
+    advance_epoch_with_subsidy_and_scores(800, scores, scenario);
+
+    // Check that the rewards were distributed according to the scores.
+    // Each pool gets +200 IOTA. 
+    assert_validator_self_stake_amounts(
+        validator_addrs(),
+        vector[ 
+            (100 + 50) * NANOS_PER_IOTA, // 200 * 1/4 = 50
+            (200) * NANOS_PER_IOTA, // slashed
+            (300 + 150) * NANOS_PER_IOTA, // 200 * 3/4 = 150
+            (400) * NANOS_PER_IOTA, // slashed 
+        ],
+        scenario,
+    );
+
     scenario_val.end();
 }
 

--- a/crates/iota-framework/packages/iota-system/tests/validator_set_tests.move
+++ b/crates/iota-framework/packages/iota-system/tests/validator_set_tests.move
@@ -975,6 +975,11 @@ fun advance_epoch_with_dummy_rewards(
         |i| i,
     );
 
+   let scores = vector::tabulate!(
+        validator_set.committee_validator_addresses().length(),
+        |_| 65536u64,    
+    );
+
     validator_set.advance_epoch(
         &mut dummy_computation_charge,
         &mut vec_map::empty(),
@@ -984,6 +989,7 @@ fun advance_epoch_with_dummy_rewards(
         0, // low_stake_grace_period
         committee_size,
         eligible_validators,
+        scores,
         scenario.ctx(),
     );
 
@@ -999,6 +1005,13 @@ fun advance_epoch_with_eligible_validators(
     scenario.next_epoch(@0x0);
     let mut dummy_computation_charge = balance::zero();
 
+
+
+    let scores = vector::tabulate!(
+        validator_set.committee_validator_addresses().length(),
+        |_| 65536u64,    
+    );
+
     validator_set.advance_epoch(
         &mut dummy_computation_charge,
         &mut vec_map::empty(),
@@ -1008,6 +1021,7 @@ fun advance_epoch_with_eligible_validators(
         0, // low_stake_grace_period
         committee_size,
         eligible_validators,
+        scores,
         scenario.ctx(),
     );
 
@@ -1031,6 +1045,11 @@ fun advance_epoch_with_low_stake_params(
         |i| i,
     );
 
+   let scores = vector::tabulate!(
+        validator_set.committee_validator_addresses().length(),
+        |_| 65536u64,    
+    );
+
     validator_set.advance_epoch(
         &mut dummy_computation_charge,
         &mut vec_map::empty(),
@@ -1040,6 +1059,7 @@ fun advance_epoch_with_low_stake_params(
         low_stake_grace_period,
         committee_size,
         eligible_validators,
+        scores,
         scenario.ctx(),
     );
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1448,7 +1448,12 @@ impl ProtocolConfig {
     }
 
     pub fn score_based_rewards(&self) -> bool {
-        self.feature_flags.score_based_rewards
+        let score_based_rewards = self.feature_flags.score_based_rewards;
+        assert!(
+            !score_based_rewards || self.scorer_version.is_some(),
+            "score_based_rewards requires scorer_version to be set"
+        );
+        score_based_rewards
     }
 }
 

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -450,6 +450,7 @@ pub struct AdvanceEpochParams {
     pub epoch_start_timestamp_ms: u64,
     pub max_committee_members_count: u64,
     pub eligible_active_validators: Vec<u64>,
+    pub scores: Vec<u64>,
 }
 
 #[cfg(msim)]

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -294,6 +294,13 @@ impl VersionedMisbehaviorReport {
             VersionedMisbehaviorReport::V1(report) => report.verify(committee_size),
         }
     }
+
+    /// Returns an iterator over references to some of the fields in the report.
+    pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&Vec<u64>> {
+        match self {
+            VersionedMisbehaviorReport::V1(report) => report.iterate_over_metrics_v1(),
+        }
+    }
 }
 
 // MisbehaviorReportV1 contains lists of faulty blocks, equivocation and missing
@@ -324,6 +331,16 @@ impl MisbehaviorReportV1 {
             return false;
         }
         true
+    }
+
+    fn iterate_over_metrics_v1(&self) -> std::vec::IntoIter<&Vec<u64>> {
+        vec![
+            &self.faulty_blocks_provable,
+            &self.faulty_blocks_unprovable,
+            &self.missing_proposals,
+            &self.equivocations,
+        ]
+        .into_iter()
     }
 }
 

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -310,7 +310,7 @@ pub struct MisbehaviorReportV1 {
 impl MisbehaviorReportV1 {
     pub fn verify(&self, committee_size: usize) -> bool {
         // This version of reports are valid as long as they contain the counts for all
-        // authorities.  Future versions may contain proofs that need verification.
+        // authorities. Future versions may contain proofs that need verification.
         // However, since the validity of a proof is deeply coupled with the protocol
         // version and the consensus mechanism being used, we cannot verify it here. In
         // the future, reports should be unwrapped (or translated) to a type verifiable

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -20,8 +20,7 @@ use shared_crypto::intent::IntentScope;
 
 use crate::{
     base_types::{
-        AuthorityName, CommitRound, ConciseableName, ObjectID, ObjectRef, SequenceNumber,
-        TransactionDigest,
+        AuthorityName, ConciseableName, ObjectID, ObjectRef, SequenceNumber, TransactionDigest,
     },
     crypto::{AuthoritySignature, DefaultHash},
     digests::{ConsensusCommitDigest, Digest},
@@ -91,10 +90,10 @@ pub enum ConsensusTransactionKey {
     NewJWKFetched(Box<(AuthorityName, JwkId, JWK)>),
     RandomnessDkgMessage(AuthorityName),
     RandomnessDkgConfirmation(AuthorityName),
-    // If a validator submits more than one report for the same round, we update the
-    // scoring metrics using the maximum reported metric, so CommitRound is sufficient to
-    // identify a report from a single AuthorityName.
-    MisbehaviorReport(AuthorityName, CommitRound),
+    // If a validator submits more than one report for the same checkpoint, we update the
+    // scoring metrics using the maximum reported metric, so the checkpoint sequence number is
+    // sufficient to identify a report from a single AuthorityName.
+    MisbehaviorReport(AuthorityName, u64 /* checkpoint_seq */),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -107,8 +106,13 @@ impl Debug for ConsensusTransactionKey {
                 write!(f, "CheckpointSignature({:?}, {:?})", name.concise(), seq)
             }
             Self::EndOfPublish(name) => write!(f, "EndOfPublish({:?})", name.concise()),
-            Self::MisbehaviorReport(name, round) => {
-                write!(f, "MisbehaviorReport({:?},{:?})", name.concise(), round)
+            Self::MisbehaviorReport(name, checkpoint_seq) => {
+                write!(
+                    f,
+                    "MisbehaviorReport({:?},{:?})",
+                    name.concise(),
+                    checkpoint_seq
+                )
             }
             Self::CapabilityNotification(name, generation) => write!(
                 f,
@@ -268,7 +272,11 @@ pub enum ConsensusTransactionKind {
     // of `RandomnessDkgMessages` have been received locally, to complete the key generation
     // process. Contents are a serialized `fastcrypto_tbls::dkg::Confirmation`.
     RandomnessDkgConfirmation(AuthorityName, Vec<u8>),
-    MisbehaviorReport(AuthorityName, VersionedMisbehaviorReport, CommitRound),
+    MisbehaviorReport(
+        AuthorityName,
+        VersionedMisbehaviorReport,
+        u64, // checkpoint_seq
+    ),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -563,10 +571,10 @@ impl ConsensusTransaction {
         }
     }
 
-    pub fn new_misbehavior_report_v1(
+    pub fn new_misbehavior_report(
         authority: AuthorityName,
-        report: &MisbehaviorsV1<Vec<u64>>,
-        round: CommitRound,
+        report: &VersionedMisbehaviorReport,
+        checkpoint_seq: u64,
     ) -> Self {
         let serialized_report =
             bcs::to_bytes(report).expect("report serialization should not fail");
@@ -577,8 +585,8 @@ impl ConsensusTransaction {
             tracking_id,
             kind: ConsensusTransactionKind::MisbehaviorReport(
                 authority,
-                VersionedMisbehaviorReport::V1(report.clone()),
-                round,
+                report.clone(),
+                checkpoint_seq,
             ),
         }
     }
@@ -603,8 +611,8 @@ impl ConsensusTransaction {
             ConsensusTransactionKind::EndOfPublish(authority) => {
                 ConsensusTransactionKey::EndOfPublish(*authority)
             }
-            ConsensusTransactionKind::MisbehaviorReport(authority, _, round) => {
-                ConsensusTransactionKey::MisbehaviorReport(*authority, *round)
+            ConsensusTransactionKind::MisbehaviorReport(authority, _, checkpoint_seq) => {
+                ConsensusTransactionKey::MisbehaviorReport(*authority, *checkpoint_seq)
             }
             ConsensusTransactionKind::CapabilityNotificationV1(cap) => {
                 ConsensusTransactionKey::CapabilityNotification(cap.authority, cap.generation)

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -285,7 +285,7 @@ impl ConsensusTransactionKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum VersionedMisbehaviorReport {
-    V1(MisbehaviorReportV1),
+    V1(MisbehaviorsV1<Vec<u64>>),
 }
 
 impl VersionedMisbehaviorReport {
@@ -298,23 +298,24 @@ impl VersionedMisbehaviorReport {
     /// Returns an iterator over references to some of the fields in the report.
     pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&Vec<u64>> {
         match self {
-            VersionedMisbehaviorReport::V1(report) => report.iterate_over_metrics_v1(),
+            VersionedMisbehaviorReport::V1(report) => report.iter(),
         }
     }
 }
 
-// MisbehaviorReportV1 contains lists of faulty blocks, equivocation and missing
-// proposal counts for each authority. This first version does not include any
-// type of proof.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MisbehaviorReportV1 {
-    pub faulty_blocks_provable: Vec<u64>,
-    pub faulty_blocks_unprovable: Vec<u64>,
-    pub equivocations: Vec<u64>,
-    pub missing_proposals: Vec<u64>,
+// MisbehaviorsV1 contains lists of all metrics used in v1 of misbehavior
+// reports, with a value for each metric. The metrics (misbeheaviors) include,
+// faulty blocks, equivocation and missing proposal counts for each authority.
+// This first version does not include any type of proof.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MisbehaviorsV1<T> {
+    pub faulty_blocks_provable: T,
+    pub faulty_blocks_unprovable: T,
+    pub missing_proposals: T,
+    pub equivocations: T,
 }
 
-impl MisbehaviorReportV1 {
+impl MisbehaviorsV1<Vec<u64>> {
     pub fn verify(&self, committee_size: usize) -> bool {
         // This version of reports are valid as long as they contain the counts for all
         // authorities. Future versions may contain proofs that need verification.
@@ -332,8 +333,9 @@ impl MisbehaviorReportV1 {
         }
         true
     }
-
-    fn iterate_over_metrics_v1(&self) -> std::vec::IntoIter<&Vec<u64>> {
+}
+impl<T> MisbehaviorsV1<T> {
+    pub fn iter(&self) -> std::vec::IntoIter<&T> {
         vec![
             &self.faulty_blocks_provable,
             &self.faulty_blocks_unprovable,
@@ -341,6 +343,33 @@ impl MisbehaviorReportV1 {
             &self.equivocations,
         ]
         .into_iter()
+    }
+    // Returns an iterator over references to major misbehavior fields in the
+    // report. Major misbehaviors carry a higher penalty in the scoring system.
+    pub fn iter_major_misbehaviors(&self) -> std::vec::IntoIter<&T> {
+        vec![&self.equivocations].into_iter()
+    }
+    // Returns an iterator over references to minor misbehavior fields in the
+    // report. Minor misbehaviors carry a lower penalty in the scoring system.
+    pub fn iter_minor_misbehaviors(&self) -> std::vec::IntoIter<&T> {
+        vec![
+            &self.faulty_blocks_provable,
+            &self.faulty_blocks_unprovable,
+            &self.missing_proposals,
+        ]
+        .into_iter()
+    }
+}
+
+impl<T> FromIterator<T> for MisbehaviorsV1<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut iterator = iter.into_iter();
+        Self {
+            faulty_blocks_provable: iterator.next().expect("Not enough elements in iterator"),
+            faulty_blocks_unprovable: iterator.next().expect("Not enough elements in iterator"),
+            missing_proposals: iterator.next().expect("Not enough elements in iterator"),
+            equivocations: iterator.next().expect("Not enough elements in iterator"),
+        }
     }
 }
 
@@ -536,7 +565,7 @@ impl ConsensusTransaction {
 
     pub fn new_misbehavior_report_v1(
         authority: AuthorityName,
-        report: &MisbehaviorReportV1,
+        report: &MisbehaviorsV1<Vec<u64>>,
         round: CommitRound,
     ) -> Self {
         let serialized_report =

--- a/crates/iota-types/src/scoring_metrics.rs
+++ b/crates/iota-types/src/scoring_metrics.rs
@@ -21,6 +21,7 @@ pub enum VersionedScoringMetrics {
 // Basic getters, setters and increments for the metrics.
 impl VersionedScoringMetrics {
     pub fn new(committee_size: usize, protocol_config: &ProtocolConfig) -> Self {
+        // Any version of ScoringMetrics created here must be initialized to zero.
         match protocol_config.scorer_version_as_option() {
             None | Some(1) => VersionedScoringMetrics::V1(ScoringMetricsV1::new(committee_size)),
             _ => panic!("Unsupported scorer version"),
@@ -259,8 +260,8 @@ impl VersionedScoringMetrics {
                 VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
                     faulty_blocks_provable,
                     faulty_blocks_unprovable,
-                    equivocations,
                     missing_proposals,
+                    equivocations,
                 })
             }
         }
@@ -270,8 +271,8 @@ impl VersionedScoringMetrics {
 pub struct ScoringMetricsV1 {
     faulty_blocks_provable: Vec<AtomicU64>,
     faulty_blocks_unprovable: Vec<AtomicU64>,
-    equivocations: Vec<AtomicU64>,
     missing_proposals: Vec<AtomicU64>,
+    equivocations: Vec<AtomicU64>,
 }
 
 impl ScoringMetricsV1 {
@@ -281,11 +282,11 @@ impl ScoringMetricsV1 {
             faulty_blocks_provable: (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
             // Blocks considered faulty before passing the signature check.
             faulty_blocks_unprovable: (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
+            // Number or rounds that the authority did not propose any block
+            missing_proposals: (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
             // Number of additional blocks issued by a validator within rounds where another block
             // was already produced by them.
             equivocations: (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
-            // Number or rounds that the authority did not propose any block
-            missing_proposals: (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
         }
     }
 }

--- a/crates/iota-types/src/scoring_metrics.rs
+++ b/crates/iota-types/src/scoring_metrics.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use iota_protocol_config::ProtocolConfig;
 
-use crate::messages_consensus::{MisbehaviorReportV1, VersionedMisbehaviorReport};
+use crate::messages_consensus::{MisbehaviorsV1, VersionedMisbehaviorReport};
 
 // This struct represents the scoring metrics collected by all authorities. They
 // are stored locally by each authority and then converted to a misbehavior
@@ -257,7 +257,7 @@ impl VersionedScoringMetrics {
                     .iter()
                     .map(|metric| metric.load(Ordering::Relaxed))
                     .collect();
-                VersionedMisbehaviorReport::V1(MisbehaviorReportV1 {
+                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
                     faulty_blocks_provable,
                     faulty_blocks_unprovable,
                     missing_proposals,

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -494,6 +494,34 @@ impl EndOfEpochTransactionKind {
         })
     }
 
+    pub fn new_change_epoch_v4(
+        next_epoch: EpochId,
+        protocol_version: ProtocolVersion,
+        storage_charge: u64,
+        computation_charge: u64,
+        computation_charge_burned: u64,
+        storage_rebate: u64,
+        non_refundable_storage_fee: u64,
+        epoch_start_timestamp_ms: u64,
+        system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>,
+        eligible_active_validators: Vec<u64>,
+        scores: Vec<u64>,
+    ) -> Self {
+        Self::ChangeEpochV4(ChangeEpochV4 {
+            epoch: next_epoch,
+            protocol_version,
+            storage_charge,
+            computation_charge,
+            computation_charge_burned,
+            storage_rebate,
+            non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            system_packages,
+            eligible_active_validators,
+            scores,
+        })
+    }
+
     pub fn new_authenticator_state_expire(
         min_epoch: u64,
         authenticator_obj_initial_shared_version: SequenceNumber,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -948,6 +948,31 @@ mod checked {
         construct_advance_epoch_pt_impl(builder, params, call_arg_vec)
     }
 
+    pub fn construct_advance_epoch_pt_v4(
+        builder: ProgrammableTransactionBuilder,
+        params: &AdvanceEpochParams,
+    ) -> Result<ProgrammableTransaction, ExecutionError> {
+        // the first three arguments to the advance_epoch function, namely
+        // validator_subsidy, storage_charges and computation_charges, are
+        // common to both v1, v2, v3 and v4 and are added in
+        // `construct_advance_epoch_pt_impl`. The remaining arguments are added
+        // here.
+        let call_arg_vec = vec![
+            CallArg::Pure(bcs::to_bytes(&params.computation_charge_burned).unwrap()), /* computation_charge_burned: u64 */
+            CallArg::IOTA_SYSTEM_MUT, // wrapper: &mut IotaSystemState
+            CallArg::Pure(bcs::to_bytes(&params.epoch).unwrap()), // new_epoch: u64
+            CallArg::Pure(bcs::to_bytes(&params.next_protocol_version.as_u64()).unwrap()), /* next_protocol_version: u64 */
+            CallArg::Pure(bcs::to_bytes(&params.storage_rebate).unwrap()), // storage_rebate: u64
+            CallArg::Pure(bcs::to_bytes(&params.non_refundable_storage_fee).unwrap()), /* non_refundable_storage_fee: u64 */
+            CallArg::Pure(bcs::to_bytes(&params.reward_slashing_rate).unwrap()), /* reward_slashing_rate: u64 */
+            CallArg::Pure(bcs::to_bytes(&params.epoch_start_timestamp_ms).unwrap()), /* epoch_start_timestamp_ms: u64 */
+            CallArg::Pure(bcs::to_bytes(&params.max_committee_members_count).unwrap()), /* max_committee_members_count: u64 */
+            CallArg::Pure(bcs::to_bytes(&params.eligible_active_validators).unwrap()), /* eligible_active_validators: Vec<u64> */
+            CallArg::Pure(bcs::to_bytes(&params.scores).unwrap()), // scores: Vec<u64>
+        ];
+        construct_advance_epoch_pt_impl(builder, params, call_arg_vec)
+    }
+
     /// Advances the epoch by executing a `ProgrammableTransaction`. If the
     /// transaction fails, it switches to safe mode and retries the epoch
     /// advancement in a more controlled environment. The function also
@@ -1045,6 +1070,7 @@ mod checked {
             // separate AdvanceEpochParams struct.
             max_committee_members_count: 0,
             eligible_active_validators: vec![],
+            scores: vec![],
         };
         let advance_epoch_pt = construct_advance_epoch_pt_v1(builder, &params)?;
         advance_epoch_impl(
@@ -1087,9 +1113,10 @@ mod checked {
             reward_slashing_rate: protocol_config.reward_slashing_rate(),
             epoch_start_timestamp_ms: change_epoch_v2.epoch_start_timestamp_ms,
             max_committee_members_count: protocol_config.max_committee_members_count(),
-            // AdvanceEpochV2 does not use this field, but keeping them to avoid creating a
+            // AdvanceEpochV2 does not use these fields, but keeping them to avoid creating a
             // separate AdvanceEpochParams struct.
             eligible_active_validators: vec![],
+            scores: vec![],
         };
         let advance_epoch_pt = construct_advance_epoch_pt_v2(builder, &params)?;
         advance_epoch_impl(
@@ -1133,6 +1160,9 @@ mod checked {
             epoch_start_timestamp_ms: change_epoch_v3.epoch_start_timestamp_ms,
             max_committee_members_count: protocol_config.max_committee_members_count(),
             eligible_active_validators: change_epoch_v3.eligible_active_validators,
+            // AdvanceEpochV3 does not use these fields, but keeping them to avoid creating a
+            // separate AdvanceEpochParams struct.
+            scores: vec![],
         };
         let advance_epoch_pt = construct_advance_epoch_pt_v3(builder, &params)?;
         advance_epoch_impl(
@@ -1163,7 +1193,6 @@ mod checked {
         metrics: Arc<LimitsMetrics>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> Result<(), ExecutionError> {
-        // To do: pass scores
         let params = AdvanceEpochParams {
             epoch: change_epoch_v4.epoch,
             next_protocol_version: change_epoch_v4.protocol_version,
@@ -1177,8 +1206,9 @@ mod checked {
             epoch_start_timestamp_ms: change_epoch_v4.epoch_start_timestamp_ms,
             max_committee_members_count: protocol_config.max_committee_members_count(),
             eligible_active_validators: change_epoch_v4.eligible_active_validators,
+            scores: change_epoch_v4.scores,
         };
-        let advance_epoch_pt = construct_advance_epoch_pt_v3(builder, &params)?;
+        let advance_epoch_pt = construct_advance_epoch_pt_v4(builder, &params)?;
         advance_epoch_impl(
             advance_epoch_pt,
             params,


### PR DESCRIPTION
```mermaid
---
config:
  gitGraph:
    {parallelCommits: true,
    mainBranchName: 'Feature',
    rotateCommitLabel: true}
---
gitGraph
   commit id: "Initial commit"
   commit id: "Old Scorer" tag: "PR8530"
  commit id: "add ChangeEpochV4" tag: "PR9159"
    commit id: "add MisbehaviorReports" tag: "PR9175"
   commit id: "add ScoringMetrics" tag: "PR9176"
   commit id: "add Scorer" tag: "PR9177"
   commit id: "add ScoringMetricsStore" tag: "PR9178"
commit id: "add report validation" tag: "PR9362"
   checkout Feature
branch scoring-function
commit id: "add scoring function" 
branch report-creation
commit id: "add report creation" 
checkout Feature
merge  scoring-function tag: "THIS PR"
```
# Description of change

We Introduce the scoring formulas used for the validator report mechanism, which where only placeholder before this PR.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Introduce new scoring formulas for the validator score mechanism
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
