### PR TITLE
chore(starfish): remove redundant log message in fetch task

### DIFF
--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -577,7 +577,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
 
     /// Starts a task to fetch missing transactions from other authorities.
     async fn start_fetch_missing_transactions_task(&mut self) -> ConsensusResult<()> {
-        info!("Kick in periodic synchronizer to fetch missing transactions");
         // Get missing transactions from the core
         let missing_transactions = self
             .core_dispatcher


### PR DESCRIPTION
# Description of change

Remove redundant log message in `TransactionSychronizer` periodic fetch task.

## Links to any relevant issues


## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
