### PR TITLE
feat(rest-kv): Add support for multiget requests

### DIFF
--- a/crates/iota-kvstore/src/bigtable/client.rs
+++ b/crates/iota-kvstore/src/bigtable/client.rs
@@ -209,24 +209,26 @@ impl KeyValueStoreReader for BigTableClient {
         Ok(checkpoints)
     }
 
-    async fn get_checkpoint_by_digest(
+    async fn get_checkpoints_by_digest(
         &mut self,
-        digest: CheckpointDigest,
-    ) -> Result<Option<Checkpoint>, Self::Error> {
-        let key = digest.inner().to_vec();
-        let latest_row_cells = self
-            .multi_get(CHECKPOINTS_BY_DIGEST_TABLE, vec![key], None)
+        digests: &[CheckpointDigest],
+    ) -> Result<Vec<Checkpoint>, Self::Error> {
+        let keys = digests
+            .iter()
+            .map(|digest| digest.inner().to_vec())
+            .collect::<Vec<_>>();
+        let seq_nums = self
+            .multi_get(CHECKPOINTS_BY_DIGEST_TABLE, keys, None)
             .await?
-            .pop();
-        if let Some(cells) = latest_row_cells {
-            if let Some(cell) = cells.into_iter().next() {
-                let sequence_number = u64::from_be_bytes(cell.value.as_slice().try_into()?);
-                if let Some(chk) = self.get_checkpoints(&[sequence_number]).await?.pop() {
-                    return Ok(Some(chk));
-                }
-            }
-        }
-        Ok(None)
+            .into_iter()
+            .filter_map(|row_cells| {
+                row_cells
+                    .into_iter()
+                    .next()
+                    .map(|cell| cell.value.as_slice().try_into().map(u64::from_be_bytes))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        self.get_checkpoints(&seq_nums).await
     }
 }
 

--- a/crates/iota-kvstore/src/lib.rs
+++ b/crates/iota-kvstore/src/lib.rs
@@ -29,25 +29,33 @@ pub trait KeyValueStoreReader {
     type Error;
 
     /// Fetches a list of objects by their keys.
+    ///
+    /// Not found objects are omitted from the output list.
     async fn get_objects(&mut self, objects: &[ObjectKey]) -> Result<Vec<Object>, Self::Error>;
 
     /// Fetches a list of transactions by their digests.
+    ///
+    /// Not found transactions are omitted from the output list.
     async fn get_transactions(
         &mut self,
         transactions: &[TransactionDigest],
     ) -> Result<Vec<TransactionData>, Self::Error>;
 
     /// Fetches a list of checkpoints by their sequence numbers.
+    ///
+    /// Not found checkpoints are omitted from the output list.
     async fn get_checkpoints(
         &mut self,
         sequence_numbers: &[CheckpointSequenceNumber],
     ) -> Result<Vec<Checkpoint>, Self::Error>;
 
-    /// Fetches a checkpoint by its digest.
-    async fn get_checkpoint_by_digest(
+    /// Fetches a list of checkpoints by their digests.
+    ///
+    /// Not found checkpoints are omitted from the output list.
+    async fn get_checkpoints_by_digest(
         &mut self,
-        digest: CheckpointDigest,
-    ) -> Result<Option<Checkpoint>, Self::Error>;
+        digests: &[CheckpointDigest],
+    ) -> Result<Vec<Checkpoint>, Self::Error>;
 }
 
 /// Writing key-value data to a persistent store, such as objects, transactions,

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -3,7 +3,10 @@
 
 //! This module provides a client for interacting with the key-value store.
 
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 
 use anyhow::Result;
 use bytes::Bytes;
@@ -11,6 +14,8 @@ use iota_kvstore::{BigTableClient, KeyValueStoreReader};
 use iota_storage::http_key_value_store::Key;
 use iota_types::storage::ObjectKey;
 use serde::{Deserialize, Serialize};
+
+use crate::errors::ApiError;
 
 /// Configuration for the [`KvStoreClient`] used to access data from BigTableDB
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -63,97 +68,224 @@ impl KvStoreClient {
         self.start_time.elapsed()
     }
 
-    /// Get value as [`Bytes`] from the kv store.
+    /// Gets value as [`Bytes`] from the kv store.
     ///
     /// Based on the provided [`Key`] fetch the data from BigTableDB.
-    pub async fn get(&self, key: Key) -> Result<Option<Bytes>> {
+    pub async fn get(&self, key: Key) -> Result<Option<Bytes>, ApiError> {
+        let results = self.multi_get(vec![key]).await?;
+        Ok(results.into_iter().next().unwrap_or(None))
+    }
+
+    /// Gets multiple values as [`Vec`]<[`Option`]<[`Bytes`]>> from the kv
+    /// store.
+    ///
+    /// Based on the provided [`Vec`]<[`Key`]> fetch the data from BigTableDB.
+    /// Returns a vector of the same length and order as the input keys.
+    /// Each entry is `Some(bytes)` if the key was found, or `None` if not
+    /// found.
+    ///
+    /// All keys must be of the same type, otherwise [`ApiError::BadRequest`] is
+    /// returned.
+    pub async fn multi_get(&self, keys: Vec<Key>) -> Result<Vec<Option<Bytes>>, ApiError> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let mut client = self.bigtable_client.clone();
-        match key {
-            Key::Transaction(transaction_digest) => {
-                let transactions = client.get_transactions(&[transaction_digest]).await?;
 
-                let data = transactions
-                    .first()
-                    .map(|tx_data| bcs::to_bytes(&tx_data.transaction).map(Bytes::from))
-                    .transpose()?;
+        // Use the first key to determine the type - all keys should be of the same type
+        match keys.first().expect("emptiness was checked earlier") {
+            Key::Transaction(_) => {
+                let digests = Self::extract_keys(&keys, |k| match k {
+                    Key::Transaction(digest) => Some(*digest),
+                    _ => None,
+                })?;
 
-                Ok(data)
+                let transactions = client.get_transactions(&digests).await?;
+
+                let ordered = Self::restore_order(digests, transactions, |tx_data| {
+                    *tx_data.transaction.digest()
+                });
+                Self::extract_values_and_serialize(ordered, |tx_data| Some(&tx_data.transaction))
             }
-            Key::TransactionEffects(transaction_digest) => {
-                let transactions = client.get_transactions(&[transaction_digest]).await?;
+            Key::TransactionEffects(_) => {
+                let digests = Self::extract_keys(&keys, |k| match k {
+                    Key::TransactionEffects(digest) => Some(*digest),
+                    _ => None,
+                })?;
 
-                let data = transactions
-                    .first()
-                    .map(|tx_data| bcs::to_bytes(&tx_data.effects).map(Bytes::from))
-                    .transpose()?;
+                let transactions = client.get_transactions(&digests).await?;
 
-                Ok(data)
+                let ordered = Self::restore_order(digests, transactions, |tx_data| {
+                    *tx_data.transaction.digest()
+                });
+                Self::extract_values_and_serialize(ordered, |tx_data| Some(&tx_data.effects))
             }
-            Key::CheckpointContents(chk_seq_num) => {
-                let checkpoints = client.get_checkpoints(&[chk_seq_num]).await?;
+            Key::CheckpointContents(_) => {
+                let seq_nums = Self::extract_keys(&keys, |k| match k {
+                    Key::CheckpointContents(seq_num) => Some(*seq_num),
+                    _ => None,
+                })?;
 
-                let data = checkpoints
-                    .first()
-                    .map(|chk| bcs::to_bytes(&chk.contents).map(Bytes::from))
-                    .transpose()?;
+                let checkpoints = client.get_checkpoints(&seq_nums).await?;
 
-                Ok(data)
+                let ordered = Self::restore_order(seq_nums, checkpoints, |chk| {
+                    *chk.summary.data().sequence_number()
+                });
+                Self::extract_values_and_serialize(ordered, |chk| Some(&chk.contents))
             }
-            Key::CheckpointSummary(chk_seq_num) => {
-                let checkpoints = client.get_checkpoints(&[chk_seq_num]).await?;
+            Key::CheckpointSummary(_) => {
+                let seq_nums = Self::extract_keys(&keys, |k| match k {
+                    Key::CheckpointSummary(seq_num) => Some(*seq_num),
+                    _ => None,
+                })?;
 
-                let data = checkpoints
-                    .first()
-                    .map(|chk| bcs::to_bytes(&chk.summary).map(Bytes::from))
-                    .transpose()?;
+                let checkpoints = client.get_checkpoints(&seq_nums).await?;
 
-                Ok(data)
+                let ordered = Self::restore_order(seq_nums, checkpoints, |chk| {
+                    *chk.summary.data().sequence_number()
+                });
+                Self::extract_values_and_serialize(ordered, |chk| Some(&chk.summary))
             }
-            Key::CheckpointSummaryByDigest(checkpoint_digest) => {
-                let checkpoint = client.get_checkpoint_by_digest(checkpoint_digest).await?;
+            Key::CheckpointSummaryByDigest(_) => {
+                let checkpoint_digests = Self::extract_keys(&keys, |k| match k {
+                    Key::CheckpointSummaryByDigest(checkpoint_digest) => Some(*checkpoint_digest),
+                    _ => None,
+                })?;
 
-                let checkpoint = checkpoint
-                    .map(|chk| bcs::to_bytes(&chk.summary).map(Bytes::from))
-                    .transpose()?;
+                let checkpoints = client
+                    .get_checkpoints_by_digest(&checkpoint_digests)
+                    .await?;
 
-                Ok(checkpoint)
+                let ordered = Self::restore_order(checkpoint_digests, checkpoints, |chk| {
+                    *chk.summary.digest()
+                });
+                Self::extract_values_and_serialize(ordered, |chk| Some(&chk.summary))
             }
-            Key::TransactionToCheckpoint(transaction_digest) => {
-                let transactions = client.get_transactions(&[transaction_digest]).await?;
+            Key::TransactionToCheckpoint(_) => {
+                let digests = Self::extract_keys(&keys, |k| match k {
+                    Key::TransactionToCheckpoint(digest) => Some(*digest),
+                    _ => None,
+                })?;
 
-                let data = transactions
-                    .first()
-                    .map(|tx_data| bcs::to_bytes(&tx_data.checkpoint_number).map(Bytes::from))
-                    .transpose()?;
+                let transactions = client.get_transactions(&digests).await?;
 
-                Ok(data)
+                let ordered = Self::restore_order(digests, transactions, |tx_data| {
+                    *tx_data.transaction.digest()
+                });
+                Self::extract_values_and_serialize(ordered, |tx_data| {
+                    Some(&tx_data.checkpoint_number)
+                })
             }
-            Key::ObjectKey(object_id, sequence_number) => {
-                let object_key = ObjectKey(object_id, sequence_number);
-                let objects = client.get_objects(&[object_key]).await?;
+            Key::ObjectKey(_, _) => {
+                let object_keys = Self::extract_keys(&keys, |k| match k {
+                    Key::ObjectKey(object_id, sequence_number) => {
+                        Some(ObjectKey(*object_id, *sequence_number))
+                    }
+                    _ => None,
+                })?;
 
-                let data = objects
-                    .first()
-                    .map(|object| bcs::to_bytes(object).map(Bytes::from))
-                    .transpose()?;
+                let objects = client.get_objects(&object_keys).await?;
 
-                Ok(data)
+                let ordered = Self::restore_order(object_keys, objects, |object| {
+                    ObjectKey(object.id(), object.version())
+                });
+                Self::extract_values_and_serialize(ordered, |object| Some(object))
             }
-            Key::EventsByTransactionDigest(transaction_digest) => {
-                let transactions = client.get_transactions(&[transaction_digest]).await?;
+            Key::EventsByTransactionDigest(_) => {
+                let digests = Self::extract_keys(&keys, |k| match k {
+                    Key::EventsByTransactionDigest(digest) => Some(*digest),
+                    _ => None,
+                })?;
 
-                let data = transactions
-                    .first()
-                    .and_then(|tx_data| {
-                        tx_data
-                            .events
-                            .as_ref()
-                            .map(|ev| bcs::to_bytes(ev).map(Bytes::from))
-                    })
-                    .transpose()?;
+                let transactions = client.get_transactions(&digests).await?;
 
-                Ok(data)
+                let ordered = Self::restore_order(digests, transactions, |tx_data| {
+                    *tx_data.transaction.digest()
+                });
+                Self::extract_values_and_serialize(ordered, |tx_data| tx_data.events.as_ref())
             }
         }
+        .map_err(Into::into)
+    }
+
+    /// Extracts specific key type from a general [`Key`] type.
+    ///
+    /// Takes:
+    /// - `keys`: The list of keys to extract from
+    /// - `extractor`: Function that returns Some(extracted_value) for the
+    ///   target variant, None otherwise
+    ///
+    /// Returns a vector of extracted values. Returns [`ApiError::BadRequest`]
+    /// if any extraction returns None value.
+    fn extract_keys<T, F>(keys: &[Key], extractor: F) -> Result<Vec<T>, ApiError>
+    where
+        F: Fn(&Key) -> Option<T>,
+    {
+        keys.iter()
+            .map(|k| {
+                extractor(k).ok_or_else(|| {
+                    ApiError::BadRequest("all keys should be of the same type".to_string())
+                })
+            })
+            .collect()
+    }
+
+    /// Maps `results` from KV back to original order specified by `keys`.
+    ///
+    /// Takes:
+    /// - `keys`: The original list of keys in the order they were requested
+    /// - `results`: The results returned from the KV client (may be in
+    ///   different order or missing items)
+    /// - `key_extractor`: Function to extract the key from a result item
+    ///
+    /// Returns a vector in the same order as `keys`, with `Some(T)` for found
+    /// items and `None` for missing items.
+    fn restore_order<K, T, F>(keys: Vec<K>, results: Vec<T>, key_extractor: F) -> Vec<Option<T>>
+    where
+        K: std::hash::Hash + Eq,
+        T: Clone,
+        F: Fn(&T) -> K,
+    {
+        // Create a map from key to result data
+        let results_map: HashMap<K, T> = results
+            .into_iter()
+            .map(|item| (key_extractor(&item), item))
+            .collect();
+
+        // Map back to original order
+        keys.into_iter()
+            .map(|key| results_map.get(&key).cloned())
+            .collect()
+    }
+
+    /// Extracts final values from KV response and serializes them.
+    ///
+    /// Takes:
+    /// - `ordered_results`: Results in the desired order (with None for missing
+    ///   items)
+    /// - `value_extractor`: Function to extract the value from a result item
+    ///
+    /// Returns a vector of serialized bytes, with `None` for missing or empty
+    /// values.
+    fn extract_values_and_serialize<T, V, G>(
+        ordered_results: Vec<Option<T>>,
+        value_extractor: G,
+    ) -> Result<Vec<Option<Bytes>>>
+    where
+        V: Serialize,
+        G: Fn(&T) -> Option<&V>,
+    {
+        ordered_results
+            .iter()
+            .map(|opt_item| {
+                opt_item
+                    .as_ref()
+                    .and_then(&value_extractor)
+                    .map(|value| bcs::to_bytes(value).map(Bytes::from))
+                    .transpose()
+                    .map_err(Into::into)
+            })
+            .collect::<Result<Vec<_>>>()
     }
 }

--- a/crates/iota-rest-kv/src/errors.rs
+++ b/crates/iota-rest-kv/src/errors.rs
@@ -23,6 +23,13 @@ pub enum ApiError {
     InternalServerError,
 }
 
+impl From<anyhow::Error> for ApiError {
+    fn from(err: anyhow::Error) -> Self {
+        tracing::error!("internal server error: {err}");
+        ApiError::InternalServerError
+    }
+}
+
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let status_code = match self {

--- a/crates/iota-rest-kv/src/main.rs
+++ b/crates/iota-rest-kv/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fs, path::PathBuf};
+use std::{fs, num::NonZeroUsize, path::PathBuf};
 
 use anyhow::Result;
 use clap::Parser;
@@ -45,6 +45,12 @@ pub struct RestApiConfig {
     #[serde(flatten)]
     pub kv_store_config: KvStoreConfig,
     pub server_address: std::net::SocketAddr,
+    #[serde(default = "default_multiget_max_items")]
+    pub multiget_max_items: NonZeroUsize,
+}
+
+fn default_multiget_max_items() -> NonZeroUsize {
+    NonZeroUsize::new(100).unwrap()
 }
 
 #[tokio::main]

--- a/crates/iota-rest-kv/src/main.rs
+++ b/crates/iota-rest-kv/src/main.rs
@@ -50,7 +50,7 @@ pub struct RestApiConfig {
 }
 
 fn default_multiget_max_items() -> NonZeroUsize {
-    NonZeroUsize::new(100).unwrap()
+    NonZeroUsize::new(100).expect("value should be greater than 0")
 }
 
 #[tokio::main]

--- a/crates/iota-rest-kv/src/routes/health.rs
+++ b/crates/iota-rest-kv/src/routes/health.rs
@@ -4,7 +4,7 @@
 use axum::{Json, extract::State, response::IntoResponse};
 use serde::Serialize;
 
-use crate::types::SharedKvStoreClient;
+use crate::types::SharedRestServerAppState;
 
 bin_version::bin_version!();
 
@@ -25,11 +25,11 @@ pub struct HealthResponse {
 ///
 /// This endpoint provides information about the server's health, including
 /// the version, Git hash and uptime.
-pub async fn health(State(kv_store_client): State<SharedKvStoreClient>) -> impl IntoResponse {
+pub async fn health(State(app_state): State<SharedRestServerAppState>) -> impl IntoResponse {
     let response = HealthResponse {
         version: VERSION.to_owned(),
         git_hash: GIT_REVISION.to_owned(),
-        uptime: format!("{:?}", kv_store_client.get_uptime()),
+        uptime: format!("{:?}", app_state.kv_store_client.get_uptime()),
         status: "OK".to_owned(),
     };
     Json(response)

--- a/crates/iota-rest-kv/src/routes/kv_store.rs
+++ b/crates/iota-rest-kv/src/routes/kv_store.rs
@@ -1,9 +1,23 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+use axum::{
+    Json,
+    body::Body,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use iota_storage::http_key_value_store::{ItemType, Key};
+use serde::Deserialize;
 
-use axum::{body::Body, extract::State, http::StatusCode, response::IntoResponse};
+use crate::{errors::ApiError, extractors::ExtractPath, types::SharedRestServerAppState};
 
-use crate::{errors::ApiError, extractors::ExtractPath, types::SharedKvStoreClient};
+/// Request payload for multi_get_objects_post containing list of keys.
+#[derive(Deserialize, Debug)]
+pub struct MultiGetRequest {
+    /// List of base64url-encoded keys to retrieve.
+    pub keys: Vec<String>,
+}
 
 /// Retrieves data associated with a given key from the KV store as raw
 /// [`Bytes`](bytes::Bytes).
@@ -18,14 +32,81 @@ use crate::{errors::ApiError, extractors::ExtractPath, types::SharedKvStoreClien
 ///   server error` is returned.
 pub async fn data_as_bytes(
     ExtractPath(key): ExtractPath,
-    State(kv_store_client): State<SharedKvStoreClient>,
+    State(app_state): State<SharedRestServerAppState>,
 ) -> Result<impl IntoResponse, ApiError> {
-    match kv_store_client.get(key).await {
-        Ok(Some(bytes)) => Ok(bytes.into_response()),
-        Ok(None) => Ok((StatusCode::NO_CONTENT, Body::empty()).into_response()),
-        Err(err) => {
-            tracing::error!("cannot fetch data from kv store: {err}");
-            Err(ApiError::InternalServerError)
-        }
+    app_state
+        .kv_store_client
+        .get(key)
+        .await
+        .map(|res| match res {
+            Some(bytes) => bytes.into_response(),
+            None => (StatusCode::NO_CONTENT, Body::empty()).into_response(),
+        })
+}
+
+/// Retrieves multiple objects via POST request with JSON payload.
+///
+/// # Path Parameters
+///
+/// - `item_type`: The type of items to get (e.g., "cs", "cc", "tx")
+///
+/// # Request Body
+///
+/// JSON object with `keys` field:
+///
+/// ```json
+/// {
+///   "keys": ["AAEAAAAAAAAA", "AAIAAAAAAAAA", "AAMAAAAAAAAA"]
+/// }
+/// ```
+///
+/// Where:
+/// - `keys`: Array of base64url-encoded keys for given `item_type`. The same
+///   kind of key and encoding user would use in single item GET request.
+///
+/// # Returns
+///
+/// * If successful, returns a BCS-serialized
+///   [`Vec`]<[`Option`]<[`Bytes`](bytes::Bytes)>> with a `200 OK` status code.
+///   The vector has the same length and order as the `keys` list in the request
+///   body. Each entry is `Some(bytes)` if the key was found, or `None` if the
+///   key was not found.
+/// * If no keys are provided or the number of keys exceeds the configured
+///   `multiget_max_items` limit, a `400 bad request error` is returned.
+/// * If the keys cannot be parsed, a `400 bad request error` is returned.
+/// * If heterogenous key types are requested (e.g. checkpoints by sequence id
+///   and by digest), a `400 bad request error` is returned.
+/// * If an error occurs while interacting with the KV store, an `500 internal
+///   server error` is returned.
+pub async fn multi_get_data(
+    Path(item_type): Path<ItemType>,
+    State(app_state): State<SharedRestServerAppState>,
+    Json(payload): Json<MultiGetRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    if payload.keys.is_empty() {
+        return Err(ApiError::BadRequest("no keys provided".to_string()));
     }
+
+    if payload.keys.len() > app_state.multiget_max_items.get() {
+        return Err(ApiError::BadRequest(format!(
+            "too many keys: requested {}, maximum allowed is {}",
+            payload.keys.len(),
+            app_state.multiget_max_items
+        )));
+    }
+
+    let item_type_str = item_type.to_string();
+    let keys = payload
+        .keys
+        .iter()
+        .map(|encoded_key| {
+            Key::new(item_type_str.as_str(), encoded_key.as_str())
+                .map_err(|err| ApiError::BadRequest(format!("invalid key '{encoded_key}': {err}")))
+        })
+        .collect::<Result<Vec<Key>, ApiError>>()?;
+
+    let results = app_state.kv_store_client.multi_get(keys).await?;
+
+    let bcs_data = bcs::to_bytes(&results).map_err(|_| ApiError::InternalServerError)?;
+    Ok(bcs_data.into_response())
 }

--- a/crates/iota-rest-kv/src/server.rs
+++ b/crates/iota-rest-kv/src/server.rs
@@ -3,11 +3,14 @@
 
 //! This module includes helper wrappers for building and starting a REST API
 //! server.
-
 use std::{net::SocketAddr, sync::Arc};
 
 use anyhow::Result;
-use axum::{Router, response::IntoResponse, routing::get};
+use axum::{
+    Router,
+    response::IntoResponse,
+    routing::{get, post},
+};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -15,6 +18,7 @@ use crate::{
     bigtable::KvStoreClient,
     errors::ApiError,
     routes::{health, kv_store},
+    types::RestServerAppState,
 };
 
 /// A wrapper which builds the components needed for the REST API server and
@@ -33,10 +37,14 @@ impl Server {
     pub async fn new(config: RestApiConfig, token: CancellationToken) -> Result<Self> {
         let kv_store_client = KvStoreClient::new(config.kv_store_config).await?;
 
-        let shared_state = Arc::new(kv_store_client);
+        let shared_state = Arc::new(RestServerAppState {
+            kv_store_client: Arc::new(kv_store_client),
+            multiget_max_items: config.multiget_max_items,
+        });
 
         let router = Router::new()
             .route("/health", get(health::health))
+            .route("/{item_type}", post(kv_store::multi_get_data))
             .route("/{item_type}/{key}", get(kv_store::data_as_bytes))
             .with_state(shared_state)
             .fallback(fallback);

--- a/crates/iota-rest-kv/src/types.rs
+++ b/crates/iota-rest-kv/src/types.rs
@@ -3,10 +3,15 @@
 
 //! This module includes types and useful conversions.
 
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
 use crate::bigtable::KvStoreClient;
 
-/// Represents a shared instance of the [`KvStoreClient`], primerely used by the
+/// Represents a shared instance of the application state, used by the
 /// REST API server global [`State`](axum::extract::State).
-pub type SharedKvStoreClient = Arc<KvStoreClient>;
+pub type SharedRestServerAppState = Arc<RestServerAppState>;
+
+pub struct RestServerAppState {
+    pub kv_store_client: Arc<KvStoreClient>,
+    pub multiget_max_items: NonZeroUsize,
+}


### PR DESCRIPTION
# Description of change

This change introduces new `POST /{item_type}` endpoint to iota-rest-kv.

The endpoint has similar function to already existing `GET /{item_type}/{key}` endpoint, but it allows many keys to be fetched at once, not only one.

Examples:

- Single item GET for `0x5` obj at version `1844674`: `curl -X GET http://127.0.0.1:3555/ob/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXCJRwAAAAAAA`
- Single item GET for `0x6` obj at version `1844675`: `curl -X GET http://127.0.0.1:3555/ob/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbDJRwAAAAAAA`
- Multiget to get both those objects: 
```
curl -X POST http://127.0.0.1:3555/ob \
  -H "Content-Type: application/json" \
  -d '{
  "keys": [
    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXCJRwAAAAAAA",
    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbDJRwAAAAAAA"
  ]
}'
```

This returns a BCS-serialized `Vec<Option<Bytes>>` with the same length and order as the `keys` array in the input payload. Found values will be `Some`, not found values will be `None`.

The base64-url encoding of keys on the input was kept in the multiget version, since that is the format `iota-storage` expects when constructing the `Key`s.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9413

## How the change has been tested

The server has been started locally, connected to the devnet bigtable, and queried with custom script to test different multi and single object get scenarios.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
