### PR TITLE
chore(iota-core): Remove irrelevant TODO comments regarding parking_lot::Mutex

### DIFF
--- a/crates/iota-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/iota-core/src/consensus_manager/mysticeti_manager.rs
@@ -40,7 +40,6 @@ pub struct MysticetiManager {
     protocol_keypair: ProtocolKeyPair,
     network_keypair: NetworkKeyPair,
     storage_base_path: PathBuf,
-    // TODO: switch to parking_lot::Mutex.
     running: Mutex<Running>,
     metrics: Arc<ConsensusManagerMetrics>,
     registry_service: RegistryService,
@@ -49,7 +48,6 @@ pub struct MysticetiManager {
     // Use a shared lazy mysticeti client so we can update the internal mysticeti
     // client that gets created for every new epoch.
     client: Arc<LazyMysticetiClient>,
-    // TODO: switch to parking_lot::Mutex.
     consensus_handler: Mutex<Option<MysticetiConsensusHandler>>,
     consumer_monitor: ArcSwapOption<CommitConsumerMonitor>,
 }

--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -39,8 +39,6 @@ pub struct StarfishManager {
     protocol_keypair: ProtocolKeyPair,
     network_keypair: NetworkKeyPair,
     storage_base_path: PathBuf,
-    // TODO: https://github.com/iotaledger/iota/issues/8351
-    // Consider switching to parking_lot::Mutex as it has less overhead.
     running: Mutex<Running>,
     metrics: Arc<ConsensusManagerMetrics>,
     registry_service: RegistryService,
@@ -49,8 +47,6 @@ pub struct StarfishManager {
     // Use a shared lazy starfish client so we can update the internal starfish
     // client that gets created for every new epoch.
     client: Arc<LazyStarfishClient>,
-    // TODO: https://github.com/iotaledger/iota/issues/8351
-    // Consider switching to parking_lot::Mutex as it has less overhead.
     consensus_handler: Mutex<Option<StarfishConsensusHandler>>,
     consumer_monitor: ArcSwapOption<CommitConsumerMonitor>,
 }


### PR DESCRIPTION
# Description of change

Remove irrelevant TODO comments regarding parking_lot::Mutex. Switching those to `parking_lot` would not bring much performance improvement because those locks are only handled on startup/shutdown, so using async mutex is perfectly fine. 

## Links to any relevant issues

Resolves #8351 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
