### PR TITLE
fix(consensus): return last own block with None if transactions are missing

### DIFF
--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -253,26 +253,22 @@ impl Core {
         // refs can be ignored as the missing transactions will be fetched by the
         // periodic transactions' synchronizer.
         self.try_commit().unwrap();
-        let last_proposed_block = match self.try_propose(ReasonToCreateBlock::Recover).unwrap() {
-            (Some(block), _) => Some(block),
-            (None, _) => {
-                let last_proposed_block = self.dag_state.read().recover_last_own_block();
-                if self.should_propose() {
-                    assert!(
-                        last_proposed_block.round() != GENESIS_ROUND,
-                        "At minimum a block of round higher than genesis should have been produced during recovery"
-                    );
+        let last_own_non_genesis_block =
+            match self.try_propose(ReasonToCreateBlock::Recover).unwrap() {
+                (Some(block), _) => Some(block),
+                (None, _) => {
+                    if let Some(last_proposed_block) =
+                        self.dag_state.read().get_last_own_non_genesis_block()
+                    {
+                        // if no new block proposed then just re-broadcast the last proposed one to
+                        // ensure liveness.
+                        self.signals.new_block(last_proposed_block.clone()).unwrap();
+                        Some(last_proposed_block)
+                    } else {
+                        None
+                    }
                 }
-                if last_proposed_block.round() != GENESIS_ROUND {
-                    // if no new block proposed then just re-broadcast the last proposed one to
-                    // ensure liveness.
-                    self.signals.new_block(last_proposed_block.clone()).unwrap();
-                    Some(last_proposed_block)
-                } else {
-                    None
-                }
-            }
-        };
+            };
 
         // Try to set up leader timeout if needed.
         // This needs to be called after try_commit() and try_propose(), which may
@@ -280,8 +276,8 @@ impl Core {
         self.try_signal_new_round();
 
         info!(
-            "Core recovery completed with last proposed block {:?}",
-            last_proposed_block.map(|b| b.verified_block_header)
+            "Core recovery completed with last proposed (non-genesis) block {:?}",
+            last_own_non_genesis_block.map(|b| b.verified_block_header)
         );
 
         self

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -867,29 +867,25 @@ impl DagState {
             .collect()
     }
 
-    /// Gets the last proposed block from this authority.
-    /// If no block is proposed yet, returns Genesis block.
-    /// NOTE: the method panics if transactions or headers are not found in DAG
-    /// State for the most recent header, as that should not happen for
-    /// correct initialization
-    pub(crate) fn recover_last_own_block(&self) -> VerifiedBlock {
+    /// Gets the last proposed (non-genesis) block from this authority.
+    /// NOTE: the method will not panic if transactions or headers are not found
+    /// in DAG State for the most recent header, as that could happen for
+    /// instance when own header is synced and the node is restarted.
+    pub(crate) fn get_last_own_non_genesis_block(&self) -> Option<VerifiedBlock> {
         if let Some(last) = self.recent_headers_refs_by_authority[self.context.own_index].last() {
-            let header = self
-                .recent_block_headers
-                .get(last)
-                .expect("Block header should exist for the most recent blocks");
-            let transactions = self.recent_transactions_by_authority[last.author]
-                .get(last)
-                .expect("Transactions should exist for the most recent blocks");
-            return VerifiedBlock::new(header.clone(), transactions.clone());
+            if last.round > GENESIS_ROUND {
+                if let (Some(last_header), Some(last_transactions)) = (
+                    self.recent_block_headers.get(last),
+                    self.recent_transactions_by_authority[last.author].get(last),
+                ) {
+                    return Some(VerifiedBlock::new(
+                        last_header.clone(),
+                        last_transactions.clone(),
+                    ));
+                }
+            }
         }
-
-        let (_, genesis_block) = self
-            .genesis
-            .iter()
-            .find(|(block_ref, _)| block_ref.author == self.context.own_index)
-            .expect("Genesis should be found for authority {authority_index}");
-        genesis_block.clone()
+        None
     }
 
     /// Gets the last proposed block header from this authority.
@@ -2439,8 +2435,8 @@ mod test {
 
         // Check the last proposed block
         assert_eq!(
-            dag_state.recover_last_own_block(),
-            dag_builder.blocks(num_rounds..=num_rounds)[0].clone()
+            dag_state.get_last_own_non_genesis_block(),
+            Some(dag_builder.blocks(num_rounds..=num_rounds)[0].clone())
         );
 
         // Destroy the dag state.
@@ -2472,8 +2468,8 @@ mod test {
 
         // The last proposed block should be from the round 5
         assert_eq!(
-            dag_state.recover_last_own_block(),
-            dag_builder.blocks(5..=5)[0].clone()
+            dag_state.get_last_own_non_genesis_block(),
+            Some(dag_builder.blocks(5..=5)[0].clone())
         );
 
         // Block headers and transactions above round 5 should not be in DagState,
@@ -2920,7 +2916,10 @@ mod test {
                 .into_iter()
                 .find(|block| block.author() == context.own_index)
                 .unwrap();
-            assert_eq!(dag_state.read().recover_last_own_block(), my_genesis_block);
+            assert_eq!(
+                dag_state.read().get_last_proposed_block_header(),
+                my_genesis_block.verified_block_header
+            );
         }
 
         // WHEN adding some block headers for authorities, only the last ones should be


### PR DESCRIPTION
# Description of change

Fix recovery logic for Starfish to safely handle cases where a node's own non-genesis block may not be available in the DAG State after restart. Instead of panicking when transactions are missing, the recovery process now gracefully returns None and continues.

## Links to any relevant issues

Fixes #9439

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
