### PR TITLE
fix(verifier): align authenticator checks to be the same as entry function

### DIFF
--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/receiving.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/receiving.snap
@@ -9,4 +9,4 @@ A: object(0,0)
 task 1, lines 8-25:
 //# publish --sender A
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A datatype instantiation must be an option of pure types, offending argument: StructInstantiation(DatatypeHandleIndex(5), [StructInstantiation(DatatypeHandleIndex(2), [Struct(DatatypeHandleIndex(3))])])"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function parameter type: iota::transfer::Receiving<iota::coin::Coin<iota::iota::IOTA>>. Receiving objects are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-types/src/lib.rs
+++ b/crates/iota-types/src/lib.rs
@@ -310,7 +310,7 @@ pub fn is_object_vector(
     }
 }
 
-fn is_object_struct(
+pub fn is_object_struct(
     view: &CompiledModule,
     function_type_args: &[AbilitySet],
     s: &SignatureToken,

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-25:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A datatype must be a string or an ID, offending argument: Struct(DatatypeHandleIndex(1))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: _::object::Object. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/object/mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-27:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(Struct(DatatypeHandleIndex(1)))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut _::object::Object. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A datatype must be a string or an ID, offending argument: Struct(DatatypeHandleIndex(1))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: std::option::Option<_::option::NonObject>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_immutable_ref.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-22:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9370800,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<_::option::NonObject>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/non_object_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(StructInstantiation(DatatypeHandleIndex(5), [Struct(DatatypeHandleIndex(1))]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<_::option::NonObject>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-28:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A datatype must be a string or an ID, offending argument: Struct(DatatypeHandleIndex(1))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: std::option::Option<_::option::Object>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_immutable_ref.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-24:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9142800,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<_::option::Object>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/object_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-24:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(StructInstantiation(DatatypeHandleIndex(5), [Struct(DatatypeHandleIndex(1))]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<_::option::Object>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_immutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_immutable_reference.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-20:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8876800,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<u8>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_mutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/primitive_mutable_reference.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(StructInstantiation(DatatypeHandleIndex(4), [U8]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<u8>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_immutable_ref.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-20:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8983200,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<T0>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_non_object_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(StructInstantiation(DatatypeHandleIndex(4), [TypeParameter(0)]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-24:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A type parameter cannot have the 'key' ability, offending argument: TypeParameter(0)"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: std::option::Option<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_immutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_immutable_reference.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-20:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9028800,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<T0>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_mutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/template_object_mutable_reference.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(StructInstantiation(DatatypeHandleIndex(4), [TypeParameter(0)]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-25:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A datatype instantiation must be an option of pure types, offending argument: StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)])"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: std::option::Option<_::option::NonObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_immutable_ref.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-25:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9712800,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<_::option::NonObjectTemplated<T0>>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_non_object_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-25:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(StructInstantiation(DatatypeHandleIndex(5), [StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)])]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<_::option::NonObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-30:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A datatype instantiation must be an option of pure types, offending argument: StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)])"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: std::option::Option<_::option::ObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_immutable_ref.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-25:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9576000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &std::option::Option<_::option::ObjectTemplated<T0>>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/option/templated_object_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-25:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(StructInstantiation(DatatypeHandleIndex(5), [StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)])]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut std::option::Option<_::option::ObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/by_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/by_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid account type. Account can only be a reference type, offending argument: MutableReference(StructInstantiation(DatatypeHandleIndex(3), [Struct(DatatypeHandleIndex(0))]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &mut iota::transfer::Receiving<_::receiving::Object>. Valid types for the first parameter are immutable references to an object type."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-27:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid account type. Account can only be a reference type, offending argument: StructInstantiation(DatatypeHandleIndex(3), [Struct(DatatypeHandleIndex(0))])"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: iota::transfer::Receiving<_::receiving::Object>. Valid types for the first parameter are immutable references to an object type."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/datatype_inst_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/datatype_inst_immutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-25:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid account type. Account can only be a Datatype, offending argument: Reference(StructInstantiation(DatatypeHandleIndex(5), [U8, StructInstantiation(DatatypeHandleIndex(3), [Struct(DatatypeHandleIndex(0))])]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &iota::vec_map::VecMap<u8, iota::transfer::Receiving<_::receiving::Object>>. Valid types for the first parameter are immutable references to an object type."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/immutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid account type. Account can only be a Datatype, offending argument: Reference(StructInstantiation(DatatypeHandleIndex(3), [Struct(DatatypeHandleIndex(0))]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &iota::transfer::Receiving<_::receiving::Object>. Valid types for the first parameter are immutable references to an object type."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_immutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-24:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid account type. Account can only be a Datatype, offending argument: Reference(StructInstantiation(DatatypeHandleIndex(5), [StructInstantiation(DatatypeHandleIndex(3), [Struct(DatatypeHandleIndex(0))])]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &std::option::Option<iota::transfer::Receiving<_::receiving::Object>>. Valid types for the first parameter are immutable references to an object type."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/option_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-24:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid account type. Account can only be a reference type, offending argument: MutableReference(StructInstantiation(DatatypeHandleIndex(5), [StructInstantiation(DatatypeHandleIndex(3), [Struct(DatatypeHandleIndex(0))])]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &mut std::option::Option<iota::transfer::Receiving<_::receiving::Object>>. Valid types for the first parameter are immutable references to an object type."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_immutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-24:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid account type. Account can only be a Datatype, offending argument: Reference(Vector(StructInstantiation(DatatypeHandleIndex(3), [Struct(DatatypeHandleIndex(0))])))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &vector<iota::transfer::Receiving<_::receiving::Object>>. Valid types for the first parameter are immutable references to an object type."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/receiving/vector_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid account type. Account can only be a reference type, offending argument: MutableReference(Vector(StructInstantiation(DatatypeHandleIndex(3), [Struct(DatatypeHandleIndex(0))])))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &mut vector<iota::transfer::Receiving<_::receiving::Object>>. Valid types for the first parameter are immutable references to an object type."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/account_cant_be_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/account_cant_be_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-19:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid account type. Account can only be a reference type, offending argument: MutableReference(Struct(DatatypeHandleIndex(0)))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: &mut _::signature::Account. Valid types for the first parameter are immutable references to an object type."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/account_cant_be_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/account_cant_be_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-18:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid account type. Account can only be a reference type, offending argument: Struct(DatatypeHandleIndex(0))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: _::signature::Account. Valid types for the first parameter are immutable references to an object type."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/account_isnt_struct.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/account_isnt_struct.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-15:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid account type. Account can only be a reference type, offending argument: U64"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid authenticator function account type: u64. Valid types for the first parameter are immutable references to an object type."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_cant_be_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_cant_be_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-19:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'auth_context_cant_be_mutable_ref' can only receive\n            'AuthContext' as immutable reference"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'auth_context_cant_be_mutable_ref' can only receive 'AuthContext' as immutable reference"), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_cant_be_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_cant_be_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-15:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'auth_context_cant_be_value' can only receive\n            'AuthContext' as immutable reference"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'auth_context_cant_be_value' can only receive 'AuthContext' as immutable reference"), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_isnt_struct.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/auth_context_isnt_struct.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-15:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'auth_context_isnt_struct' can only receive\n            'AuthContext' as immutable reference"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Authenticator function 'auth_context_isnt_struct' can only receive 'AuthContext' as immutable reference"), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/with_signer.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/signature/with_signer.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-15:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. Signer is not a pure type, offending argument: Signer"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: signer. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A type parameter cannot have the 'key' ability, offending argument: TypeParameter(0)"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: T0. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/object_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(TypeParameter(0))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut T0. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-25:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A datatype instantiation must be an option of pure types, offending argument: StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)])"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: _::template::NonObjectTemplated<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_immutable_ref.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-25:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9424000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &_::template::NonObjectTemplated<T0>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_non_object_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-25:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut _::template::NonObjectTemplated<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-28:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A datatype instantiation must be an option of pure types, offending argument: StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)])"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: _::template::ObjectTemplated<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_immutable_ref.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-25:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9279600,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &_::template::ObjectTemplated<T0>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/template/templated_object_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-25:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)]))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut _::template::ObjectTemplated<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A datatype must be a string or an ID, offending argument: Struct(DatatypeHandleIndex(1))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: vector<_::vector::NonObject>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_immutable_ref.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-22:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8990800,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<_::vector::NonObject>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/non_object_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(Vector(Struct(DatatypeHandleIndex(1))))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<_::vector::NonObject>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-26:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A datatype must be a string or an ID, offending argument: Struct(DatatypeHandleIndex(1))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: vector<_::vector::Object>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_immutable_ref.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-24:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8770400,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<_::vector::Object>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/object_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-24:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(Vector(Struct(DatatypeHandleIndex(1))))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<_::vector::Object>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_immutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_immutable_reference.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-20:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8504400,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<u8>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_mutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/primitive_mutable_reference.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(Vector(U8))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<u8>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_immutable_ref.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-20:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8610800,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<T0>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_non_object_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(Vector(TypeParameter(0)))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-22:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A type parameter cannot have the 'key' ability, offending argument: TypeParameter(0)"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: vector<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_immutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_immutable_reference.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-20:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8656400,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<T0>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_mutable_reference.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/template_object_mutable_reference.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-20:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(Vector(TypeParameter(0)))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<T0>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-24:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A datatype instantiation must be an option of pure types, offending argument: StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)])"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: vector<_::vector::NonObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_immutable_ref.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-24:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9340400,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<_::vector::NonObjectTemplated<T0>>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_non_object_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-24:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(Vector(StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)])))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<_::vector::NonObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_by_value.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_by_value.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-29:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. A datatype instantiation must be an option of pure types, offending argument: StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)])"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: vector<_::vector::ObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_immutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_immutable_ref.snap
@@ -5,6 +5,5 @@ processed 1 task
 
 task 0, lines 4-24:
 //# publish
