### PR TITLE
fix(docker): cached builds need to copy in the same command

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 **/.terraform/
 target/
 **/*Dockerfile
+**/*Dockerfile.cache
 *.md
 build/
 storage/

--- a/dev-tools/iota-private-network/bootstrap.sh
+++ b/dev-tools/iota-private-network/bootstrap.sh
@@ -162,23 +162,23 @@ main() {
       echo "Please run as root or with sudo"
       exit 1
     fi
-    [ -d "$TEMP_EXPORT_DIR" ] && rm -rf "$TEMP_EXPORT_DIR"
+  
+  [ -d "$TEMP_EXPORT_DIR" ] && rm -rf "$TEMP_EXPORT_DIR"
 
-    [ -d "$PRIVATE_DATA_DIR" ] && ./cleanup.sh
+  [ -d "$PRIVATE_DATA_DIR" ] && ./cleanup.sh
 
-    # Generate genesis template if missing
-    generate_genesis_template_if_missing
+  # Generate genesis template if missing
+  generate_genesis_template_if_missing
 
-    # Only check overlay file existence
-    check_configs_exist "$OVERLAY_PATH"
+  # Only check overlay file existence
+  check_configs_exist "$OVERLAY_PATH"
 
-    for image in "iotaledger/iota-tools" "iotaledger/iota-node" "iotaledger/iota-indexer"; do
-      check_docker_image_exist "$image"
-    done
+  for image in "iotaledger/iota-tools" "iotaledger/iota-node" "iotaledger/iota-indexer"; do
+    check_docker_image_exist "$image"
+  done
 
-    generate_genesis_files
-    create_folder_for_postgres
-
+  generate_genesis_files
+  create_folder_for_postgres
 
   echo "Done"
 }

--- a/dev-tools/iota-private-network/build.sh
+++ b/dev-tools/iota-private-network/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Determine script's location to resolve the relative path correctly
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
+
+# Go to ../../docker/iota-node with pushd and build the image
+pushd "$SCRIPT_DIR/../../docker/iota-node"
+./build.sh
+popd
+
+# Go to ../../docker/iota-indexer with pushd and build the image
+pushd "$SCRIPT_DIR/../../docker/iota-indexer"
+./build.sh
+popd
+
+# Go to ../../docker/iota-tools with pushd and build the image
+pushd "$SCRIPT_DIR/../../docker/iota-tools"
+./build.sh
+popd

--- a/docker/iota-data-ingestion/Dockerfile
+++ b/docker/iota-data-ingestion/Dockerfile
@@ -29,13 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build the binaries
+# Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-data-ingestion \
-      --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binaries to the working directory
-RUN cp $TARGET_FOLDER/iota-data-ingestion ./iota-data-ingestion
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-data-ingestion ./iota-data-ingestion
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-graphql-rpc/Dockerfile
+++ b/docker/iota-graphql-rpc/Dockerfile
@@ -29,13 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build the binaries
+# Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-graphql-rpc \
-      --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binaries to the working directory
-RUN cp $TARGET_FOLDER/iota-graphql-rpc ./iota-graphql-rpc
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-graphql-rpc ./iota-graphql-rpc
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-indexer/Dockerfile
+++ b/docker/iota-indexer/Dockerfile
@@ -29,13 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build the binaries
+# Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-indexer \
-      --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binaries to the working directory
-RUN cp $TARGET_FOLDER/iota-indexer ./iota-indexer
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-indexer ./iota-indexer
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-node/Dockerfile
+++ b/docker/iota-node/Dockerfile
@@ -29,13 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build the binaries
+# Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-node \
-      --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binaries to the working directory
-RUN cp $TARGET_FOLDER/iota-node ./iota-node
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-node ./iota-node
 
 
 # Production image

--- a/docker/iota-proxy/Dockerfile
+++ b/docker/iota-proxy/Dockerfile
@@ -29,13 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build the binaries
+# Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-proxy \
-      --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binaries to the working directory
-RUN cp $TARGET_FOLDER/iota-proxy ./iota-proxy
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-proxy ./iota-proxy
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-rest-kv/Dockerfile
+++ b/docker/iota-rest-kv/Dockerfile
@@ -29,13 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build the binaries
+# Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-rest-kv \
-      --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binaries to the working directory
-RUN cp $TARGET_FOLDER/iota-rest-kv ./iota-rest-kv
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-rest-kv ./iota-rest-kv
 
 
 # Production image

--- a/docker/iota-rosetta/Dockerfile
+++ b/docker/iota-rosetta/Dockerfile
@@ -29,13 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build the binaries
+# Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-rosetta \
-      --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binaries to the working directory
-RUN cp $TARGET_FOLDER/iota-rosetta ./iota-rosetta
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-rosetta ./iota-rosetta
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-source-validation-service/Dockerfile
+++ b/docker/iota-source-validation-service/Dockerfile
@@ -29,13 +29,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build the binaries
+# Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-source-validation-service \
-      --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binaries to the working directory
-RUN cp $TARGET_FOLDER/iota-source-validation-service ./iota-source-validation-service
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-source-validation-service ./iota-source-validation-service
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/iota-tools/Dockerfile
+++ b/docker/iota-tools/Dockerfile
@@ -31,7 +31,7 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build the binaries
+# Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-node \
       --bin stress \
@@ -41,10 +41,8 @@ RUN cargo build --profile ${PROFILE} \
       --bin iota-cluster-test \
       --bin iota-tool \
       --bin iota-genesis-builder \
-      --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binaries to the working directory
-RUN cp $TARGET_FOLDER/iota-node ./iota-node && \
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-node ./iota-node && \
     cp $TARGET_FOLDER/stress ./stress && \
     cp $TARGET_FOLDER/iota-analytics-indexer ./iota-analytics-indexer && \
     cp $TARGET_FOLDER/iota ./iota && \

--- a/docker/iota/Dockerfile
+++ b/docker/iota/Dockerfile
@@ -30,13 +30,11 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
-# Build the binaries
+# Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota \
-      --features ${CARGO_BUILD_FEATURES:=default}
-
-# Copy the built binaries to the working directory
-RUN cp $TARGET_FOLDER/iota ./iota
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota ./iota
 
 # Production image
 FROM debian:bookworm-slim AS runtime

--- a/docker/utils/build-script.sh
+++ b/docker/utils/build-script.sh
@@ -63,7 +63,7 @@ echo
 echo "Building \"$IMAGE_TAG\" docker image"
 echo "Dockerfile:                 $DOCKERFILE"
 echo "docker context:             $REPO_ROOT"
-echo "profile: 					  $PROFILE"
+echo "profile:                    $PROFILE"
 echo "builder rust image version: $RUST_IMAGE_VERSION"
 echo "cargo build features:       $CARGO_BUILD_FEATURES"
 echo "build date:                 $BUILD_DATE"


### PR DESCRIPTION
# Description of change

Unfortunately we broke the cached builds in the last PR #9179.
We need to run the compile and the copy step in the same RUN command, otherwise the target binary can't be found.
This PR fixes that.


## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes