### PR TITLE
fix(aws-orchestrator): nvme support

### DIFF
--- a/crates/iota-aws-orchestrator/src/client/aws.rs
+++ b/crates/iota-aws-orchestrator/src/client/aws.rs
@@ -238,11 +238,12 @@ impl AwsClient {
 
     /// Return the command to mount the first (standard) NVMe drive.
     fn nvme_mount_command(&self) -> Vec<String> {
-        const DRIVE: &str = "nvme1n1";
         let directory = self.settings.working_dir.display();
         vec![
-            format!("(sudo mkfs.ext4 -E nodiscard /dev/{DRIVE} || true)"),
-            format!("(sudo mount /dev/{DRIVE} {directory} || true)"),
+            "export NVME_DRIVE=$(nvme list | awk '/NVMe Instance Storage/ {print $1; exit}')"
+                .to_string(),
+            "(sudo mkfs.ext4 -E nodiscard $NVME_DRIVE || true)".to_string(),
+            format!("(sudo mount $NVME_DRIVE {directory} || true)"),
             format!("sudo chmod 777 -R {directory}"),
         ]
     }

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -255,7 +255,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             basic_commands.extend([
                 // The following dependencies:
                 // * build-essential: prevent the error: [error: linker `cc` not found].
-                "sudo apt-get -y install build-essential cmake clang lld protobuf-compiler pkg-config",
+                "sudo apt-get -y install build-essential cmake clang lld protobuf-compiler pkg-config nvme-cli",
                 // Install rust (non-interactive).
                 "curl --proto \"=https\" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y",
                 "echo \"source $HOME/.cargo/env\" | tee -a ~/.bashrc",


### PR DESCRIPTION
# Description of change

nvme mount command changed the drive string being hardcoded to being dynamic.


## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
