### PR TITLE
feat(iota-indexer):  add fallback storage type conversion to indexer ones needed for JSON RPC API

### DIFF
--- a/crates/iota-indexer/src/historical_fallback/convert.rs
+++ b/crates/iota-indexer/src/historical_fallback/convert.rs
@@ -1,8 +1,11 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Provides helper functions and types for converting historical fallback
-//! types into Indexer-compatible types for the JSON-RPC API.
+//! Conversion utilities for historical fallback data.
+//!
+//! This module provides wrapper types that enable conversion from raw data
+//! fetched from historical fallback storage into the `Stored*` or JSON-RPC
+//! compatible types used by the Indexer's JSON-RPC API layer.
 
 use std::sync::Arc;
 
@@ -32,9 +35,9 @@ use crate::{
     types::{IndexedCheckpoint, IndexedObject, IndexedTransaction},
 };
 
-/// Represents the data needed to fetch from historical fallback storage in
-/// order to convert it into compatible types the indexer can use for JSON RPC
-/// API.
+/// Wrapper for an [`Object`] fetched from historical fallback storage.
+///
+/// Contains all data needed to reconstruct a [`StoredObject`].
 #[derive(Debug, Clone)]
 pub struct HistoricalFallbackObject(Object);
 
@@ -48,8 +51,10 @@ impl HistoricalFallbackObject {
         self.0
     }
 
-    /// Inspect the inner [`Object`] and determine whether it represents a
-    /// Dynamic Field or a Dynamic Object Field based on its type.
+    /// Determines if the inner [`Object`] is a Dynamic Field or Dynamic Object
+    /// Field.
+    ///
+    /// Returns `None` if the object is neither.
     fn df_kind(&self) -> Option<DynamicFieldType> {
         extract_df_kind(&self.0)
     }
@@ -66,9 +71,10 @@ impl From<HistoricalFallbackObject> for StoredObject {
     }
 }
 
-/// Represents the data needed to fetch from historical fallback storage in
-/// order to convert it into compatible types the indexer can use for JSON RPC
-/// API.
+/// Wrapper for [`CertifiedCheckpointSummary`] with its [`CheckpointContents`]
+/// data fetched from historical fallback storage.
+///
+/// Contains all data needed to reconstruct a [`StoredCheckpoint`].
 #[derive(Debug, Clone)]
 pub struct HistoricalFallbackCheckpoint((CertifiedCheckpointSummary, CheckpointContents));
 
@@ -99,11 +105,13 @@ impl From<HistoricalFallbackCheckpoint> for StoredCheckpoint {
     }
 }
 
-/// Represents the data needed to fetch from historical fallback storage in
-/// order to convert it into compatible types the indexer can use for JSON RPC
-/// API.
+/// Wrapper for [`TransactionEvents`] and additional data fetched from
+/// historical fallback storage.
+///
+/// Contains all data needed to reconstruct [`IotaEvent`]s.
 #[derive(Debug, Clone)]
 pub struct HistoricalFallbackEvents {
+    /// Events emitted during transaction execution.
     events: TransactionEvents,
     /// Checkpoint timestamp.
     timestamp: u64,
@@ -118,7 +126,8 @@ impl HistoricalFallbackEvents {
         }
     }
 
-    /// Converts the raw [`Event`]s into JSON RPC compatible [`IotaEvent`]s.
+    /// Converts the raw [`TransactionEvents`] into JSON RPC compatible
+    /// [`IotaEvent`]s.
     #[expect(dead_code)]
     pub(crate) async fn into_iota_events(
         self,
@@ -136,13 +145,16 @@ impl HistoricalFallbackEvents {
     }
 }
 
-/// Represents the data needed to fetch from historical fallback storage in
-/// order to convert it into compatible types the indexer can
-/// use for JSON RPC API.
+/// Wrapper for a complete transaction fetched from historical fallback storage.
+///
+/// Contains all data needed to reconstruct a [`StoredTransaction`].
 #[derive(Debug, Clone)]
 pub struct HistoricalFallbackTransaction {
+    /// The signed transaction.
     transaction: Transaction,
+    /// The effects produced by executing this transaction.
     effects: TransactionEffects,
+    /// Events emitted during transaction execution, if any.
     events: Option<TransactionEvents>,
     /// Objects state before the transaction was executed.
     input_objects: Vec<Object>,

--- a/crates/iota-indexer/src/historical_fallback/convert.rs
+++ b/crates/iota-indexer/src/historical_fallback/convert.rs
@@ -9,93 +9,56 @@
 
 use std::sync::Arc;
 
-use iota_json_rpc_types::{IotaEvent, IotaTransactionKind};
+use iota_json_rpc_types::IotaEvent;
 use iota_package_resolver::{PackageStore, Resolver};
+use iota_rest_api::CheckpointTransaction;
 use iota_types::{
     digests::TransactionDigest,
-    dynamic_field::DynamicFieldType,
-    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
+    effects::TransactionEvents,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
     },
     object::Object,
-    transaction::{Transaction, TransactionDataAPI},
 };
 use prometheus::Registry;
 
 use crate::{
     errors::IndexerResult,
-    ingestion::{common::prepare::extract_df_kind, primary::prepare::InMemTxChanges},
+    ingestion::{common::prepare::extract_df_kind, primary::prepare::try_new_indexed_transaction},
     metrics::IndexerMetrics,
     models::{
         checkpoints::StoredCheckpoint,
         objects::StoredObject,
         transactions::{StoredTransaction, tx_events_to_iota_tx_events},
     },
-    types::{IndexedCheckpoint, IndexedObject, IndexedTransaction},
+    types::{IndexedCheckpoint, IndexedObject},
 };
 
