### PR TITLE
feat(consensus): update orchestrator with Mainnet network latencies

### DIFF
--- a/crates/iota-aws-orchestrator/src/benchmark.rs
+++ b/crates/iota-aws-orchestrator/src/benchmark.rs
@@ -55,7 +55,7 @@ pub struct BenchmarkParameters<T> {
     /// the nodes.
     pub use_internal_ip_address: bool,
     /// The topology of private network latencies, RandomGeographical,
-    /// RandomClustered, HardCodedClustered, or MainNet
+    /// RandomClustered, HardCodedClustered, or Mainnet
     pub latency_topology: Option<TopologyLayout>,
     /// Maximum latency between two nodes in the private network.
     pub maximum_latency: u16,
@@ -76,7 +76,7 @@ impl<T: BenchmarkType> Default for BenchmarkParameters<T> {
             load: 500,
             duration: Duration::from_secs(60),
             use_internal_ip_address: true,
-            latency_topology: Some(TopologyLayout::MainNet),
+            latency_topology: Some(TopologyLayout::Mainnet),
             perturbation_spec: PerturbationSpec::None,
             protocol_switch_each_epoch: false,
             maximum_latency: 400,
@@ -177,7 +177,7 @@ pub struct BenchmarkParametersGenerator<T> {
     /// IP address for inter-node communication.
     use_internal_ip_address: bool,
     /// The topology of private network latencies, RandomGeographical,
-    /// RandomClustered, HardCodedClustered, or MainNet
+    /// RandomClustered, HardCodedClustered, or Mainnet
     pub latency_topology: Option<TopologyLayout>,
     /// Maximum latency between two nodes in the private network.
     pub maximum_latency: u16,
@@ -240,7 +240,7 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
             iterations: 0,
             use_internal_ip_address,
             perturbation_spec: PerturbationSpec::None,
-            latency_topology: Some(TopologyLayout::MainNet),
+            latency_topology: Some(TopologyLayout::Mainnet),
             protocol_switch_each_epoch: false,
             maximum_latency: 400,
             epoch_duration_ms: None,

--- a/crates/iota-aws-orchestrator/src/benchmark.rs
+++ b/crates/iota-aws-orchestrator/src/benchmark.rs
@@ -54,7 +54,8 @@ pub struct BenchmarkParameters<T> {
     /// they should use their internal IPs to avoid paying for data sent between
     /// the nodes.
     pub use_internal_ip_address: bool,
-    /// The topology of private network latencies, Geographical or Clustered
+    /// The topology of private network latencies, RandomGeographical,
+    /// RandomClustered, HardCodedClustered, or MainNet
     pub latency_topology: Option<TopologyLayout>,
     /// Maximum latency between two nodes in the private network.
     pub maximum_latency: u16,
@@ -75,7 +76,7 @@ impl<T: BenchmarkType> Default for BenchmarkParameters<T> {
             load: 500,
             duration: Duration::from_secs(60),
             use_internal_ip_address: true,
-            latency_topology: Some(TopologyLayout::Geographical),
+            latency_topology: Some(TopologyLayout::MainNet),
             perturbation_spec: PerturbationSpec::None,
             protocol_switch_each_epoch: false,
             maximum_latency: 400,
@@ -175,7 +176,8 @@ pub struct BenchmarkParametersGenerator<T> {
     /// Flag indicating whether nodes should advertise their internal or public
     /// IP address for inter-node communication.
     use_internal_ip_address: bool,
-    /// The topology of private network latencies, Geographical or Clustered
+    /// The topology of private network latencies, RandomGeographical,
+    /// RandomClustered, HardCodedClustered, or MainNet
     pub latency_topology: Option<TopologyLayout>,
     /// Maximum latency between two nodes in the private network.
     pub maximum_latency: u16,
@@ -238,7 +240,7 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
             iterations: 0,
             use_internal_ip_address,
             perturbation_spec: PerturbationSpec::None,
-            latency_topology: Some(TopologyLayout::Geographical),
+            latency_topology: Some(TopologyLayout::MainNet),
             protocol_switch_each_epoch: false,
             maximum_latency: 400,
             epoch_duration_ms: None,

--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -285,7 +285,7 @@ pub enum LatencyTopology {
     /// Uses a hardcoded 10x10 matrix with 10 equal-sized regions.
     HardCodedClustered,
     /// Uses mainnet validator region distribution for latencies.
-    MainNet,
+    Mainnet,
 }
 
 fn parse_duration(arg: &str) -> Result<Duration, std::num::ParseIntError> {
@@ -455,7 +455,7 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
                 Some(LatencyTopology::HardCodedClustered) => {
                     Some(TopologyLayout::HardCodedClustered)
                 }
-                Some(LatencyTopology::MainNet) => Some(TopologyLayout::MainNet),
+                Some(LatencyTopology::Mainnet) => Some(TopologyLayout::Mainnet),
                 None => None,
             };
 

--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -278,12 +278,14 @@ pub enum PerturbationSpec {
 pub enum LatencyTopology {
     /// Generates a latency matrix for each node, randomly positioned on a
     /// cylinder.
-    Geographical,
-    /// Generates a latency matrix by clustering nodes into clusters and
-    /// randomly positioning clusters on a cylinder.
-    Clustered,
-    /// Uses a hardcoded clustered matrix 10x10 in the net_latency module.
-    HardCoded,
+    RandomGeographical,
+    /// Generates a latency matrix by randomly clustering nodes into clusters
+    /// and randomly positioning clusters on a cylinder.
+    RandomClustered,
+    /// Uses a hardcoded 10x10 matrix with 10 equal-sized regions.
+    HardCodedClustered,
+    /// Uses mainnet validator region distribution for latencies.
+    MainNet,
 }
 
 fn parse_duration(arg: &str) -> Result<Duration, std::num::ParseIntError> {
@@ -444,11 +446,16 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
             };
 
             let latency_topology = match latency_topology {
-                Some(LatencyTopology::Geographical) => Some(TopologyLayout::Geographical),
-                Some(LatencyTopology::Clustered) => {
-                    Some(TopologyLayout::Clustered { number_of_clusters })
+                Some(LatencyTopology::RandomGeographical) => {
+                    Some(TopologyLayout::RandomGeographical)
                 }
-                Some(LatencyTopology::HardCoded) => Some(TopologyLayout::HardCoded),
+                Some(LatencyTopology::RandomClustered) => {
+                    Some(TopologyLayout::RandomClustered { number_of_clusters })
+                }
+                Some(LatencyTopology::HardCodedClustered) => {
+                    Some(TopologyLayout::HardCodedClustered)
+                }
+                Some(LatencyTopology::MainNet) => Some(TopologyLayout::MainNet),
                 None => None,
             };
 

--- a/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
@@ -3,20 +3,34 @@
 
 use super::{PerturbationSpec, TopologyLayout};
 
+// Mainnet validator region indices (0-9 correspond to RTT_LATENCY_TABLE
+// rows/cols). Extracted from current IOTA Mainnet validator list
+// and checking IP geolocation.
+// Distribution: 18x US-East, 4x US-West, 2x Canada, 21x EU-West,
+// 13x EU-North, 8x AP-Southeast, 1x AP-South, 1x AP-Northeast
+const MAINNET_NODE_REGIONS: [usize; 70] = [
+    5, 3, 0, 3, 3, 3, 8, 3, 0, 5, 3, 5, 3, 3, 8, 5, 0, 1, 3, 1, 0, 5, 3, 5, 0, 5, 0, 0, 5, 5, 3, 5,
+    3, 0, 3, 5, 3, 9, 3, 8, 0, 3, 3, 3, 2, 7, 0, 1, 0, 2, 0, 5, 0, 8, 8, 1, 0, 8, 0, 0, 3, 3, 8, 0,
+    3, 0, 8, 5, 0, 0,
+];
+
 // RTT table for 10 AWS regions, in milliseconds.
-// Strict triangle inequality: d(i,j) + 1 <= d(i,k) + d(k,j) for all distinct
-// i,j,k.
+// Based on actual AWS inter-region latency measurements from cloudping.co
+// Enforces triangle inequality: d(i,j) <= d(i,k) + d(k,j) for all distinct
+// i,j,k Regions: 0=us-east-1, 1=us-west-1, 2=ca-central-1, 3=eu-west-1,
+//          4=eu-south-1, 5=eu-north-1, 6=sa-east-1, 7=ap-south-1,
+//          8=ap-southeast-1, 9=ap-northeast-1
 const RTT_LATENCY_TABLE: [[u16; 10]; 10] = [
-    [1, 14, 96, 112, 198, 65, 68, 105, 192, 146],
-    [14, 1, 95, 122, 196, 78, 67, 103, 189, 142],
-    [96, 95, 1, 204, 281, 155, 29, 50, 143, 227],
-    [112, 122, 204, 1, 309, 175, 176, 213, 299, 254],
-    [198, 196, 281, 309, 1, 137, 254, 268, 150, 101],
-    [65, 78, 155, 175, 137, 1, 127, 164, 226, 108],
-    [68, 67, 29, 176, 254, 127, 1, 38, 125, 199],
-    [105, 103, 50, 213, 268, 164, 38, 1, 148, 236],
-    [192, 189, 143, 299, 150, 226, 125, 148, 1, 140],
-    [146, 142, 227, 254, 101, 108, 199, 236, 140, 1],
+    [0, 67, 15, 68, 101, 107, 111, 187, 215, 147], // us-east-1
+    [67, 0, 79, 129, 161, 168, 170, 230, 173, 107], // us-west-1
+    [15, 79, 0, 68, 101, 104, 123, 188, 223, 155], // ca-central-1
+    [68, 129, 68, 0, 36, 39, 176, 121, 173, 203],  // eu-west-1
+    [101, 161, 101, 36, 0, 31, 210, 111, 155, 218], // eu-south-1
+    [107, 168, 104, 39, 31, 0, 215, 139, 179, 242], // eu-north-1
+    [111, 170, 123, 176, 210, 215, 0, 294, 325, 257], // sa-east-1
+    [187, 230, 188, 121, 111, 139, 294, 0, 61, 129], // ap-south-1
+    [215, 173, 223, 173, 155, 179, 325, 61, 0, 68], // ap-southeast-1
+    [147, 107, 155, 203, 218, 242, 257, 129, 68, 0], // ap-northeast-1
 ];
 
 pub struct LatencyMatrixBuilder {
@@ -52,13 +66,13 @@ impl LatencyMatrixBuilder {
         Self {
             number_of_instances,
             max_latency: 300,
-            topology_layout: TopologyLayout::Geographical,
+            topology_layout: TopologyLayout::MainNet,
             perturbation_spec: PerturbationSpec::None,
             matrix: vec![vec![0u16; number_of_instances]; number_of_instances],
         }
     }
     pub fn with_topology_layout(mut self, topology_layout: TopologyLayout) -> Self {
-        if let TopologyLayout::Clustered { number_of_clusters } = topology_layout {
+        if let TopologyLayout::RandomClustered { number_of_clusters } = topology_layout {
             self.matrix = vec![vec![0u16; number_of_clusters]; number_of_clusters];
         }
         self.topology_layout = topology_layout;
@@ -131,6 +145,21 @@ impl LatencyMatrixBuilder {
         matrix
     }
 
+    /// Build a mainnet topology matrix using validator region assignments
+    /// and RTT_LATENCY_TABLE for inter-region latencies.
+    fn fill_mainnet(&mut self) {
+        let n = self.number_of_instances;
+
+        for i in 0..n {
+            let region_i = MAINNET_NODE_REGIONS[i % MAINNET_NODE_REGIONS.len()];
+            for j in 0..n {
+                let region_j = MAINNET_NODE_REGIONS[j % MAINNET_NODE_REGIONS.len()];
+                // Use RTT value and convert to one-way latency
+                self.matrix[i][j] = RTT_LATENCY_TABLE[region_i][region_j] / 2;
+            }
+        }
+    }
+
     /// Apply "broken triangle" to up to `k` triangles of the form (i, i+1,
     /// i+2). Ensures: latency(A,B) + latency(B,C) + added_latency =
     /// latency(A,C)
@@ -184,11 +213,14 @@ impl LatencyMatrixBuilder {
 
     pub fn build(mut self) -> Vec<Vec<u16>> {
         match self.topology_layout {
-            TopologyLayout::HardCoded => {
+            TopologyLayout::HardCodedClustered => {
                 self.matrix = RTT_LATENCY_TABLE
                     .map(|row| row.map(|x| x / 2))
                     .map(|row| row.to_vec())
                     .to_vec();
+            }
+            TopologyLayout::MainNet => {
+                self.fill_mainnet();
             }
             _ => self.fill_geographical(),
         };
@@ -218,7 +250,7 @@ mod tests {
     #[ignore]
     fn test_latency_matrix() {
         let matrix = LatencyMatrixBuilder::new(4)
-            .with_topology_layout(TopologyLayout::Geographical)
+            .with_topology_layout(TopologyLayout::RandomGeographical)
             .with_perturbation_spec(PerturbationSpec::None)
             .with_max_latency(500)
             .build();
@@ -228,7 +260,7 @@ mod tests {
     #[ignore]
     fn test_latency_clustered() {
         let matrix = LatencyMatrixBuilder::new(12)
-            .with_topology_layout(TopologyLayout::Clustered {
+            .with_topology_layout(TopologyLayout::RandomClustered {
                 number_of_clusters: 4,
             })
             .with_perturbation_spec(PerturbationSpec::None)
@@ -241,7 +273,7 @@ mod tests {
     #[ignore]
     fn test_apply_broken_triangle() {
         let matrix = LatencyMatrixBuilder::new(4)
-            .with_topology_layout(TopologyLayout::Geographical)
+            .with_topology_layout(TopologyLayout::RandomGeographical)
             .with_perturbation_spec(PerturbationSpec::BrokenTriangle {
                 number_of_triangles: 2,
                 added_latency: 100,
@@ -255,7 +287,7 @@ mod tests {
     #[ignore]
     fn test_clustered_broken_triangle() {
         let matrix = LatencyMatrixBuilder::new(12)
-            .with_topology_layout(TopologyLayout::Clustered {
+            .with_topology_layout(TopologyLayout::RandomClustered {
                 number_of_clusters: 4,
             })
             .with_perturbation_spec(PerturbationSpec::BrokenTriangle {
@@ -263,6 +295,17 @@ mod tests {
                 added_latency: 100,
             })
             .with_max_latency(500)
+            .build();
+        println!("{:?}", matrix);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_mainnet_10_instances() {
+        let matrix = LatencyMatrixBuilder::new(10)
+            .with_topology_layout(TopologyLayout::MainNet)
+            .with_perturbation_spec(PerturbationSpec::None)
+            .with_max_latency(300)
             .build();
         println!("{:?}", matrix);
     }

--- a/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
@@ -66,7 +66,7 @@ impl LatencyMatrixBuilder {
         Self {
             number_of_instances,
             max_latency: 300,
-            topology_layout: TopologyLayout::MainNet,
+            topology_layout: TopologyLayout::Mainnet,
             perturbation_spec: PerturbationSpec::None,
             matrix: vec![vec![0u16; number_of_instances]; number_of_instances],
         }
@@ -219,7 +219,7 @@ impl LatencyMatrixBuilder {
                     .map(|row| row.to_vec())
                     .to_vec();
             }
-            TopologyLayout::MainNet => {
+            TopologyLayout::Mainnet => {
                 self.fill_mainnet();
             }
             _ => self.fill_geographical(),
@@ -303,7 +303,7 @@ mod tests {
     #[ignore]
     fn test_mainnet_10_instances() {
         let matrix = LatencyMatrixBuilder::new(10)
-            .with_topology_layout(TopologyLayout::MainNet)
+            .with_topology_layout(TopologyLayout::Mainnet)
             .with_perturbation_spec(PerturbationSpec::None)
             .with_max_latency(300)
             .build();

--- a/crates/iota-aws-orchestrator/src/net_latency/mod.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/mod.rs
@@ -11,12 +11,14 @@ pub mod latency_matrix_builder;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum TopologyLayout {
-    /// All Nodes are distributed with their own latencies, no clusters
-    Geographical,
-    /// Nodes are distributed in number_of_clusters clusters
-    Clustered { number_of_clusters: usize },
-    /// Use the hardcoded 10x10 clustered matrix
-    HardCoded,
+    /// All nodes are randomly distributed with their own latencies, no clusters
+    RandomGeographical,
+    /// Nodes are randomly distributed in number_of_clusters clusters
+    RandomClustered { number_of_clusters: usize },
+    /// Uses a hardcoded 10x10 matrix with 10 equal-sized regions
+    HardCodedClustered,
+    /// Use mainnet validator region distribution with shuffled order
+    MainNet,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -78,7 +80,7 @@ impl<'a> NetworkLatencyCommandBuilder<'a> {
     pub fn new(instances: &'a [Instance]) -> Self {
         Self {
             instances,
-            topology_layout: TopologyLayout::Geographical,
+            topology_layout: TopologyLayout::RandomGeographical,
             perturbation_spec: PerturbationSpec::None,
             max_latency: 500,
         }
@@ -145,7 +147,7 @@ mod tests {
                 added_latency: 50,
                 number_of_triangles: 2,
             })
-            .with_topology_layout(TopologyLayout::Geographical)
+            .with_topology_layout(TopologyLayout::RandomGeographical)
             .build_network_latency_matrix();
         println!(
             "{:?}",

--- a/crates/iota-aws-orchestrator/src/net_latency/mod.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/mod.rs
@@ -18,7 +18,7 @@ pub enum TopologyLayout {
     /// Uses a hardcoded 10x10 matrix with 10 equal-sized regions
     HardCodedClustered,
     /// Use mainnet validator region distribution with shuffled order
-    MainNet,
+    Mainnet,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
# Description of change

To simulate a more realistic deployment, we add a new feature to mimic Mainnet latencies to the orchestrator. A few renames are applied. Right now 4 options to mimic latencies through the orchestrator are available:
```
- RandomGeographical,
- RandomClustered
- HardCodedClustered
- Mainnet
```

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

