### PR TITLE
chore: remove spammy warnings in move tests

### DIFF
--- a/crates/iota-adapter-transactional-tests/tests/upgrade/add_ability_during_upgrade.move
+++ b/crates/iota-adapter-transactional-tests/tests/upgrade/add_ability_during_upgrade.move
@@ -12,7 +12,6 @@ module Test_V0::base {
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
-    use iota::object::UID;
     public struct Foo has key {
         id: UID
     }
@@ -50,7 +49,6 @@ module Test_V1::base {
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
-    use iota::object::UID;
     public struct Foo has store, key {
         id: UID
     }

--- a/crates/iota-adapter-transactional-tests/tests/upgrade/add_ability_during_upgrade.move
+++ b/crates/iota-adapter-transactional-tests/tests/upgrade/add_ability_during_upgrade.move
@@ -12,6 +12,7 @@ module Test_V0::base {
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
+    use iota::object::UID;
     public struct Foo has key {
         id: UID
     }
@@ -49,6 +50,7 @@ module Test_V1::base {
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
+    use iota::object::UID;
     public struct Foo has store, key {
         id: UID
     }

--- a/crates/iota-benchmark/src/workloads/data/adversarial/sources/adversarial.move
+++ b/crates/iota-benchmark/src/workloads/data/adversarial/sources/adversarial.move
@@ -3,11 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module adversarial::adversarial {
-    use std::vector;
     use iota::bcs;
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer;
     use iota::event;
     use iota::dynamic_field::{add, borrow};
     use std::string::Self;

--- a/crates/iota-core/src/unit_tests/data/depends_on_basics/sources/depends_on_basics.move
+++ b/crates/iota-core/src/unit_tests/data/depends_on_basics/sources/depends_on_basics.move
@@ -6,7 +6,6 @@
 /// along with your own.
 module depends::depends_on_basics {
     use examples::object_basics;
-    use iota::tx_context::TxContext;
 
     public entry fun delegate(ctx: &mut TxContext) {
         object_basics::share(ctx);

--- a/crates/iota-core/src/unit_tests/data/entry_point_types/sources/entry_point_types.move
+++ b/crates/iota-core/src/unit_tests/data/entry_point_types/sources/entry_point_types.move
@@ -5,10 +5,6 @@
 module entry_point_types::entry_point_types {
     use std::ascii;
     use std::string;
-    use iota::tx_context::TxContext;
-    use std::vector;
-    use std::option::Option;
-
 
     public entry fun ascii_arg(s: ascii::String, len: u64, _: &mut TxContext) {
         assert!(ascii::length(&s) == len, 0);

--- a/crates/iota-core/src/unit_tests/data/entry_point_vector/sources/objects_vector.move
+++ b/crates/iota-core/src/unit_tests/data/entry_point_vector/sources/objects_vector.move
@@ -3,11 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module entry_point_vector::entry_point_vector {
-    use iota::object::{Self, UID};
-    use iota::transfer;
-    use iota::tx_context::{Self, TxContext};
-    use std::vector;
-
     public struct Obj has key, store {
         id: UID,
         value: u64

--- a/crates/iota-core/src/unit_tests/data/managed_coin/sources/managed.move
+++ b/crates/iota-core/src/unit_tests/data/managed_coin/sources/managed.move
@@ -4,12 +4,8 @@
 
 /// A module to test coin index.
 module fungible_tokens::managed {
-    use std::option;
     use iota::coin::{Self, Coin, TreasuryCap};
-    use iota::transfer;
-    use iota::object::{Self, UID};
     use iota::table_vec::{Self, TableVec};
-    use iota::tx_context::{Self, TxContext};
 
     public struct PublicRedEnvelope has key, store {
         id: UID,

--- a/crates/iota-core/src/unit_tests/data/move_random/sources/move_random.move
+++ b/crates/iota-core/src/unit_tests/data/move_random/sources/move_random.move
@@ -3,11 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module examples::move_random {
-    use std::vector;
-    use iota::object::{Self, UID};
-    use iota::transfer;
-    use iota::tx_context::TxContext;
-
     public struct Object has key, store {
         id: UID,
         data: vector<u64>,

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/makes_another_object/sources/base.move
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/makes_another_object/sources/base.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module base_addr::base {
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer;
     use iota::event;
 
     public struct A<T> {

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/makes_new_object/sources/base.move
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/makes_new_object/sources/base.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module base_addr::base {
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer;
     use iota::event;
 
     public struct A<T> {

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/new_object/sources/base.move
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/new_object/sources/base.move
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module base_addr::base {
-    use iota::object::UID;
-
     public struct A<T> {
         f1: bool,
         f2: T

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/object_cross_module_ref/sources/base.move
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/object_cross_module_ref/sources/base.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module base_addr::base {
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer;
     use base_addr::friend_module::{Self, X};
 
     public struct A has store, drop {

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/object_cross_module_ref1/sources/base.move
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/object_cross_module_ref1/sources/base.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module base_addr::base {
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer;
     use base_addr::friend_module::{Self, X, Z};
 
     public struct A has store, drop {

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/object_cross_module_ref2/sources/base.move
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/object_cross_module_ref2/sources/base.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module base_addr::base {
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer;
     use base_addr::friend_module::{Self, X, Y, Z};
 
     public struct A has store, drop {

--- a/crates/iota-core/src/unit_tests/data/object_basics/sources/object_basics.move
+++ b/crates/iota-core/src/unit_tests/data/object_basics/sources/object_basics.move
@@ -9,9 +9,6 @@ module examples::object_basics {
     use iota::random::Random;
     use iota::dynamic_object_field as ofield;
     use iota::event;
-    use iota::object::{Self, UID, ID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer;
 
     public struct Object has key, store {
         id: UID,

--- a/crates/iota-core/src/unit_tests/data/object_owner/sources/object_owner.move
+++ b/crates/iota-core/src/unit_tests/data/object_owner/sources/object_owner.move
@@ -3,12 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module object_owner::object_owner {
-    use std::option::{Self, Option};
     use iota::dynamic_object_field;
     use iota::dynamic_field;
-    use iota::object::{Self, ID, UID};
-    use iota::transfer;
-    use iota::tx_context::{Self, TxContext};
 
     public struct Parent has key {
         id: UID,

--- a/crates/iota-core/src/unit_tests/data/object_wrapping/sources/object_wrapping.move
+++ b/crates/iota-core/src/unit_tests/data/object_wrapping/sources/object_wrapping.move
@@ -3,11 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module object_wrapping::object_wrapping {
-    use std::option::{Self, Option};
-    use iota::transfer;
-    use iota::tx_context::{Self, TxContext};
-    use iota::object::{Self, UID};
-
     public struct Child has key, store {
         id: UID,
     }

--- a/crates/iota-core/src/unit_tests/data/publish_with_event/sources/publish.move
+++ b/crates/iota-core/src/unit_tests/data/publish_with_event/sources/publish.move
@@ -6,7 +6,6 @@ module examples::publish_with_event {
     use std::ascii::{Self, String};
 
     use iota::event;
-    use iota::tx_context::TxContext;
 
     public struct PublishEvent has copy, drop {
         foo: String

--- a/crates/iota-core/src/unit_tests/data/shared_object_deletion/sources/shared_object_deletion.move
+++ b/crates/iota-core/src/unit_tests/data/shared_object_deletion/sources/shared_object_deletion.move
@@ -4,11 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module shared_object_deletion::o2 {
-    use std::vector;
-    use iota::object::{Self, UID};
-    use iota::transfer;
-    use iota::tx_context::{Self, TxContext};
-
     public struct Obj has key, store {
         id: UID,
         flipped: bool

--- a/crates/iota-core/src/unit_tests/data/transitive_dependencies/root/sources/trusted_coin.move
+++ b/crates/iota-core/src/unit_tests/data/transitive_dependencies/root/sources/trusted_coin.move
@@ -5,7 +5,6 @@
 /// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
 module examples::trusted_coin {
     use iota::coin::{Self, TreasuryCap};
-    use iota::transfer;
 
     /// Name of the coin
     public struct TRUSTED_COIN has drop {}

--- a/crates/iota-core/src/unit_tests/data/transitive_dependencies/root/sources/trusted_coin.move
+++ b/crates/iota-core/src/unit_tests/data/transitive_dependencies/root/sources/trusted_coin.move
@@ -4,10 +4,8 @@
 
 /// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
 module examples::trusted_coin {
-    use std::option;
     use iota::coin::{Self, TreasuryCap};
     use iota::transfer;
-    use iota::tx_context::{Self, TxContext};
 
     /// Name of the coin
     public struct TRUSTED_COIN has drop {}

--- a/crates/iota-core/src/unit_tests/data/tto/sources/tto1.move
+++ b/crates/iota-core/src/unit_tests/data/tto/sources/tto1.move
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module tto::M1 {
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer::{Self, Receiving};
+    use iota::transfer::Receiving;
     use iota::dynamic_object_field;
 
     public struct A has key, store {

--- a/crates/iota-core/src/unit_tests/data/tto/sources/tto2.move
+++ b/crates/iota-core/src/unit_tests/data/tto/sources/tto2.move
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module tto::M2 {
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer::{Self, Receiving};
+    use iota::transfer::Receiving;
     use iota::dynamic_field as df;
 
     public struct A has key, store {

--- a/crates/iota-core/src/unit_tests/data/tto/sources/tto3.move
+++ b/crates/iota-core/src/unit_tests/data/tto/sources/tto3.move
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module tto::M3 {
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer::{Self, Receiving};
+    use iota::transfer::{Receiving};
 
     public struct A has key, store {
         id: UID,

--- a/crates/iota-core/src/unit_tests/data/tto/sources/tto3.move
+++ b/crates/iota-core/src/unit_tests/data/tto/sources/tto3.move
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module tto::M3 {
-    use iota::transfer::{Receiving};
+    use iota::transfer::Receiving;
 
     public struct A has key, store {
         id: UID,

--- a/crates/iota-core/src/unit_tests/data/tto/sources/tto4.move
+++ b/crates/iota-core/src/unit_tests/data/tto/sources/tto4.move
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module tto::M4 {
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer::{Self, Receiving};
+    use iota::transfer::Receiving;
 
     public struct A has key, store {
         id: UID,

--- a/crates/iota-core/src/unit_tests/data/tto/sources/tto5.move
+++ b/crates/iota-core/src/unit_tests/data/tto/sources/tto5.move
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module tto::M5 {
-    use iota::transfer::{Receiving};
+    use iota::transfer::Receiving;
     use iota::dynamic_object_field as dof;
 
     public struct A has key, store {

--- a/crates/iota-core/src/unit_tests/data/tto/sources/tto5.move
+++ b/crates/iota-core/src/unit_tests/data/tto/sources/tto5.move
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module tto::M5 {
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer::{Self, Receiving};
+    use iota::transfer::{Receiving};
     use iota::dynamic_object_field as dof;
 
     public struct A has key, store {

--- a/crates/iota-core/src/unit_tests/data/type_params/sources/m1.move
+++ b/crates/iota-core/src/unit_tests/data/type_params/sources/m1.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module type_params::m1 {
-    use iota::object::{Self, UID};
-    use iota::tx_context::TxContext;
-    use iota::transfer;
     use type_params::m2;
 
     public struct Object has key, store {

--- a/crates/iota-core/src/unit_tests/data/type_params/sources/m2.move
+++ b/crates/iota-core/src/unit_tests/data/type_params/sources/m2.move
@@ -3,10 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module type_params::m2 {
-    use iota::object::{Self, UID};
-    use iota::tx_context::TxContext;
-    use iota::transfer;
-
     public struct AnotherObject has key, store {
         id: UID,
         value: u64,

--- a/crates/iota-core/src/unit_tests/data/type_params/sources/m3.move
+++ b/crates/iota-core/src/unit_tests/data/type_params/sources/m3.move
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module type_params::m3 {
-    use iota::transfer;
-
     public entry fun transfer_object<T: key + store>(o: T, recipient: address) {
         transfer::public_transfer(o, recipient);
     }

--- a/crates/iota-core/src/unit_tests/data/type_params_extra/sources/m1.move
+++ b/crates/iota-core/src/unit_tests/data/type_params_extra/sources/m1.move
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module type_params::m1 {
-    use iota::transfer;
-
     public entry fun transfer_object<T: key + store>(o: T, recipient: address) {
         transfer::public_transfer(o, recipient);
     }

--- a/crates/iota-cost/tests/data/dummy_modules_publish/sources/trusted_coin.move
+++ b/crates/iota-cost/tests/data/dummy_modules_publish/sources/trusted_coin.move
@@ -4,10 +4,7 @@
 
 /// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
 module examples::trusted_coin {
-    use std::option;
     use iota::coin::{Self, TreasuryCap};
-    use iota::transfer;
-    use iota::tx_context::{Self, TxContext};
 
     /// Name of the coin
     public struct TRUSTED_COIN has drop {}

--- a/crates/iota-e2e-tests/tests/framework_upgrades/add_key_ability/sources/modules.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/add_key_ability/sources/modules.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_system::msim_extra_1 {
-    use iota::object::UID;
-    use iota::tx_context::TxContext;
-
     public struct Type has drop {
         x: u64,
     }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/add_struct_ability/sources/modules.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/add_struct_ability/sources/modules.move
@@ -3,10 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_system::msim_extra_1 {
-    use iota::object::{Self, UID};
-    use iota::transfer;
-    use iota::tx_context::{Self, TxContext};
-
     public struct Type has drop, copy {
         x: u64,
     }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/base/sources/modules.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/base/sources/modules.move
@@ -3,10 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_system::msim_extra_1 {
-    use iota::object::{Self, UID};
-    use iota::transfer;
-    use iota::tx_context::{Self, TxContext};
-
     public struct Type has drop {
         x: u64,
     }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/change_entry_function_signature/sources/modules.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/change_entry_function_signature/sources/modules.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_system::msim_extra_1 {
-    use iota::object::UID;
-    use iota::tx_context::TxContext;
-
     public struct Type has drop {
         x: u64,
     }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/change_public_function_signature/sources/modules.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/change_public_function_signature/sources/modules.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_system::msim_extra_1 {
-    use iota::object::UID;
-    use iota::tx_context::TxContext;
-
     public struct Type has drop {
         x: u64,
     }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/change_struct_ability/sources/modules.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/change_struct_ability/sources/modules.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_system::msim_extra_1 {
-    use iota::object::UID;
-    use iota::tx_context::TxContext;
-
     public struct Type {
         x: u64,
     }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/change_struct_layout/sources/modules.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/change_struct_layout/sources/modules.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_system::msim_extra_1 {
-    use iota::object::UID;
-    use iota::tx_context::TxContext;
-
     public struct Type has drop {
         x: u64,
         y: u64,

--- a/crates/iota-e2e-tests/tests/framework_upgrades/change_type_constraint/sources/modules.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/change_type_constraint/sources/modules.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_system::msim_extra_1 {
-    use iota::object::UID;
-    use iota::tx_context::TxContext;
-
     public struct Type has drop {
         x: u64,
     }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/compatible/sources/modules.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/compatible/sources/modules.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_system::msim_extra_1 {
-    use iota::object::UID;
-    use iota::tx_context::TxContext;
-
     public struct Type has drop {
         x: u64
     }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/extra_package/sources/modules.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/extra_package/sources/modules.move
@@ -3,10 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_extra::msim_extra_1 {
-    use iota::object::{Self, UID};
-    use iota::transfer;
-    use iota::tx_context::TxContext;
-
     public struct S has key { id: UID }
 
     fun init(ctx: &mut TxContext) {

--- a/crates/iota-e2e-tests/tests/move_test_code/sources/shared_objects_version.move
+++ b/crates/iota-e2e-tests/tests/move_test_code/sources/shared_objects_version.move
@@ -3,10 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module move_test_code::shared_objects_version {
-    use iota::object::{Self, UID};
-    use iota::transfer;
-    use iota::tx_context::{Self, TxContext};
-
     public struct Counter has key {
         id: UID,
         value: u64,

--- a/crates/iota-e2e-tests/tests/move_test_code/sources/tto1.move
+++ b/crates/iota-e2e-tests/tests/move_test_code/sources/tto1.move
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module move_test_code::tto {
-    use iota::transfer::{Receiving};
+    use iota::transfer::Receiving;
 
     public struct A has key, store {
         id: UID,

--- a/crates/iota-e2e-tests/tests/move_test_code/sources/tto1.move
+++ b/crates/iota-e2e-tests/tests/move_test_code/sources/tto1.move
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module move_test_code::tto {
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer::{Self, Receiving};
+    use iota::transfer::{Receiving};
 
     public struct A has key, store {
         id: UID,

--- a/crates/iota-json-rpc-tests/tests/data/dummy_modules_publish/sources/trusted_coin.move
+++ b/crates/iota-json-rpc-tests/tests/data/dummy_modules_publish/sources/trusted_coin.move
@@ -4,10 +4,7 @@
 
 /// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
 module examples::trusted_coin {
-    use std::option;
     use iota::coin::{Self, TreasuryCap};
-    use iota::transfer;
-    use iota::tx_context::{Self, TxContext};
 
     /// Name of the coin
     public struct TRUSTED_COIN has drop {}

--- a/crates/iota-package-resolver/tests/packages/d0/sources/m.move
+++ b/crates/iota-package-resolver/tests/packages/d0/sources/m.move
@@ -4,8 +4,6 @@
 
 #[allow(unused_field)]
 module d::m {
-    use iota::object::UID;
-
     public struct O<T, phantom U> has key, store {
         id: UID,
         xs: vector<T>,

--- a/crates/iota-package-resolver/tests/packages/e0/sources/m.move
+++ b/crates/iota-package-resolver/tests/packages/e0/sources/m.move
@@ -6,7 +6,6 @@
 module e::m {
     use std::ascii::String as ASCII;
     use std::string::String as UTF8;
-    use iota::object::UID;
 
     public struct O has key { id: UID }
 

--- a/crates/iota-package-resolver/tests/packages/e0/sources/m.move
+++ b/crates/iota-package-resolver/tests/packages/e0/sources/m.move
@@ -5,7 +5,6 @@
 #[allow(unused_field)]
 module e::m {
     use std::ascii::String as ASCII;
-    use std::option::Option;
     use std::string::String as UTF8;
     use iota::object::UID;
 

--- a/crates/iota-single-node-benchmark/move_package/sources/benchmark.move
+++ b/crates/iota-single-node-benchmark/move_package/sources/benchmark.move
@@ -5,15 +5,9 @@
 module move_benchmark::benchmark {
     use std::ascii;
     use std::ascii::String;
-    use std::vector;
     use iota::coin::Coin;
     use iota::dynamic_field;
-    use iota::object;
-    use iota::object::UID;
     use iota::iota::IOTA;
-    use iota::transfer;
-    use iota::tx_context;
-    use iota::tx_context::TxContext;
 
     public fun transfer_coin(coin: Coin<IOTA>, ctx: &TxContext) {
         transfer::public_transfer(coin, tx_context::sender(ctx));

--- a/crates/iota-surfer/tests/move_building_blocks/sources/limits.move
+++ b/crates/iota-surfer/tests/move_building_blocks/sources/limits.move
@@ -3,12 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module move_building_blocks::limits {
-    use iota::object::UID;
-    use iota::object;
-    use iota::tx_context::TxContext;
-    use std::vector;
-    use iota::transfer;
-    use iota::tx_context;
     use iota::dynamic_field;
 
     public struct ObjectWithVector has key, store {

--- a/crates/iota-surfer/tests/move_building_blocks/sources/objects.move
+++ b/crates/iota-surfer/tests/move_building_blocks/sources/objects.move
@@ -3,15 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module move_building_blocks::objects {
-    use iota::object::UID;
-    use std::option::Option;
     use iota::table::Table;
-    use iota::tx_context::TxContext;
-    use iota::object;
-    use std::option;
     use iota::table;
-    use iota::transfer;
-    use iota::tx_context;
 
     public struct Object has key, store {
         id: UID,

--- a/crates/iota-surfer/tests/random/sources/random.move
+++ b/crates/iota-surfer/tests/random/sources/random.move
@@ -3,10 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module random::random_test {
-    use iota::object::UID;
-    use iota::object;
-    use iota::tx_context::TxContext;
-    use iota::transfer;
     use iota::random;
 
 

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check/base/sources/ascii.move
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check/base/sources/ascii.move
@@ -5,9 +5,6 @@
 /// The `ASCII` module defines basic string and char newtypes in Move that verify
 /// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 module base::ascii {
-    use std::vector;
-    use std::option::{Self, Option};
-
     /// An invalid ASCII character was encountered when creating an ASCII string.
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
 

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check/upgraded/sources/ascii.move
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check/upgraded/sources/ascii.move
@@ -5,9 +5,6 @@
 /// The `ASCII` module defines basic string and char newtypes in Move that verify
 /// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 module base::ascii {
-    use std::option::{Option, Self};
-    use std::vector;
-
     /// An ASCII character.
     public struct Char has copy, drop, store {
         byte: u8,

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_alpha_rename/base/sources/ascii.move
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_alpha_rename/base/sources/ascii.move
@@ -5,9 +5,6 @@
 /// The `ASCII` module defines basic string and char newtypes in Move that verify
 /// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 module base::ascii {
-    use std::vector;
-    use std::option::{Self, Option};
-
     /// An invalid ASCII character was encountered when creating an ASCII string.
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
 

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_alpha_rename/upgraded/sources/ascii.move
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_alpha_rename/upgraded/sources/ascii.move
@@ -5,9 +5,6 @@
 /// The `ASCII` module defines basic string and char newtypes in Move that verify
 /// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 module base::ascii {
-    use std::option::{Option, Self};
-    use std::vector;
-
     /// An ASCII character.
     public struct Char has copy, drop, store {
         byte: u8,

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_local_shuffle/base/sources/ascii.move
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_local_shuffle/base/sources/ascii.move
@@ -5,9 +5,6 @@
 /// The `ASCII` module defines basic string and char newtypes in Move that verify
 /// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 module base::ascii {
-    use std::vector;
-    use std::option::{Self, Option};
-
     /// An invalid ASCII character was encountered when creating an ASCII string.
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
 

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_local_shuffle/upgraded/sources/ascii.move
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_local_shuffle/upgraded/sources/ascii.move
@@ -5,9 +5,6 @@
 /// The `ASCII` module defines basic string and char newtypes in Move that verify
 /// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 module base::ascii {
-    use std::option::{Option, Self};
-    use std::vector;
-
     /// An ASCII character.
     public struct Char has copy, drop, store {
         byte: u8,

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_inclusion_check/base/sources/ascii.move
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_inclusion_check/base/sources/ascii.move
@@ -5,9 +5,6 @@
 /// The `ASCII` module defines basic string and char newtypes in Move that verify
 /// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 module base::ascii {
-    use std::vector;
-    use std::option::{Self, Option};
-
     /// An invalid ASCII character was encountered when creating an ASCII string.
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
 

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_inclusion_check/upgraded/sources/ascii.move
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_inclusion_check/upgraded/sources/ascii.move
@@ -5,9 +5,6 @@
 /// The `ASCII` module defines basic string and char newtypes in Move that verify
 /// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 module base::ascii {
-    use std::option::{Option, Self};
-    use std::vector;
-
     /// An ASCII character.
     public struct Char has copy, drop, store {
         byte: u8,

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_invalid_equality_inclusion_check/base/sources/ascii.move
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_invalid_equality_inclusion_check/base/sources/ascii.move
@@ -5,9 +5,6 @@
 /// The `ASCII` module defines basic string and char newtypes in Move that verify
 /// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 module base::ascii {
-    use std::vector;
-    use std::option::{Self, Option};
-
     /// An invalid ASCII character was encountered when creating an ASCII string.
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
 

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_invalid_equality_inclusion_check/upgraded/sources/ascii.move
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_invalid_equality_inclusion_check/upgraded/sources/ascii.move
@@ -5,9 +5,6 @@
 /// The `ASCII` module defines basic string and char newtypes in Move that verify
 /// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 module base::ascii {
-    use std::vector;
-    use std::option::{Self, Option};
-
     /// An invalid ASCII character was encountered when creating an ASCII string.
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
 

--- a/crates/iota/tests/data/dummy_modules_publish/sources/trusted_coin.move
+++ b/crates/iota/tests/data/dummy_modules_publish/sources/trusted_coin.move
@@ -4,10 +4,7 @@
 
 /// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
 module examples::trusted_coin {
-    use std::option;
     use iota::coin::{Self, TreasuryCap};
-    use iota::transfer;
-    use iota::tx_context::{Self, TxContext};
 
     /// Name of the coin
     public struct TRUSTED_COIN has drop {}

--- a/crates/iota/tests/data/linter/sources/suppression_stats.move
+++ b/crates/iota/tests/data/linter/sources/suppression_stats.move
@@ -7,10 +7,6 @@
 
 #[allow(lint(custom_state_change))]
 module linter::suppression_stats {
-    use iota::object::UID;
-    use iota::transfer;
-    use iota::tx_context::{Self, TxContext};
-
     #[allow(unused_field)]
     public struct S1 has key, store {
         id: UID

--- a/crates/iota/tests/data/move_call_args_linter/sources/object_basics.move
+++ b/crates/iota/tests/data/move_call_args_linter/sources/object_basics.move
@@ -5,9 +5,6 @@
 /// Test CTURD object basics (create, transfer, update, read, delete)
 module examples::object_basics {
     use iota::event;
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer;
 
     public struct Object has key, store {
         id: UID,

--- a/crates/iota/tests/data/ptb_complex_args_test_functions/sources/test_module.move
+++ b/crates/iota/tests/data/ptb_complex_args_test_functions/sources/test_module.move
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module test_functions::test_module {
-    use iota::object::{Self, UID};
-    use iota::tx_context::TxContext;
-    use iota::transfer;
     use std::ascii::String as AS;
     use std::string::String as US;
 

--- a/crates/iota/tests/data/sod/sources/sod.move
+++ b/crates/iota/tests/data/sod/sources/sod.move
@@ -3,10 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sod::sod {
-    use iota::object::{Self, UID};
-    use iota::tx_context::TxContext;
-    use iota::transfer;
-
     public struct A has key, store {
         id: UID,
     }

--- a/crates/iota/tests/data/tto/sources/tto1.move
+++ b/crates/iota/tests/data/tto/sources/tto1.move
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module tto::tto {
-    use iota::transfer::{Receiving};
+    use iota::transfer::Receiving;
 
     public struct A has key, store {
         id: UID,

--- a/crates/iota/tests/data/tto/sources/tto1.move
+++ b/crates/iota/tests/data/tto/sources/tto1.move
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module tto::tto {
-    use iota::object::{Self, UID};
-    use iota::tx_context::{Self, TxContext};
-    use iota::transfer::{Self, Receiving};
+    use iota::transfer::{Receiving};
 
     public struct A has key, store {
         id: UID,

--- a/crates/transaction-fuzzer/data/coin_factory/sources/coin_factory.move
+++ b/crates/transaction-fuzzer/data/coin_factory/sources/coin_factory.move
@@ -2,11 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 module coiner::coin_factory {
-    use std::option;
     use iota::coin::{Self, Coin, TreasuryCap};
-    use iota::transfer;
-    use std::vector;
-    use iota::tx_context::{Self, TxContext};
 
     public struct COIN_FACTORY has drop {}
 

--- a/dapps/regulated-token/sources/denylist.move
+++ b/dapps/regulated-token/sources/denylist.move
@@ -15,10 +15,7 @@
 /// - the current implementation is not optimized for a large number of records
 /// and the final one will feature better collection type;
 module regulated_token::denylist_rule {
-    use std::option;
-    use std::vector;
     use iota::bag::{Self, Bag};
-    use iota::tx_context::TxContext;
     use iota::token::{Self, TokenPolicy, TokenPolicyCap, ActionRequest};
 
     /// Trying to `verify` but the sender or the recipient is on the denylist.

--- a/dapps/regulated-token/sources/reg.move
+++ b/dapps/regulated-token/sources/reg.move
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module regulated_token::reg {
-    use std::option;
-    use iota::tx_context::{sender, TxContext};
-    use iota::transfer;
+    use iota::tx_context::sender;
     use iota::coin::{Self, TreasuryCap};
     use iota::token::{Self, Token, TokenPolicy};
 

--- a/docs/examples/move/ctf/challenge_6/sources/recycle.move
+++ b/docs/examples/move/ctf/challenge_6/sources/recycle.move
@@ -1,5 +1,5 @@
 module ctf::recycle {
-    use iota::transfer::{Receiving};
+    use iota::transfer::Receiving;
     use iota::dynamic_field as df;
     use ctf::pizza::{Self, PizzaBox};
 

--- a/docs/examples/move/move-overview/conventions/separation.move
+++ b/docs/examples/move/move-overview/conventions/separation.move
@@ -1,7 +1,4 @@
 module conventions::wallet {
-
-    use iota::object::UID;
-
     public struct Wallet has key, store {
         id: UID,
         amount: u64
@@ -9,9 +6,6 @@ module conventions::wallet {
 }
 
 module conventions::claw_back_wallet {
-
-    use iota::object::UID;
-
     public struct Wallet has key {
         id: UID,
         amount: u64

--- a/examples/move/transfer-to-shared-object/sources/shared_coins.move
+++ b/examples/move/transfer-to-shared-object/sources/shared_coins.move
@@ -4,7 +4,7 @@
 /// This example demonstrates how to receive objects to a shared object and transfer them again.
 module shared_coins::shared_coins {
     use iota::coin::Coin;
-    use iota::transfer::{Receiving};
+    use iota::transfer::Receiving;
     use iota::iota::IOTA;
 
     /// Coins, anyone can deposit and transfer.

--- a/sdk/kiosk/test/e2e/data/hero/sources/hero.move
+++ b/sdk/kiosk/test/e2e/data/hero/sources/hero.move
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module hero::hero {
-    use iota::tx_context::{TxContext};
-    use iota::object::{Self, UID};
     use iota::package;
 
     public struct Hero has key, store {


### PR DESCRIPTION
# Description of change

This PR removes all explicit imports of symbols, from move files, that are already imported by default according to https://github.com/iotaledger/iota/blob/develop/external-crates/move/crates/move-compiler/src/expansion/name_validation.rs.

Explicitly importing such a symbol results in a warning, which makes it hard to locate actual errors in the CI like in https://github.com/iotaledger/iota/actions/runs/20099499564/job/57669749311#step:9:3351.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
