### PR TITLE
chore: bump rust toolchain to 1.91

### DIFF
--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -1400,7 +1400,7 @@ mod test {
             .collect();
 
         // Round 11 blocks.
-        let round_11 = vec![
+        let round_11 = [
             // This will connect to round 12.
             VerifiedBlock::new_for_test(
                 TestBlock::new(11, 0)
@@ -1452,7 +1452,7 @@ mod test {
             round_11[1].reference(),
             round_11[5].reference(),
         ];
-        let round_12 = vec![
+        let round_12 = [
             VerifiedBlock::new_for_test(
                 TestBlock::new(12, 0)
                     .set_timestamp_ms(1200)
@@ -1480,7 +1480,7 @@ mod test {
             round_12[2].reference(),
             round_11[2].reference(),
         ];
-        let round_13 = vec![
+        let round_13 = [
             VerifiedBlock::new_for_test(
                 TestBlock::new(12, 1)
                     .set_timestamp_ms(1300)

--- a/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
@@ -51,7 +51,7 @@ pub fn generate_block_matrix(n: usize, k: usize) -> Vec<Vec<bool>> {
 
     // For symmetry, we assign blocks in round-robin pairs:
     // node i blocks nodes (i+1)%n, (i+2)%n, ..., (i+k)%n
-    #[allow(clippy::needless_range_loop)]
+    #[expect(clippy::needless_range_loop)]
     for i in 0..n {
         for offset in 1..=k {
             let j = (i + offset) % n;
@@ -133,7 +133,7 @@ impl LatencyMatrixBuilder {
         let cluster_of = |idx: usize| -> usize {
             idx * c / self.number_of_instances // 0..n-1 -> 0..c-1
         };
-        #[allow(clippy::needless_range_loop)]
+        #[expect(clippy::needless_range_loop)]
         for i in 0..self.number_of_instances {
             let ci = cluster_of(i);
 
@@ -201,7 +201,7 @@ impl LatencyMatrixBuilder {
         let n = self.matrix.len();
         let blocking_matrix =
             generate_block_matrix(self.matrix.len(), number_of_blocking_connections);
-        #[allow(clippy::needless_range_loop)]
+        #[expect(clippy::needless_range_loop)]
         for i in 0..n {
             for j in 0..n {
                 if !blocking_matrix[i][j] {

--- a/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/latency_matrix_builder.rs
@@ -51,6 +51,7 @@ pub fn generate_block_matrix(n: usize, k: usize) -> Vec<Vec<bool>> {
 
     // For symmetry, we assign blocks in round-robin pairs:
     // node i blocks nodes (i+1)%n, (i+2)%n, ..., (i+k)%n
+    #[allow(clippy::needless_range_loop)]
     for i in 0..n {
         for offset in 1..=k {
             let j = (i + offset) % n;

--- a/crates/iota-aws-orchestrator/src/net_latency/mod.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/mod.rs
@@ -113,6 +113,7 @@ impl<'a> NetworkLatencyCommandBuilder<'a> {
             HashMap::new();
         for (i, instance) in self.instances.iter().enumerate() {
             let entry = instance2instance_latency_map.entry(instance).or_default();
+            #[allow(clippy::needless_range_loop)]
             for j in 0..self.instances.len() {
                 if latency_matrix[i][j] == 0 {
                     // no need to generate latency commands where latency is 0

--- a/crates/iota-aws-orchestrator/src/net_latency/mod.rs
+++ b/crates/iota-aws-orchestrator/src/net_latency/mod.rs
@@ -113,7 +113,7 @@ impl<'a> NetworkLatencyCommandBuilder<'a> {
             HashMap::new();
         for (i, instance) in self.instances.iter().enumerate() {
             let entry = instance2instance_latency_map.entry(instance).or_default();
-            #[allow(clippy::needless_range_loop)]
+            #[expect(clippy::needless_range_loop)]
             for j in 0..self.instances.len() {
                 if latency_matrix[i][j] == 0 {
                     // no need to generate latency commands where latency is 0

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -98,7 +98,7 @@ pub async fn execute_certificate_with_execution_error(
                 .epoch_store_for_testing()
                 .assign_shared_object_versions_for_tests(
                     authority.get_object_cache_reader().as_ref(),
-                    &vec![VerifiedExecutableTransaction::new_from_certificate(
+                    &[VerifiedExecutableTransaction::new_from_certificate(
                         certificate.clone(),
                     )],
                 )?;
@@ -108,7 +108,7 @@ pub async fn execute_certificate_with_execution_error(
                 .epoch_store_for_testing()
                 .assign_shared_object_versions_for_tests(
                     fullnode.get_object_cache_reader().as_ref(),
-                    &vec![VerifiedExecutableTransaction::new_from_certificate(
+                    &[VerifiedExecutableTransaction::new_from_certificate(
                         certificate.clone(),
                     )],
                 )?;

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -645,14 +645,11 @@ mod tests {
             .with_starting_objects(std::slice::from_ref(&shared_object))
             .build()
             .await;
-        let certs = vec![
-            generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 3),
+        let certs = [generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 3),
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, false)], 5),
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 9),
-            generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 11),
-        ];
-        let effects = vec![
-            TestEffectsBuilder::new(certs[0].data()).build(),
+            generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 11)];
+        let effects = [TestEffectsBuilder::new(certs[0].data()).build(),
             TestEffectsBuilder::new(certs[1].data())
                 .with_shared_input_versions(BTreeMap::from([(id, SequenceNumber::from_u64(4))]))
                 .build(),
@@ -661,8 +658,7 @@ mod tests {
                 .build(),
             TestEffectsBuilder::new(certs[3].data())
                 .with_shared_input_versions(BTreeMap::from([(id, SequenceNumber::from_u64(10))]))
-                .build(),
-        ];
+                .build()];
         let epoch_store = authority.epoch_store_for_testing();
         let assigned_versions = SharedObjVerManager::assign_versions_from_effects(
             certs

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -645,11 +645,14 @@ mod tests {
             .with_starting_objects(std::slice::from_ref(&shared_object))
             .build()
             .await;
-        let certs = [generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 3),
+        let certs = [
+            generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 3),
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, false)], 5),
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 9),
-            generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 11)];
-        let effects = [TestEffectsBuilder::new(certs[0].data()).build(),
+            generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 11),
+        ];
+        let effects = [
+            TestEffectsBuilder::new(certs[0].data()).build(),
             TestEffectsBuilder::new(certs[1].data())
                 .with_shared_input_versions(BTreeMap::from([(id, SequenceNumber::from_u64(4))]))
                 .build(),
@@ -658,7 +661,8 @@ mod tests {
                 .build(),
             TestEffectsBuilder::new(certs[3].data())
                 .with_shared_input_versions(BTreeMap::from([(id, SequenceNumber::from_u64(10))]))
-                .build()];
+                .build(),
+        ];
         let epoch_store = authority.epoch_store_for_testing();
         let assigned_versions = SharedObjVerManager::assign_versions_from_effects(
             certs

--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -110,7 +110,7 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
             let message = CheckpointSignatureMessage { summary };
             let transaction = ConsensusTransaction::new_checkpoint_signature_message(message);
             self.sender
-                .submit_to_consensus(&vec![transaction], epoch_store)?;
+                .submit_to_consensus(&[transaction], epoch_store)?;
             self.metrics
                 .last_sent_checkpoint_signature
                 .set(checkpoint_seq as i64);

--- a/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
@@ -2667,8 +2667,7 @@ enum CapabilityNotificationErrorType {
 
 impl CapabilityNotificationErrorType {
     fn create_non_retryable_errors(count: usize) -> Vec<Self> {
-        let base_errors = vec![
-            Self::NonRetryable(IotaError::FullNodeCantHandleAuthorityCapabilities),
+        let base_errors = [Self::NonRetryable(IotaError::FullNodeCantHandleAuthorityCapabilities),
             Self::NonRetryable(IotaError::UnsupportedFeature {
                 error: "Test unsupported feature".to_string(),
             }),
@@ -2678,8 +2677,7 @@ impl CapabilityNotificationErrorType {
             Self::NonRetryable(IotaError::InvalidAuthenticator),
             Self::NonRetryable(IotaError::InvalidSignature {
                 error: "Test invalid signature".to_string(),
-            }),
-        ];
+            })];
         (0..count)
             .map(|i| base_errors[i % base_errors.len()].clone())
             .collect()

--- a/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
@@ -2667,7 +2667,8 @@ enum CapabilityNotificationErrorType {
 
 impl CapabilityNotificationErrorType {
     fn create_non_retryable_errors(count: usize) -> Vec<Self> {
-        let base_errors = [Self::NonRetryable(IotaError::FullNodeCantHandleAuthorityCapabilities),
+        let base_errors = [
+            Self::NonRetryable(IotaError::FullNodeCantHandleAuthorityCapabilities),
             Self::NonRetryable(IotaError::UnsupportedFeature {
                 error: "Test unsupported feature".to_string(),
             }),
@@ -2677,7 +2678,8 @@ impl CapabilityNotificationErrorType {
             Self::NonRetryable(IotaError::InvalidAuthenticator),
             Self::NonRetryable(IotaError::InvalidSignature {
                 error: "Test invalid signature".to_string(),
-            })];
+            }),
+        ];
         (0..count)
             .map(|i| base_errors[i % base_errors.len()].clone())
             .collect()

--- a/crates/iota-core/src/unit_tests/shared_object_deletion_tests.rs
+++ b/crates/iota-core/src/unit_tests/shared_object_deletion_tests.rs
@@ -1012,7 +1012,7 @@ async fn test_shifting_mutate_and_deletes_multiple_objects() {
     // Tx_8
     let tx_8 = runner.mutate_shared_obj_tx(so2, so2_isv).await;
 
-    let txs = vec![tx_1, tx_2, tx_3, tx_4, tx_5, tx_6, tx_7, tx_8];
+    let txs = [tx_1, tx_2, tx_3, tx_4, tx_5, tx_6, tx_7, tx_8];
     let mut certs = vec![];
     for tx in txs.iter() {
         certs.push(

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -2154,7 +2154,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
             let signed = to_sender_signed_transaction(data, &senders[9].1);
             signed_tx_into_certificate(signed).await
         };
-        send_batch_consensus_no_execution(&authority, &vec![cert0.clone(), cert1.clone()], true)
+        send_batch_consensus_no_execution(&authority, &[cert0.clone(), cert1.clone()], true)
             .await;
         let response = client
             .handle_soft_bundle_certificates_v1(

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -2154,8 +2154,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
             let signed = to_sender_signed_transaction(data, &senders[9].1);
             signed_tx_into_certificate(signed).await
         };
-        send_batch_consensus_no_execution(&authority, &[cert0.clone(), cert1.clone()], true)
-            .await;
+        send_batch_consensus_no_execution(&authority, &[cert0.clone(), cert1.clone()], true).await;
         let response = client
             .handle_soft_bundle_certificates_v1(
                 HandleSoftBundleCertificatesRequestV1 {

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -148,15 +148,15 @@ impl std::ops::Add<u64> for ProtocolVersion {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Copy, PartialOrd, Ord, Eq, ValueEnum)]
-#[derive(Default)]
+#[derive(
+    Clone, Serialize, Deserialize, Debug, PartialEq, Copy, PartialOrd, Ord, Eq, ValueEnum, Default,
+)]
 pub enum Chain {
     Mainnet,
     Testnet,
     #[default]
     Unknown,
 }
-
 
 impl Chain {
     pub fn as_str(self) -> &'static str {

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -149,17 +149,14 @@ impl std::ops::Add<u64> for ProtocolVersion {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Copy, PartialOrd, Ord, Eq, ValueEnum)]
+#[derive(Default)]
 pub enum Chain {
     Mainnet,
     Testnet,
+    #[default]
     Unknown,
 }
 
-impl Default for Chain {
-    fn default() -> Self {
-        Self::Unknown
-    }
-}
 
 impl Chain {
     pub fn as_str(self) -> &'static str {

--- a/crates/iota/src/client_ptb/token.rs
+++ b/crates/iota/src/client_ptb/token.rs
@@ -15,37 +15,37 @@ pub struct Lexeme<'t>(
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Token {
-    /// --[a-zA-Z0-9_-]+
+    /// `--[a-zA-Z0-9_-]+`
     Command,
-    /// -[a-zA-Z0-9]
+    /// `-[a-zA-Z0-9]`
     Flag,
-    /// [a-zA-Z_][a-zA-Z0-9_-]*
+    /// `[a-zA-Z_][a-zA-Z0-9_-]*`
     Ident,
-    /// [1-9][0-9_]*
+    /// `[1-9][0-9_]*`
     Number,
-    /// 0x[0-9a-fA-F][0-9a-fA-F_]*
+    /// `0x[0-9a-fA-F][0-9a-fA-F_]*`
     HexNumber,
-    /// "..." | '...'
+    /// `"..." | '...'`
     String,
-    /// ::
+    /// `::`
     ColonColon,
-    /// ,
+    /// `,`
     Comma,
-    /// [
+    /// `[`
     LBracket,
-    /// ]
+    /// `]`
     RBracket,
-    /// (
+    /// `(`
     LParen,
-    /// )
+    /// `)`
     RParen,
-    /// <
+    /// `<`
     LAngle,
-    /// >
+    /// `>`
     RAngle,
-    /// @
+    /// `@`
     At,
-    /// .
+    /// `.`
     Dot,
 
     /// End of input.

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1317,7 +1317,7 @@ mod tests {
                 acknowledgments.clone(),
             );
 
-        let expected = vec![ref_a, ref_b, ref_c, ref_d, ref_e, ref_a];
+        let expected = [ref_a, ref_b, ref_c, ref_d, ref_e, ref_a];
         assert_eq!(references.len(), expected.len());
         for r in references.iter() {
             assert!(expected.contains(r));

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1927,7 +1927,7 @@ mod test {
             .collect();
 
         // Round 11 block headers.
-        let round_11_headers = vec![
+        let round_11_headers = [
             // This will connect to round 12.
             VerifiedBlockHeader::new_for_test(
                 TestBlockHeader::new(11, 0)
@@ -1979,7 +1979,7 @@ mod test {
             round_11_headers[1].reference(),
             round_11_headers[5].reference(),
         ];
-        let round_12_headers = vec![
+        let round_12_headers = [
             VerifiedBlockHeader::new_for_test(
                 TestBlockHeader::new(12, 0)
                     .set_timestamp_ms(1200)
@@ -2007,7 +2007,7 @@ mod test {
             round_12_headers[2].reference(),
             round_11_headers[2].reference(),
         ];
-        let round_13_headers = vec![
+        let round_13_headers = [
             VerifiedBlockHeader::new_for_test(
                 TestBlockHeader::new(12, 1)
                     .set_timestamp_ms(1300)

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -155,16 +155,14 @@ async fn scan_block_headers(
 ) {
     let store = test_store.store();
 
-    let written_blocks = vec![
-        VerifiedBlock::new_for_test(TestBlockHeader::new(9, 0).build()),
+    let written_blocks = [VerifiedBlock::new_for_test(TestBlockHeader::new(9, 0).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(10, 0).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(10, 1).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(11, 1).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(11, 3).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(12, 1).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(13, 2).build()),
-        VerifiedBlock::new_for_test(TestBlockHeader::new(13, 1).build()),
-    ];
+        VerifiedBlock::new_for_test(TestBlockHeader::new(13, 1).build())];
 
     // Write block headers
     store
@@ -205,12 +203,10 @@ async fn scan_block_headers(
     );
 
     // Add more headers and test scanning
-    let additional_blocks = vec![
-        VerifiedBlock::new_for_test(TestBlockHeader::new(14, 2).build()),
+    let additional_blocks = [VerifiedBlock::new_for_test(TestBlockHeader::new(14, 2).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(15, 0).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(15, 1).build()),
-        VerifiedBlock::new_for_test(TestBlockHeader::new(16, 3).build()),
-    ];
+        VerifiedBlock::new_for_test(TestBlockHeader::new(16, 3).build())];
 
     // Write additional block headers
     store
@@ -271,14 +267,12 @@ async fn read_and_contain_transactions(
 ) {
     let store = test_store.store();
 
-    let written_blocks = vec![
-        VerifiedBlock::new_for_test(TestBlockHeader::new(9, 0).build()),
+    let written_blocks = [VerifiedBlock::new_for_test(TestBlockHeader::new(9, 0).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(10, 0).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(10, 1).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(11, 1).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(11, 3).build()),
-        VerifiedBlock::new_for_test(TestBlockHeader::new(12, 1).build()),
-    ];
+        VerifiedBlock::new_for_test(TestBlockHeader::new(12, 1).build())];
     // Write transactions to store
     let written_transactions: Vec<_> = written_blocks
         .iter()

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -155,14 +155,16 @@ async fn scan_block_headers(
 ) {
     let store = test_store.store();
 
-    let written_blocks = [VerifiedBlock::new_for_test(TestBlockHeader::new(9, 0).build()),
+    let written_blocks = [
+        VerifiedBlock::new_for_test(TestBlockHeader::new(9, 0).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(10, 0).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(10, 1).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(11, 1).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(11, 3).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(12, 1).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(13, 2).build()),
-        VerifiedBlock::new_for_test(TestBlockHeader::new(13, 1).build())];
+        VerifiedBlock::new_for_test(TestBlockHeader::new(13, 1).build()),
+    ];
 
     // Write block headers
     store
@@ -203,10 +205,12 @@ async fn scan_block_headers(
     );
 
     // Add more headers and test scanning
-    let additional_blocks = [VerifiedBlock::new_for_test(TestBlockHeader::new(14, 2).build()),
+    let additional_blocks = [
+        VerifiedBlock::new_for_test(TestBlockHeader::new(14, 2).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(15, 0).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(15, 1).build()),
-        VerifiedBlock::new_for_test(TestBlockHeader::new(16, 3).build())];
+        VerifiedBlock::new_for_test(TestBlockHeader::new(16, 3).build()),
+    ];
 
     // Write additional block headers
     store
@@ -267,12 +271,14 @@ async fn read_and_contain_transactions(
 ) {
     let store = test_store.store();
 
-    let written_blocks = [VerifiedBlock::new_for_test(TestBlockHeader::new(9, 0).build()),
+    let written_blocks = [
+        VerifiedBlock::new_for_test(TestBlockHeader::new(9, 0).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(10, 0).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(10, 1).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(11, 1).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(11, 3).build()),
-        VerifiedBlock::new_for_test(TestBlockHeader::new(12, 1).build())];
+        VerifiedBlock::new_for_test(TestBlockHeader::new(12, 1).build()),
+    ];
     // Write transactions to store
     let written_transactions: Vec<_> = written_blocks
         .iter()

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.90"
+channel = "1.91"


### PR DESCRIPTION
# Description of change

Bump rust toolchain from 1.90 to 1.91.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