-/// Wrapper for an [`Object`] fetched from historical fallback storage.
+/// Alias for an [`Object`] fetched from historical fallback storage.
 ///
 /// Contains all data needed to reconstruct a [`StoredObject`].
-#[derive(Debug, Clone)]
-pub struct HistoricalFallbackObject(Object);
+type HistoricalFallbackObject = Object;
 
-impl HistoricalFallbackObject {
-    pub fn new(object: Object) -> Self {
-        Self(object)
-    }
-
-    /// Returns the inner [`Object`].
-    pub fn into_inner(self) -> Object {
-        self.0
-    }
-
-    /// Determines if the inner [`Object`] is a Dynamic Field or Dynamic Object
-    /// Field.
-    ///
-    /// Returns `None` if the object is neither.
-    fn df_kind(&self) -> Option<DynamicFieldType> {
-        extract_df_kind(&self.0)
-    }
-}
-
-impl From<HistoricalFallbackObject> for StoredObject {
-    fn from(object: HistoricalFallbackObject) -> Self {
-        let df_kind = object.df_kind();
-        // StoredObject::from implementation does not require a checkpoint sequence
-        // number, in this regard it is safe to hardcode the checkpoint sequence number
-        // to 0.
-        let indexed = IndexedObject::from_object(0, object.into_inner(), df_kind);
-        StoredObject::from(indexed)
-    }
-}
-
-/// Wrapper for [`CertifiedCheckpointSummary`] with its [`CheckpointContents`]
+/// Alias for [`CertifiedCheckpointSummary`] with its [`CheckpointContents`]
 /// data fetched from historical fallback storage.
 ///
 /// Contains all data needed to reconstruct a [`StoredCheckpoint`].
-#[derive(Debug, Clone)]
-pub struct HistoricalFallbackCheckpoint((CertifiedCheckpointSummary, CheckpointContents));
+type HistoricalFallbackCheckpoint = (CertifiedCheckpointSummary, CheckpointContents);
 
