### PR TITLE
feat: support `deny` for move authenticators

### DIFF
--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.move
@@ -52,7 +52,7 @@ module test_account::abstract_account {
 
         let account_address = object::id_address(&account);
 
-        account::create_shared_account_v1(account, authenticator);
+        account::create_account_v1(account, authenticator);
 
         account_address
     }

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.move
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.move
@@ -1,0 +1,99 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// using a regulated coin in an authenticator
+
+//# init --addresses test_coin=0x0 test_account=0x0 --accounts A C
+
+//# publish --sender C
+module test_coin::regulated_coin {
+    use iota::coin;
+
+    public struct REGULATED_COIN has drop {}
+
+    fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency_v1(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            false,
+            ctx,
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_share_object(coin);
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}
+
+// a `REGULATED_COIN` shared instance that will be used as an authenticator input
+//# view-object 1,0
+
+//# publish --sender A --dependencies test_coin
+module test_account::abstract_account {
+    use iota::account::{Self, AuthenticatorInfoV1};
+    use iota::auth_context::AuthContext;
+    use iota::coin::Coin;
+    use test_coin::regulated_coin::REGULATED_COIN;
+
+    public struct AbstractAccount has key {
+        id: UID,
+    }
+
+    public fun create(
+        authenticator: AuthenticatorInfoV1<AbstractAccount>,
+        ctx: &mut TxContext,
+    ): address {
+        let account = AbstractAccount { id: object::new(ctx) };
+
+        let account_address = object::id_address(&account);
+
+        account::create_shared_account_v1(account, authenticator);
+
+        account_address
+    }
+
+    #[authenticator]
+    public fun authenticate(
+        _account: &AbstractAccount,
+        _denied: &Coin<REGULATED_COIN>,
+        _auth_ctx: &AuthContext,
+        _ctx: &TxContext,
+    ) {}
+}
+
+//# programmable --sender A --inputs object(3,1) "abstract_account" "authenticate" 7000000000
+//> 0: iota::account::create_auth_info_v1<test_account::abstract_account::AbstractAccount>(Input(0), Input(1), Input(2));
+//> 1: test_account::abstract_account::create(Result(0));
+//> 2: SplitCoins(Gas, [Input(3)]);
+//> 3: TransferObjects([Result(2)], Result(1));
+
+// account-owned coin used for gas payment
+//# view-object 4,0
+
+//# set-address account_addr object(4,2)
+
+// use a `REGULATED_COIN` coin as an authenticator input, which is allowed
+//# abstract --account immshared(4,2) --gas-payment 4,0 --auth-inputs immshared(1,0) --ptb-inputs 100 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1));
+
+// deny `account_addr` from using `REGULATED_COIN` coins
+//# run iota::coin::deny_list_v1_add --args object(0x403) object(1,2) @account_addr --type-args test_coin::regulated_coin::REGULATED_COIN --sender C
+
+// attempt to use a `REGULATED_COIN` instance as an authenticator input, which is denied
+//# abstract --account immshared(4,2) --gas-payment 4,0 --auth-inputs immshared(1,0) --ptb-inputs 100 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1));
+
+// allow `account_addr` using `REGULATED_COIN` coins
+//# run iota::coin::deny_list_v1_remove --args object(0x403) object(1,2) @account_addr --type-args test_coin::regulated_coin::REGULATED_COIN --sender C
+
+// use a `REGULATED_COIN` coin as an authenticator input, which is allowed
+//# abstract --account immshared(4,2) --gas-payment 4,0 --auth-inputs immshared(1,0) --ptb-inputs 100 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1));

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.snap
@@ -31,7 +31,7 @@ task 3, lines 36-67:
 //# publish --sender A --dependencies test_coin
 created: object(3,0), object(3,1)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 11270800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 11217600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 4, lines 69-75:
 //# programmable --sender A --inputs object(3,1) "abstract_account" "authenticate" 7000000000
@@ -68,7 +68,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 8, lines 86-88:
 //# run iota::coin::deny_list_v1_add --args object(0x403) object(1,2) @account_addr --type-args test_coin::regulated_coin::REGULATED_COIN --sender C
-events: Event { package_id: iota, transaction_module: Identifier("coin"), sender: C, type_: StructTag { address: iota, module: Identifier("deny_list"), name: Identifier("PerTypeConfigCreated"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0, 96, 48, 55, 54, 98, 97, 56, 56, 97, 49, 55, 52, 50, 57, 52, 55, 55, 52, 49, 53, 57, 53, 101, 99, 99, 49, 97, 101, 97, 101, 48, 56, 55, 101, 101, 57, 98, 55, 100, 97, 57, 97, 52, 49, 48, 101, 100, 53, 48, 57, 54, 57, 48, 50, 57, 102, 52, 51, 98, 52, 99, 52, 100, 52, 99, 58, 58, 114, 101, 103, 117, 108, 97, 116, 101, 100, 95, 99, 111, 105, 110, 58, 58, 82, 69, 71, 85, 76, 65, 84, 69, 68, 95, 67, 79, 73, 78, 17, 198, 23, 134, 3, 114, 42, 13, 255, 11, 243, 17, 5, 80, 121, 128, 204, 88, 106, 237, 106, 102, 181, 163, 83, 206, 180, 126, 108, 222, 119, 46] }
+events: Event { package_id: iota, transaction_module: Identifier("coin"), sender: C, type_: StructTag { address: iota, module: Identifier("deny_list"), name: Identifier("PerTypeConfigCreated"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0, 96, 48, 55, 54, 98, 97, 56, 56, 97, 49, 55, 52, 50, 57, 52, 55, 55, 52, 49, 53, 57, 53, 101, 99, 99, 49, 97, 101, 97, 101, 48, 56, 55, 101, 101, 57, 98, 55, 100, 97, 57, 97, 52, 49, 48, 101, 100, 53, 48, 57, 54, 57, 48, 50, 57, 102, 52, 51, 98, 52, 99, 52, 100, 52, 99, 58, 58, 114, 101, 103, 117, 108, 97, 116, 101, 100, 95, 99, 111, 105, 110, 58, 58, 82, 69, 71, 85, 76, 65, 84, 69, 68, 95, 67, 79, 73, 78, 10, 172, 118, 187, 93, 143, 133, 166, 194, 130, 99, 96, 80, 192, 80, 118, 152, 19, 186, 26, 196, 136, 193, 134, 191, 171, 149, 151, 215, 117, 65, 99] }
 created: object(8,0), object(8,1), object(8,2)
 mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,1), object(1,2)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 12144800,  storage_rebate: 2758800, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.snap
@@ -1,0 +1,91 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 12 tasks
+
+init:
+A: object(0,0), C: object(0,1)
+
+task 1, lines 8-33:
+//# publish --sender C
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 18506000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 34:
+//# view-object 1,0
+Owner: Shared( 2 )
+Version: 2
+Contents: iota::coin::Coin<test_coin::regulated_coin::REGULATED_COIN> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    balance: iota::balance::Balance<test_coin::regulated_coin::REGULATED_COIN> {
+        value: 10000u64,
+    },
+}
+
+task 3, lines 36-67:
+//# publish --sender A --dependencies test_coin
+created: object(3,0), object(3,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 11270800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 4, lines 69-75:
+//# programmable --sender A --inputs object(3,1) "abstract_account" "authenticate" 7000000000
+//> 0: iota::account::create_auth_info_v1<test_account::abstract_account::AbstractAccount>(Input(0), Input(1), Input(2));
+//> 1: test_account::abstract_account::create(Result(0));
+//> 2: SplitCoins(Gas, [Input(3)]);
+//> 3: TransferObjects([Result(2)], Result(1));
+// account-owned coin used for gas payment
+created: object(4,0), object(4,1), object(4,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6657600,  storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 5, line 76:
+//# view-object 4,0
+Owner: Account Address ( fake(4,2) )
+Version: 3
+Contents: iota::coin::Coin<iota::iota::IOTA> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    balance: iota::balance::Balance<iota::iota::IOTA> {
+        value: 7000000000u64,
+    },
+}
+
+task 7, lines 81-85:
+//# abstract --account immshared(4,2) --gas-payment 4,0 --auth-inputs immshared(1,0) --ptb-inputs 100 @A
+created: object(7,0)
+mutated: object(4,0)
+unchanged_shared: object(1,0), object(4,2)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 8, lines 86-88:
+//# run iota::coin::deny_list_v1_add --args object(0x403) object(1,2) @account_addr --type-args test_coin::regulated_coin::REGULATED_COIN --sender C
+events: Event { package_id: iota, transaction_module: Identifier("coin"), sender: C, type_: StructTag { address: iota, module: Identifier("deny_list"), name: Identifier("PerTypeConfigCreated"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0, 96, 48, 55, 54, 98, 97, 56, 56, 97, 49, 55, 52, 50, 57, 52, 55, 55, 52, 49, 53, 57, 53, 101, 99, 99, 49, 97, 101, 97, 101, 48, 56, 55, 101, 101, 57, 98, 55, 100, 97, 57, 97, 52, 49, 48, 101, 100, 53, 48, 57, 54, 57, 48, 50, 57, 102, 52, 51, 98, 52, 99, 52, 100, 52, 99, 58, 58, 114, 101, 103, 117, 108, 97, 116, 101, 100, 95, 99, 111, 105, 110, 58, 58, 82, 69, 71, 85, 76, 65, 84, 69, 68, 95, 67, 79, 73, 78, 17, 198, 23, 134, 3, 114, 42, 13, 255, 11, 243, 17, 5, 80, 121, 128, 204, 88, 106, 237, 106, 102, 181, 163, 83, 206, 180, 126, 108, 222, 119, 46] }
+created: object(8,0), object(8,1), object(8,2)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,1), object(1,2)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 12144800,  storage_rebate: 2758800, non_refundable_storage_fee: 0
+
+task 9, lines 89-93:
+//# abstract --account immshared(4,2) --gas-payment 4,0 --auth-inputs immshared(1,0) --ptb-inputs 100 @A
+Error: Error checking transaction input objects: AddressDeniedForCoin { address: object(4,2), coin_type: "object(1,5)::regulated_coin::REGULATED_COIN" }
+
+task 10, lines 94-96:
+//# run iota::coin::deny_list_v1_remove --args object(0x403) object(1,2) @account_addr --type-args test_coin::regulated_coin::REGULATED_COIN --sender C
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,1), object(1,2)
+deleted: object(8,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4377600,  storage_rebate: 6832400, non_refundable_storage_fee: 0
+
+task 11, lines 97-99:
+//# abstract --account immshared(4,2) --gas-payment 4,0 --auth-inputs immshared(1,0) --ptb-inputs 100 @A
+created: object(11,0)
+mutated: object(4,0)
+unchanged_shared: object(1,0), object(4,2)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 980400, non_refundable_storage_fee: 0

--- a/crates/iota-config/src/transaction_deny_config.rs
+++ b/crates/iota-config/src/transaction_deny_config.rs
@@ -199,7 +199,7 @@ impl TransactionDenyConfigBuilder {
         self
     }
 
-    pub fn move_authenticator_disabled(mut self) -> Self {
+    pub fn disable_move_authenticator(mut self) -> Self {
         self.config.move_authenticator_disabled = true;
         self
     }

--- a/crates/iota-config/src/transaction_deny_config.rs
+++ b/crates/iota-config/src/transaction_deny_config.rs
@@ -77,6 +77,10 @@ pub struct TransactionDenyConfig {
     /// A list of disabled OAuth providers for zkLogin
     #[serde(default)]
     zklogin_disabled_providers: HashSet<String>,
+
+    /// Whether `MoveAuthenticator` is disabled
+    #[serde(default)]
+    move_authenticator_disabled: bool,
     // TODO: We could consider add a deny list for types that we want to disable public transfer.
     // TODO: We could also consider disable more types of commands, such as transfer, split and
     // etc.
@@ -124,6 +128,10 @@ impl TransactionDenyConfig {
 
     pub fn zklogin_disabled_providers(&self) -> &HashSet<String> {
         &self.zklogin_disabled_providers
+    }
+
+    pub fn move_authenticator_disabled(&self) -> bool {
+        self.move_authenticator_disabled
     }
 }
 
@@ -188,6 +196,11 @@ impl TransactionDenyConfigBuilder {
 
     pub fn add_zklogin_disabled_provider(mut self, provider: String) -> Self {
         self.config.zklogin_disabled_providers.insert(provider);
+        self
+    }
+
+    pub fn move_authenticator_disabled(mut self) -> Self {
+        self.config.move_authenticator_disabled = true;
         self
     }
 }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -926,6 +926,7 @@ impl AuthorityState {
             tx_data.sender(),
             &tx_checked_input_objects,
             &tx_receiving_objects,
+            &auth_checked_input_objects,
             &self.get_object_store(),
         )?;
 

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -887,7 +887,7 @@ impl AuthorityState {
         iota_transaction_checks::deny::check_transaction_for_signing(
             tx_data,
             transaction.tx_signatures(),
-            &tx_data.input_objects()?,
+            &transaction.input_objects()?,
             &tx_data.receiving_objects(),
             &self.config.transaction_deny_config,
             self.get_backing_package_store().as_ref(),

--- a/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
@@ -25,8 +25,8 @@ use iota_types::{
         TransactionData, VerifiedCertificate, VerifiedTransaction,
     },
     utils::{
-        get_zklogin_user_address, make_zklogin_tx, to_sender_signed_transaction,
-        to_sender_signed_transaction_with_multi_signers,
+        get_zklogin_user_address, make_move_authenticator_tx, make_zklogin_tx,
+        to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers,
     },
 };
 use move_core_types::ident_str;
@@ -496,4 +496,77 @@ async fn test_certificate_deny() {
             ..
         }
     ));
+}
+
+#[tokio::test]
+async fn test_move_authenticator_disabled() {
+    let (network_config, state) = setup_test(
+        TransactionDenyConfigBuilder::new()
+            .disable_move_authenticator()
+            .build(),
+    )
+    .await;
+    let account = get_accounts_and_coins(&network_config, &state)[0].0;
+    let tx = make_move_authenticator_tx(account);
+
+    let result = state
+        .handle_transaction(
+            &state.epoch_store_for_testing(),
+            VerifiedTransaction::new_from_verified(tx),
+        )
+        .await;
+
+    assert_denied(&result);
+}
+
+#[tokio::test]
+async fn test_move_account_denied() {
+    let (network_config, state) = setup_test(TransactionDenyConfigBuilder::new().build()).await;
+    let account = get_accounts_and_coins(&network_config, &state)[0].0;
+
+    let state = reload_state_with_new_deny_config(
+        &network_config,
+        state,
+        TransactionDenyConfigBuilder::new()
+            .add_denied_address(account)
+            .build(),
+    )
+    .await;
+
+    let tx = make_move_authenticator_tx(account);
+
+    let result = state
+        .handle_transaction(
+            &state.epoch_store_for_testing(),
+            VerifiedTransaction::new_from_verified(tx),
+        )
+        .await;
+
+    assert_denied(&result);
+}
+
+#[tokio::test]
+async fn test_move_authenticator_input_denied() {
+    let (network_config, state) = setup_test(TransactionDenyConfigBuilder::new().build()).await;
+    let account = get_accounts_and_coins(&network_config, &state)[0].0;
+
+    let state = reload_state_with_new_deny_config(
+        &network_config,
+        state,
+        TransactionDenyConfigBuilder::new()
+            .add_denied_object(account.into())
+            .build(),
+    )
+    .await;
+
+    let tx = make_move_authenticator_tx(account);
+
+    let result = state
+        .handle_transaction(
+            &state.epoch_store_for_testing(),
+            VerifiedTransaction::new_from_verified(tx),
+        )
+        .await;
+
+    assert_denied(&result);
 }

--- a/crates/iota-transaction-checks/src/deny.rs
+++ b/crates/iota-transaction-checks/src/deny.rs
@@ -91,6 +91,11 @@ fn check_disabled_features(
                 ),
                 "zkLogin OAuth provider is temporarily disabled"
             )
+        } else if let GenericSignature::MoveAuthenticator(_) = s {
+            deny_if_true!(
+                filter_config.move_authenticator_disabled(),
+                "MoveAuthenticator is temporarily disabled"
+            );
         }
         Ok(())
     })?;

