### PR TITLE
feat(consensus): use distant regions in the node arrangement first

### DIFF
--- a/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
@@ -6,12 +6,12 @@ use super::{PerturbationSpec, TopologyLayout};
 // Mainnet validator region indices (0-9 correspond to RTT_LATENCY_TABLE
 // rows/cols). Extracted from current IOTA Mainnet validator list
 // and checking IP geolocation.
-// Distribution: 18x US-East, 4x US-West, 2x Canada, 21x EU-West,
+// Distribution: 20x US-East, 4x US-West, 2x Canada, 21x EU-West,
 // 13x EU-North, 8x AP-Southeast, 1x AP-South, 1x AP-Northeast
 const MAINNET_NODE_REGIONS: [usize; 70] = [
-    8, 8, 9, 7, 3, 3, 5, 3, 0, 5, 3, 5, 3, 3, 5, 5, 0, 1, 3, 1, 0, 5, 3, 5, 0, 5, 0, 0, 5, 5, 3, 5,
-    3, 0, 3, 5, 3, 0, 3, 8, 0, 3, 3, 3, 2, 0, 0, 1, 0, 2, 0, 5, 0, 8, 8, 1, 0, 8, 0, 0, 3, 3, 8, 0,
-    3, 0, 0, 5, 0, 0,
+    5, 9, 0, 8, 8, 3, 8, 3, 0, 5, 3, 5, 3, 3, 8, 5, 0, 1, 3, 1, 0, 5, 3, 5, 0, 5, 0, 0, 5, 5, 3, 5,
+    3, 0, 3, 5, 3, 3, 3, 8, 0, 3, 3, 3, 2, 7, 0, 1, 0, 2, 0, 5, 0, 8, 3, 1, 0, 8, 0, 0, 3, 3, 8, 0,
+    3, 0, 3, 5, 0, 0,
 ];
 
 // RTT table for 10 AWS regions, in milliseconds.
@@ -308,5 +308,21 @@ mod tests {
             .with_max_latency(300)
             .build();
         println!("{:?}", matrix);
+    }
+
+    #[test]
+    fn test_mainnet_region_distribution() {
+        let expected = [(0, 20), (1, 4), (2, 2), (3, 21), (5, 13), (7, 1), (8, 8), (9, 1)];
+        let mut counts = [0usize; 10];
+        for &region in &MAINNET_NODE_REGIONS {
+            counts[region] += 1;
+        }
+        for &(region, expected_count) in &expected {
+            assert_eq!(
+                counts[region], expected_count,
+                "Region {}: expected {}, got {}",
+                region, expected_count, counts[region]
+            );
+        }
     }
 }

--- a/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
@@ -9,9 +9,9 @@ use super::{PerturbationSpec, TopologyLayout};
 // Distribution: 18x US-East, 4x US-West, 2x Canada, 21x EU-West,
 // 13x EU-North, 8x AP-Southeast, 1x AP-South, 1x AP-Northeast
 const MAINNET_NODE_REGIONS: [usize; 70] = [
-    5, 3, 0, 3, 3, 3, 8, 3, 0, 5, 3, 5, 3, 3, 8, 5, 0, 1, 3, 1, 0, 5, 3, 5, 0, 5, 0, 0, 5, 5, 3, 5,
-    3, 0, 3, 5, 3, 9, 3, 8, 0, 3, 3, 3, 2, 7, 0, 1, 0, 2, 0, 5, 0, 8, 8, 1, 0, 8, 0, 0, 3, 3, 8, 0,
-    3, 0, 8, 5, 0, 0,
+    8, 8, 9, 7, 3, 3, 5, 3, 0, 5, 3, 5, 3, 3, 5, 5, 0, 1, 3, 1, 0, 5, 3, 5, 0, 5, 0, 0, 5, 5, 3, 5,
+    3, 0, 3, 5, 3, 0, 3, 8, 0, 3, 3, 3, 2, 0, 0, 1, 0, 2, 0, 5, 0, 8, 8, 1, 0, 8, 0, 0, 3, 3, 8, 0,
+    3, 0, 0, 5, 0, 0,
 ];
 
 // RTT table for 10 AWS regions, in milliseconds.

--- a/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
@@ -312,7 +312,16 @@ mod tests {
 
     #[test]
     fn test_mainnet_region_distribution() {
-        let expected = [(0, 20), (1, 4), (2, 2), (3, 21), (5, 13), (7, 1), (8, 8), (9, 1)];
+        let expected = [
+            (0, 20),
+            (1, 4),
+            (2, 2),
+            (3, 21),
+            (5, 13),
+            (7, 1),
+            (8, 8),
+            (9, 1),
+        ];
         let mut counts = [0usize; 10];
         for &region in &MAINNET_NODE_REGIONS {
             counts[region] += 1;


### PR DESCRIPTION
# Description of change

For easy debugging and making experiments, we shuffle the node arrangement to use more distant nodes at first positions,

## Links to any relevant issues

Fixes #9426 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