-impl HistoricalFallbackCheckpoint {
-    pub fn new(
-        checkpoint_summary: CertifiedCheckpointSummary,
-        checkpoint_contents: CheckpointContents,
-    ) -> Self {
-        Self((checkpoint_summary, checkpoint_contents))
-    }
-
-    /// Returns the inner [`CertifiedCheckpointSummary`] and
-    /// [`CheckpointContents`].
-    pub fn into_inner(self) -> (CertifiedCheckpointSummary, CheckpointContents) {
-        self.0
+impl From<HistoricalFallbackObject> for StoredObject {
+    fn from(object: HistoricalFallbackObject) -> Self {
+        let df_kind = extract_df_kind(&object);
+        // StoredObject::from implementation does not require a checkpoint sequence
+        // number, in this regard it is safe to hardcode the checkpoint sequence number
+        // to 0.
+        let indexed = IndexedObject::from_object(0, object, df_kind);
+        StoredObject::from(indexed)
     }
 }
 
 impl From<HistoricalFallbackCheckpoint> for StoredCheckpoint {
     fn from(checkpoint: HistoricalFallbackCheckpoint) -> Self {
-        let (checkpoint_summary, checkpoint_contents) = checkpoint.into_inner();
+        let (checkpoint_summary, checkpoint_contents) = checkpoint;
         // StoredCheckpoint::from implementation does not use the `successful_tx_num`
         // param in IndexedCheckpoint::from_iota_checkpoint, in this regard it is safe
         // to hardcode to 0.
@@ -150,17 +113,8 @@ impl HistoricalFallbackEvents {
 /// Contains all data needed to reconstruct a [`StoredTransaction`].
 #[derive(Debug, Clone)]
 pub struct HistoricalFallbackTransaction {
-    /// The signed transaction.
-    transaction: Transaction,
-    /// The effects produced by executing this transaction.
-    effects: TransactionEffects,
-    /// Events emitted during transaction execution, if any.
-    events: Option<TransactionEvents>,
-    /// Objects state before the transaction was executed.
-    input_objects: Vec<Object>,
-    /// Objects that were mutated, created or unwrapped by this transaction
-    /// after its execution.
-    output_objects: Vec<Object>,
+    /// Checkpointed transaction data.
+    checkpoint_transaction: CheckpointTransaction,
     /// Checkpoint sequence number the transaction is part of.
     checkpoint_sequence_number: CheckpointSequenceNumber,
     /// Checkpoint timestamp.
@@ -170,19 +124,11 @@ pub struct HistoricalFallbackTransaction {
 impl HistoricalFallbackTransaction {
     #[expect(dead_code)]
     pub fn new(
-        transaction: Transaction,
-        effects: TransactionEffects,
-        events: impl Into<Option<TransactionEvents>>,
-        input_objects: Vec<Object>,
-        output_objects: Vec<Object>,
+        checkpoint_transaction: CheckpointTransaction,
         checkpoint_summary: CertifiedCheckpointSummary,
     ) -> Self {
         Self {
-            transaction,
-            effects,
-            events: events.into(),
-            input_objects,
-            output_objects,
+            checkpoint_transaction,
             checkpoint_sequence_number: checkpoint_summary.sequence_number,
             timestamp: checkpoint_summary.timestamp_ms,
         }
@@ -192,47 +138,23 @@ impl HistoricalFallbackTransaction {
     /// [`StoredTransaction`].
     #[expect(dead_code)]
     async fn into_stored_transaction(self) -> IndexerResult<StoredTransaction> {
-        let tx_digest = self.transaction.digest();
-        let tx_data = self.transaction.transaction_data();
+        // StoredTransaction::try_into_iota_transaction_block_response implementation
+        // does not use the `tx_sequence_number`, in this regard it is safe to
+        // hardcode to 0.
+        //
+        // If in future iterations, the `tx_sequence_number` will be needed, by
+        // importing the CheckpointContents we'll be able to derive it by using the
+        // CheckpointContents::enumerate_transactions method.
+        let tx_sequence_number = 0;
 
-        let events = self
-            .events
-            .as_ref()
-            .map(|events| events.data.clone())
-            .unwrap_or_default();
-
-        let transaction_kind = IotaTransactionKind::from(tx_data.kind());
-
-        let objects = self
-            .input_objects
-            .iter()
-            .chain(self.output_objects.iter())
-            .collect::<Vec<_>>();
-
-        let (balance_change, object_changes) =
-            InMemTxChanges::new(&objects, IndexerMetrics::new(&Registry::new()))
-                .get_changes(tx_data, &self.effects, tx_digest)
-                .await?;
-
-        let indexed_tx = IndexedTransaction {
-            // StoredTransaction::from implementation does not use the `tx_sequence_number`, in this
-            // regard it is safe to hardcode to 0.
-            tx_sequence_number: 0,
-            tx_digest: *tx_digest,
-            checkpoint_sequence_number: self.checkpoint_sequence_number,
-            timestamp_ms: self.timestamp,
-            sender_signed_data: self.transaction.data().clone(),
-            successful_tx_num: if self.effects.status().is_ok() {
-                tx_data.kind().tx_count() as u64
-            } else {
-                0
-            },
-            effects: self.effects,
-            object_changes,
-            balance_change,
-            events,
-            transaction_kind,
-        };
+        let indexed_tx = try_new_indexed_transaction(
+            &self.checkpoint_transaction,
+            tx_sequence_number,
+            self.checkpoint_sequence_number,
+            self.timestamp,
+            &IndexerMetrics::new(&Registry::new()),
+        )
+        .await?;
 
         Ok(StoredTransaction::from(&indexed_tx))
     }

--- a/crates/iota-indexer/src/historical_fallback/convert.rs
+++ b/crates/iota-indexer/src/historical_fallback/convert.rs
@@ -24,7 +24,7 @@ use prometheus::Registry;
 
 use crate::{
     errors::IndexerResult,
-    ingestion::{common::prepare::extract_df_kind, primary::prepare::try_new_indexed_transaction},
+    ingestion::{common::prepare::extract_df_kind, primary::prepare::PrimaryWorker},
     metrics::IndexerMetrics,
     models::{
         checkpoints::StoredCheckpoint,
@@ -147,7 +147,7 @@ impl HistoricalFallbackTransaction {
         // CheckpointContents::enumerate_transactions method.
         let tx_sequence_number = 0;
 
-        let indexed_tx = try_new_indexed_transaction(
+        let indexed_tx = PrimaryWorker::index_transaction(
             &self.checkpoint_transaction,
             tx_sequence_number,
             self.checkpoint_sequence_number,

--- a/crates/iota-indexer/src/historical_fallback/convert.rs
+++ b/crates/iota-indexer/src/historical_fallback/convert.rs
@@ -1,0 +1,227 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provides helper functions and types for converting historical fallback
+//! types into Indexer-compatible types for the JSON-RPC API.
+
+use std::sync::Arc;
+
+use iota_json_rpc_types::{IotaEvent, IotaTransactionKind};
+use iota_package_resolver::{PackageStore, Resolver};
+use iota_types::{
+    digests::TransactionDigest,
+    dynamic_field::DynamicFieldType,
+    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
+    messages_checkpoint::{
+        CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
+    },
+    object::Object,
+    transaction::{Transaction, TransactionDataAPI},
+};
+use prometheus::Registry;
+
+use crate::{
+    errors::IndexerResult,
+    ingestion::{common::prepare::extract_df_kind, primary::prepare::InMemTxChanges},
+    metrics::IndexerMetrics,
+    models::{
+        checkpoints::StoredCheckpoint,
+        objects::StoredObject,
+        transactions::{StoredTransaction, tx_events_to_iota_tx_events},
+    },
+    types::{IndexedCheckpoint, IndexedObject, IndexedTransaction},
+};
+
+/// Represents the data needed to fetch from historical fallback storage in
+/// order to convert it into compatible types the indexer can use for JSON RPC
+/// API.
+#[derive(Debug, Clone)]
+pub struct HistoricalFallbackObject(Object);
+
+impl HistoricalFallbackObject {
+    pub fn new(object: Object) -> Self {
+        Self(object)
+    }
+
+    /// Returns the inner [`Object`].
+    pub fn into_inner(self) -> Object {
+        self.0
+    }
+
+    /// Inspect the inner [`Object`] and determine whether it represents a
+    /// Dynamic Field or a Dynamic Object Field based on its type.
+    fn df_kind(&self) -> Option<DynamicFieldType> {
+        extract_df_kind(&self.0)
+    }
+}
+
+impl From<HistoricalFallbackObject> for StoredObject {
+    fn from(object: HistoricalFallbackObject) -> Self {
+        let df_kind = object.df_kind();
+        // StoredObject::from implementation does not require a checkpoint sequence
+        // number, in this regard it is safe to hardcode the checkpoint sequence number
+        // to 0.
+        let indexed = IndexedObject::from_object(0, object.into_inner(), df_kind);
+        StoredObject::from(indexed)
+    }
+}
+
+/// Represents the data needed to fetch from historical fallback storage in
+/// order to convert it into compatible types the indexer can use for JSON RPC
+/// API.
+#[derive(Debug, Clone)]
+pub struct HistoricalFallbackCheckpoint((CertifiedCheckpointSummary, CheckpointContents));
+
+impl HistoricalFallbackCheckpoint {
+    pub fn new(
+        checkpoint_summary: CertifiedCheckpointSummary,
+        checkpoint_contents: CheckpointContents,
+    ) -> Self {
+        Self((checkpoint_summary, checkpoint_contents))
+    }
+
+    /// Returns the inner [`CertifiedCheckpointSummary`] and
+    /// [`CheckpointContents`].
+    pub fn into_inner(self) -> (CertifiedCheckpointSummary, CheckpointContents) {
+        self.0
+    }
+}
+
+impl From<HistoricalFallbackCheckpoint> for StoredCheckpoint {
+    fn from(checkpoint: HistoricalFallbackCheckpoint) -> Self {
+        let (checkpoint_summary, checkpoint_contents) = checkpoint.into_inner();
+        // StoredCheckpoint::from implementation does not use the `successful_tx_num`
+        // param in IndexedCheckpoint::from_iota_checkpoint, in this regard it is safe
+        // to hardcode to 0.
+        let indexed =
+            IndexedCheckpoint::from_iota_checkpoint(&checkpoint_summary, &checkpoint_contents, 0);
+        StoredCheckpoint::from(&indexed)
+    }
+}
+
+/// Represents the data needed to fetch from historical fallback storage in
+/// order to convert it into compatible types the indexer can use for JSON RPC
+/// API.
+#[derive(Debug, Clone)]
+pub struct HistoricalFallbackEvents {
+    events: TransactionEvents,
+    /// Checkpoint timestamp.
+    timestamp: u64,
+}
+
+impl HistoricalFallbackEvents {
+    #[expect(dead_code)]
+    pub fn new(events: TransactionEvents, checkpoint_summary: CertifiedCheckpointSummary) -> Self {
+        Self {
+            events,
+            timestamp: checkpoint_summary.timestamp_ms,
+        }
+    }
+
+    /// Converts the raw [`Event`]s into JSON RPC compatible [`IotaEvent`]s.
+    #[expect(dead_code)]
+    pub(crate) async fn into_iota_events(
+        self,
+        package_resolver: Arc<Resolver<impl PackageStore>>,
+        tx_digest: TransactionDigest,
+    ) -> IndexerResult<Vec<IotaEvent>> {
+        tx_events_to_iota_tx_events(
+            self.events,
+            package_resolver,
+            tx_digest,
+            Some(self.timestamp),
+        )
+        .await
+        .map(|tx_block_event| tx_block_event.data)
+    }
+}
+
+/// Represents the data needed to fetch from historical fallback storage in
+/// order to convert it into compatible types the indexer can
+/// use for JSON RPC API.
+#[derive(Debug, Clone)]
+pub struct HistoricalFallbackTransaction {
+    transaction: Transaction,
+    effects: TransactionEffects,
+    events: Option<TransactionEvents>,
+    /// Objects state before the transaction was executed.
+    input_objects: Vec<Object>,
+    /// Objects that were mutated, created or unwrapped by this transaction
+    /// after its execution.
+    output_objects: Vec<Object>,
+    /// Checkpoint sequence number the transaction is part of.
+    checkpoint_sequence_number: CheckpointSequenceNumber,
+    /// Checkpoint timestamp.
+    timestamp: u64,
+}
+
+impl HistoricalFallbackTransaction {
+    #[expect(dead_code)]
+    pub fn new(
+        transaction: Transaction,
+        effects: TransactionEffects,
+        events: impl Into<Option<TransactionEvents>>,
+        input_objects: Vec<Object>,
+        output_objects: Vec<Object>,
+        checkpoint_summary: CertifiedCheckpointSummary,
+    ) -> Self {
+        Self {
+            transaction,
+            effects,
+            events: events.into(),
+            input_objects,
+            output_objects,
+            checkpoint_sequence_number: checkpoint_summary.sequence_number,
+            timestamp: checkpoint_summary.timestamp_ms,
+        }
+    }
+
+    /// Converts the historical fallback transaction into a
+    /// [`StoredTransaction`].
+    #[expect(dead_code)]
+    async fn into_stored_transaction(self) -> IndexerResult<StoredTransaction> {
+        let tx_digest = self.transaction.digest();
+        let tx_data = self.transaction.transaction_data();
+
+        let events = self
+            .events
+            .as_ref()
+            .map(|events| events.data.clone())
+            .unwrap_or_default();
+
+        let transaction_kind = IotaTransactionKind::from(tx_data.kind());
+
+        let objects = self
+            .input_objects
+            .iter()
+            .chain(self.output_objects.iter())
+            .collect::<Vec<_>>();
+
+        let (balance_change, object_changes) =
+            InMemTxChanges::new(&objects, IndexerMetrics::new(&Registry::new()))
+                .get_changes(tx_data, &self.effects, tx_digest)
+                .await?;
+
+        let indexed_tx = IndexedTransaction {
+            // StoredTransaction::from implementation does not use the `tx_sequence_number`, in this
+            // regard it is safe to hardcode to 0.
+            tx_sequence_number: 0,
+            tx_digest: *tx_digest,
+            checkpoint_sequence_number: self.checkpoint_sequence_number,
+            timestamp_ms: self.timestamp,
+            sender_signed_data: self.transaction.data().clone(),
+            successful_tx_num: if self.effects.status().is_ok() {
+                tx_data.kind().tx_count() as u64
+            } else {
+                0
+            },
+            effects: self.effects,
+            object_changes,
+            balance_change,
+            events,
+            transaction_kind,
+        };
+
+        Ok(StoredTransaction::from(&indexed_tx))
+    }
+}

--- a/crates/iota-indexer/src/historical_fallback/mod.rs
+++ b/crates/iota-indexer/src/historical_fallback/mod.rs
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provides the necessary types and client implementation for querying
+//! historical fallback data from KV Store.
+//!
+//! Its primary use is to support fetching historical data to compensate for
+//! missing data from the Postgres database when the pruning feature is enabled
+//! for the JSON-RPC API.
+
+pub(crate) mod convert;

--- a/crates/iota-indexer/src/ingestion/common/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/common/prepare.rs
@@ -63,29 +63,27 @@ impl<'chk> Extractor<'chk> {
 
 /// If `o` is a dynamic `Field<K, V>`, determine whether it represents a Dynamic
 /// Field or a Dynamic Object Field based on its type.
-pub(crate) fn try_extract_df_kind(o: &Object) -> IndexerResult<Option<DynamicFieldType>> {
+pub(crate) fn extract_df_kind(o: &Object) -> Option<DynamicFieldType> {
     // Skip if not a move object
-    let Some(move_object) = o.data.try_as_move() else {
-        return Ok(None);
-    };
+    let move_object = o.data.try_as_move()?;
 
     if !move_object.type_().is_dynamic_field() {
-        return Ok(None);
+        return None;
     }
 
     let type_: StructTag = move_object.type_().clone().into();
     let [name, _] = type_.type_params.as_slice() else {
-        return Ok(None);
+        return None;
     };
 
-    Ok(Some(
+    Some(
         if matches!(name, TypeTag::Struct(s) if DynamicFieldInfo::is_dynamic_object_field_wrapper(s))
         {
             DynamicFieldType::DynamicObject
         } else {
             DynamicFieldType::DynamicField
         },
-    ))
+    )
 }
 
 /// Represent an object that is live at a certain snapshot
@@ -103,7 +101,7 @@ impl LiveObject {
         transaction_digest: TransactionDigest,
         object: Object,
     ) -> IndexerResult<Self> {
-        let df_kind = try_extract_df_kind(&object)?;
+        let df_kind = extract_df_kind(&object);
         let indexed_object =
             IndexedObject::from_object(checkpoint_sequence_number, object, df_kind);
         Ok(Self {

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -32,7 +32,7 @@ use crate::{
     db::ConnectionPool,
     errors::IndexerError,
     ingestion::{
-        common::prepare::{CheckpointObjectChanges, try_extract_df_kind},
+        common::prepare::{CheckpointObjectChanges, extract_df_kind},
         primary::persist::{
             CheckpointDataToCommit, EpochToCommit, TransactionObjectChangesToCommit,
         },
@@ -539,10 +539,10 @@ impl PrimaryWorker {
         let changed_objects = latest_live_output_objects
             .into_iter()
             .map(|o| {
-                try_extract_df_kind(o)
-                    .map(|df_kind| IndexedObject::from_object(checkpoint_seq, o.clone(), df_kind))
+                let df_kind = extract_df_kind(o);
+                IndexedObject::from_object(checkpoint_seq, o.clone(), df_kind)
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Vec<_>>();
         Ok(TransactionObjectChangesToCommit {
             changed_objects,
             deleted_objects: indexed_eventually_removed_objects,
@@ -578,10 +578,10 @@ impl PrimaryWorker {
         let changed_objects = output_objects
             .into_iter()
             .map(|o| {
-                try_extract_df_kind(o)
-                    .map(|df_kind| IndexedObject::from_object(checkpoint_seq, o.clone(), df_kind))
+                let df_kind = extract_df_kind(o);
+                IndexedObject::from_object(checkpoint_seq, o.clone(), df_kind)
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Vec<_>>();
 
         Ok(TransactionObjectChangesToCommit {
             changed_objects,

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -368,12 +368,21 @@ impl PrimaryWorker {
         checkpoint_timestamp_ms: u64,
         metrics: &IndexerMetrics,
     ) -> IndexerResult<IndexedTransactionComponents> {
+        let db_txn = try_new_indexed_transaction(
+            tx,
+            tx_sequence_number,
+            checkpoint_seq,
+            checkpoint_timestamp_ms,
+            metrics,
+        )
+        .await?;
+
         let CheckpointTransaction {
             transaction: sender_signed_data,
             effects: fx,
             events,
-            input_objects,
-            output_objects,
+            input_objects: _,
+            output_objects: _,
         } = tx;
 
         let tx_digest = sender_signed_data.digest();
@@ -411,33 +420,6 @@ impl PrimaryWorker {
             .flat_map(StoredDisplay::try_from_event)
             .map(|display| (display.object_type.clone(), display))
             .collect();
-
-        let objects = input_objects
-            .iter()
-            .chain(output_objects.iter())
-            .collect::<Vec<_>>();
-
-        let (balance_change, object_changes) = InMemTxChanges::new(&objects, metrics.clone())
-            .get_changes(tx, fx, tx_digest)
-            .await?;
-
-        let db_txn = IndexedTransaction {
-            tx_sequence_number,
-            tx_digest: *tx_digest,
-            checkpoint_sequence_number: checkpoint_seq,
-            timestamp_ms: checkpoint_timestamp_ms,
-            sender_signed_data: sender_signed_data.data().clone(),
-            effects: fx.clone(),
-            object_changes,
-            balance_change,
-            events,
-            transaction_kind,
-            successful_tx_num: if fx.status().is_ok() {
-                tx.kind().tx_count() as u64
-            } else {
-                0
-            },
-        };
 
         // Input Objects
         let input_objects = tx
@@ -825,4 +807,52 @@ impl iota_types::storage::ObjectStore for EpochEndIndexingObjectStore<'_> {
             .cloned()
             .cloned())
     }
+}
+
+/// Creates a new [`IndexedTransaction`]
+pub(crate) async fn try_new_indexed_transaction(
+    tx: &CheckpointTransaction,
+    tx_sequence_number: u64,
+    checkpoint_seq: CheckpointSequenceNumber,
+    checkpoint_timestamp_ms: u64,
+    metrics: &IndexerMetrics,
+) -> IndexerResult<IndexedTransaction> {
+    let tx_digest = tx.transaction.digest();
+    let tx_data = tx.transaction.transaction_data();
+
+    let events = tx
+        .events
+        .as_ref()
+        .map(|events| events.data.clone())
+        .unwrap_or_default();
+
+    let transaction_kind = IotaTransactionKind::from(tx_data.kind());
+
+    let objects = tx
+        .input_objects
+        .iter()
+        .chain(tx.output_objects.iter())
+        .collect::<Vec<_>>();
+
+    let (balance_change, object_changes) = InMemTxChanges::new(&objects, metrics.clone())
+        .get_changes(tx_data, &tx.effects, tx_digest)
+        .await?;
+
+    Ok(IndexedTransaction {
+        tx_sequence_number,
+        tx_digest: *tx_digest,
+        checkpoint_sequence_number: checkpoint_seq,
+        timestamp_ms: checkpoint_timestamp_ms,
+        sender_signed_data: tx.transaction.data().clone(),
+        successful_tx_num: if tx.effects.status().is_ok() {
+            tx_data.kind().tx_count() as u64
+        } else {
+            0
+        },
+        effects: tx.effects.clone(),
+        object_changes,
+        balance_change,
+        events,
+        transaction_kind,
+    })
 }

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -381,8 +381,7 @@ impl PrimaryWorker {
             transaction: sender_signed_data,
             effects: fx,
             events,
-            input_objects: _,
-            output_objects: _,
+            ..
         } = tx;
 
         let tx_digest = sender_signed_data.digest();

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -338,7 +338,7 @@ impl PrimaryWorker {
             }
 
             let (indexed_tx, tx_indices, indexed_events, events_indices, stored_displays) =
-                Self::index_transaction(
+                Self::index_transaction_components(
                     tx,
                     tx_sequence_number,
                     *checkpoint_seq,
@@ -361,14 +361,14 @@ impl PrimaryWorker {
         ))
     }
 
-    pub(crate) async fn index_transaction(
+    pub(crate) async fn index_transaction_components(
         tx: &CheckpointTransaction,
         tx_sequence_number: u64,
         checkpoint_seq: CheckpointSequenceNumber,
         checkpoint_timestamp_ms: u64,
         metrics: &IndexerMetrics,
     ) -> IndexerResult<IndexedTransactionComponents> {
-        let db_txn = try_new_indexed_transaction(
+        let db_txn = Self::index_transaction(
             tx,
             tx_sequence_number,
             checkpoint_seq,
@@ -488,6 +488,54 @@ impl PrimaryWorker {
             db_event_indices,
             db_displays,
         ))
+    }
+
+    /// Creates a new [`IndexedTransaction`]
+    pub(crate) async fn index_transaction(
+        tx: &CheckpointTransaction,
+        tx_sequence_number: u64,
+        checkpoint_seq: CheckpointSequenceNumber,
+        checkpoint_timestamp_ms: u64,
+        metrics: &IndexerMetrics,
+    ) -> IndexerResult<IndexedTransaction> {
+        let tx_digest = tx.transaction.digest();
+        let tx_data = tx.transaction.transaction_data();
+
+        let events = tx
+            .events
+            .as_ref()
+            .map(|events| events.data.clone())
+            .unwrap_or_default();
+
+        let transaction_kind = IotaTransactionKind::from(tx_data.kind());
+
+        let objects = tx
+            .input_objects
+            .iter()
+            .chain(tx.output_objects.iter())
+            .collect::<Vec<_>>();
+
+        let (balance_change, object_changes) = InMemTxChanges::new(&objects, metrics.clone())
+            .get_changes(tx_data, &tx.effects, tx_digest)
+            .await?;
+
+        Ok(IndexedTransaction {
+            tx_sequence_number,
+            tx_digest: *tx_digest,
+            checkpoint_sequence_number: checkpoint_seq,
+            timestamp_ms: checkpoint_timestamp_ms,
+            sender_signed_data: tx.transaction.data().clone(),
+            successful_tx_num: if tx.effects.status().is_ok() {
+                tx_data.kind().tx_count() as u64
+            } else {
+                0
+            },
+            effects: tx.effects.clone(),
+            object_changes,
+            balance_change,
+            events,
+            transaction_kind,
+        })
     }
 
     pub(crate) async fn index_checkpoint_objects(
@@ -806,52 +854,4 @@ impl iota_types::storage::ObjectStore for EpochEndIndexingObjectStore<'_> {
             .cloned()
             .cloned())
     }
-}
-
-/// Creates a new [`IndexedTransaction`]
-pub(crate) async fn try_new_indexed_transaction(
-    tx: &CheckpointTransaction,
-    tx_sequence_number: u64,
-    checkpoint_seq: CheckpointSequenceNumber,
-    checkpoint_timestamp_ms: u64,
-    metrics: &IndexerMetrics,
-) -> IndexerResult<IndexedTransaction> {
-    let tx_digest = tx.transaction.digest();
-    let tx_data = tx.transaction.transaction_data();
-
-    let events = tx
-        .events
-        .as_ref()
-        .map(|events| events.data.clone())
-        .unwrap_or_default();
-
-    let transaction_kind = IotaTransactionKind::from(tx_data.kind());
-
-    let objects = tx
-        .input_objects
-        .iter()
-        .chain(tx.output_objects.iter())
-        .collect::<Vec<_>>();
-
-    let (balance_change, object_changes) = InMemTxChanges::new(&objects, metrics.clone())
-        .get_changes(tx_data, &tx.effects, tx_digest)
-        .await?;
-
-    Ok(IndexedTransaction {
-        tx_sequence_number,
-        tx_digest: *tx_digest,
-        checkpoint_sequence_number: checkpoint_seq,
-        timestamp_ms: checkpoint_timestamp_ms,
-        sender_signed_data: tx.transaction.data().clone(),
-        successful_tx_num: if tx.effects.status().is_ok() {
-            tx_data.kind().tx_count() as u64
-        } else {
-            0
-        },
-        effects: tx.effects.clone(),
-        object_changes,
-        balance_change,
-        events,
-        transaction_kind,
-    })
 }

--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -34,6 +34,7 @@ pub mod backfill;
 pub mod config;
 pub mod db;
 pub mod errors;
+pub mod historical_fallback;
 pub mod indexer;
 pub mod ingestion;
 pub mod metrics;

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -387,8 +387,10 @@ impl StoredTransaction {
             };
             let tx_events = TransactionEvents { data: events };
 
-            tx_events_to_iota_tx_events(tx_events, package_resolver, tx_digest, timestamp_ms)
-                .await?
+            Some(
+                tx_events_to_iota_tx_events(tx_events, package_resolver, tx_digest, timestamp_ms)
+                    .await?,
+            )
         } else {
             None
         };
@@ -509,7 +511,7 @@ pub async fn tx_events_to_iota_tx_events(
     package_resolver: Arc<Resolver<impl PackageStore>>,
     tx_digest: TransactionDigest,
     timestamp: Option<u64>,
-) -> Result<Option<IotaTransactionBlockEvents>, IndexerError> {
+) -> Result<IotaTransactionBlockEvents, IndexerError> {
     let mut iota_event_futures = vec![];
     let tx_events_data_len = tx_events.data.len();
     for tx_event in tx_events.data.clone() {
@@ -557,5 +559,5 @@ pub async fn tx_events_to_iota_tx_events(
         })
         .collect::<Result<Vec<_>, _>>()?;
     let iota_tx_events = IotaTransactionBlockEvents { data: iota_events };
-    Ok(Some(iota_tx_events))
+    Ok(iota_tx_events)
 }

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -21,7 +21,7 @@ use iota_types::{
 use crate::{
     errors::IndexerError,
     ingestion::{
-        common::prepare::try_extract_df_kind,
+        common::prepare::extract_df_kind,
         primary::{
             persist::TransactionObjectChangesToCommit,
             prepare::{IndexedTransactionComponents, PrimaryWorker},
@@ -446,15 +446,14 @@ impl<'a> TransactionExtractor<'a> {
             .output_objects
             .iter()
             .map(|o| {
-                try_extract_df_kind(o).map(|df_kind| {
-                    IndexedObject::from_object(
-                        0, // checkpoint sequence number, ignored in further processing
-                        o.clone(),
-                        df_kind,
-                    )
-                })
+                let df_kind = extract_df_kind(o);
+                IndexedObject::from_object(
+                    0, // checkpoint sequence number, ignored in further processing
+                    o.clone(),
+                    df_kind,
+                )
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Vec<_>>();
 
         Ok(TransactionObjectChangesToCommit {
             changed_objects,

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -466,7 +466,7 @@ impl<'a> TransactionExtractor<'a> {
     ) -> IndexerResult<IndexedTransactionComponents> {
         let handle = tokio::runtime::Handle::current();
         handle.block_on(async move {
-            PrimaryWorker::index_transaction(
+            PrimaryWorker::index_transaction_components(
                 self.full_tx_data,
                 self.optimistic_sequence_number,
                 0, // checkpoint sequence number - unknown

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1468,9 +1468,7 @@ impl IndexerReader {
         let iota_tx_events =
             tx_events_to_iota_tx_events(tx_events, self.package_resolver(), digest, timestamp_ms)
                 .await?;
-        Ok(iota_tx_events.map_or(vec![], |transaction_block_events| {
-            transaction_block_events.data
-        }))
+        Ok(iota_tx_events.data)
     }
 
     pub async fn try_get_checkpointed_transaction_events(

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -49,6 +49,7 @@ pub struct IndexedCheckpoint {
     pub non_refundable_storage_fee: u64,
     pub checkpoint_commitments: Vec<CheckpointCommitment>,
     pub validator_signature: AggregateAuthoritySignature,
+    // Note: not used in StoredCheckpoint conversion and in code overall.
     pub successful_tx_num: usize,
     pub end_of_epoch_data: Option<EndOfEpochData>,
     pub end_of_epoch: bool,


### PR DESCRIPTION
# Description of change

This PR adds the initial implementation of type conversion needed to be satisfied in order to incorporate the fallback historical storage to compensate missing data in Postgres once pruning is enable for the indexer.

## Links to any relevant issues

fixes #9409 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch doe snot affect the normal operation of the indexer, this no additional test were executed..