--- a/crates/iota-types/src/deny_list_v1.rs
+++ b/crates/iota-types/src/deny_list_v1.rs
@@ -123,11 +123,16 @@ impl MoveTypeTagTrait for GlobalPauseKey {
 #[instrument(level = "trace", skip_all)]
 pub fn check_coin_deny_list_v1_during_signing(
     address: IotaAddress,
-    input_objects: &CheckedInputObjects,
-    receiving_objects: &ReceivingObjects,
+    tx_input_objects: &CheckedInputObjects,
+    tx_receiving_objects: &ReceivingObjects,
+    auth_input_objects: &Option<CheckedInputObjects>,
     object_store: &dyn ObjectStore,
 ) -> UserInputResult {
-    let coin_types = input_object_coin_types_for_denylist_check(input_objects, receiving_objects);
+    let coin_types = input_object_coin_types_for_denylist_check(
+        tx_input_objects,
+        tx_receiving_objects,
+        auth_input_objects,
+    );
     for coin_type in coin_types {
         let Some(deny_list) = get_per_type_coin_deny_list_v1(&coin_type, object_store) else {
             continue;
@@ -303,13 +308,21 @@ where
 /// that it's not a regulated coin.
 #[instrument(level = "trace", skip_all)]
 fn input_object_coin_types_for_denylist_check(
-    input_objects: &CheckedInputObjects,
-    receiving_objects: &ReceivingObjects,
+    tx_input_objects: &CheckedInputObjects,
+    tx_receiving_objects: &ReceivingObjects,
+    auth_input_objects: &Option<CheckedInputObjects>,
 ) -> BTreeSet<String> {
-    let all_objects = input_objects
+    let all_objects = tx_input_objects
         .inner()
         .iter_objects()
-        .chain(receiving_objects.iter_objects());
+        .chain(tx_receiving_objects.iter_objects())
+        .chain(
+            auth_input_objects
+                .as_ref()
+                .map(|auth_input_objects| auth_input_objects.inner().iter_objects())
+                .into_iter()
+                .flatten(),
+        );
     all_objects
         .filter_map(|obj| {
             if obj.is_gas_coin() {

--- a/crates/iota-types/src/unit_tests/utils.rs
+++ b/crates/iota-types/src/unit_tests/utils.rs
@@ -304,4 +304,37 @@ mod zk_login {
         ))
     }
 }
+
+mod move_authenticator {
+    pub use crate::move_authenticator::MoveAuthenticator;
+    use crate::{
+        base_types::IotaAddress,
+        object::OBJECT_START_VERSION,
+        signature::GenericSignature,
+        transaction::{CallArg, ObjectArg, SenderSignedData, Transaction},
+        utils::make_transaction_data,
+    };
+
+    /// Make a transaction signed with `MoveAuthenticator` for testing.
+    pub fn make_move_authenticator_tx(address: IotaAddress) -> Transaction {
+        let data = make_transaction_data(address);
+
+        // There is no a real Move account behind this address.
+        //
+        // TODO: if it is necessary, AA accounts need to be supported properly in the
+        // `AuthorityState` used for testing.
+        let self_call_arg = CallArg::Object(ObjectArg::SharedObject {
+            id: address.into(),
+            initial_shared_version: OBJECT_START_VERSION,
+            mutable: false,
+        });
+        let authenticator = GenericSignature::MoveAuthenticator(
+            MoveAuthenticator::new_for_testing(vec![], vec![], self_call_arg),
+        );
+
+        Transaction::new(SenderSignedData::new(data, vec![authenticator]))
+    }
+}
+
+pub use move_authenticator::*;
 pub use zk_login::*;


### PR DESCRIPTION
# Description of change

Support `Deny` for Move authenticators on the signing phase.

## Links to any relevant issues

fixes #8856 

