### PR TITLE
fix(consensus): fix the logic for advancing threshold clock for a supermajority validator

### DIFF
--- a/consensus/core/src/threshold_clock.rs
+++ b/consensus/core/src/threshold_clock.rs
@@ -29,9 +29,8 @@ impl ThresholdClock {
         }
     }
 
-    /// Add a block's author to the aggregator. If quorum (2f+1) is reached,
-    /// advance to the next round and record latency metrics.
-    /// Returns true if quorum was reached.
+    /// If quorum (2f+1) is reached, advance to the next round and record
+    /// latency metrics. Returns true if quorum was reached.
     fn try_advance_round(&mut self, new_round: Round) -> bool {
         if self.aggregator.reached_threshold(&self.context.committee) {
             self.aggregator.clear();

--- a/consensus/core/src/threshold_clock.rs
+++ b/consensus/core/src/threshold_clock.rs
@@ -29,35 +29,49 @@ impl ThresholdClock {
         }
     }
 
-    /// Add the block reference that have been accepted and advance the round
-    /// accordingly.
+    /// Add a block's author to the aggregator. If quorum (2f+1) is reached,
+    /// advance to the next round and record latency metrics.
+    /// Returns true if quorum was reached.
+    fn try_advance_round(&mut self, new_round: Round) -> bool {
+        if self.aggregator.reached_threshold(&self.context.committee) {
+            self.aggregator.clear();
+            self.round = new_round;
+
+            let now = Instant::now();
+            self.context
+                .metrics
+                .node_metrics
+                .quorum_receive_latency
+                .observe(now.duration_since(self.quorum_ts).as_secs_f64());
+            self.quorum_ts = now;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Add the block reference and advance the round accordingly.
+    ///
+    /// Round advancement rules:
+    /// - block.round < current: ignored (stale block)
+    /// - block.round > current: jump to block.round, start collecting stake there
+    /// - block.round == current: continue accumulating stake until quorum (2f+1) reached
+    ///
+    /// When quorum is reached, advance to round + 1.
     pub(crate) fn add_block(&mut self, block: BlockRef) {
         match block.round.cmp(&self.round) {
-            // Blocks with round less then what we currently build are irrelevant here
             Ordering::Less => {}
-            // If we processed block for round r, we also have stored 2f+1 blocks from r-1
             Ordering::Greater => {
+                // Jump to the new round and start with fresh state
                 self.aggregator.clear();
                 self.aggregator.add(block.author, &self.context.committee);
                 self.round = block.round;
             }
             Ordering::Equal => {
-                if self.aggregator.add(block.author, &self.context.committee) {
-                    self.aggregator.clear();
-                    // We have seen 2f+1 blocks for current round, advance
-                    self.round = block.round + 1;
-
-                    // now record the time of receipt from last quorum
-                    let now = Instant::now();
-                    self.context
-                        .metrics
-                        .node_metrics
-                        .quorum_receive_latency
-                        .observe(now.duration_since(self.quorum_ts).as_secs_f64());
-                    self.quorum_ts = now;
-                }
+                self.aggregator.add(block.author, &self.context.committee);
             }
         }
+        self.try_advance_round(block.round + 1);
     }
 
     /// Add the block references that have been successfully processed and
@@ -161,5 +175,60 @@ mod tests {
 
         let result = aggregator.add_blocks(block_refs);
         assert_eq!(Some(5), result);
+    }
+
+    /// Test that when jumping to a higher round, the first block's author is
+    /// tracked, allowing subsequent blocks to form quorum.
+    #[tokio::test]
+    async fn test_threshold_clock_round_skip_then_quorum() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mut clock = ThresholdClock::new(0, context);
+
+        // Jump from round 0 to round 5 - author should be tracked
+        clock.add_block(BlockRef::new(5, AuthorityIndex::new_for_test(0), BlockDigest::default()));
+        assert_eq!(clock.get_round(), 5);
+
+        // Add more blocks at round 5 to reach quorum (need 3 of 4)
+        clock.add_block(BlockRef::new(5, AuthorityIndex::new_for_test(1), BlockDigest::default()));
+        assert_eq!(clock.get_round(), 5);
+
+        clock.add_block(BlockRef::new(5, AuthorityIndex::new_for_test(2), BlockDigest::default()));
+        assert_eq!(clock.get_round(), 6); // Quorum reached
+    }
+
+    /// Test that a super-majority authority (>2/3 stake) immediately advances
+    /// the round when jumping to a higher round.
+    #[tokio::test]
+    async fn test_threshold_clock_super_majority_round_skip() {
+        use crate::metrics::test_metrics;
+        use consensus_config::Parameters;
+        use tempfile::TempDir;
+
+        // Authority 0 has 5/7 stake (>2/3 quorum threshold)
+        let (committee, _) = consensus_config::local_committee_and_keys(0, vec![5, 1, 1]);
+        let metrics = test_metrics(3);
+        let temp_dir = TempDir::new().unwrap();
+
+        let context = Arc::new(crate::context::Context::new(
+            0,
+            AuthorityIndex::new_for_test(0),
+            committee,
+            Parameters { db_path: temp_dir.keep(), ..Default::default() },
+            iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE(),
+            metrics,
+            Arc::new(crate::context::Clock::default()),
+        ));
+
+        let mut clock = ThresholdClock::new(0, context);
+
+        // Single block from super-majority authority at round 5 reaches quorum immediately
+        clock.add_block(BlockRef::new(5, AuthorityIndex::new_for_test(0), BlockDigest::default()));
+        assert_eq!(clock.get_round(), 6);
+
+        // Stale blocks from round 5 should be ignored
+        clock.add_block(BlockRef::new(5, AuthorityIndex::new_for_test(1), BlockDigest::default()));
+        assert_eq!(clock.get_round(), 6);
+        clock.add_block(BlockRef::new(5, AuthorityIndex::new_for_test(2), BlockDigest::default()));
+        assert_eq!(clock.get_round(), 6);
     }
 }

--- a/consensus/core/src/threshold_clock.rs
+++ b/consensus/core/src/threshold_clock.rs
@@ -53,8 +53,10 @@ impl ThresholdClock {
     ///
     /// Round advancement rules:
     /// - block.round < current: ignored (stale block)
-    /// - block.round > current: jump to block.round, start collecting stake there
-    /// - block.round == current: continue accumulating stake until quorum (2f+1) reached
+    /// - block.round > current: jump to block.round, start collecting stake
+    ///   there
+    /// - block.round == current: continue accumulating stake until quorum
+    ///   (2f+1) reached
     ///
     /// When quorum is reached, advance to round + 1.
     pub(crate) fn add_block(&mut self, block: BlockRef) {
@@ -184,14 +186,26 @@ mod tests {
         let mut clock = ThresholdClock::new(0, context);
 
         // Jump from round 0 to round 5 - author should be tracked
-        clock.add_block(BlockRef::new(5, AuthorityIndex::new_for_test(0), BlockDigest::default()));
+        clock.add_block(BlockRef::new(
+            5,
+            AuthorityIndex::new_for_test(0),
+            BlockDigest::default(),
+        ));
         assert_eq!(clock.get_round(), 5);
 
         // Add more blocks at round 5 to reach quorum (need 3 of 4)
-        clock.add_block(BlockRef::new(5, AuthorityIndex::new_for_test(1), BlockDigest::default()));
+        clock.add_block(BlockRef::new(
+            5,
+            AuthorityIndex::new_for_test(1),
+            BlockDigest::default(),
+        ));
         assert_eq!(clock.get_round(), 5);
 
-        clock.add_block(BlockRef::new(5, AuthorityIndex::new_for_test(2), BlockDigest::default()));
+        clock.add_block(BlockRef::new(
+            5,
+            AuthorityIndex::new_for_test(2),
+            BlockDigest::default(),
+        ));
         assert_eq!(clock.get_round(), 6); // Quorum reached
     }
 
@@ -199,9 +213,10 @@ mod tests {
     /// the round when jumping to a higher round.
     #[tokio::test]
     async fn test_threshold_clock_super_majority_round_skip() {
-        use crate::metrics::test_metrics;
         use consensus_config::Parameters;
         use tempfile::TempDir;
+
+        use crate::metrics::test_metrics;
 
         // Authority 0 has 5/7 stake (>2/3 quorum threshold)
         let (committee, _) = consensus_config::local_committee_and_keys(0, vec![5, 1, 1]);
@@ -212,7 +227,10 @@ mod tests {
             0,
             AuthorityIndex::new_for_test(0),
             committee,
-            Parameters { db_path: temp_dir.keep(), ..Default::default() },
+            Parameters {
+                db_path: temp_dir.keep(),
+                ..Default::default()
+            },
             iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE(),
             metrics,
             Arc::new(crate::context::Clock::default()),
@@ -220,14 +238,27 @@ mod tests {
 
         let mut clock = ThresholdClock::new(0, context);
 
-        // Single block from super-majority authority at round 5 reaches quorum immediately
-        clock.add_block(BlockRef::new(5, AuthorityIndex::new_for_test(0), BlockDigest::default()));
+        // Single block from super-majority authority at round 5 reaches quorum
+        // immediately
+        clock.add_block(BlockRef::new(
+            5,
+            AuthorityIndex::new_for_test(0),
+            BlockDigest::default(),
+        ));
         assert_eq!(clock.get_round(), 6);
 
         // Stale blocks from round 5 should be ignored
-        clock.add_block(BlockRef::new(5, AuthorityIndex::new_for_test(1), BlockDigest::default()));
+        clock.add_block(BlockRef::new(
+            5,
+            AuthorityIndex::new_for_test(1),
+            BlockDigest::default(),
+        ));
         assert_eq!(clock.get_round(), 6);
-        clock.add_block(BlockRef::new(5, AuthorityIndex::new_for_test(2), BlockDigest::default()));
+        clock.add_block(BlockRef::new(
+            5,
+            AuthorityIndex::new_for_test(2),
+            BlockDigest::default(),
+        ));
         assert_eq!(clock.get_round(), 6);
     }
 }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -466,7 +466,7 @@ impl DagState {
         self.recent_block_headers
             .insert(block_ref, block_header.clone());
         self.recent_headers_refs_by_authority[block_ref.author].insert(block_ref);
-        self.threshold_clock.add_block(block_ref);
+        self.threshold_clock.add_block_header(block_ref);
         self.highest_accepted_round = max(self.highest_accepted_round, block_header.round());
         self.context
             .metrics

--- a/crates/starfish/core/src/threshold_clock.rs
+++ b/crates/starfish/core/src/threshold_clock.rs
@@ -53,8 +53,10 @@ impl ThresholdClock {
     ///
     /// Round advancement rules:
     /// - block.round < current: ignored (stale block)
-    /// - block.round > current: jump to block.round, start collecting stake there
-    /// - block.round == current: continue accumulating stake until quorum (2f+1) reached
+    /// - block.round > current: jump to block.round, start collecting stake
+    ///   there
+    /// - block.round == current: continue accumulating stake until quorum
+    ///   (2f+1) reached
     ///
     /// When quorum is reached, advance to round + 1.
     pub(crate) fn add_block_header(&mut self, block_header: BlockRef) {
@@ -63,11 +65,13 @@ impl ThresholdClock {
             Ordering::Greater => {
                 // Jump to the new round and start with fresh state
                 self.aggregator.clear();
-                self.aggregator.add(block_header.author, &self.context.committee);
+                self.aggregator
+                    .add(block_header.author, &self.context.committee);
                 self.round = block_header.round;
             }
             Ordering::Equal => {
-                self.aggregator.add(block_header.author, &self.context.committee);
+                self.aggregator
+                    .add(block_header.author, &self.context.committee);
             }
         }
         self.try_advance_round(block_header.round + 1);
@@ -162,14 +166,46 @@ mod tests {
         let mut aggregator = ThresholdClock::new(0, context);
 
         let block_refs = vec![
-            BlockRef::new(0, AuthorityIndex::new_for_test(0), BlockHeaderDigest::default()),
-            BlockRef::new(0, AuthorityIndex::new_for_test(1), BlockHeaderDigest::default()),
-            BlockRef::new(0, AuthorityIndex::new_for_test(2), BlockHeaderDigest::default()),
-            BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockHeaderDigest::default()),
-            BlockRef::new(1, AuthorityIndex::new_for_test(3), BlockHeaderDigest::default()),
-            BlockRef::new(2, AuthorityIndex::new_for_test(1), BlockHeaderDigest::default()),
-            BlockRef::new(1, AuthorityIndex::new_for_test(1), BlockHeaderDigest::default()),
-            BlockRef::new(5, AuthorityIndex::new_for_test(2), BlockHeaderDigest::default()),
+            BlockRef::new(
+                0,
+                AuthorityIndex::new_for_test(0),
+                BlockHeaderDigest::default(),
+            ),
+            BlockRef::new(
+                0,
+                AuthorityIndex::new_for_test(1),
+                BlockHeaderDigest::default(),
+            ),
+            BlockRef::new(
+                0,
+                AuthorityIndex::new_for_test(2),
+                BlockHeaderDigest::default(),
+            ),
+            BlockRef::new(
+                1,
+                AuthorityIndex::new_for_test(0),
+                BlockHeaderDigest::default(),
+            ),
+            BlockRef::new(
+                1,
+                AuthorityIndex::new_for_test(3),
+                BlockHeaderDigest::default(),
+            ),
+            BlockRef::new(
+                2,
+                AuthorityIndex::new_for_test(1),
+                BlockHeaderDigest::default(),
+            ),
+            BlockRef::new(
+                1,
+                AuthorityIndex::new_for_test(1),
+                BlockHeaderDigest::default(),
+            ),
+            BlockRef::new(
+                5,
+                AuthorityIndex::new_for_test(2),
+                BlockHeaderDigest::default(),
+            ),
         ];
 
         let result = aggregator.add_blocks(block_refs);
@@ -184,14 +220,26 @@ mod tests {
         let mut clock = ThresholdClock::new(0, context);
 
         // Jump from round 0 to round 5 - author should be tracked
-        clock.add_block_header(BlockRef::new(5, AuthorityIndex::new_for_test(0), BlockHeaderDigest::default()));
+        clock.add_block_header(BlockRef::new(
+            5,
+            AuthorityIndex::new_for_test(0),
+            BlockHeaderDigest::default(),
+        ));
         assert_eq!(clock.get_round(), 5);
 
         // Add more blocks at round 5 to reach quorum (need 3 of 4)
-        clock.add_block_header(BlockRef::new(5, AuthorityIndex::new_for_test(1), BlockHeaderDigest::default()));
+        clock.add_block_header(BlockRef::new(
+            5,
+            AuthorityIndex::new_for_test(1),
+            BlockHeaderDigest::default(),
+        ));
         assert_eq!(clock.get_round(), 5);
 
-        clock.add_block_header(BlockRef::new(5, AuthorityIndex::new_for_test(2), BlockHeaderDigest::default()));
+        clock.add_block_header(BlockRef::new(
+            5,
+            AuthorityIndex::new_for_test(2),
+            BlockHeaderDigest::default(),
+        ));
         assert_eq!(clock.get_round(), 6); // Quorum reached
     }
 
@@ -199,9 +247,10 @@ mod tests {
     /// the round when jumping to a higher round.
     #[tokio::test]
     async fn test_threshold_clock_super_majority_round_skip() {
-        use crate::metrics::test_metrics;
         use starfish_config::Parameters;
         use tempfile::TempDir;
+
+        use crate::metrics::test_metrics;
 
         // Authority 0 has 5/7 stake (>2/3 quorum threshold)
         let (committee, _) = starfish_config::local_committee_and_keys(0, vec![5, 1, 1]);
@@ -212,7 +261,10 @@ mod tests {
             0,
             AuthorityIndex::new_for_test(0),
             committee,
-            Parameters { db_path: temp_dir.keep(), ..Default::default() },
+            Parameters {
+                db_path: temp_dir.keep(),
+                ..Default::default()
+            },
             iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE(),
             metrics,
             Arc::new(crate::context::Clock::default()),
@@ -220,14 +272,27 @@ mod tests {
 
         let mut clock = ThresholdClock::new(0, context);
 
-        // Single block from super-majority authority at round 5 reaches quorum immediately
-        clock.add_block_header(BlockRef::new(5, AuthorityIndex::new_for_test(0), BlockHeaderDigest::default()));
+        // Single block from super-majority authority at round 5 reaches quorum
+        // immediately
+        clock.add_block_header(BlockRef::new(
+            5,
+            AuthorityIndex::new_for_test(0),
+            BlockHeaderDigest::default(),
+        ));
         assert_eq!(clock.get_round(), 6);
 
         // Stale blocks from round 5 should be ignored
-        clock.add_block_header(BlockRef::new(5, AuthorityIndex::new_for_test(1), BlockHeaderDigest::default()));
+        clock.add_block_header(BlockRef::new(
+            5,
+            AuthorityIndex::new_for_test(1),
+            BlockHeaderDigest::default(),
+        ));
         assert_eq!(clock.get_round(), 6);
-        clock.add_block_header(BlockRef::new(5, AuthorityIndex::new_for_test(2), BlockHeaderDigest::default()));
+        clock.add_block_header(BlockRef::new(
+            5,
+            AuthorityIndex::new_for_test(2),
+            BlockHeaderDigest::default(),
+        ));
         assert_eq!(clock.get_round(), 6);
     }
 }

--- a/crates/starfish/core/src/threshold_clock.rs
+++ b/crates/starfish/core/src/threshold_clock.rs
@@ -29,35 +29,48 @@ impl ThresholdClock {
         }
     }
 
-    /// Add the block reference that have been accepted and advance the round
-    /// accordingly.
-    pub(crate) fn add_block(&mut self, block: BlockRef) {
-        match block.round.cmp(&self.round) {
-            // Blocks with round less than what we currently build are irrelevant here
+    /// If quorum (2f+1) is reached, advance to the next round and record
+    /// latency metrics. Returns true if quorum was reached.
+    fn try_advance_round(&mut self, new_round: Round) -> bool {
+        if self.aggregator.reached_threshold(&self.context.committee) {
+            self.aggregator.clear();
+            self.round = new_round;
+
+            let now = Instant::now();
+            self.context
+                .metrics
+                .node_metrics
+                .quorum_receive_latency
+                .observe(now.duration_since(self.quorum_ts).as_secs_f64());
+            self.quorum_ts = now;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Add the block reference and advance the round accordingly.
+    ///
+    /// Round advancement rules:
+    /// - block.round < current: ignored (stale block)
+    /// - block.round > current: jump to block.round, start collecting stake there
+    /// - block.round == current: continue accumulating stake
+    ///
+    /// When quorum is reached, advance to next round: round + 1.
+    pub(crate) fn add_block_header(&mut self, block_header: BlockRef) {
+        match block_header.round.cmp(&self.round) {
             Ordering::Less => {}
-            // If we processed block for round r, we also have stored 2f+1 blocks from r-1
             Ordering::Greater => {
+                // Jump to the new round and start with fresh state
                 self.aggregator.clear();
-                self.aggregator.add(block.author, &self.context.committee);
-                self.round = block.round;
+                self.aggregator.add(block_header.author, &self.context.committee);
+                self.round = block_header.round;
             }
             Ordering::Equal => {
-                if self.aggregator.add(block.author, &self.context.committee) {
-                    self.aggregator.clear();
-                    // We have seen 2f+1 blocks for current round, advance
-                    self.round = block.round + 1;
-
-                    // now record the time of receipt from last quorum
-                    let now = Instant::now();
-                    self.context
-                        .metrics
-                        .node_metrics
-                        .quorum_receive_latency
-                        .observe(now.duration_since(self.quorum_ts).as_secs_f64());
-                    self.quorum_ts = now;
-                }
+                self.aggregator.add(block_header.author, &self.context.committee);
             }
         }
+        self.try_advance_round(block_header.round + 1);
     }
 
     /// Add the block references that have been successfully processed and
@@ -67,7 +80,7 @@ impl ThresholdClock {
     fn add_blocks(&mut self, blocks: Vec<BlockRef>) -> Option<Round> {
         let previous_round = self.round;
         for block_ref in blocks {
-            self.add_block(block_ref);
+            self.add_block_header(block_ref);
         }
         (self.round > previous_round).then_some(self.round)
     }
@@ -93,49 +106,49 @@ mod tests {
         let context = Arc::new(Context::new_for_test(4).0);
         let mut aggregator = ThresholdClock::new(0, context);
 
-        aggregator.add_block(BlockRef::new(
+        aggregator.add_block_header(BlockRef::new(
             0,
             AuthorityIndex::new_for_test(0),
             BlockHeaderDigest::default(),
         ));
         assert_eq!(aggregator.get_round(), 0);
-        aggregator.add_block(BlockRef::new(
+        aggregator.add_block_header(BlockRef::new(
             0,
             AuthorityIndex::new_for_test(1),
             BlockHeaderDigest::default(),
         ));
         assert_eq!(aggregator.get_round(), 0);
-        aggregator.add_block(BlockRef::new(
+        aggregator.add_block_header(BlockRef::new(
             0,
             AuthorityIndex::new_for_test(2),
             BlockHeaderDigest::default(),
         ));
         assert_eq!(aggregator.get_round(), 1);
-        aggregator.add_block(BlockRef::new(
+        aggregator.add_block_header(BlockRef::new(
             1,
             AuthorityIndex::new_for_test(0),
             BlockHeaderDigest::default(),
         ));
         assert_eq!(aggregator.get_round(), 1);
-        aggregator.add_block(BlockRef::new(
+        aggregator.add_block_header(BlockRef::new(
             1,
             AuthorityIndex::new_for_test(3),
             BlockHeaderDigest::default(),
         ));
         assert_eq!(aggregator.get_round(), 1);
-        aggregator.add_block(BlockRef::new(
+        aggregator.add_block_header(BlockRef::new(
             2,
             AuthorityIndex::new_for_test(1),
             BlockHeaderDigest::default(),
         ));
         assert_eq!(aggregator.get_round(), 2);
-        aggregator.add_block(BlockRef::new(
+        aggregator.add_block_header(BlockRef::new(
             1,
             AuthorityIndex::new_for_test(1),
             BlockHeaderDigest::default(),
         ));
         assert_eq!(aggregator.get_round(), 2);
-        aggregator.add_block(BlockRef::new(
+        aggregator.add_block_header(BlockRef::new(
             5,
             AuthorityIndex::new_for_test(2),
             BlockHeaderDigest::default(),
@@ -193,5 +206,60 @@ mod tests {
 
         let result = aggregator.add_blocks(block_refs);
         assert_eq!(Some(5), result);
+    }
+
+    /// Test that when jumping to a higher round, the first block's author is
+    /// tracked, allowing subsequent blocks to form quorum.
+    #[tokio::test]
+    async fn test_threshold_clock_round_skip_then_quorum() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mut clock = ThresholdClock::new(0, context);
+
+        // Jump from round 0 to round 5 - author should be tracked
+        clock.add_block_header(BlockRef::new(5, AuthorityIndex::new_for_test(0), BlockHeaderDigest::default()));
+        assert_eq!(clock.get_round(), 5);
+
+        // Add more blocks at round 5 to reach quorum (need 3 of 4)
+        clock.add_block_header(BlockRef::new(5, AuthorityIndex::new_for_test(1), BlockHeaderDigest::default()));
+        assert_eq!(clock.get_round(), 5);
+
+        clock.add_block_header(BlockRef::new(5, AuthorityIndex::new_for_test(2), BlockHeaderDigest::default()));
+        assert_eq!(clock.get_round(), 6); // Quorum reached
+    }
+
+    /// Test that a super-majority authority (>2/3 stake) immediately advances
+    /// the round when jumping to a higher round.
+    #[tokio::test]
+    async fn test_threshold_clock_super_majority_round_skip() {
+        use crate::metrics::test_metrics;
+        use starfish_config::Parameters;
+        use tempfile::TempDir;
+
+        // Authority 0 has 5/7 stake (>2/3 quorum threshold)
+        let (committee, _) = starfish_config::local_committee_and_keys(0, vec![5, 1, 1]);
+        let metrics = test_metrics();
+        let temp_dir = TempDir::new().unwrap();
+
+        let context = Arc::new(crate::context::Context::new(
+            0,
+            AuthorityIndex::new_for_test(0),
+            committee,
+            Parameters { db_path: temp_dir.keep(), ..Default::default() },
+            iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE(),
+            metrics,
+            Arc::new(crate::context::Clock::default()),
+        ));
+
+        let mut clock = ThresholdClock::new(0, context);
+
+        // Single block from super-majority authority at round 5 reaches quorum immediately
+        clock.add_block_header(BlockRef::new(5, AuthorityIndex::new_for_test(0), BlockHeaderDigest::default()));
+        assert_eq!(clock.get_round(), 6);
+
+        // Stale blocks from round 5 should be ignored
+        clock.add_block_header(BlockRef::new(5, AuthorityIndex::new_for_test(1), BlockHeaderDigest::default()));
+        assert_eq!(clock.get_round(), 6);
+        clock.add_block_header(BlockRef::new(5, AuthorityIndex::new_for_test(2), BlockHeaderDigest::default()));
+        assert_eq!(clock.get_round(), 6);
     }
 }

--- a/crates/starfish/core/src/threshold_clock.rs
+++ b/crates/starfish/core/src/threshold_clock.rs
@@ -54,9 +54,9 @@ impl ThresholdClock {
     /// Round advancement rules:
     /// - block.round < current: ignored (stale block)
     /// - block.round > current: jump to block.round, start collecting stake there
-    /// - block.round == current: continue accumulating stake
+    /// - block.round == current: continue accumulating stake until quorum (2f+1) reached
     ///
-    /// When quorum is reached, advance to next round: round + 1.
+    /// When quorum is reached, advance to round + 1.
     pub(crate) fn add_block_header(&mut self, block_header: BlockRef) {
         match block_header.round.cmp(&self.round) {
             Ordering::Less => {}
@@ -162,46 +162,14 @@ mod tests {
         let mut aggregator = ThresholdClock::new(0, context);
 
         let block_refs = vec![
-            BlockRef::new(
-                0,
-                AuthorityIndex::new_for_test(0),
-                BlockHeaderDigest::default(),
-            ),
-            BlockRef::new(
-                0,
-                AuthorityIndex::new_for_test(1),
-                BlockHeaderDigest::default(),
-            ),
-            BlockRef::new(
-                0,
-                AuthorityIndex::new_for_test(2),
-                BlockHeaderDigest::default(),
-            ),
-            BlockRef::new(
-                1,
-                AuthorityIndex::new_for_test(0),
-                BlockHeaderDigest::default(),
-            ),
-            BlockRef::new(
-                1,
-                AuthorityIndex::new_for_test(3),
-                BlockHeaderDigest::default(),
-            ),
-            BlockRef::new(
-                2,
-                AuthorityIndex::new_for_test(1),
-                BlockHeaderDigest::default(),
-            ),
-            BlockRef::new(
-                1,
-                AuthorityIndex::new_for_test(1),
-                BlockHeaderDigest::default(),
-            ),
-            BlockRef::new(
-                5,
-                AuthorityIndex::new_for_test(2),
-                BlockHeaderDigest::default(),
-            ),
+            BlockRef::new(0, AuthorityIndex::new_for_test(0), BlockHeaderDigest::default()),
+            BlockRef::new(0, AuthorityIndex::new_for_test(1), BlockHeaderDigest::default()),
+            BlockRef::new(0, AuthorityIndex::new_for_test(2), BlockHeaderDigest::default()),
+            BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockHeaderDigest::default()),
+            BlockRef::new(1, AuthorityIndex::new_for_test(3), BlockHeaderDigest::default()),
+            BlockRef::new(2, AuthorityIndex::new_for_test(1), BlockHeaderDigest::default()),
+            BlockRef::new(1, AuthorityIndex::new_for_test(1), BlockHeaderDigest::default()),
+            BlockRef::new(5, AuthorityIndex::new_for_test(2), BlockHeaderDigest::default()),
         ];
 
         let result = aggregator.add_blocks(block_refs);

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -577,7 +577,7 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
 
     /// Starts a task to fetch missing transactions from other authorities.
     async fn start_fetch_missing_transactions_task(&mut self) -> ConsensusResult<()> {
-        info!("Kick in periodic synchronizer to fetch missing transactions");
+        debug!("Kick in periodic synchronizer to fetch missing transactions");
         // Get missing transactions from the core
         let missing_transactions = self
             .core_dispatcher

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -577,7 +577,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
 
     /// Starts a task to fetch missing transactions from other authorities.
     async fn start_fetch_missing_transactions_task(&mut self) -> ConsensusResult<()> {
-        debug!("Kick in periodic synchronizer to fetch missing transactions");
         // Get missing transactions from the core
         let missing_transactions = self
             .core_dispatcher


### PR DESCRIPTION
# Description of change

Fix threshold clock round advancement logic when processing blocks from higher rounds.

  Previously, when the threshold clock jumped to a higher round (receiving a block with `round > current_round`), the first block's author stake was recorded but the quorum check wasn't performed. This caused issues for a validator with super-majority stake (>2/3), as they should immediately advance the round upon receiving their own block from a higher round, but the quorum check only ran in the Equal branch. 

This  change is especially important when running the network containing only one validator as a simple restart would not let the validator to properly restart the consensus logic.

  The fix refactors the logic by:
  1. Extracting quorum checking into a new `try_advance_round()` helper method
  2. Calling `try_advance_round()` after every block addition, regardless of whether the block triggered a round jump or was added to the current round's aggregator.
  3. This ensures super-majority validators properly advance rounds when jumping to higher rounds.

  The same fix is applied to both consensus/core (Mysticeti) and crates/starfish/core (Starfish) threshold clock implementations.


## Links to any relevant issues

Fixes #9537 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works:
    - test_threshold_clock_round_skip_then_quorum: Verifies that after jumping to a higher round, subsequent blocks can form quorum
    - test_threshold_clock_super_majority_round_skip: Verifies that a super-majority authority (>2/3 stake) immediately advances the round when jumping to a
  higher round
- [x] I have checked that new and existing unit tests pass locally with my changes

