### PR TITLE
fix(graphql-rpc): resolve module origin correctly in move abort errors

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/errors/clever_errors.snap
+++ b/crates/iota-graphql-e2e-tests/tests/errors/clever_errors.snap
@@ -220,179 +220,60 @@ Response: {
     "transactionBlocks": {
       "nodes": [
         {
-          "effects": null
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callU32' (line 152), abort 'ImAU32': 9"
+          }
         },
         {
-          "effects": null
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callU64' (line 155), abort 'ImAU64': 10"
+          }
         },
         {
-          "effects": null
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callU128' (line 158), abort 'ImAU128': 11"
+          }
         },
         {
-          "effects": null
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callU256' (line 161), abort 'ImAU256': 12"
+          }
         },
         {
-          "effects": null
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callAddress' (line 164), abort 'ImAnAddress': 0x000000000000000000000000000000000000000000000000000000000000000d"
+          }
         },
         {
-          "effects": null
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callString' (line 167), abort 'ImAString': This is a string in v2"
+          }
         },
         {
-          "effects": null
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callU64vec' (line 170), abort 'ImNotAString': BgEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAABQAAAAAAAAAGAAAAAAAAAA=="
+          }
         },
         {
-          "effects": null
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::normalAbort' (instruction 1), abort code: 0"
+          }
         },
         {
-          "effects": null
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::assertLineNo' (line 176)"
+          }
         }
       ]
     }
