### PR TITLE
fix(indexer): Improve waiting for objects history in read api tests

### DIFF
--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -333,7 +333,7 @@ pub async fn indexer_wait_for_transaction(
     .expect("timeout waiting for indexer to catchup to given transaction");
 }
 
-pub async fn execute_tx_and_wait_for_indexer(
+pub async fn execute_tx_and_wait_for_indexer_checkpoint(
     indexer_client: &HttpClient,
     store: &PgIndexerStore,
     tx_bytes: TransactionBlockBytes,

--- a/crates/iota-indexer/tests/rpc-tests/coin_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/coin_api.rs
@@ -32,7 +32,7 @@ use test_cluster::TestCluster;
 use tokio::sync::OnceCell;
 
 use crate::common::{
-    ApiTestSetup, execute_tx_and_wait_for_indexer, indexer_wait_for_object,
+    ApiTestSetup, execute_tx_and_wait_for_indexer_checkpoint, indexer_wait_for_object,
     indexer_wait_for_transaction, publish_test_move_package,
     start_test_cluster_with_read_write_indexer,
 };
@@ -1062,5 +1062,5 @@ async fn transfer_all_coins(
         .await
         .unwrap();
 
-    execute_tx_and_wait_for_indexer(indexer_client, store, tx_bytes, keypair).await;
+    execute_tx_and_wait_for_indexer_checkpoint(indexer_client, store, tx_bytes, keypair).await;
 }

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -47,7 +47,7 @@ use move_core_types::{
 use crate::{
     coin_api::execute_move_call,
     common::{
-        ApiTestSetup, execute_tx_and_wait_for_indexer, execute_tx_must_succeed,
+        ApiTestSetup, execute_tx_and_wait_for_indexer_checkpoint, execute_tx_must_succeed,
         indexer_wait_for_checkpoint, indexer_wait_for_latest_checkpoint, indexer_wait_for_object,
         indexer_wait_for_transaction, rpc_call_error_msg_matches,
         start_test_cluster_with_read_write_indexer,
@@ -902,7 +902,7 @@ fn test_query_transaction_blocks_from_and_to_address() -> Result<(), anyhow::Err
             )
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, store, transfer_request, &keypair).await;
+        execute_tx_and_wait_for_indexer_checkpoint(client, store, transfer_request, &keypair).await;
 
         let query = IotaTransactionBlockResponseQuery::new_with_filter(
             TransactionFilter::FromAndToAddress {
@@ -979,7 +979,8 @@ fn test_query_by_recently_executed_tx_cursor() -> Result<(), anyhow::Error> {
             .await
             .unwrap();
         let digest_3 =
-            execute_tx_and_wait_for_indexer(client, store, transfer_request, &keypair).await;
+            execute_tx_and_wait_for_indexer_checkpoint(client, store, transfer_request, &keypair)
+                .await;
 
         assert_paginated_filtered_transactions(
             client,
@@ -1043,7 +1044,7 @@ fn test_query_transaction_blocks_from_or_to_address() -> Result<(), anyhow::Erro
             )
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, store, transfer_request, &keypair).await;
+        execute_tx_and_wait_for_indexer_checkpoint(client, store, transfer_request, &keypair).await;
 
         let query = IotaTransactionBlockResponseQuery::new_with_filter(
             TransactionFilter::FromOrToAddress { addr: address },

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -1,13 +1,13 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fs::File, path::Path, str::FromStr, sync::Arc, time::Duration};
+use std::{fs::File, path::Path, str::FromStr, sync::Arc};
 
 use hex::FromHex;
 use iota_indexer::{
     config::PruningOptions,
     models::transactions::StoredTransaction,
-    store::package_resolver::IndexerStorePackageResolver,
+    store::{PgIndexerStore, package_resolver::IndexerStorePackageResolver},
     test_utils::{TestDatabase, db_url},
 };
 use iota_json::{call_args, type_args};
@@ -34,14 +34,16 @@ use iota_types::{
     utils::to_sender_signed_transaction,
 };
 use itertools::Itertools;
+use jsonrpsee::http_client::HttpClient;
 use move_core_types::identifier::Identifier;
 use serde_json::Value;
 
 use crate::{
     common::{
-        ApiTestSetup, FIXTURES_DIR, execute_tx_and_wait_for_indexer, indexer_wait_for_checkpoint,
-        indexer_wait_for_checkpoint_pruned, indexer_wait_for_object, indexer_wait_for_transaction,
-        rpc_call_error_msg_matches, start_test_cluster_with_read_write_indexer,
+        ApiTestSetup, FIXTURES_DIR, execute_tx_and_wait_for_indexer_checkpoint,
+        indexer_wait_for_checkpoint, indexer_wait_for_checkpoint_pruned, indexer_wait_for_object,
+        indexer_wait_for_transaction, rpc_call_error_msg_matches,
+        start_test_cluster_with_read_write_indexer,
     },
     write_api::{create_basic_object, deploy_basics_pkg},
 };
@@ -268,10 +270,13 @@ fn multi_get_transaction_blocks_with_options(options: IotaTransactionBlockRespon
     });
 }
 
-async fn wait_for_objects_history() {
-    // Objects history is not filled by optimistic indexing, this method waits a few
-    // seconds so that checkpoint indexing has a chance to kick in
-    tokio::time::sleep(Duration::from_secs(3)).await;
+async fn wait_for_objects_history(
+    tx_digest: TransactionDigest,
+    pg_store: &PgIndexerStore,
+    indexer_client: &HttpClient,
+) {
+    // we need tx to be checkpointed so that changes to objects_history are written
+    indexer_wait_for_transaction(tx_digest, pg_store, indexer_client).await
 }
 
 #[test]
@@ -1508,15 +1513,15 @@ fn try_get_past_object_version_found() {
 
         let (sender, _): (_, AccountKeyPair) = get_key_pair();
 
-        let gas_ref = cluster
-            .fund_address_and_return_gas(
+        let (gas_ref, tx_digest) = cluster
+            .fund_address_and_return_gas_and_tx(
                 cluster.get_reference_gas_price().await,
                 Some(10_000_000_000),
                 sender,
             )
             .await;
 
-        wait_for_objects_history().await;
+        wait_for_objects_history(tx_digest, store, client).await;
 
         let result = client
             .try_get_past_object(gas_ref.0, gas_ref.1, None)
@@ -1550,15 +1555,15 @@ fn try_get_past_object_version_not_found() {
 
         let (sender, _): (_, AccountKeyPair) = get_key_pair();
 
-        let gas_ref = cluster
-            .fund_address_and_return_gas(
+        let (gas_ref, tx_digest) = cluster
+            .fund_address_and_return_gas_and_tx(
                 cluster.get_reference_gas_price().await,
                 Some(10_000_000_000),
                 sender,
             )
             .await;
 
-        wait_for_objects_history().await;
+        wait_for_objects_history(tx_digest, store, client).await;
 
         let missing_version = gas_ref.1.one_before().expect("version should be > 0");
 
@@ -1589,15 +1594,15 @@ fn try_get_past_object_version_too_high() {
 
         let (sender, _): (_, AccountKeyPair) = get_key_pair();
 
-        let gas_ref = cluster
-            .fund_address_and_return_gas(
+        let (gas_ref, tx_digest) = cluster
+            .fund_address_and_return_gas_and_tx(
                 cluster.get_reference_gas_price().await,
                 Some(10_000_000_000),
                 sender,
             )
             .await;
 
-        wait_for_objects_history().await;
+        wait_for_objects_history(tx_digest, store, client).await;
 
         let latest_version = gas_ref.1;
         let asked_version = latest_version.next();
@@ -1641,8 +1646,8 @@ fn try_get_past_object_object_deleted() {
         let nft_object_ref = cluster.get_latest_object_ref(&nft_object_id).await;
 
         // Delete the NFT
-        delete_nft(context, sender, package_id, nft_object_ref).await;
-        wait_for_objects_history().await;
+        let delete_nft_tx = delete_nft(context, sender, package_id, nft_object_ref).await;
+        wait_for_objects_history(delete_nft_tx.digest, store, client).await;
 
         let deleted_version = nft_object_ref.1.next();
 
@@ -1750,23 +1755,24 @@ fn try_multi_get_past_objects() {
 
         // Create valid objects
         let (sender, _): (_, AccountKeyPair) = get_key_pair();
-        let gas_ref_1 = cluster
-            .fund_address_and_return_gas(
+        let (gas_ref_1, tx_digest_1) = cluster
+            .fund_address_and_return_gas_and_tx(
                 cluster.get_reference_gas_price().await,
                 Some(10_000_000_000),
                 sender,
             )
             .await;
 
-        let gas_ref_2 = cluster
-            .fund_address_and_return_gas(
+        let (gas_ref_2, tx_digest_2) = cluster
+            .fund_address_and_return_gas_and_tx(
                 cluster.get_reference_gas_price().await,
                 Some(10_000_000_000),
                 sender,
             )
             .await;
 
-        wait_for_objects_history().await;
+        wait_for_objects_history(tx_digest_1, store, client).await;
+        wait_for_objects_history(tx_digest_2, store, client).await;
 
         let requests = vec![
             IotaGetPastObjectRequest {
@@ -1876,8 +1882,7 @@ fn try_get_object_before_version() {
             )
             .await
             .expect("transfer should succeed");
-        execute_tx_and_wait_for_indexer(client, store, tx_bytes, &keypair).await;
-        wait_for_objects_history().await;
+        execute_tx_and_wait_for_indexer_checkpoint(client, store, tx_bytes, &keypair).await;
 
         let (latest_object, latest_version, _) = cluster.get_latest_object_ref(&gas_ref.0).await;
 

--- a/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
+++ b/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
@@ -33,7 +33,7 @@ use jsonrpsee::http_client::HttpClient;
 use test_cluster::TestCluster;
 
 use crate::common::{
-    ApiTestSetup, execute_tx_and_wait_for_indexer, execute_tx_must_succeed,
+    ApiTestSetup, execute_tx_and_wait_for_indexer_checkpoint, execute_tx_must_succeed,
     indexer_wait_for_checkpoint, indexer_wait_for_latest_checkpoint, indexer_wait_for_object,
     start_test_cluster_with_read_write_indexer,
 };
@@ -695,7 +695,13 @@ fn request_withdraw_timelocked_stake_from_pending() {
                 )
                 .await
                 .unwrap();
-            execute_tx_and_wait_for_indexer(cluster.rpc_client(), &store, tx_bytes, &keypair).await;
+            execute_tx_and_wait_for_indexer_checkpoint(
+                cluster.rpc_client(),
+                &store,
+                tx_bytes,
+                &keypair,
+            )
+            .await;
 
             let staked_iota = client.get_timelocked_stakes(address).await.unwrap();
             let stake = &staked_iota[0].stakes[0];
@@ -710,7 +716,7 @@ fn request_withdraw_timelocked_stake_from_pending() {
                 )
                 .await
                 .unwrap();
-            execute_tx_and_wait_for_indexer(&client, &store, tx_bytes, &keypair).await;
+            execute_tx_and_wait_for_indexer_checkpoint(&client, &store, tx_bytes, &keypair).await;
 
             let staked_iota = client.get_timelocked_stakes(address).await.unwrap();
             assert!(staked_iota.is_empty());

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -53,6 +53,7 @@ use iota_types::{
     base_types::{AuthorityName, ConciseableName, IotaAddress, ObjectID, ObjectRef},
     committee::{Committee, CommitteeTrait, EpochId},
     crypto::{AccountKeyPair, IotaKeyPair, KeypairTraits, get_key_pair},
+    digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEvents},
     error::IotaResult,
     governance::MIN_VALIDATOR_JOINING_STAKE_NANOS,
@@ -728,14 +729,15 @@ impl TestCluster {
     }
 
     /// This call sends some funds from the seeded faucet address to the funding
-    /// address for the given amount and returns the gas object ref. This
-    /// is useful to construct transactions from the funding address.
-    pub async fn fund_address_and_return_gas(
+    /// address for the given amount and returns the gas object ref and
+    /// transaction digest. This is useful to construct transactions from
+    /// the funding address.
+    pub async fn fund_address_and_return_gas_and_tx(
         &self,
         rgp: u64,
         amount: Option<u64>,
         funding_address: IotaAddress,
-    ) -> ObjectRef {
+    ) -> (ObjectRef, TransactionDigest) {
         let Faucet { address, keypair } = &self
             .faucet
             .as_ref()
@@ -768,14 +770,34 @@ impl TestCluster {
             .await
             .unwrap();
 
-        response
+        let object_ref = response
             .effects
+            .as_ref()
             .unwrap()
             .created()
             .first()
             .unwrap()
             .reference
-            .to_object_ref()
+            .to_object_ref();
+
+        let tx_digest = response.digest;
+
+        (object_ref, tx_digest)
+    }
+
+    /// This call sends some funds from the seeded faucet address to the funding
+    /// address for the given amount and returns the gas object ref. This
+    /// is useful to construct transactions from the funding address.
+    pub async fn fund_address_and_return_gas(
+        &self,
+        rgp: u64,
+        amount: Option<u64>,
+        funding_address: IotaAddress,
+    ) -> ObjectRef {
+        let (object_ref, _tx_digest) = self
+            .fund_address_and_return_gas_and_tx(rgp, amount, funding_address)
+            .await;
+        object_ref
     }
 
     pub async fn transfer_iota_must_exceed(


### PR DESCRIPTION
# Description of change

Improve waiting for objects history in read api tests.

Hardcoded 3 seconds sleep was replaced by waiting for checkpoint on transaction that changed the object.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9550

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
