### PR TITLE
fix(core): Fix fullnode setup in iota-aws-orchestrator

### DIFF
--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -430,11 +430,12 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
 
             // Wait until all fullnodes are reachable (otherwise clients might fail when a
             // fullnode is not listening yet).
+            display::action("Await fullnode ready...");
             let commands = self
                 .client_instances
                 .iter()
                 .cloned()
-                .map(|i| (i, "curl http://127.0.0.1:9000".to_owned())); // fullnodes default json RPC address
+                .map(|i| (i, "curl http://127.0.0.1:9000 -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"iota_getLatestCheckpointSequenceNumber\",\"params\":[],\"id\":1}'".to_owned())); // fullnodes default json RPC address
             self.ssh_manager.wait_for_success(commands).await;
 
             display::done();

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -513,6 +513,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
                         .execute_per_instance(metrics_commands.clone(), CommandContext::default())
                         .await?;
                     for (i, (stdout, _stderr)) in stdio.iter().enumerate() {
+                        display::action(format!("Processing metrics from client {}\n", i));
                         let measurement = Measurement::from_prometheus::<P>(stdout);
                         aggregator.add(i, measurement);
                     }

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -428,14 +428,14 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
                 .execute_per_instance(targets, context)
                 .await?;
 
-            // Wait until all fullnodes are reachable (otherwise clients might fail when a
-            // fullnode is not listening yet).
+            // Wait until all fullnodes are fully started by querying the latest checkpoint
+            // (otherwise clients might fail when a fullnode is not listening yet).
             display::action("Await fullnode ready...");
             let commands = self
                 .client_instances
                 .iter()
                 .cloned()
-                .map(|i| (i, "curl http://127.0.0.1:9000 -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"iota_getLatestCheckpointSequenceNumber\",\"params\":[],\"id\":1}'".to_owned())); // fullnodes default json RPC address
+                .map(|i| (i, "curl http://127.0.0.1:9000 -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"iota_getLatestCheckpointSequenceNumber\",\"params\":[],\"id\":1}'".to_owned()));
             self.ssh_manager.wait_for_success(commands).await;
 
             display::done();
@@ -481,15 +481,6 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         let metrics_commands = self
             .protocol_commands
             .clients_metrics_command(self.client_instances.clone(), parameters);
-
-        // TODO: Remove this when consensus client latency metrics are available.
-        // We will be getting latency metrics directly from consensus nodes instead from
-        // the nw client
-        // metrics_commands.append(
-        //     &mut self
-        //         .protocol_commands
-        //         .nodes_metrics_command(self.node_instances.clone(), parameters),
-        // );
 
         let mut aggregator = MeasurementsCollection::new(&self.settings, parameters.clone());
         let mut metrics_interval = time::interval(self.scrape_interval);

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -477,18 +477,18 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         ));
 
         // Regularly scrape the client
-        let mut metrics_commands = self
+        let metrics_commands = self
             .protocol_commands
             .clients_metrics_command(self.client_instances.clone(), parameters);
 
         // TODO: Remove this when consensus client latency metrics are available.
         // We will be getting latency metrics directly from consensus nodes instead from
         // the nw client
-        metrics_commands.append(
-            &mut self
-                .protocol_commands
-                .nodes_metrics_command(self.node_instances.clone(), parameters),
-        );
+        // metrics_commands.append(
+        //     &mut self
+        //         .protocol_commands
+        //         .nodes_metrics_command(self.node_instances.clone(), parameters),
+        // );
 
         let mut aggregator = MeasurementsCollection::new(&self.settings, parameters.clone());
         let mut metrics_interval = time::interval(self.scrape_interval);

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -183,7 +183,7 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
     fn fullnode_command<I>(
         &self,
         instances: I,
-        _parameters: &BenchmarkParameters<IotaBenchmarkType>,
+        parameters: &BenchmarkParameters<IotaBenchmarkType>,
     ) -> Vec<(Instance, String)>
     where
         I: IntoIterator<Item = Instance>,
@@ -195,6 +195,18 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
             .enumerate()
             .map(|(i, instance)| {
                 let config_path: PathBuf = working_dir.join(iota_config::IOTA_FULLNODE_CONFIG);
+                let fullnode_ip = match parameters.use_internal_ip_address {
+                    true => &instance.private_ip,
+                    false => &instance.main_ip,
+                };
+
+                // Update fullnode.yaml to use the correct IP for P2P config using a safer approach
+                // Escape quotes for proper handling inside tmux wrapper
+                let update_p2p_config = format!(
+                    "sed -i 's|listen-address: \\\"127.0.0.1:|listen-address: \\\"0.0.0.0:|' {0} && sed -i 's|external-address: /ip4/127.0.0.1/|external-address: /ip4/{1}/|' {0}",
+                    config_path.display(),
+                    fullnode_ip
+                );
 
                 let run = [
                     "cargo run --release --bin iota-node --",
@@ -204,6 +216,7 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                 let command = [
                     "source $HOME/.cargo/env",
                     "export RUSTFLAGS='-C target-cpu=native'",
+                    &update_p2p_config,
                     &run,
                 ]
                 .join(" && ");

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -200,7 +200,7 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                     false => &instance.main_ip,
                 };
 
-                // Update fullnode.yaml to use the correct IP for P2P config using a safer approach
+                // Overwrite listen address and external address with 0.0.0.0 and actual fullnode IP.
                 // Escape quotes for proper handling inside tmux wrapper
                 let update_p2p_config = format!(
                     "sed -i 's|listen-address: \\\"127.0.0.1:|listen-address: \\\"0.0.0.0:|' {0} && sed -i 's|external-address: /ip4/127.0.0.1/|external-address: /ip4/{1}/|' {0}",


### PR DESCRIPTION
# Description of change

This PR fixes the fullnode IP configuration, updates the health check to use the latest-checkpoint API, and includes several minor improvements.


## Links to any relevant issues

Part of #8846 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes


