### PR TITLE
feat(consensus,starfish): `CommitSyncer` optimizations

### DIFF
--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -456,13 +456,40 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // Get requested blocks from store.
         let blocks = if commit_sync_handle {
-            // For commit sync, we respond with all blocks from the store
-            self.dag_state
-                .read()
-                .get_blocks(&block_refs)
-                .into_iter()
-                .flatten()
-                .collect()
+            // For commit sync, optimize by fetching from store for blocks below GC round
+            let gc_round = self.dag_state.read().gc_round();
+
+            // Partition block_refs into those below and at-or-above GC round
+            let (below_gc, above_gc): (Vec<_>, Vec<_>) = block_refs
+                .iter()
+                .partition(|block_ref| block_ref.round < gc_round);
+
+            let mut blocks = Vec::new();
+
+            // Fetch blocks below GC from store
+            if !below_gc.is_empty() {
+                let store_blocks = self
+                    .store
+                    .read_blocks(&below_gc)?
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>();
+                blocks.extend(store_blocks);
+            }
+
+            // Fetch blocks at-or-above GC from dag_state
+            if !above_gc.is_empty() {
+                let dag_blocks = self
+                    .dag_state
+                    .read()
+                    .get_blocks(&above_gc)
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>();
+                blocks.extend(dag_blocks);
+            }
+
+            blocks
         } else {
             // For periodic or live synchronizer, we respond with requested blocks from the
             // store and with additional blocks from the cache

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -561,6 +561,10 @@ impl<C: NetworkClient> CommitSyncer<C> {
         commit_range: CommitRange,
         timeout: Duration,
     ) -> ConsensusResult<CertifiedCommits> {
+        // Maximum delay between consecutive pipelined requests, to avoid
+        // overwhelming the peer while still maintaining reasonable throughput.
+        const MAX_PIPELINE_DELAY: Duration = Duration::from_secs(1);
+
         let hostname = inner
             .context
             .committee
@@ -614,7 +618,8 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 async move {
                     // 4. Send out pipelined fetch requests to avoid overloading the target
                     //    authority.
-                    sleep(timeout * i as u32 / num_chunks).await;
+                    let individual_delay = (timeout / num_chunks).min(MAX_PIPELINE_DELAY);
+                    sleep(individual_delay * i as u32).await;
                     // TODO: add some retries.
                     let serialized_blocks = inner
                         .network_client

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -769,7 +769,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // Get requested block headers from store.
         let serialized_headers = if commit_sync_handle {
-            // For commit sync, optimize by fetching from store for blocks below GC round
+            // For commit sync, optimize by fetching from store for headers below GC round
             let gc_round = self.dag_state.read().gc_round_for_last_solid_commit();
 
             // Partition block_refs into those below and at-or-above GC round
@@ -779,7 +779,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
             let mut headers = Vec::new();
 
-            // Fetch blocks below GC from store
+            // Read headers below GC from store
             if !below_gc.is_empty() {
                 let store_headers = self
                     .store
@@ -790,7 +790,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 headers.extend(store_headers);
             }
 
-            // Fetch blocks at-or-above GC from dag_state
+            // Read headers at-or-above GC from dag_state
             if !above_gc.is_empty() {
                 let dag_headers = self
                     .dag_state
@@ -1018,7 +1018,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             &self.context.committee,
         )?;
 
-        // Optimize by fetching from store for blocks below GC round
+        // Optimize by reading from store for transactions below GC round
         let gc_round = self.dag_state.read().gc_round_for_last_solid_commit();
 
         // Partition block_refs into those below and at-or-above GC round

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -769,13 +769,40 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // Get requested block headers from store.
         let serialized_headers = if commit_sync_handle {
-            // For commit sync, we respond with all blocks from the store
-            self.dag_state
-                .read()
-                .get_serialized_block_headers(&block_refs)
-                .into_iter()
-                .flatten()
-                .collect()
+            // For commit sync, optimize by fetching from store for blocks below GC round
+            let gc_round = self.dag_state.read().gc_round_for_last_solid_commit();
+
+            // Partition block_refs into those below and at-or-above GC round
+            let (below_gc, above_gc): (Vec<_>, Vec<_>) = block_refs
+                .iter()
+                .partition(|block_ref| block_ref.round < gc_round);
+
+            let mut headers = Vec::new();
+
+            // Fetch blocks below GC from store
+            if !below_gc.is_empty() {
+                let store_headers = self
+                    .store
+                    .read_serialized_block_headers(&below_gc)?
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>();
+                headers.extend(store_headers);
+            }
+
+            // Fetch blocks at-or-above GC from dag_state
+            if !above_gc.is_empty() {
+                let dag_headers = self
+                    .dag_state
+                    .read()
+                    .get_serialized_block_headers(&above_gc)
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>();
+                headers.extend(dag_headers);
+            }
+
+            headers
         } else {
             // For periodic or live synchronizer, we respond with requested blocks from the
             // store and with additional blocks from the cache
@@ -991,21 +1018,46 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             &self.context.committee,
         )?;
 
-        // Get the transactions from the dag state
-        let transactions = self
-            .dag_state
-            .read()
-            .get_serialized_transactions(&block_refs);
+        // Optimize by fetching from store for blocks below GC round
+        let gc_round = self.dag_state.read().gc_round_for_last_solid_commit();
 
-        // Return the serialized transactions
-        let result: Vec<_> = transactions
+        // Partition block_refs into those below and at-or-above GC round
+        let (below_gc, above_gc): (Vec<_>, Vec<_>) = block_refs
+            .iter()
+            .partition(|block_ref| block_ref.round < gc_round);
+
+        // Fetch transactions below GC from store
+        let store_transactions = if !below_gc.is_empty() {
+            self.store
+                .read_serialized_transactions(&below_gc)?
+                .into_iter()
+                .zip(below_gc.iter())
+                .collect::<Vec<_>>()
+        } else {
+            vec![]
+        };
+
+        // Fetch transactions at-or-above GC from dag_state
+        let dag_transactions = if !above_gc.is_empty() {
+            self.dag_state
+                .read()
+                .get_serialized_transactions(&above_gc)
+                .into_iter()
+                .zip(above_gc.iter())
+                .collect::<Vec<_>>()
+        } else {
+            vec![]
+        };
+
+        // Combine and serialize the results
+        let result: Vec<_> = store_transactions
             .into_iter()
-            .zip(block_refs)
+            .chain(dag_transactions.into_iter())
             .filter_map(|(opt_serialized_tx, block_ref)| {
                 opt_serialized_tx.map(|serialized_tx| {
                     Bytes::from(
                         bcs::to_bytes(&SerializedTransactions {
-                            block_ref,
+                            block_ref: *block_ref,
                             serialized_transactions: serialized_tx,
                         })
                         .map_err(ConsensusError::SerializationFailure)

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -619,6 +619,10 @@ impl<C: NetworkClient> CommitSyncer<C> {
         commit_range: CommitRange,
         timeout: Duration,
     ) -> ConsensusResult<CertifiedCommits> {
+        // Maximum delay between consecutive pipelined requests, to avoid
+        // overwhelming the peer while still maintaining reasonable throughput.
+        const MAX_PIPELINE_DELAY: Duration = Duration::from_secs(1);
+
         let _timer = inner
             .context
             .metrics
@@ -684,7 +688,8 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 async move {
                     // 4. Send out pipelined fetch requests to avoid overloading the target
                     //    authority.
-                    sleep(timeout * i as u32 / num_chunks).await;
+                    let individual_delay = (timeout / num_chunks).min(MAX_PIPELINE_DELAY);
+                    sleep(individual_delay * i as u32).await;
                     // TODO: add some retries.
                     let serialized_block_headers = inner
                         .network_client
@@ -754,8 +759,10 @@ impl<C: NetworkClient> CommitSyncer<C> {
                     let inner = inner.clone();
                     async move {
                         // 9. Send out pipelined fetch requests to avoid overloading the target
-                        //    authority.
-                        sleep(timeout * i as u32 / num_tx_chunks.max(1)).await;
+                        //    authority. Offset by half delay to interleave with header requests.
+                        let individual_delay =
+                            (timeout / num_tx_chunks.max(1)).min(MAX_PIPELINE_DELAY);
+                        sleep(individual_delay * i as u32 + individual_delay / 2).await;
                         let serialized_transactions = inner
                             .network_client
                             .fetch_transactions(


### PR DESCRIPTION
# Description of change

This PR optimizes pipeline request delays for improved throughput and optimizes handling of fetch_transactions. fetch_block/header endpoints to avoid holding the `DAGState` read lock for long periods of time - for older blocks we read directly from the store, which can significantly reduce impact of responing to CommitSyncer requests from syncing peers. 

## Links to any relevant issues

Fixes #9273 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
