### PR TITLE
feat(dev-tools/grafana-local): quick docker-compose to examine prometheus snapshots

### DIFF
--- a/dev-tools/grafana-local/README.md
+++ b/dev-tools/grafana-local/README.md
@@ -14,3 +14,31 @@ Take care of the ports alignment in `tempo.yaml` and `docker-compose.yaml`. The 
 
 To navigate to the Tempo UI, open Grafana and go to "Data Sources". Select "Explore" in Tempo block and you can start querying spans.
 <img src="./grafana-datasources-tempo.png" width="100%"/>
+
+## Examining prometheus snapshots
+
+1. Extract the snapshot tarball
+
+```bash
+tar czf prometheus-backup.tar.gz /path/to/extracted/snapshot
+```
+
+2. export the `SNAPSHOT_DIR_PATH` environment variable to point to the extracted snapshot directory
+
+```bash
+export SNAPSHOT_DIR_PATH=/path/to/extracted/snapshot
+```
+
+3. Run the following command to start a local grafana and prometheus instance with the snapshot
+
+```bash
+docker compose -f docker-compose.prom-snapshot.yaml up -d
+```
+
+4. Access grafana at `http://localhost:3000`
+
+5. Remove the local grafana and prometheus instance after use
+
+```bash
+docker compose -f docker-compose.prom-snapshot.yaml down
+```

--- a/dev-tools/grafana-local/docker-compose.prom-snapshot.yaml
+++ b/dev-tools/grafana-local/docker-compose.prom-snapshot.yaml
@@ -1,39 +1,18 @@
 services:
-  tempo:
-    image: grafana/tempo:latest
-    command: ["-config.file=/etc/tempo.yaml"]
-    volumes:
-      - ./tempo.yaml:/etc/tempo.yaml
-      - ./tempo-data:/tmp/tempo
-    networks:
-      iota-network:
-    ports:
-      - "14268:14268" # jaeger ingest
-      - "3200:3200" # tempo
-      - "9095:9095" # tempo grpc
-      - "4317:4317" # otlp grpc
-      - "4318:4318" # otlp http
-      - "9411:9411" # zipkin
   prometheus:
     image: prom/prometheus:latest
     user: "0:0"
     command:
       - --config.file=/etc/prometheus.yaml
       - --storage.tsdb.path=/prometheus
-    networks:
-      iota-network:
     volumes:
       - ./prometheus-snapshot.yaml:/etc/prometheus.yaml:ro
       - ${SNAPSHOT_DIR_PATH}:/prometheus
     ports:
       - "9090:9090"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
 
   grafana:
     image: grafana/grafana:10.1.1
-    networks:
-      iota-network:
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
       - ./dashboards:/etc/grafana/provisioning/dashboards
@@ -41,28 +20,6 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
-      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor,tempoServiceGraph
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/provisioning/dashboards/cluster-status-dashboard.json
     ports:
       - "3000:3000"
-
-  node-exporter:
-    image: prom/node-exporter:latest
-    container_name: node-exporter
-    restart: unless-stopped
-    networks:
-      iota-network:
-    volumes:
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
-      - /:/rootfs:ro
-    command:
-      - "--path.procfs=/host/proc"
-      - "--path.rootfs=/rootfs"
-      - "--path.sysfs=/host/sys"
-      - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
-    ports:
-      - "9100:9100"
-networks:
-  iota-network:
-    name: prom-snapshot_iota-network
-    external: false

--- a/dev-tools/grafana-local/docker-compose.prom-snapshot.yaml
+++ b/dev-tools/grafana-local/docker-compose.prom-snapshot.yaml
@@ -1,0 +1,68 @@
+services:
+  tempo:
+    image: grafana/tempo:latest
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+      - ./tempo-data:/tmp/tempo
+    networks:
+      iota-network:
+    ports:
+      - "14268:14268" # jaeger ingest
+      - "3200:3200" # tempo
+      - "9095:9095" # tempo grpc
+      - "4317:4317" # otlp grpc
+      - "4318:4318" # otlp http
+      - "9411:9411" # zipkin
+  prometheus:
+    image: prom/prometheus:latest
+    user: "0:0"
+    command:
+      - --config.file=/etc/prometheus.yaml
+      - --storage.tsdb.path=/prometheus
+    networks:
+      iota-network:
+    volumes:
+      - ./prometheus-snapshot.yaml:/etc/prometheus.yaml:ro
+      - ${SNAPSHOT_DIR_PATH}:/prometheus
+    ports:
+      - "9090:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:10.1.1
+    networks:
+      iota-network:
+    volumes:
+      - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - ./dashboards:/etc/grafana/provisioning/dashboards
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor,tempoServiceGraph
+    ports:
+      - "3000:3000"
+
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter
+    restart: unless-stopped
+    networks:
+      iota-network:
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
+    ports:
+      - "9100:9100"
+networks:
+  iota-network:
+    name: prom-snapshot_iota-network
+    external: false

--- a/dev-tools/grafana-local/prometheus-snapshot.yaml
+++ b/dev-tools/grafana-local/prometheus-snapshot.yaml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 1h
+  evaluation_interval: 1h
+
+# No scrape jobs -> Prometheus will NOT ingest anything new,
+# it will only serve the data from the snapshot.
+scrape_configs: []


### PR DESCRIPTION
# Description of change
Adds a simple docker compose file to easily deploy the local grafana and prometheus instances with a downloaded prometheus snapshot.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
