### PR TITLE
fix(gRPC): adapt to new iota-sdk-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6478,7 +6478,7 @@ dependencies = [
  "http 1.3.1",
  "iota-grpc-types",
  "iota-json-rpc-types",
- "iota-rust-sdk",
+ "iota-sdk-types",
  "iota-types",
  "move-core-types",
  "serde_json",
@@ -6518,7 +6518,7 @@ version = "1.14.0-alpha"
 dependencies = [
  "bcs",
  "iota-json-rpc-types",
- "iota-rust-sdk",
+ "iota-sdk-types",
  "iota-types",
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/crates/iota-grpc-client/Cargo.toml
+++ b/crates/iota-grpc-client/Cargo.toml
@@ -15,7 +15,6 @@ anyhow.workspace = true
 base64.workspace = true
 futures.workspace = true
 http.workspace = true
-iota-sdk2.workspace = true
 serde_json.workspace = true
 tap.workspace = true
 tonic = { workspace = true, features = ["tls-ring"] }
@@ -23,5 +22,6 @@ tonic = { workspace = true, features = ["tls-ring"] }
 # internal dependencies
 iota-grpc-types.workspace = true
 iota-json-rpc-types.workspace = true
+iota-sdk-types.workspace = true
 iota-types.workspace = true
 move-core-types.workspace = true

--- a/crates/iota-grpc-client/src/response_ext.rs
+++ b/crates/iota-grpc-client/src/response_ext.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 use iota_grpc_types::headers;
-use iota_sdk2::types::Digest;
+use iota_sdk_types::Digest;
 
 /// Extension trait used to facilitate retrieval of IOTA specific data from
 /// responses

--- a/crates/iota-grpc-server/src/ledger_service/get_objects.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_objects.rs
@@ -134,8 +134,9 @@ fn get_object_impl(
             .ok_or_else(|| ObjectNotFoundError::new(object_id))?
     };
 
-    // Convert to iota_sdk2 type
-    // TODO: Remove this conversion when we migrate iota-types to iota_sdk2 types
+    // Convert to iota-sdk-types type
+    // TODO: Remove this conversion when we migrate iota-types to iota-sdk-types
+    // types
     let sdk_object = object
         .try_into()
         .map_err(|e: SdkTypeConversionError| anyhow::Error::msg(e.to_string()))?;

--- a/crates/iota-grpc-types/Cargo.toml
+++ b/crates/iota-grpc-types/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 [dependencies]
 # external dependencies
 bcs.workspace = true
-iota-sdk2.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 serde.workspace = true
@@ -22,4 +21,5 @@ tonic-prost.workspace = true
 
 # internal dependencies
 iota-json-rpc-types.workspace = true
+iota-sdk-types.workspace = true
 iota-types.workspace = true

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/checkpoint.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/checkpoint.rs
@@ -11,14 +11,14 @@ use crate::{field::FieldMaskTree, merge::Merge, proto::TryFromProtoError, v0::bc
 // CheckpointSummary
 //
 
-impl From<iota_sdk2::types::CheckpointSummary> for CheckpointSummary {
-    fn from(summary: iota_sdk2::types::CheckpointSummary) -> Self {
+impl From<iota_sdk_types::CheckpointSummary> for CheckpointSummary {
+    fn from(summary: iota_sdk_types::CheckpointSummary) -> Self {
         Self::merge_from(summary, &FieldMaskTree::new_wildcard())
     }
 }
 
-impl Merge<iota_sdk2::types::CheckpointSummary> for CheckpointSummary {
-    fn merge(&mut self, source: iota_sdk2::types::CheckpointSummary, mask: &FieldMaskTree) {
+impl Merge<iota_sdk_types::CheckpointSummary> for CheckpointSummary {
+    fn merge(&mut self, source: iota_sdk_types::CheckpointSummary, mask: &FieldMaskTree) {
         if mask.contains(Self::BCS_FIELD.name) {
             self.bcs = Some(BcsData::serialize(&source).unwrap());
         }
@@ -43,7 +43,7 @@ impl Merge<&CheckpointSummary> for CheckpointSummary {
     }
 }
 
-impl TryFrom<&CheckpointSummary> for iota_sdk2::types::CheckpointSummary {
+impl TryFrom<&CheckpointSummary> for iota_sdk_types::CheckpointSummary {
     type Error = TryFromProtoError;
 
     fn try_from(
@@ -60,14 +60,14 @@ impl TryFrom<&CheckpointSummary> for iota_sdk2::types::CheckpointSummary {
 // CheckpointContents
 //
 
-impl From<iota_sdk2::types::CheckpointContents> for CheckpointContents {
-    fn from(value: iota_sdk2::types::CheckpointContents) -> Self {
+impl From<iota_sdk_types::CheckpointContents> for CheckpointContents {
+    fn from(value: iota_sdk_types::CheckpointContents) -> Self {
         Self::merge_from(value, &FieldMaskTree::new_wildcard())
     }
 }
 
-impl Merge<iota_sdk2::types::CheckpointContents> for CheckpointContents {
-    fn merge(&mut self, source: iota_sdk2::types::CheckpointContents, mask: &FieldMaskTree) {
+impl Merge<iota_sdk_types::CheckpointContents> for CheckpointContents {
+    fn merge(&mut self, source: iota_sdk_types::CheckpointContents, mask: &FieldMaskTree) {
         if mask.contains(Self::BCS_FIELD.name) {
             self.bcs = Some(BcsData::serialize(&source).unwrap());
         }
@@ -92,7 +92,7 @@ impl Merge<&CheckpointContents> for CheckpointContents {
     }
 }
 
-impl TryFrom<&CheckpointContents> for iota_sdk2::types::CheckpointContents {
+impl TryFrom<&CheckpointContents> for iota_sdk_types::CheckpointContents {
     type Error = TryFromProtoError;
 
     fn try_from(value: &CheckpointContents) -> Result<Self, Self::Error> {
@@ -108,8 +108,8 @@ impl TryFrom<&CheckpointContents> for iota_sdk2::types::CheckpointContents {
 // Checkpoint
 //
 
-impl Merge<&iota_sdk2::types::CheckpointSummary> for Checkpoint {
-    fn merge(&mut self, source: &iota_sdk2::types::CheckpointSummary, mask: &FieldMaskTree) {
+impl Merge<&iota_sdk_types::CheckpointSummary> for Checkpoint {
+    fn merge(&mut self, source: &iota_sdk_types::CheckpointSummary, mask: &FieldMaskTree) {
         if mask.contains(Self::SEQUENCE_NUMBER_FIELD.name) {
             self.sequence_number = Some(source.sequence_number);
         }
@@ -120,10 +120,10 @@ impl Merge<&iota_sdk2::types::CheckpointSummary> for Checkpoint {
     }
 }
 
-impl Merge<iota_sdk2::types::ValidatorAggregatedSignature> for Checkpoint {
+impl Merge<iota_sdk_types::ValidatorAggregatedSignature> for Checkpoint {
     fn merge(
         &mut self,
-        source: iota_sdk2::types::ValidatorAggregatedSignature,
+        source: iota_sdk_types::ValidatorAggregatedSignature,
         mask: &FieldMaskTree,
     ) {
         if mask.contains(Self::SIGNATURE_FIELD.name) {
@@ -132,8 +132,8 @@ impl Merge<iota_sdk2::types::ValidatorAggregatedSignature> for Checkpoint {
     }
 }
 
-impl Merge<iota_sdk2::types::CheckpointContents> for Checkpoint {
-    fn merge(&mut self, source: iota_sdk2::types::CheckpointContents, mask: &FieldMaskTree) {
+impl Merge<iota_sdk_types::CheckpointContents> for Checkpoint {
+    fn merge(&mut self, source: iota_sdk_types::CheckpointContents, mask: &FieldMaskTree) {
         if let Some(submask) = mask.subtree(Self::CONTENTS_FIELD.name) {
             self.contents = Some(CheckpointContents::merge_from(source, &submask));
         }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/epoch.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/epoch.rs
@@ -13,8 +13,8 @@ use crate::{field::FieldMaskTree, merge::Merge, proto::TryFromProtoError};
 // ValidatorCommitteeMember
 //
 
-impl From<iota_sdk2::types::ValidatorCommitteeMember> for ValidatorCommitteeMember {
-    fn from(value: iota_sdk2::types::ValidatorCommitteeMember) -> Self {
+impl From<iota_sdk_types::ValidatorCommitteeMember> for ValidatorCommitteeMember {
+    fn from(value: iota_sdk_types::ValidatorCommitteeMember) -> Self {
         Self {
             public_key: Some(value.public_key.as_bytes().to_vec().into()),
             weight: Some(value.stake),
@@ -22,7 +22,7 @@ impl From<iota_sdk2::types::ValidatorCommitteeMember> for ValidatorCommitteeMemb
     }
 }
 
-impl TryFrom<&ValidatorCommitteeMember> for iota_sdk2::types::ValidatorCommitteeMember {
+impl TryFrom<&ValidatorCommitteeMember> for iota_sdk_types::ValidatorCommitteeMember {
     type Error = TryFromProtoError;
 
     fn try_from(
@@ -32,7 +32,7 @@ impl TryFrom<&ValidatorCommitteeMember> for iota_sdk2::types::ValidatorCommittee
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing("public_key"))?
             .as_ref()
-            .pipe(iota_sdk2::types::Bls12381PublicKey::from_bytes)
+            .pipe(iota_sdk_types::Bls12381PublicKey::from_bytes)
             .map_err(|e| {
                 TryFromProtoError::invalid(ValidatorCommitteeMember::PUBLIC_KEY_FIELD, e)
             })?;
@@ -45,8 +45,8 @@ impl TryFrom<&ValidatorCommitteeMember> for iota_sdk2::types::ValidatorCommittee
 // ValidatorCommittee
 //
 
-impl From<iota_sdk2::types::ValidatorCommittee> for ValidatorCommittee {
-    fn from(value: iota_sdk2::types::ValidatorCommittee) -> Self {
+impl From<iota_sdk_types::ValidatorCommittee> for ValidatorCommittee {
+    fn from(value: iota_sdk_types::ValidatorCommittee) -> Self {
         Self {
             epoch: Some(value.epoch),
             members: Some(ValidatorCommitteeMembers {
@@ -56,7 +56,7 @@ impl From<iota_sdk2::types::ValidatorCommittee> for ValidatorCommittee {
     }
 }
 
-impl TryFrom<&ValidatorCommittee> for iota_sdk2::types::ValidatorCommittee {
+impl TryFrom<&ValidatorCommittee> for iota_sdk_types::ValidatorCommittee {
     type Error = TryFromProtoError;
 
     fn try_from(value: &ValidatorCommittee) -> Result<Self, Self::Error> {

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/object.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/object.rs
@@ -13,8 +13,8 @@ use crate::{
 };
 
 // TODO: Wrap Object into a type with a version
-impl Merge<&iota_sdk2::types::object::Object> for Object {
-    fn merge(&mut self, source: &iota_sdk2::types::object::Object, mask: &FieldMaskTree) {
+impl Merge<&iota_sdk_types::object::Object> for Object {
+    fn merge(&mut self, source: &iota_sdk_types::object::Object, mask: &FieldMaskTree) {
         if mask.contains("bcs") {
             if let Ok(bcs_bytes) = bcs::to_bytes(source) {
                 self.bcs = Some(BcsData {

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/signatures.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/signatures.rs
@@ -11,15 +11,15 @@ use crate::{field::FieldMaskTree, merge::Merge, proto::TryFromProtoError, v0::bc
 // ValidatorAggregatedSignature
 //
 
-impl From<iota_sdk2::types::ValidatorAggregatedSignature> for ValidatorAggregatedSignature {
-    fn from(value: iota_sdk2::types::ValidatorAggregatedSignature) -> Self {
+impl From<iota_sdk_types::ValidatorAggregatedSignature> for ValidatorAggregatedSignature {
+    fn from(value: iota_sdk_types::ValidatorAggregatedSignature) -> Self {
         Self {
             bcs: Some(BcsData::serialize(&value).unwrap()),
         }
     }
 }
 
-impl TryFrom<&ValidatorAggregatedSignature> for iota_sdk2::types::ValidatorAggregatedSignature {
+impl TryFrom<&ValidatorAggregatedSignature> for iota_sdk_types::ValidatorAggregatedSignature {
     type Error = TryFromProtoError;
 
     fn try_from(value: &ValidatorAggregatedSignature) -> Result<Self, Self::Error> {
@@ -35,14 +35,14 @@ impl TryFrom<&ValidatorAggregatedSignature> for iota_sdk2::types::ValidatorAggre
 // UserSignature
 //
 
-impl From<iota_sdk2::types::UserSignature> for UserSignature {
-    fn from(value: iota_sdk2::types::UserSignature) -> Self {
+impl From<iota_sdk_types::UserSignature> for UserSignature {
+    fn from(value: iota_sdk_types::UserSignature) -> Self {
         Self::merge_from(value, &FieldMaskTree::new_wildcard())
     }
 }
 
-impl Merge<iota_sdk2::types::UserSignature> for UserSignature {
-    fn merge(&mut self, source: iota_sdk2::types::UserSignature, mask: &FieldMaskTree) {
+impl Merge<iota_sdk_types::UserSignature> for UserSignature {
+    fn merge(&mut self, source: iota_sdk_types::UserSignature, mask: &FieldMaskTree) {
         if mask.contains(Self::BCS_FIELD.name) {
             self.bcs = Some(BcsData::serialize(&source).unwrap());
         }
@@ -59,7 +59,7 @@ impl Merge<&UserSignature> for UserSignature {
     }
 }
 
-impl TryFrom<&UserSignature> for iota_sdk2::types::UserSignature {
+impl TryFrom<&UserSignature> for iota_sdk_types::UserSignature {
     type Error = TryFromProtoError;
 
     fn try_from(value: &UserSignature) -> Result<Self, Self::Error> {

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/types.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/types.rs
@@ -6,32 +6,8 @@ include!("../../../generated/iota.grpc.v0.types.rs");
 include!("../../../generated/iota.grpc.v0.types.field_info.rs");
 include!("../../../generated/iota.grpc.v0.types.accessors.rs");
 
-impl From<iota_sdk2::types::Digest> for Digest {
-    fn from(value: iota_sdk2::types::Digest) -> Self {
-        Self {
-            digest: value.into_inner().to_vec().into(),
-        }
-    }
-}
-
-impl From<iota_sdk2::types::CheckpointDigest> for Digest {
-    fn from(value: iota_sdk2::types::CheckpointDigest) -> Self {
-        Self {
-            digest: value.into_inner().to_vec().into(),
-        }
-    }
-}
-
-impl From<iota_sdk2::types::CheckpointContentsDigest> for Digest {
-    fn from(value: iota_sdk2::types::CheckpointContentsDigest) -> Self {
-        Self {
-            digest: value.into_inner().to_vec().into(),
-        }
-    }
-}
-
-impl From<iota_sdk2::types::ObjectDigest> for Digest {
-    fn from(value: iota_sdk2::types::ObjectDigest) -> Self {
+impl From<iota_sdk_types::Digest> for Digest {
+    fn from(value: iota_sdk_types::Digest) -> Self {
         Self {
             digest: value.into_inner().to_vec().into(),
         }


### PR DESCRIPTION
# Description of change

This PR fixes the compile errors in the gRPC feature branch introduced by the new `iota-sdk-types` in #9360.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes