### PR TITLE
fix(iota-replay): Handle ChangeEpochV4

### DIFF
--- a/crates/iota-replay/src/data_fetcher.rs
+++ b/crates/iota-replay/src/data_fetcher.rs
@@ -584,6 +584,12 @@ impl DataFetcher for RemoteFetcher {
                             .await?
                             .base_gas_price(),
                     ),
+                    EndOfEpochTransactionKind::ChangeEpochV4(change) => (
+                        change.epoch_start_timestamp_ms,
+                        self.get_protocol_config(protocol_version)
+                            .await?
+                            .base_gas_price(),
+                    ),
                     EndOfEpochTransactionKind::AuthenticatorStateCreate
                     | EndOfEpochTransactionKind::AuthenticatorStateExpire(_) => continue,
                 };


### PR DESCRIPTION
# Description of change

Handle new enum variant ChangeEpochV4 in the iota-replay crate.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
