### PR TITLE
fix(orchestrator): make non-zero timestamp when running benchmark

### DIFF
--- a/crates/iota-aws-orchestrator/src/benchmark.rs
+++ b/crates/iota-aws-orchestrator/src/benchmark.rs
@@ -65,6 +65,9 @@ pub struct BenchmarkParameters<T> {
     pub protocol_switch_each_epoch: bool,
     /// Optional: Epoch duration in milliseconds, default is 1h
     pub epoch_duration_ms: Option<u64>,
+    /// Computed chain start timestamp (computed once in next() if
+    /// use_current_timestamp_for_genesis is true)
+    pub chain_start_timestamp_ms: Option<u64>,
 }
 
 impl<T: BenchmarkType> Default for BenchmarkParameters<T> {
@@ -81,6 +84,7 @@ impl<T: BenchmarkType> Default for BenchmarkParameters<T> {
             protocol_switch_each_epoch: false,
             maximum_latency: 400,
             epoch_duration_ms: None,
+            chain_start_timestamp_ms: None,
         }
     }
 }
@@ -89,8 +93,13 @@ impl<T: BenchmarkType> Debug for BenchmarkParameters<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{:?}-{:?}-{}-{}-{}",
-            self.benchmark_type, self.faults, self.nodes, self.load, self.use_internal_ip_address,
+            "{:?}-{:?}-{}-{}-{}-{:?}",
+            self.benchmark_type,
+            self.faults,
+            self.nodes,
+            self.load,
+            self.use_internal_ip_address,
+            self.chain_start_timestamp_ms,
         )
     }
 }
@@ -99,8 +108,12 @@ impl<T> Display for BenchmarkParameters<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{} nodes ({}) - {} tx/s (use internal IPs: {})",
-            self.nodes, self.faults, self.load, self.use_internal_ip_address
+            "{} nodes ({}) - {} tx/s (use internal IPs: {}; use current timestamp: {:?})",
+            self.nodes,
+            self.faults,
+            self.load,
+            self.use_internal_ip_address,
+            self.chain_start_timestamp_ms,
         )
     }
 }
@@ -119,6 +132,7 @@ impl<T> BenchmarkParameters<T> {
         protocol_switch_each_epoch: bool,
         maximum_latency: u16,
         epoch_duration_ms: Option<u64>,
+        chain_start_timestamp_ms: Option<u64>,
     ) -> Self {
         Self {
             benchmark_type,
@@ -132,6 +146,7 @@ impl<T> BenchmarkParameters<T> {
             protocol_switch_each_epoch,
             maximum_latency,
             epoch_duration_ms,
+            chain_start_timestamp_ms,
         }
     }
 }
@@ -187,6 +202,8 @@ pub struct BenchmarkParametersGenerator<T> {
     pub protocol_switch_each_epoch: bool,
     /// Optional: Epoch duration in milliseconds, default is 1h
     epoch_duration_ms: Option<u64>,
+    /// Use current system time as genesis chain start timestamp instead of 0
+    use_current_timestamp_for_genesis: bool,
 }
 
 impl<T: BenchmarkType> Iterator for BenchmarkParametersGenerator<T> {
@@ -194,6 +211,17 @@ impl<T: BenchmarkType> Iterator for BenchmarkParametersGenerator<T> {
 
     /// Return the next set of benchmark parameters to run.
     fn next(&mut self) -> Option<Self::Item> {
+        // Compute timestamp once if needed
+        let chain_start_timestamp_ms = if self.use_current_timestamp_for_genesis {
+            Some(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis() as u64,
+            )
+        } else {
+            None
+        };
         self.next_load.map(|load| {
             BenchmarkParameters::new(
                 self.benchmark_type.clone(),
@@ -207,6 +235,7 @@ impl<T: BenchmarkType> Iterator for BenchmarkParametersGenerator<T> {
                 self.protocol_switch_each_epoch,
                 self.maximum_latency,
                 self.epoch_duration_ms,
+                chain_start_timestamp_ms,
             )
         })
     }
@@ -244,6 +273,7 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
             protocol_switch_each_epoch: false,
             maximum_latency: 400,
             epoch_duration_ms: None,
+            use_current_timestamp_for_genesis: false,
         }
     }
 
@@ -287,6 +317,11 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
 
     pub fn with_epoch_duration(mut self, epoch_duration_ms: Option<u64>) -> Self {
         self.epoch_duration_ms = epoch_duration_ms;
+        self
+    }
+
+    pub fn with_current_timestamp_for_genesis(mut self, use_current_timestamp: bool) -> Self {
+        self.use_current_timestamp_for_genesis = use_current_timestamp;
         self
     }
 

--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -175,6 +175,11 @@ pub enum Operation {
         /// latency_perturbation_spec
         #[arg(long, value_name = "INT", default_value = "1", global = true)]
         blocking_connections: usize,
+
+        /// Use current system time as genesis chain start timestamp instead of
+        /// 0
+        #[arg(long, action, default_value_t = false)]
+        use_current_timestamp_for_genesis: bool,
     },
 
     /// Print a summary of the specified measurements collection.
@@ -389,6 +394,7 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
             maximum_latency,
             epoch_duration_ms,
             blocking_connections,
+            use_current_timestamp_for_genesis,
         } => {
             // Create a new orchestrator to instruct the testbed.
             let username = testbed.username();
@@ -468,6 +474,7 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
                     .with_protocol_switch_each_epoch(protocol_switch_each_epoch)
                     .with_max_latency(maximum_latency)
                     .with_epoch_duration(epoch_duration_ms)
+                    .with_current_timestamp_for_genesis(use_current_timestamp_for_genesis)
                     .with_faults(fault_type);
 
             Orchestrator::new(

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -96,16 +96,24 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
             })
             .collect::<Vec<_>>()
             .join(" ");
