### PR TITLE
fix(CLI+REST): fix `estimate_gas_budget_from_gas_cost` calculation

### DIFF
--- a/crates/iota-rest-api/src/transactions/resolve.rs
+++ b/crates/iota-rest-api/src/transactions/resolve.rs
@@ -16,7 +16,7 @@ use iota_sdk2::types::{
 use iota_types::{
     base_types::{IotaAddress, ObjectID, ObjectRef},
     effects::TransactionEffectsAPI,
-    gas::GasCostSummary,
+    gas::estimate_gas_budget_from_gas_cost,
     gas_coin::GasCoin,
     move_package::MovePackage,
     transaction::{
@@ -542,27 +542,6 @@ fn find_arg_uses(
 
 fn matches_input_arg(arg: Argument, arg_idx: usize) -> bool {
     matches!(arg, Argument::Input(idx) if idx as usize == arg_idx)
-}
-
-/// Estimate the gas budget using the gas_cost_summary from a previous DryRun
-///
-/// The estimated gas budget is computed as following:
-/// * the maximum between A and B, where: A = computation cost +
-///   GAS_SAFE_OVERHEAD * reference gas price B = computation cost + storage
-///   cost - storage rebate + GAS_SAFE_OVERHEAD * reference gas price overhead
-///
-/// This gas estimate is computed similarly as in the TypeScript SDK
-fn estimate_gas_budget_from_gas_cost(
-    gas_cost_summary: &GasCostSummary,
-    reference_gas_price: u64,
-) -> u64 {
-    const GAS_SAFE_OVERHEAD: u64 = 1000;
-
-    let safe_overhead = GAS_SAFE_OVERHEAD * reference_gas_price;
-    let computation_cost_with_overhead = gas_cost_summary.computation_cost + safe_overhead;
-
-    let gas_usage = gas_cost_summary.net_gas_usage() + safe_overhead as i64;
-    computation_cost_with_overhead.max(if gas_usage < 0 { 0 } else { gas_usage as u64 })
 }
 
 fn select_gas(

--- a/crates/iota-rest-api/src/transactions/resolve.rs
+++ b/crates/iota-rest-api/src/transactions/resolve.rs
@@ -129,11 +129,25 @@ async fn resolve_transaction(
     let budget = if let Some(user_provided_budget) = user_provided_budget {
         user_provided_budget
     } else {
+        let mut estimation_transaction = resolved_transaction.clone();
+        estimation_transaction.gas_data_mut().payment = Vec::new();
+        estimation_transaction.gas_data_mut().budget = protocol_config.max_tx_gas();
+
         // Hardcoded dry run simulation
         let dry_run_checks = VmChecks::Enabled;
         let simulation_result = executor
-            .simulate_transaction(resolved_transaction.clone(), dry_run_checks)
+            .simulate_transaction(estimation_transaction, dry_run_checks)
             .map_err(anyhow::Error::from)?;
+
+        if !simulation_result.effects.status().is_ok() {
+            return Err(RestError::new(
+                axum::http::StatusCode::BAD_REQUEST,
+                format!(
+                    "Budget estimation failed with status: {:?}.",
+                    simulation_result.effects.status()
+                ),
+            ));
+        }
 
         let estimate = estimate_gas_budget_from_gas_cost(
             simulation_result.effects.gas_cost_summary(),
@@ -141,7 +155,24 @@ async fn resolve_transaction(
             resolved_transaction.gas_data().payment.len(),
             &protocol_config,
         );
+
+        // If the request specified gas payment, then transaction.gas_data().budget
+        // should have been resolved to the cumulative balance of those coins.
+        // We don't want to return a resolved transaction where the gas payment
+        // can't satisfy the budget, so validate that balance can actually cover the
+        // estimated budget.
+        let gas_balance = resolved_transaction.gas_data().budget;
+        if gas_balance < estimate {
+            return Err(RestError::new(
+                axum::http::StatusCode::BAD_REQUEST,
+                format!(
+                    "Insufficient gas balance to cover estimated transaction cost. \
+                    Available gas balance: {gas_balance} NANOS. Estimated gas budget required: {estimate} NANOS"
+                ),
+            ));
+        }
         resolved_transaction.gas_data_mut().budget = estimate;
+
         estimate
     };
 

--- a/crates/iota-rest-api/src/transactions/resolve.rs
+++ b/crates/iota-rest-api/src/transactions/resolve.rs
@@ -138,6 +138,8 @@ async fn resolve_transaction(
         let estimate = estimate_gas_budget_from_gas_cost(
             simulation_result.effects.gas_cost_summary(),
             reference_gas_price,
+            resolved_transaction.gas_data().payment.len(),
+            &protocol_config,
         );
         resolved_transaction.gas_data_mut().budget = estimate;
         estimate

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -5,6 +5,29 @@
 
 pub use checked::*;
 
+// An amount of gas (in gas units) that is added to transactions as an overhead
+// to ensure transactions do not fail.
+pub const GAS_SAFE_OVERHEAD: u64 = 1000;
+
+/// Estimate the gas budget using the gas_cost_summary from a previous DryRun
+///
+/// The estimated gas budget is computed as following:
+/// * the maximum between A and B, where: A = computation cost +
+///   GAS_SAFE_OVERHEAD * reference gas price B = computation cost + storage
+///   cost - storage rebate + GAS_SAFE_OVERHEAD * reference gas price overhead
+///
+/// This gas estimate is computed similarly as in the TypeScript SDK
+pub fn estimate_gas_budget_from_gas_cost(
+    gas_cost_summary: &GasCostSummary,
+    reference_gas_price: u64,
+) -> u64 {
+    let safe_overhead = GAS_SAFE_OVERHEAD * reference_gas_price;
+    let computation_cost_with_overhead = gas_cost_summary.computation_cost + safe_overhead;
+
+    let gas_usage = gas_cost_summary.net_gas_usage() + safe_overhead as i64;
+    computation_cost_with_overhead.max(if gas_usage < 0 { 0 } else { gas_usage as u64 })
+}
+
 #[iota_macros::with_checked_arithmetic]
 pub mod checked {
 

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -9,23 +9,69 @@ pub use checked::*;
 // to ensure transactions do not fail.
 pub const GAS_SAFE_OVERHEAD: u64 = 1000;
 
-/// Estimate the gas budget using the gas_cost_summary from a previous DryRun
-///
-/// The estimated gas budget is computed as following:
-/// * the maximum between A and B, where: A = computation cost +
-///   GAS_SAFE_OVERHEAD * reference gas price B = computation cost + storage
-///   cost - storage rebate + GAS_SAFE_OVERHEAD * reference gas price overhead
-///
-/// This gas estimate is computed similarly as in the TypeScript SDK
-pub fn estimate_gas_budget_from_gas_cost(
-    gas_cost_summary: &GasCostSummary,
-    reference_gas_price: u64,
-) -> u64 {
-    let safe_overhead = GAS_SAFE_OVERHEAD * reference_gas_price;
-    let computation_cost_with_overhead = gas_cost_summary.computation_cost + safe_overhead;
+const GAS_COIN_SIZE_BYTES: u64 = 40;
 
-    let gas_usage = gas_cost_summary.net_gas_usage() + safe_overhead as i64;
-    computation_cost_with_overhead.max(if gas_usage < 0 { 0 } else { gas_usage as u64 })
+/// Estimate the gas budget for a transaction based on simulation results.
+///
+/// The estimation includes:
+/// 1. Base cost from gas_cost_summary (computation + storage costs)
+/// 2. Cost of loading gas payment objects (which weren't loaded during
+///    simulation)
+/// 3. Rounding up to the protocol gas rounding step (typically 1000 NANOS)
+/// 4. Adding safe overhead buffer (1000 * reference_gas_price)
+/// 5. Clamping to max_tx_gas protocol limit
+pub fn estimate_gas_budget_from_gas_cost(
+    gas_cost_summary: &crate::gas::GasCostSummary,
+    reference_gas_price: u64,
+    num_payment_objects_on_request: usize,
+    protocol_config: &iota_protocol_config::ProtocolConfig,
+) -> u64 {
+    const GAS_SAFE_OVERHEAD: u64 = 1000;
+
+    // Calculate base estimate from gas cost summary (in NANOS)
+    let gas_usage = gas_cost_summary.net_gas_usage();
+    let base_estimate_nanos =
+        gas_cost_summary
+            .computation_cost
+            .max(if gas_usage < 0 { 0 } else { gas_usage as u64 });
+
+    // Calculate cost of loading gas payment objects.
+    // Subtract 1 because the simulation already loaded one ephemeral gas coin.
+    let num_payment_objects_for_estimation = {
+        let total = if num_payment_objects_on_request == 0 {
+            protocol_config.max_gas_payment_objects() as u64
+        } else {
+            num_payment_objects_on_request as u64
+        };
+        total.saturating_sub(1)
+    };
+
+    // Calculate gas loading cost in gas units
+    let gas_loading_cost_units = num_payment_objects_for_estimation
+        .saturating_mul(GAS_COIN_SIZE_BYTES)
+        .saturating_mul(protocol_config.obj_access_cost_read_per_byte());
+
+    // Round up to the nearest gas rounding step (in gas units)
+    let rounded_gas_loading_cost_units =
+        if let Some(step) = protocol_config.gas_rounding_step_as_option() {
+            gas_loading_cost_units.next_multiple_of(step)
+        } else {
+            gas_loading_cost_units
+        };
+
+    // Convert gas loading cost to NANOS
+    let gas_loading_cost_nanos = rounded_gas_loading_cost_units.saturating_mul(reference_gas_price);
+
+    // Calculate safe overhead buffer in NANOS
+    let safe_overhead_nanos = GAS_SAFE_OVERHEAD.saturating_mul(reference_gas_price);
+
+    // Add all together: base (NANOS) + loading (NANOS) + overhead (NANOS)
+    let estimate_nanos = base_estimate_nanos
+        .saturating_add(gas_loading_cost_nanos)
+        .saturating_add(safe_overhead_nanos);
+
+    // Clamp to max_tx_gas to ensure we don't exceed the protocol limit
+    estimate_nanos.min(protocol_config.max_tx_gas())
 }
 
 #[iota_macros::with_checked_arithmetic]

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -54,7 +54,10 @@ pub fn estimate_gas_budget_from_gas_cost(
     // Round up to the nearest gas rounding step (in gas units)
     let rounded_gas_loading_cost_units =
         if let Some(step) = protocol_config.gas_rounding_step_as_option() {
-            gas_loading_cost_units.next_multiple_of(step)
+            match gas_loading_cost_units.checked_next_multiple_of(step) {
+                Some(rounded) => rounded,
+                None => u64::MAX,
+            }
         } else {
             gas_loading_cost_units
         };

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -9,7 +9,7 @@ pub use checked::*;
 // to ensure transactions do not fail.
 pub const GAS_SAFE_OVERHEAD: u64 = 1000;
 
-const GAS_COIN_SIZE_BYTES: u64 = 40;
+const GAS_COIN_BCS_BYTES_SIZE: u64 = 40;
 
 /// Estimate the gas budget for a transaction based on simulation results.
 ///
@@ -21,13 +21,11 @@ const GAS_COIN_SIZE_BYTES: u64 = 40;
 /// 4. Adding safe overhead buffer (1000 * reference_gas_price)
 /// 5. Clamping to max_tx_gas protocol limit
 pub fn estimate_gas_budget_from_gas_cost(
-    gas_cost_summary: &crate::gas::GasCostSummary,
+    gas_cost_summary: &GasCostSummary,
     reference_gas_price: u64,
     num_payment_objects_on_request: usize,
     protocol_config: &iota_protocol_config::ProtocolConfig,
 ) -> u64 {
-    const GAS_SAFE_OVERHEAD: u64 = 1000;
-
     // Calculate base estimate from gas cost summary (in NANOS)
     let gas_usage = gas_cost_summary.net_gas_usage();
     let base_estimate_nanos =
@@ -48,7 +46,7 @@ pub fn estimate_gas_budget_from_gas_cost(
 
     // Calculate gas loading cost in gas units
     let gas_loading_cost_units = num_payment_objects_for_estimation
-        .saturating_mul(GAS_COIN_SIZE_BYTES)
+        .saturating_mul(GAS_COIN_BCS_BYTES_SIZE)
         .saturating_mul(protocol_config.obj_access_cost_read_per_byte());
 
     // Round up to the nearest gas rounding step (in gas units)

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -57,7 +57,7 @@ use iota_types::{
     crypto::{EmptySignInfo, SignatureScheme},
     digests::{ChainIdentifier, TransactionDigest},
     error::IotaError,
-    gas::{GasCostSummary, get_gas_balance},
+    gas::{estimate_gas_budget_from_gas_cost, get_gas_balance},
     gas_coin::GasCoin,
     iota_serde,
     message_envelope::Envelope,
@@ -112,9 +112,6 @@ use crate::{
 mod profiler_tests;
 
 static USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
-
-/// Only to be used within CLI
-pub const GAS_SAFE_OVERHEAD: u64 = 1000;
 
 #[derive(Parser)]
 pub enum IotaClientCommands {
@@ -3240,17 +3237,6 @@ pub async fn estimate_gas_budget(
             dry_run.unwrap_err()
         )
     }
-}
-
-pub fn estimate_gas_budget_from_gas_cost(
-    gas_cost_summary: &GasCostSummary,
-    reference_gas_price: u64,
-) -> u64 {
-    let safe_overhead = GAS_SAFE_OVERHEAD * reference_gas_price;
-    let computation_cost_with_overhead = gas_cost_summary.computation_cost + safe_overhead;
-
-    let gas_usage = gas_cost_summary.net_gas_usage() + safe_overhead as i64;
-    computation_cost_with_overhead.max(if gas_usage < 0 { 0 } else { gas_usage as u64 })
 }
 
 /// Queries the protocol config for the maximum gas allowed in a transaction.

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -3223,13 +3223,30 @@ pub async fn estimate_gas_budget(
     sponsor: Option<IotaAddress>,
 ) -> Result<u64, anyhow::Error> {
     let client = context.get_client().await?;
+    let num_payment_objects_on_request = gas_payment.len();
     let dry_run =
         execute_dry_run(context, signer, kind, None, gas_price, gas_payment, sponsor).await;
     if let Ok(IotaClientCommandResult::DryRun(dry_run)) = dry_run {
         let rgp = client.read_api().get_reference_gas_price().await?;
+        let protocol_version = client
+            .read_api()
+            .get_protocol_config(None)
+            .await?
+            .protocol_version;
+        let chain_id = client.read_api().get_chain_identifier().await?;
+        let protocol_config = ProtocolConfig::get_for_version(
+            protocol_version,
+            match ChainIdentifier::from_chain_short_id(chain_id.as_str()) {
+                Some(chain_id) => chain_id.chain(),
+                None => Chain::Unknown,
+            },
+        );
+
         Ok(estimate_gas_budget_from_gas_cost(
             dry_run.effects.gas_cost_summary(),
             rgp,
+            num_payment_objects_on_request,
+            &protocol_config,
         ))
     } else {
         bail!(

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -3205,15 +3205,13 @@ pub async fn execute_dry_run(
 }
 
 /// Call a dry run with the transaction data to estimate the gas budget.
+///
 /// The estimated gas budget is computed as following:
-/// * the maximum between A and B, where:
-///
-/// A = computation cost + GAS_SAFE_OVERHEAD * reference gas price
-/// B = computation cost + storage cost - storage rebate + GAS_SAFE_OVERHEAD *
-/// reference gas price overhead
-///
-/// This gas estimate is computed exactly as in the TypeScript SDK
-/// <https://github.com/iotaledger/iota/blob/3c4369270605f78a243842098b7029daf8d883d9/sdk/typescript/src/transactions/TransactionBlock.ts#L845-L858>
+/// 1. Base cost from transaction simulation (computation + storage)
+/// 2. Cost of loading gas payment objects
+/// 3. Rounding up to the protocol gas rounding step (typically 1000 NANOS)
+/// 4. Adding safe overhead buffer (1000 * reference_gas_price)
+/// 5. Clamping to max_tx_gas protocol limit
 pub async fn estimate_gas_budget(
     context: &mut WalletContext,
     signer: IotaAddress,
@@ -3224,8 +3222,12 @@ pub async fn estimate_gas_budget(
 ) -> Result<u64, anyhow::Error> {
     let client = context.get_client().await?;
     let num_payment_objects_on_request = gas_payment.len();
-    let dry_run =
-        execute_dry_run(context, signer, kind, None, gas_price, gas_payment, sponsor).await;
+
+    // We don't pass the gas payment objects here, so that the dry run uses the
+    // ephemeral gas coin object. This is needed to get an accurate gas cost
+    // estimation via "estimate_gas_budget_from_gas_cost".
+    let dry_run = execute_dry_run(context, signer, kind, None, gas_price, vec![], sponsor).await;
+
     if let Ok(IotaClientCommandResult::DryRun(dry_run)) = dry_run {
         let rgp = client.read_api().get_reference_gas_price().await?;
         let protocol_version = client

--- a/crates/iota/src/displays/dry_run_tx_block.rs
+++ b/crates/iota/src/displays/dry_run_tx_block.rs
@@ -8,12 +8,13 @@ use iota_json_rpc_types::{
     DryRunTransactionBlockResponse, IotaTransactionBlockDataAPI, IotaTransactionBlockEffectsAPI,
     ObjectChange,
 };
+use iota_types::gas::estimate_gas_budget_from_gas_cost;
 use tabled::{
     builder::Builder as TableBuilder,
     settings::{Panel as TablePanel, Style as TableStyle, style::HorizontalLine},
 };
 
-use crate::{client_commands::estimate_gas_budget_from_gas_cost, displays::Pretty};
+use crate::displays::Pretty;
 impl Display for Pretty<'_, DryRunTransactionBlockResponse> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Pretty(response) = self;

--- a/crates/iota/src/displays/dry_run_tx_block.rs
+++ b/crates/iota/src/displays/dry_run_tx_block.rs
@@ -8,6 +8,7 @@ use iota_json_rpc_types::{
     DryRunTransactionBlockResponse, IotaTransactionBlockDataAPI, IotaTransactionBlockEffectsAPI,
     ObjectChange,
 };
+use iota_protocol_config::ProtocolConfig;
 use iota_types::gas::estimate_gas_budget_from_gas_cost;
 use tabled::{
     builder::Builder as TableBuilder,
@@ -104,7 +105,9 @@ impl Display for Pretty<'_, DryRunTransactionBlockResponse> {
             "Estimated gas cost (includes a small buffer): {} NANOS",
             estimate_gas_budget_from_gas_cost(
                 response.effects.gas_cost_summary(),
-                response.input.gas_data().price
+                response.input.gas_data().price,
+                response.input.gas_data().payment.len(),
+                &ProtocolConfig::get_for_max_version_UNSAFE()
             )
         )
     }


### PR DESCRIPTION
# Description of change

The function `estimate_gas_budget_from_gas_cost` can be found twice in the codebase. I moved the implementation to `iota-types` in the first commit, and changed all call sites. 

The second commit fixes the budget estimation with a backport from [upstream](https://github.com/MystenLabs/sui/pull/24354). I had to find equivalent parameters in the call sites, because upstream forgot to fix both implementations, so I couldn't port the change 1:1. 

In the `Display` function of `DryRunTransactionBlockResponse` there was no access to the `ProtocolConfig`, but I used `ProtocolConfig::get_for_max_version_UNSAFE()`, which is a good enough replacement in this case I guess.

I also had to change the call to dry_run, to use the ephemeral gas coin in the CLI and in the REST API by not providing a gas object.

# Description from upstream:

The budget estimation logic in the simulate gRPC API was underestimating the required gas budget, causing transactions to fail with INSUFFICIENT_GAS errors.

## The Bug
When estimating the gas budget for a transaction:

1. If the request provided payment coins, we used those coins on the estimation simulation AND used their balance as the budget. This caused the estimation to fail with
`InsufficientCoinBalance` because the entire balance was reserved for gas, leaving nothing available for the actual transaction operations.

2. We didn't check the status of the budget estimation effects - we just grabbed the used gas and computed our estimate. This meant the estimate was wrong because it didn't include the
parts of the PTB that didn't execute after the failure.

In mainnet with lower gas prices, this caused estimates that were too low, resulting in `INSUFFICIENT_GAS` failures.

## The Fix
1. Fixed estimation simulation setup:

- Set payment coins to vec![] for the budget simulation (to defer to the ephemeral gas coin)
- Set budget to max_tx_gas() instead of coin balance
- Check the status of the budget estimation transaction to ensure it succeeded before using its gas costs

2. Account for gas loading costs: Since we now run estimation with `payment = vec![]`, we need to manually calculate the cost to load gas payment objects

- Cost = `(num_payment_objects - 1) * 40 bytes * obj_access_cost_read_per_byte * reference_gas_price`
- Subtract 1 because the simulation already loaded one ephemeral gas coin
- Default to 255 payment objects if none specified (protocol maximum)
- Verified empirically that a `GasCoin` is exactly 40 bytes in BCS encoding

3. Improved estimation calculation:

- Base cost from simulation (computation + storage)
- Add gas loading cost
- Round up to gas rounding step (1000 MIST)
- Add safe overhead buffer (1000 * reference_gas_price)
- Clamp to max_tx_gas

4. Increased ephemeral gas coin: Bumped `DEV_INSPECT_GAS_COIN_VALUE` from 1M SUI to 1B SUI to prevent balance issues in simulations

## Test plan
Reproduced the bug locally on a mainnet fullnode using the exact failing transaction from the bug report. Confirmed the fix:

Before: `"success": false, "error": "INSUFFICIENT_GAS",` budget estimate: 1,104,880 MIST
After: `"success": true,` budget estimate: 3,071,000 MIST (correctly accounts for all costs)

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Fixed budget estimation bug that caused transactions to fail with "INSUFFICIENT_GAS" error by properly simulating budget estimation and accounting for gas payment object
loading costs
- [ ] Rust SDK:
- [ ] REST API:
