### PR TITLE
fix(graphql-rpc): load empty object keys correctly

### DIFF
--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -1337,6 +1337,10 @@ impl Loader<HistoricalKey> for Db {
         use objects_history::dsl as h;
         use objects_version::dsl as v;
 
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
         let id_versions: BTreeSet<_> = keys
             .iter()
             .map(|key| (key.id.into_vec(), key.version as i64))
@@ -1404,6 +1408,10 @@ impl Loader<OptimisticKey> for Db {
 
     async fn load(&self, keys: &[OptimisticKey]) -> Result<HashMap<OptimisticKey, Object>, Error> {
         use objects::dsl as o;
+
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
 
         let id_versions: BTreeSet<_> = keys
             .iter()


### PR DESCRIPTION
# Description of change

Avoids unfiltered queries when loading empty object keys. 

Currently the loaders are used correctly, but the fix makes the implementation more robust for future misuses.

## Links to any relevant issues

Fixes #9400 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

