### PR TITLE
feat(indexer): Use historic fallback in IndexerAPI

### DIFF
--- a/crates/iota-indexer/src/errors.rs
+++ b/crates/iota-indexer/src/errors.rs
@@ -82,6 +82,9 @@ pub enum IndexerError {
     #[error("Indexer failed to assign TX global order with error: `{0}`")]
     PostgresUniqueTxGlobalOrderViolation(String),
 
+    #[error("Indexer cannot provide results because of pruned data: `{0}`")]
+    PostgresDataPruned(String),
+
     #[error("Indexer failed to initialize fullnode Http client with error: `{0}`")]
     HttpClientInit(String),
 

--- a/crates/iota-indexer/src/errors.rs
+++ b/crates/iota-indexer/src/errors.rs
@@ -82,8 +82,8 @@ pub enum IndexerError {
     #[error("Indexer failed to assign TX global order with error: `{0}`")]
     PostgresUniqueTxGlobalOrderViolation(String),
 
-    #[error("Indexer cannot provide results because of pruned data: `{0}`")]
-    PostgresDataPruned(String),
+    #[error("Missing data due to pruning: `{0}`")]
+    DataPruned(String),
 
     #[error("Indexer failed to initialize fullnode Http client with error: `{0}`")]
     HttpClientInit(String),

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -142,7 +142,12 @@ where
     T: for<'de> Deserialize<'de>,
 {
     bcs::from_bytes(bytes)
-        .tap_err(|e| warn!("Error deserializing data for key {key:?}: {e:?}",))
+        .tap_err(|e| {
+            warn!(
+                "Error deserializing data for key {key:?} into type {}: {e:?}",
+                std::any::type_name::<T>()
+            )
+        })
         .ok()
 }
 

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -70,6 +70,7 @@ pub(crate) trait KeyValueStoreClient {
     ) -> IndexerResult<Vec<Option<Object>>>;
 }
 
+#[derive(Clone)]
 pub(crate) struct HttpRestKVClient {
     base_url: Url,
     client: Client,

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -55,6 +55,7 @@ pub type OutputObjects = Vec<Object>;
 /// [`IndexerReader`](crate::read::IndexerReader) for fallback capabilities
 /// when the indexer is unable to fetch data from the database, which is
 /// especially useful when pruning is enabled.
+#[derive(Clone)]
 pub(crate) struct HistoricalFallbackReader {
     /// Client responsible for fetching data from the historical fallback
     /// storage through REST API interface.
@@ -396,7 +397,7 @@ impl HistoricalFallbackReader {
         checkpoint_sequence_number: CheckpointSequenceNumber,
         limit: usize,
         is_descending: bool,
-    ) -> IndexerResult<Vec<Option<StoredTransaction>>> {
+    ) -> IndexerResult<Vec<StoredTransaction>> {
         if limit == 0 {
             return Ok(vec![]);
         }
@@ -441,7 +442,15 @@ impl HistoricalFallbackReader {
             .take(limit)
             .collect::<Vec<TransactionDigest>>();
 
-        self.transactions(&tx_digests).await
+        let transactions = self.transactions(&tx_digests).await?;
+
+        if transactions.iter().any(|tx| tx.is_none()) {
+            return Err(IndexerError::HistoricalFallbackStorageError(format!(
+                "KV doesn't have full transaction data for checkpoint {checkpoint_sequence_number}"
+            )));
+        }
+
+        Ok(transactions.into_iter().flatten().collect::<Vec<_>>())
     }
 
     /// Fetches events for a specific transaction.

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1613,7 +1613,7 @@ impl IndexerReader {
         {
             let fallback_reason = format!("fallback triggered by {err}");
             kv_reader
-                .transaction_events(tx_digest, cursor, limit, descending_order)
+                .events(tx_digest, cursor, limit, descending_order)
                 .await
                 .context(&fallback_reason)
         } else {

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -56,10 +56,11 @@ use tap::TapFallible;
 use crate::{
     apis::GovernanceReadApi,
     db::{ConnectionConfig, ConnectionPool, ConnectionPoolConfig},
-    errors::IndexerError,
+    errors::{Context, IndexerError},
+    historical_fallback::reader::HistoricalFallbackReader,
     models::{
         address_metrics::StoredAddressMetrics,
-        checkpoints::{StoredChainIdentifier, StoredCheckpoint},
+        checkpoints::{StoredChainIdentifier, StoredCheckpoint, StoredCpTx},
         display::StoredDisplay,
         epoch::StoredEpochInfo,
         events::StoredEvent,
@@ -98,6 +99,7 @@ pub struct IndexerReader {
     pool: ConnectionPool,
     package_resolver: PackageResolver,
     obj_type_cache: Arc<Mutex<SizedCache<String, Option<ObjectID>>>>,
+    kv_reader: Option<Arc<HistoricalFallbackReader>>,
 }
 
 pub type PackageResolver = Arc<Resolver<PackageStoreWithLruCache<IndexerStorePackageResolver>>>;
@@ -113,6 +115,7 @@ impl IndexerReader {
             pool,
             package_resolver,
             obj_type_cache,
+            kv_reader: None,
         }
     }
 
@@ -1014,14 +1017,37 @@ impl IndexerReader {
         })
     }
 
-    async fn query_transaction_blocks_by_checkpoint_impl(
+    async fn get_lowest_unpruned_checkpoint(&self) -> IndexerResult<StoredCpTx> {
+        let pool = self.get_pool();
+        // This should be replaced with reading the "watermarks" table once it is used
+        // by the pruner
+        run_query_async!(&pool, |conn| {
+            pruner_cp_watermark::dsl::pruner_cp_watermark
+                .order_by(pruner_cp_watermark::checkpoint_sequence_number.asc())
+                .first::<StoredCpTx>(conn)
+        })
+    }
+
+    async fn query_transaction_blocks_from_db_by_checkpoint_impl(
         &self,
         checkpoint_seq: u64,
-        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
-        cursor_tx_seq: Option<i64>,
+        cursor: Option<TransactionDigest>,
         limit: usize,
         is_descending: bool,
-    ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
+    ) -> IndexerResult<Vec<StoredTransaction>> {
+        let lowest_unpruned_cp = self.get_lowest_unpruned_checkpoint().await?;
+        if checkpoint_seq < lowest_unpruned_cp.checkpoint_sequence_number as u64 {
+            return Err(IndexerError::PostgresDataPruned(format!(
+                "requesting data from checkpoint {checkpoint_seq}, lowest not pruned checkpoint is {}",
+                lowest_unpruned_cp.checkpoint_sequence_number
+            )));
+        }
+        let cursor_tx_seq = if let Some(cursor) = cursor {
+            Some(self.resolve_cursor_tx_digest_to_seq_num(cursor).await?)
+        } else {
+            None
+        };
+
         let pool = self.get_pool();
         let tx_range: (i64, i64) = run_query_async!(&pool, move |conn| {
             pruner_cp_watermark::dsl::pruner_cp_watermark
@@ -1053,12 +1079,9 @@ impl IndexerReader {
             query = query.order(transactions::dsl::tx_sequence_number.asc());
         }
         let pool = self.get_pool();
-        let stored_txes = run_query_async!(&pool, move |conn| query
+        run_query_async!(&pool, move |conn| query
             .limit(limit as i64)
-            .load::<StoredTransaction>(conn))?;
-
-        self.stored_transaction_to_transaction_block(stored_txes, options)
-            .await
+            .load::<StoredTransaction>(conn))
     }
 
     pub async fn query_transaction_blocks_in_blocking_task(
@@ -1097,6 +1120,58 @@ impl IndexerReader {
         .await
     }
 
+    async fn query_transaction_blocks_from_given_checkpoint(
+        &self,
+        checkpoint_seq: u64,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        is_descending: bool,
+        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
+    ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
+        let db_res = self
+            .query_transaction_blocks_from_db_by_checkpoint_impl(
+                checkpoint_seq,
+                cursor,
+                limit,
+                is_descending,
+            )
+            .await;
+        let stored_txs = if let (Err(IndexerError::PostgresDataPruned(err)), Some(kv_reader)) =
+            (db_res.as_ref(), self.kv_reader.as_ref())
+        {
+            let fallback_reason = format!("fallback triggered by {err}");
+            let txs = kv_reader
+                .checkpoint_transactions(cursor, checkpoint_seq, limit, is_descending)
+                .await
+                .context(&fallback_reason)?;
+            if txs.iter().any(|tx| tx.is_none()) {
+                return Err(IndexerError::Generic(format!(
+                    "Historic Fallback failed, KV doesn't have full data for checkpoint {checkpoint_seq}, {fallback_reason}"
+                )));
+            }
+            txs.into_iter().flatten().collect::<Vec<_>>()
+        } else {
+            db_res?
+        };
+        self.stored_transaction_to_transaction_block(stored_txs, options)
+            .await
+    }
+
+    async fn resolve_cursor_tx_digest_to_seq_num(
+        &self,
+        cursor: TransactionDigest,
+    ) -> IndexerResult<i64> {
+        let pool = self.get_pool();
+        run_query_async!(&pool, move |conn| {
+            tx_digests::table
+                .select(tx_digests::tx_sequence_number)
+                // we filter the tx_digests table because it is indexed by digest,
+                // transactions (and other tables) are not
+                .filter(tx_digests::tx_digest.eq(cursor.into_inner().to_vec()))
+                .first::<i64>(conn)
+        })
+    }
+
     async fn query_transaction_blocks_impl_with_checkpointed_data_only(
         &self,
         filter: Option<TransactionFilterKind>,
@@ -1105,17 +1180,24 @@ impl IndexerReader {
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
+        match filter {
+            Some(TransactionFilterKind::V1(TransactionFilter::Checkpoint(seq)))
+            | Some(TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(seq))) => {
+                return self
+                    .query_transaction_blocks_from_given_checkpoint(
+                        seq,
+                        cursor,
+                        limit,
+                        is_descending,
+                        options,
+                    )
+                    .await;
+            }
+            _ => {} // remaining cases will be handled below
+        };
+
         let cursor_tx_seq = if let Some(cursor) = cursor {
-            let pool = self.get_pool();
-            let tx_seq = run_query_async!(&pool, move |conn| {
-                tx_digests::table
-                    .select(tx_digests::tx_sequence_number)
-                    // we filter the tx_digests table because it is indexed by digest,
-                    // transactions (and other tables) are not
-                    .filter(tx_digests::tx_digest.eq(cursor.into_inner().to_vec()))
-                    .first::<i64>(conn)
-            })?;
-            Some(tx_seq)
+            Some(self.resolve_cursor_tx_digest_to_seq_num(cursor).await?)
         } else {
             None
         };
@@ -1129,19 +1211,12 @@ impl IndexerReader {
             "".to_string()
         };
         let order_str = if is_descending { "DESC" } else { "ASC" };
+
         let (table_name, main_where_clause) = match filter {
             // Processed above
-            Some(TransactionFilterKind::V1(TransactionFilter::Checkpoint(seq)))
-            | Some(TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(seq))) => {
-                return self
-                    .query_transaction_blocks_by_checkpoint_impl(
-                        seq,
-                        options,
-                        cursor_tx_seq,
-                        limit,
-                        is_descending,
-                    )
-                    .await;
+            Some(TransactionFilterKind::V1(TransactionFilter::Checkpoint(_)))
+            | Some(TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(_))) => {
+                unreachable!("handled in earlier match statement")
             }
             // FIXME: sanitize module & function
             Some(TransactionFilterKind::V1(TransactionFilter::MoveFunction {
@@ -1524,35 +1599,65 @@ impl IndexerReader {
         limit: usize,
         descending_order: bool,
     ) -> IndexerResult<Vec<IotaEvent>> {
-        let ckpt_events = self
-            .query_events_by_tx_digest_checkpointed(tx_digest, cursor, limit, descending_order)
-            .await?;
+        let db_res = self
+            .query_events_from_db_by_tx_digest_checkpointed(
+                tx_digest,
+                cursor,
+                limit,
+                descending_order,
+            )
+            .await;
 
-        let mut iota_event_futures = vec![];
-        for stored_event in ckpt_events {
-            iota_event_futures.push(tokio::task::spawn(
-                stored_event.try_into_iota_event(self.package_resolver.clone()),
-            ));
+        if let (Err(IndexerError::PostgresDataPruned(err)), Some(kv_reader)) =
+            (db_res.as_ref(), self.kv_reader.as_ref())
+        {
+            let fallback_reason = format!("fallback triggered by {err}");
+            kv_reader
+                .transaction_events(tx_digest, cursor, limit, descending_order)
+                .await
+                .context(&fallback_reason)
+        } else {
+            let mut iota_event_futures = vec![];
+            for stored_event in db_res? {
+                iota_event_futures.push(tokio::task::spawn(
+                    stored_event.try_into_iota_event(self.package_resolver.clone()),
+                ));
+            }
+
+            futures::future::join_all(iota_event_futures)
+                .await
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))
         }
-
-        let iota_events = futures::future::join_all(iota_event_futures)
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))?;
-        Ok(iota_events)
     }
 
-    async fn query_events_by_tx_digest_checkpointed(
+    async fn query_events_from_db_by_tx_digest_checkpointed(
         &self,
         tx_digest: TransactionDigest,
         cursor: Option<EventID>,
         limit: usize,
         descending_order: bool,
     ) -> IndexerResult<Vec<StoredEvent>> {
+        let tx_seq = self
+            .resolve_cursor_tx_digest_to_seq_num(tx_digest)
+            .await
+            .map_err(|err| {
+                IndexerError::PostgresDataPruned(format!(
+                    "Data for tx {tx_digest} potentially pruned: {err}"
+                ))
+            })?;
+        let lowest_unpruned_cp = self.get_lowest_unpruned_checkpoint().await?;
+        if tx_seq < lowest_unpruned_cp.min_tx_sequence_number {
+            return Err(IndexerError::PostgresDataPruned(format!(
+                "requesting data for tx seq {tx_seq}, lowest not pruned tx seq is {}",
+                lowest_unpruned_cp.min_tx_sequence_number
+            )));
+        }
+
         let mut query = events::table.into_boxed();
 
         if let Some(cursor) = cursor {
@@ -1578,14 +1683,7 @@ impl IndexerReader {
             query = query.order(events::event_sequence_number.asc());
         }
 
-        query = query.filter(
-            events::tx_sequence_number.nullable().eq(tx_digests::table
-                .select(tx_digests::tx_sequence_number)
-                // we filter the tx_digests table because it is indexed by digest,
-                // events table is not
-                .filter(tx_digests::tx_digest.eq(tx_digest.into_inner().to_vec()))
-                .single_value()),
-        );
+        query = query.filter(events::tx_sequence_number.nullable().eq(tx_seq));
 
         let pool = self.get_pool();
         run_query_async!(&pool, move |conn| {
@@ -1600,27 +1698,23 @@ impl IndexerReader {
         limit: usize,
         descending_order: bool,
     ) -> IndexerResult<Vec<IotaEvent>> {
-        let pool = self.get_pool();
+        if let EventFilter::Transaction(tx_digest) = filter {
+            return self
+                .query_events_by_tx_digest_checkpointed_only(
+                    tx_digest,
+                    cursor,
+                    limit,
+                    descending_order,
+                )
+                .await;
+        }
+
         let (tx_seq, event_seq) = if let Some(cursor) = cursor {
             let EventID {
                 tx_digest,
                 event_seq,
             } = cursor;
-            let tx_seq = run_query_async!(&pool, move |conn| {
-                transactions::dsl::transactions
-                    .select(transactions::tx_sequence_number)
-                    .filter(
-                        transactions::tx_sequence_number
-                            .nullable()
-                            .eq(tx_digests::table
-                                .select(tx_digests::tx_sequence_number)
-                                // we filter the tx_digests table because it is indexed by digest,
-                                // transactions table is not
-                                .filter(tx_digests::tx_digest.eq(tx_digest.into_inner().to_vec()))
-                                .single_value()),
-                    )
-                    .first::<i64>(conn)
-            })?;
+            let tx_seq: i64 = self.resolve_cursor_tx_digest_to_seq_num(tx_digest).await?;
             (tx_seq, event_seq as i64)
         } else if descending_order {
             let max_tx_seq = i64::MAX;
@@ -1662,15 +1756,8 @@ impl IndexerReader {
                 order_clause,
                 limit,
             )
-        } else if let EventFilter::Transaction(tx_digest) = filter {
-            return self
-                .query_events_by_tx_digest_checkpointed_only(
-                    tx_digest,
-                    cursor,
-                    limit,
-                    descending_order,
-                )
-                .await;
+        } else if let EventFilter::Transaction(_) = filter {
+            unreachable!("case handled earlier in the function")
         } else {
             let main_where_clause = match filter {
                 EventFilter::Package(package_id) => {

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -90,7 +90,7 @@ pub const OPTIMISTIC_SEQUENCE_NUMBER_STR: &str = "optimistic_sequence_number";
 pub const TX_DIGEST_STR: &str = "tx_digest";
 pub const EVENT_SEQUENCE_NUMBER_STR: &str = "event_sequence_number";
 
-/// Encapsulate the logic for reading from the database.
+/// Encapsulates the logic for reading from the database.
 ///
 /// Provides a set of methods to perform read operations,
 /// including resolution of packages.
@@ -100,6 +100,31 @@ pub struct IndexerReader {
     package_resolver: PackageResolver,
     obj_type_cache: Arc<Mutex<SizedCache<String, Option<ObjectID>>>>,
     kv_reader: Option<Arc<HistoricalFallbackReader>>,
+}
+
+/// Encapsulates the logic for reading checkpointed data from the database.
+///
+/// This reader only accesses finalized checkpoint data and does not read
+/// optimistic transactions or historical fallback data from the key-value
+/// store.
+///
+/// Note that object queries will include optimistic data,
+/// as it is stored in the same table as checkpointed objects.
+pub struct CheckpointedDBReader<'a> {
+    main_reader: &'a IndexerReader,
+}
+
+/// Encapsulates the logic for reading checkpointed data with historical
+/// fallback.
+///
+/// This reader first attempts to read from the database. If data is not found,
+/// it falls back to the key-value store (when available). It does not read
+/// optimistic transactions.
+///
+/// Note that object queries will include optimistic data,
+/// as it is stored in the same table as checkpointed objects.
+pub struct CheckpointedDBWithHistoricalFallbackReader<'a> {
+    main_reader: &'a IndexerReader,
 }
 
 pub type PackageResolver = Arc<Resolver<PackageStoreWithLruCache<IndexerStorePackageResolver>>>;
@@ -117,6 +142,14 @@ impl IndexerReader {
             obj_type_cache,
             kv_reader: None,
         }
+    }
+
+    pub fn checkpointed_db(&self) -> CheckpointedDBReader<'_> {
+        CheckpointedDBReader::new(self)
+    }
+
+    pub fn checkpointed_db_with_fallback(&self) -> CheckpointedDBWithHistoricalFallbackReader<'_> {
+        CheckpointedDBWithHistoricalFallbackReader::new(self)
     }
 
     pub fn new_with_config<T: Into<String>>(
@@ -1017,63 +1050,6 @@ impl IndexerReader {
         })
     }
 
-    async fn query_transaction_blocks_from_db_by_checkpoint_impl(
-        &self,
-        checkpoint_seq: u64,
-        cursor: Option<TransactionDigest>,
-        limit: usize,
-        is_descending: bool,
-    ) -> IndexerResult<Vec<StoredTransaction>> {
-        let pool = self.get_pool();
-        let Some(tx_range) = run_query_async!(&pool, move |conn| {
-            pruner_cp_watermark::dsl::pruner_cp_watermark
-                .select((
-                    pruner_cp_watermark::min_tx_sequence_number,
-                    pruner_cp_watermark::max_tx_sequence_number,
-                ))
-                // we filter the pruner_cp_watermark table because it is indexed by
-                // checkpoint_sequence_number, transactions is not
-                .filter(pruner_cp_watermark::checkpoint_sequence_number.eq(checkpoint_seq as i64))
-                .first::<(i64, i64)>(conn)
-                .optional()
-        })?
-        else {
-            // This check should be replaced with reading the "watermarks" table once it is
-            // used by the pruner
-            return Err(IndexerError::PostgresDataPruned(format!(
-                "requesting data from checkpoint {checkpoint_seq}, which is not available",
-            )));
-        };
-
-        let cursor_tx_seq = if let Some(cursor) = cursor {
-            Some(self.resolve_cursor_tx_digest_to_seq_num(cursor).await?)
-        } else {
-            None
-        };
-
-        let mut query = transactions::dsl::transactions
-            .filter(transactions::tx_sequence_number.between(tx_range.0, tx_range.1))
-            .into_boxed();
-
-        // Translate transaction digest cursor to tx sequence number
-        if let Some(cursor_tx_seq) = cursor_tx_seq {
-            if is_descending {
-                query = query.filter(transactions::dsl::tx_sequence_number.lt(cursor_tx_seq));
-            } else {
-                query = query.filter(transactions::dsl::tx_sequence_number.gt(cursor_tx_seq));
-            }
-        }
-        if is_descending {
-            query = query.order(transactions::dsl::tx_sequence_number.desc());
-        } else {
-            query = query.order(transactions::dsl::tx_sequence_number.asc());
-        }
-        let pool = self.get_pool();
-        run_query_async!(&pool, move |conn| query
-            .limit(limit as i64)
-            .load::<StoredTransaction>(conn))
-    }
-
     pub async fn query_transaction_blocks_in_blocking_task(
         &self,
         filter: Option<TransactionFilter>,
@@ -1110,70 +1086,6 @@ impl IndexerReader {
         .await
     }
 
-    async fn query_transaction_blocks_from_given_checkpoint(
-        &self,
-        checkpoint_seq: u64,
-        cursor: Option<TransactionDigest>,
-        limit: usize,
-        is_descending: bool,
-        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
-    ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
-        let db_res = self
-            .query_transaction_blocks_from_db_by_checkpoint_impl(
-                checkpoint_seq,
-                cursor,
-                limit,
-                is_descending,
-            )
-            .await;
-        let stored_txs = if let (Err(IndexerError::PostgresDataPruned(err)), Some(kv_reader)) =
-            (db_res.as_ref(), self.kv_reader.as_ref())
-        {
-            let fallback_reason = format!("fallback triggered by {err}");
-            let txs = kv_reader
-                .checkpoint_transactions(cursor, checkpoint_seq, limit, is_descending)
-                .await
-                .context(&fallback_reason)?;
-            if txs.iter().any(|tx| tx.is_none()) {
-                return Err(IndexerError::Generic(format!(
-                    "Historic Fallback failed, KV doesn't have full data for checkpoint {checkpoint_seq}, {fallback_reason}"
-                )));
-            }
-            txs.into_iter().flatten().collect::<Vec<_>>()
-        } else {
-            db_res?
-        };
-        self.stored_transaction_to_transaction_block(stored_txs, options)
-            .await
-    }
-
-    async fn resolve_cursor_tx_digest_to_seq_num(
-        &self,
-        cursor: TransactionDigest,
-    ) -> IndexerResult<i64> {
-        self.resolve_cursor_tx_digest_to_seq_num_maybe(cursor)
-            .await?
-            .ok_or_else(|| {
-                IndexerError::PostgresRead(format!("transaction with digest {cursor} not found"))
-            })
-    }
-
-    async fn resolve_cursor_tx_digest_to_seq_num_maybe(
-        &self,
-        cursor: TransactionDigest,
-    ) -> IndexerResult<Option<i64>> {
-        let pool = self.get_pool();
-        run_query_async!(&pool, move |conn| {
-            tx_digests::table
-                .select(tx_digests::tx_sequence_number)
-                // we filter the tx_digests table because it is indexed by digest,
-                // transactions (and other tables) are not
-                .filter(tx_digests::tx_digest.eq(cursor.into_inner().to_vec()))
-                .first::<i64>(conn)
-                .optional()
-        })
-    }
-
     async fn query_transaction_blocks_impl_with_checkpointed_data_only(
         &self,
         filter: Option<TransactionFilterKind>,
@@ -1186,7 +1098,8 @@ impl IndexerReader {
             Some(TransactionFilterKind::V1(TransactionFilter::Checkpoint(seq)))
             | Some(TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(seq))) => {
                 return self
-                    .query_transaction_blocks_from_given_checkpoint(
+                    .checkpointed_db_with_fallback()
+                    .query_transactions_by_checkpoint_seq(
                         seq,
                         cursor,
                         limit,
@@ -1199,7 +1112,11 @@ impl IndexerReader {
         };
 
         let cursor_tx_seq = if let Some(cursor) = cursor {
-            Some(self.resolve_cursor_tx_digest_to_seq_num(cursor).await?)
+            Some(
+                self.checkpointed_db()
+                    .resolve_cursor_tx_digest_to_seq_num(cursor)
+                    .await?,
+            )
         } else {
             None
         };
@@ -1594,109 +1511,6 @@ impl IndexerReader {
         })
     }
 
-    async fn query_events_by_tx_digest_checkpointed_only(
-        &self,
-        tx_digest: TransactionDigest,
-        cursor: Option<EventID>,
-        limit: usize,
-        descending_order: bool,
-    ) -> IndexerResult<Vec<IotaEvent>> {
-        let db_res = self
-            .query_events_from_db_by_tx_digest_checkpointed(
-                tx_digest,
-                cursor,
-                limit,
-                descending_order,
-            )
-            .await;
-
-        if let (Err(IndexerError::PostgresDataPruned(err)), Some(kv_reader)) =
-            (db_res.as_ref(), self.kv_reader.as_ref())
-        {
-            let fallback_reason = format!("fallback triggered by {err}");
-            kv_reader
-                .events(tx_digest, cursor, limit, descending_order)
-                .await
-                .context(&fallback_reason)
-        } else {
-            let mut iota_event_futures = vec![];
-            for stored_event in db_res? {
-                iota_event_futures.push(tokio::task::spawn(
-                    stored_event.try_into_iota_event(self.package_resolver.clone()),
-                ));
-            }
-
-            futures::future::join_all(iota_event_futures)
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))
-        }
-    }
-
-    async fn check_tx_pruned(&self, tx_digest: TransactionDigest) -> IndexerResult<bool> {
-        // there is no way to distinguish now between pruned, and not existing txs
-        self.resolve_cursor_tx_digest_to_seq_num_maybe(tx_digest)
-            .await
-            .map(|seq| seq.is_none())
-    }
-
-    async fn query_events_from_db_by_tx_digest_checkpointed(
-        &self,
-        tx_digest: TransactionDigest,
-        cursor: Option<EventID>,
-        limit: usize,
-        descending_order: bool,
-    ) -> IndexerResult<Vec<StoredEvent>> {
-        let mut query = events::table.into_boxed();
-
-        if let Some(cursor) = cursor {
-            if cursor.tx_digest != tx_digest {
-                return Err(IndexerError::InvalidArgument(
-                    "Cursor tx_digest does not match the tx_digest in the query.".into(),
-                ));
-            }
-            if descending_order {
-                query = query.filter(events::event_sequence_number.lt(cursor.event_seq as i64));
-            } else {
-                query = query.filter(events::event_sequence_number.gt(cursor.event_seq as i64));
-            }
-        } else if descending_order {
-            query = query.filter(events::event_sequence_number.le(i64::MAX));
-        } else {
-            query = query.filter(events::event_sequence_number.ge(0));
-        };
-
-        if descending_order {
-            query = query.order(events::event_sequence_number.desc());
-        } else {
-            query = query.order(events::event_sequence_number.asc());
-        }
-
-        query = query.filter(
-            events::tx_sequence_number.nullable().eq(tx_digests::table
-                .select(tx_digests::tx_sequence_number)
-                // we filter the tx_digests table because it is indexed by digest,
-                // events table is not
-                .filter(tx_digests::tx_digest.eq(tx_digest.into_inner().to_vec()))
-                .single_value()),
-        );
-
-        let pool = self.get_pool();
-        let query = query.limit(limit as i64);
-        let db_events = run_query_async!(&pool, move |conn| { query.load::<StoredEvent>(conn) })?;
-        if db_events.is_empty() && self.check_tx_pruned(tx_digest).await? {
-            return Err(IndexerError::PostgresDataPruned(format!(
-                "data for tx {tx_digest} potentially pruned"
-            )));
-        }
-
-        Ok(db_events)
-    }
-
     pub(crate) async fn query_only_checkpointed_events_in_blocking_task(
         &self,
         filter: EventFilter,
@@ -1706,12 +1520,8 @@ impl IndexerReader {
     ) -> IndexerResult<Vec<IotaEvent>> {
         if let EventFilter::Transaction(tx_digest) = filter {
             return self
-                .query_events_by_tx_digest_checkpointed_only(
-                    tx_digest,
-                    cursor,
-                    limit,
-                    descending_order,
-                )
+                .checkpointed_db_with_fallback()
+                .query_events_by_tx_digest(tx_digest, cursor, limit, descending_order)
                 .await;
         }
 
@@ -1720,7 +1530,10 @@ impl IndexerReader {
                 tx_digest,
                 event_seq,
             } = cursor;
-            let tx_seq: i64 = self.resolve_cursor_tx_digest_to_seq_num(tx_digest).await?;
+            let tx_seq: i64 = self
+                .checkpointed_db()
+                .resolve_cursor_tx_digest_to_seq_num(tx_digest)
+                .await?;
             (tx_seq, event_seq as i64)
         } else if descending_order {
             let max_tx_seq = i64::MAX;
@@ -2520,6 +2333,241 @@ impl DataReader for IndexerReader {
         Ok(epoch_info
             .reference_gas_price
             .ok_or_else(|| anyhow::anyhow!("missing latest reference_gas_price"))?)
+    }
+}
+
+impl<'a> CheckpointedDBReader<'a> {
+    pub fn new(reader: &'a IndexerReader) -> Self {
+        Self {
+            main_reader: reader,
+        }
+    }
+
+    async fn query_transactions_by_checkpoint_seq(
+        &self,
+        checkpoint_seq: u64,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredTransaction>> {
+        let pool = self.main_reader.get_pool();
+        let Some(tx_range) = run_query_async!(&pool, move |conn| {
+            pruner_cp_watermark::dsl::pruner_cp_watermark
+                .select((
+                    pruner_cp_watermark::min_tx_sequence_number,
+                    pruner_cp_watermark::max_tx_sequence_number,
+                ))
+                // we filter the pruner_cp_watermark table because it is indexed by
+                // checkpoint_sequence_number, transactions is not
+                .filter(pruner_cp_watermark::checkpoint_sequence_number.eq(checkpoint_seq as i64))
+                .first::<(i64, i64)>(conn)
+                .optional()
+        })?
+        else {
+            // This check should be replaced with reading the "watermarks" table once it is
+            // used by the pruner
+            return Err(IndexerError::PostgresDataPruned(format!(
+                "requesting data from checkpoint {checkpoint_seq}, which is not available",
+            )));
+        };
+
+        let cursor_tx_seq = if let Some(cursor) = cursor {
+            Some(self.resolve_cursor_tx_digest_to_seq_num(cursor).await?)
+        } else {
+            None
+        };
+
+        let mut query = transactions::dsl::transactions
+            .filter(transactions::tx_sequence_number.between(tx_range.0, tx_range.1))
+            .into_boxed();
+
+        // Translate transaction digest cursor to tx sequence number
+        if let Some(cursor_tx_seq) = cursor_tx_seq {
+            if is_descending {
+                query = query.filter(transactions::dsl::tx_sequence_number.lt(cursor_tx_seq));
+            } else {
+                query = query.filter(transactions::dsl::tx_sequence_number.gt(cursor_tx_seq));
+            }
+        }
+        if is_descending {
+            query = query.order(transactions::dsl::tx_sequence_number.desc());
+        } else {
+            query = query.order(transactions::dsl::tx_sequence_number.asc());
+        }
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, move |conn| query
+            .limit(limit as i64)
+            .load::<StoredTransaction>(conn))
+    }
+
+    async fn query_events_by_tx_digest(
+        &self,
+        tx_digest: TransactionDigest,
+        cursor: Option<EventID>,
+        limit: usize,
+        descending_order: bool,
+    ) -> IndexerResult<Vec<StoredEvent>> {
+        let mut query = events::table.into_boxed();
+
+        if let Some(cursor) = cursor {
+            if cursor.tx_digest != tx_digest {
+                return Err(IndexerError::InvalidArgument(
+                    "Cursor tx_digest does not match the tx_digest in the query.".into(),
+                ));
+            }
+            if descending_order {
+                query = query.filter(events::event_sequence_number.lt(cursor.event_seq as i64));
+            } else {
+                query = query.filter(events::event_sequence_number.gt(cursor.event_seq as i64));
+            }
+        } else if descending_order {
+            query = query.filter(events::event_sequence_number.le(i64::MAX));
+        } else {
+            query = query.filter(events::event_sequence_number.ge(0));
+        };
+
+        if descending_order {
+            query = query.order(events::event_sequence_number.desc());
+        } else {
+            query = query.order(events::event_sequence_number.asc());
+        }
+
+        query = query.filter(
+            events::tx_sequence_number.nullable().eq(tx_digests::table
+                .select(tx_digests::tx_sequence_number)
+                // we filter the tx_digests table because it is indexed by digest,
+                // events table is not
+                .filter(tx_digests::tx_digest.eq(tx_digest.into_inner().to_vec()))
+                .single_value()),
+        );
+
+        let pool = self.main_reader.get_pool();
+        let query = query.limit(limit as i64);
+        let db_events = run_query_async!(&pool, move |conn| { query.load::<StoredEvent>(conn) })?;
+        if db_events.is_empty() && self.check_tx_pruned(tx_digest).await? {
+            return Err(IndexerError::PostgresDataPruned(format!(
+                "data for tx {tx_digest} potentially pruned"
+            )));
+        }
+
+        Ok(db_events)
+    }
+
+    async fn check_tx_pruned(&self, tx_digest: TransactionDigest) -> IndexerResult<bool> {
+        // there is no way to distinguish now between pruned, and not existing txs
+        self.resolve_cursor_tx_digest_to_seq_num_maybe(tx_digest)
+            .await
+            .map(|seq| seq.is_none())
+    }
+
+    async fn resolve_cursor_tx_digest_to_seq_num(
+        &self,
+        cursor: TransactionDigest,
+    ) -> IndexerResult<i64> {
+        self.resolve_cursor_tx_digest_to_seq_num_maybe(cursor)
+            .await?
+            .ok_or_else(|| {
+                IndexerError::PostgresRead(format!("transaction with digest {cursor} not found"))
+            })
+    }
+
+    async fn resolve_cursor_tx_digest_to_seq_num_maybe(
+        &self,
+        cursor: TransactionDigest,
+    ) -> IndexerResult<Option<i64>> {
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, move |conn| {
+            tx_digests::table
+                .select(tx_digests::tx_sequence_number)
+                // we filter the tx_digests table because it is indexed by digest,
+                // transactions (and other tables) are not
+                .filter(tx_digests::tx_digest.eq(cursor.into_inner().to_vec()))
+                .first::<i64>(conn)
+                .optional()
+        })
+    }
+}
+
+impl<'a> CheckpointedDBWithHistoricalFallbackReader<'a> {
+    pub fn new(reader: &'a IndexerReader) -> Self {
+        Self {
+            main_reader: reader,
+        }
+    }
+
+    async fn query_transactions_by_checkpoint_seq(
+        &self,
+        checkpoint_seq: u64,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        is_descending: bool,
+        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
+    ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
+        let db_res = self
+            .main_reader
+            .checkpointed_db()
+            .query_transactions_by_checkpoint_seq(checkpoint_seq, cursor, limit, is_descending)
+            .await;
+        let stored_txs = if let (Err(IndexerError::PostgresDataPruned(err)), Some(kv_reader)) =
+            (db_res.as_ref(), self.main_reader.kv_reader.as_ref())
+        {
+            let fallback_reason = format!("fallback triggered by {err}");
+            let txs = kv_reader
+                .checkpoint_transactions(cursor, checkpoint_seq, limit, is_descending)
+                .await
+                .context(&fallback_reason)?;
+            if txs.iter().any(|tx| tx.is_none()) {
+                return Err(IndexerError::Generic(format!(
+                    "Historic Fallback failed, KV doesn't have full data for checkpoint {checkpoint_seq}, {fallback_reason}"
+                )));
+            }
+            txs.into_iter().flatten().collect::<Vec<_>>()
+        } else {
+            db_res?
+        };
+        self.main_reader
+            .stored_transaction_to_transaction_block(stored_txs, options)
+            .await
+    }
+
+    async fn query_events_by_tx_digest(
+        &self,
+        tx_digest: TransactionDigest,
+        cursor: Option<EventID>,
+        limit: usize,
+        descending_order: bool,
+    ) -> IndexerResult<Vec<IotaEvent>> {
+        let db_res = self
+            .main_reader
+            .checkpointed_db()
+            .query_events_by_tx_digest(tx_digest, cursor, limit, descending_order)
+            .await;
+
+        if let (Err(IndexerError::PostgresDataPruned(err)), Some(kv_reader)) =
+            (db_res.as_ref(), self.main_reader.kv_reader.as_ref())
+        {
+            let fallback_reason = format!("fallback triggered by {err}");
+            kv_reader
+                .events(tx_digest, cursor, limit, descending_order)
+                .await
+                .context(&fallback_reason)
+        } else {
+            let mut iota_event_futures = vec![];
+            for stored_event in db_res? {
+                iota_event_futures.push(tokio::task::spawn(
+                    stored_event.try_into_iota_event(self.main_reader.package_resolver.clone()),
+                ));
+            }
+
+            futures::future::join_all(iota_event_futures)
+                .await
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))
+        }
     }
 }
 

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -60,7 +60,7 @@ use crate::{
     historical_fallback::reader::HistoricalFallbackReader,
     models::{
         address_metrics::StoredAddressMetrics,
-        checkpoints::{StoredChainIdentifier, StoredCheckpoint, StoredCpTx},
+        checkpoints::{StoredChainIdentifier, StoredCheckpoint},
         display::StoredDisplay,
         epoch::StoredEpochInfo,
         events::StoredEvent,
@@ -1017,17 +1017,6 @@ impl IndexerReader {
         })
     }
 
-    async fn get_lowest_unpruned_checkpoint(&self) -> IndexerResult<StoredCpTx> {
-        let pool = self.get_pool();
-        // This should be replaced with reading the "watermarks" table once it is used
-        // by the pruner
-        run_query_async!(&pool, |conn| {
-            pruner_cp_watermark::dsl::pruner_cp_watermark
-                .order_by(pruner_cp_watermark::checkpoint_sequence_number.asc())
-                .first::<StoredCpTx>(conn)
-        })
-    }
-
     async fn query_transaction_blocks_from_db_by_checkpoint_impl(
         &self,
         checkpoint_seq: u64,
@@ -1035,21 +1024,8 @@ impl IndexerReader {
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<StoredTransaction>> {
-        let lowest_unpruned_cp = self.get_lowest_unpruned_checkpoint().await?;
-        if checkpoint_seq < lowest_unpruned_cp.checkpoint_sequence_number as u64 {
-            return Err(IndexerError::PostgresDataPruned(format!(
-                "requesting data from checkpoint {checkpoint_seq}, lowest not pruned checkpoint is {}",
-                lowest_unpruned_cp.checkpoint_sequence_number
-            )));
-        }
-        let cursor_tx_seq = if let Some(cursor) = cursor {
-            Some(self.resolve_cursor_tx_digest_to_seq_num(cursor).await?)
-        } else {
-            None
-        };
-
         let pool = self.get_pool();
-        let tx_range: (i64, i64) = run_query_async!(&pool, move |conn| {
+        let Some(tx_range) = run_query_async!(&pool, move |conn| {
             pruner_cp_watermark::dsl::pruner_cp_watermark
                 .select((
                     pruner_cp_watermark::min_tx_sequence_number,
@@ -1059,7 +1035,21 @@ impl IndexerReader {
                 // checkpoint_sequence_number, transactions is not
                 .filter(pruner_cp_watermark::checkpoint_sequence_number.eq(checkpoint_seq as i64))
                 .first::<(i64, i64)>(conn)
-        })?;
+                .optional()
+        })?
+        else {
+            // This check should be replaced with reading the "watermarks" table once it is
+            // used by the pruner
+            return Err(IndexerError::PostgresDataPruned(format!(
+                "requesting data from checkpoint {checkpoint_seq}, which is not available",
+            )));
+        };
+
+        let cursor_tx_seq = if let Some(cursor) = cursor {
+            Some(self.resolve_cursor_tx_digest_to_seq_num(cursor).await?)
+        } else {
+            None
+        };
 
         let mut query = transactions::dsl::transactions
             .filter(transactions::tx_sequence_number.between(tx_range.0, tx_range.1))
@@ -1161,6 +1151,17 @@ impl IndexerReader {
         &self,
         cursor: TransactionDigest,
     ) -> IndexerResult<i64> {
+        self.resolve_cursor_tx_digest_to_seq_num_maybe(cursor)
+            .await?
+            .ok_or_else(|| {
+                IndexerError::PostgresRead(format!("transaction with digest {cursor} not found"))
+            })
+    }
+
+    async fn resolve_cursor_tx_digest_to_seq_num_maybe(
+        &self,
+        cursor: TransactionDigest,
+    ) -> IndexerResult<Option<i64>> {
         let pool = self.get_pool();
         run_query_async!(&pool, move |conn| {
             tx_digests::table
@@ -1169,6 +1170,7 @@ impl IndexerReader {
                 // transactions (and other tables) are not
                 .filter(tx_digests::tx_digest.eq(cursor.into_inner().to_vec()))
                 .first::<i64>(conn)
+                .optional()
         })
     }
 
@@ -1635,6 +1637,13 @@ impl IndexerReader {
         }
     }
 
+    async fn check_tx_pruned(&self, tx_digest: TransactionDigest) -> IndexerResult<bool> {
+        // there is no way to distinguish now between pruned, and not existing txs
+        self.resolve_cursor_tx_digest_to_seq_num_maybe(tx_digest)
+            .await
+            .map(|seq| seq.is_none())
+    }
+
     async fn query_events_from_db_by_tx_digest_checkpointed(
         &self,
         tx_digest: TransactionDigest,
@@ -1642,22 +1651,6 @@ impl IndexerReader {
         limit: usize,
         descending_order: bool,
     ) -> IndexerResult<Vec<StoredEvent>> {
-        let tx_seq = self
-            .resolve_cursor_tx_digest_to_seq_num(tx_digest)
-            .await
-            .map_err(|err| {
-                IndexerError::PostgresDataPruned(format!(
-                    "Data for tx {tx_digest} potentially pruned: {err}"
-                ))
-            })?;
-        let lowest_unpruned_cp = self.get_lowest_unpruned_checkpoint().await?;
-        if tx_seq < lowest_unpruned_cp.min_tx_sequence_number {
-            return Err(IndexerError::PostgresDataPruned(format!(
-                "requesting data for tx seq {tx_seq}, lowest not pruned tx seq is {}",
-                lowest_unpruned_cp.min_tx_sequence_number
-            )));
-        }
-
         let mut query = events::table.into_boxed();
 
         if let Some(cursor) = cursor {
@@ -1683,12 +1676,25 @@ impl IndexerReader {
             query = query.order(events::event_sequence_number.asc());
         }
 
-        query = query.filter(events::tx_sequence_number.nullable().eq(tx_seq));
+        query = query.filter(
+            events::tx_sequence_number.nullable().eq(tx_digests::table
+                .select(tx_digests::tx_sequence_number)
+                // we filter the tx_digests table because it is indexed by digest,
+                // events table is not
+                .filter(tx_digests::tx_digest.eq(tx_digest.into_inner().to_vec()))
+                .single_value()),
+        );
 
         let pool = self.get_pool();
-        run_query_async!(&pool, move |conn| {
-            query.limit(limit as i64).load::<StoredEvent>(conn)
-        })
+        let query = query.limit(limit as i64);
+        let db_events = run_query_async!(&pool, move |conn| { query.load::<StoredEvent>(conn) })?;
+        if db_events.is_empty() && self.check_tx_pruned(tx_digest).await? {
+            return Err(IndexerError::PostgresDataPruned(format!(
+                "data for tx {tx_digest} potentially pruned"
+            )));
+        }
+
+        Ok(db_events)
     }
 
     pub(crate) async fn query_only_checkpointed_events_in_blocking_task(

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -99,31 +99,14 @@ pub struct IndexerReader {
     pool: ConnectionPool,
     package_resolver: PackageResolver,
     obj_type_cache: Arc<Mutex<SizedCache<String, Option<ObjectID>>>>,
-    kv_reader: Option<Arc<HistoricalFallbackReader>>,
+    kv_reader: Option<HistoricalFallbackReader>,
 }
 
-/// Encapsulates the logic for reading checkpointed data from the database.
+/// Encapsulates the logic for reading data from the database.
 ///
-/// This reader only accesses finalized checkpoint data and does not read
-/// optimistic transactions or historical fallback data from the key-value
-/// store.
-///
-/// Note that object queries will include optimistic data,
-/// as it is stored in the same table as checkpointed objects.
-pub struct CheckpointedDBReader<'a> {
-    main_reader: &'a IndexerReader,
-}
-
-/// Encapsulates the logic for reading checkpointed data with historical
-/// fallback.
-///
-/// This reader first attempts to read from the database. If data is not found,
-/// it falls back to the key-value store (when available). It does not read
-/// optimistic transactions.
-///
-/// Note that object queries will include optimistic data,
-/// as it is stored in the same table as checkpointed objects.
-pub struct CheckpointedDBWithHistoricalFallbackReader<'a> {
+/// This reader only reads data from the DB (checkpointed or optimistic data)
+/// and does not read historical fallback data from the key-value store.
+pub struct DBReader<'a> {
     main_reader: &'a IndexerReader,
 }
 
@@ -144,12 +127,8 @@ impl IndexerReader {
         }
     }
 
-    pub fn checkpointed_db(&self) -> CheckpointedDBReader<'_> {
-        CheckpointedDBReader::new(self)
-    }
-
-    pub fn checkpointed_db_with_fallback(&self) -> CheckpointedDBWithHistoricalFallbackReader<'_> {
-        CheckpointedDBWithHistoricalFallbackReader::new(self)
+    pub fn db(&self) -> DBReader<'_> {
+        DBReader::new(self)
     }
 
     pub fn new_with_config<T: Into<String>>(
@@ -1086,6 +1065,33 @@ impl IndexerReader {
         .await
     }
 
+    async fn query_transactions_by_checkpoint_seq_with_fallback(
+        &self,
+        checkpoint_seq: u64,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        is_descending: bool,
+        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
+    ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
+        let db_res = self
+            .db()
+            .query_transactions_by_checkpoint_seq(checkpoint_seq, cursor, limit, is_descending)
+            .await;
+        let stored_txs = if let (Err(IndexerError::PostgresDataPruned(err)), Some(kv_reader)) =
+            (db_res.as_ref(), self.kv_reader.as_ref())
+        {
+            let fallback_reason = format!("fallback triggered by {err}");
+            kv_reader
+                .checkpoint_transactions(cursor, checkpoint_seq, limit, is_descending)
+                .await
+                .context(&fallback_reason)?
+        } else {
+            db_res?
+        };
+        self.stored_transaction_to_transaction_block(stored_txs, options)
+            .await
+    }
+
     async fn query_transaction_blocks_impl_with_checkpointed_data_only(
         &self,
         filter: Option<TransactionFilterKind>,
@@ -1098,8 +1104,7 @@ impl IndexerReader {
             Some(TransactionFilterKind::V1(TransactionFilter::Checkpoint(seq)))
             | Some(TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(seq))) => {
                 return self
-                    .checkpointed_db_with_fallback()
-                    .query_transactions_by_checkpoint_seq(
+                    .query_transactions_by_checkpoint_seq_with_fallback(
                         seq,
                         cursor,
                         limit,
@@ -1113,7 +1118,7 @@ impl IndexerReader {
 
         let cursor_tx_seq = if let Some(cursor) = cursor {
             Some(
-                self.checkpointed_db()
+                self.db()
                     .resolve_cursor_tx_digest_to_seq_num(cursor)
                     .await?,
             )
@@ -1511,6 +1516,45 @@ impl IndexerReader {
         })
     }
 
+    async fn query_events_by_tx_digest_with_fallback(
+        &self,
+        tx_digest: TransactionDigest,
+        cursor: Option<EventID>,
+        limit: usize,
+        descending_order: bool,
+    ) -> IndexerResult<Vec<IotaEvent>> {
+        let db_res = self
+            .db()
+            .query_events_by_tx_digest(tx_digest, cursor, limit, descending_order)
+            .await;
+
+        if let (Err(IndexerError::PostgresDataPruned(err)), Some(kv_reader)) =
+            (db_res.as_ref(), self.kv_reader.as_ref())
+        {
+            let fallback_reason = format!("fallback triggered by {err}");
+            kv_reader
+                .events(tx_digest, cursor, limit, descending_order)
+                .await
+                .context(&fallback_reason)
+        } else {
+            let mut iota_event_futures = vec![];
+            for stored_event in db_res? {
+                iota_event_futures.push(tokio::task::spawn(
+                    stored_event.try_into_iota_event(self.package_resolver.clone()),
+                ));
+            }
+
+            futures::future::join_all(iota_event_futures)
+                .await
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))
+        }
+    }
+
     pub(crate) async fn query_only_checkpointed_events_in_blocking_task(
         &self,
         filter: EventFilter,
@@ -1520,8 +1564,7 @@ impl IndexerReader {
     ) -> IndexerResult<Vec<IotaEvent>> {
         if let EventFilter::Transaction(tx_digest) = filter {
             return self
-                .checkpointed_db_with_fallback()
-                .query_events_by_tx_digest(tx_digest, cursor, limit, descending_order)
+                .query_events_by_tx_digest_with_fallback(tx_digest, cursor, limit, descending_order)
                 .await;
         }
 
@@ -1531,7 +1574,7 @@ impl IndexerReader {
                 event_seq,
             } = cursor;
             let tx_seq: i64 = self
-                .checkpointed_db()
+                .db()
                 .resolve_cursor_tx_digest_to_seq_num(tx_digest)
                 .await?;
             (tx_seq, event_seq as i64)
@@ -2336,7 +2379,7 @@ impl DataReader for IndexerReader {
     }
 }
 
-impl<'a> CheckpointedDBReader<'a> {
+impl<'a> DBReader<'a> {
     pub fn new(reader: &'a IndexerReader) -> Self {
         Self {
             main_reader: reader,
@@ -2485,89 +2528,6 @@ impl<'a> CheckpointedDBReader<'a> {
                 .first::<i64>(conn)
                 .optional()
         })
-    }
-}
-
-impl<'a> CheckpointedDBWithHistoricalFallbackReader<'a> {
-    pub fn new(reader: &'a IndexerReader) -> Self {
-        Self {
-            main_reader: reader,
-        }
-    }
-
-    async fn query_transactions_by_checkpoint_seq(
-        &self,
-        checkpoint_seq: u64,
-        cursor: Option<TransactionDigest>,
-        limit: usize,
-        is_descending: bool,
-        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
-    ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
-        let db_res = self
-            .main_reader
-            .checkpointed_db()
-            .query_transactions_by_checkpoint_seq(checkpoint_seq, cursor, limit, is_descending)
-            .await;
-        let stored_txs = if let (Err(IndexerError::PostgresDataPruned(err)), Some(kv_reader)) =
-            (db_res.as_ref(), self.main_reader.kv_reader.as_ref())
-        {
-            let fallback_reason = format!("fallback triggered by {err}");
-            let txs = kv_reader
-                .checkpoint_transactions(cursor, checkpoint_seq, limit, is_descending)
-                .await
-                .context(&fallback_reason)?;
-            if txs.iter().any(|tx| tx.is_none()) {
-                return Err(IndexerError::Generic(format!(
-                    "Historic Fallback failed, KV doesn't have full data for checkpoint {checkpoint_seq}, {fallback_reason}"
-                )));
-            }
-            txs.into_iter().flatten().collect::<Vec<_>>()
-        } else {
-            db_res?
-        };
-        self.main_reader
-            .stored_transaction_to_transaction_block(stored_txs, options)
-            .await
-    }
-
-    async fn query_events_by_tx_digest(
-        &self,
-        tx_digest: TransactionDigest,
-        cursor: Option<EventID>,
-        limit: usize,
-        descending_order: bool,
-    ) -> IndexerResult<Vec<IotaEvent>> {
-        let db_res = self
-            .main_reader
-            .checkpointed_db()
-            .query_events_by_tx_digest(tx_digest, cursor, limit, descending_order)
-            .await;
-
-        if let (Err(IndexerError::PostgresDataPruned(err)), Some(kv_reader)) =
-            (db_res.as_ref(), self.main_reader.kv_reader.as_ref())
-        {
-            let fallback_reason = format!("fallback triggered by {err}");
-            kv_reader
-                .events(tx_digest, cursor, limit, descending_order)
-                .await
-                .context(&fallback_reason)
-        } else {
-            let mut iota_event_futures = vec![];
-            for stored_event in db_res? {
-                iota_event_futures.push(tokio::task::spawn(
-                    stored_event.try_into_iota_event(self.main_reader.package_resolver.clone()),
-                ));
-            }
-
-            futures::future::join_all(iota_event_futures)
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))
-        }
     }
 }
 

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -127,6 +127,8 @@ impl IndexerReader {
         }
     }
 
+    /// Returns a [`DBReader`] bound to this `IndexerReader` instance which
+    /// allows to perform database reads.
     pub fn db(&self) -> DBReader<'_> {
         DBReader::new(self)
     }
@@ -1077,14 +1079,13 @@ impl IndexerReader {
             .db()
             .query_transactions_by_checkpoint_seq(checkpoint_seq, cursor, limit, is_descending)
             .await;
-        let stored_txs = if let (Err(IndexerError::PostgresDataPruned(err)), Some(kv_reader)) =
+        let stored_txs = if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
             (db_res.as_ref(), self.kv_reader.as_ref())
         {
-            let fallback_reason = format!("fallback triggered by {err}");
             kv_reader
                 .checkpoint_transactions(cursor, checkpoint_seq, limit, is_descending)
                 .await
-                .context(&fallback_reason)?
+                .context(&format!("fallback triggered by {err}"))?
         } else {
             db_res?
         };
@@ -1100,20 +1101,18 @@ impl IndexerReader {
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
-        match filter {
-            Some(TransactionFilterKind::V1(TransactionFilter::Checkpoint(seq)))
-            | Some(TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(seq))) => {
-                return self
-                    .query_transactions_by_checkpoint_seq_with_fallback(
-                        seq,
-                        cursor,
-                        limit,
-                        is_descending,
-                        options,
-                    )
-                    .await;
-            }
-            _ => {} // remaining cases will be handled below
+        if let Some(TransactionFilterKind::V1(TransactionFilter::Checkpoint(seq)))
+        | Some(TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(seq))) = filter
+        {
+            return self
+                .query_transactions_by_checkpoint_seq_with_fallback(
+                    seq,
+                    cursor,
+                    limit,
+                    is_descending,
+                    options,
+                )
+                .await;
         };
 
         let cursor_tx_seq = if let Some(cursor) = cursor {
@@ -1528,14 +1527,13 @@ impl IndexerReader {
             .query_events_by_tx_digest(tx_digest, cursor, limit, descending_order)
             .await;
 
-        if let (Err(IndexerError::PostgresDataPruned(err)), Some(kv_reader)) =
+        if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
             (db_res.as_ref(), self.kv_reader.as_ref())
         {
-            let fallback_reason = format!("fallback triggered by {err}");
             kv_reader
                 .events(tx_digest, cursor, limit, descending_order)
                 .await
-                .context(&fallback_reason)
+                .context(&format!("fallback triggered by {err}"))
         } else {
             let mut iota_event_futures = vec![];
             for stored_event in db_res? {
@@ -2409,7 +2407,7 @@ impl<'a> DBReader<'a> {
         else {
             // This check should be replaced with reading the "watermarks" table once it is
             // used by the pruner
-            return Err(IndexerError::PostgresDataPruned(format!(
+            return Err(IndexerError::DataPruned(format!(
                 "requesting data from checkpoint {checkpoint_seq}, which is not available",
             )));
         };
@@ -2488,7 +2486,7 @@ impl<'a> DBReader<'a> {
         let query = query.limit(limit as i64);
         let db_events = run_query_async!(&pool, move |conn| { query.load::<StoredEvent>(conn) })?;
         if db_events.is_empty() && self.check_tx_pruned(tx_digest).await? {
-            return Err(IndexerError::PostgresDataPruned(format!(
+            return Err(IndexerError::DataPruned(format!(
                 "data for tx {tx_digest} potentially pruned"
             )));
         }

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -28,7 +28,6 @@ use iota_types::{
     IOTA_FRAMEWORK_ADDRESS, MOVE_STDLIB_PACKAGE_ID,
     base_types::{IotaAddress, ObjectID},
     crypto::{AccountKeyPair, get_key_pair},
-    digests::TransactionDigest,
     dynamic_field::DynamicFieldName,
     gas_coin::GAS,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -412,9 +411,24 @@ fn query_events_supported_events() {
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
+        let real_tx_digest = client
+            .query_transaction_blocks(
+                IotaTransactionBlockResponseQuery {
+                    filter: None,
+                    options: None,
+                },
+                None,
+                Some(1),
+                None,
+            )
+            .await
+            .unwrap()
+            .data[0]
+            .digest;
+
         let supported_filters = vec![
             EventFilter::Sender(IotaAddress::ZERO),
-            EventFilter::Transaction(TransactionDigest::ZERO),
+            EventFilter::Transaction(real_tx_digest),
             EventFilter::Package(ObjectID::ZERO),
             EventFilter::MoveEventModule {
                 package: ObjectID::ZERO,
@@ -428,8 +442,9 @@ fn query_events_supported_events() {
         ];
 
         for event_filter in supported_filters {
+            let err_str = format!("query_events should suceed for filter: {event_filter:?}");
             let result = client.query_events(event_filter, None, None, None).await;
-            assert!(result.is_ok());
+            result.expect(&err_str);
         }
     });
 }

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -442,7 +442,7 @@ fn query_events_supported_events() {
         ];
 
         for event_filter in supported_filters {
-            let err_str = format!("query_events should suceed for filter: {event_filter:?}");
+            let err_str = format!("query_events should succeed for filter: {event_filter:?}");
             let result = client.query_events(event_filter, None, None, None).await;
             result.expect(&err_str);
         }


### PR DESCRIPTION
# Description of change

Use historic fallback in IndexerAPI

This includes:
- query_transaction_blocks:
    - support for case when user filters by checkpoints sequence id (this is handled with no additional overhead to queries on unpruned data)
- query_events
    - support for case when user filters by tx digest (this adds an overhead to queries on unpruned data that return 0 events, as we cannot distinguish case when data is pruned vs. case where data is not pruned but there are just no matching events)


## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9474

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

change not effective yet, so no QA for now

