### PR TITLE
fix(build-cache): fix features flag

### DIFF
--- a/crates/iota-build-cache-server/src/cache.rs
+++ b/crates/iota-build-cache-server/src/cache.rs
@@ -690,9 +690,9 @@ impl BuildCache {
         };
 
         let features_arg = if !features.is_empty() {
-            let features_str = features.join(" ");
+            let features_str = features.join(",");
             info!("Building with features: \"{features_str}\"");
-            Some(format!("--features=\"{features_str}\""))
+            Some(format!("--features={features_str}"))
         } else {
             None
         };


### PR DESCRIPTION
# Description of change

The feature flag was not correctly escaped, so the cargo build command couldn't find the specified features in the workspace. This PR fixes that.