### PR TITLE
feat(move): Add custom attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8170,6 +8170,7 @@ dependencies = [
 name = "iota-verifier-latest"
 version = "0.1.0"
 dependencies = [
+ "bcs",
  "iota-types",
  "move-abstract-interpreter",
  "move-abstract-stack",

--- a/crates/iota-move-build/src/lib.rs
+++ b/crates/iota-move-build/src/lib.rs
@@ -22,11 +22,15 @@ use iota_types::{
     base_types::ObjectID,
     error::{IotaError, IotaResult},
     is_system_package,
-    move_package::{FnInfo, FnInfoKey, FnInfoMap, MovePackage},
+    move_package::{
+        FnInfo, FnInfoKey, FnInfoMap, MovePackage, RuntimeModuleMetadata,
+        RuntimeModuleMetadataWrapper,
+    },
 };
 use iota_verifier::verifier as iota_bytecode_verifier;
 use move_binary_format::{
     CompiledModule,
+    file_format_common::IOTA_METADATA_KEY,
     normalized::{self, Type},
 };
 use move_bytecode_utils::{Modules, layout::SerdeLayoutBuilder, module_cache::GetModule};
@@ -290,10 +294,14 @@ pub fn build_from_resolution_graph(
         BuildConfig::compile_package(&resolution_graph, &mut std::io::sink())
     };
 
-    let (package, fn_info) = result.map_err(|error| IotaError::ModuleBuildFailure {
+    let (mut package, fn_info) = result.map_err(|error| IotaError::ModuleBuildFailure {
         // Use [Debug] formatting to capture [anyhow] error context
         error: format!("{error:?}"),
     })?;
+
+    // Based on the information found in `fn_info`, fill in the metadata for each
+    // compiled module
+    fill_metadata(&mut package, &fn_info)?;
 
     if run_bytecode_verifier {
         verify_bytecode(&package, &fn_info)?;
@@ -342,6 +350,37 @@ fn collect_bytecode_deps(
     }
 
     Ok(bytecode_deps)
+}
+
+/// Fill metadata
+fn fill_metadata(package: &mut MoveCompiledPackage, _fn_info_map: &FnInfoMap) -> IotaResult<()> {
+    for module in package
+        .root_compiled_units
+        .iter_mut()
+        .map(|unit| &mut unit.unit.module)
+    {
+        let runtime_metadata = RuntimeModuleMetadata::default();
+        // for fn_def in &module.function_defs {
+        //    let fn_handle = module.function_handle_at(fn_def.function);
+        //    let fn_name = module.identifier_at(fn_handle.name);
+        //    fill metadata with custom logic
+        //    if let Some(version) =
+        //    get_attribute(fn_name, module, fn_info_map)
+        //.   {
+        //       runtime_metadata.add_function_attribute(
+        //           fn_name.to_string(),
+        //           IotaAttribute::attribute(version),
+        //       );
+        //    };
+        // }
+        if !runtime_metadata.is_empty() {
+            module.metadata.push(move_core_types::metadata::Metadata {
+                key: IOTA_METADATA_KEY.to_vec(),
+                value: RuntimeModuleMetadataWrapper::from(runtime_metadata).to_bcs_bytes(),
+            });
+        }
+    }
+    Ok(())
 }
 
 /// Check that the compiled modules in `package` are valid

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1301,7 +1301,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "16",
+              "maxSupportedProtocolVersion": "17",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_passkey_in_multisig": false,

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1327,6 +1327,7 @@
                 "enable_poseidon": true,
                 "enable_vdf": true,
                 "hardened_otw_check": true,
+                "iota_metadata_module_bytes": false,
                 "minimize_child_object_mutations": false,
                 "native_charging_v2": true,
                 "no_extraneous_module_bytes": true,

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1327,7 +1327,7 @@
                 "enable_poseidon": true,
                 "enable_vdf": true,
                 "hardened_otw_check": true,
-                "iota_metadata_module_bytes": false,
+                "metadata_in_module_bytes": false,
                 "minimize_child_object_mutations": false,
                 "native_charging_v2": true,
                 "no_extraneous_module_bytes": true,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -372,6 +372,11 @@ struct FeatureFlags {
     // If true, then transactions are committed only for traversed headers
     #[serde(skip_serializing_if = "is_false")]
     consensus_commit_transactions_only_for_traversed_headers: bool,
+
+    // If true, it allows metadata bytes indexed with the iota key in a compiled module
+    // This flag is used to provide the correct MoveVM configuration for clients.
+    #[serde(skip_serializing_if = "is_false")]
+    iota_metadata_module_bytes: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1261,6 +1266,10 @@ impl ProtocolConfig {
 
     pub fn passkey_auth(&self) -> bool {
         self.feature_flags.passkey_auth
+    }
+
+    pub fn iota_metadata_module_bytes(&self) -> bool {
+        self.feature_flags.iota_metadata_module_bytes
     }
 
     pub fn max_transaction_size_bytes(&self) -> u64 {
@@ -2314,6 +2323,9 @@ impl ProtocolConfig {
                     // Enable committing transactions only for traversed headers in Starfish
                     cfg.feature_flags
                         .consensus_commit_transactions_only_for_traversed_headers = true;
+                    if chain != Chain::Mainnet && chain != Chain::Testnet {
+                        cfg.feature_flags.iota_metadata_module_bytes = true;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-pub const MAX_PROTOCOL_VERSION: u64 = 16;
+pub const MAX_PROTOCOL_VERSION: u64 = 17;
 
 // Record history of protocol version allocations here:
 //
@@ -91,6 +91,8 @@ pub const MAX_PROTOCOL_VERSION: u64 = 16;
 //             AuthorityCapabilities notification.
 //             Enable committing transactions only for traversed headers in
 //             Starfish.
+// Version 17: Allow metadata bytes indexed with a dedicated key in compiled
+//             Move modules in devnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -373,7 +375,7 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     consensus_commit_transactions_only_for_traversed_headers: bool,
 
-    // If true, it allows metadata bytes indexed with the iota key in a compiled module
+    // If true, it allows metadata bytes indexed with a dedicated key in a compiled module.
     // This flag is used to provide the correct MoveVM configuration for clients.
     #[serde(skip_serializing_if = "is_false")]
     metadata_in_module_bytes: bool,
@@ -2324,6 +2326,8 @@ impl ProtocolConfig {
                     // Enable committing transactions only for traversed headers in Starfish
                     cfg.feature_flags
                         .consensus_commit_transactions_only_for_traversed_headers = true;
+                }
+                17 => {
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
                         cfg.feature_flags.metadata_in_module_bytes = true;
                     }

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -376,7 +376,7 @@ struct FeatureFlags {
     // If true, it allows metadata bytes indexed with the iota key in a compiled module
     // This flag is used to provide the correct MoveVM configuration for clients.
     #[serde(skip_serializing_if = "is_false")]
-    iota_metadata_module_bytes: bool,
+    metadata_in_module_bytes: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1268,10 +1268,6 @@ impl ProtocolConfig {
         self.feature_flags.passkey_auth
     }
 
-    pub fn iota_metadata_module_bytes(&self) -> bool {
-        self.feature_flags.iota_metadata_module_bytes
-    }
-
     pub fn max_transaction_size_bytes(&self) -> u64 {
         // Provide a default value if protocol config version is too low.
         self.consensus_max_transaction_size_bytes
@@ -1450,9 +1446,14 @@ impl ProtocolConfig {
         );
         res
     }
+
     pub fn consensus_commit_transactions_only_for_traversed_headers(&self) -> bool {
         self.feature_flags
             .consensus_commit_transactions_only_for_traversed_headers
+    }
+
+    pub fn metadata_in_module_bytes(&self) -> bool {
+        self.feature_flags.metadata_in_module_bytes
     }
 }
 
@@ -2324,7 +2325,7 @@ impl ProtocolConfig {
                     cfg.feature_flags
                         .consensus_commit_transactions_only_for_traversed_headers = true;
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
-                        cfg.feature_flags.iota_metadata_module_bytes = true;
+                        cfg.feature_flags.metadata_in_module_bytes = true;
                     }
                 }
                 // Use this template when making changes:

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_17.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_17.snap
@@ -2,19 +2,13 @@
 source: crates/iota-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 16
+version: 17
 feature_flags:
   consensus_transaction_ordering: ByGasPrice
-  enable_poseidon: true
-  enable_group_ops_native_function_msm: true
   per_object_congestion_control_mode: TotalTxCount
-  consensus_choice: Starfish
   zklogin_max_epoch_upper_bound_delta: 30
-  enable_vdf: true
-  passkey_auth: true
   relocate_event_module: true
   protocol_defined_base_fee: true
-  uncompressed_g1_group_elements: true
   disallow_new_modules_in_deps_only_packages: true
   native_charging_v2: true
   convert_type_argument_error: true
@@ -25,7 +19,6 @@ feature_flags:
   consensus_round_prober_probe_accepted_rounds: true
   consensus_zstd_compression: true
   congestion_control_min_free_execution_slot: true
-  accept_passkey_in_multisig: true
   consensus_batched_block_sync: true
   congestion_control_gas_price_feedback_mechanism: true
   validate_identifier_inputs: true
@@ -36,7 +29,6 @@ feature_flags:
   select_committee_from_eligible_validators: true
   track_non_committee_eligible_validators: true
   select_committee_supporting_next_epoch_version: true
-  consensus_median_timestamp_with_checkpoint_enforcement: true
   consensus_commit_transactions_only_for_traversed_headers: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
@@ -219,7 +211,6 @@ hash_blake2b256_data_cost_per_block: 2
 hash_keccak256_cost_base: 10
 hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
-poseidon_bn254_cost_base: 260
 poseidon_bn254_cost_per_block: 388
 group_ops_bls12381_decode_scalar_cost: 7
 group_ops_bls12381_decode_g1_cost: 2848
@@ -261,8 +252,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-vdf_verify_vdf_cost: 1500
-vdf_hash_to_input_cost: 100
 bcs_per_byte_serialized_cost: 2
 bcs_legacy_min_output_size_cost: 1
 bcs_failure_cost: 52
@@ -311,4 +300,3 @@ max_soft_bundle_size: 5
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
 max_committee_members_count: 80
 consensus_gc_depth: 60
-max_congestion_limit_overshoot_per_commit: 100

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_17.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_17.snap
@@ -2,19 +2,13 @@
 source: crates/iota-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 16
+version: 17
 feature_flags:
   consensus_transaction_ordering: ByGasPrice
-  enable_poseidon: true
-  enable_group_ops_native_function_msm: true
   per_object_congestion_control_mode: TotalTxCount
-  consensus_choice: Starfish
   zklogin_max_epoch_upper_bound_delta: 30
-  enable_vdf: true
-  passkey_auth: true
   relocate_event_module: true
   protocol_defined_base_fee: true
-  uncompressed_g1_group_elements: true
   disallow_new_modules_in_deps_only_packages: true
   native_charging_v2: true
   convert_type_argument_error: true
@@ -25,7 +19,6 @@ feature_flags:
   consensus_round_prober_probe_accepted_rounds: true
   consensus_zstd_compression: true
   congestion_control_min_free_execution_slot: true
-  accept_passkey_in_multisig: true
   consensus_batched_block_sync: true
   congestion_control_gas_price_feedback_mechanism: true
   validate_identifier_inputs: true
@@ -219,7 +212,6 @@ hash_blake2b256_data_cost_per_block: 2
 hash_keccak256_cost_base: 10
 hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
-poseidon_bn254_cost_base: 260
 poseidon_bn254_cost_per_block: 388
 group_ops_bls12381_decode_scalar_cost: 7
 group_ops_bls12381_decode_g1_cost: 2848
@@ -261,8 +253,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-vdf_verify_vdf_cost: 1500
-vdf_hash_to_input_cost: 100
 bcs_per_byte_serialized_cost: 2
 bcs_legacy_min_output_size_cost: 1
 bcs_failure_cost: 52
@@ -311,4 +301,3 @@ max_soft_bundle_size: 5
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
 max_committee_members_count: 80
 consensus_gc_depth: 60
-max_congestion_limit_overshoot_per_commit: 100

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_16.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_16.snap
@@ -38,6 +38,7 @@ feature_flags:
   select_committee_supporting_next_epoch_version: true
   consensus_median_timestamp_with_checkpoint_enforcement: true
   consensus_commit_transactions_only_for_traversed_headers: true
+  iota_metadata_module_bytes: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_16.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_16.snap
@@ -38,7 +38,7 @@ feature_flags:
   select_committee_supporting_next_epoch_version: true
   consensus_median_timestamp_with_checkpoint_enforcement: true
   consensus_commit_transactions_only_for_traversed_headers: true
-  iota_metadata_module_bytes: true
+  metadata_in_module_bytes: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_17.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_17.snap
@@ -2,7 +2,7 @@
 source: crates/iota-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 16
+version: 17
 feature_flags:
   consensus_transaction_ordering: ByGasPrice
   enable_poseidon: true
@@ -38,6 +38,7 @@ feature_flags:
   select_committee_supporting_next_epoch_version: true
   consensus_median_timestamp_with_checkpoint_enforcement: true
   consensus_commit_transactions_only_for_traversed_headers: true
+  metadata_in_module_bytes: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/iota-swarm-config/tests/snapshot_tests.rs
 expression: genesis_config
-snapshot_kind: text
 ---
 ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 16
+  protocol_version: 17
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
 accounts:

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -1,15 +1,14 @@
 ---
 source: crates/iota-swarm-config/tests/snapshot_tests.rs
 expression: genesis.iota_system_object().into_genesis_version_for_tooling()
-snapshot_kind: text
 ---
 epoch: 0
-protocol_version: 16
+protocol_version: 17
 system_state_version: 1
 iota_treasury_cap:
   inner:
     id:
-      id: "0x6ad713762902d1164c5ce28c6d73bf87dfa4d5687264d5f48a9338bbe56f5afa"
+      id: "0xbb3de506b1e4f51822828ce47cce019a15bd8a4615abdfda21c95b4f9ba6e4e6"
     total_supply:
       value: "751500000000000000"
 validators:
@@ -245,13 +244,13 @@ validators:
         next_epoch_primary_address: ~
         extra_fields:
           id:
-            id: "0x143df0c4cf92fb6e6b5414ae0ed40d376470da2aab7d4ee8c6143b21e4133af2"
+            id: "0x1cc4dbe72ebe82c490bff3a2946ef1601786bb5ffdfafbb8c9e082d3e402d092"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x57fd6f3c990bd4cf39492be0e870587f850ef8299fed3ea33eff99c007c93cb9"
+      operation_cap_id: "0x5bfaa648a263780ecb24139588ac31168f87f43a724751fd39d93bbc844c151d"
       gas_price: 1000
       staking_pool:
-        id: "0x84ea256aba002a0d6dc7fa97b76ad8d734144f0417f415b4f2df3480d34c4d5c"
+        id: "0xc5b27d16104265c3c7d639f73f223e0ea6719ef6832c311f2268dda4c9d4c7f2"
         activation_epoch: 0
         deactivation_epoch: ~
         iota_balance: 1500000000000000
@@ -259,14 +258,14 @@ validators:
           value: 0
         pool_token_balance: 1500000000000000
         exchange_rates:
-          id: "0x623b77a018a4d3a6309be071152e7fc1d1c8b3ae18a770dbe82b66ed355e504b"
+          id: "0x4c0316f660dcfb16eb099f0ffe786b4157dab3c0fb9002effda205e9cd541460"
           size: 1
         pending_stake: 0
         pending_total_iota_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xab7f9767dd79ef474a945b23e3def2f9b2803f390b6f8f3724c979d9cfc30de5"
+            id: "0xce3443ae6202d495eef9fc7849e3c426894fec1f984f0efa7e1428e3342134a4"
           size: 0
       commission_rate: 200
       next_epoch_stake: 1500000000000000
@@ -274,27 +273,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x72ea4e43c23d7679934494f71b3276bd45b25d219a290dd954fffd217eaa5700"
+          id: "0x43c2cf3c43ed1dc7d8b4e8ca538d5fad5a448dc06718a7ea139aa1d63e8ab45d"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xbd9a1c7ff9aab0920b8d4b2b4415e27de8ef2374e58ab2d5233201c895885034"
+      id: "0x9f04ca26c3af9f3971ac1b9b82f7b87a4d2044f32d954ddfab1a079a5b4857c1"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xec572c6d5efdb6bcf89d3c211821f2789ad84dfb4c8876112832a2c394f9c349"
+    id: "0xd897a9de3a14b1709e0f11b8c1fa137af4c6834fbc4b90089ddc571c1b4c9dbd"
     size: 1
   inactive_validators:
-    id: "0xc430817feffebf2285b52a4e1407d42880861ea5fb98eecaadccd0777a2e3684"
+    id: "0xde04c9bb1b130eacdde826868bc77bb86a9b7f09afb770cb6ce61373f1d8149e"
     size: 0
   validator_candidates:
-    id: "0x492f6098cbb6d702be54124e7f822ce5c3c86a2e3010d9947562a46c509fe6ad"
+    id: "0x782cb5a1d5daf3663c4958148cc66cf7a773cbe0097578fc91cd804a0a1530bb"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x3dfef34cba3cffa1d0edd4a0c0e77e1ece7fe68e99418ea9e83f6d6cb0120bb6"
+      id: "0xaaf67dcd329633b280f7f0f6574ec015aa48e24deaf6183bacb656d22457ad90"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -311,7 +310,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x71b8c30ae6e5c9533521369bffa503f9d47f8abb1334d1992d6505b73484351d"
+      id: "0x8953761a7d866dbfb97e27aa10a64f6fc61a96821be1bac42a18b2a129abf634"
     size: 0
 iota_system_admin_cap:
   dummy_field: false
@@ -328,5 +327,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x279ba9735091c8518b9e01a02904a8ab2cb6ac867f36e33dd08bbebf4f9fbe02"
+    id: "0xf53c7d1da4d53ebbf0dab43e2b9735046dc06c077fe53e873e06aaa81d12de85"
   size: 0

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -572,6 +572,11 @@ pub enum IotaError {
     ObjectSerialization { error: String },
     #[error("Failure deserializing object in the requested format: {:?}", error)]
     ObjectDeserialization { error: String },
+    #[error(
+        "Failure deserializing runtime module metadata in the requested format: {:?}",
+        error
+    )]
+    RuntimeModuleMetadataDeserialization { error: String },
     #[error("Event store component is not active on this node")]
     NoEventStore,
 

--- a/crates/iota-types/src/execution_config_utils.rs
+++ b/crates/iota-types/src/execution_config_utils.rs
@@ -16,6 +16,7 @@ pub fn to_binary_config(protocol_config: &ProtocolConfig) -> BinaryConfig {
             .min_move_binary_format_version_as_option()
             .unwrap_or(VERSION_1),
         protocol_config.no_extraneous_module_bytes(),
+        protocol_config.iota_metadata_module_bytes(),
         TableConfig {
             module_handles: protocol_config
                 .binary_module_handles_as_option()

--- a/crates/iota-types/src/execution_config_utils.rs
+++ b/crates/iota-types/src/execution_config_utils.rs
@@ -16,7 +16,7 @@ pub fn to_binary_config(protocol_config: &ProtocolConfig) -> BinaryConfig {
             .min_move_binary_format_version_as_option()
             .unwrap_or(VERSION_1),
         protocol_config.no_extraneous_module_bytes(),
-        protocol_config.iota_metadata_module_bytes(),
+        protocol_config.metadata_in_module_bytes(),
         TableConfig {
             module_handles: protocol_config
                 .binary_module_handles_as_option()

--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -791,3 +791,111 @@ fn build_upgraded_type_origin_table(
         Ok(new_table)
     }
 }
+
+/// IOTA specific metadata attached to the metadata section of file_format.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeModuleMetadataWrapper {
+    pub version: u64,
+    #[serde_as(as = "Bytes")]
+    pub inner: Vec<u8>,
+}
+
+impl RuntimeModuleMetadataWrapper {
+    pub fn to_bcs_bytes(&self) -> Vec<u8> {
+        bcs::to_bytes(&self).unwrap()
+    }
+}
+
+impl From<RuntimeModuleMetadata> for RuntimeModuleMetadataWrapper {
+    fn from(metadata: RuntimeModuleMetadata) -> Self {
+        match metadata {
+            RuntimeModuleMetadata::V1(inner) => RuntimeModuleMetadataWrapper {
+                version: 1,
+                inner: inner.to_bcs_bytes(),
+            },
+        }
+    }
+}
+
+/// IOTA specific metadata attached to the metadata section of file_format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RuntimeModuleMetadata {
+    V1(RuntimeModuleMetadataV1),
+}
+
+impl RuntimeModuleMetadata {
+    pub fn is_empty(&self) -> bool {
+        match self {
+            RuntimeModuleMetadata::V1(metadata) => metadata.is_empty(),
+        }
+    }
+
+    pub fn fun_attributes_iter(
+        &self,
+    ) -> Box<dyn Iterator<Item = (&String, &Vec<IotaAttribute>)> + '_> {
+        match self {
+            RuntimeModuleMetadata::V1(metadata) => Box::new(metadata.fun_attributes.iter()),
+        }
+    }
+}
+
+impl Default for RuntimeModuleMetadata {
+    fn default() -> Self {
+        RuntimeModuleMetadata::V1(RuntimeModuleMetadataV1::default())
+    }
+}
+
+impl TryFrom<RuntimeModuleMetadataWrapper> for RuntimeModuleMetadata {
+    type Error = IotaError;
+
+    fn try_from(wrapper: RuntimeModuleMetadataWrapper) -> Result<Self, Self::Error> {
+        match wrapper.version {
+            1 => {
+                let inner: RuntimeModuleMetadataV1 =
+                    bcs::from_bytes(&wrapper.inner).map_err(|e| {
+                        IotaError::RuntimeModuleMetadataDeserialization {
+                            error: e.to_string(),
+                        }
+                    })?;
+                Ok(RuntimeModuleMetadata::V1(inner))
+            }
+            _ => Err(IotaError::RuntimeModuleMetadataDeserialization {
+                error: format!(
+                    "Unsupported runtime module metadata version: {}",
+                    wrapper.version
+                ),
+            }),
+        }
+    }
+}
+
+/// The list of iota attribute types recognized by the compiler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum IotaAttribute {
+    // Attribute(Attribute),
+}
+
+/// V1 of IOTA specific metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RuntimeModuleMetadataV1 {
+    /// Attributes attached to functions, by definition index.
+    pub fun_attributes: BTreeMap<String, Vec<IotaAttribute>>,
+}
+
+impl RuntimeModuleMetadataV1 {
+    pub fn add_function_attribute(&mut self, function_name: String, attribute: IotaAttribute) {
+        self.fun_attributes
+            .entry(function_name)
+            .or_default()
+            .push(attribute);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.fun_attributes.is_empty()
+    }
+
+    pub fn to_bcs_bytes(&self) -> Vec<u8> {
+        bcs::to_bytes(&self).unwrap()
+    }
+}

--- a/external-crates/move/crates/move-binary-format/src/binary_config.rs
+++ b/external-crates/move/crates/move-binary-format/src/binary_config.rs
@@ -64,6 +64,7 @@ pub struct BinaryConfig {
     pub max_binary_format_version: u32,
     pub min_binary_format_version: u32,
     pub check_no_extraneous_bytes: bool,
+    pub check_iota_metadata_bytes: bool,
     pub table_config: TableConfig,
 }
 
@@ -72,12 +73,14 @@ impl BinaryConfig {
         max_binary_format_version: u32,
         min_binary_format_version: u32,
         check_no_extraneous_bytes: bool,
+        check_iota_metadata_bytes: bool,
         table_config: TableConfig,
     ) -> Self {
         Self {
             max_binary_format_version,
             min_binary_format_version,
             check_no_extraneous_bytes,
+            check_iota_metadata_bytes,
             table_config,
         }
     }
@@ -93,6 +96,7 @@ impl BinaryConfig {
             max_binary_format_version,
             min_binary_format_version,
             check_no_extraneous_bytes,
+            check_iota_metadata_bytes: check_no_extraneous_bytes,
             table_config: TableConfig::legacy(),
         }
     }
@@ -104,6 +108,7 @@ impl BinaryConfig {
             max_binary_format_version: VERSION_MAX,
             min_binary_format_version: VERSION_1,
             check_no_extraneous_bytes,
+            check_iota_metadata_bytes: check_no_extraneous_bytes,
             table_config: TableConfig::legacy(),
         }
     }
@@ -115,6 +120,7 @@ impl BinaryConfig {
             max_binary_format_version: VERSION_MAX,
             min_binary_format_version: VERSION_1,
             check_no_extraneous_bytes: true,
+            check_iota_metadata_bytes: true,
             table_config: TableConfig::legacy(),
         }
     }

--- a/external-crates/move/crates/move-binary-format/src/deserializer.rs
+++ b/external-crates/move/crates/move-binary-format/src/deserializer.rs
@@ -572,7 +572,9 @@ fn build_common_tables(
                 check_table_size!(constant_pool, *constant_pool_max);
             }
             TableType::METADATA => {
-                if binary.check_no_extraneous_bytes() || binary.version() < VERSION_5 {
+                if !binary.check_iota_metadata_bytes() && binary.check_no_extraneous_bytes()
+                    || binary.version() < VERSION_5
+                {
                     return Err(
                         PartialVMError::new(StatusCode::MALFORMED).with_message(format!(
                             "metadata declarations not applicable in bytecode version {}",
@@ -580,8 +582,21 @@ fn build_common_tables(
                         )),
                     );
                 }
-                load_metadata(binary, table, common.get_metadata())?;
-                // we do not read metadata, nothing to check
+                let metadata = common.get_metadata();
+                load_metadata(binary, table, metadata)?;
+                // only in the case of check_iota_metadata_bytes we read
+                // metadata and check
+                if binary.check_iota_metadata_bytes() {
+                    check_table_size!(metadata, 1);
+                    if metadata[0].key != IOTA_METADATA_KEY {
+                        return Err(PartialVMError::new(StatusCode::MALFORMED).with_message(
+                            format!(
+                                "metadata declaration is using the {:?} key instead of the dedicated iota key",
+                                metadata[0].key
+                            ),
+                        ));
+                    }
+                }
             }
             TableType::IDENTIFIERS => {
                 let identifiers = common.get_identifiers();
@@ -2211,6 +2226,10 @@ impl<'a, 'b> VersionedBinary<'a, 'b> {
 
     fn check_no_extraneous_bytes(&self) -> bool {
         self.binary_config.check_no_extraneous_bytes
+    }
+
+    fn check_iota_metadata_bytes(&self) -> bool {
+        self.binary_config.check_iota_metadata_bytes
     }
 }
 

--- a/external-crates/move/crates/move-binary-format/src/file_format_common.rs
+++ b/external-crates/move/crates/move-binary-format/src/file_format_common.rs
@@ -33,6 +33,8 @@ const _: () = {
     assert!(BinaryFlavor::mask_and_shift_to_unflavor(x) == BinaryFlavor::IOTA_FLAVOR);
 };
 
+pub static IOTA_METADATA_KEY: &[u8] = "iota::metadata".as_bytes();
+
 /// Encoding of the flavor into the version of the binary format for versions >=
 /// 7.
 pub struct BinaryFlavor;

--- a/external-crates/move/crates/move-binary-format/src/unit_tests/deserializer_tests.rs
+++ b/external-crates/move/crates/move-binary-format/src/unit_tests/deserializer_tests.rs
@@ -338,6 +338,72 @@ fn no_metadata() {
 }
 
 #[test]
+fn iota_metadata() {
+    let test_success = |bytes| {
+        CompiledModule::deserialize_with_config(
+            bytes,
+            &BinaryConfig::with_extraneous_bytes_check(true),
+        )
+        .unwrap();
+    };
+    let test_fail = |bytes| {
+        // error with flag true
+        let status_code = CompiledModule::deserialize_with_config(
+            bytes,
+            &BinaryConfig::with_extraneous_bytes_check(true),
+        )
+        .unwrap_err()
+        .major_status();
+        assert_eq!(status_code, StatusCode::MALFORMED);
+    };
+
+    // empty metadata
+    let mut module = basic_test_module();
+    module.metadata.push(Metadata {
+        key: vec![],
+        value: vec![],
+    });
+    let test2 = {
+        let mut v = vec![];
+        module.serialize(&mut v).unwrap();
+        v
+    };
+    test_fail(&test2);
+
+    // malformed key metadata
+    let mut module = basic_test_module();
+    module.metadata.push(Metadata {
+        key: IOTA_METADATA_KEY.to_ascii_uppercase().to_vec(),
+        value: vec![],
+    });
+    let test2 = {
+        let mut v = vec![];
+        module.serialize(&mut v).unwrap();
+        v
+    };
+    test_fail(&test2);
+
+    // iota metadata
+    let metadata_bytes = {
+        let module = basic_test_module();
+        let mut v = vec![];
+        module.serialize(&mut v).unwrap();
+        v
+    };
+    let mut module = basic_test_module();
+    module.metadata.push(Metadata {
+        key: IOTA_METADATA_KEY.to_vec(),
+        value: metadata_bytes.clone(),
+    });
+    let test2 = {
+        let mut v = vec![];
+        module.serialize(&mut v).unwrap();
+        v
+    };
+    test_success(&test2);
+}
+
+#[test]
 fn deserialize_below_min_version() {
     let mut module = basic_test_module();
     module.version = VERSION_MIN;

--- a/external-crates/move/crates/move-binary-format/src/unit_tests/serializer_tests.rs
+++ b/external-crates/move/crates/move-binary-format/src/unit_tests/serializer_tests.rs
@@ -69,7 +69,7 @@ fn enum_serialize_version_invalid() {
 
     CompiledModule::deserialize_with_config(
         &v,
-        &BinaryConfig::new(VERSION_6, VERSION_6, true, TableConfig::legacy()),
+        &BinaryConfig::new(VERSION_6, VERSION_6, true, true, TableConfig::legacy()),
     )
     .unwrap();
 }
@@ -126,14 +126,14 @@ fn versions_serialization_round_trip() {
         // Can deserialize at version 6
         let module6 = CompiledModule::deserialize_with_config(
             &v,
-            &BinaryConfig::new(VERSION_6, VERSION_6, true, TableConfig::legacy()),
+            &BinaryConfig::new(VERSION_6, VERSION_6, true, true, TableConfig::legacy()),
         )
         .unwrap();
 
         // Can deserialize at version max
         let module7 = CompiledModule::deserialize_with_config(
             &v,
-            &BinaryConfig::new(VERSION_MAX, VERSION_6, true, TableConfig::legacy()),
+            &BinaryConfig::new(VERSION_MAX, VERSION_6, true, true, TableConfig::legacy()),
         )
         .unwrap();
 

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     diag,
     diagnostics::{Diagnostic, DiagnosticReporter},
-    shared::string_utils::format_oxford_list,
+    shared::{known_attributes::KnownAttribute, string_utils::format_oxford_list},
 };
 
 //**************************************************************************************************
@@ -288,6 +288,14 @@ impl Flavor {
     pub const CORE: &'static str = "core";
     pub const IOTA: &'static str = "iota";
     pub const ALL: &'static [Self] = &[Self::Core, Self::Iota];
+
+    pub fn resolve_known_attribute(self, attribute_str: impl AsRef<str>) -> Option<KnownAttribute> {
+        use crate::iota_mode::known_attributes::KnownAttribute as IotaKnownAttribute;
+        match self {
+            Flavor::Core => None,
+            Flavor::Iota => IotaKnownAttribute::resolve(attribute_str),
+        }
+    }
 }
 
 impl FeatureGate {

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -1165,7 +1165,8 @@ fn gate_known_attribute(context: &mut Context, loc: Loc, known: &KnownAttribute)
         | KnownAttribute::DefinesPrimitive(_)
         | KnownAttribute::External(_)
         | KnownAttribute::Syntax(_)
-        | KnownAttribute::Deprecation(_) => (),
+        | KnownAttribute::Deprecation(_)
+        | KnownAttribute::Flavored(_) => (),
         KnownAttribute::Error(_) => {
             let pkg = context.current_package();
             context.check_feature(pkg, FeatureGate::CleverAssertions, loc);
@@ -1186,7 +1187,9 @@ fn unique_attributes(
             | E::Attribute_::Assigned(n, _)
             | E::Attribute_::Parameterized(n, _) => *n,
         };
-        let name_ = match known_attributes::KnownAttribute::resolve(sym) {
+        let current_package = context.current_package();
+        let flavor = context.env().flavor(current_package);
+        let name_ = match known_attributes::KnownAttribute::resolve(sym, flavor) {
             None => E::AttributeName_::Unknown(sym),
             Some(known) => {
                 debug_assert!(known.name() == sym.as_str());

--- a/external-crates/move/crates/move-compiler/src/iota_mode/known_attributes/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/iota_mode/known_attributes/mod.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! IOTA Known Attributes
+
+use std::{collections::BTreeSet, fmt};
+
+use crate::shared::known_attributes::{AttributePosition, KnownAttribute as MoveKnownAttribute};
+
+/// The list of attribute types recognized by the compiler for the IOTA
+/// Flavor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum KnownAttribute {}
+
+impl KnownAttribute {
+    pub fn resolve(_attribute_str: impl AsRef<str>) -> Option<MoveKnownAttribute> {
+        // Some(match attribute_str.as_ref() {
+        //     Attribute::ATTRIBUTE => Attribute.into(),
+        //     _ => return None,
+        // })
+        return None;
+    }
+
+    pub const fn name(&self) -> &str {
+        // match self {
+        //    Self::Attribute(a) => a.name(),
+        //}
+        unimplemented!()
+    }
+
+    pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
+        // match self {
+        //    Self::Attribute(a) => a.expected_positions(),
+        //}
+        unimplemented!()
+    }
+}
+
+//**************************************************************************************************
+// Display
+//**************************************************************************************************
+
+impl fmt::Display for KnownAttribute {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // match self {
+        //    Self::Authenticator(a) => a.fmt(f),
+        //}
+        unimplemented!()
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/iota_mode/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/iota_mode/mod.rs
@@ -9,6 +9,7 @@ use crate::diagnostics::codes::{DiagnosticInfo, Severity, custom};
 
 pub mod id_leak;
 pub mod info;
+pub mod known_attributes;
 pub mod linters;
 pub mod typing;
 

--- a/external-crates/move/crates/move-compiler/src/parser/verification_attribute_filter.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/verification_attribute_filter.rs
@@ -9,6 +9,7 @@ use move_symbol_pool::Symbol;
 use crate::{
     diag,
     diagnostics::DiagnosticReporter,
+    editions::Flavor,
     parser::{
         ast as P,
         filter::{FilterContext, filter_program},
@@ -48,7 +49,12 @@ impl FilterContext for Context<'_> {
     // * It is annotated #[verify_only] and verify mode is not set
     fn should_remove_by_attributes(&mut self, attrs: &[P::Attributes]) -> bool {
         use known_attributes::VerificationAttribute;
-        let flattened_attrs: Vec<_> = attrs.iter().flat_map(verification_attributes).collect();
+        let current_package = self.current_package;
+        let flavor = self.env.flavor(current_package);
+        let flattened_attrs: Vec<_> = attrs
+            .iter()
+            .flat_map(|attr| verification_attributes(attr, flavor))
+            .collect();
         let is_verify_only_loc = flattened_attrs
             .iter()
             .map(|attr| match attr {
@@ -91,16 +97,17 @@ pub fn program(compilation_env: &CompilationEnv, prog: P::Program) -> P::Program
 
 fn verification_attributes(
     attrs: &P::Attributes,
+    flavor: Flavor,
 ) -> Vec<(Loc, known_attributes::VerificationAttribute)> {
     use known_attributes::KnownAttribute;
     attrs
         .value
         .iter()
-        .filter_map(
-            |attr| match KnownAttribute::resolve(attr.value.attribute_name().value)? {
+        .filter_map(|attr| {
+            match KnownAttribute::resolve(attr.value.attribute_name().value, flavor)? {
                 KnownAttribute::Verification(verify_attr) => Some((attr.loc, verify_attr)),
                 _ => None,
-            },
-        )
+            }
+        })
         .collect()
 }

--- a/external-crates/move/crates/move-compiler/src/shared/known_attributes.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/known_attributes.rs
@@ -2,10 +2,96 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! Attributes
+//!
+//! The compiler has a built in system for processing arbitrary attributes,
+//! but has no generalized concept of validating or storing them.
+//! A fully compiled program will loose all attributes by the end of compilation
+//! and while attributes are initially processed and propagated through the
+//! stages, they have no effect until they are handled by the developer.
+//! This means that adding an attribute stub is simple, but properly handling it
+//! may happen on an arbitrary stage of compilation.
+//!
+//! ## Processing stages
+//!
+//! The **parser** stage of compilation will extract everything the compiler
+//! understands about an attribute. Where is it from, what form does it have,
+//! but nothing else is known.
+//! During the **expansion** stage an attribute will be turned into a
+//! [KnownAttribute] or unknown attribute after it passed the
+//! [AttributePosition] check and any associated values will be attached to it.
+//! After this point the attributes will propagate through the stages up until
+//! **to_bytecode** at which point they will be discarded completely.
+//!
+//! ## Structure
+//!
+//! There are tree types of attributes, defined in the **expansion**
+//! stage.
+//!
+//! Named attributes, which only have an identifier to them.
+//! ```text
+//! #[NamedAttribute]
+//! ....
+//! ```
+//! which can be listed in one unit or separated into more lines:
+//! ```text
+//! #[NamedAttribute1, NamedAttribute2]
+//! ...
+//!
+//! #[NamedAttribute1]
+//! #[NamedAttribute2]
+//! ...
+//! ```
+//! Assigned attributes, which also have an associated value:
+//! ```text
+//! #[AssignedAttribute = AttributeValue]
+//! ...
+//! ```
+//! which can be listed/grouped similarly to the named version above.
+//!
+//! Parameterized attributes, which can recursively contain
+//! all other types of attributes:
+//! ```text
+//! #[Parameterized(NamedAttribute)]
+//! ...
+//!
+//! #[Parameterized(AssignedAttribute = AttributeValue)]
+//! ...
+//!
+//! #[Parameterized(Parameterized(...))]
+//! ...
+//! ```
+//! which follows the same listing rules as seen above.
+//!
+//! The compiler ensures that no duplicate attributes are specified
+//! and checks if the values fit into a set of allowed types, but
+//! there is no further validation. Everything else is up to the
+//! developer.
+//!
+//! ## Attribute implementation patterns
+//!
+//! Simple **named** and **assigned** attributes are easy to implement and apart
+//! from setting the appropriate [AttributePosition] and trait implementations
+//! only require a type check to be implemented by the developer.
+//!
+//! **Parameterized** attributes are considerably trickier to be used properly
+//! as they can contain other attribute types recursively, but
+//! [AttributePosition] is not capable of expressing that a given attribute may
+//! only appear in such a nested structure. This means that after defining the
+//! top level **parameterized** attribute it is up the developer to define
+//! exactly what internal formats are expected.
+//! For example see [TestingAttribute::ExpectedFailure] implementation.
+
 use std::{collections::BTreeSet, fmt};
 
 use once_cell::sync::Lazy;
 
+use crate::editions::Flavor;
+
+/// All the code positions at which an attribute may be placed
+/// at in code.
+///
+/// A [KnownAttribute] specifies on which positions it may appear.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AttributePosition {
     AddressBlock,
@@ -19,6 +105,10 @@ pub enum AttributePosition {
     Spec,
 }
 
+/// The list of attribute types recognized by the compiler.
+///
+/// These variants not necessarily specify a single attribute
+/// , but a whole class of them like [KnownAttribute::Testing].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum KnownAttribute {
     Testing(TestingAttribute),
@@ -30,6 +120,7 @@ pub enum KnownAttribute {
     Syntax(SyntaxAttribute),
     Error(ErrorAttribute),
     Deprecation(DeprecationAttribute),
+    Flavored(FlavoredAttribute),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -80,6 +171,12 @@ pub struct ErrorAttribute;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DeprecationAttribute;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FlavoredAttribute {
+    pub name: &'static str,
+    pub expected_positions: &'static BTreeSet<AttributePosition>,
+}
+
 impl AttributePosition {
     const ALL: &'static [Self] = &[
         Self::AddressBlock,
@@ -94,23 +191,25 @@ impl AttributePosition {
 }
 
 impl KnownAttribute {
-    pub fn resolve(attribute_str: impl AsRef<str>) -> Option<Self> {
-        Some(match attribute_str.as_ref() {
-            TestingAttribute::TEST => TestingAttribute::Test.into(),
-            TestingAttribute::TEST_ONLY => TestingAttribute::TestOnly.into(),
-            TestingAttribute::EXPECTED_FAILURE => TestingAttribute::ExpectedFailure.into(),
-            TestingAttribute::RAND_TEST => TestingAttribute::RandTest.into(),
-            VerificationAttribute::VERIFY_ONLY => VerificationAttribute::VerifyOnly.into(),
-            NativeAttribute::BYTECODE_INSTRUCTION => NativeAttribute::BytecodeInstruction.into(),
-            DiagnosticAttribute::ALLOW => DiagnosticAttribute::Allow.into(),
-            DiagnosticAttribute::LINT_ALLOW => DiagnosticAttribute::LintAllow.into(),
-            DefinesPrimitive::DEFINES_PRIM => DefinesPrimitive.into(),
-            ExternalAttribute::EXTERNAL => ExternalAttribute.into(),
-            SyntaxAttribute::SYNTAX => SyntaxAttribute::Syntax.into(),
-            ErrorAttribute::ERROR => ErrorAttribute.into(),
-            DeprecationAttribute::DEPRECATED => DeprecationAttribute.into(),
-            _ => return None,
-        })
+    pub fn resolve(attribute_str: impl AsRef<str>, flavor: Flavor) -> Option<Self> {
+        match attribute_str.as_ref() {
+            TestingAttribute::TEST => Some(TestingAttribute::Test.into()),
+            TestingAttribute::TEST_ONLY => Some(TestingAttribute::TestOnly.into()),
+            TestingAttribute::EXPECTED_FAILURE => Some(TestingAttribute::ExpectedFailure.into()),
+            TestingAttribute::RAND_TEST => Some(TestingAttribute::RandTest.into()),
+            VerificationAttribute::VERIFY_ONLY => Some(VerificationAttribute::VerifyOnly.into()),
+            NativeAttribute::BYTECODE_INSTRUCTION => {
+                Some(NativeAttribute::BytecodeInstruction.into())
+            }
+            DiagnosticAttribute::ALLOW => Some(DiagnosticAttribute::Allow.into()),
+            DiagnosticAttribute::LINT_ALLOW => Some(DiagnosticAttribute::LintAllow.into()),
+            DefinesPrimitive::DEFINES_PRIM => Some(DefinesPrimitive.into()),
+            ExternalAttribute::EXTERNAL => Some(ExternalAttribute.into()),
+            SyntaxAttribute::SYNTAX => Some(SyntaxAttribute::Syntax.into()),
+            ErrorAttribute::ERROR => Some(ErrorAttribute.into()),
+            DeprecationAttribute::DEPRECATED => Some(DeprecationAttribute.into()),
+            _ => flavor.resolve_known_attribute(attribute_str),
+        }
     }
 
     pub const fn name(&self) -> &str {
@@ -124,6 +223,7 @@ impl KnownAttribute {
             Self::Syntax(a) => a.name(),
             Self::Error(a) => a.name(),
             Self::Deprecation(a) => a.name(),
+            Self::Flavored(a) => a.name(),
         }
     }
 
@@ -138,6 +238,7 @@ impl KnownAttribute {
             Self::Syntax(a) => a.expected_positions(),
             Self::Error(a) => a.expected_positions(),
             Self::Deprecation(a) => a.expected_positions(),
+            Self::Flavored(a) => a.expected_positions(),
         }
     }
 }
@@ -357,6 +458,16 @@ impl DeprecationAttribute {
     }
 }
 
+impl FlavoredAttribute {
+    pub const fn name(&self) -> &str {
+        self.name
+    }
+
+    pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
+        self.expected_positions
+    }
+}
+
 //**************************************************************************************************
 // Display
 //**************************************************************************************************
@@ -389,6 +500,7 @@ impl fmt::Display for KnownAttribute {
             Self::Syntax(a) => a.fmt(f),
             Self::Error(a) => a.fmt(f),
             Self::Deprecation(a) => a.fmt(f),
+            Self::Flavored(a) => a.fmt(f),
         }
     }
 }
@@ -447,6 +559,12 @@ impl fmt::Display for DeprecationAttribute {
     }
 }
 
+impl fmt::Display for FlavoredAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
 //**************************************************************************************************
 // From
 //**************************************************************************************************
@@ -494,5 +612,10 @@ impl From<ErrorAttribute> for KnownAttribute {
 impl From<DeprecationAttribute> for KnownAttribute {
     fn from(a: DeprecationAttribute) -> Self {
         Self::Deprecation(a)
+    }
+}
+impl From<FlavoredAttribute> for KnownAttribute {
+    fn from(a: FlavoredAttribute) -> Self {
+        Self::Flavored(a)
     }
 }

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -480,6 +480,10 @@ impl CompilationEnv {
         self.package_config(package).edition
     }
 
+    pub fn flavor(&self, package: Option<Symbol>) -> Flavor {
+        self.package_config(package).flavor
+    }
+
     pub fn package_config(&self, package: Option<Symbol>) -> &PackageConfig {
         package
             .and_then(|p| self.package_configs.get(&p))

--- a/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
@@ -12,6 +12,7 @@ use crate::{
     command_line::compiler::FullyCompiledProgram,
     diag,
     diagnostics::DiagnosticReporter,
+    editions::Flavor,
     parser::{
         ast::{self as P, DocComment, NamePath, PathEntry},
         filter::{FilterContext, filter_program},
@@ -68,7 +69,12 @@ impl FilterContext for Context<'_> {
     // * If it is a library and is annotated as #[test]
     fn should_remove_by_attributes(&mut self, attrs: &[P::Attributes]) -> bool {
         use known_attributes::TestingAttribute;
-        let flattened_attrs: Vec<_> = attrs.iter().flat_map(test_attributes).collect();
+        let current_package = self.current_package;
+        let flavor = self.env.flavor(current_package);
+        let flattened_attrs: Vec<_> = attrs
+            .iter()
+            .flat_map(|attrs| test_attributes(attrs, flavor))
+            .collect();
         let is_test_only = flattened_attrs.iter().any(|attr| {
             matches!(
                 attr.1,
@@ -235,13 +241,16 @@ fn create_test_poison(mloc: Loc) -> P::ModuleMember {
     })
 }
 
-fn test_attributes(attrs: &P::Attributes) -> Vec<(Loc, known_attributes::TestingAttribute)> {
+fn test_attributes(
+    attrs: &P::Attributes,
+    flavor: Flavor,
+) -> Vec<(Loc, known_attributes::TestingAttribute)> {
     use known_attributes::KnownAttribute;
     attrs
         .value
         .iter()
-        .filter_map(
-            |attr| match KnownAttribute::resolve(attr.value.attribute_name().value)? {
+        .filter_map(|attr| {
+            match KnownAttribute::resolve(attr.value.attribute_name().value, flavor)? {
                 KnownAttribute::Testing(test_attr) => Some((attr.loc, test_attr)),
                 KnownAttribute::Verification(_)
                 | KnownAttribute::Native(_)
@@ -250,8 +259,9 @@ fn test_attributes(attrs: &P::Attributes) -> Vec<(Loc, known_attributes::Testing
                 | KnownAttribute::External(_)
                 | KnownAttribute::Syntax(_)
                 | KnownAttribute::Error(_)
-                | KnownAttribute::Deprecation(_) => None,
-            },
-        )
+                | KnownAttribute::Deprecation(_)
+                | KnownAttribute::Flavored(_) => None,
+            }
+        })
         .collect()
 }

--- a/iota-execution/latest/iota-verifier/Cargo.toml
+++ b/iota-execution/latest/iota-verifier/Cargo.toml
@@ -8,6 +8,10 @@ publish = false
 description = "Move framework for IOTA platform"
 
 [dependencies]
+# external dependencies
+bcs.workspace = true
+
+# internal dependencies
 iota-types.workspace = true
 move-abstract-interpreter = { path = "../../../external-crates/move/crates/move-abstract-interpreter" }
 move-abstract-stack.workspace = true

--- a/iota-execution/latest/iota-verifier/src/lib.rs
+++ b/iota-execution/latest/iota-verifier/src/lib.rs
@@ -10,6 +10,7 @@ pub mod id_leak_verifier;
 pub mod meter;
 pub mod one_time_witness_verifier;
 pub mod private_generics;
+pub mod runtime_module_metadata;
 pub mod struct_with_key_verifier;
 
 use iota_types::error::{ExecutionError, ExecutionErrorKind};

--- a/iota-execution/latest/iota-verifier/src/runtime_module_metadata.rs
+++ b/iota-execution/latest/iota-verifier/src/runtime_module_metadata.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! This pass verifies necessary properties for runtime module metadata, i.e.
+//! the module metadata used by the IOTA at runtime.
+//! A compiled module may contain at most one metadata item, which must be
+//! indexed by the IOTA metadata key. If present, the metadata item must be
+//! deserializable and must satisfy any additional checks imposed by the runtime
+//! metadata version.
+
+use std::collections::BTreeSet;
+
+use iota_types::{
+    error::ExecutionError,
+    move_package::{RuntimeModuleMetadata, RuntimeModuleMetadataWrapper},
+};
+use move_binary_format::{file_format::CompiledModule, file_format_common::IOTA_METADATA_KEY};
+
+use crate::verification_failure;
+
+/// Verifies the runtime module metadata of the given module.
+/// If the module does not contain any runtime metadata, just pass.
+/// If the module contains runtime metadata, it must satisfy the following:
+/// 1. The module metadata must contain at most one metadata item, which is
+///    indexed by the IOTA metadata key.
+/// 2. The metadata item must be deserializable into
+///    `RuntimeModuleMetadataWrapper`.
+/// 3. The deserialized metadata must satisfy any additional checks imposed by
+///    the runtime metadata version.
+pub fn verify_module(module: &CompiledModule) -> Result<(), ExecutionError> {
+    if !module.metadata.is_empty() {
+        if module.metadata.len() > 1 {
+            return Err(verification_failure(
+                "Module metadata must contain at most one metadata item, that is the IOTA metadata"
+                    .to_string(),
+            ));
+        }
+        let iota_metadata = &module.metadata[0];
+        if iota_metadata.key != IOTA_METADATA_KEY {
+            return Err(verification_failure(
+                "Module metadata must contain at most one metadata item, indexed by the IOTA metadata key"
+                    .to_string(),
+            ));
+        }
+        let metadata = bcs::from_bytes::<RuntimeModuleMetadataWrapper>(&iota_metadata.value)
+            .map_err(|err| {
+                verification_failure(format!(
+                    "Failed to read bcs bytes for IOTA module metadata: {err}",
+                ))
+            })?
+            .try_into()
+            .map_err(|err| {
+                verification_failure(format!(
+                    "Failed to deserialize runtime IOTA module metadata from wrapper: {err}",
+                ))
+            })?;
+        verify_runtime_metadata(module, &metadata)?;
+    }
+
+    Ok(())
+}
+
+fn verify_runtime_metadata(
+    _module: &CompiledModule,
+    metadata: &RuntimeModuleMetadata,
+) -> Result<(), ExecutionError> {
+    for (fn_name, fn_attributes) in metadata.fun_attributes_iter() {
+        let mut seen = BTreeSet::new();
+        // Verify each function attribute
+        for attribute in fn_attributes {
+            if !seen.insert(attribute) {
+                return Err(verification_failure(format!(
+                    "Duplicate attribute {attribute:?} found for function {fn_name}"
+                )));
+            }
+            // Currently no checks are implemented for the runtime metadata.
+            // Future checks can be added here as needed.
+        }
+    }
+
+    Ok(())
+}

--- a/iota-execution/latest/iota-verifier/src/verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/verifier.rs
@@ -10,7 +10,7 @@ use move_bytecode_verifier_meter::{Meter, dummy::DummyMeter};
 
 use crate::{
     entry_points_verifier, global_storage_access_verifier, id_leak_verifier,
-    one_time_witness_verifier, private_generics, struct_with_key_verifier,
+    one_time_witness_verifier, private_generics, runtime_module_metadata, struct_with_key_verifier,
 };
 
 /// Helper for a "canonical" verification of a module.
@@ -24,7 +24,8 @@ pub fn iota_verify_module_metered(
     id_leak_verifier::verify_module(module, meter)?;
     private_generics::verify_module(module)?;
     entry_points_verifier::verify_module(module, fn_info_map)?;
-    one_time_witness_verifier::verify_module(module, fn_info_map)
+    one_time_witness_verifier::verify_module(module, fn_info_map)?;
+    runtime_module_metadata::verify_module(module)
 }
 
 /// Runs the IOTA verifier and checks if the error counts as an IOTA verifier


### PR DESCRIPTION
# Description of change
This PR cherry picks 2 commits in common to enable authenticator and move view attributes at the move level.
Changes:
1. Added a generic FlavoredAttribute which can then allow us to define new attributes within the iota_mode compiler part.
2. Introduces a new protocol feature flag (iota_metadata_module_bytes) to allow the insertion of metadata in the serialized compiled modules (bytecode). This kind of operation was disabled before this PR, with the flag no_extraneous_module_bytes. Instead, iota_metadata_module_bytes  allows to fill this metadata field during the execution of build_from_resolution_graph. At the module deserializer level, the only performed check is that metadata have only 1 field and the metadata key is hardcoded. During the execution of the iota-verifier, the metadata value is checked for having well formed metadata struct (later authenticate and view functions checks will be performed here).

### Release Notes

- [x] Protocol: Added metadata_in_module_bytes flag to allow the insertion of IOTA specific metadata in the serialized compiled modules (bytecode).
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