-created: object(1,0), object(1,1)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9196000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &vector<_::vector::ObjectTemplated<T0>>.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_mutable_ref.snap
+++ b/crates/iota-verifier-transactional-tests/tests/authenticator_functions/vector/templated_object_mutable_ref.snap
@@ -6,4 +6,4 @@ processed 1 task
 task 0, lines 4-24:
 //# publish
 Error: Transaction Effects Status: IOTA Move Bytecode Verification Error. Please run the IOTA Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid pure type. MutableReference is not a pure type, offending argument: MutableReference(Vector(StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)])))"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: IotaMoveVerificationError, source: Some("Invalid parameter type for authenticator function: &mut vector<_::vector::ObjectTemplated<T0>>. Valid types are immutable references to objects or primitive types."), command: Some(0) } }

--- a/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
@@ -170,7 +170,7 @@ fn verify_authenticate_account_type(
 /// function. Check that:
 /// - no Receiving objects are passed at all;
 /// - no objects are passed by value or by mutable reference, but only by
-///  immutable reference;
+///   immutable reference;
 /// - only primitive types are allowed by value.
 fn verify_authenticate_param_type(
     module: &CompiledModule,

--- a/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
@@ -3,31 +3,29 @@
 
 /// Account authenticator verifier
 ///
-/// This module contains the verifier for the `authenticate` function used
+/// This module contains the verifier for the authenticator function used
 /// by account objects to verify access to the account. The verifier checks
 /// that the function signature matches the expected signature for an
-/// `authenticate` function.
+/// authenticator function.
 use iota_types::{
     Identifier,
     auth_context::{AuthContext, AuthContextKind},
-    base_types::{
-        RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TxContext, TxContextKind,
-    },
+    base_types::{TxContext, TxContextKind},
     error::ExecutionError,
-    id::RESOLVED_IOTA_ID,
-    transfer::RESOLVED_RECEIVING_STRUCT,
+    is_object_struct, is_primitive,
+    transfer::Receiving,
 };
 use move_binary_format::{
     CompiledModule,
     file_format::{AbilitySet, SignatureToken, Visibility},
 };
-use move_bytecode_utils::resolve_struct;
+use move_bytecode_utils::format_signature_token;
 
 use crate::verification_failure;
 
-/// Verify if a given function can be used as an `authenticate` function
+/// Verify if a given function can be used as an authenticator function
 ///
-/// A function is an authenticate function if:
+/// A function is an authenticator function if:
 /// - only has read-only inputs (immutable owned/shared references or pure
 ///   types)
 /// - has no return type
@@ -78,7 +76,8 @@ pub fn verify_authenticate_func_v1(
     // Additional restrictions on the first argument type are enforced in the
     // following check.
     let account_parameter = &function_signature.0[0];
-    verify_authenticate_account_type(module, account_parameter).map_err(verification_failure)?;
+    verify_authenticate_account_type(module, &function_handle.type_parameters, account_parameter)
+        .map_err(verification_failure)?;
 
     // Check params 2nd to N-2th /////////////////////////////
 
@@ -102,7 +101,7 @@ pub fn verify_authenticate_func_v1(
     let tx_context = &function_signature.0[function_signature.len() - 1];
 
     // AuthContext could potentially be passed as value, but that opens up the
-    // possibility for the `authenticate` function to receive it as mutable
+    // possibility for the authenticator function to receive it as mutable
     // value, from which it could mutate before passing it to further `authenticate`
     // functions, so similarly to TxContext, it is simply not allowed.
     if !matches!(
@@ -110,13 +109,12 @@ pub fn verify_authenticate_func_v1(
         AuthContextKind::Immutable
     ) {
         return Err(verification_failure(format!(
-            "Authenticator function '{function_identifier}' can only receive
-            'AuthContext' as immutable reference"
+            "Authenticator function '{function_identifier}' can only receive 'AuthContext' as immutable reference"
         )));
     }
 
     // TxContext can only be an immutable reference. Passing it as mutable would
-    // allow `authenticate` functions to create objects, which would be
+    // allow authenticator functions to create objects, which would be
     // problematic.
     if !matches!(
         TxContext::kind(module, tx_context),
@@ -139,80 +137,41 @@ pub fn verify_authenticate_func_v1(
     Ok(())
 }
 
-/// Verify that the first parameter type of the authenticate function is an
+/// Verify that the first parameter type of the authenticator function is an
 /// immutable reference to an Object type, i.e., a Datatype with `key` ability.
 fn verify_authenticate_account_type(
     module: &CompiledModule,
+    function_type_args: &[AbilitySet],
     param: &SignatureToken,
 ) -> Result<(), String> {
     use SignatureToken::*;
 
-    match param {
-        Reference(ref_param) => match &**ref_param {
-            Datatype(i) => {
-                if module.datatype_handle_at(*i).abilities.has_key() {
-                    Ok(())
-                } else {
-                    Err(format!(
-                        "Invalid account type. Account must be a Datatype with key ability, offending argument: {param:?}"
-                    ))
-                }
-            }
-            _ => Err(format!(
-                "Invalid account type. Account can only be a Datatype, offending argument: {param:?}"
-            )),
-        },
-        _ => Err(format!(
-            "Invalid account type. Account can only be a reference type, offending argument: {param:?}"
-        )),
-    }
-}
-
-/// Verify that the parameter type when it is an immutable reference.
-/// An immutable reference is valid for an authenticate function in any case
-/// except for the `iota::transfer::Receiving` struct
-fn verify_immutable_reference(
-    module: &CompiledModule,
-    param: &SignatureToken,
-) -> Result<(), String> {
-    use SignatureToken::*;
-
-    match param {
-        U8 | U16 | U32 | U64 | U128 | U256 | Bool | Address | Datatype(_) | TypeParameter(_) => {
-            Ok(())
-        }
-        Vector(inner) => verify_immutable_reference(module, inner),
-        DatatypeInstantiation(datatype_instance) => {
-            let (idx, type_args) = &**datatype_instance;
-            let resolved_struct = resolve_struct(module, *idx);
-            if resolved_struct == RESOLVED_RECEIVING_STRUCT {
-                Err(format!(
-                    "Invalid immutable reference. A datatype instantiation must NOT be a receiving struct, offending argument: {param:?}"
-                ))
-            } else {
-                for type_arg in type_args.iter() {
-                    verify_immutable_reference(module, type_arg)?
-                }
-                Ok(())
+    // Check that the parameter is an immutable reference
+    if let Reference(ref_param) = param {
+        // Check that the referenced type is a Datatype or DatatypeInstantiation
+        if let Datatype(_) | DatatypeInstantiation(_) = &**ref_param {
+            // Check that the referenced type is an object struct
+            let abilities = module
+                .abilities(ref_param, function_type_args)
+                .map_err(|vm_err| vm_err.to_string())?;
+            // If it has the `key` ability, it's an object struct
+            if abilities.has_key() {
+                return Ok(());
             }
         }
-        Signer => Err(format!(
-            "Invalid immutable reference. Signer cannot be immutably referenced, offending argument: {param:?}"
-        )),
-        Reference(_) => Err(format!(
-            "Invalid immutable reference. Reference cannot be immutably referenced, offending argument: {param:?}"
-        )),
-        MutableReference(_) => Err(format!(
-            "Invalid immutable reference. MutableReference cannot be immutably referenced, offending argument: {param:?}"
-        )),
     }
+    Err(format!(
+        "Invalid authenticator function account type: {}. Valid types for the first parameter are immutable references to an object type.",
+        format_signature_token(module, param),
+    ))
 }
 
-/// Verify that the parameter type is a valid type for an `authenticate`
-/// function The parameter type can be:
-/// - an immutable reference to anything but a receiving object (see
-///   [verify_immutable_reference])
-/// - a pure input type (see [verify_pure_input_type])
+/// Verify that the parameter type is a valid type for an authenticator
+/// function. Check that:
+/// - no Receiving objects are passed at all;
+/// - no objects are passed by value or by mutable reference, but only by
+///  immutable reference;
+/// - only primitive types are allowed by value.
 fn verify_authenticate_param_type(
     module: &CompiledModule,
     function_type_args: &[AbilitySet],
@@ -220,113 +179,34 @@ fn verify_authenticate_param_type(
 ) -> Result<(), String> {
     use SignatureToken::*;
 
-    match param {
-        Reference(ref_param) => verify_immutable_reference(module, ref_param),
-        _ => verify_pure_input_type(module, function_type_args, param),
+    // Reject receiving objects even if passed by immutable reference
+    if Receiving::is_receiving(module, param) {
+        return Err(format!(
+            "Invalid authenticator function parameter type: {}. Receiving objects are invalid. Valid types are immutable references to objects or primitive types.",
+            format_signature_token(module, param),
+        ));
     }
-}
-
-/// Evaluate that signature type is of [pure input](https://docs.iota.org/developer/iota-101/transactions/ptb/programmable-transaction-blocks#inputs)
-///
-/// ATTENTION!///
-/// This check implements a very loose definition of a pure type, because it is
-/// based on the assumption that the authenticate function is executed
-/// equivalently to a PTB with a single command.
-/// 1. This means that potentially, a parameter of type `T`, with `T` being a
-///    generic, would be accepted by the check of this verify function even if
-///    the instance of `T` is not pure by definition. An example is passing an
-///    instance of the `Simple` as concrete type of T; in this case, `Simple` is
-///    not considered pure. This verify function works as this because it is
-///    executed in a moment in which the concrete types of a generic are not
-///    known. However, since the authenticate function is executed equivalently
-///    to a PTB with a single command, this assures that only pure types and
-///    objects can actually be passed by design. So the case of having ´Simple´
-///    as concrete type of `T` cannot exist.
-/// 2. Moreover, this check assures that no object can be passed as concrete
-///    type of a generic `T` because in the constraints of every generic it
-///    checks that the `key` ability is not set. This is not enough because a
-///    case like this could happen `fn authenticate()<T>(...)` where the key
-///    constraint is not set. In this case the compiler helps us by forcing the
-///    `T` concrete type to have a `drop` ability. To calm the compiler down the
-///    function `authenticate` must either:
-///    1. not use the `<T: drop>` constraint and return the parameter with type
-///       `T` -> this is not allowed by design, as an authenticate function has
-///       no returns;
-///    2. not use the `<T: drop>` constraint but the `<T: key>` constraint ->
-///       this is not allowed by this verify function;
-///    3. use the `<T: drop>` constraint -> this means no object type can be
-///       used as concrete type because an object with `drop` ability cannot
-///       exist.
-///
-///
-/// A parameter is considered `pure input` if that can't be used to modify
-/// ledger state in any way, i.e., not an object, and that can be constructed
-/// before calling the function itself.
-///
-/// A general struct, with no unresolved template arguments:
-/// ```move
-/// public struct Simple has store {
-///   a: u8,
-///   some_vec: vector<ascii::String>
-/// }
-/// ```
-/// is not considered a `pure input` either as it is not a built-in type so it
-/// can't be constructed before the (single) PTB move call itself. On
-/// the contrary std::ascii::String and std::string::String are okay.
-/// On a similar notion a simple `vector<T>` and an `Option<T>` are both also
-/// acceptable as they are built-in move types with rust side counterpart as
-/// long as `T` is recursively `pure` as well.
-fn verify_pure_input_type(
-    module: &CompiledModule,
-    function_type_args: &[AbilitySet],
-    param: &SignatureToken,
-) -> Result<(), String> {
-    use SignatureToken::*;
 
     match param {
-        U8 | U16 | U32 | U64 | U128 | U256 | Bool | Address => Ok(()),
-        Vector(inner) => verify_pure_input_type(module, function_type_args, inner),
-        Datatype(handle_index) => {
-            let resolved_struct = resolve_struct(module, *handle_index);
-            if resolved_struct == RESOLVED_ASCII_STR
-                || resolved_struct == RESOLVED_UTF8_STR
-                || resolved_struct == RESOLVED_IOTA_ID
-            {
+        Reference(inner) => {
+            if is_object_struct(module, function_type_args, inner)? {
                 Ok(())
             } else {
                 Err(format!(
-                    "Invalid pure type. A datatype must be a string or an ID, offending argument: {param:?}"
+                    "Invalid parameter type for authenticator function: {}.  Non object immutable references are invalid. Valid types are immutable references to objects or primitive types.",
+                    format_signature_token(module, param)
                 ))
             }
         }
-        DatatypeInstantiation(datatype_instance) => {
-            let (idx, type_args) = &**datatype_instance;
-            let resolved_struct = resolve_struct(module, *idx);
-            if resolved_struct == RESOLVED_STD_OPTION && type_args.len() == 1 {
-                verify_pure_input_type(module, function_type_args, &type_args[0])
-            } else {
-                Err(format!(
-                    "Invalid pure type. A datatype instantiation must be an option of pure types, offending argument: {param:?}"
-                ))
-            }
-        }
-        TypeParameter(idx) => {
-            if function_type_args[*idx as usize].has_key() {
-                Err(format!(
-                    "Invalid pure type. A type parameter cannot have the 'key' ability, offending argument: {param:?}"
-                ))
-            } else {
+        _ => {
+            if is_primitive(module, function_type_args, param) {
                 Ok(())
+            } else {
+                Err(format!(
+                    "Invalid parameter type for authenticator function: {}. Valid types are immutable references to objects or primitive types.",
+                    format_signature_token(module, param)
+                ))
             }
         }
-        Signer => Err(format!(
-            "Invalid pure type. Signer is not a pure type, offending argument: {param:?}"
-        )),
-        Reference(_) => Err(format!(
-            "Invalid pure type. Reference is not a pure type, offending argument: {param:?}"
-        )),
-        MutableReference(_) => Err(format!(
-            "Invalid pure type. MutableReference is not a pure type, offending argument: {param:?}"
-        )),
     }
 }


### PR DESCRIPTION
# Description of change

Simplify authenticator fn checks and make them similar to an entry function checks, without requiring the function to have the `entry` modifier.

## Links to any relevant issues

Fixes #9512 

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
