### PR TITLE
fix(consensus): fix genesis issues for `aws-orchestrator`

### DIFF
--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -1340,9 +1340,8 @@ fn should_update_provable_metrics(error: &ConsensusError, source: &str) -> bool 
         && (is_from_signed_block_verification(error)
             || matches!(
                 error,
-                ConsensusError::BlockRejected { .. }
-                //| ConsensusError::MalformedAncestorBlock { .. }
-                ))
+                ConsensusError::BlockRejected { .. } //| ConsensusError::MalformedAncestorBlock { .. }
+            ))
     {
         return true;
     }

--- a/crates/iota-aws-orchestrator/src/benchmark.rs
+++ b/crates/iota-aws-orchestrator/src/benchmark.rs
@@ -62,8 +62,8 @@ pub struct BenchmarkParameters<T> {
     pub perturbation_spec: PerturbationSpec,
     /// Flag used to switch between mysticety and starfish every epoch.
     pub protocol_switch_each_epoch: bool,
-    /// Flag to skip generation of the latency matrix in private networks.
-    pub keep_latencies: bool,
+    /// Optional: Epoch duration in milliseconds, default is 1h
+    pub epoch_duration_ms: Option<u64>,
 }
 
 impl<T: BenchmarkType> Default for BenchmarkParameters<T> {
@@ -79,7 +79,7 @@ impl<T: BenchmarkType> Default for BenchmarkParameters<T> {
             perturbation_spec: PerturbationSpec::None,
             protocol_switch_each_epoch: false,
             maximum_latency: 400,
-            keep_latencies: false,
+            epoch_duration_ms: None,
         }
     }
 }
@@ -117,7 +117,7 @@ impl<T> BenchmarkParameters<T> {
         perturbation_spec: PerturbationSpec,
         protocol_switch_each_epoch: bool,
         maximum_latency: u16,
-        keep_latencies: bool,
+        epoch_duration_ms: Option<u64>,
     ) -> Self {
         Self {
             benchmark_type,
@@ -130,7 +130,7 @@ impl<T> BenchmarkParameters<T> {
             perturbation_spec,
             protocol_switch_each_epoch,
             maximum_latency,
-            keep_latencies,
+            epoch_duration_ms,
         }
     }
 }
@@ -183,8 +183,8 @@ pub struct BenchmarkParametersGenerator<T> {
     pub perturbation_spec: PerturbationSpec,
     /// Flag used to switch between mysticety and starfish every epoch.
     pub protocol_switch_each_epoch: bool,
-    /// Flag to skip generation of the latency matrix in private networks.
-    pub keep_latencies: bool,
+    /// Optional: Epoch duration in milliseconds, default is 1h
+    epoch_duration_ms: Option<u64>,
 }
 
 impl<T: BenchmarkType> Iterator for BenchmarkParametersGenerator<T> {
@@ -204,7 +204,7 @@ impl<T: BenchmarkType> Iterator for BenchmarkParametersGenerator<T> {
                 self.perturbation_spec.clone(),
                 self.protocol_switch_each_epoch,
                 self.maximum_latency,
-                self.keep_latencies,
+                self.epoch_duration_ms,
             )
         })
     }
@@ -241,7 +241,7 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
             latency_topology: Some(TopologyLayout::Geographical),
             protocol_switch_each_epoch: false,
             maximum_latency: 400,
-            keep_latencies: false,
+            epoch_duration_ms: None,
         }
     }
 
@@ -283,8 +283,8 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
         self
     }
 
-    pub fn with_keep_latencies(mut self, keep_latencies: bool) -> Self {
-        self.keep_latencies = keep_latencies;
+    pub fn with_epoch_duration(mut self, epoch_duration_ms: Option<u64>) -> Self {
+        self.epoch_duration_ms = epoch_duration_ms;
         self
     }
 

--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -166,6 +166,10 @@ pub enum Operation {
         /// default: false, aka use starfish in every epoch.
         #[clap(long, action, default_value_t = false, global = true)]
         protocol_switch_each_epoch: bool,
+
+        /// Optional: Epoch duration in milliseconds, default is 1h
+        #[arg(long, value_name = "INT", global = true)]
+        epoch_duration_ms: Option<u64>,
     },
 
     /// Print a summary of the specified measurements collection.
@@ -375,6 +379,7 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
             number_of_clusters,
             protocol_switch_each_epoch,
             maximum_latency,
+            epoch_duration_ms,
         } => {
             // Create a new orchestrator to instruct the testbed.
             let username = testbed.username();
@@ -445,6 +450,7 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
                     .with_latency_topology(latency_topology)
                     .with_protocol_switch_each_epoch(protocol_switch_each_epoch)
                     .with_max_latency(maximum_latency)
+                    .with_epoch_duration(epoch_duration_ms)
                     .with_faults(fault_type);
 
             Orchestrator::new(

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -99,6 +99,11 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
             "cargo run --release --bin iota --",
             "genesis",
             &format!("-f --working-dir {working_dir} --benchmark-ips {ips}"),
+            parameters
+                .epoch_duration_ms
+                .map(|epoch_duration_ms| format!("--epoch-duration-ms {epoch_duration_ms}"))
+                .as_deref()
+                .unwrap_or(""),
         ]
         .join(" ");
 
@@ -266,7 +271,7 @@ impl IotaProtocol {
                 false => x.main_ip.to_string(),
             })
             .collect();
-        let genesis_config = GenesisConfig::new_for_benchmarks(&ips);
+        let genesis_config = GenesisConfig::new_for_benchmarks(&ips, parameters.epoch_duration_ms);
         let mut addresses = Vec::new();
         if let Some(validator_configs) = genesis_config.validator_config_info.as_ref() {
             for (i, validator_info) in validator_configs.iter().enumerate() {
@@ -308,7 +313,7 @@ impl ProtocolMetrics for IotaProtocol {
             })
             .unzip();
 
-        GenesisConfig::new_for_benchmarks(&ips)
+        GenesisConfig::new_for_benchmarks(&ips, parameters.epoch_duration_ms)
             .validator_config_info
             .expect("No validator in genesis")
             .iter()

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -344,7 +344,7 @@ impl GenesisConfig {
     /// predictable to facilitate benchmarks orchestration. Only the main ip
     /// addresses of the validators are specified (as those are often
     /// dictated by the cloud provider hosing the testbed).
-    pub fn new_for_benchmarks(ips: &[String]) -> Self {
+    pub fn new_for_benchmarks(ips: &[String], epoch_duration_ms: Option<u64>) -> Self {
         // Set the validator's configs. They should be the same across multiple runs to
         // ensure reproducibility.
         let mut rng = StdRng::seed_from_u64(Self::BENCHMARKS_RNG_SEED);
@@ -371,7 +371,13 @@ impl GenesisConfig {
                     // Generate one genesis gas object per validator (this seems a good rule of
                     // thumb to produce enough gas objects for most types of
                     // benchmarks).
-                    gas_amounts: vec![Self::BENCHMARK_GAS_AMOUNT; 5],
+                    gas_amounts: vec![
+                        u64::min(
+                            Self::BENCHMARK_GAS_AMOUNT,
+                            u64::MAX / (6u64 * validator_config_info.len() as u64),
+                        );
+                        5
+                    ],
                 }
             })
             .collect();
@@ -380,7 +386,11 @@ impl GenesisConfig {
         // it own genesis; it is thus important they have the same parameters.
         let parameters = GenesisCeremonyParameters {
             chain_start_timestamp_ms: 0,
-            epoch_duration_ms: Self::BENCHMARK_EPOCH_DURATION_MS,
+            epoch_duration_ms: if let Some(duration_ms) = epoch_duration_ms {
+                duration_ms
+            } else {
+                Self::BENCHMARK_EPOCH_DURATION_MS
+            },
             ..GenesisCeremonyParameters::new()
         };
 

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -1095,7 +1095,7 @@ async fn genesis(
                 keystore.save()?;
 
                 // Make a new genesis config from the provided ip addresses.
-                GenesisConfig::new_for_benchmarks(&ips)
+                GenesisConfig::new_for_benchmarks(&ips, epoch_duration_ms)
             } else if keystore_path.exists() {
                 let existing_keys = FileBasedKeystore::new(&keystore_path)?.addresses();
                 GenesisConfig::for_local_testing_with_addresses(existing_keys)


### PR DESCRIPTION
# Description of change
This PR fixes the limit in the genesis `--benchmark-ips` command so that more then 60 nodes can be run in benchmark.
It also adds the `--epoch-duration-ms` optional flag for `benchmark` that allows us to run custom benchmark epochs.

## Links to any relevant issues

fixes #9380 .

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