+        let epoch_duration_flag = parameters
+            .epoch_duration_ms
+            .map(|epoch_duration_ms| format!("--epoch-duration-ms {epoch_duration_ms}"))
+            .unwrap_or_default();
+        let chain_start_timestamp_flag = parameters
+            .chain_start_timestamp_ms
+            .map(|timestamp_ms| format!("--chain-start-timestamp-ms {timestamp_ms}"))
+            .unwrap_or_default();
         let genesis = [
             "cargo run --release --bin iota --",
             "genesis",
             &format!("-f --working-dir {working_dir} --benchmark-ips {ips}"),
-            parameters
-                .epoch_duration_ms
-                .map(|epoch_duration_ms| format!("--epoch-duration-ms {epoch_duration_ms}"))
-                .as_deref()
-                .unwrap_or(""),
+            &epoch_duration_flag,
+            &chain_start_timestamp_flag,
         ]
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
         .join(" ");
 
         [
@@ -325,7 +333,11 @@ impl IotaProtocol {
                 false => x.main_ip.to_string(),
             })
             .collect();
-        let genesis_config = GenesisConfig::new_for_benchmarks(&ips, parameters.epoch_duration_ms);
+        let genesis_config = GenesisConfig::new_for_benchmarks(
+            &ips,
+            parameters.epoch_duration_ms,
+            parameters.chain_start_timestamp_ms,
+        );
         let mut addresses = Vec::new();
         if let Some(validator_configs) = genesis_config.validator_config_info.as_ref() {
             for (i, validator_info) in validator_configs.iter().enumerate() {
@@ -366,25 +378,28 @@ impl ProtocolMetrics for IotaProtocol {
                 )
             })
             .unzip();
