### PR TITLE
feat: add blocking connections perturbation_spec

### DIFF
--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -170,6 +170,11 @@ pub enum Operation {
         /// Optional: Epoch duration in milliseconds, default is 1h
         #[arg(long, value_name = "INT", global = true)]
         epoch_duration_ms: Option<u64>,
+
+        /// Number of blocking connections in the blocking
+        /// latency_perturbation_spec
+        #[arg(long, value_name = "INT", default_value = "1", global = true)]
+        blocking_connections: usize,
     },
 
     /// Print a summary of the specified measurements collection.
@@ -265,6 +270,7 @@ pub enum Load {
 #[derive(ValueEnum, Clone, Debug)]
 pub enum PerturbationSpec {
     BrokenTriangle,
+    Blocking,
     // potentially other options later
 }
 
@@ -380,6 +386,7 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
             protocol_switch_each_epoch,
             maximum_latency,
             epoch_duration_ms,
+            blocking_connections,
         } => {
             // Create a new orchestrator to instruct the testbed.
             let username = testbed.username();
@@ -430,6 +437,9 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
                         number_of_triangles,
                     }
                 }
+                Some(PerturbationSpec::Blocking) => net_latency::PerturbationSpec::Blocking {
+                    number_of_blocked_connections: blocking_connections,
+                },
                 None => net_latency::PerturbationSpec::None,
             };
 

--- a/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
@@ -29,6 +29,24 @@ pub struct LatencyMatrixBuilder {
 
 use rand::{Rng, rng};
 
+pub fn generate_block_matrix(n: usize, k: usize) -> Vec<Vec<bool>> {
+    let k = k / 2;
+
+    // Start with everything "true" (normal)
+    let mut matrix = vec![vec![true; n]; n];
+
+    // For symmetry, we assign blocks in round-robin pairs:
+    // node i blocks nodes (i+1)%n, (i+2)%n, ..., (i+k)%n
+    for i in 0..n {
+        for offset in 1..=k {
+            let j = (i + offset) % n;
+            matrix[i][j] = false;
+            matrix[j][i] = false; // enforce symmetry
+        }
+    }
+
+    matrix
+}
 impl LatencyMatrixBuilder {
     pub fn new(number_of_instances: usize) -> Self {
         Self {
@@ -143,6 +161,27 @@ impl LatencyMatrixBuilder {
         }
     }
 
+    fn apply_blocking(&mut self, number_of_blocking_connections: usize) {
+        if self.matrix.len() < 3 {
+            return;
+        }
+        if number_of_blocking_connections > self.matrix.len() / 2 {
+            return;
+        }
+        let n = self.matrix.len();
+        let blocking_matrix =
+            generate_block_matrix(self.matrix.len(), number_of_blocking_connections);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..n {
+            for j in 0..n {
+                if !blocking_matrix[i][j] {
+                    // add 10s to latency of blocked connections.
+                    self.matrix[i][j] = self.matrix[i][j].saturating_add(10000);
+                }
+            }
+        }
+    }
+
     pub fn build(mut self) -> Vec<Vec<u16>> {
         match self.topology_layout {
             TopologyLayout::HardCoded => {
@@ -159,6 +198,11 @@ impl LatencyMatrixBuilder {
                 added_latency,
             } => {
                 self.apply_broken_triangle(number_of_triangles, added_latency);
+            }
+            PerturbationSpec::Blocking {
+                number_of_blocked_connections,
+            } => {
+                self.apply_blocking(number_of_blocked_connections);
             }
             PerturbationSpec::None => {}
         };

--- a/crates/iota-aws-orchestrator/src/net_latency/mod.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/mod.rs
@@ -29,6 +29,10 @@ pub enum PerturbationSpec {
         number_of_triangles: u16,
         added_latency: u16,
     },
+    /// Blocking connections
+    Blocking {
+        number_of_blocked_connections: usize,
+    },
 }
 
 pub struct NetworkLatencyCommandBuilder<'a> {


### PR DESCRIPTION
# Description of change

Adds the `PerturbationSpec::Blocking` to the `aws-orchestrator` for generating a latency matrix with `k` blocking connections.

## Links to any relevant issues

fixes #9416.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

