### PR TITLE
feat(starfish): Optimize `committed_transactions()` to return slice instead of cloning

### DIFF
--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -94,7 +94,7 @@ pub(crate) trait CommitAPI {
     fn timestamp_ms(&self) -> BlockTimestampMs;
     fn leader(&self) -> BlockRef;
     fn blocks(&self) -> &[BlockRef];
-    fn committed_transactions(&self) -> Vec<BlockRef>;
+    fn committed_transactions(&self) -> &[BlockRef];
 }
 
 /// Specifies one consensus commit.
@@ -146,10 +146,8 @@ impl CommitAPI for CommitV1 {
         &self.blocks
     }
 
-    // TODO: https://github.com/iotaledger/iota/issues/8375
-    // Does this need to be a vector? block refs are a slice == less cloning?
-    fn committed_transactions(&self) -> Vec<BlockRef> {
-        self.committed_transactions.clone()
+    fn committed_transactions(&self) -> &[BlockRef] {
+        &self.committed_transactions
     }
 }
 
@@ -647,7 +645,7 @@ pub fn load_pending_subdag_from_store(
     PendingSubDag::new(
         leader_block_ref,
         block_headers,
-        commit.committed_transactions().clone(),
+        commit.committed_transactions().to_vec(),
         commit.timestamp_ms(),
         commit.reference(),
         reputation_scores_desc,

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -350,7 +350,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             for certified_commit in commits.commits() {
                 // Collect committed_transactions from the TrustedCommit
                 for block_ref in certified_commit.committed_transactions() {
-                    expected_transactions.insert(block_ref);
+                    expected_transactions.insert(*block_ref);
                 }
 
                 // Collect available transactions from VerifiedTransactions
@@ -662,6 +662,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
         let committed_tx_refs: Vec<BlockRef> = commits
             .iter()
             .flat_map(|c| c.committed_transactions())
+            .copied()
             .collect();
 
         // 3b. Identify which committed transaction blocks are NOT in the committed

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -156,7 +156,7 @@ impl Linearizer {
         let sub_dag = PendingSubDag::new(
             leader_block.reference(),
             to_commit,
-            commit.committed_transactions(),
+            commit.committed_transactions().to_vec(),
             timestamp_ms,
             commit.reference(),
             reputation_scores_desc,


### PR DESCRIPTION
# Description of change

Changed the return type of CommitAPI::committed_transactions() from Vec<BlockRef> to &[BlockRef] to avoid unnecessary cloning. This reduces allocations in the consensus protocol's hot path.

Changes:
- Updated trait definition and implementation to return &[BlockRef]
- Modified call sites to explicitly use .to_vec() only where ownership is needed (2 locations)
- Most call sites (3 out of 5) now benefit from zero-copy access

## Links to any relevant issues

Resolves #8375

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes