### PR TITLE
feat(starfish,iota-core): Remove `ConsensusOutputAPI` header dependency

### DIFF
--- a/crates/iota-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/iota-core/src/consensus_types/consensus_output_api.rs
@@ -48,7 +48,7 @@ macro_rules! impl_consensus_output_api {
         // How to get the `&[u8]` txs iterator source (something with `.iter()` over tx buffers)
         txs = |$txs_item:ident| $txs_expr:expr,
         // How to get the number of committed headers in the commit
-        committed_headers = |$committed_headers_item:ident| $committed_headers_expr:expr
+        committed_header_refs = |$committed_header_refs_item:ident| $committed_header_refs_expr:expr
     ) => {
         impl ConsensusOutputAPI for $ty {
             fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>> {
@@ -121,10 +121,7 @@ macro_rules! impl_consensus_output_api {
             fn number_of_headers_in_commit_by_authority(&self) -> Vec<(AuthorityIndex, u64)> {
                 let $self_ident = self;
                 let mut num_of_committed_headers = BTreeMap::new();
-                ({
-                    let $committed_headers_item = $self_ident;
-                    $committed_headers_expr
-                })
+                    $committed_header_refs_expr
                 .iter()
                 .for_each(|block_ref| {
                     let author_index = block_ref.author.value() as AuthorityIndex;
@@ -141,7 +138,7 @@ macro_rules! impl_consensus_output_api {
 // consensus_core::CommittedSubDag:
 // - iterate over `self.blocks`
 // - per-item accessors: round()/author().value()/transactions()
-// - committed_headers: map blocks to BlockRef
+// - committed_header_refs: map blocks to BlockRef
 impl_consensus_output_api! {
     type = consensus_core::CommittedSubDag,
     commit_digest = consensus_core::CommitDigest,
@@ -149,14 +146,14 @@ impl_consensus_output_api! {
     round   = |block| block.round(),
     author  = |block| block.author().value(),
     txs     = |block| block.transactions(),
-    committed_headers = |self_| self_.blocks.iter().map(|b| b.reference()).collect::<Vec<_>>()
+    committed_header_refs = |self_| self_.blocks.iter().map(|b| b.reference()).collect::<Vec<_>>()
 }
 
 // starfish_core::CommittedSubDag:
 // - iterate over `self.transactions` (VerifiedTransactions)
 // - per-item accessors via block_ref(): .round / .author.value()
 // - txs via vt.transactions()
-// - committed_headers: use committed_header_refs from SubDagBase
+// - committed_header_refs: use committed_header_refs from SubDagBase
 impl_consensus_output_api! {
     type = starfish_core::CommittedSubDag,
     commit_digest = starfish_core::CommitDigest,
@@ -164,5 +161,5 @@ impl_consensus_output_api! {
     round   = |vt| vt.block_ref().round,
     author  = |vt| vt.block_ref().author.value(),
     txs     = |vt| vt.transactions(),
-    committed_headers = |self_| &self_.base.committed_header_refs
+    committed_header_refs = |self_| &self_.base.committed_header_refs
 }

--- a/crates/iota-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/iota-core/src/consensus_types/consensus_output_api.rs
@@ -6,7 +6,6 @@ use std::{collections::BTreeMap, fmt::Display};
 
 use consensus_core::BlockAPI;
 use iota_types::{digests::ConsensusCommitDigest, messages_consensus::ConsensusTransaction};
-use starfish_core::BlockHeaderAPI;
 
 use crate::consensus_types::AuthorityIndex;
 /// A list of tuples of:
@@ -122,12 +121,15 @@ macro_rules! impl_consensus_output_api {
             fn number_of_headers_in_commit_by_authority(&self) -> Vec<(AuthorityIndex, u64)> {
                 let $self_ident = self;
                 let mut num_of_committed_headers = BTreeMap::new();
-                $committed_headers_expr
-                    .iter()
-                    .for_each(|block| {
-                        let author_index = block.author().value() as AuthorityIndex;
-                        *num_of_committed_headers.entry(author_index).or_insert(0) += 1;
-                    });
+                ({
+                    let $committed_headers_item = $self_ident;
+                    $committed_headers_expr
+                })
+                .iter()
+                .for_each(|block_ref| {
+                    let author_index = block_ref.author.value() as AuthorityIndex;
+                    *num_of_committed_headers.entry(author_index).or_insert(0) += 1;
+                });
                 num_of_committed_headers.into_iter().collect()
             }
         }
@@ -139,6 +141,7 @@ macro_rules! impl_consensus_output_api {
 // consensus_core::CommittedSubDag:
 // - iterate over `self.blocks`
 // - per-item accessors: round()/author().value()/transactions()
+// - committed_headers: map blocks to BlockRef
 impl_consensus_output_api! {
     type = consensus_core::CommittedSubDag,
     commit_digest = consensus_core::CommitDigest,
@@ -146,13 +149,14 @@ impl_consensus_output_api! {
     round   = |block| block.round(),
     author  = |block| block.author().value(),
     txs     = |block| block.transactions(),
-    committed_headers = |self_| self_.blocks
+    committed_headers = |self_| self_.blocks.iter().map(|b| b.reference()).collect::<Vec<_>>()
 }
 
 // starfish_core::CommittedSubDag:
 // - iterate over `self.transactions` (VerifiedTransactions)
 // - per-item accessors via block_ref(): .round / .author.value()
 // - txs via vt.transactions()
+// - committed_headers: use committed_header_refs from SubDagBase
 impl_consensus_output_api! {
     type = starfish_core::CommittedSubDag,
     commit_digest = starfish_core::CommitDigest,
@@ -160,5 +164,5 @@ impl_consensus_output_api! {
     round   = |vt| vt.block_ref().round,
     author  = |vt| vt.block_ref().author.value(),
     txs     = |vt| vt.transactions(),
-    committed_headers = |self_| self_.headers
+    committed_headers = |self_| &self_.base.committed_header_refs
 }

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -374,9 +374,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        CommittedSubDag,
-        block_header::{BlockHeaderAPI as _, GENESIS_ROUND},
-        transaction::NoopTransactionVerifier,
+        CommittedSubDag, block_header::GENESIS_ROUND, transaction::NoopTransactionVerifier,
     };
 
     #[rstest]
@@ -570,11 +568,11 @@ mod tests {
                     if let Ok(Some(committed_subdag)) =
                         tokio::time::timeout(remaining, receiver.recv()).await
                     {
-                        for header in &committed_subdag.headers {
-                            if header.round() > GENESIS_ROUND {
-                                let author_index = header.author();
+                        for block_ref in &committed_subdag.base.committed_header_refs {
+                            if block_ref.round > GENESIS_ROUND {
+                                let author_index = block_ref.author;
                                 last_round_committed_blocks[author_index] =
-                                    max(last_round_committed_blocks[author_index], header.round());
+                                    max(last_round_committed_blocks[author_index], block_ref.round);
                             }
                         }
 
@@ -778,8 +776,8 @@ mod tests {
                 .await
                 .expect("Timed out while waiting for at least one committed block from authority 1")
         {
-            for header in &result.headers {
-                if header.round() > GENESIS_ROUND && header.author() == index_1 {
+            for block_ref in &result.base.committed_header_refs {
+                if block_ref.round > GENESIS_ROUND && block_ref.author == index_1 {
                     break 'outer;
                 }
             }
@@ -859,8 +857,8 @@ mod tests {
         // authority
         let received_from_authority_1 = timeout(Duration::from_secs(10), async {
             'outer: while let Some(result) = receiver_1.recv().await {
-                for header in &result.headers {
-                    if header.round() > GENESIS_ROUND && header.author() == index_1 {
+                for block_ref in &result.base.committed_header_refs {
+                    if block_ref.round > GENESIS_ROUND && block_ref.author == index_1 {
                         break 'outer;
                     }
                 }

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -370,6 +370,8 @@ pub struct SubDagBase {
     pub leader: BlockRef,
     /// All the block headers that are traversed on DAG starting with the leader
     pub headers: Vec<VerifiedBlockHeader>,
+    /// Block references of committed headers
+    pub committed_header_refs: Vec<BlockRef>,
     /// The timestamp of the commit, obtained from the timestamp of the leader
     /// block.
     pub timestamp_ms: BlockTimestampMs,
@@ -467,6 +469,7 @@ impl CommittedSubDag {
     pub fn new(
         leader: BlockRef,
         headers: Vec<VerifiedBlockHeader>,
+        committed_header_refs: Vec<BlockRef>,
         transactions: Vec<VerifiedTransactions>,
         timestamp_ms: BlockTimestampMs,
         commit_ref: CommitRef,
@@ -476,6 +479,7 @@ impl CommittedSubDag {
             base: SubDagBase {
                 leader,
                 headers,
+                committed_header_refs,
                 timestamp_ms,
                 commit_ref,
                 reputation_scores_desc,
@@ -556,6 +560,7 @@ impl PendingSubDag {
     pub fn new(
         leader: BlockRef,
         headers: Vec<VerifiedBlockHeader>,
+        committed_header_refs: Vec<BlockRef>,
         committed_transaction_refs: Vec<BlockRef>,
         timestamp_ms: BlockTimestampMs,
         commit_ref: CommitRef,
@@ -565,6 +570,7 @@ impl PendingSubDag {
             base: SubDagBase {
                 leader,
                 headers,
+                committed_header_refs,
                 timestamp_ms,
                 commit_ref,
                 reputation_scores_desc,
@@ -647,7 +653,8 @@ pub fn load_pending_subdag_from_store(
     PendingSubDag::new(
         leader_block_ref,
         block_headers,
-        commit.committed_transactions().clone(),
+        commit.blocks().to_vec(),
+        commit.committed_transactions(),
         commit.timestamp_ms(),
         commit.reference(),
         reputation_scores_desc,

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -865,11 +865,15 @@ impl Debug for CommitRange {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use crate::{
+        BlockHeaderAPI, BlockTimestampMs, CommitDigest, VerifiedBlockHeader,
         block_header::{TestBlockHeader, VerifiedBlock},
+        commit::{CommitRange, TrustedCommit, WAVE_LENGTH, load_pending_subdag_from_store},
         context::Context,
         encoder::create_encoder,
-        storage::{WriteBatch, mem_store::MemStore},
+        storage::{Store, WriteBatch, mem_store::MemStore},
     };
 
     #[tokio::test]

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -368,9 +368,19 @@ pub type CommitVote = CommitRef;
 pub struct SubDagBase {
     /// A reference to the leader of the sub-dag
     pub leader: BlockRef,
-    /// All the block headers that are traversed on DAG starting with the leader
+
+    /// All the block headers that are traversed on DAG starting with the
+    /// leader.
+    ///
+    /// Required for leader scoring (ancestors) and metrics (timestamp_ms).
+    /// In the future, it may be optional when syncing via FastCommitSyncer.
     pub headers: Vec<VerifiedBlockHeader>,
-    /// Block references of committed headers
+
+    /// Block references of committed headers.
+    ///
+    /// Used for operations that only need reference data (round, author,
+    /// digest) without full header details. Removes dependency on the
+    /// optional headers field in ConsensusOutputAPI trait implementation.
     pub committed_header_refs: Vec<BlockRef>,
     /// The timestamp of the commit, obtained from the timestamp of the leader
     /// block.
@@ -411,17 +421,6 @@ impl SubDagBase {
             .map(|(round_auth, set)| (round_auth, set.into_iter().collect()))
             .collect()
     }
-
-    /// Helper method to format blocks consistently for display
-    fn format_block_refs(&self) -> String {
-        format_block_digests(
-            &self
-                .headers
-                .iter()
-                .map(|b| b.reference())
-                .collect::<Vec<_>>(),
-        )
-    }
 }
 
 impl Display for SubDagBase {
@@ -431,7 +430,7 @@ impl Display for SubDagBase {
             "CommittedSubDag(leader={}, ref={}, blocks=[{}])",
             self.leader,
             self.commit_ref,
-            self.format_block_refs(),
+            format_block_digests(&self.committed_header_refs),
         )
     }
 }
@@ -443,7 +442,7 @@ impl fmt::Debug for SubDagBase {
             "{}@{} ([{}];{}ms;rs{:?})",
             self.leader,
             self.commit_ref,
-            self.format_block_refs(),
+            format_block_digests(&self.committed_header_refs),
             self.timestamp_ms,
             self.reputation_scores_desc
         )
@@ -512,7 +511,7 @@ impl Display for CommittedSubDag {
             "CommittedSubDag(leader={}, ref={}, blocks=[{}], committed_transactions=[{}])",
             self.leader,
             self.commit_ref,
-            self.base.format_block_refs(),
+            format_block_digests(&self.committed_header_refs),
             self.format_transaction_refs(),
         )
     }
@@ -525,7 +524,7 @@ impl fmt::Debug for CommittedSubDag {
             "{}@{} ([{}];[{}];{}ms;rs{:?})",
             self.leader,
             self.commit_ref,
-            self.base.format_block_refs(),
+            format_block_digests(&self.committed_header_refs),
             self.format_transaction_refs(),
             self.timestamp_ms,
             self.reputation_scores_desc
@@ -595,7 +594,7 @@ impl Display for PendingSubDag {
             "PendingSubDag(leader={}, ref={}, blocks=[{}], committed_transactions=[{}])",
             self.leader,
             self.commit_ref,
-            self.base.format_block_refs(),
+            format_block_digests(&self.committed_header_refs),
             format_block_digests(&self.committed_transaction_refs),
         )
     }
@@ -608,7 +607,7 @@ impl fmt::Debug for PendingSubDag {
             "{}@{} ([{}];[{}];{}ms;rs{:?})",
             self.leader,
             self.commit_ref,
-            self.base.format_block_refs(),
+            format_block_digests(&self.committed_header_refs),
             format_block_digests(&self.committed_transaction_refs),
             self.timestamp_ms,
             self.reputation_scores_desc
@@ -866,9 +865,6 @@ impl Debug for CommitRange {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use super::*;
     use crate::{
         block_header::{TestBlockHeader, VerifiedBlock},
         context::Context,

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -529,9 +529,9 @@ mod tests {
                 // committed subdag
                 assert_eq!(subdag.headers.len(), num_authorities);
             }
-            for block_header in subdag.headers.iter() {
-                expected_stored_refs.push(block_header.reference());
-                assert!(block_header.round() <= leaders[idx].round());
+            for block_ref in subdag.base.committed_header_refs.iter() {
+                expected_stored_refs.push(*block_ref);
+                assert!(block_ref.round <= leaders[idx].round());
             }
             assert_eq!(subdag.commit_ref.index, idx as CommitIndex + 1);
         }

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -205,6 +205,7 @@ impl CommitSolidifier {
             Ok(CommittedSubDag::new(
                 subdag.leader,
                 subdag.base.headers.clone(),
+                subdag.base.committed_header_refs.clone(),
                 transactions,
                 subdag.timestamp_ms,
                 subdag.commit_ref,
@@ -504,7 +505,11 @@ mod tests {
 
             PendingSubDag::new(
                 leader,
-                all_committed_block_headers,
+                all_committed_block_headers.clone(),
+                all_committed_block_headers
+                    .iter()
+                    .map(|h| h.reference())
+                    .collect(),
                 self.committed_refs,
                 123456,
                 CommitRef {

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2322,7 +2322,6 @@ mod test {
             (core_fixture_own.core, core_fixture_own.commit_receiver);
         let _ = core_own.add_blocks(dag_builder.blocks(1..=total_rounds));
         let mut existing_headers = HashSet::new();
-        let mut all_traversed_headers = Vec::new();
         let mut all_sequenced_transactions = Vec::new();
         // Check the commits that are produced after processing blocks.
         // Record traversed headers and sequenced transactions
@@ -2333,7 +2332,6 @@ mod test {
             for block_ref in &base.committed_header_refs {
                 existing_headers.insert(*block_ref);
             }
-            all_traversed_headers.extend(base.headers.clone());
             for transaction in &transactions {
                 // Transactions from all authors except authority_to_skip should also have a
                 // corresponding block_ref being traversed in the committed sub_dag

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2330,8 +2330,8 @@ mod test {
             let sub_dag_leader_round = sub_dag.leader.round;
             let CommittedSubDag { base, transactions } = sub_dag;
 
-            for header in &base.headers {
-                existing_headers.insert(header.reference());
+            for block_ref in &base.committed_header_refs {
+                existing_headers.insert(*block_ref);
             }
             all_traversed_headers.extend(base.headers.clone());
             for transaction in &transactions {

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -13,7 +13,10 @@ use rand::{SeedableRng, prelude::SliceRandom, rngs::StdRng};
 use starfish_config::{AuthorityIndex, Stake};
 
 use crate::{
-    CommitIndex, Round, commit::CommitRange, context::Context, dag_state::DagState,
+    CommitIndex, Round,
+    commit::CommitRange,
+    context::Context,
+    dag_state::DagState,
     leader_scoring::ReputationScores,
 };
 
@@ -441,7 +444,7 @@ mod tests {
         block_header::{
             BlockHeaderDigest, BlockRef, BlockTimestampMs, TestBlockHeader, VerifiedBlockHeader,
         },
-        commit::{CommitDigest, CommitInfo, CommitRef, CommittedSubDag, TrustedCommit},
+        commit::{CommitAPI, CommitDigest, CommitInfo, CommitRef, CommittedSubDag, TrustedCommit},
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
     };
@@ -684,6 +687,7 @@ mod tests {
                 BlockRef::new(1, AuthorityIndex::ZERO, BlockHeaderDigest::MIN),
                 vec![],
                 vec![],
+                vec![],
                 context.clock.timestamp_utc_ms(),
                 CommitRef::new(1, CommitDigest::MIN),
                 vec![],
@@ -784,6 +788,7 @@ mod tests {
             CommittedSubDag::new(
                 leader_ref,
                 blocks,
+                last_commit.blocks().to_vec(),
                 vec![], // Committed transactions are not important for this test.
                 context.clock.timestamp_utc_ms(),
                 last_commit.reference(),

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -13,10 +13,7 @@ use rand::{SeedableRng, prelude::SliceRandom, rngs::StdRng};
 use starfish_config::{AuthorityIndex, Stake};
 
 use crate::{
-    CommitIndex, Round,
-    commit::CommitRange,
-    context::Context,
-    dag_state::DagState,
+    CommitIndex, Round, commit::CommitRange, context::Context, dag_state::DagState,
     leader_scoring::ReputationScores,
 };
 

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -156,6 +156,7 @@ impl Linearizer {
         let sub_dag = PendingSubDag::new(
             leader_block.reference(),
             to_commit,
+            commit.blocks().to_vec(),
             commit.committed_transactions(),
             timestamp_ms,
             commit.reference(),

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -526,8 +526,8 @@ mod tests {
                 // from 2 rounds before the leader round
                 assert_eq!(subdag.committed_transaction_refs.len(), num_authorities);
             }
-            for header in subdag.headers.iter() {
-                assert!(header.round() <= leaders[idx].round());
+            for block_ref in subdag.base.committed_header_refs.iter() {
+                assert!(block_ref.round <= leaders[idx].round());
             }
 
             for committed_transactions_ref in subdag.committed_transaction_refs.iter() {
@@ -738,8 +738,8 @@ mod tests {
                 .collect::<Vec<_>>(),
             block_refs_wave_2
         );
-        for header in subdag.headers.iter() {
-            assert!(header.round() <= expected_second_commit.leader().round);
+        for block_ref in subdag.base.committed_header_refs.iter() {
+            assert!(block_ref.round <= expected_second_commit.leader().round);
         }
     }
 
@@ -883,8 +883,8 @@ mod tests {
                     assert_eq!(authors, (0..=3).map(AuthorityIndex::new_for_test).collect());
                 }
             }
-            for header in subdag.headers.iter() {
-                assert!(header.round() <= leaders[idx].round());
+            for block_ref in subdag.base.committed_header_refs.iter() {
+                assert!(block_ref.round <= leaders[idx].round());
             }
 
             for committed_transactions_ref in subdag.committed_transaction_refs.iter() {

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -729,15 +729,7 @@ mod tests {
         // Using the same sorting as used in CommittedSubDag::sort
         block_refs_wave_2
             .sort_by(|a, b| a.round.cmp(&b.round).then_with(|| a.author.cmp(&b.author)));
-        assert_eq!(
-            subdag
-                .headers
-                .clone()
-                .into_iter()
-                .map(|b| b.reference())
-                .collect::<Vec<_>>(),
-            block_refs_wave_2
-        );
+        assert_eq!(subdag.committed_header_refs, block_refs_wave_2);
         for block_ref in subdag.base.committed_header_refs.iter() {
             assert!(block_ref.round <= expected_second_commit.leader().round);
         }

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -19,7 +19,7 @@ use crate::{
         TestBlockHeader, Transaction, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
         VerifiedTransactions, genesis_block_headers,
     },
-    commit::{CertifiedCommit, CommitDigest, TrustedCommit, WAVE_LENGTH},
+    commit::{CertifiedCommit, CommitAPI, CommitDigest, TrustedCommit, WAVE_LENGTH},
     context::Context,
     dag_state::{DagState, TransactionSource},
     encoder::{ShardEncoder, create_encoder},
@@ -322,6 +322,7 @@ impl DagBuilder {
             let sub_dag = CommittedSubDag::new(
                 leader_block_ref,
                 to_commit,
+                commit.blocks().to_vec(),
                 vec![],
                 last_timestamp_ms,
                 commit.reference(),


### PR DESCRIPTION
# Description of change

Remove ConsensusOutputAPI implementation dependency on block headers and simplify usages.

## Links to any relevant issues

Resolves #9340 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
