### PR TITLE
refactor(graphql-rpc): resolve availability of transactions

### DIFF
--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -4603,11 +4603,12 @@ type TransactionBlockEffects {
 	"""
 	timestamp: DateTime
 	"""
-	The epoch this transaction was finalized in.
+	The epoch this transaction was executed in.
 	"""
 	epoch: Epoch
 	"""
-	The checkpoint this transaction was finalized in.
+	The checkpoint this transaction was finalized in, if it is within the
+	available range.
 	"""
 	checkpoint: Checkpoint
 	"""

--- a/crates/iota-graphql-rpc/src/consistency.rs
+++ b/crates/iota-graphql-rpc/src/consistency.rs
@@ -16,6 +16,9 @@ use crate::{
     },
 };
 
+/// The checkpoint sequence number for entities not available for view.
+pub(crate) const UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER: u64 = u64::MAX;
+
 #[derive(Copy, Clone)]
 pub(crate) enum View {
     /// Return objects that fulfill the filtering criteria, even if there are

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -29,6 +29,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     config::ServiceConfig,
     connection::ScanConnection,
+    consistency::UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER,
     data::{self, DataLoader, Db, DbConnection, QueryExecutor},
     error::Error,
     server::{builder::get_write_api, watermark_task::Watermark},
@@ -174,13 +175,15 @@ impl TransactionBlock {
     /// transaction block is a sponsored transaction block.
     async fn gas_input(&self, ctx: &Context<'_>) -> Option<GasInput> {
         let checkpoint_viewed_at =
-            if matches!(self.inner, TransactionBlockInner::Checkpointed { .. }) {
+            if matches!(self.inner, TransactionBlockInner::Checkpointed { .. })
+                && self.is_available()
+            {
                 self.checkpoint_viewed_at
             } else {
-                // Non-checkpointed transactions have a sentinel checkpoint_viewed_at value that
-                // generally prevents access to further queries, but inputs should
-                // generally be available so try to access them at the high
-                // watermark.
+                // Non-checkpointed and unavailable transactions have a sentinel
+                // checkpoint_viewed_at value that generally prevents access to
+                // further queries, but inputs should generally be available so
+                // try to access them at the high watermark.
                 let Watermark { checkpoint, .. } = *ctx.data_unchecked();
                 checkpoint
             };
@@ -485,6 +488,11 @@ impl TransactionBlock {
         }
 
         Ok(conn)
+    }
+
+    /// Returns whether this transaction block is within the available range.
+    pub(crate) fn is_available(&self) -> bool {
+        self.checkpoint_viewed_at < UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -538,22 +538,18 @@ impl Loader<DigestKey> for Db {
         for key in keys {
             let digest_bytes = key.digest.as_slice();
 
-            match transaction_digest_to_stored.get(digest_bytes) {
-                Some(stored)
-                    if (key.checkpoint_viewed_at as i64) >= stored.checkpoint_sequence_number =>
-                {
-                    // Filter by key's checkpoint viewed at here. Doing this in memory because it
-                    // should be quite rare that this query actually filters something,
-                    // but encoding it in SQL is complicated.
-                    let tx_block = TransactionBlock {
-                        inner: TransactionBlockInner::try_from(stored.clone())?,
-                        checkpoint_viewed_at: key.checkpoint_viewed_at,
-                    };
-                    results.insert(*key, tx_block);
+            if let Some(stored) = transaction_digest_to_stored.get(digest_bytes) {
+                let mut checkpoint_viewed_at = key.checkpoint_viewed_at;
+                if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
+                    checkpoint_viewed_at = UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER;
                 }
-                _ => {
-                    missing_digests.push(key.digest.to_vec());
-                }
+                let tx_block = TransactionBlock {
+                    inner: TransactionBlockInner::try_from(stored.clone())?,
+                    checkpoint_viewed_at,
+                };
+                results.insert(*key, tx_block);
+            } else {
+                missing_digests.push(key.digest.to_vec());
             }
         }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -588,7 +588,7 @@ impl Loader<DigestKey> for Db {
                 if let Some(optimistic) = transaction_digest_to_optimistic.get(digest_bytes) {
                     let tx_block = TransactionBlock {
                         inner: TransactionBlockInner::try_from(optimistic.clone())?,
-                        checkpoint_viewed_at: u64::MAX,
+                        checkpoint_viewed_at: UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER,
                     };
                     results.insert(*key, tx_block);
                 }

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -17,7 +17,7 @@ use iota_types::{
 };
 
 use crate::{
-    consistency::ConsistentIndexCursor,
+    consistency::{ConsistentIndexCursor, UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER},
     data::package_resolver::PackageResolver,
     error::Error,
     types::{
@@ -466,7 +466,7 @@ impl TransactionBlockEffects {
         Ok(Some(DateTime::from_ms(stored_tx.timestamp_ms)?))
     }
 
-    /// The epoch this transaction was finalized in.
+    /// The epoch this transaction was executed in.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
             ctx,
@@ -477,13 +477,17 @@ impl TransactionBlockEffects {
         .extend()
     }
 
-    /// The checkpoint this transaction was finalized in.
+    /// The checkpoint this transaction was finalized in, if it is within the
+    /// available range.
     async fn checkpoint(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
         // If the transaction data is not a checkpointed transaction, it's not in the
         // checkpoint yet so we return None.
         let TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } = &self.kind else {
             return Ok(None);
         };
+        if !self.is_available() {
+            return Ok(None);
+        }
 
         Checkpoint::query(
             ctx,
@@ -519,6 +523,11 @@ impl TransactionBlockEffects {
             TransactionBlockEffectsKind::DryRun { native, .. } => native,
             TransactionBlockEffectsKind::Executed { native, .. } => native,
         }
+    }
+
+    /// Returns whether the parent transaction is within the available range.
+    pub(crate) fn is_available(&self) -> bool {
+        self.checkpoint_viewed_at < UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER
     }
 }
 

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -4607,11 +4607,12 @@ type TransactionBlockEffects {
 	"""
 	timestamp: DateTime
 	"""
-	The epoch this transaction was finalized in.
+	The epoch this transaction was executed in.
 	"""
 	epoch: Epoch
 	"""
-	The checkpoint this transaction was finalized in.
+	The checkpoint this transaction was finalized in, if it is within the
+	available range.
 	"""
 	checkpoint: Checkpoint
 	"""


### PR DESCRIPTION
# Description of change

This patch introduces a way to resolve explicitly the availability of transactions. This refines the existing classification, by allowing checkpointed transaction to be either _available_ (i.e. within the available range of checkpoints) or _unavailable_. Availability can then be used for more granular control on the query results.

The dataloader of transactions now returns checkpointed transactions, flagging them as unavailable.

## Links to any relevant issues

Part of #9402

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

