### PR TITLE
feat(indexer): Allow user to supply rest KV url on the CLI

### DIFF
--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -165,7 +165,7 @@ cargo run --bin iota-indexer -- help
 
 #### Historic Fallback (REST KV Store)
 
-The indexer supports an experimental historic fallback feature via the `--rest-kv-url` flag.
+The indexer supports an experimental historic fallback feature via the `--fallback-kv-url` flag.
 This feature allows the indexer to fall back to a REST KV store for historical data when it's not available in the primary database.
 It depends on the API served by the `iota-rest-kv` crate, which is still being finalized and subject to change.
 

--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -161,6 +161,17 @@ cargo run --bin iota-indexer -- help-deprecated
 cargo run --bin iota-indexer -- help
 ```
 
+### Experimental Features
+
+#### Historic Fallback (REST KV Store)
+
+The indexer supports an experimental historic fallback feature via the `--rest-kv-url` flag.
+This feature allows the indexer to fall back to a REST KV store for historical data when it's not available in the primary database.
+It depends on the API served by the `iota-rest-kv` crate, which is still being finalized and subject to change.
+
+> [!WARNING]
+> This is an experimental feature and is subject to change without notice.
+
 ### Running tests
 
 To run the tests, a running postgres instance is required.

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -109,11 +109,23 @@ pub struct JsonRpcConfig {
     #[command(flatten)]
     pub iota_names_options: IotaNamesOptions,
 
+    #[command(flatten)]
+    pub historic_fallback_options: HistoricFallbackOptions,
+
     #[clap(long, default_value = "0.0.0.0:9000")]
     pub rpc_address: SocketAddr,
 
     #[clap(long)]
     pub rpc_client_url: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct HistoricFallbackOptions {
+    #[arg(
+        long,
+        help = "Experimental: REST KV store URL for historic fallback. Depends on the iota-rest-kv API which is still being finalized."
+    )]
+    pub rest_kv_url: Option<Url>,
 }
 
 #[derive(Args, Debug, Default, Clone)]
@@ -395,8 +407,8 @@ pub mod deprecated {
 
     use crate::{
         config::{
-            Command, IndexerConfig, IngestionConfig, IngestionSources, IotaNamesOptions,
-            JsonRpcConfig, PruningOptions, SnapshotLagConfig,
+            Command, HistoricFallbackOptions, IndexerConfig, IngestionConfig, IngestionSources,
+            IotaNamesOptions, JsonRpcConfig, PruningOptions, SnapshotLagConfig,
         },
         db::ConnectionPoolConfig,
         errors::IndexerError,
@@ -601,6 +613,7 @@ pub mod deprecated {
                         old_conf.rpc_server_port,
                     ),
                     rpc_client_url: old_conf.rpc_client_url,
+                    historic_fallback_options: HistoricFallbackOptions { rest_kv_url: None },
                 })
             } else if old_conf.fullnode_sync_worker {
                 Command::Indexer {
@@ -722,6 +735,7 @@ mod test {
         parse_args::<JsonRpcConfig>([
             "--rpc-address=127.0.0.1:8080",
             "--rpc-client-url=http://example.com",
+            "--rest-kv-url=http://example.com/restkv/",
         ])
         .unwrap();
 

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -125,7 +125,7 @@ pub struct HistoricFallbackOptions {
         long,
         help = "Experimental: REST KV store URL for historic fallback. Depends on the iota-rest-kv API which is still being finalized."
     )]
-    pub rest_kv_url: Option<Url>,
+    pub fallback_kv_url: Option<Url>,
 }
 
 #[derive(Args, Debug, Default, Clone)]
@@ -613,7 +613,9 @@ pub mod deprecated {
                         old_conf.rpc_server_port,
                     ),
                     rpc_client_url: old_conf.rpc_client_url,
-                    historic_fallback_options: HistoricFallbackOptions { rest_kv_url: None },
+                    historic_fallback_options: HistoricFallbackOptions {
+                        fallback_kv_url: None,
+                    },
                 })
             } else if old_conf.fullnode_sync_worker {
                 Command::Indexer {
@@ -735,7 +737,7 @@ mod test {
         parse_args::<JsonRpcConfig>([
             "--rpc-address=127.0.0.1:8080",
             "--rpc-client-url=http://example.com",
-            "--rest-kv-url=http://example.com/restkv/",
+            "--fallback-kv-url=http://example.com/restkv/",
         ])
         .unwrap();
 

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -9,8 +9,6 @@
 //! the indexer is unable to fetch data from the database, which is especially
 //! useful when pruning is enabled.
 
-#![expect(dead_code)]
-
 use std::collections::HashMap;
 
 use futures::future;

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -16,6 +16,7 @@ use crate::{
     config::{IngestionConfig, JsonRpcConfig, RetentionConfig, SnapshotLagConfig},
     db::ConnectionPool,
     errors::IndexerError,
+    historical_fallback::reader::HistoricalFallbackReader,
     ingestion::{
         primary::orchestration::PrimaryPipeline, snapshot::orchestration::SnapshotPipelineBuilder,
     },
@@ -168,7 +169,21 @@ impl Indexer {
             "IOTA Indexer Reader (version {:?}) started...",
             env!("CARGO_PKG_VERSION")
         );
-        let read = IndexerReader::new(connection_pool);
+
+        let mut read = IndexerReader::new(connection_pool.clone());
+
+        if let Some(rest_kv_url) = &config.historic_fallback_options.rest_kv_url {
+            let historic_fallback_reader =
+                HistoricalFallbackReader::new(rest_kv_url.as_str(), read.package_resolver())?;
+            info!(
+                "HistoricalFallbackReader initialized with URL: {}",
+                rest_kv_url
+            );
+            read.with_historical_fallback(historic_fallback_reader);
+        } else {
+            info!("No config for HistoricalFallbackReader provided, skipping...");
+        }
+
         let handle = build_json_rpc_server(store, registry, read, config, metrics)
             .await
             .expect("json rpc server should not run into errors upon start.");

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -172,12 +172,12 @@ impl Indexer {
 
         let mut read = IndexerReader::new(connection_pool.clone());
 
-        if let Some(rest_kv_url) = &config.historic_fallback_options.rest_kv_url {
+        if let Some(fallback_kv_url) = &config.historic_fallback_options.fallback_kv_url {
             let historic_fallback_reader =
-                HistoricalFallbackReader::new(rest_kv_url.as_str(), read.package_resolver())?;
+                HistoricalFallbackReader::new(fallback_kv_url.as_str(), read.package_resolver())?;
             info!(
                 "HistoricalFallbackReader initialized with URL: {}",
-                rest_kv_url
+                fallback_kv_url
             );
             read.with_historical_fallback(historic_fallback_reader);
         } else {

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -175,11 +175,8 @@ impl Indexer {
         if let Some(fallback_kv_url) = &config.historic_fallback_options.fallback_kv_url {
             let historic_fallback_reader =
                 HistoricalFallbackReader::new(fallback_kv_url.as_str(), read.package_resolver())?;
-            info!(
-                "HistoricalFallbackReader initialized with URL: {}",
-                fallback_kv_url
-            );
-            read.with_historical_fallback(historic_fallback_reader);
+            info!("HistoricalFallbackReader initialized with URL: {fallback_kv_url}");
+            read.with_fallback_reader(historic_fallback_reader);
         } else {
             info!("No config for HistoricalFallbackReader provided, skipping...");
         }

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -134,6 +134,13 @@ impl IndexerReader {
         DBReader::new(self)
     }
 
+    /// Sets the historical fallback reader for this IndexerReader.
+    /// This allows the reader to fall back to historical KV storage when data
+    /// is not available in Postgres.
+    pub(crate) fn with_historical_fallback(&mut self, kv_reader: HistoricalFallbackReader) {
+        self.fallback = Some(kv_reader);
+    }
+
     pub fn new_with_config<T: Into<String>>(
         db_url: T,
         config: ConnectionPoolConfig,

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -134,13 +134,6 @@ impl IndexerReader {
         DBReader::new(self)
     }
 
-    /// Sets the historical fallback reader for this IndexerReader.
-    /// This allows the reader to fall back to historical KV storage when data
-    /// is not available in Postgres.
-    pub(crate) fn with_historical_fallback(&mut self, kv_reader: HistoricalFallbackReader) {
-        self.fallback = Some(kv_reader);
-    }
-
     pub fn new_with_config<T: Into<String>>(
         db_url: T,
         config: ConnectionPoolConfig,
@@ -166,7 +159,6 @@ impl IndexerReader {
     ///
     /// In case the IndexerReader fails to retrieve data, the fallback reader
     /// will be used to retrieve the data.
-    #[expect(dead_code)]
     pub(crate) fn with_fallback_reader(&mut self, fallback: HistoricalFallbackReader) {
         self.fallback = Some(fallback);
     }

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -150,6 +150,9 @@ pub async fn start_test_indexer_impl(
         } => {
             let config = crate::config::JsonRpcConfig {
                 iota_names_options: IotaNamesOptions::default(),
+                historic_fallback_options: crate::config::HistoricFallbackOptions {
+                    rest_kv_url: None,
+                },
                 rpc_address: reader_mode_rpc_url.parse().unwrap(),
                 rpc_client_url: rpc_url,
             };

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -151,7 +151,7 @@ pub async fn start_test_indexer_impl(
             let config = crate::config::JsonRpcConfig {
                 iota_names_options: IotaNamesOptions::default(),
                 historic_fallback_options: crate::config::HistoricFallbackOptions {
-                    rest_kv_url: None,
+                    fallback_kv_url: None,
                 },
                 rpc_address: reader_mode_rpc_url.parse().unwrap(),
                 rpc_client_url: rpc_url,

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -376,7 +376,7 @@ fn start_indexer_reader(fullnode_rpc_url: impl Into<String>, database_name: Opti
     let config = JsonRpcConfig {
         iota_names_options: IotaNamesOptions::default(),
         historic_fallback_options: iota_indexer::config::HistoricFallbackOptions {
-            rest_kv_url: None,
+            fallback_kv_url: None,
         },
         rpc_address: SocketAddr::new(DEFAULT_INDEXER_IP.parse().unwrap(), port),
         rpc_client_url: fullnode_rpc_url.into(),

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -375,6 +375,9 @@ fn start_indexer_reader(fullnode_rpc_url: impl Into<String>, database_name: Opti
 
     let config = JsonRpcConfig {
         iota_names_options: IotaNamesOptions::default(),
+        historic_fallback_options: iota_indexer::config::HistoricFallbackOptions {
+            rest_kv_url: None,
+        },
         rpc_address: SocketAddr::new(DEFAULT_INDEXER_IP.parse().unwrap(), port),
         rpc_client_url: fullnode_rpc_url.into(),
     };


### PR DESCRIPTION
# Description of change

Allow user to supply rest KV url on the CLI, like: `--rest-kv-url=http://example.com/restkv/`

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9456

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

skipping QA as we will do it later when the functionality will be ready on the feature branch

### Release Notes

- [x] Indexer: (Experimental 🧪) New CLI argument added: `--rest-kv-url` that can be used to configure Rest KV service, which can be used by the Indexer for fallback in case user queries for data that is already pruned. Note that this is experimental and the interface can still change without notice. 

