### PR TITLE
feat(aws): add settings to configure toolchain and features per binary

### DIFF
--- a/crates/iota-aws-orchestrator/assets/settings-template.json
+++ b/crates/iota-aws-orchestrator/assets/settings-template.json
@@ -27,5 +27,19 @@
     "repository": {
         "url": "https://github.com/iotaledger/iota.git",
         "commit": "main"
+    },
+    "build_configs": {
+        "iota": {
+            "toolchain": "stable",
+            "features": []
+        },
+        "iota-node": {
+            "toolchain": "stable",
+            "features": []
+        },
+        "stress": {
+            "toolchain": "stable",
+            "features": []
+        }
     }
 }

--- a/crates/iota-aws-orchestrator/src/build_cache.rs
+++ b/crates/iota-aws-orchestrator/src/build_cache.rs
@@ -9,8 +9,7 @@ use crate::{
     client::Instance,
     display,
     error::TestbedResult,
-    orchestrator::BuildGroups,
-    settings::Settings,
+    settings::{BuildGroups, Settings},
     ssh::{CommandContext, SshConnectionManager},
 };
 

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::HashMap,
+    collections::HashSet,
     fs::{self},
     marker::PhantomData,
     path::PathBuf,
@@ -24,7 +24,7 @@ use crate::{
     monitor::{Monitor, Prometheus},
     net_latency::NetworkLatencyCommandBuilder,
     protocol::{ProtocolCommands, ProtocolMetrics},
-    settings::Settings,
+    settings::{BuildGroups, Settings, build_cargo_command},
     ssh::{CommandContext, CommandStatus, SshConnectionManager},
 };
 
@@ -170,11 +170,9 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         parameters: &BenchmarkParameters<T>,
     ) -> TestbedResult<()> {
         // Run one node per instance.
-        let targets = self.protocol_commands.node_command(
-            instances.clone(),
-            parameters,
-            self.settings.build_cache_enabled(),
-        );
+        let targets = self
+            .protocol_commands
+            .node_command(instances.clone(), parameters);
 
         let repo = self.settings.repository_name();
         let context = CommandContext::new()
@@ -219,6 +217,26 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         let working_dir_cmd = format!("mkdir -p {working_dir}");
         let git_clone_cmd = format!("(git clone {url} || true)");
 
+        // Collect all unique non-"stable" rust toolchains from build configs
+        let toolchain_cmds: Vec<String> = if !use_precompiled_binaries {
+            self.settings
+                .build_configs
+                .values()
+                .filter_map(|config| {
+                    config
+                        .toolchain
+                        .as_ref()
+                        .filter(|t| t.as_str() != "stable")
+                        .cloned()
+                })
+                .collect::<HashSet<String>>()
+                .into_iter()
+                .map(|toolchain| format!("rustup toolchain install {toolchain}"))
+                .collect()
+        } else {
+            vec![]
+        };
+
         let mut basic_commands = vec![
             "sudo apt-get update",
             "sudo apt-get -y upgrade",
@@ -244,6 +262,11 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
                 "source $HOME/.cargo/env",
                 "rustup default stable",
             ]);
+
+            // Add the toolchain install commands to basic_commands
+            for cmd in &toolchain_cmds {
+                basic_commands.push(cmd.as_str());
+            }
         } else {
             // Create cargo env file if using precompiled binaries, so that the source
             // commands don't fail.
@@ -256,9 +279,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             .map(|x| x.as_str())
             .collect();
 
-        let protocol_dependencies = self
-            .protocol_commands
-            .protocol_dependencies(use_precompiled_binaries);
+        let protocol_dependencies = self.protocol_commands.protocol_dependencies();
 
         let command = [
             &basic_commands[..],
@@ -342,26 +363,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             .wait_for_command(self.instances(), id, CommandStatus::Terminated)
             .await?;
 
-        // Define the binaries to build/download
-        let binaries = vec![
-            BinaryBuildConfig {
-                name: "iota".to_string(),
-                toolchain: None,
-                features: vec![],
-            },
-            BinaryBuildConfig {
-                name: "iota-node".to_string(),
-                toolchain: None,
-                features: vec![],
-            },
-            BinaryBuildConfig {
-                name: "stress".to_string(),
-                toolchain: None,
-                features: vec![],
-            },
-        ];
-
-        let build_groups: BuildGroups = build_configs_to_groups(binaries);
+        let build_groups = self.settings.build_groups();
 
         // Check if build cache is enabled
         if self.settings.build_cache_enabled() {
@@ -395,50 +397,13 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         // Build each group separately
         for (i, (group, binary_names)) in build_groups.iter().enumerate() {
             // Build arguments
-            let mut args = vec!["build", "--release"];
-
-            let toolchain_arg = if let Some(tc) = group.toolchain.as_deref() {
-                if tc != "stable" {
-                    Some(format!("+{tc}"))
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-
-            // Add toolchain if specified
-            if let Some(ref t) = toolchain_arg {
-                args.insert(0, t);
-            }
-
-            let features_arg = if !group.features.is_empty() {
-                let features_str = group.features.join(" ");
-                Some(format!("--features=\"{features_str}\""))
-            } else {
-                None
-            };
-
-            // Add features if specified
-            if let Some(ref f) = features_arg {
-                args.push(f);
-            }
-
-            let bin_flags = binary_names
-                .iter()
-                .map(|name| format!("--bin {name}"))
-                .collect::<Vec<_>>()
-                .join(" ");
-
-            // Add bin flags
-            args.push(bin_flags.as_str());
-
-            let build_command = [
-                "source \"$HOME/.cargo/env\"".to_string(),
-                "export RUSTFLAGS='-C target-cpu=native'".to_string(),
-                format!("cargo {}", args.join(" ")),
-            ]
-            .join(" && ");
+            let binary_names_refs: Vec<&str> = binary_names.iter().map(|s| s.as_str()).collect();
+            let build_command = build_cargo_command(
+                "build",
+                group.toolchain.clone(),
+                group.features.clone(),
+                &binary_names_refs,
+            );
 
             // print the full command for logging
             display::action(format!(
@@ -463,11 +428,9 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
 
         // Generate the genesis configuration file and the keystore allowing access to
         // gas objects.
-        let command = self.protocol_commands.genesis_command(
-            self.node_instances.iter(),
-            parameters,
-            self.settings.build_cache_enabled(),
-        );
+        let command = self
+            .protocol_commands
+            .genesis_command(self.node_instances.iter(), parameters);
         display::action(format!("Genesis command: {command}"));
         let repo_name = self.settings.repository_name();
         let context = CommandContext::new().with_execute_from_path(repo_name.into());
@@ -520,11 +483,9 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             display::action("Setting up full nodes");
 
             // Deploy the fullnodes.
-            let targets = self.protocol_commands.fullnode_command(
-                self.client_instances.clone(),
-                parameters,
-                self.settings.build_cache_enabled(),
-            );
+            let targets = self
+                .protocol_commands
+                .fullnode_command(self.client_instances.clone(), parameters);
 
             let repo = self.settings.repository_name();
             let context = CommandContext::new()
@@ -551,11 +512,9 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         display::action("Setting up load generators");
 
         // Deploy the load generators.
-        let targets = self.protocol_commands.client_command(
-            self.client_instances.clone(),
-            parameters,
-            self.settings.build_cache_enabled(),
-        );
+        let targets = self
+            .protocol_commands
+            .client_command(self.client_instances.clone(), parameters);
 
         let repo = self.settings.repository_name();
         let context = CommandContext::new()
@@ -781,36 +740,3 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         Ok(())
     }
 }
-
-struct BinaryBuildConfig {
-    name: String,
-    toolchain: Option<String>,
-    features: Vec<String>,
-}
-
-type BinaryBuildConfigs = Vec<BinaryBuildConfig>;
-
-fn build_configs_to_groups(build_configs: BinaryBuildConfigs) -> BuildGroups {
-    // Group binaries by toolchain and features to minimize build steps
-    let mut groups: BuildGroups = HashMap::new();
-
-    for binary in build_configs {
-        let mut features = binary.features.clone();
-        features.sort(); // Sort for consistent grouping
-
-        let group = BuildGroup {
-            toolchain: binary.toolchain.clone(),
-            features,
-        };
-        groups.entry(group).or_default().push(binary.name);
-    }
-    groups
-}
-
-#[derive(Hash, Eq, PartialEq, Clone)]
-pub struct BuildGroup {
-    pub toolchain: Option<String>,
-    pub features: Vec<String>,
-}
-
-pub type BuildGroups = HashMap<BuildGroup, Vec<String>>;

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -397,12 +397,13 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         // Build each group separately
         for (i, (group, binary_names)) in build_groups.iter().enumerate() {
             // Build arguments
-            let binary_names_refs: Vec<&str> = binary_names.iter().map(|s| s.as_str()).collect();
             let build_command = build_cargo_command(
                 "build",
                 group.toolchain.clone(),
                 group.features.clone(),
-                &binary_names_refs,
+                binary_names,
+                &[] as &[&str],
+                &[] as &[&str],
             );
 
             // print the full command for logging

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    collections::HashMap,
     fmt::{Debug, Display},
     path::PathBuf,
     str::FromStr,
@@ -17,7 +18,7 @@ use crate::{
     benchmark::{BenchmarkParameters, BenchmarkType},
     client::Instance,
     display,
-    settings::Settings,
+    settings::{BinaryBuildConfig, Settings, build_cargo_command},
 };
 
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -55,11 +56,48 @@ impl BenchmarkType for IotaBenchmarkType {}
 pub struct IotaProtocol {
     working_dir: PathBuf,
     use_fullnode_for_execution: bool,
+    use_precompiled_binaries: bool,
+    build_configs: HashMap<String, BinaryBuildConfig>,
+}
+
+impl IotaProtocol {
+    /// Make a new instance of the IOTA protocol commands generator.
+    pub fn new(settings: &Settings) -> Self {
+        Self {
+            working_dir: [&settings.working_dir, &iota_config::IOTA_CONFIG_DIR.into()]
+                .iter()
+                .collect(),
+            use_fullnode_for_execution: settings.use_fullnode_for_execution,
+            use_precompiled_binaries: settings.build_cache_enabled(),
+            build_configs: settings.build_configs.clone(),
+        }
+    }
+
+    /// Build the command to run a binary, either using precompiled binary or
+    /// cargo run. Returns the command string with proper toolchain and
+    /// features configured.
+    fn run_binary_command(&self, binary_name: &str) -> String {
+        if self.use_precompiled_binaries {
+            // The precompiled binary is located in the working directory
+            format!("./target/release/{binary_name}")
+        } else {
+            let build_config = self
+                .build_configs
+                .get(binary_name)
+                .expect("No build config found for binary");
+            build_cargo_command(
+                "run",
+                build_config.toolchain.clone(),
+                build_config.features.clone(),
+                &[binary_name],
+            )
+        }
+    }
 }
 
 impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
-    fn protocol_dependencies(&self, use_precompiled_binaries: bool) -> Vec<&'static str> {
-        if !use_precompiled_binaries {
+    fn protocol_dependencies(&self) -> Vec<&'static str> {
+        if !self.use_precompiled_binaries {
             return vec!["sudo apt-get -y install libudev-dev libpq5 libpq-dev"];
         }
 
@@ -80,7 +118,6 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
         &self,
         instances: I,
         parameters: &BenchmarkParameters<IotaBenchmarkType>,
-        use_precompiled_binaries: bool,
     ) -> String
     where
         I: Iterator<Item = &'a Instance>,
@@ -106,15 +143,10 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
             .map(|timestamp_ms| format!("--chain-start-timestamp-ms {timestamp_ms}"))
             .unwrap_or_default();
 
-        let iota_command = if use_precompiled_binaries {
-            // the precompiled binary is located in the working directory
-            "./target/release/iota"
-        } else {
-            "cargo run --release --bin iota --"
-        };
+        let iota_command = self.run_binary_command("iota");
 
         let genesis = [
-            iota_command,
+            iota_command.as_str(),
             "genesis",
             &format!("-f --working-dir {working_dir} --benchmark-ips {ips}"),
             &epoch_duration_flag,
@@ -124,13 +156,9 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join(" ");
-        let command = [
-            &format!("mkdir -p {working_dir}"),
-            "source $HOME/.cargo/env",
-            "export RUSTFLAGS='-C target-cpu=native'",
-            &genesis,
-        ]
-        .join(" && ");
+
+        let mkdir_cmd = format!("mkdir -p {working_dir}");
+        let command = [mkdir_cmd.as_str(), genesis.as_str()].join(" && ");
 
         display::action(format!("\n Genesis Command: {command}"));
 
@@ -157,7 +185,6 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
         &self,
         instances: I,
         parameters: &BenchmarkParameters<IotaBenchmarkType>,
-        use_precompiled_binaries: bool,
     ) -> Vec<(Instance, String)>
     where
         I: IntoIterator<Item = Instance>,
@@ -173,15 +200,10 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                     iota_config::validator_config_file(network_address.clone(), i);
                 let config_path: PathBuf = working_dir.join(validator_config);
 
-                let iota_node_command = if use_precompiled_binaries {
-                    // the precompiled binary is located in the working directory
-                    "./target/release/iota-node"
-                } else {
-                    "cargo run --release --bin iota-node --"
-                };
+                let iota_node_command = self.run_binary_command("iota-node");
 
                 let run = [
-                    iota_node_command,
+                    iota_node_command.as_str(),
                     &format!(
                         "--config-path {} --listen-address {}",
                         config_path.display(),
@@ -189,9 +211,8 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                     ),
                 ]
                 .join(" ");
+
                 let command = [
-                    "source $HOME/.cargo/env",
-                    "export RUSTFLAGS='-C target-cpu=native'",
                     if parameters.protocol_switch_each_epoch {
                         "export CONSENSUS_PROTOCOL=swap_each_epoch"
                     } else {
@@ -212,7 +233,6 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
         &self,
         instances: I,
         parameters: &BenchmarkParameters<IotaBenchmarkType>,
-        use_precompiled_binaries: bool,
     ) -> Vec<(Instance, String)>
     where
         I: IntoIterator<Item = Instance>,
@@ -237,23 +257,17 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                     fullnode_ip
                 );
 
-                let iota_node_command = if use_precompiled_binaries {
-                    // the precompiled binary is located in the working directory
-                    "./target/release/iota-node"
-                } else {
-                    "cargo run --release --bin iota-node --"
-                };
+                let iota_node_command = self.run_binary_command("iota-node");
 
                 let run = [
-                    iota_node_command,
+                    iota_node_command.as_str(),
                     &format!("--config-path {}", config_path.display(),),
                 ]
                 .join(" ");
+
                 let command = [
-                    "source $HOME/.cargo/env",
-                    "export RUSTFLAGS='-C target-cpu=native'",
-                    &update_p2p_config,
-                    &run,
+                    update_p2p_config.as_str(),
+                    run.as_str(),
                 ]
                 .join(" && ");
 
@@ -268,7 +282,6 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
         &self,
         instances: I,
         parameters: &BenchmarkParameters<IotaBenchmarkType>,
-        use_precompiled_binaries: bool,
     ) -> Vec<(Instance, String)>
     where
         I: IntoIterator<Item = Instance>,
@@ -303,15 +316,10 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                 let gas_key = &gas_keys[i % committee_size];
                 let gas_address = IotaAddress::from(&gas_key.public());
 
-                let stress_command = if use_precompiled_binaries {
-                    // the precompiled binary is located in the working directory
-                    "./target/release/stress"
-                } else {
-                    "cargo run --release --bin stress --"
-                };
+                let stress_command = self.run_binary_command("stress");
 
                 let mut run = [
-                    stress_command,
+                    stress_command.as_str(),
                     "--num-client-threads 24 --num-server-threads 1",
                     "--local false --num-transfer-accounts 2",
                     &format!("--genesis-blob-path {genesis} --keystore-path {keystore}",),
@@ -325,13 +333,13 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                     &format!("--client-metric-host 0.0.0.0 --client-metric-port {metrics_port}"),
                 ]
                 .join(" ");
+
                 if self.use_fullnode_for_execution {
                     run.push_str(" --use-fullnode-for-execution true");
                     run.push_str(" --fullnode-rpc-addresses http://127.0.0.1:9000");
                 }
+
                 let command = [
-                    "source $HOME/.cargo/env",
-                    "export RUSTFLAGS='-C target-cpu=native'",
                     // required for stress binary, otherwise it will use the CARGO_MANIFEST_DIR,
                     // which is set during compilation time
                     "export MOVE_EXAMPLES_DIR=$(pwd)/examples/move",
@@ -349,16 +357,6 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
 
 impl IotaProtocol {
     const CLIENT_METRICS_PORT: u16 = GenesisConfig::BENCHMARKS_PORT_OFFSET + 2000;
-
-    /// Make a new instance of the IOTA protocol commands generator.
-    pub fn new(settings: &Settings) -> Self {
-        Self {
-            working_dir: [&settings.working_dir, &iota_config::IOTA_CONFIG_DIR.into()]
-                .iter()
-                .collect(),
-            use_fullnode_for_execution: settings.use_fullnode_for_execution,
-        }
-    }
 
     /// Creates the network addresses in multi address format for the instances.
     /// It returns the Instance and the corresponding address.

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -18,7 +18,7 @@ use crate::{
     benchmark::{BenchmarkParameters, BenchmarkType},
     client::Instance,
     display,
-    settings::{BinaryBuildConfig, Settings, build_cargo_command},
+    settings::{BinaryBuildConfig, Settings, build_cargo_command, join_non_empty_strings},
 };
 
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -76,10 +76,29 @@ impl IotaProtocol {
     /// Build the command to run a binary, either using precompiled binary or
     /// cargo run. Returns the command string with proper toolchain and
     /// features configured.
-    fn run_binary_command(&self, binary_name: &str) -> String {
+    fn run_binary_command<S1: AsRef<str>, S2: AsRef<str>>(
+        &self,
+        binary_name: &str,
+        setup_commands: &[S1],
+        additional_args: &[S2],
+    ) -> String {
         if self.use_precompiled_binaries {
             // The precompiled binary is located in the working directory
-            format!("./target/release/{binary_name}")
+            let binary_path = format!("./target/release/{binary_name}");
+            let binary_command = join_non_empty_strings(
+                &std::iter::once(binary_path.as_str())
+                    .chain(additional_args.iter().map(|s| s.as_ref()))
+                    .collect::<Vec<_>>(),
+                " ",
+            );
+
+            let all_commands: Vec<String> = setup_commands
+                .iter()
+                .map(|s| s.as_ref().to_string())
+                .chain(std::iter::once(binary_command))
+                .collect();
+
+            join_non_empty_strings(&all_commands, " && ")
         } else {
             let build_config = self
                 .build_configs
@@ -90,6 +109,8 @@ impl IotaProtocol {
                 build_config.toolchain.clone(),
                 build_config.features.clone(),
                 &[binary_name],
+                setup_commands,
+                additional_args,
             )
         }
     }
@@ -143,26 +164,20 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
             .map(|timestamp_ms| format!("--chain-start-timestamp-ms {timestamp_ms}"))
             .unwrap_or_default();
 
-        let iota_command = self.run_binary_command("iota");
+        let iota_command = self.run_binary_command(
+            "iota",
+            &[&format!("mkdir -p {working_dir}")],
+            &[
+                "genesis",
+                &format!("-f --working-dir {working_dir} --benchmark-ips {ips}"),
+                &epoch_duration_flag,
+                &chain_start_timestamp_flag,
+            ],
+        );
 
-        let genesis = [
-            iota_command.as_str(),
-            "genesis",
-            &format!("-f --working-dir {working_dir} --benchmark-ips {ips}"),
-            &epoch_duration_flag,
-            &chain_start_timestamp_flag,
-        ]
-        .into_iter()
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ");
+        display::action(format!("\n Genesis Command: {iota_command}"));
 
-        let mkdir_cmd = format!("mkdir -p {working_dir}");
-        let command = [mkdir_cmd.as_str(), genesis.as_str()].join(" && ");
-
-        display::action(format!("\n Genesis Command: {command}"));
-
-        command
+        iota_command
     }
 
     fn monitor_command<I>(&self, _instances: I) -> Vec<(Instance, String)>
@@ -200,31 +215,25 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                     iota_config::validator_config_file(network_address.clone(), i);
                 let config_path: PathBuf = working_dir.join(validator_config);
 
-                let iota_node_command = self.run_binary_command("iota-node");
-
-                let run = [
-                    iota_node_command.as_str(),
-                    &format!(
-                        "--config-path {} --listen-address {}",
-                        config_path.display(),
-                        network_address.with_zero_ip()
-                    ),
-                ]
-                .join(" ");
-
-                let command = [
-                    if parameters.protocol_switch_each_epoch {
+                let iota_node_command = self.run_binary_command(
+                    "iota-node",
+                    &[if parameters.protocol_switch_each_epoch {
                         "export CONSENSUS_PROTOCOL=swap_each_epoch"
                     } else {
                         "export CONSENSUS_PROTOCOL=starfish"
-                    },
-                    &run,
-                ]
-                .join(" && ");
+                    }],
+                    &[&format!(
+                        "--config-path {} --listen-address {}",
+                        config_path.display(),
+                        network_address.with_zero_ip()
+                    )],
+                );
 
-                display::action(format!("\n Validator-node Command ({i}): {command}"));
+                display::action(format!(
+                    "\n Validator-node Command ({i}): {iota_node_command}"
+                ));
 
-                (instance, command)
+                (instance, iota_node_command)
             })
             .collect()
     }
@@ -249,31 +258,23 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                     false => &instance.main_ip,
                 };
 
-                // Overwrite listen address and external address with 0.0.0.0 and actual fullnode IP.
-                // Escape quotes for proper handling inside tmux wrapper
-                let update_p2p_config = format!(
-                    "sed -i 's|listen-address: \\\"127.0.0.1:|listen-address: \\\"0.0.0.0:|' {0} && sed -i 's|external-address: /ip4/127.0.0.1/|external-address: /ip4/{1}/|' {0}",
-                    config_path.display(),
-                    fullnode_ip
+                let iota_node_command = self.run_binary_command(
+                    "iota-node",
+                    &[
+                        // Overwrite listen address and external address with 0.0.0.0 and actual fullnode IP.
+                        // Escape quotes for proper handling inside tmux wrapper
+                        &format!(
+                            "sed -i 's|listen-address: \\\"127.0.0.1:|listen-address: \\\"0.0.0.0:|' {0} && sed -i 's|external-address: /ip4/127.0.0.1/|external-address: /ip4/{1}/|' {0}",
+                            config_path.display(),
+                            fullnode_ip
+                        )
+                    ],
+                    &[&format!("--config-path {}", config_path.display())],
                 );
 
-                let iota_node_command = self.run_binary_command("iota-node");
+                display::action(format!("\n Full-node Command ({i}): {iota_node_command}"));
 
-                let run = [
-                    iota_node_command.as_str(),
-                    &format!("--config-path {}", config_path.display(),),
-                ]
-                .join(" ");
-
-                let command = [
-                    update_p2p_config.as_str(),
-                    run.as_str(),
-                ]
-                .join(" && ");
-
-                display::action(format!("\n Full-node Command ({i}): {command}"));
-
-                (instance, command)
+                (instance, iota_node_command)
             })
             .collect()
     }
@@ -311,45 +312,41 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
             .into_iter()
             .enumerate()
             .map(|(i, instance)| {
-                let genesis = genesis_path.display();
-                let keystore = keystore_path.display();
+                let genesis = genesis_path.display().to_string();
+                let keystore = keystore_path.display().to_string();
                 let gas_key = &gas_keys[i % committee_size];
                 let gas_address = IotaAddress::from(&gas_key.public());
 
-                let stress_command = self.run_binary_command("stress");
-
-                let mut run = [
-                    stress_command.as_str(),
-                    "--num-client-threads 24 --num-server-threads 1",
-                    "--local false --num-transfer-accounts 2",
-                    &format!("--genesis-blob-path {genesis} --keystore-path {keystore}",),
-                    &format!("--primary-gas-owner-id {gas_address}"),
-                    "bench",
-                    &format!("--in-flight-ratio 30 --num-workers 24 --target-qps {load_share}"),
-                    &format!(
+                let mut stress_args: Vec<String> = vec![
+                    "--num-client-threads 24 --num-server-threads 1".to_string(),
+                    "--local false --num-transfer-accounts 2".to_string(),
+                    format!("--genesis-blob-path {genesis} --keystore-path {keystore}"),
+                    format!("--primary-gas-owner-id {gas_address}"),
+                    "bench".to_string(),
+                    format!("--in-flight-ratio 30 --num-workers 24 --target-qps {load_share}"),
+                    format!(
                         "--shared-counter {shared_counter} --transfer-object {transfer_objects}"
                     ),
-                    "--shared-counter-hotness-factor 50",
-                    &format!("--client-metric-host 0.0.0.0 --client-metric-port {metrics_port}"),
-                ]
-                .join(" ");
+                    "--shared-counter-hotness-factor 50".to_string(),
+                    format!("--client-metric-host 0.0.0.0 --client-metric-port {metrics_port}"),
+                ];
 
                 if self.use_fullnode_for_execution {
-                    run.push_str(" --use-fullnode-for-execution true");
-                    run.push_str(" --fullnode-rpc-addresses http://127.0.0.1:9000");
+                    stress_args.push("--use-fullnode-for-execution true".to_string());
+                    stress_args.push("--fullnode-rpc-addresses http://127.0.0.1:9000".to_string());
                 }
 
-                let command = [
+                let stress_command = self.run_binary_command(
+                    "stress",
                     // required for stress binary, otherwise it will use the CARGO_MANIFEST_DIR,
                     // which is set during compilation time
-                    "export MOVE_EXAMPLES_DIR=$(pwd)/examples/move",
-                    &run,
-                ]
-                .join(" && ");
+                    &["export MOVE_EXAMPLES_DIR=$(pwd)/examples/move"],
+                    &stress_args,
+                );
 
-                display::action(format!("\n Stress Command ({i}): {command}"));
+                display::action(format!("\n Stress Command ({i}): {stress_command}"));
 
-                (instance, command)
+                (instance, stress_command)
             })
             .collect()
     }

--- a/crates/iota-aws-orchestrator/src/protocol/mod.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/mod.rs
@@ -16,7 +16,7 @@ pub mod iota;
 /// from the orchestrator.
 pub trait ProtocolCommands<T: BenchmarkType> {
     /// The list of dependencies to install (e.g., through apt-get).
-    fn protocol_dependencies(&self, use_precompiled_binaries: bool) -> Vec<&'static str>;
+    fn protocol_dependencies(&self) -> Vec<&'static str>;
 
     /// The directories of all databases (that should be erased before each
     /// run).
@@ -24,12 +24,7 @@ pub trait ProtocolCommands<T: BenchmarkType> {
 
     /// The command to generate the genesis and all configuration files. This
     /// command is run on each remote machine.
-    fn genesis_command<'a, I>(
-        &self,
-        instances: I,
-        parameters: &BenchmarkParameters<T>,
-        use_precompiled_binaries: bool,
-    ) -> String
+    fn genesis_command<'a, I>(&self, instances: I, parameters: &BenchmarkParameters<T>) -> String
     where
         I: Iterator<Item = &'a Instance>;
 
@@ -39,7 +34,6 @@ pub trait ProtocolCommands<T: BenchmarkType> {
         &self,
         instances: I,
         parameters: &BenchmarkParameters<T>,
-        use_precompiled_binaries: bool,
     ) -> Vec<(Instance, String)>
     where
         I: IntoIterator<Item = Instance>;
@@ -50,7 +44,6 @@ pub trait ProtocolCommands<T: BenchmarkType> {
         &self,
         instances: I,
         parameters: &BenchmarkParameters<T>,
-        use_precompiled_binaries: bool,
     ) -> Vec<(Instance, String)>
     where
         I: IntoIterator<Item = Instance>;
@@ -65,7 +58,6 @@ pub trait ProtocolCommands<T: BenchmarkType> {
         &self,
         instances: I,
         parameters: &BenchmarkParameters<T>,
-        use_precompiled_binaries: bool,
     ) -> Vec<(Instance, String)>
     where
         I: IntoIterator<Item = Instance>;

--- a/crates/iota-aws-orchestrator/src/settings.rs
+++ b/crates/iota-aws-orchestrator/src/settings.rs
@@ -36,10 +36,12 @@ pub fn build_cargo_command<S1: AsRef<str>, S2: AsRef<str>, S3: AsRef<str>>(
 ) -> String {
     let toolchain_arg = toolchain
         .as_ref()
+        .filter(|t| t.as_str() != "stable")
         .map(|t| format!("+{t}"))
         .unwrap_or_default();
 
     let target_dir_arg = toolchain
+        .filter(|t| t != "stable")
         .map(|t| format!("--target-dir target_{t}"))
         .unwrap_or_default();
 
@@ -57,20 +59,21 @@ pub fn build_cargo_command<S1: AsRef<str>, S2: AsRef<str>, S3: AsRef<str>>(
 
     let additional_args_str = join_non_empty_strings(additional_args, " ");
 
-    let cargo_command = join_non_empty_strings(
-        &[
-            "cargo",
-            &toolchain_arg,
-            subcommand,
-            &target_dir_arg,
-            "--release",
-            &binaries_args,
-            &features_arg,
-            "--",
-            &additional_args_str,
-        ],
-        " ",
-    );
+    let mut cargo_args = vec![
+        "cargo",
+        &toolchain_arg,
+        subcommand,
+        &target_dir_arg,
+        "--release",
+        &binaries_args,
+        &features_arg,
+    ];
+
+    if !additional_args_str.is_empty() {
+        cargo_args.extend(&["--", &additional_args_str]);
+    }
+
+    let cargo_command = join_non_empty_strings(&cargo_args, " ");
 
     let default_setup = [
         "source \"$HOME/.cargo/env\"",

--- a/crates/iota-aws-orchestrator/src/settings.rs
+++ b/crates/iota-aws-orchestrator/src/settings.rs
@@ -7,6 +7,7 @@ use std::{
     env,
     fmt::Display,
     fs::{self},
+    hash::Hash,
     path::{Path, PathBuf},
 };
 
@@ -14,6 +15,53 @@ use reqwest::Url;
 use serde::{Deserialize, Deserializer, de::Error};
 
 use crate::error::{SettingsError, SettingsResult};
+
+pub fn build_cargo_command(
+    subcommand: &str,
+    toolchain: Option<String>,
+    features: Vec<String>,
+    binaries: &[&str],
+) -> String {
+    let toolchain_arg = toolchain
+        .as_ref()
+        .map(|t| format!("+{t}"))
+        .unwrap_or_default();
+    let target_dir_arg = toolchain
+        .map(|t| format!(" --target-dir target_{t}"))
+        .unwrap_or_default();
+    let features_arg = if features.is_empty() {
+        "".to_string()
+    } else {
+        format!(" --features \"{}\"", features.join(" "))
+    };
+    let binaries_args = binaries
+        .iter()
+        .map(|name| format!("--bin {}", name))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let cargo_command = vec![
+        "cargo",
+        &toolchain_arg,
+        subcommand,
+        &target_dir_arg,
+        "--release",
+        &binaries_args,
+        &features_arg,
+        "--",
+    ]
+    .into_iter()
+    .filter(|f| !f.is_empty())
+    .collect::<Vec<_>>()
+    .join(" ");
+
+    [
+        "source \"$HOME/.cargo/env\"",
+        "export RUSTFLAGS='-C target-cpu=native'",
+        &cargo_command,
+    ]
+    .join(" && ")
+}
 
 /// The git repository holding the codebase.
 #[derive(Deserialize, Clone)]
@@ -70,6 +118,16 @@ pub struct BuildCache {
     pub servers: HashMap<String, BuildCacheServer>,
 }
 
+#[derive(Deserialize, Clone)]
+pub struct BinaryBuildConfig {
+    /// Select rust toolchain to build and run the binary.
+    #[serde(default)]
+    pub toolchain: Option<String>,
+    /// Additional features to enable when building the binary.
+    #[serde(default)]
+    pub features: Vec<String>,
+}
+
 /// The testbed settings. Those are topically specified in a file.
 #[derive(Deserialize, Clone)]
 pub struct Settings {
@@ -120,6 +178,9 @@ pub struct Settings {
     /// the instances.
     #[serde(default = "default_logs_dir")]
     pub logs_dir: PathBuf,
+    /// Binary build configuration.
+    #[serde(default)]
+    pub build_configs: HashMap<String, BinaryBuildConfig>,
 }
 
 fn default_working_dir() -> PathBuf {
@@ -205,6 +266,28 @@ impl Settings {
             .unwrap_or(false)
     }
 
+    /// Get build groups for the default binaries (iota, iota-node, stress).
+    /// Groups binaries by toolchain and features to minimize build steps.
+    pub fn build_groups(&self) -> BuildGroups {
+        let mut groups: BuildGroups = HashMap::new();
+
+        for name in ["iota", "iota-node", "stress"] {
+            let config = self.build_configs.get(name);
+
+            let mut features = config.map(|c| c.features.clone()).unwrap_or_default();
+            features.sort(); // Sort for consistent grouping
+
+            let group = BuildGroup {
+                toolchain: config.and_then(|c| c.toolchain.clone()),
+                features,
+            };
+
+            groups.entry(group).or_default().push(name.to_string());
+        }
+
+        groups
+    }
+
     /// Get the build cache server configuration for a specific CPU target.
     pub fn build_cache_server_for_target(&self, cpu_target: &str) -> Option<&BuildCacheServer> {
         self.build_cache.as_ref().and_then(|build_cache| {
@@ -270,9 +353,21 @@ impl Settings {
             use_fullnode_for_execution: false,
             results_dir: "results".into(),
             logs_dir: "logs".into(),
+            build_configs: HashMap::new(),
         }
     }
 }
+
+/// Represents a group of binaries that can be built together with the same
+/// toolchain and features.
+#[derive(Hash, Eq, PartialEq, Clone)]
+pub struct BuildGroup {
+    pub toolchain: Option<String>,
+    pub features: Vec<String>,
+}
+
+/// Maps build groups to the list of binary names in each group.
+pub type BuildGroups = HashMap<BuildGroup, Vec<String>>;
 
 // Resolves ${ENV} into it's value for each env variable.
 fn resolve_env(s: &str) -> String {

--- a/crates/iota-aws-orchestrator/src/settings.rs
+++ b/crates/iota-aws-orchestrator/src/settings.rs
@@ -16,51 +16,74 @@ use serde::{Deserialize, Deserializer, de::Error};
 
 use crate::error::{SettingsError, SettingsResult};
 
-pub fn build_cargo_command(
+/// Helper function to filter out empty strings and join them with a separator.
+pub(crate) fn join_non_empty_strings<S: AsRef<str>>(items: &[S], separator: &str) -> String {
+    items
+        .iter()
+        .map(|s| s.as_ref())
+        .filter(|f| !f.is_empty())
+        .collect::<Vec<_>>()
+        .join(separator)
+}
+
+pub fn build_cargo_command<S1: AsRef<str>, S2: AsRef<str>, S3: AsRef<str>>(
     subcommand: &str,
     toolchain: Option<String>,
     features: Vec<String>,
-    binaries: &[&str],
+    binaries: &[S1],
+    setup_commands: &[S2],
+    additional_args: &[S3],
 ) -> String {
     let toolchain_arg = toolchain
         .as_ref()
         .map(|t| format!("+{t}"))
         .unwrap_or_default();
+
     let target_dir_arg = toolchain
-        .map(|t| format!(" --target-dir target_{t}"))
+        .map(|t| format!("--target-dir target_{t}"))
         .unwrap_or_default();
+
     let features_arg = if features.is_empty() {
         "".to_string()
     } else {
-        format!(" --features \"{}\"", features.join(" "))
+        format!("--features \"{}\"", features.join(" "))
     };
-    let binaries_args = binaries
+
+    let binaries_args: Vec<String> = binaries
         .iter()
-        .map(|name| format!("--bin {}", name))
-        .collect::<Vec<_>>()
-        .join(" ");
+        .map(|name| format!("--bin {}", name.as_ref()))
+        .collect();
+    let binaries_args = join_non_empty_strings(&binaries_args, " ");
 
-    let cargo_command = vec![
-        "cargo",
-        &toolchain_arg,
-        subcommand,
-        &target_dir_arg,
-        "--release",
-        &binaries_args,
-        &features_arg,
-        "--",
-    ]
-    .into_iter()
-    .filter(|f| !f.is_empty())
-    .collect::<Vec<_>>()
-    .join(" ");
+    let additional_args_str = join_non_empty_strings(additional_args, " ");
 
-    [
+    let cargo_command = join_non_empty_strings(
+        &[
+            "cargo",
+            &toolchain_arg,
+            subcommand,
+            &target_dir_arg,
+            "--release",
+            &binaries_args,
+            &features_arg,
+            "--",
+            &additional_args_str,
+        ],
+        " ",
+    );
+
+    let default_setup = [
         "source \"$HOME/.cargo/env\"",
         "export RUSTFLAGS='-C target-cpu=native'",
-        &cargo_command,
-    ]
-    .join(" && ")
+    ];
+
+    let all_commands: Vec<String> = default_setup
+        .iter()
+        .map(|s| s.to_string())
+        .chain(setup_commands.iter().map(|s| s.as_ref().to_string()))
+        .chain(std::iter::once(cargo_command))
+        .collect();
+    join_non_empty_strings(&all_commands, " && ")
 }
 
 /// The git repository holding the codebase.


### PR DESCRIPTION
# Description of change

This PR adds a section to the `aws-orchestrator` settings to configure toolchain and features per binary.
This is needed for the tests with the `flamegraph-alloc` flag that will be introduced by #9298

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes