### PR TITLE
refactor(iota-graphql-rpc): increase InMemory broker channel size

### DIFF
--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -1,10 +1,15 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::num::NonZeroUsize;
+
 use async_graphql::{Context, OutputType, ResultExt, SimpleObject, Subscription, Union};
 use futures::{Stream, StreamExt, TryStreamExt, future};
 use iota_indexer::read::IndexerReader;
-use iota_indexer_streaming::{memory::InMemory, metrics::InMemoryStreamMetrics};
+use iota_indexer_streaming::{
+    memory::{Config, InMemory},
+    metrics::InMemoryStreamMetrics,
+};
 use iota_json_rpc_types::Filter;
 use iota_types::supported_protocol_versions::Chain;
 use prometheus::Registry;
@@ -22,6 +27,10 @@ use crate::{
 };
 
 mod filter;
+
+/// Represents the channel size of the [`InMemory`] broker.
+const BROKER_CHANNEL_SIZE: NonZeroUsize =
+    NonZeroUsize::new(10_000).expect("value should be greater than 0");
 
 /// Notifies that the subscription consumer has fallen behind the live
 /// subscription stream and missed one or more payloads.
@@ -134,9 +143,13 @@ impl GraphQLStream {
         indexer_reader: IndexerReader,
         registry: &Registry,
     ) -> Result<Self, Error> {
+        let config = Config {
+            channel_buffer_size: BROKER_CHANNEL_SIZE,
+            ..Default::default()
+        };
         let streamer = InMemory::new(
             db_url,
-            Default::default(),
+            config,
             indexer_reader,
             InMemoryStreamMetrics::new(registry),
         )


### PR DESCRIPTION
# Description of change

This PR increases the channel size for the `InMemory` broker.

## Links to any relevant issues

fixes #9366 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> The following patch does not affect the normal operation of the indexer, thus tests were skipped.