-  },
-  "errors": [
-    {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9",
-      "locations": [
-        {
-          "line": 6,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        0,
-        "effects",
-        "errors"
-      ]
-    },
-    {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9",
-      "locations": [
-        {
-          "line": 6,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        1,
-        "effects",
-        "errors"
-      ]
-    },
-    {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9",
-      "locations": [
-        {
-          "line": 6,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        2,
-        "effects",
-        "errors"
-      ]
-    },
-    {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9",
-      "locations": [
-        {
-          "line": 6,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        3,
-        "effects",
-        "errors"
-      ]
-    },
-    {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9",
-      "locations": [
-        {
-          "line": 6,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        4,
-        "effects",
-        "errors"
-      ]
-    },
-    {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9",
-      "locations": [
-        {
-          "line": 6,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        5,
-        "effects",
-        "errors"
-      ]
-    },
-    {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9",
-      "locations": [
-        {
-          "line": 6,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        6,
-        "effects",
-        "errors"
-      ]
-    },
-    {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9",
-      "locations": [
-        {
-          "line": 6,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        7,
-        "effects",
-        "errors"
-      ]
-    },
-    {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9",
-      "locations": [
-        {
-          "line": 6,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        8,
-        "effects",
-        "errors"
-      ]
-    }
-  ]
+  }
 }

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -12,17 +12,9 @@ use iota_package_resolver::{CleverError, ErrorConstants};
 use iota_types::{
     effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
     event::Event as NativeEvent,
-    execution_status::{
-        ExecutionFailureStatus, ExecutionStatus as NativeExecutionStatus, MoveLocation,
-        MoveLocationOpt,
-    },
-    transaction::{
-        Command, ProgrammableTransaction, SenderSignedData as NativeSenderSignedData,
-        TransactionData as NativeTransactionData, TransactionDataAPI,
-        TransactionKind as NativeTransactionKind,
-    },
+    execution_status::{ExecutionFailureStatus, ExecutionStatus as NativeExecutionStatus},
+    transaction::TransactionData as NativeTransactionData,
 };
-use move_core_types::account_address::AccountAddress;
 
 use crate::{
     consistency::ConsistentIndexCursor,
@@ -129,9 +121,8 @@ impl TransactionBlockEffects {
     /// displaying the abort code and location.
     async fn errors(&self, ctx: &Context<'_>) -> Result<Option<String>> {
         let resolver: &PackageResolver = ctx.data_unchecked();
-        let status = self.resolve_native_status_impl(resolver).await?;
 
-        match status {
+        match self.native().status() {
             NativeExecutionStatus::Success => Ok(None),
 
             NativeExecutionStatus::Failure {
@@ -528,92 +519,6 @@ impl TransactionBlockEffects {
             TransactionBlockEffectsKind::DryRun { native, .. } => native,
             TransactionBlockEffectsKind::Executed { native, .. } => native,
         }
-    }
-
-    /// Get the transaction data from the transaction block effects.
-    /// Will error if the transaction data is not available/invalid, but this
-    /// should not occur.
-    fn transaction_data(&self) -> Result<NativeTransactionData> {
-        Ok(match &self.kind {
-            TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
-                let s: NativeSenderSignedData = bcs::from_bytes(&stored_tx.raw_transaction)
-                    .map_err(|e| {
-                        Error::Internal(format!("Error deserializing transaction data: {e}"))
-                    })?;
-                s.transaction_data().clone()
-            }
-            TransactionBlockEffectsKind::DryRun { tx_data, .. } => tx_data.clone(),
-            TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
-                let data: NativeSenderSignedData = bcs::from_bytes(&optimistic_tx.raw_transaction)
-                    .map_err(|e| {
-                        Error::Internal(format!("Error deserializing transaction data: {e}"))
-                    })?;
-                data.transaction_data().clone()
-            }
-        })
-    }
-
-    /// Get the programmable transaction from the transaction block effects.
-    /// * If the transaction was unable to be retrieved, this will return an
-    ///   Err.
-    /// * If the transaction was able to be retrieved but was not a programmable
-    ///   transaction, this will return Ok(None).
-    /// * If the transaction was a programmable transaction, this will return
-    ///   Ok(Some(tx)).
-    fn programmable_transaction(&self) -> Result<Option<ProgrammableTransaction>> {
-        let tx_data = self.transaction_data()?;
-        match tx_data.into_kind() {
-            NativeTransactionKind::ProgrammableTransaction(tx) => Ok(Some(tx)),
-            _ => Ok(None),
-        }
-    }
-
-    /// Resolves the module ID within a Move abort to the storage ID of the
-    /// package that the abort occurred in.
-    /// * If the error is not a Move abort, or the Move call in the programmable
-    ///   transaction cannot be found, this function will do nothing.
-    /// * If the error is a Move abort and the storage ID is unable to be
-    ///   resolved an error is returned.
-    async fn resolve_native_status_impl(
-        &self,
-        resolver: &PackageResolver,
-    ) -> Result<NativeExecutionStatus> {
-        let mut status = self.native().status().clone();
-        if let NativeExecutionStatus::Failure {
-            error:
-                ExecutionFailureStatus::MoveAbort(MoveLocation { module, .. }, _)
-                | ExecutionFailureStatus::MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation {
-                    module,
-                    ..
-                }))),
-            command: Some(command_idx),
-        } = &mut status
-        {
-            // Get the Move call that this error is associated with.
-            if let Some(Command::MoveCall(ptb_call)) = self
-                .programmable_transaction()?
-                .and_then(|ptb| ptb.commands.into_iter().nth(*command_idx))
-            {
-                let package_address = AccountAddress::from(ptb_call.package);
-
-                if &package_address != module.address() {
-                    // Move abort occurs in one of the dependencies of the package, and we
-                    // need to resolve the runtime module ID to the storage ID. The linkage table of
-                    // the package called in the PTB is used to this end.
-                    //
-                    // This is important to make sure that we look at the correct version of the
-                    // module when resolving the error.
-                    let module_new = module.clone();
-                    *module = resolver
-                        .resolve_module_id(module_new, package_address)
-                        .await
-                        .map_err(|e| {
-                            Error::Internal(format!("Error resolving Move location: {e}"))
-                        })?;
-                }
-            }
-        }
-        Ok(status)
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -22,6 +22,7 @@ use iota_types::{
         TransactionKind as NativeTransactionKind,
     },
 };
+use move_core_types::account_address::AccountAddress;
 
 use crate::{
     consistency::ConsistentIndexCursor,
@@ -593,15 +594,23 @@ impl TransactionBlockEffects {
                 .programmable_transaction()?
                 .and_then(|ptb| ptb.commands.into_iter().nth(*command_idx))
             {
-                let module_new = module.clone();
-                // Resolve the runtime module ID in the Move abort to the storage ID of the
-                // package that the abort occurred in. This is important to make
-                // sure that we look at the correct version of the module when
-                // resolving the error.
-                *module = resolver
-                    .resolve_module_id(module_new, ptb_call.package.into())
-                    .await
-                    .map_err(|e| Error::Internal(format!("Error resolving Move location: {e}")))?;
+                let package_address = AccountAddress::from(ptb_call.package);
+
+                if &package_address != module.address() {
+                    // Move abort occurs in one of the dependencies of the package, and we
+                    // need to resolve the runtime module ID to the storage ID. The linkage table of
+                    // the package called in the PTB is used to this end.
+                    //
+                    // This is important to make sure that we look at the correct version of the
+                    // module when resolving the error.
+                    let module_new = module.clone();
+                    *module = resolver
+                        .resolve_module_id(module_new, package_address)
+                        .await
+                        .map_err(|e| {
+                            Error::Internal(format!("Error resolving Move location: {e}"))
+                        })?;
+                }
             }
         }
         Ok(status)


### PR DESCRIPTION
# Description of change

This patch fixes an issue with the resolution of the errors of a failed transactions in GraphQL. Namely, the resolver was assuming that the location of the error was represented by the runtime id, instead of the storage id.

This is not the case anymore: The storage id is used to represent the move location where the error occurs.

After removing the obsolete logic, when we request the errors for the failed transaction
```graphql
{
  transactionBlock(digest: "Facc1j5Y4u1uYuRXMYag83wGWSL1dYMLtHhkRCAYXRGQ") {
    effects {
      status
      errors
    }
  }
}
```

we get the following response

```json
{
  "data": {
    "transactionBlock": {
      "effects": {
        "status": "FAILURE",
        "errors": "Error in 6th command, from '0x9ce7f6e1575d59241a4e9d8029ed527ec01e867bfb8639698c483b5757bcd079::trading::execute_increase_order_internal' (instruction 91), abort code: 10"
      }
    }
  }
}

```
## Links to any relevant issues

Fixes #9539 

## How the change has been tested

Describe the tests that you ran to verify your changes.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

THe patch does not affect any of these areas.

### Release Notes

- [x] GraphQL: Fixes resolution of move abort errors for failed transactions
