### PR TITLE
feat: bump `iota` to `v1.13.1-rc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,7 +1841,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "const-str",
  "git-version",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "iota"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5489,7 +5489,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-sdk-types",
  "iota-simulator",
  "iota-source-validation",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5570,7 +5570,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "arrow-array 53.1.0",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -5663,7 +5663,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5716,7 +5716,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -5759,7 +5759,7 @@ dependencies = [
 
 [[package]]
 name = "iota-build-cache-server"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5801,7 +5801,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-move-build",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-sdk-types",
  "iota-swarm",
  "iota-swarm-config",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5842,7 +5842,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5871,7 +5871,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5972,7 +5972,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6027,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6122,7 +6122,7 @@ dependencies = [
  "iota-node",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-sdk-types",
  "iota-simulator",
  "iota-storage",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "serde_yaml",
 ]
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6208,7 +6208,7 @@ dependencies = [
  "iota-keys",
  "iota-metrics",
  "iota-network-stack",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-sdk-types",
  "iota-types",
  "parking_lot 0.12.3",
@@ -6232,7 +6232,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6252,7 +6252,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6270,7 +6270,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6291,7 +6291,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6341,7 +6341,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6351,7 +6351,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6359,7 +6359,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6372,7 +6372,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6447,7 +6447,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6460,14 +6460,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "axum 0.8.4",
 ]
 
 [[package]]
 name = "iota-grpc-client"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "futures",
@@ -6481,7 +6481,7 @@ dependencies = [
 
 [[package]]
 name = "iota-grpc-server"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6504,7 +6504,7 @@ dependencies = [
 
 [[package]]
 name = "iota-grpc-types"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "bcs",
  "iota-json-rpc-types",
@@ -6518,7 +6518,7 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "axum 0.8.4",
  "bytes",
@@ -6539,7 +6539,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6604,7 +6604,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-streaming"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "async-trait",
  "futures",
@@ -6638,7 +6638,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6713,7 +6713,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6732,7 +6732,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6751,7 +6751,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6770,7 +6770,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6804,7 +6804,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "bip32",
@@ -6825,7 +6825,7 @@ dependencies = [
 
 [[package]]
 name = "iota-kvstore"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6864,7 +6864,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger-signer"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6872,7 +6872,7 @@ dependencies = [
  "bip32",
  "clap",
  "iota-ledger",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-sdk-types",
  "thiserror 1.0.64",
  "tokio",
@@ -6881,7 +6881,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6895,7 +6895,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-types",
  "move-core-types",
  "object_store 0.10.2",
@@ -6914,7 +6914,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -6924,7 +6924,7 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6936,7 +6936,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "backoff",
@@ -6957,7 +6957,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -7021,7 +7021,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -7042,7 +7042,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "bin-version",
  "clap",
@@ -7075,7 +7075,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7087,7 +7087,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -7126,7 +7126,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anemo",
  "bcs",
@@ -7155,7 +7155,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7208,7 +7208,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7232,7 +7232,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7244,7 +7244,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-alt"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "move-package-alt",
  "serde",
@@ -7252,7 +7252,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7268,13 +7268,13 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -7284,7 +7284,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7305,7 +7305,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -7315,7 +7315,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "clap",
  "insta",
@@ -7330,7 +7330,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7339,7 +7339,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7354,7 +7354,7 @@ dependencies = [
  "hex",
  "hyper 1.4.1",
  "iota-metrics",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-tls",
  "iota-types",
  "itertools 0.13.0",
@@ -7382,7 +7382,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7398,7 +7398,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-transaction-checks",
  "iota-types",
  "jsonrpsee",
@@ -7427,7 +7427,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7456,7 +7456,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-kv"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7483,7 +7483,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7500,7 +7500,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-sdk-types",
  "iota-swarm-config",
  "iota-types",
@@ -7524,7 +7524,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7534,7 +7534,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-sdk-types",
  "iota-types",
  "itertools 0.13.0",
@@ -7589,7 +7589,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7654,7 +7654,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7676,7 +7676,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7710,7 +7710,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7737,7 +7737,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "colored",
@@ -7747,7 +7747,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -7769,7 +7769,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7784,7 +7784,7 @@ dependencies = [
  "iota-move",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-source-validation",
  "move-core-types",
  "move-package",
@@ -7805,7 +7805,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7856,7 +7856,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "bcs",
  "clap",
@@ -7884,7 +7884,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "futures",
@@ -7911,7 +7911,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -7939,7 +7939,7 @@ dependencies = [
 
 [[package]]
 name = "iota-synthetic-ingestion"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7956,12 +7956,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-sdk-types",
  "iota-types",
  "move-core-types",
@@ -7969,7 +7969,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7991,7 +7991,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -8013,7 +8013,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -8036,7 +8036,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8052,7 +8052,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -8065,7 +8065,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8110,7 +8110,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8184,7 +8184,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8212,7 +8212,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11562,7 +11562,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13544,7 +13544,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14340,7 +14340,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -14427,7 +14427,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -14445,7 +14445,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.13.0-beta",
+ "iota-sdk 1.13.1-rc",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -15347,7 +15347,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -15419,7 +15419,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "bcs",
  "bincode",
@@ -15448,7 +15448,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -15458,7 +15458,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "serde",
  "thiserror 1.0.64",
@@ -15466,7 +15466,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "1.13.0-beta"
+version = "1.13.1-rc"
 
 [workspace.metadata.cargo-udeps.ignore]
 normal = ["move-package-alt"]

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -114,12 +114,12 @@ task 15, lines 64-69:
 //# run-graphql --show-usage --show-headers --show-service-version
 Headers: {
     "content-type": "application/graphql-response+json",
-    "x-iota-rpc-version": "1.13.0-testing-no-sha",
+    "x-iota-rpc-version": "1.13.1-testing-no-sha",
     "vary": "origin, access-control-request-method, access-control-request-headers",
     "access-control-allow-origin": "*",
     "content-length": "157",
 }
-Service version: 1.13.0-testing-no-sha
+Service version: 1.13.1-testing-no-sha
 Response: {
   "data": {
     "checkpoint": {

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "1.13.0-beta"
+    "version": "1.13.1-rc"
   },
   "methods": [
     {


### PR DESCRIPTION
# Description of change

Bump `iota` to `v1.13.1-rc` in preparation for `Testnet` release.
