### PR TITLE
fix(indexer): Mark indexer store tasks as "CALLED_FROM_BLOCKING_POOL"

### DIFF
--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -79,7 +79,10 @@ use crate::{
         objects, objects_history, objects_snapshot, objects_version, optimistic_transactions,
         packages, pruner_cp_watermark, transactions, tx_digests, tx_global_order,
     },
-    store::{diesel_macro::*, package_resolver::IndexerStorePackageResolver},
+    store::{
+        diesel_macro::{mark_in_blocking_pool, *},
+        package_resolver::IndexerStorePackageResolver,
+    },
     types::{IndexerResult, OwnerType},
 };
 
@@ -146,8 +149,7 @@ impl IndexerReader {
         let this = self.clone();
         let current_span = tracing::Span::current();
         tokio::task::spawn_blocking(move || {
-            CALLED_FROM_BLOCKING_POOL
-                .with(|in_blocking_pool| *in_blocking_pool.borrow_mut() = true);
+            mark_in_blocking_pool();
             let _guard = current_span.enter();
             f(this)
         })

--- a/crates/iota-indexer/src/store/mod.rs
+++ b/crates/iota-indexer/src/store/mod.rs
@@ -19,6 +19,14 @@ pub mod diesel_macro {
         pub static CALLED_FROM_BLOCKING_POOL: std::cell::RefCell<bool> = const { std::cell::RefCell::new(false) };
     }
 
+    /// Marks the current thread as being in a blocking pool.
+    ///
+    /// Call this at the start of any `spawn_blocking` closure that will perform
+    /// blocking DB operations.
+    pub fn mark_in_blocking_pool() {
+        CALLED_FROM_BLOCKING_POOL.with(|in_blocking_pool| *in_blocking_pool.borrow_mut() = true);
+    }
+
     #[macro_export]
     macro_rules! read_only_repeatable_blocking {
         ($pool:expr, $query:expr) => {{
@@ -145,12 +153,11 @@ pub mod diesel_macro {
             use $crate::{
                 db::{PoolConnection, get_pool_connection},
                 errors::IndexerError,
-                store::diesel_macro::CALLED_FROM_BLOCKING_POOL,
+                store::diesel_macro::mark_in_blocking_pool,
             };
             let current_span = tracing::Span::current();
             tokio::task::spawn_blocking(move || {
-                CALLED_FROM_BLOCKING_POOL
-                    .with(|in_blocking_pool| *in_blocking_pool.borrow_mut() = true);
+                mark_in_blocking_pool();
                 let _guard = current_span.enter();
                 let mut pool_conn = get_pool_connection($pool).unwrap();
 

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+
 use core::result::Result::Ok;
 use std::{
     any::Any as StdAny,
@@ -74,7 +75,7 @@ use crate::{
         tx_global_order, tx_input_objects, tx_kinds, tx_recipients, tx_senders,
         tx_wrapped_or_deleted_objects, watermarks,
     },
-    store::IndexerStore,
+    store::{IndexerStore, diesel_macro::mark_in_blocking_pool},
     transactional_blocking_with_retry,
     types::{
         EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEvent, IndexedObject,
@@ -1744,6 +1745,7 @@ impl PgIndexerStore {
         let this = self.clone();
         let current_span = tracing::Span::current();
         tokio::task::spawn_blocking(move || {
+            mark_in_blocking_pool();
             let _guard = current_span.enter();
             f(this)
         })
@@ -1764,6 +1766,7 @@ impl PgIndexerStore {
         let current_span = tracing::Span::current();
         let guard = self.metrics.tokio_blocking_task_wait_latency.start_timer();
         tokio::task::spawn_blocking(move || {
+            mark_in_blocking_pool();
             let _guard = current_span.enter();
             let _elapsed = guard.stop_and_record();
             f(this)


### PR DESCRIPTION
# Description of change

Some of the blocking DB queries require CALLED_FROM_BLOCKING_POOL to be set to true, otherwise they panic.

PgIndexerStore should set this flag to true similarly to how IndexerReader is doing it, so that blocking DB queries work properly.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9464

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
