### PR TITLE
fix(iota-core): Fix differences between StarfishConsensusHandler and MysticetiConsensusHandler

### DIFF
--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -517,6 +517,7 @@ pub struct StarfishConsensusHandler {
 
 impl StarfishConsensusHandler {
     pub fn new(
+        last_processed_commit_at_startup: starfish_core::CommitIndex,
         mut consensus_handler: ConsensusHandler<CheckpointService>,
         mut receiver: UnboundedReceiver<starfish_core::CommittedSubDag>,
         commit_consumer_monitor: Arc<starfish_core::CommitConsumerMonitor>,
@@ -526,10 +527,14 @@ impl StarfishConsensusHandler {
             // backpressure.
             while let Some(consensus_output) = receiver.recv().await {
                 let commit_index = consensus_output.commit_ref.index;
-                consensus_handler
-                    .handle_consensus_output(consensus_output)
-                    .await;
-                commit_consumer_monitor.set_highest_handled_commit(commit_index);
+                if commit_index <= last_processed_commit_at_startup {
+                    consensus_handler.handle_prior_consensus_output(consensus_output);
+                } else {
+                    consensus_handler
+                        .handle_consensus_output(consensus_output)
+                        .await;
+                    commit_consumer_monitor.set_highest_handled_commit(commit_index);
+                }
             }
         });
         Self {

--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -135,10 +135,11 @@ impl ConsensusManagerTrait for StarfishManager {
         let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
 
         let consensus_handler = consensus_handler_initializer.new_consensus_handler();
-        let consumer = CommitConsumer::new(
-            commit_sender,
-            consensus_handler.last_processed_subdag_index() as CommitIndex,
-        );
+
+        let num_prior_commits = protocol_config.consensus_num_requested_prior_commits_at_startup();
+        let last_processed_commit = consensus_handler.last_processed_subdag_index() as CommitIndex;
+        let starting_commit = last_processed_commit.saturating_sub(num_prior_commits);
+        let consumer = CommitConsumer::new(commit_sender, starting_commit);
         let monitor = consumer.monitor();
 
         // If there is a previous consumer monitor, it indicates that the consensus
@@ -197,13 +198,20 @@ impl ConsensusManagerTrait for StarfishManager {
         self.client.set(client);
 
         // spin up the new starfish consensus handler to listen for committed sub dags
-        let handler = StarfishConsensusHandler::new(consensus_handler, commit_receiver, monitor);
+        let handler = StarfishConsensusHandler::new(
+            last_processed_commit,
+            consensus_handler,
+            commit_receiver,
+            monitor,
+        );
 
         let mut consensus_handler = self.consensus_handler.lock().await;
         *consensus_handler = Some(handler);
 
         // Wait until all locally available commits have been processed
+        info!("replaying commits at startup");
         registered_authority.0.replay_complete().await;
+        info!("Startup commit replay complete");
     }
 
     async fn shutdown(&self) {

--- a/crates/iota-core/src/mysticeti_adapter.rs
+++ b/crates/iota-core/src/mysticeti_adapter.rs
@@ -90,6 +90,7 @@ impl ConsensusClient for LazyMysticetiClient {
             .iter()
             .map(|t| bcs::to_bytes(t).expect("Serializing consensus transaction cannot fail"))
             .collect::<Vec<_>>();
+
         let (block_ref, status_waiter) = client
             .as_ref()
             .expect("Client should always be returned")

--- a/crates/iota-core/src/unit_tests/mysticeti_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/mysticeti_manager_tests.rs
@@ -4,20 +4,26 @@
 
 use std::{sync::Arc, time::Duration};
 
+use arc_swap::ArcSwap;
+use consensus_core::{CommitDigest, CommitRef, CommittedSubDag, TestBlock, VerifiedBlock};
 use fastcrypto::traits::KeyPair;
 use futures::FutureExt;
-use iota_metrics::RegistryService;
+use iota_metrics::{RegistryService, monitored_mpsc::unbounded_channel};
 use iota_swarm_config::network_config_builder::ConfigBuilder;
-use iota_types::messages_checkpoint::{
-    CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary,
+use iota_types::{
+    iota_system_state::epoch_start_iota_system_state::EpochStartSystemStateTrait,
+    messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary},
 };
 use prometheus::Registry;
 use tokio::{sync::mpsc, time::sleep};
 
 use crate::{
-    authority::{AuthorityState, test_authority_builder::TestAuthorityBuilder},
+    authority::{
+        AuthorityMetrics, AuthorityState, backpressure::BackpressureManager,
+        test_authority_builder::TestAuthorityBuilder,
+    },
     checkpoints::{CheckpointMetrics, CheckpointService, CheckpointServiceNoop},
-    consensus_handler::ConsensusHandlerInitializer,
+    consensus_handler::{ConsensusHandler, ConsensusHandlerInitializer, MysticetiConsensusHandler},
     consensus_manager::{
         ConsensusManagerMetrics, ConsensusManagerTrait, mysticeti_manager::MysticetiManager,
     },
@@ -136,4 +142,92 @@ async fn test_mysticeti_manager() {
         // THEN
         assert!(!manager.is_running().await);
     }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_mysticeti_consensus_handler_handles_older_commits() {
+    // GIVEN
+    let network_config = ConfigBuilder::new_with_temp_dir()
+        .committee_size(4.try_into().unwrap())
+        .build();
+
+    let state = TestAuthorityBuilder::new()
+        .with_network_config(&network_config, 0)
+        .build()
+        .await;
+
+    let epoch_store = state.epoch_store_for_testing().clone();
+    let new_epoch_start_state = epoch_store.epoch_start_state();
+    let consensus_committee = new_epoch_start_state.get_consensus_committee();
+
+    let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
+    let backpressure_manager = BackpressureManager::new_for_tests();
+
+    let consensus_handler = ConsensusHandler::new(
+        epoch_store.clone(),
+        checkpoint_service_for_testing(state.clone()),
+        state.transaction_manager().clone(),
+        state.get_object_cache_reader().clone(),
+        state.get_transaction_cache_reader().clone(),
+        Arc::new(ArcSwap::default()),
+        consensus_committee.clone(),
+        metrics,
+        backpressure_manager.subscribe(),
+    );
+
+    // Create commits 1-10, where commits 1-7 are "older" (already processed at
+    // startup) and commits 8-10 are "newer" (should be processed normally)
+    let all_commits: Vec<_> = (1..=10)
+        .map(|commit_idx| {
+            let round = commit_idx as u32;
+            let leader_authority = (commit_idx % consensus_committee.size() as u64) as u32;
+
+            let leader_block =
+                VerifiedBlock::new_for_test(TestBlock::new(round, leader_authority).build());
+
+            let timestamp_ms = round as u64 * 1000;
+            // Create a simple commit with just the leader block reference
+            // We don't need full blocks or transactions for this test
+            CommittedSubDag::new(
+                leader_block.reference(),
+                vec![leader_block],
+                timestamp_ms,
+                CommitRef::new(commit_idx as u32, CommitDigest::MIN),
+                vec![],
+            )
+        })
+        .collect();
+
+    // Set last_processed_commit_at_startup to 7
+    let last_processed_commit_at_startup = 7;
+
+    let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
+    let commit_consumer = consensus_core::CommitConsumer::new(commit_sender.clone(), 0);
+    let commit_consumer_monitor = commit_consumer.monitor().clone();
+
+    // WHEN we create the MysticetiConsensusHandler
+    let _handler = MysticetiConsensusHandler::new(
+        last_processed_commit_at_startup,
+        consensus_handler,
+        commit_receiver,
+        commit_consumer_monitor.clone(),
+    );
+
+    // Send all commits in order
+    for commit in all_commits {
+        commit_sender.send(commit).unwrap();
+    }
+
+    // Give time for processing
+    sleep(Duration::from_millis(100)).await;
+
+    // THEN verify that the highest handled commit is only updated for newer commits
+    // (8-10) Commits 1-7 should have been processed as prior commits and
+    // not update the monitor
+    let highest_handled = commit_consumer_monitor.highest_handled_commit();
+    assert_eq!(
+        highest_handled, 10,
+        "Expected highest handled commit to be 10, got {}",
+        highest_handled
+    );
 }

--- a/crates/iota-core/src/unit_tests/starfish_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/starfish_manager_tests.rs
@@ -197,7 +197,7 @@ async fn test_starfish_consensus_handler_handles_older_commits() {
                 leader_block_header.reference(),
                 vec![leader_block_header],
                 vec![],
-                (1000 + commit_idx * 1000) as u64,
+                1000 + commit_idx * 1000,
                 StarfishCommitRef::new(commit_idx as u32, StarfishCommitDigest::MIN),
                 vec![],
             )

--- a/crates/iota-core/src/unit_tests/starfish_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/starfish_manager_tests.rs
@@ -3,20 +3,29 @@
 
 use std::{sync::Arc, time::Duration};
 
+use arc_swap::ArcSwap;
 use fastcrypto::traits::KeyPair;
 use futures::FutureExt;
-use iota_metrics::RegistryService;
+use iota_metrics::{RegistryService, monitored_mpsc::unbounded_channel};
 use iota_swarm_config::network_config_builder::ConfigBuilder;
-use iota_types::messages_checkpoint::{
-    CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary,
+use iota_types::{
+    iota_system_state::epoch_start_iota_system_state::EpochStartSystemStateTrait,
+    messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary},
 };
 use prometheus::Registry;
+use starfish_core::{
+    CommitDigest as StarfishCommitDigest, CommitRef as StarfishCommitRef,
+    CommittedSubDag as StarfishCommittedSubDag, TestBlockHeader, VerifiedBlockHeader,
+};
 use tokio::{sync::mpsc, task::yield_now, time::sleep};
 
 use crate::{
-    authority::{AuthorityState, test_authority_builder::TestAuthorityBuilder},
+    authority::{
+        AuthorityMetrics, AuthorityState, backpressure::BackpressureManager,
+        test_authority_builder::TestAuthorityBuilder,
+    },
     checkpoints::{CheckpointMetrics, CheckpointService, CheckpointServiceNoop},
-    consensus_handler::ConsensusHandlerInitializer,
+    consensus_handler::{ConsensusHandler, ConsensusHandlerInitializer, StarfishConsensusHandler},
     consensus_manager::{
         ConsensusManagerMetrics, ConsensusManagerTrait, starfish_manager::StarfishManager,
     },
@@ -138,4 +147,93 @@ async fn test_starfish_manager() {
         // Yield to ensure that RocksDB releases the lock before the next iteration.
         yield_now().await;
     }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_starfish_consensus_handler_handles_older_commits() {
+    // GIVEN
+    let configs = ConfigBuilder::new_with_temp_dir()
+        .committee_size(4.try_into().unwrap())
+        .build();
+
+    let config = &configs.validator_configs()[0];
+    let secret = Arc::pin(config.authority_key_pair().copy());
+    let genesis = config.genesis().unwrap();
+
+    let state = TestAuthorityBuilder::new()
+        .with_genesis_and_keypair(genesis, &secret)
+        .build()
+        .await;
+
+    let epoch_store = state.epoch_store_for_testing().clone();
+    let new_epoch_start_state = epoch_store.epoch_start_state();
+    let consensus_committee = new_epoch_start_state.get_consensus_committee();
+
+    let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
+    let backpressure_manager = BackpressureManager::new_for_tests();
+
+    let consensus_handler = ConsensusHandler::new(
+        epoch_store.clone(),
+        checkpoint_service_for_testing(state.clone()),
+        state.transaction_manager().clone(),
+        state.get_object_cache_reader().clone(),
+        state.get_transaction_cache_reader().clone(),
+        Arc::new(ArcSwap::default()),
+        consensus_committee.clone(),
+        metrics,
+        backpressure_manager.subscribe(),
+    );
+
+    // Create commits 1-10, where commits 1-7 are "older" (already processed at
+    // startup) and commits 8-10 are "newer" (should be processed normally)
+    let all_commits: Vec<_> = (1..=10)
+        .map(|commit_idx| {
+            let round = commit_idx as u32;
+            let leader_authority = (commit_idx % consensus_committee.size() as u64) as u8;
+            let leader_block_header = VerifiedBlockHeader::new_for_test(
+                TestBlockHeader::new(round, leader_authority).build(),
+            );
+            StarfishCommittedSubDag::new(
+                leader_block_header.reference(),
+                vec![leader_block_header],
+                vec![],
+                (1000 + commit_idx * 1000) as u64,
+                StarfishCommitRef::new(commit_idx as u32, StarfishCommitDigest::MIN),
+                vec![],
+            )
+        })
+        .collect();
+
+    // Set last_processed_commit_at_startup to 7
+    let last_processed_commit_at_startup = 7;
+
+    let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
+    let commit_consumer = starfish_core::CommitConsumer::new(commit_sender.clone(), 0);
+    let commit_consumer_monitor = commit_consumer.monitor().clone();
+
+    // WHEN we create the StarfishConsensusHandler
+    let _handler = StarfishConsensusHandler::new(
+        last_processed_commit_at_startup,
+        consensus_handler,
+        commit_receiver,
+        commit_consumer_monitor.clone(),
+    );
+
+    // Send all commits in order
+    for commit in all_commits {
+        commit_sender.send(commit).unwrap();
+    }
+
+    // Give time for processing
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // THEN verify that the highest handled commit is only updated for newer commits
+    // (8-10) Commits 1-7 should have been processed as prior commits and
+    // not update the monitor
+    let highest_handled = commit_consumer_monitor.highest_handled_commit();
+    assert_eq!(
+        highest_handled, 10,
+        "Expected highest handled commit to be 10, got {}",
+        highest_handled
+    );
 }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1066,7 +1066,6 @@ pub(crate) fn genesis_block_headers(context: &Context) -> Vec<VerifiedBlockHeade
 }
 
 /// This struct is public for testing in other crates.
-#[cfg(test)]
 #[derive(Clone)]
 pub struct TestBlockHeader {
     ancestors: Vec<BlockRef>,
@@ -1074,12 +1073,11 @@ pub struct TestBlockHeader {
     block_header: BlockHeaderV1,
 }
 
-#[cfg(test)]
 impl TestBlockHeader {
     /// Creates a simple block with no transactions and without real computation
     /// of transactions commitment. Use it when you don't need to check the
     /// commitment and don't want to create and pass the encoder.
-    pub(crate) fn new(round: Round, author: u8) -> Self {
+    pub fn new(round: Round, author: u8) -> Self {
         Self {
             block_header: BlockHeaderV1 {
                 round,
@@ -1091,6 +1089,8 @@ impl TestBlockHeader {
             acknowledgments: vec![],
         }
     }
+
+    #[cfg(test)]
     pub(crate) fn new_with_commitment(
         round: Round,
         author: u8,
@@ -1117,6 +1117,7 @@ impl TestBlockHeader {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn new_with_transaction(
         round: Round,
         author: u8,

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -59,11 +59,9 @@ mod test_dag_parser;
 
 /// Exported consensus API.
 pub use authority_node::ConsensusAuthority;
-#[cfg(test)]
-pub use block_header::TestBlockHeader;
 pub use block_header::{BlockHeaderAPI, BlockRef, Round};
 /// Exported API for testing.
-pub use block_header::{BlockTimestampMs, Transaction, VerifiedBlockHeader};
+pub use block_header::{BlockTimestampMs, TestBlockHeader, Transaction, VerifiedBlockHeader};
 pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
 pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
 pub use context::Clock;


### PR DESCRIPTION
# Description of change

Fix differences between Starfish and Mysticeti in handling of previously processed commits at startup by introducing a replay mechanism. Adjust `StarfishConsensusHandler` to manage commit ranges effectively and log replay progress.

## Links to any relevant issues

Fixes #9484 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes