### PR TITLE
feat(graphql-rpc): Optimize reading objects_history in consistent views

### DIFF
--- a/crates/iota-graphql-rpc/src/consistency.rs
+++ b/crates/iota-graphql-rpc/src/consistency.rs
@@ -119,21 +119,20 @@ pub(crate) fn build_objects_query(
     filter_fn: impl Fn(RawQuery) -> RawQuery,
     newer_criteria: impl Fn(RawQuery) -> RawQuery,
 ) -> RawQuery {
-    // Subquery to be used in `LEFT JOIN` against the inner queries for more recent
-    // object versions
-    let newer = newer_criteria(filter!(
-        query!("SELECT object_id, object_version FROM objects_history"),
-        format!(
-            r#"checkpoint_sequence_number BETWEEN {} AND {}"#,
-            range.first, range.last
-        )
-    ));
-
     let mut snapshot_objs_inner = query!("SELECT * FROM objects_snapshot");
     snapshot_objs_inner = filter_fn(snapshot_objs_inner);
 
     let mut snapshot_objs = match view {
         View::Consistent => {
+            // Subquery to be used in `LEFT JOIN` for more recent object versions
+            let newer = newer_criteria(filter!(
+                query!("SELECT object_id, object_version FROM objects_history"),
+                format!(
+                    r#"checkpoint_sequence_number BETWEEN {} AND {}"#,
+                    range.first, range.last
+                )
+            ));
+
             // The `LEFT JOIN` serves as a filter to remove objects that have a more recent
             // version
             let mut snapshot_objs = query!(
@@ -163,36 +162,44 @@ pub(crate) fn build_objects_query(
 
     // Similar to the snapshot query, construct the filtered inner query for the
     // history table.
-    let mut history_objs_inner = query!("SELECT * FROM objects_history");
-    history_objs_inner = filter_fn(history_objs_inner);
+    let mut history_window = query!("SELECT * FROM objects_history");
+    history_window = filter_fn(history_window);
 
     let mut history_objs = match view {
         View::Consistent => {
             // Additionally bound the inner `objects_history` query by the checkpoint range
-            history_objs_inner = filter!(
-                history_objs_inner,
+            history_window = filter!(
+                history_window,
                 format!(
                     r#"checkpoint_sequence_number BETWEEN {} AND {}"#,
                     range.first, range.last
                 )
             );
 
-            let mut history_objs = query!(
-                r#"SELECT candidates.* FROM ({}) candidates
-                    LEFT JOIN ({}) newer
-                    ON (candidates.object_id = newer.object_id AND candidates.object_version < newer.object_version)"#,
-                history_objs_inner,
-                newer
+            let newest = newer_criteria(filter!(
+                query!("SELECT object_id, MAX(object_version) AS max_version FROM objects_history"),
+                format!(
+                    r#"checkpoint_sequence_number BETWEEN {} AND {}"#,
+                    range.first, range.last
+                )
+            ))
+            .group_by("object_id");
+
+            let history_objs = query!(
+                r#"WITH history_window AS ({}),
+                    newest AS ({})
+                    SELECT candidates.* FROM history_window candidates
+                    JOIN newest
+                    ON candidates.object_id = newest.object_id
+                    AND candidates.object_version = newest.max_version"#,
+                history_window,
+                newest
             );
-            history_objs = filter!(history_objs, "newer.object_version IS NULL");
             history_objs
         }
         View::Historical => {
             // The cursor pagination logic refers to the table with the `candidates` alias
-            query!(
-                "SELECT candidates.* FROM ({}) candidates",
-                history_objs_inner
-            )
+            query!("SELECT candidates.* FROM ({}) candidates", history_window)
         }
     };
 


### PR DESCRIPTION
# Description of change

Optimize reading objects_history in consistent views.

The original approach was reading all matching (that passed `filter_fn` and the `range` check) rows from `objects_history` and then filtered them to leave only those that for given object_id DON'T have any other row in `objects_history` that satisfies `newer_criteria`, `range` check and that have higher version than selected row.

The filter we use when getting objects is different than the filter we use when trying to determine if it is the most recent version,  and this actually is relevant.

Imagine we have object A which at version 3 belongs to Bob, and at Version 5 belongs to Alice.
Now if we want to find all objects belonging to Bob, and in our available range we see A both in versions 3 and 5, we shouldn't return A:3 because that's the most recent version that satisfies the criteria but rather we should not return the object at all, because at the most recent version of it in our available range the object doesn't belong to Bob.

So the behaviour of the new query is like: "fetch all objects that match the criteria, but eventually return only those that happen to be the most recent version of given object in given checkpoint range", which should give the same results as the original approach. (the assumption for this is that `newer_criteria` will NOT filter out object version that should be returned, and it is the case in current codebase).

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/7296

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
