### PR TITLE
fix(starfish): Propagate traversed blocks after restart

### DIFF
--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -262,6 +262,11 @@ impl CommitObserver {
             let pending_sub_dag =
                 load_pending_subdag_from_store(self.store.as_ref(), commit, reputation_scores);
 
+            // Rebuild traversed headers tracker so recovery can honor the
+            // traversed-headers gate when committing transactions.
+            self.linearizer
+                .record_traversed_headers(pending_sub_dag.headers.iter());
+
             // Recover transaction acknowledgments tracker state by adding transaction
             // acknowledgments from all pending sub-dags that still might
             // correctly acknowledge transactions.

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -173,7 +173,7 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                 },
                  // A new block was created. Set a timer in min_block_delay
                 Ok(block) = new_block.recv() => {
-                    debug!("New block {block:?} was created and seen in leader timeout task");
+                    debug!("New block {:?} was created and seen in leader timeout task", block.verified_block_header);
                     last_own_block_round = Some(block.round());
 
                     min_block_delay_timed_out = false;

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -341,6 +341,26 @@ impl Linearizer {
         acknowledged_map
     }
 
+    /// Record headers as traversed when recovering state so transaction commit
+    /// checks can succeed after a restart.
+    pub(crate) fn record_traversed_headers<'a>(
+        &mut self,
+        headers: impl IntoIterator<Item = &'a VerifiedBlockHeader>,
+    ) {
+        if !self
+            .context
+            .protocol_config
+            .consensus_commit_transactions_only_for_traversed_headers()
+        {
+            return;
+        }
+
+        for header in headers {
+            self.traversed_headers_tracker
+                .insert(header.reference());
+        }
+    }
+
     /// Calculates the commit's timestamp using the median of leader's parents
     /// (leader.round - 1) timestamps by stake. To ensure that commit timestamp
     /// monotonicity is respected, it is compared against the

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -356,8 +356,7 @@ impl Linearizer {
         }
 
         for header in headers {
-            self.traversed_headers_tracker
-                .insert(header.reference());
+            self.traversed_headers_tracker.insert(header.reference());
         }
     }
 


### PR DESCRIPTION
# Description of change

This PR fixes an issue with Starfish that corrupts the node and its database after node restarts.

## Links to any relevant issues

Resolves #9203 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

