### PR TITLE
feat(iota-indexer): add historical fallback support in Read Api

### DIFF
--- a/crates/iota-indexer/src/apis/read_api.rs
+++ b/crates/iota-indexer/src/apis/read_api.rs
@@ -42,7 +42,7 @@ impl ReadApi {
     }
 
     async fn get_checkpoint(&self, id: CheckpointId) -> Result<Checkpoint, IndexerError> {
-        match self.inner.get_checkpoint(id).await {
+        match self.inner.get_checkpoint_with_fallback(id).await {
             Ok(Some(checkpoint)) => Ok(checkpoint),
             Ok(None) => Err(IndexerError::InvalidArgument(format!(
                 "Checkpoint {id:?} not found"
@@ -250,7 +250,7 @@ impl ReadApiServer for ReadApi {
         let options = options.unwrap_or_default();
         let txn = self
             .inner
-            .get_single_transaction_block_response(digest, options)
+            .get_single_transaction_block_response_with_fallback(digest, options)
             .await?;
 
         let txn = txn.ok_or_else(|| {
@@ -289,7 +289,7 @@ impl ReadApiServer for ReadApi {
     ) -> RpcResult<IotaPastObjectResponse> {
         let past_object_read = self
             .inner
-            .get_past_object_read(object_id, version, false)
+            .get_past_object_read_with_fallback(object_id, version, false)
             .await?;
 
         self.past_object_read_to_response(options, past_object_read)
@@ -303,7 +303,7 @@ impl ReadApiServer for ReadApi {
     ) -> RpcResult<IotaPastObjectResponse> {
         let past_object_read = self
             .inner
-            .get_past_object_read(object_id, version, true)
+            .get_past_object_read_with_fallback(object_id, version, true)
             .await?;
 
         self.past_object_read_to_response(None, past_object_read)
@@ -320,7 +320,7 @@ impl ReadApiServer for ReadApi {
         for request in past_objects {
             let past_object_read = self
                 .inner
-                .get_past_object_read(request.object_id, request.version, false)
+                .get_past_object_read_with_fallback(request.object_id, request.version, false)
                 .await?;
 
             responses.push(
@@ -356,7 +356,7 @@ impl ReadApiServer for ReadApi {
 
         let mut checkpoints = self
             .inner
-            .get_checkpoints(cursor, limit + 1, descending_order)
+            .get_checkpoints_with_fallback(cursor, limit + 1, descending_order)
             .await?;
 
         let has_next_page = checkpoints.len() > limit;
@@ -373,7 +373,7 @@ impl ReadApiServer for ReadApi {
 
     async fn get_events(&self, transaction_digest: TransactionDigest) -> RpcResult<Vec<IotaEvent>> {
         self.inner
-            .get_transaction_events_in_blocking_task(transaction_digest)
+            .get_transaction_events_with_fallback(transaction_digest)
             .await
             .map_err(Into::into)
     }

--- a/crates/iota-indexer/src/apis/read_api.rs
+++ b/crates/iota-indexer/src/apis/read_api.rs
@@ -42,12 +42,8 @@ impl ReadApi {
     }
 
     async fn get_checkpoint(&self, id: CheckpointId) -> Result<Checkpoint, IndexerError> {
-        match self
-            .inner
-            .spawn_blocking(move |this| this.get_checkpoint(id))
-            .await
-        {
-            Ok(Some(epoch_info)) => Ok(epoch_info),
+        match self.inner.get_checkpoint(id).await {
+            Ok(Some(checkpoint)) => Ok(checkpoint),
             Ok(None) => Err(IndexerError::InvalidArgument(format!(
                 "Checkpoint {id:?} not found"
             ))),
@@ -360,7 +356,7 @@ impl ReadApiServer for ReadApi {
 
         let mut checkpoints = self
             .inner
-            .spawn_blocking(move |this| this.get_checkpoints(cursor, limit + 1, descending_order))
+            .get_checkpoints(cursor, limit + 1, descending_order)
             .await?;
 
         let has_next_page = checkpoints.len() > limit;

--- a/crates/iota-indexer/src/errors.rs
+++ b/crates/iota-indexer/src/errors.rs
@@ -82,9 +82,6 @@ pub enum IndexerError {
     #[error("Indexer failed to assign TX global order with error: `{0}`")]
     PostgresUniqueTxGlobalOrderViolation(String),
 
-    #[error("Missing data due to pruning: `{0}`")]
-    DataPruned(String),
-
     #[error("Indexer failed to initialize fullnode Http client with error: `{0}`")]
     HttpClientInit(String),
 
@@ -164,6 +161,9 @@ pub enum IndexerError {
     },
     #[error("historical fallback storage error: {0}")]
     HistoricalFallbackStorageError(String),
+
+    #[error("Missing data due to pruning: `{0}`")]
+    DataPruned(String),
 }
 
 pub type IndexerResult<T> = Result<T, IndexerError>;

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -214,49 +214,22 @@ impl HistoricalFallbackReader {
 
     /// Fetches multiple checkpoints from the historical fallback storage.
     ///
-    /// Returns checkpoints in paginated form, supporting both ascending and
-    /// descending order.
-    ///
-    /// # Pagination Behavior
-    ///
-    /// | cursor | descending | Result                      |
-    /// |--------|------------|-----------------------------|
-    /// | `n`    | `false`    | Starts from checkpoint n+1  |
-    /// | `n`    | `true`     | Starts from checkpoint n-1  |
-    ///
     /// # NOTE
     /// `StoredCheckpoint.successful_tx_num` is hardcoded to 0, due to missing
     /// data in the historical fallback. It can be derived but the operations
     /// could be expensive. Can be added in future iterations.
     pub(crate) async fn checkpoints(
         &self,
-        cursor: CheckpointSequenceNumber,
-        limit: usize,
-        descending_order: bool,
+        checkpoints: Vec<CheckpointSequenceNumber>,
     ) -> IndexerResult<Vec<Option<StoredCheckpoint>>> {
-        if limit == 0 {
-            return Ok(vec![]);
-        }
-
-        let seq_nums: Vec<CheckpointSequenceNumber> = if descending_order {
-            // descending: start from cursor - 1, go down `limit` items
-            let end = cursor.saturating_sub(limit as u64);
-            (end..cursor).rev().collect()
-        } else {
-            // ascending: start from cursor + 1, go up `limit` items
-            let start = cursor + 1;
-            let end = start + limit as u64;
-            (start..end).collect()
-        };
-
-        if seq_nums.is_empty() {
+        if checkpoints.is_empty() {
             return Ok(vec![]);
         }
 
         let (summaries, contents) = tokio::try_join!(
             self.client
-                .multi_get_checkpoints_summaries_by_sequence_numbers(&seq_nums),
-            self.client.multi_get_checkpoints_contents(&seq_nums)
+                .multi_get_checkpoints_summaries_by_sequence_numbers(&checkpoints),
+            self.client.multi_get_checkpoints_contents(&checkpoints)
         )?;
 
         let checkpoints = summaries
@@ -279,14 +252,23 @@ impl HistoricalFallbackReader {
             self.resolve_checkpoints(tx_digests)
         )?;
 
-        let Some(historical_events) = events.into_iter().next().and_then(|events| {
-            let (summary, _) = checkpoint_summaries.get(&tx_digest).cloned()?;
-            Some(HistoricalFallbackEvents::new(events?, summary))
-        }) else {
+        // check first if transaction exists, all valid transaction are part of a
+        // checkpoint, if not found then the provided digest is invalid.
+        let (summary, _) = checkpoint_summaries
+            .get(&tx_digest)
+            .cloned()
+            .ok_or_else(|| {
+                IndexerError::HistoricalFallbackStorageError(format!(
+                    "transaction: {tx_digest} does not exist"
+                ))
+            })?;
+
+        let Some(Some(events)) = events.into_iter().next() else {
+            // transaction does not have associated events.
             return Ok(vec![]);
         };
 
-        historical_events
+        HistoricalFallbackEvents::new(events, summary)
             .into_iota_events(self.package_resolver.clone(), tx_digest)
             .await
     }

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -185,9 +185,7 @@ impl OptimisticTransactionExecutor {
         effects: &TransactionEffects,
     ) -> Result<bool, IndexerError> {
         self.read
-            .deep_check_all_transactions_are_indexed_in_blocking_task(
-                effects.dependencies().to_vec(),
-            )
+            .deep_check_all_transactions_are_indexed_in_blocking_task(effects.dependencies())
             .await
     }
 

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -21,6 +21,7 @@ use diesel::{
     sql_types::{BigInt, Bool},
 };
 use fastcrypto::encoding::{Encoding, Hex};
+use futures::FutureExt;
 use iota_json_rpc_types::{
     AddressMetrics, Balance, CheckpointId, Coin as IotaCoin, DisplayFieldsResponse, EpochInfo,
     EventFilter, IotaCoinMetadata, IotaEvent, IotaMoveValue, IotaObjectDataFilter,
@@ -274,50 +275,28 @@ impl IndexerReader {
     /// Searches the requested object version and checkpoint sequence number
     /// in `objects_version` and fetches the requested object from
     /// `objects_history`.
+    ///
+    /// Returns [`IndexerError::DataPruned`] if the object version exists but
+    /// history was pruned
     pub(crate) async fn get_past_object_read(
         &self,
         object_id: ObjectID,
         object_version: SequenceNumber,
         before_version: bool,
-    ) -> Result<PastObjectRead, IndexerError> {
+    ) -> IndexerResult<PastObjectRead> {
         let object_version_num = object_version.value() as i64;
 
         // Query objects_version to find the requested version and relevant
         // checkpoint sequence number considering the `before_version` flag.
-        let pool = self.get_pool();
-        let object_id_bytes = object_id.to_vec();
-        let object_version_info: Option<StoredObjectVersion> =
-            run_query_async!(&pool, move |conn| {
-                let mut query = objects_version::dsl::objects_version
-                    .filter(objects_version::object_id.eq(&object_id_bytes))
-                    .into_boxed();
-
-                if before_version {
-                    query = query.filter(objects_version::object_version.lt(object_version_num));
-                } else {
-                    query = query.filter(objects_version::object_version.eq(object_version_num));
-                }
-
-                query
-                    .order_by(objects_version::object_version.desc())
-                    .limit(1)
-                    .first::<StoredObjectVersion>(conn)
-                    .optional()
-            })?;
+        let object_version_info = self
+            .db()
+            .get_object_version(object_id, object_version, before_version)
+            .await?;
 
         let Some(object_version_info) = object_version_info else {
             // Check if the object ever existed.
-            let pool = self.get_pool();
-            let object_id_bytes = object_id.to_vec();
-            let latest_existing_version: Option<i64> = run_query_async!(&pool, move |conn| {
-                objects_version::dsl::objects_version
-                    .filter(objects_version::object_id.eq(&object_id_bytes))
-                    .order_by(objects_version::object_version.desc())
-                    .select(objects_version::object_version)
-                    .limit(1)
-                    .first::<i64>(conn)
-                    .optional()
-            })?;
+            let latest_existing_version =
+                self.db().latest_existing_object_version(object_id).await?;
 
             return match latest_existing_version {
                 Some(latest) if object_version_num > latest => Ok(PastObjectRead::VersionTooHigh {
@@ -326,45 +305,13 @@ impl IndexerReader {
                     latest_version: SequenceNumber::from(latest as u64),
                 }),
                 Some(_) => Ok(PastObjectRead::VersionNotFound(object_id, object_version)),
-                None => {
-                    // fallback to historical storage
-                    let Some(fallback) = self.fallback_reader() else {
-                        return Ok(PastObjectRead::ObjectNotExists(object_id));
-                    };
-
-                    let Some(obj) = fallback
-                        .objects(&[(object_id, object_version)], before_version)
-                        .await?
-                        .pop()
-                        .flatten()
-                    else {
-                        return Ok(PastObjectRead::VersionNotFound(object_id, object_version));
-                    };
-
-                    // Note: We use `StoredObject.try_into_object_read` here instead of
-                    // `StoredHistoryObject.try_into_past_object_read` because the fallback
-                    // storage returns `StoredObject`. Both methods share the same logic for
-                    // resolving the MoveStructLayout via `package_resolver.type_layout()`.
-                    // The key difference is that `try_into_past_object_read` also handles
-                    // the `WrappedOrDeleted` status, which for this iteration, we handle explicitly
-                    // as a `VersionNotFound`.
-                    match obj
-                        .try_into_object_read(self.package_resolver.clone())
-                        .await?
-                    {
-                        ObjectRead::NotExists(_) | ObjectRead::Deleted(_) => {
-                            Ok(PastObjectRead::VersionNotFound(object_id, object_version))
-                        }
-                        ObjectRead::Exists(obj_ref, object, layout) => {
-                            Ok(PastObjectRead::VersionFound(obj_ref, object, layout))
-                        }
-                    }
-                }
+                None => Ok(PastObjectRead::ObjectNotExists(object_id)),
             };
         };
 
-        // Query objects_history for the object with the requested version.
+        // query objects_history for the object with the requested version.
         let history_object = self
+            .db()
             .get_stored_history_object(
                 object_id,
                 object_version_info.object_version,
@@ -377,35 +324,71 @@ impl IndexerReader {
                 obj.try_into_past_object_read(self.package_resolver.clone())
                     .await
             }
-            None => Err(IndexerError::PersistentStorageDataCorruption(format!(
-                "Object version {} not found in objects_history for object {}",
-                object_version_info.object_version, object_id
+            None => Err(IndexerError::DataPruned(format!(
+                "Object version {} not found in objects_history for object {object_id}",
+                object_version_info.object_version
             ))),
         }
     }
 
-    pub async fn get_stored_history_object(
+    /// Fetches a past object by its ID and version.
+    ///
+    /// - If `before_version` is `false`, it looks for the exact version.
+    /// - If `true`, it finds the latest version before the given one.
+    ///
+    /// Searches the requested object version and checkpoint sequence number
+    /// in `objects_version` and fetches the requested object from
+    /// `objects_history`.
+    ///
+    /// Retrieval order:
+    /// 1. Postgres database (`objects_version` + `objects_history`)
+    /// 2. Historical fallback storage (if enabled)
+    pub(crate) async fn get_past_object_read_with_fallback(
         &self,
         object_id: ObjectID,
-        object_version: i64,
-        checkpoint_sequence_number: i64,
-    ) -> Result<Option<StoredHistoryObject>, IndexerError> {
-        let pool = self.get_pool();
-        let object_id_bytes = object_id.to_vec();
-        run_query_async!(&pool, move |conn| {
-            // Match on the primary key.
-            let query = objects_history::dsl::objects_history
-                .filter(objects_history::checkpoint_sequence_number.eq(checkpoint_sequence_number))
-                .filter(objects_history::object_id.eq(&object_id_bytes))
-                .filter(objects_history::object_version.eq(object_version))
-                .into_boxed();
+        object_version: SequenceNumber,
+        before_version: bool,
+    ) -> IndexerResult<PastObjectRead> {
+        let past_object_read_result = self
+            .get_past_object_read(object_id, object_version, before_version)
+            .await;
 
-            query
-                .order_by(objects_history::object_version.desc())
-                .limit(1)
-                .first::<StoredHistoryObject>(conn)
-                .optional()
-        })
+        let Some(fallback) = self.fallback_reader().filter(|_| {
+            matches!(
+                past_object_read_result,
+                Err(IndexerError::DataPruned(_)) | Ok(PastObjectRead::ObjectNotExists(_))
+            )
+        }) else {
+            return past_object_read_result;
+        };
+
+        let Some(obj) = fallback
+            .objects(&[(object_id, object_version)], before_version)
+            .await?
+            .pop()
+            .flatten()
+        else {
+            return Ok(PastObjectRead::VersionNotFound(object_id, object_version));
+        };
+
+        // Note: We use `StoredObject.try_into_object_read` here instead of
+        // `StoredHistoryObject.try_into_past_object_read` because the fallback
+        // storage returns `StoredObject`. Both methods share the same logic for
+        // resolving the MoveStructLayout via `package_resolver.type_layout()`.
+        // The key difference is that `try_into_past_object_read` also handles
+        // the `WrappedOrDeleted` status, which for this iteration, we handle explicitly
+        // as a `VersionNotFound`.
+        match obj
+            .try_into_object_read(self.package_resolver.clone())
+            .await?
+        {
+            ObjectRead::NotExists(_) | ObjectRead::Deleted(_) => {
+                Ok(PastObjectRead::VersionNotFound(object_id, object_version))
+            }
+            ObjectRead::Exists(obj_ref, object, layout) => {
+                Ok(PastObjectRead::VersionFound(obj_ref, object, layout))
+            }
+        }
     }
 
     pub async fn get_package(&self, package_id: ObjectID) -> Result<Package, IndexerError> {
@@ -559,26 +542,6 @@ impl IndexerReader {
         Ok(checkpoint_digest.into())
     }
 
-    pub fn get_checkpoint_from_db(
-        &self,
-        checkpoint_id: CheckpointId,
-    ) -> Result<Option<StoredCheckpoint>, IndexerError> {
-        let stored_checkpoint = run_query!(&self.pool, |conn| {
-            match checkpoint_id {
-                CheckpointId::SequenceNumber(seq) => checkpoints::dsl::checkpoints
-                    .filter(checkpoints::sequence_number.eq(seq as i64))
-                    .first::<StoredCheckpoint>(conn)
-                    .optional(),
-                CheckpointId::Digest(digest) => checkpoints::dsl::checkpoints
-                    .filter(checkpoints::checkpoint_digest.eq(digest.into_inner().to_vec()))
-                    .first::<StoredCheckpoint>(conn)
-                    .optional(),
-            }
-        })?;
-
-        Ok(stored_checkpoint)
-    }
-
     pub fn get_latest_checkpoint_from_db(&self) -> Result<StoredCheckpoint, IndexerError> {
         let stored_checkpoint = run_query!(&self.pool, |conn| {
             checkpoints::dsl::checkpoints
@@ -589,14 +552,16 @@ impl IndexerReader {
         Ok(stored_checkpoint)
     }
 
-    pub async fn get_checkpoint(
+    /// Fetches a single checkpoint by either its sequence number or digest.
+    ///
+    /// Retrieval order:
+    /// 1. Postgres database
+    /// 2. Historical fallback storage (if enabled)
+    pub async fn get_checkpoint_with_fallback(
         &self,
         checkpoint_id: CheckpointId,
-    ) -> Result<Option<iota_json_rpc_types::Checkpoint>, IndexerError> {
-        let stored_checkpoint = match self
-            .spawn_blocking(move |this| this.get_checkpoint_from_db(checkpoint_id))
-            .await?
-        {
+    ) -> IndexerResult<Option<iota_json_rpc_types::Checkpoint>> {
+        let stored_checkpoint = match self.db().get_checkpoint(checkpoint_id).await? {
             Some(stored_checkpoint) => stored_checkpoint,
             None => {
                 // fallback to historical storage
@@ -630,35 +595,6 @@ impl IndexerReader {
         Ok(self.get_latest_checkpoint()?.timestamp_ms)
     }
 
-    fn get_checkpoints_from_db(
-        &self,
-        cursor: Option<u64>,
-        limit: usize,
-        descending_order: bool,
-    ) -> Result<Vec<StoredCheckpoint>, IndexerError> {
-        run_query!(&self.pool, |conn| {
-            let mut boxed_query = checkpoints::table.into_boxed();
-            if let Some(cursor) = cursor {
-                if descending_order {
-                    boxed_query =
-                        boxed_query.filter(checkpoints::sequence_number.lt(cursor as i64));
-                } else {
-                    boxed_query =
-                        boxed_query.filter(checkpoints::sequence_number.gt(cursor as i64));
-                }
-            }
-            if descending_order {
-                boxed_query = boxed_query.order_by(checkpoints::sequence_number.desc());
-            } else {
-                boxed_query = boxed_query.order_by(checkpoints::sequence_number.asc());
-            }
-
-            boxed_query
-                .limit(limit as i64)
-                .load::<StoredCheckpoint>(conn)
-        })
-    }
-
     /// Determines whether the fallback should be used to fetch more
     /// checkpoints in case of data being pruned.
     fn should_fetch_from_fallback(
@@ -688,20 +624,27 @@ impl IndexerReader {
         }
     }
 
-    pub async fn get_checkpoints(
+    /// Fetches checkpoints from the indexer storage.
+    ///
+    /// Retrieval order:
+    /// 1. Postgres database
+    /// 2. Historical fallback storage (if enabled)
+    ///
+    /// Returns [`IndexerError::DataPruned`] if the requested checkpoint range
+    /// is not available and fallback is not enabled.
+    pub async fn get_checkpoints_with_fallback(
         &self,
         cursor: Option<u64>,
         limit: usize,
         descending_order: bool,
     ) -> Result<Vec<iota_json_rpc_types::Checkpoint>, IndexerError> {
         let checkpoints = self
-            .spawn_blocking(move |this| {
-                this.get_checkpoints_from_db(cursor, limit, descending_order)?
-                    .into_iter()
-                    .map(iota_json_rpc_types::Checkpoint::try_from)
-                    .collect::<Result<Vec<_>, IndexerError>>()
-            })
-            .await?;
+            .db()
+            .get_checkpoints(cursor, limit, descending_order)
+            .await?
+            .into_iter()
+            .map(iota_json_rpc_types::Checkpoint::try_from)
+            .collect::<IndexerResult<Vec<_>>>()?;
 
         if !Self::should_fetch_from_fallback(cursor, descending_order, limit, &checkpoints) {
             return Ok(checkpoints);
@@ -764,9 +707,7 @@ impl IndexerReader {
         &self,
         digests: &[TransactionDigest],
     ) -> Result<bool, IndexerError> {
-        let stored_transactions = self
-            .multi_get_transactions_in_blocking_task(digests)
-            .await?;
+        let stored_transactions = self.multi_get_transactions(digests).await?;
         if stored_transactions.len() != digests.len() {
             return Ok(false);
         }
@@ -793,6 +734,7 @@ impl IndexerReader {
             return Ok(true);
         };
         let checkpoint = self
+            .db()
             .get_checkpoint(CheckpointId::SequenceNumber(
                 max_transaction_checkpoint as u64,
             ))
@@ -828,157 +770,64 @@ impl IndexerReader {
         .await
     }
 
-    fn get_checkpointed_transactions(
-        &self,
-        digests: &[Vec<u8>],
-    ) -> Result<Vec<StoredTransaction>, IndexerError> {
-        run_query!(&self.pool, |conn| {
-            transactions::table
-                .inner_join(
-                    tx_digests::table
-                        .on(transactions::tx_sequence_number.eq(tx_digests::tx_sequence_number)),
-                )
-                // we filter the tx_digests table because it is indexed by digest,
-                // transactions table is not
-                .filter(tx_digests::tx_digest.eq_any(digests))
-                .select(StoredTransaction::as_select())
-                .load::<StoredTransaction>(conn)
-        })
-    }
-
-    fn get_optimistic_transactions(
-        &self,
-        digests: &[Vec<u8>],
-    ) -> Result<Vec<OptimisticTransaction>, IndexerError> {
-        run_query!(&self.pool, |conn| {
-            optimistic_transactions::table
-                .inner_join(
-                    tx_global_order::table.on(optimistic_transactions::global_sequence_number
-                        .eq(tx_global_order::global_sequence_number)
-                        .and(
-                            optimistic_transactions::optimistic_sequence_number
-                                .eq(tx_global_order::optimistic_sequence_number),
-                        )),
-                )
-                // we filter the `tx_global_order` table because it is indexed by digest,
-                // optimistic_transactions table is not
-                .filter(tx_global_order::tx_digest.eq_any(digests))
-                .select(OptimisticTransaction::as_select())
-                .load::<OptimisticTransaction>(conn)
-        })
-    }
-
-    fn get_optimistic_transactions_with_cp_info(
-        &self,
-        digests: &[Vec<u8>],
-    ) -> Result<Vec<(OptimisticTransaction, Option<i64>)>, IndexerError> {
-        run_query!(&self.pool, |conn| {
-            optimistic_transactions::table
-                .inner_join(
-                    tx_global_order::table.on(optimistic_transactions::global_sequence_number
-                        .eq(tx_global_order::global_sequence_number)
-                        .and(
-                            optimistic_transactions::optimistic_sequence_number
-                                .eq(tx_global_order::optimistic_sequence_number),
-                        )),
-                )
-                // we filter the `tx_global_order` table because it is indexed by digest,
-                // optimistic_transactions table is not
-                .filter(tx_global_order::tx_digest.eq_any(digests))
-                .select((
-                    OptimisticTransaction::as_select(),
-                    tx_global_order::chk_tx_sequence_number,
-                ))
-                .load::<(OptimisticTransaction, Option<i64>)>(conn)
-        })
-    }
-
-    async fn get_single_transaction(
-        &self,
-        digest: TransactionDigest,
-    ) -> IndexerResult<Option<StoredTransaction>> {
-        let digest_bytes = digest.inner().to_vec();
-        let optimistic_tx_future = {
-            let digest_bytes = digest_bytes.clone();
-            self.spawn_blocking(move |this| {
-                this.get_optimistic_transactions_with_cp_info(&[digest_bytes])
-                    .map(|mut txs| txs.pop())
-            })
-        };
-        let checkpointed_tx_future = {
-            let digest_bytes = digest_bytes.clone();
-            self.spawn_blocking(move |this| {
-                this.get_checkpointed_transactions(&[digest_bytes])
-                    .map(|mut txs| txs.pop())
-            })
-        };
-        tokio::pin!(optimistic_tx_future, checkpointed_tx_future);
-
-        let result = tokio::select! {
-                checkpointed_tx = &mut checkpointed_tx_future => match checkpointed_tx? {
-                    Some(checkpointed_tx) => Some(checkpointed_tx),
-                    None => optimistic_tx_future
-                        .await?
-                        .map(|(optimistic_tx, _)| optimistic_tx.into()),
-                },
-                optimistic_tx_with_cp_info = &mut optimistic_tx_future => {
-                    match optimistic_tx_with_cp_info? {
-                        Some((optimistic_tx, Some(_cp_info))) => Some(
-                            checkpointed_tx_future
-                                .await?
-                                .unwrap_or_else(|| optimistic_tx.into()),
-                        ),
-                        Some((optimistic_tx, None)) => Some(optimistic_tx.into()),
-                        None => checkpointed_tx_future.await?,
-                    }
-                }
-        };
-
-        Ok(result)
-    }
-
-    async fn multi_get_transactions_in_blocking_task(
+    /// Fetches multiple transactions from the database.
+    ///
+    ///  Retrieval order:
+    /// 1. Checkpointed data (finalized transactions)
+    /// 2. Optimistic data (pending transactions not yet checkpointed)
+    async fn multi_get_transactions(
         &self,
         digests: &[TransactionDigest],
-    ) -> Result<Vec<StoredTransaction>, IndexerError> {
-        let check_for_missing_tx_digests =
-            |requested_digests: &[Vec<u8>], fetched_txs: &[StoredTransaction]| -> Vec<Vec<u8>> {
-                let fetched_txs_digests_set = fetched_txs
-                    .iter()
-                    .map(|tx| &tx.transaction_digest)
-                    .collect::<HashSet<&Vec<u8>>>();
-                requested_digests
-                    .iter()
-                    .filter(|digest| !fetched_txs_digests_set.contains(digest))
-                    .cloned()
-                    .collect::<Vec<Vec<u8>>>()
-            };
-
+    ) -> IndexerResult<Vec<StoredTransaction>> {
         let digests: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
-        let digests_clone = digests.clone();
         let checkpointed_txs = self
-            .spawn_blocking(move |this| this.get_checkpointed_transactions(&digests_clone))
+            .db()
+            .get_checkpointed_transactions(digests.clone())
             .await?;
 
         if checkpointed_txs.len() == digests.len() {
             return Ok(checkpointed_txs);
         }
 
-        let missing_digests = check_for_missing_tx_digests(&digests, &checkpointed_txs);
+        let missing_digests = Self::check_for_missing_tx_digests(&digests, &checkpointed_txs);
         let optimistic_txs = self
-            .spawn_blocking(move |this| this.get_optimistic_transactions(&missing_digests))
+            .db()
+            .get_optimistic_transactions(missing_digests)
             .await?;
 
-        let db_transactions = checkpointed_txs
+        Ok(checkpointed_txs
             .into_iter()
             .chain(optimistic_txs.into_iter().map(Into::into))
-            .collect::<Vec<StoredTransaction>>();
+            .collect::<Vec<StoredTransaction>>())
+    }
 
-        if db_transactions.len() == digests.len() {
-            return Ok(db_transactions);
-        }
+    /// Fetches multiple transactions from the indexer storage.
+    ///
+    /// Retrieval order:
+    /// 1. Checkpointed data (finalized transactions)
+    /// 2. Optimistic data (pending transactions not yet checkpointed)
+    /// 3. Historical fallback storage (if enabled)
+    async fn multi_get_transactions_with_fallback(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> IndexerResult<Vec<StoredTransaction>> {
+        let fetched_transactions = self.multi_get_transactions(digests).await?;
 
-        let missing_digests = check_for_missing_tx_digests(&digests, &db_transactions)
+        // fallback to historical storage
+        let Some(fallback) = self
+            .fallback_reader()
+            // As for now we don't have a way to identify if the user requested pruned or invalid
+            // transaction digests. As a measure, we check if the number of requested transactions
+            // matches the number of fetched transactions. In case of missing transactions,
+            // if fallback is enabled, we use it to fetch the missing ones.
+            .filter(|_| fetched_transactions.len() != digests.len())
+        else {
+            // return data from database.
+            return Ok(fetched_transactions);
+        };
+
+        let digests: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
+        let missing_digests = Self::check_for_missing_tx_digests(&digests, &fetched_transactions)
             .iter()
             .map(|digest| {
                 TransactionDigest::try_from(digest.as_slice()).map_err(|e| {
@@ -989,31 +838,33 @@ impl IndexerReader {
             })
             .collect::<IndexerResult<Vec<TransactionDigest>>>()?;
 
-        // fallback to historical storage
-        let Some(fallback) = self.fallback_reader() else {
-            return Err(IndexerError::DataPruned(
-                "requested transaction range is not available".into(),
-            ));
-        };
-
         let historical_transactions = fallback
             .transactions(&missing_digests)
             .await?
             .into_iter()
-            .flatten();
-
-        let transactions = db_transactions
-            .into_iter()
-            .chain(historical_transactions)
+            .flatten()
             .collect::<Vec<StoredTransaction>>();
 
-        if transactions.len() == digests.len() {
-            return Ok(transactions);
-        }
+        Ok(fetched_transactions
+            .into_iter()
+            .chain(historical_transactions.into_iter())
+            .collect())
+    }
 
-        Err(IndexerError::HistoricalFallbackStorageError(
-            "some transactions are not available".into(),
-        ))
+    /// Checks for missing transaction digests in the fetched transactions.
+    fn check_for_missing_tx_digests(
+        requested_digests: &[Vec<u8>],
+        fetched_txs: &[StoredTransaction],
+    ) -> Vec<Vec<u8>> {
+        let fetched_txs_digests_set = fetched_txs
+            .iter()
+            .map(|tx| &tx.transaction_digest)
+            .collect::<HashSet<&Vec<u8>>>();
+        requested_digests
+            .iter()
+            .filter(|digest| !fetched_txs_digests_set.contains(digest))
+            .cloned()
+            .collect::<Vec<Vec<u8>>>()
     }
 
     /// This method tries to transform [`StoredTransaction`] values
@@ -1551,19 +1402,22 @@ impl IndexerReader {
         digests: &[TransactionDigest],
         options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
     ) -> Result<Vec<iota_json_rpc_types::IotaTransactionBlockResponse>, IndexerError> {
-        let stored_txes = self
-            .multi_get_transactions_in_blocking_task(digests)
-            .await?;
+        let stored_txes = self.multi_get_transactions_with_fallback(digests).await?;
         self.stored_transaction_to_transaction_block(stored_txes, options)
             .await
     }
 
-    pub(crate) async fn get_single_transaction_block_response(
+    /// Fetches a single transaction block from the indexer storage.
+    ///
+    /// Retrieval order:
+    /// 1. Postgres database
+    /// 2. Historical fallback storage (if enabled)
+    pub(crate) async fn get_single_transaction_block_response_with_fallback(
         &self,
         digest: TransactionDigest,
         options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
     ) -> IndexerResult<Option<IotaTransactionBlockResponse>> {
-        let stored_tx = match self.get_single_transaction(digest).await? {
+        let stored_tx = match self.db().get_single_transaction(digest).await? {
             Some(tx) => Some(tx),
             None => {
                 // fallback to historical storage
@@ -1637,80 +1491,58 @@ impl IndexerReader {
         Ok(transactions)
     }
 
-    pub async fn get_transaction_events_in_blocking_task(
+    /// Fetches transaction events from the indexer storage.
+    ///
+    /// Retrieval order:
+    /// 1. Checkpointed data (finalized transactions)
+    /// 2. Optimistic data (pending transactions not yet checkpointed)
+    /// 3. Historical fallback storage (if enabled)
+    ///
+    /// Returns [`IndexerError::DataPruned`] if the data is not available
+    /// in Postgres database.
+    pub async fn get_transaction_events_with_fallback(
         &self,
         digest: TransactionDigest,
     ) -> Result<Vec<iota_json_rpc_types::IotaEvent>, IndexerError> {
-        // try checkpointed data, then optimistic, then fallback if not found
-        let (timestamp_ms, serialized_events) = if let Some((timestamp_ms, events)) =
-            self.try_get_checkpointed_transaction_events(digest).await?
+        if let Some((timestamp_ms, serialized_events)) = self
+            .db()
+            .try_get_checkpointed_transaction_events(digest)
+            .await?
         {
-            (Some(timestamp_ms as u64), events)
-        } else if let Some(events) = self.get_optimistic_transaction_events(digest).await? {
-            (None, events)
-        } else if let Some(fallback) = self.fallback_reader() {
-            // fallback to historical storage.
+            return self
+                .convert_stored_events(digest, serialized_events, Some(timestamp_ms as u64))
+                .await;
+        }
+
+        if let Some(serialized_events) = self.db().get_optimistic_transaction_events(digest).await?
+        {
+            return self
+                .convert_stored_events(digest, serialized_events, None)
+                .await;
+        }
+
+        if let Some(fallback) = self.fallback_reader() {
             return fallback.all_events(digest).await;
-        } else {
-            return Err(IndexerError::DataPruned(
-                "requested events not available".into(),
-            ));
-        };
+        }
 
+        Err(IndexerError::DataPruned(
+            "requested events not available".into(),
+        ))
+    }
+
+    /// Converts [`StoredTransactionEvents`] into
+    /// [`IotaEvent`](iota_json_rpc_types::IotaEvent).
+    async fn convert_stored_events(
+        &self,
+        digest: TransactionDigest,
+        serialized_events: StoredTransactionEvents,
+        timestamp_ms: Option<u64>,
+    ) -> Result<Vec<iota_json_rpc_types::IotaEvent>, IndexerError> {
         let events = stored_events_to_events(serialized_events)?;
-
         let tx_events = TransactionEvents { data: events };
-
         tx_events_to_iota_tx_events(tx_events, self.package_resolver(), digest, timestamp_ms)
             .await
             .map(|iota_tx_event| iota_tx_event.data)
-    }
-
-    pub async fn try_get_checkpointed_transaction_events(
-        &self,
-        digest: TransactionDigest,
-    ) -> Result<Option<(i64, StoredTransactionEvents)>, IndexerError> {
-        let pool = self.get_pool();
-        run_query_async!(&pool, move |conn| {
-            transactions::table
-                .filter(
-                    transactions::tx_sequence_number
-                        .nullable()
-                        .eq(tx_digests::table
-                            .select(tx_digests::tx_sequence_number)
-                            // we filter the tx_digests table because it is indexed by digest,
-                            // transactions table is not
-                            .filter(tx_digests::tx_digest.eq(digest.into_inner().to_vec()))
-                            .single_value()),
-                )
-                .select((transactions::timestamp_ms, transactions::events))
-                .first::<(i64, StoredTransactionEvents)>(conn)
-                .optional()
-        })
-    }
-
-    pub async fn get_optimistic_transaction_events(
-        &self,
-        digest: TransactionDigest,
-    ) -> Result<Option<StoredTransactionEvents>, IndexerError> {
-        let pool = self.get_pool();
-        run_query_async!(&pool, move |conn| {
-            optimistic_transactions::table
-                .inner_join(
-                    tx_global_order::table.on(optimistic_transactions::global_sequence_number
-                        .eq(tx_global_order::global_sequence_number)
-                        .and(
-                            optimistic_transactions::optimistic_sequence_number
-                                .eq(tx_global_order::optimistic_sequence_number),
-                        )),
-                )
-                // we filter the `tx_global_order` table because it is indexed by digest,
-                // optimistic_transactions table is not
-                .filter(tx_global_order::tx_digest.eq(digest.into_inner().to_vec()))
-                .select(optimistic_transactions::events)
-                .first::<StoredTransactionEvents>(conn)
-                .optional()
-        })
     }
 
     async fn query_events_by_tx_digest_with_fallback(
@@ -2724,6 +2556,276 @@ impl<'a> DBReader<'a> {
                 .first::<i64>(conn)
                 .optional()
         })
+    }
+
+    pub async fn try_get_checkpointed_transaction_events(
+        &self,
+        digest: TransactionDigest,
+    ) -> IndexerResult<Option<(i64, StoredTransactionEvents)>> {
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, move |conn| {
+            transactions::table
+                .filter(
+                    transactions::tx_sequence_number
+                        .nullable()
+                        .eq(tx_digests::table
+                            .select(tx_digests::tx_sequence_number)
+                            // we filter the tx_digests table because it is indexed by digest,
+                            // transactions table is not
+                            .filter(tx_digests::tx_digest.eq(digest.into_inner().to_vec()))
+                            .single_value()),
+                )
+                .select((transactions::timestamp_ms, transactions::events))
+                .first::<(i64, StoredTransactionEvents)>(conn)
+                .optional()
+        })
+    }
+
+    pub async fn get_optimistic_transaction_events(
+        &self,
+        digest: TransactionDigest,
+    ) -> IndexerResult<Option<StoredTransactionEvents>> {
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, move |conn| {
+            optimistic_transactions::table
+                .inner_join(
+                    tx_global_order::table.on(optimistic_transactions::global_sequence_number
+                        .eq(tx_global_order::global_sequence_number)
+                        .and(
+                            optimistic_transactions::optimistic_sequence_number
+                                .eq(tx_global_order::optimistic_sequence_number),
+                        )),
+                )
+                // we filter the `tx_global_order` table because it is indexed by digest,
+                // optimistic_transactions table is not
+                .filter(tx_global_order::tx_digest.eq(digest.into_inner().to_vec()))
+                .select(optimistic_transactions::events)
+                .first::<StoredTransactionEvents>(conn)
+                .optional()
+        })
+    }
+
+    async fn get_checkpoint(
+        &self,
+        checkpoint_id: CheckpointId,
+    ) -> IndexerResult<Option<StoredCheckpoint>> {
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, |conn| {
+            match checkpoint_id {
+                CheckpointId::SequenceNumber(seq) => checkpoints::dsl::checkpoints
+                    .filter(checkpoints::sequence_number.eq(seq as i64))
+                    .first::<StoredCheckpoint>(conn)
+                    .optional(),
+                CheckpointId::Digest(digest) => checkpoints::dsl::checkpoints
+                    .filter(checkpoints::checkpoint_digest.eq(digest.into_inner().to_vec()))
+                    .first::<StoredCheckpoint>(conn)
+                    .optional(),
+            }
+        })
+    }
+
+    async fn get_checkpoints(
+        &self,
+        cursor: Option<u64>,
+        limit: usize,
+        descending_order: bool,
+    ) -> IndexerResult<Vec<StoredCheckpoint>> {
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, |conn| {
+            let mut boxed_query = checkpoints::table.into_boxed();
+            if let Some(cursor) = cursor {
+                if descending_order {
+                    boxed_query =
+                        boxed_query.filter(checkpoints::sequence_number.lt(cursor as i64));
+                } else {
+                    boxed_query =
+                        boxed_query.filter(checkpoints::sequence_number.gt(cursor as i64));
+                }
+            }
+            if descending_order {
+                boxed_query = boxed_query.order_by(checkpoints::sequence_number.desc());
+            } else {
+                boxed_query = boxed_query.order_by(checkpoints::sequence_number.asc());
+            }
+
+            boxed_query
+                .limit(limit as i64)
+                .load::<StoredCheckpoint>(conn)
+        })
+    }
+
+    async fn get_object_version(
+        &self,
+        object_id: ObjectID,
+        object_version: SequenceNumber,
+        before_version: bool,
+    ) -> IndexerResult<Option<StoredObjectVersion>> {
+        let object_version_num = object_version.value() as i64;
+        let pool = self.main_reader.get_pool();
+
+        // query objects_version to find the requested version
+        run_query_async!(&pool, move |conn| {
+            let mut query = objects_version::dsl::objects_version
+                .filter(objects_version::object_id.eq(object_id.as_ref()))
+                .into_boxed();
+
+            if before_version {
+                query = query.filter(objects_version::object_version.lt(object_version_num));
+            } else {
+                query = query.filter(objects_version::object_version.eq(object_version_num));
+            }
+
+            query
+                .order_by(objects_version::object_version.desc())
+                .limit(1)
+                .first::<StoredObjectVersion>(conn)
+                .optional()
+        })
+    }
+
+    async fn latest_existing_object_version(
+        &self,
+        object_id: ObjectID,
+    ) -> IndexerResult<Option<i64>> {
+        let pool = self.main_reader.get_pool();
+
+        run_query_async!(&pool, move |conn| {
+            objects_version::dsl::objects_version
+                .filter(objects_version::object_id.eq(object_id.as_ref()))
+                .order_by(objects_version::object_version.desc())
+                .select(objects_version::object_version)
+                .limit(1)
+                .first::<i64>(conn)
+                .optional()
+        })
+    }
+
+    pub async fn get_stored_history_object(
+        &self,
+        object_id: ObjectID,
+        object_version: i64,
+        checkpoint_sequence_number: i64,
+    ) -> IndexerResult<Option<StoredHistoryObject>> {
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, move |conn| {
+            // Match on the primary key.
+            let query = objects_history::dsl::objects_history
+                .filter(objects_history::checkpoint_sequence_number.eq(checkpoint_sequence_number))
+                .filter(objects_history::object_id.eq(object_id.as_ref()))
+                .filter(objects_history::object_version.eq(object_version))
+                .into_boxed();
+
+            query
+                .order_by(objects_history::object_version.desc())
+                .limit(1)
+                .first::<StoredHistoryObject>(conn)
+                .optional()
+        })
+    }
+
+    async fn get_optimistic_transactions_with_cp_info(
+        &self,
+        digests: Vec<Vec<u8>>,
+    ) -> IndexerResult<Vec<(OptimisticTransaction, Option<i64>)>> {
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, |conn| {
+            optimistic_transactions::table
+                .inner_join(
+                    tx_global_order::table.on(optimistic_transactions::global_sequence_number
+                        .eq(tx_global_order::global_sequence_number)
+                        .and(
+                            optimistic_transactions::optimistic_sequence_number
+                                .eq(tx_global_order::optimistic_sequence_number),
+                        )),
+                )
+                // we filter the `tx_global_order` table because it is indexed by digest,
+                // optimistic_transactions table is not
+                .filter(tx_global_order::tx_digest.eq_any(digests))
+                .select((
+                    OptimisticTransaction::as_select(),
+                    tx_global_order::chk_tx_sequence_number,
+                ))
+                .load::<(OptimisticTransaction, Option<i64>)>(conn)
+        })
+    }
+
+    async fn get_checkpointed_transactions(
+        &self,
+        digests: Vec<Vec<u8>>,
+    ) -> IndexerResult<Vec<StoredTransaction>> {
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, |conn| {
+            transactions::table
+                .inner_join(
+                    tx_digests::table
+                        .on(transactions::tx_sequence_number.eq(tx_digests::tx_sequence_number)),
+                )
+                // we filter the tx_digests table because it is indexed by digest,
+                // transactions table is not
+                .filter(tx_digests::tx_digest.eq_any(digests))
+                .select(StoredTransaction::as_select())
+                .load::<StoredTransaction>(conn)
+        })
+    }
+
+    async fn get_optimistic_transactions(
+        &self,
+        digests: Vec<Vec<u8>>,
+    ) -> Result<Vec<OptimisticTransaction>, IndexerError> {
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, |conn| {
+            optimistic_transactions::table
+                .inner_join(
+                    tx_global_order::table.on(optimistic_transactions::global_sequence_number
+                        .eq(tx_global_order::global_sequence_number)
+                        .and(
+                            optimistic_transactions::optimistic_sequence_number
+                                .eq(tx_global_order::optimistic_sequence_number),
+                        )),
+                )
+                // we filter the `tx_global_order` table because it is indexed by digest,
+                // optimistic_transactions table is not
+                .filter(tx_global_order::tx_digest.eq_any(digests))
+                .select(OptimisticTransaction::as_select())
+                .load::<OptimisticTransaction>(conn)
+        })
+    }
+
+    async fn get_single_transaction(
+        &self,
+        digest: TransactionDigest,
+    ) -> IndexerResult<Option<StoredTransaction>> {
+        let digests = vec![digest.inner().to_vec()];
+        let optimistic_tx_future = self
+            .get_optimistic_transactions_with_cp_info(digests.clone())
+            .map(|result| result.map(|mut txs| txs.pop()));
+        let checkpointed_tx_future = self
+            .get_checkpointed_transactions(digests.clone())
+            .map(|result| result.map(|mut txs| txs.pop()));
+
+        tokio::pin!(optimistic_tx_future, checkpointed_tx_future);
+
+        let result = tokio::select! {
+                checkpointed_tx = &mut checkpointed_tx_future => match checkpointed_tx? {
+                    Some(checkpointed_tx) => Some(checkpointed_tx),
+                    None => optimistic_tx_future
+                        .await?
+                        .map(|(optimistic_tx, _)| optimistic_tx.into()),
+                },
+                optimistic_tx_with_cp_info = &mut optimistic_tx_future => {
+                    match optimistic_tx_with_cp_info? {
+                        Some((optimistic_tx, Some(_cp_info))) => Some(
+                            checkpointed_tx_future
+                                .await?
+                                .unwrap_or_else(|| optimistic_tx.into()),
+                        ),
+                        Some((optimistic_tx, None)) => Some(optimistic_tx.into()),
+                        None => checkpointed_tx_future.await?,
+                    }
+                }
+        };
+
+        Ok(result)
     }
 }
 

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -46,7 +46,7 @@ use iota_types::{
         IotaSystemStateTrait,
         iota_system_state_summary::{IotaSystemStateSummary, IotaValidatorSummary},
     },
-    messages_checkpoint::CheckpointDigest,
+    messages_checkpoint::{CheckpointDigest, CheckpointSequenceNumber},
     object::{Object, ObjectRead, PastObjectRead, bounded_visitor::BoundedVisitor},
 };
 use itertools::Itertools;
@@ -99,7 +99,7 @@ pub struct IndexerReader {
     pool: ConnectionPool,
     package_resolver: PackageResolver,
     obj_type_cache: Arc<Mutex<SizedCache<String, Option<ObjectID>>>>,
-    kv_reader: Option<HistoricalFallbackReader>,
+    fallback: Option<HistoricalFallbackReader>,
 }
 
 /// Encapsulates the logic for reading data from the database.
@@ -123,7 +123,7 @@ impl IndexerReader {
             pool,
             package_resolver,
             obj_type_cache,
-            kv_reader: None,
+            fallback: None,
         }
     }
 
@@ -152,6 +152,20 @@ impl IndexerReader {
             .map_err(|e| anyhow!("failed to initialize connection pool. Error: {:?}. If Error is None, please check whether the configured pool size (currently {}) exceeds the maximum number of connections allowed by the database.", e, config.pool_size))?;
 
         Ok(Self::new(pool))
+    }
+
+    /// Add a historical fallback reader to the indexer.
+    ///
+    /// In case the IndexerReader fails to retrieve data, the fallback reader
+    /// will be used to retrieve the data.
+    #[expect(dead_code)]
+    pub(crate) fn with_fallback_reader(&mut self, fallback: HistoricalFallbackReader) {
+        self.fallback = Some(fallback);
+    }
+
+    /// Access the internal fallback reader.
+    pub(crate) fn fallback_reader(&self) -> Option<&HistoricalFallbackReader> {
+        self.fallback.as_ref()
     }
 
     pub async fn spawn_blocking<F, R, E>(&self, f: F) -> Result<R, E>
@@ -312,7 +326,40 @@ impl IndexerReader {
                     latest_version: SequenceNumber::from(latest as u64),
                 }),
                 Some(_) => Ok(PastObjectRead::VersionNotFound(object_id, object_version)),
-                None => Ok(PastObjectRead::ObjectNotExists(object_id)),
+                None => {
+                    // fallback to historical storage
+                    let Some(fallback) = self.fallback_reader() else {
+                        return Ok(PastObjectRead::ObjectNotExists(object_id));
+                    };
+
+                    let Some(obj) = fallback
+                        .objects(&[(object_id, object_version)], before_version)
+                        .await?
+                        .pop()
+                        .flatten()
+                    else {
+                        return Ok(PastObjectRead::VersionNotFound(object_id, object_version));
+                    };
+
+                    // Note: We use `StoredObject.try_into_object_read` here instead of
+                    // `StoredHistoryObject.try_into_past_object_read` because the fallback
+                    // storage returns `StoredObject`. Both methods share the same logic for
+                    // resolving the MoveStructLayout via `package_resolver.type_layout()`.
+                    // The key difference is that `try_into_past_object_read` also handles
+                    // the `WrappedOrDeleted` status, which for this iteration, we handle explicitly
+                    // as a `VersionNotFound`.
+                    match obj
+                        .try_into_object_read(self.package_resolver.clone())
+                        .await?
+                    {
+                        ObjectRead::NotExists(_) | ObjectRead::Deleted(_) => {
+                            Ok(PastObjectRead::VersionNotFound(object_id, object_version))
+                        }
+                        ObjectRead::Exists(obj_ref, object, layout) => {
+                            Ok(PastObjectRead::VersionFound(obj_ref, object, layout))
+                        }
+                    }
+                }
             };
         };
 
@@ -542,17 +589,28 @@ impl IndexerReader {
         Ok(stored_checkpoint)
     }
 
-    pub fn get_checkpoint(
+    pub async fn get_checkpoint(
         &self,
         checkpoint_id: CheckpointId,
     ) -> Result<Option<iota_json_rpc_types::Checkpoint>, IndexerError> {
-        let stored_checkpoint = match self.get_checkpoint_from_db(checkpoint_id)? {
+        let stored_checkpoint = match self
+            .spawn_blocking(move |this| this.get_checkpoint_from_db(checkpoint_id))
+            .await?
+        {
             Some(stored_checkpoint) => stored_checkpoint,
-            None => return Ok(None),
+            None => {
+                // fallback to historical storage
+                let Some(fallback) = self.fallback_reader() else {
+                    return Ok(None);
+                };
+                match fallback.checkpoint(checkpoint_id).await? {
+                    Some(stored_checkpoint) => stored_checkpoint,
+                    None => return Ok(None),
+                }
+            }
         };
 
-        let checkpoint = iota_json_rpc_types::Checkpoint::try_from(stored_checkpoint)?;
-        Ok(Some(checkpoint))
+        iota_json_rpc_types::Checkpoint::try_from(stored_checkpoint).map(Some)
     }
 
     pub fn get_latest_checkpoint(&self) -> Result<iota_json_rpc_types::Checkpoint, IndexerError> {
@@ -601,14 +659,98 @@ impl IndexerReader {
         })
     }
 
-    pub fn get_checkpoints(
+    /// Determines whether the fallback should be used to fetch more
+    /// checkpoints in case of data being pruned.
+    fn should_fetch_from_fallback(
+        cursor: Option<u64>,
+        descending_order: bool,
+        limit: usize,
+        db_response: &[iota_json_rpc_types::Checkpoint],
+    ) -> bool {
+        match (cursor, descending_order) {
+            // pruning always removes from the lowest checkpoint upwards, so no gaps.
+            // If genesis (checkpoint 0) is present, data is intact.
+            (None, false) => db_response
+                .first()
+                .is_none_or(|chk| chk.sequence_number != 0),
+
+            // for descending, cursor just sets an upper bound. DB returns the highest checkpoint
+            // available. If we got fewer than limit, some data was pruned.
+            (None, true) | (Some(_), true) => {
+                db_response.len() != limit
+                    && db_response.last().is_some_and(|cp| cp.sequence_number != 0)
+            }
+
+            // if first checkpoint matches cursor + 1, data is contiguous from that point.
+            (Some(c), false) => db_response
+                .first()
+                .is_none_or(|chk| chk.sequence_number != c + 1),
+        }
+    }
+
+    pub async fn get_checkpoints(
         &self,
         cursor: Option<u64>,
         limit: usize,
         descending_order: bool,
     ) -> Result<Vec<iota_json_rpc_types::Checkpoint>, IndexerError> {
-        self.get_checkpoints_from_db(cursor, limit, descending_order)?
+        let checkpoints = self
+            .spawn_blocking(move |this| {
+                this.get_checkpoints_from_db(cursor, limit, descending_order)?
+                    .into_iter()
+                    .map(iota_json_rpc_types::Checkpoint::try_from)
+                    .collect::<Result<Vec<_>, IndexerError>>()
+            })
+            .await?;
+
+        if !Self::should_fetch_from_fallback(cursor, descending_order, limit, &checkpoints) {
+            return Ok(checkpoints);
+        }
+
+        // resolve the expected range of checkpoint sequence numbers
+        let checkpoints_keys: Vec<CheckpointSequenceNumber> = match (cursor, descending_order) {
+            // ascending from 0: expect [0, 1, ..., limit-1].
+            (None, false) => (0..limit as u64).collect(),
+
+            // ascending from cursor+1: expect [c+1, ..., c+limit]
+            (Some(c), false) => (c + 1..=c.saturating_add(limit as u64)).collect(),
+
+            // descending from cursor-1: expect [c-1, c-2, ..., c-limit].
+            (Some(c), true) => {
+                // cursor can be greater than the latest checkpoint, need to cap it.
+                let c = checkpoints
+                    .first()
+                    .map(|latest_checkpoint| c.min(latest_checkpoint.sequence_number + 1))
+                    .unwrap_or(c);
+
+                (c.saturating_sub(limit as u64)..c).rev().collect()
+            }
+
+            // descending from DB's latest: expect [latest, ..., latest-limit+1].
+            (None, true) => {
+                let Some(latest_checkpoint) = checkpoints.first() else {
+                    // checkpoints not synced yet.
+                    return Ok(vec![]);
+                };
+                let start = latest_checkpoint
+                    .sequence_number
+                    .saturating_sub(limit as u64 - 1);
+                (start..=latest_checkpoint.sequence_number).rev().collect()
+            }
+        };
+
+        // fallback to historical storage
+        let Some(fallback) = self.fallback_reader() else {
+            return Err(IndexerError::DataPruned(
+                "requested checkpoint range not available".into(),
+            ));
+        };
+
+        fallback
+            .checkpoints(checkpoints_keys)
+            .await?
             .into_iter()
+            .flatten()
             .map(iota_json_rpc_types::Checkpoint::try_from)
             .collect()
     }
@@ -618,11 +760,13 @@ impl IndexerReader {
     ///
     /// It uses both the `tx_global_order` table
     /// and the `checkpoints` table to cover old transactions.
-    fn deep_check_all_transactions_are_indexed(
+    pub(crate) async fn deep_check_all_transactions_are_indexed_in_blocking_task(
         &self,
         digests: &[TransactionDigest],
     ) -> Result<bool, IndexerError> {
-        let stored_transactions = self.multi_get_transactions(digests)?;
+        let stored_transactions = self
+            .multi_get_transactions_in_blocking_task(digests)
+            .await?;
         if stored_transactions.len() != digests.len() {
             return Ok(false);
         }
@@ -648,19 +792,12 @@ impl IndexerReader {
         else {
             return Ok(true);
         };
-        Ok(self
+        let checkpoint = self
             .get_checkpoint(CheckpointId::SequenceNumber(
                 max_transaction_checkpoint as u64,
-            ))?
-            .is_some())
-    }
-
-    pub(crate) async fn deep_check_all_transactions_are_indexed_in_blocking_task(
-        &self,
-        digests: Vec<TransactionDigest>,
-    ) -> Result<bool, IndexerError> {
-        self.spawn_blocking(move |this| this.deep_check_all_transactions_are_indexed(&digests))
-            .await
+            ))
+            .await?;
+        Ok(checkpoint.is_some())
     }
 
     /// Count how many entries in `tx_global_order` correspond
@@ -800,40 +937,83 @@ impl IndexerReader {
         Ok(result)
     }
 
-    fn multi_get_transactions(
+    async fn multi_get_transactions_in_blocking_task(
         &self,
         digests: &[TransactionDigest],
     ) -> Result<Vec<StoredTransaction>, IndexerError> {
+        let check_for_missing_tx_digests =
+            |requested_digests: &[Vec<u8>], fetched_txs: &[StoredTransaction]| -> Vec<Vec<u8>> {
+                let fetched_txs_digests_set = fetched_txs
+                    .iter()
+                    .map(|tx| &tx.transaction_digest)
+                    .collect::<HashSet<&Vec<u8>>>();
+                requested_digests
+                    .iter()
+                    .filter(|digest| !fetched_txs_digests_set.contains(digest))
+                    .cloned()
+                    .collect::<Vec<Vec<u8>>>()
+            };
+
         let digests: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
-        let checkpointed_txs = self.get_checkpointed_transactions(&digests)?;
+        let digests_clone = digests.clone();
+        let checkpointed_txs = self
+            .spawn_blocking(move |this| this.get_checkpointed_transactions(&digests_clone))
+            .await?;
 
         if checkpointed_txs.len() == digests.len() {
             return Ok(checkpointed_txs);
         }
 
-        let checkpointed_tx_digests_set = checkpointed_txs
-            .iter()
-            .map(|tx| &tx.transaction_digest)
-            .collect::<HashSet<&Vec<u8>>>();
-        let missing_digests = digests
-            .into_iter()
-            .filter(|digest| !checkpointed_tx_digests_set.contains(digest))
-            .collect::<Vec<Vec<u8>>>();
+        let missing_digests = check_for_missing_tx_digests(&digests, &checkpointed_txs);
+        let optimistic_txs = self
+            .spawn_blocking(move |this| this.get_optimistic_transactions(&missing_digests))
+            .await?;
 
-        let optimistic_txs = self.get_optimistic_transactions(&missing_digests)?;
-
-        Ok(checkpointed_txs
+        let db_transactions = checkpointed_txs
             .into_iter()
             .chain(optimistic_txs.into_iter().map(Into::into))
-            .collect())
-    }
+            .collect::<Vec<StoredTransaction>>();
 
-    async fn multi_get_transactions_in_blocking_task(
-        &self,
-        digests: Vec<TransactionDigest>,
-    ) -> Result<Vec<StoredTransaction>, IndexerError> {
-        self.spawn_blocking(move |this| this.multi_get_transactions(&digests))
-            .await
+        if db_transactions.len() == digests.len() {
+            return Ok(db_transactions);
+        }
+
+        let missing_digests = check_for_missing_tx_digests(&digests, &db_transactions)
+            .iter()
+            .map(|digest| {
+                TransactionDigest::try_from(digest.as_slice()).map_err(|e| {
+                    IndexerError::PersistentStorageDataCorruption(format!(
+                        "can't convert {digest:?} as tx_digest. Error: {e}",
+                    ))
+                })
+            })
+            .collect::<IndexerResult<Vec<TransactionDigest>>>()?;
+
+        // fallback to historical storage
+        let Some(fallback) = self.fallback_reader() else {
+            return Err(IndexerError::DataPruned(
+                "requested transaction range is not available".into(),
+            ));
+        };
+
+        let historical_transactions = fallback
+            .transactions(&missing_digests)
+            .await?
+            .into_iter()
+            .flatten();
+
+        let transactions = db_transactions
+            .into_iter()
+            .chain(historical_transactions)
+            .collect::<Vec<StoredTransaction>>();
+
+        if transactions.len() == digests.len() {
+            return Ok(transactions);
+        }
+
+        Err(IndexerError::HistoricalFallbackStorageError(
+            "some transactions are not available".into(),
+        ))
     }
 
     /// This method tries to transform [`StoredTransaction`] values
@@ -1080,7 +1260,7 @@ impl IndexerReader {
             .query_transactions_by_checkpoint_seq(checkpoint_seq, cursor, limit, is_descending)
             .await;
         let stored_txs = if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
-            (db_res.as_ref(), self.kv_reader.as_ref())
+            (db_res.as_ref(), self.fallback_reader())
         {
             kv_reader
                 .checkpoint_transactions(cursor, checkpoint_seq, limit, is_descending)
@@ -1372,7 +1552,7 @@ impl IndexerReader {
         options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
     ) -> Result<Vec<iota_json_rpc_types::IotaTransactionBlockResponse>, IndexerError> {
         let stored_txes = self
-            .multi_get_transactions_in_blocking_task(digests.to_vec())
+            .multi_get_transactions_in_blocking_task(digests)
             .await?;
         self.stored_transaction_to_transaction_block(stored_txes, options)
             .await
@@ -1383,17 +1563,27 @@ impl IndexerReader {
         digest: TransactionDigest,
         options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
     ) -> IndexerResult<Option<IotaTransactionBlockResponse>> {
-        let stored_tx = self.get_single_transaction(digest).await?;
-        if let Some(stored_tx) = stored_tx {
-            Ok(Some(
-                self.stored_transaction_to_transaction_block(vec![stored_tx], options)
-                    .await?
-                    .pop()
-                    .expect("there should be exactly one response"),
-            ))
-        } else {
-            Ok(None)
-        }
+        let stored_tx = match self.get_single_transaction(digest).await? {
+            Some(tx) => Some(tx),
+            None => {
+                // fallback to historical storage
+                let Some(fallback) = self.fallback_reader() else {
+                    return Ok(None);
+                };
+                fallback.transactions(&[digest]).await?.pop().flatten()
+            }
+        };
+
+        let Some(stored_tx) = stored_tx else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            self.stored_transaction_to_transaction_block(vec![stored_tx], options)
+                .await?
+                .pop()
+                .expect("there should be exactly one response"),
+        ))
     }
 
     async fn multi_get_transaction_block_response_by_sequence_numbers_in_blocking_task(
@@ -1451,22 +1641,29 @@ impl IndexerReader {
         &self,
         digest: TransactionDigest,
     ) -> Result<Vec<iota_json_rpc_types::IotaEvent>, IndexerError> {
-        let checkpointed_events = self.try_get_checkpointed_transaction_events(digest).await?;
-
-        let (timestamp_ms, serialized_events) =
-            if let Some((timestamp, events)) = checkpointed_events {
-                (Some(timestamp as u64), events)
-            } else {
-                (None, self.get_optimistic_transaction_events(digest).await?)
-            };
+        // try checkpointed data, then optimistic, then fallback if not found
+        let (timestamp_ms, serialized_events) = if let Some((timestamp_ms, events)) =
+            self.try_get_checkpointed_transaction_events(digest).await?
+        {
+            (Some(timestamp_ms as u64), events)
+        } else if let Some(events) = self.get_optimistic_transaction_events(digest).await? {
+            (None, events)
+        } else if let Some(fallback) = self.fallback_reader() {
+            // fallback to historical storage.
+            return fallback.all_events(digest).await;
+        } else {
+            return Err(IndexerError::DataPruned(
+                "requested events not available".into(),
+            ));
+        };
 
         let events = stored_events_to_events(serialized_events)?;
+
         let tx_events = TransactionEvents { data: events };
 
-        let iota_tx_events =
-            tx_events_to_iota_tx_events(tx_events, self.package_resolver(), digest, timestamp_ms)
-                .await?;
-        Ok(iota_tx_events.data)
+        tx_events_to_iota_tx_events(tx_events, self.package_resolver(), digest, timestamp_ms)
+            .await
+            .map(|iota_tx_event| iota_tx_event.data)
     }
 
     pub async fn try_get_checkpointed_transaction_events(
@@ -1495,7 +1692,7 @@ impl IndexerReader {
     pub async fn get_optimistic_transaction_events(
         &self,
         digest: TransactionDigest,
-    ) -> Result<StoredTransactionEvents, IndexerError> {
+    ) -> Result<Option<StoredTransactionEvents>, IndexerError> {
         let pool = self.get_pool();
         run_query_async!(&pool, move |conn| {
             optimistic_transactions::table
@@ -1512,6 +1709,7 @@ impl IndexerReader {
                 .filter(tx_global_order::tx_digest.eq(digest.into_inner().to_vec()))
                 .select(optimistic_transactions::events)
                 .first::<StoredTransactionEvents>(conn)
+                .optional()
         })
     }
 
@@ -1528,7 +1726,7 @@ impl IndexerReader {
             .await;
 
         if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
-            (db_res.as_ref(), self.kv_reader.as_ref())
+            (db_res.as_ref(), self.fallback_reader())
         {
             kv_reader
                 .events(tx_digest, cursor, limit, descending_order)

--- a/crates/iota-indexer/src/store/mod.rs
+++ b/crates/iota-indexer/src/store/mod.rs
@@ -38,6 +38,9 @@ pub mod diesel_macro {
         }};
     }
 
+    /// Runs a blocking SQL query.
+    ///
+    /// In an async context, it must be wrapped in an spawn blocking task.
     #[macro_export]
     macro_rules! read_only_blocking {
         ($pool:expr, $query:expr) => {{
@@ -56,6 +59,9 @@ pub mod diesel_macro {
         }};
     }
 
+    /// Runs a blocking SQL query.
+    ///
+    /// In an async context, it must be wrapped in an spawn blocking task.
     #[macro_export]
     macro_rules! transactional_blocking_with_retry {
         ($pool:expr, $query:expr, $max_elapsed:expr) => {{
@@ -95,6 +101,9 @@ pub mod diesel_macro {
         }};
     }
 
+    /// Runs a blocking SQL query.
+    ///
+    /// In an async context, it must be wrapped in an spawn blocking task.
     #[macro_export]
     macro_rules! transactional_blocking_with_retry_with_conditional_abort {
         ($pool:expr, $query:expr, $abort_condition:expr, $max_elapsed:expr) => {{
@@ -138,6 +147,7 @@ pub mod diesel_macro {
         }};
     }
 
+    /// Runs an async SQL query wrapped in a spawn blocking task.
     #[macro_export]
     macro_rules! spawn_read_only_blocking {
         ($pool:expr, $query:expr, $repeatable_read:expr) => {{
@@ -224,6 +234,9 @@ pub mod diesel_macro {
         }};
     }
 
+    /// Runs a blocking SQL query.
+    ///
+    /// In an async context, it must be wrapped in an spawn blocking task.
     #[macro_export]
     macro_rules! run_query {
         ($pool:expr, $query:expr) => {{
@@ -232,6 +245,9 @@ pub mod diesel_macro {
         }};
     }
 
+    /// Runs a blocking SQL query.
+    ///
+    /// In an async context, it must be wrapped in an spawn blocking task.
     #[macro_export]
     macro_rules! run_query_repeatable {
         ($pool:expr, $query:expr) => {{
@@ -240,6 +256,9 @@ pub mod diesel_macro {
         }};
     }
 
+    /// Runs a blocking SQL query.
+    ///
+    /// In an async context, it must be wrapped in an spawn blocking task.
     #[macro_export]
     macro_rules! run_query_with_retry {
         ($pool:expr, $query:expr, $max_elapsed:expr) => {{
@@ -264,6 +283,7 @@ pub mod diesel_macro {
         }};
     }
 
+    /// Runs an async SQL query wrapped in a spawn blocking task.
     #[macro_export]
     macro_rules! run_query_async {
         ($pool:expr, $query:expr) => {{ spawn_read_only_blocking!($pool, $query, false) }};


### PR DESCRIPTION
# Description of change
This PR adds provides historical fallback support for the following Read Api methods:

- `get_events`
- `get_checkpoint`
- `get_checkpoints`
- `get_transaction_block`
- `multi_get_transaction_blocks`
- `try_get_past_object`
- `try_get_object_before_version`
- `try_multi_get_past_objects`

## Links to any relevant issues

fixes #9473 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch only provides the initial functionality, thus no thorough test were made since we have a dedicated issue.
