### PR TITLE
chore(protocol-research): ChangeEpoch validity checks

### DIFF
--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -620,12 +620,11 @@ impl EndOfEpochTransactionKind {
                         "selecting committee only among validators supporting the protocol version not supported".to_string(),
                     ));
                 }
-                // This has to be uncommented before merging to develop
-                // if config.score_based_rewards() {
-                //     return Err(UserInputError::Unsupported(
-                //         "score based rewards enabled and
-                // required".to_string(),     ));
-                // }
+                if config.score_based_rewards() {
+                    return Err(UserInputError::Unsupported(
+                        "score based rewards should not be enabled".to_string(),
+                    ));
+                }
             }
             Self::ChangeEpochV2(_) => {
                 if !config.protocol_defined_base_fee() {
@@ -638,12 +637,11 @@ impl EndOfEpochTransactionKind {
                         "selecting committee only among validators supporting the protocol version not supported".to_string(),
                     ));
                 }
-                // This has to be uncommented before merging to develop
-                // if config.score_based_rewards() {
-                //     return Err(UserInputError::Unsupported(
-                //         "score based rewards enabled and
-                // required".to_string(),     ));
-                // }
+                if config.score_based_rewards() {
+                    return Err(UserInputError::Unsupported(
+                        "score based rewards should not be enabled".to_string(),
+                    ));
+                }
             }
             Self::ChangeEpochV3(_) => {
                 if !config.protocol_defined_base_fee() {
@@ -656,12 +654,11 @@ impl EndOfEpochTransactionKind {
                         "selecting committee only among validators supporting the protocol version required".to_string(),
                     ));
                 }
-                // This has to be uncommented before merging to develop
-                // if config.score_based_rewards() {
-                //     return Err(UserInputError::Unsupported(
-                //         "score based rewards enabled and
-                // required".to_string(),     ));
-                // }
+                if config.score_based_rewards() {
+                    return Err(UserInputError::Unsupported(
+                        "score based rewards should not be enabled".to_string(),
+                    ));
+                }
             }
             Self::ChangeEpochV4(_) => {
                 if !config.protocol_defined_base_fee() {
@@ -676,7 +673,7 @@ impl EndOfEpochTransactionKind {
                 }
                 if !config.score_based_rewards() {
                     return Err(UserInputError::Unsupported(
-                        "score based rewards not enabled".to_string(),
+                        "score based rewards should be enabled".to_string(),
                     ));
                 }
             }


### PR DESCRIPTION
# Description of change

Adding validity checks to the ChangeEpoch types to ensure that `score_based_rewards` is enabled if and only if `ChangeEpochV4` is in use.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
