### PR TITLE
feat(iota-core): Add report validation logic

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3946,7 +3946,7 @@ impl AuthorityPerEpochStore {
                     // Since this verification happens after consensus, all authorities already
                     // agreed on the set of messages that would be verified by this method. Then, we
                     // can update scores according to the validation result directly, without the
-                    // need of any aditional step (as propagating opinions about validity).
+                    // need of any additional step (as propagating opinions about validity).
                     self.scorer.update_invalid_reports_count(authority_index);
                     warn!(
                         "Received invalid misbehavior report from {:?}",

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3941,12 +3941,9 @@ impl AuthorityPerEpochStore {
                     .committee
                     .authority_index(authority)
                     .expect("authority in committee");
-                // Check validity of the report
+                // Check validity of the report and update scores depending on the result. We
+                // already have consensus on inclusion of this report in the DAG.
                 if !report.verify(self.committee.num_members()) {
-                    // Since this verification happens after consensus, all authorities already
-                    // agreed on the set of messages that would be verified by this method. Then, we
-                    // can update scores according to the validation result directly, without the
-                    // need of any additional step (as propagating opinions about validity).
                     self.scorer.update_invalid_reports_count(authority_index);
                     warn!(
                         "Received invalid misbehavior report from {:?}",

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3934,10 +3934,28 @@ impl AuthorityPerEpochStore {
                 panic!("process_consensus_transaction called with end-of-publish transaction");
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::MisbehaviorReport(_authority, _report, _),
+                kind: ConsensusTransactionKind::MisbehaviorReport(authority, report, _),
                 ..
             }) => {
-                // Validate report
+                let authority_index = self
+                    .committee
+                    .authority_index(authority)
+                    .expect("authority in committee");
+                // Check validity of the report
+                if !report.verify(self.committee.num_members()) {
+                    // Since this verification happens after consensus, all authorities already
+                    // agreed on the set of messages that would be verified by this method. Then, we
+                    // can update scores according to the validation result directly, without the
+                    // need of any aditional step (as propagating opinions about validity).
+                    self.scorer.update_invalid_reports_count(authority_index);
+                    warn!(
+                        "Received invalid misbehavior report from {:?}",
+                        authority.concise()
+                    );
+                } else {
+                    // Here we update all counts related to the information in the reports.
+                    self.scorer.update_received_reports(authority_index, report);
+                }
                 Ok(ConsensusCertificateResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -65,21 +65,20 @@ impl Scorer {
         self.invalid_reports_count[authority as usize].fetch_add(1, Ordering::Relaxed);
     }
 
+    #[expect(dead_code)]
     pub(crate) fn update_scores(&self) {
         match self.version {
             ScorerVersion::V1 => self.update_scores_v1(),
         };
     }
 
-    #[expect(dead_code)]
-    pub(crate) fn update_received_reports_and_score(
+    pub(crate) fn update_received_reports(
         &self,
         authority: u32,
         report: &VersionedMisbehaviorReport,
     ) {
         self.received_metrics[authority as usize].update_from_report(report);
         self.metrics_missing_from[authority as usize].store(false, Ordering::Relaxed);
-        self.update_scores();
     }
 
     fn update_scores_v1(&self) {
@@ -94,6 +93,7 @@ pub(crate) enum ScorerVersion {
 pub(crate) type Scores = Vec<Score>;
 pub(crate) type Score = AtomicU64;
 
+// NOTE: the tests below are going to be finalized in a different PR
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::Ordering;

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -310,7 +310,7 @@ pub struct MisbehaviorReportV1 {
 impl MisbehaviorReportV1 {
     pub fn verify(&self, committee_size: usize) -> bool {
         // This version of reports are valid as long as they contain the counts for all
-        // authorities.  Future versions may contain proofs that need verification.
+        // authorities. Future versions may contain proofs that need verification.
         // However, since the validity of a proof is deeply coupled with the protocol
         // version and the consensus mechanism being used, we cannot verify it here. In
         // the future, reports should be unwrapped (or translated) to a type verifiable


### PR DESCRIPTION
```mermaid
---
config:
  gitGraph:
    {parallelCommits: true,
    mainBranchName: 'Feature',
    rotateCommitLabel: true}
---
gitGraph
   commit id: "Initial commit"
   commit id: "Old Scorer" tag: "PR8530"
  commit id: "add ChangeEpochV4" tag: "PR9159"
    commit id: "add MisbehaviorReports" tag: "PR9175"
   commit id: "add ScoringMetrics" tag: "PR9176"
   commit id: "add Scorer" tag: "PR9177"
   commit id: "add ScoringMetricsStore" tag: "PR9178"
   checkout Feature
branch report-validation
commit id: "add report validation" 
branch scoring-function
commit id: "add scoring function" 
branch report-creation
commit id: "add report creation" 
checkout Feature
merge  report-validation tag: "THIS PR"
```


# Description of change

We build on top of the other PRs of this feature branch to enable the misbehavior reports validation logic. 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Enables misbehavior report validation
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
