### PR TITLE
fix(iota-types): use digest for ConsensusTransactionKey of MisbehaviorReport

### DIFF
--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -528,7 +528,7 @@ mod tests {
         // Set some reports for testing
         let reports_and_authorities = vec![
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![5, 0, 0],
                     faulty_blocks_unprovable: vec![0, 0, 0],
                     missing_proposals: vec![0, 0, 0],
@@ -537,7 +537,7 @@ mod tests {
                 0_u32,
             ),
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![0, 10, 0],
                     faulty_blocks_unprovable: vec![0, 0, 0],
                     missing_proposals: vec![0, 0, 0],
@@ -546,7 +546,7 @@ mod tests {
                 1_u32,
             ),
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![0, 0, 15],
                     faulty_blocks_unprovable: vec![0, 0, 0],
                     missing_proposals: vec![0, 0, 0],
@@ -574,7 +574,7 @@ mod tests {
     #[test]
     fn test_calculate_median_report() {
         let reports_and_voting_power = vec![(
-            VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
+            VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
                 faulty_blocks_provable: vec![7, 8, 9],
                 faulty_blocks_unprovable: vec![10, 11, 12],
                 missing_proposals: vec![4, 5, 6],
@@ -596,7 +596,7 @@ mod tests {
 
         let reports_and_voting_power = vec![
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![7, 8, 9],
                     faulty_blocks_unprovable: vec![10, 11, 12],
                     missing_proposals: vec![4, 5, 6],
@@ -605,7 +605,7 @@ mod tests {
                 20_u64,
             ),
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![70, 80, 90],
                     faulty_blocks_unprovable: vec![100, 110, 120],
                     missing_proposals: vec![40, 50, 60],
@@ -629,7 +629,7 @@ mod tests {
 
         let reports_and_voting_power = vec![
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![1, 8, 9],
                     faulty_blocks_unprovable: vec![10, 15, 12],
                     missing_proposals: vec![4, 5, 6],
@@ -638,7 +638,7 @@ mod tests {
                 10_u64,
             ),
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![7, 8, 9],
                     faulty_blocks_unprovable: vec![10, 11, 12],
                     missing_proposals: vec![4, 5, 6],
@@ -647,7 +647,7 @@ mod tests {
                 10_u64,
             ),
             (
-                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
                     faulty_blocks_provable: vec![6, 8, 9],
                     faulty_blocks_unprovable: vec![10, 11, 12],
                     missing_proposals: vec![4, 22, 6],

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -1475,6 +1475,7 @@ mod bcs_signable {
     impl BcsSignable for crate::committee::Committee {}
     impl BcsSignable for crate::messages_checkpoint::CheckpointSummary {}
     impl BcsSignable for crate::messages_checkpoint::CheckpointContents {}
+    impl BcsSignable for crate::messages_consensus::VersionedMisbehaviorReport {}
 
     impl BcsSignable for crate::effects::TransactionEffects {}
     impl BcsSignable for crate::effects::TransactionEvents {}

--- a/crates/iota-types/src/digests.rs
+++ b/crates/iota-types/src/digests.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, fmt};
+use std::{
+    env,
+    fmt::{self, Debug},
+};
 
 use anyhow::{anyhow, bail};
 use fastcrypto::encoding::{Base58, Encoding, Hex};
@@ -1041,6 +1044,23 @@ impl fmt::Display for ConsensusCommitDigest {
 impl fmt::Debug for ConsensusCommitDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("ConsensusCommitDigest")
+            .field(&self.0)
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema)]
+pub struct MisbehaviorReportDigest(Digest);
+
+impl MisbehaviorReportDigest {
+    pub const fn new(digest: [u8; 32]) -> Self {
+        Self(Digest::new(digest))
+    }
+}
+
+impl fmt::Debug for MisbehaviorReportDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("MisbehaviorReportDigest")
             .field(&self.0)
             .finish()
     }

--- a/crates/iota-types/src/digests.rs
+++ b/crates/iota-types/src/digests.rs
@@ -2,10 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    env,
-    fmt::{self, Debug},
-};
+use std::{env, fmt};
 
 use anyhow::{anyhow, bail};
 use fastcrypto::encoding::{Base58, Encoding, Hex};

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -288,7 +288,8 @@ impl ConsensusTransactionKind {
 pub enum VersionedMisbehaviorReport {
     V1(
         MisbehaviorsV1<Vec<u64>>,
-        #[serde(skip)] OnceCell<MisbehaviorReportDigest>,
+        #[serde(skip)]
+        OnceCell<MisbehaviorReportDigest>,
     ),
 }
 

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -15,6 +15,7 @@ use fastcrypto::{error::FastCryptoResult, groups::bls12381, hash::HashFunction};
 use fastcrypto_tbls::dkg_v1;
 use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
 use iota_sdk_types::crypto::IntentScope;
+use once_cell::sync::OnceCell;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -22,8 +23,8 @@ use crate::{
     base_types::{
         AuthorityName, ConciseableName, ObjectID, ObjectRef, SequenceNumber, TransactionDigest,
     },
-    crypto::{AuthoritySignature, DefaultHash},
-    digests::{ConsensusCommitDigest, Digest},
+    crypto::{AuthoritySignature, DefaultHash, default_hash},
+    digests::{ConsensusCommitDigest, Digest, MisbehaviorReportDigest},
     message_envelope::{Envelope, Message, VerifiedEnvelope},
     messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage},
     supported_protocol_versions::{
@@ -90,10 +91,7 @@ pub enum ConsensusTransactionKey {
     NewJWKFetched(Box<(AuthorityName, JwkId, JWK)>),
     RandomnessDkgMessage(AuthorityName),
     RandomnessDkgConfirmation(AuthorityName),
-    // If a validator submits more than one report for the same checkpoint, we update the
-    // scoring metrics using the maximum reported metric, so the checkpoint sequence number is
-    // sufficient to identify a report from a single AuthorityName.
-    MisbehaviorReport(AuthorityName, u64 /* checkpoint_seq */),
+    MisbehaviorReport(MisbehaviorReportDigest),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -106,14 +104,6 @@ impl Debug for ConsensusTransactionKey {
                 write!(f, "CheckpointSignature({:?}, {:?})", name.concise(), seq)
             }
             Self::EndOfPublish(name) => write!(f, "EndOfPublish({:?})", name.concise()),
-            Self::MisbehaviorReport(name, checkpoint_seq) => {
-                write!(
-                    f,
-                    "MisbehaviorReport({:?},{:?})",
-                    name.concise(),
-                    checkpoint_seq
-                )
-            }
             Self::CapabilityNotification(name, generation) => write!(
                 f,
                 "CapabilityNotification({:?}, {:?})",
@@ -135,6 +125,9 @@ impl Debug for ConsensusTransactionKey {
             }
             Self::RandomnessDkgConfirmation(name) => {
                 write!(f, "RandomnessDkgConfirmation({:?})", name.concise())
+            }
+            Self::MisbehaviorReport(digest) => {
+                write!(f, "MisbehaviorReport({digest:?})")
             }
         }
     }
@@ -293,20 +286,35 @@ impl ConsensusTransactionKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum VersionedMisbehaviorReport {
-    V1(MisbehaviorsV1<Vec<u64>>),
+    V1(
+        MisbehaviorsV1<Vec<u64>>,
+        #[serde(skip)] OnceCell<MisbehaviorReportDigest>,
+    ),
 }
 
 impl VersionedMisbehaviorReport {
-    pub fn verify(&self, committee_size: usize) -> bool {
-        match self {
-            VersionedMisbehaviorReport::V1(report) => report.verify(committee_size),
-        }
+    pub fn new_v1(misbehaviors: MisbehaviorsV1<Vec<u64>>) -> Self {
+        VersionedMisbehaviorReport::V1(misbehaviors, OnceCell::new())
     }
 
-    /// Returns an iterator over references to some of the fields in the report.
+    pub fn verify(&self, committee_size: usize) -> bool {
+        match self {
+            VersionedMisbehaviorReport::V1(report, _) => report.verify(committee_size),
+        }
+    }
+    // Returns an iterator over references to some of the fields in the report.
     pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&Vec<u64>> {
         match self {
-            VersionedMisbehaviorReport::V1(report) => report.iter(),
+            VersionedMisbehaviorReport::V1(report, _) => report.iter(),
+        }
+    }
+    // Returns the digest of the misbehavior report, caching it if it has not
+    // been computed yet.
+    pub fn digest(&self) -> &MisbehaviorReportDigest {
+        match self {
+            VersionedMisbehaviorReport::V1(_, digest) => {
+                digest.get_or_init(|| MisbehaviorReportDigest::new(default_hash(self)))
+            }
         }
     }
 }
@@ -611,9 +619,6 @@ impl ConsensusTransaction {
             ConsensusTransactionKind::EndOfPublish(authority) => {
                 ConsensusTransactionKey::EndOfPublish(*authority)
             }
-            ConsensusTransactionKind::MisbehaviorReport(authority, _, checkpoint_seq) => {
-                ConsensusTransactionKey::MisbehaviorReport(*authority, *checkpoint_seq)
-            }
             ConsensusTransactionKind::CapabilityNotificationV1(cap) => {
                 ConsensusTransactionKey::CapabilityNotification(cap.authority, cap.generation)
             }
@@ -636,6 +641,9 @@ impl ConsensusTransaction {
             }
             ConsensusTransactionKind::RandomnessDkgConfirmation(authority, _) => {
                 ConsensusTransactionKey::RandomnessDkgConfirmation(*authority)
+            }
+            ConsensusTransactionKind::MisbehaviorReport(_, report, _) => {
+                ConsensusTransactionKey::MisbehaviorReport(*report.digest())
             }
         }
     }

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -288,8 +288,7 @@ impl ConsensusTransactionKind {
 pub enum VersionedMisbehaviorReport {
     V1(
         MisbehaviorsV1<Vec<u64>>,
-        #[serde(skip)]
-        OnceCell<MisbehaviorReportDigest>,
+        #[serde(skip)] OnceCell<MisbehaviorReportDigest>,
     ),
 }
 
@@ -303,14 +302,14 @@ impl VersionedMisbehaviorReport {
             VersionedMisbehaviorReport::V1(report, _) => report.verify(committee_size),
         }
     }
-    // Returns an iterator over references to some of the fields in the report.
+    /// Returns an iterator over references to some of the fields in the report.
     pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&Vec<u64>> {
         match self {
             VersionedMisbehaviorReport::V1(report, _) => report.iter(),
         }
     }
-    // Returns the digest of the misbehavior report, caching it if it has not
-    // been computed yet.
+    /// Returns the digest of the misbehavior report, caching it if it has not
+    /// been computed yet.
     pub fn digest(&self) -> &MisbehaviorReportDigest {
         match self {
             VersionedMisbehaviorReport::V1(_, digest) => {

--- a/crates/iota-types/src/scoring_metrics.rs
+++ b/crates/iota-types/src/scoring_metrics.rs
@@ -189,7 +189,10 @@ impl VersionedScoringMetrics {
     // not.
     pub fn update_from_report(&self, report: &VersionedMisbehaviorReport) {
         match (self, report) {
-            (VersionedScoringMetrics::V1(metrics), VersionedMisbehaviorReport::V1(report_v1)) => {
+            (
+                VersionedScoringMetrics::V1(metrics),
+                VersionedMisbehaviorReport::V1(report_v1, _),
+            ) => {
                 for (i, value) in report_v1.faulty_blocks_provable.iter().enumerate() {
                     metrics.faulty_blocks_provable[i].fetch_max(*value, Ordering::Relaxed);
                 }
@@ -211,7 +214,7 @@ impl VersionedScoringMetrics {
     // network and needs to create a local copy of the metrics contained in it.
     pub fn from_report(report: &VersionedMisbehaviorReport) -> Self {
         match report {
-            VersionedMisbehaviorReport::V1(report_v1) => {
+            VersionedMisbehaviorReport::V1(report_v1, _) => {
                 let committee_size = report_v1.faulty_blocks_provable.len();
                 let metrics = ScoringMetricsV1::new(committee_size);
                 for (i, value) in report_v1.faulty_blocks_provable.iter().enumerate() {
@@ -257,7 +260,7 @@ impl VersionedScoringMetrics {
                     .iter()
                     .map(|metric| metric.load(Ordering::Relaxed))
                     .collect();
-                VersionedMisbehaviorReport::V1(MisbehaviorsV1 {
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
                     faulty_blocks_provable,
                     faulty_blocks_unprovable,
                     missing_proposals,


### PR DESCRIPTION
# Description of change

The `ConsensusTransactionKey` for `MisbehaviorReport` uses authority name and the checkpoint sequence number, but this may cause ambiguity if an authority submits more than one report in one checkpoint. It is better to use the digest of the misbehavior report. 

This PR adds a digest to the misbehavior reports and uses this for the consensus transactions key.


## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
