### PR TITLE
fix(iota-indexer): return the body bytes only if non-empty

### DIFF
--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -117,13 +117,15 @@ impl HttpRestKVClient {
                 .get(CONTENT_LENGTH)
                 .unwrap_or(&HeaderValue::from_static("0"))
         );
-        // return None if 400
-        if resp.status().is_success() {
-            let bytes = resp.bytes().await?;
-            Ok(Some(bytes))
-        } else {
-            Ok(None)
+
+        // return None for non-2xx responses.
+        if !resp.status().is_success() {
+            return Ok(None);
         }
+
+        let bytes = resp.bytes().await?;
+        // map the bytes to Some only if non-empty.
+        Ok((!bytes.is_empty()).then_some(bytes))
     }
 }
 


### PR DESCRIPTION
# Description of change

This PR fixes the deserialization warning log when trying to deserialize a type from bytes.

## Links to any relevant issues

fixes #9507 

## How the change has been tested

Queried transaction events, where previously the warnings were shown, now are not present anymore.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This path doe snot affect the normal operation of the indexer, thus no tests were conducted.