### PR TITLE
fix(iota-indexer): `multi_fetch` early return if input is empty

### DIFF
--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -99,9 +99,16 @@ impl HttpRestKVClient {
     }
 
     async fn multi_fetch(&self, uris: Vec<Key>) -> Vec<IndexerResult<Option<Bytes>>> {
+        if uris.is_empty() {
+            return Vec::new();
+        }
         let len = uris.len();
-        let fetches = stream::iter(uris.into_iter().map(|url| self.fetch(url)));
-        fetches.buffered(len).collect::<Vec<_>>().await
+        stream::iter(uris)
+            .map(|url| self.fetch(url))
+            // len must be greater than 0, otherwise it will enter a deadlock.
+            .buffered(len)
+            .collect()
+            .await
     }
 
     async fn fetch(&self, key: Key) -> IndexerResult<Option<Bytes>> {


### PR DESCRIPTION
# Description of change

This PR fixes an edge case where the `multi_fetch` entered in deadlock if the input was an empty vector.

## Links to any relevant issues

fixes #9508 

## How the change has been tested

Providing an empty vector as input no longer halts the whole execution.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch does not affect the normal operation of the indexer, thus no other test were conducted.