-
-        GenesisConfig::new_for_benchmarks(&ips, parameters.epoch_duration_ms)
-            .validator_config_info
-            .expect("No validator in genesis")
-            .iter()
-            .zip(instances)
-            .map(|(config, instance)| {
-                let path = format!(
-                    "{}:{}{}",
-                    match parameters.use_internal_ip_address {
-                        true => instance.private_ip,
-                        false => instance.main_ip,
-                    },
-                    config.metrics_address.port(),
-                    iota_metrics::METRICS_ROUTE
-                );
-                (instance, path)
-            })
-            .collect()
+        GenesisConfig::new_for_benchmarks(
+            &ips,
+            parameters.epoch_duration_ms,
+            parameters.chain_start_timestamp_ms,
+        )
+        .validator_config_info
+        .expect("No validator in genesis")
+        .iter()
+        .zip(instances)
+        .map(|(config, instance)| {
+            let path = format!(
+                "{}:{}{}",
+                match parameters.use_internal_ip_address {
+                    true => instance.private_ip,
+                    false => instance.main_ip,
+                },
+                config.metrics_address.port(),
+                iota_metrics::METRICS_ROUTE
+            );
+            (instance, path)
+        })
+        .collect()
     }
 
     fn clients_metrics_path<I, T>(

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -344,7 +344,11 @@ impl GenesisConfig {
     /// predictable to facilitate benchmarks orchestration. Only the main ip
     /// addresses of the validators are specified (as those are often
     /// dictated by the cloud provider hosing the testbed).
-    pub fn new_for_benchmarks(ips: &[String], epoch_duration_ms: Option<u64>) -> Self {
+    pub fn new_for_benchmarks(
+        ips: &[String],
+        epoch_duration_ms: Option<u64>,
+        chain_start_timestamp_ms: Option<u64>,
+    ) -> Self {
         // Set the validator's configs. They should be the same across multiple runs to
         // ensure reproducibility.
         let mut rng = StdRng::seed_from_u64(Self::BENCHMARKS_RNG_SEED);
@@ -385,7 +389,7 @@ impl GenesisConfig {
         // Benchmarks require a deterministic genesis. Every validator locally generates
         // it own genesis; it is thus important they have the same parameters.
         let parameters = GenesisCeremonyParameters {
-            chain_start_timestamp_ms: 0,
+            chain_start_timestamp_ms: chain_start_timestamp_ms.unwrap_or(0),
             epoch_duration_ms: if let Some(duration_ms) = epoch_duration_ms {
                 duration_ms
             } else {

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -266,6 +266,8 @@ pub enum IotaCommand {
         force: bool,
         #[arg(long)]
         epoch_duration_ms: Option<u64>,
+        #[arg(long, help = "Set the genesis chain start timestamp in milliseconds")]
+        chain_start_timestamp_ms: Option<u64>,
         #[arg(
             long,
             value_name = "ADDR",
@@ -431,6 +433,7 @@ impl IotaCommand {
                 from_config,
                 write_config,
                 epoch_duration_ms,
+                chain_start_timestamp_ms,
                 benchmark_ips,
                 with_faucet,
                 committee_size,
@@ -444,6 +447,7 @@ impl IotaCommand {
                     working_dir,
                     force,
                     epoch_duration_ms,
+                    chain_start_timestamp_ms,
                     benchmark_ips,
                     with_faucet,
                     committee_size,
@@ -740,6 +744,7 @@ async fn start(
                 false,
                 epoch_duration_ms,
                 None,
+                None,
                 false,
                 committee_size.unwrap_or(DEFAULT_COMMITTEE_SIZE),
                 local_migration_snapshots,
@@ -1007,6 +1012,7 @@ async fn genesis(
     working_dir: Option<PathBuf>,
     force: bool,
     epoch_duration_ms: Option<u64>,
+    chain_start_timestamp_ms: Option<u64>,
     benchmark_ips: Option<Vec<String>>,
     with_faucet: bool,
     committee_size: usize,
@@ -1094,8 +1100,9 @@ async fn genesis(
                 }
                 keystore.save()?;
 
-                // Make a new genesis config from the provided ip addresses.
-                GenesisConfig::new_for_benchmarks(&ips, epoch_duration_ms)
+                // Make a new genesis config from the provided ip addresses with given epoch
+                // duration and timestamp.
+                GenesisConfig::new_for_benchmarks(&ips, epoch_duration_ms, chain_start_timestamp_ms)
             } else if keystore_path.exists() {
                 let existing_keys = FileBasedKeystore::new(&keystore_path)?.addresses();
                 GenesisConfig::for_local_testing_with_addresses(existing_keys)

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -361,6 +361,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         local_migration_snapshots: vec![],
         remote_migration_snapshots: vec![],
         delegator: None,
+        chain_start_timestamp_ms: None,
     }
     .execute()
     .await?;
@@ -403,6 +404,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         local_migration_snapshots: vec![],
         remote_migration_snapshots: vec![],
         delegator: None,
+        chain_start_timestamp_ms: None,
     }
     .execute()
     .await;


### PR DESCRIPTION
# Description of change

 Add configurable genesis chain start timestamp to the IOTA orchestrator and benchmarking infrastructure, replacing the hardcoded timestamp of 0 with the current system time computed at benchmark runtime.

## Links to any relevant issues

Fixes #9445 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes