### PR TITLE
feat(tx-test-runner): support package metadata

### DIFF
--- a/crates/iota-transactional-test-runner/src/args.rs
+++ b/crates/iota-transactional-test-runner/src/args.rs
@@ -70,6 +70,8 @@ pub struct IotaInitArgs {
     pub reference_gas_price: Option<u64>,
     #[arg(long)]
     pub default_gas_price: Option<u64>,
+    #[clap(long = "move-auth")]
+    pub move_auth: Option<bool>,
     #[command(flatten)]
     pub snapshot_config: SnapshotLagConfig,
     #[arg(long)]
@@ -137,6 +139,39 @@ pub struct ProgrammableTransactionCommand {
         action = clap::ArgAction::Append,
     )]
     pub inputs: Vec<ParsedValue<IotaExtraValueArgs>>,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct AbstractTransactionCommand {
+    #[arg(
+        long = "account",
+        value_parser = ParsedValue::<IotaExtraValueArgs>::parse,
+        num_args(1),
+        action = clap::ArgAction::Append,
+    )]
+    pub account: ParsedValue<IotaExtraValueArgs>,
+    #[arg(long = "sponsor")]
+    pub sponsor: Option<String>,
+    #[arg(long = "gas-budget")]
+    pub gas_budget: Option<u64>,
+    #[arg(long)]
+    pub gas_price: Option<u64>,
+    #[arg(long = "gas-payment", value_parser = parse_fake_id)]
+    pub gas_payment: Vec<FakeID>,
+    #[arg(
+        long = "ptb-inputs",
+        value_parser = ParsedValue::<IotaExtraValueArgs>::parse,
+        num_args(1..),
+        action = clap::ArgAction::Append,
+    )]
+    pub ptb_inputs: Vec<ParsedValue<IotaExtraValueArgs>>,
+    #[arg(
+        long = "auth-inputs",
+        value_parser = ParsedValue::<IotaExtraValueArgs>::parse,
+        num_args(1..),
+        action = clap::ArgAction::Append,
+    )]
+    pub authenticator_inputs: Vec<ParsedValue<IotaExtraValueArgs>>,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -232,6 +267,7 @@ pub enum IotaSubcommand<ExtraValueArgs: ParsableValue, ExtraRunArgs: Parser> {
     ViewCheckpoint,
     RunGraphql(RunGraphqlCommand),
     Bench(RunCommand<ExtraValueArgs>, ExtraRunArgs),
+    AbstractTransaction(AbstractTransactionCommand),
 }
 
 impl<ExtraValueArgs: ParsableValue, ExtraRunArgs: Parser> clap::FromArgMatches
@@ -252,6 +288,9 @@ impl<ExtraValueArgs: ParsableValue, ExtraRunArgs: Parser> clap::FromArgMatches
             }
             Some(("programmable", matches)) => IotaSubcommand::ProgrammableTransaction(
                 ProgrammableTransactionCommand::from_arg_matches(matches)?,
+            ),
+            Some(("abstract", matches)) => IotaSubcommand::AbstractTransaction(
+                AbstractTransactionCommand::from_arg_matches(matches)?,
             ),
             Some(("upgrade", matches)) => {
                 IotaSubcommand::UpgradePackage(UpgradePackageCommand::from_arg_matches(matches)?)
@@ -306,6 +345,7 @@ impl<ExtraValueArgs: ParsableValue, ExtraRunArgs: Parser> clap::CommandFactory
             .subcommand(TransferObjectCommand::command().name("transfer-object"))
             .subcommand(ConsensusCommitPrologueCommand::command().name("consensus-commit-prologue"))
             .subcommand(ProgrammableTransactionCommand::command().name("programmable"))
+            .subcommand(AbstractTransactionCommand::command().name("abstract"))
             .subcommand(UpgradePackageCommand::command().name("upgrade"))
             .subcommand(StagePackageCommand::command().name("stage-package"))
             .subcommand(SetAddressCommand::command().name("set-address"))

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -20,7 +20,7 @@ use criterion::Criterion;
 use fastcrypto::{
     ed25519::Ed25519KeyPair,
     encoding::{Base64, Encoding},
-    traits::ToFromBytes,
+    traits::{Signer, ToFromBytes},
 };
 use iota_core::authority::{AuthorityState, test_authority_builder::TestAuthorityBuilder};
 use iota_framework::DEFAULT_FRAMEWORK_PATH;
@@ -53,17 +53,24 @@ use iota_types::{
     messages_checkpoint::{
         CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, VerifiedCheckpoint,
     },
-    move_package::MovePackage,
+    move_authenticator::MoveAuthenticator,
+    move_package::{
+        IotaAttribute, MovePackage, RuntimeModuleMetadata, RuntimeModuleMetadataWrapper,
+    },
     object::{self, GAS_VALUE_FOR_TESTING, Object, bounded_visitor::BoundedVisitor},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
+    signature::GenericSignature,
     storage::{ObjectStore, ReadStore, RestStateReader},
     transaction::{
         Argument, CallArg, Command, ProgrammableTransaction, Transaction, TransactionData,
-        TransactionDataAPI, TransactionKind, VerifiedTransaction,
+        TransactionKind, VerifiedTransaction,
     },
-    utils::{to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers},
+    utils::{
+        to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers,
+        to_sender_signed_transaction_with_optional_sponsor,
+    },
 };
-use move_binary_format::CompiledModule;
+use move_binary_format::{CompiledModule, file_format_common::IOTA_METADATA_KEY};
 use move_bytecode_utils::module_cache::GetModule;
 use move_command_line_common::files::verify_and_create_named_address_mapping;
 use move_compiler::{
@@ -76,7 +83,8 @@ use move_core_types::{
     ident_str,
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
-    parsing::address::ParsedAddress,
+    metadata::Metadata,
+    parsing::{address::ParsedAddress, values::ParsedValue},
 };
 use move_symbol_pool::Symbol;
 use move_transactional_test_runner::{
@@ -201,6 +209,7 @@ impl AdapterInitConfig {
             custom_validator_account,
             reference_gas_price,
             default_gas_price,
+            move_auth,
             snapshot_config,
             flavor,
             epochs_to_keep,
@@ -226,6 +235,9 @@ impl AdapterInitConfig {
                 panic!("Cannot set max gas in simulator mode");
             }
             protocol_config.set_max_tx_gas_for_testing(mx_tx_gas_override)
+        }
+        if let Some(enable) = move_auth {
+            protocol_config.set_enable_move_authentication_for_testing(enable);
         }
         if custom_validator_account && !simulator {
             panic!("Can only set custom validator account in simulator mode");
@@ -262,7 +274,7 @@ impl AdapterInitConfig {
 #[derive(Debug)]
 struct TestAccount {
     address: IotaAddress,
-    key_pair: AccountKeyPair,
+    key_pair: Option<AccountKeyPair>,
     gas: ObjectID,
 }
 
@@ -442,7 +454,7 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
 
     async fn publish_modules(
         &mut self,
-        modules: Vec<MaybeNamedCompiledModule>,
+        mut modules: Vec<MaybeNamedCompiledModule>,
         gas_budget: Option<u64>,
         extra: Self::ExtraPublishArgs,
     ) -> anyhow::Result<(Option<String>, Vec<MaybeNamedCompiledModule>)> {
@@ -453,6 +465,9 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
             dependencies,
             gas_price,
         } = extra;
+
+        fill_metadata(&mut modules);
+
         let named_addr_opt = modules.first().unwrap().named_address;
         let first_module_name = modules.first().unwrap().module.self_id().name().to_string();
         let modules_bytes = modules
@@ -538,8 +553,10 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                 named_address: named_addr_opt,
                 module: CompiledModule::deserialize_with_defaults(published_module_bytes).unwrap(),
                 source_map: None,
+                function_infos: None,
             })
             .collect();
+
         Ok((output, published_modules))
     }
 
@@ -790,49 +807,17 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                 if dry_run && dev_inspect {
                     bail!("Cannot set both dev-inspect and dry-run");
                 }
+                let (inputs, commands) = self.prepare_ptb_data(data, inputs)?;
 
-                let inputs = self.compiled_state().resolve_args(inputs)?;
-                let inputs: Vec<CallArg> = inputs
-                    .into_iter()
-                    .map(|arg| arg.into_call_arg(self))
-                    .collect::<anyhow::Result<_>>()?;
-                let file = data.ok_or_else(|| {
-                    anyhow::anyhow!("Missing commands for programmable transaction")
-                })?;
-                let contents = std::fs::read_to_string(file.path())?;
-                let commands = ParsedCommand::parse_vec(&contents)?;
-                let staged = &self.staged_modules;
-                let state = &self.compiled_state;
-                let commands = commands
-                    .into_iter()
-                    .map(|c| {
-                        c.into_command(
-                            &|p| {
-                                let modules = staged
-                                    .get(&Symbol::from(p))?
-                                    .modules
-                                    .iter()
-                                    .map(|m| {
-                                        let mut buf = vec![];
-                                        m.module
-                                            .serialize_with_version(m.module.version, &mut buf)
-                                            .unwrap();
-                                        buf
-                                    })
-                                    .collect();
-                                Some(modules)
-                            },
-                            &|s| Some(state.resolve_named_address(s)),
-                        )
-                    })
-                    .collect::<anyhow::Result<Vec<Command>>>()?;
                 let summary = if !dev_inspect && !dry_run {
                     let gas_budget = gas_budget.unwrap_or(DEFAULT_GAS_BUDGET);
                     let gas_price = gas_price.unwrap_or(self.gas_price);
+                    let sender = self.get_sender(sender);
                     let transaction = self.sign_sponsor_txn(
                         sender,
                         sponsor,
                         gas_payment.unwrap_or_default(),
+                        None,
                         |sender, sponsor, gas| {
                             TransactionData::new_programmable_allow_sponsor(
                                 sender,
@@ -941,7 +926,7 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                     command_lines_stop,
                     stop_line,
                     data,
-                    |adapter, modules| async {
+                    |adapter, mut modules| async {
                         // Restore the original package addresses for dependencies before performing the upgrade.
                         // This ensures package upgrades are properly linked at their correct addresses
                         // (previously, addresses referred to the dependency's original package for compilation).
@@ -952,6 +937,8 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                                 .insert(name.to_string(), addr)
                                 .unwrap_or_else(|| panic!("Internal error: expected dependency {name} in map when restoring address."));
                         }
+
+                        fill_metadata(&mut modules);
 
                         let upgraded_name = modules.first().unwrap().named_address.unwrap();
                         let package = &Symbol::from(package.as_str());
@@ -1081,6 +1068,7 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                                         named_address: Some(*address_sym),
                                         module,
                                         source_map: None,
+                                        function_infos: None,
                                     }
                                 })
                                 .collect()
@@ -1184,6 +1172,54 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                 .await?;
                 Ok(merge_output(None, None))
             }
+            IotaSubcommand::AbstractTransaction(AbstractTransactionCommand {
+                account,
+                sponsor,
+                gas_budget,
+                gas_price,
+                gas_payment,
+                ptb_inputs,
+                authenticator_inputs,
+            }) => {
+                if self.is_simulator() {
+                    bail!("Abstract transactions are not supported in simulator mode");
+                }
+                // Parse and resolve ptb inputs.
+                let (ptb_inputs, ptb_commands) = self.prepare_ptb_data(data, ptb_inputs)?;
+
+                // Parse and resolve auth inputs.
+                // Build MoveAuthenticator.
+                // Get Abstract Test Account
+                let (aa_sender, move_authenticator) =
+                    self.prepare_move_authenticator_data(authenticator_inputs, account)?;
+
+                let gas_budget = gas_budget.unwrap_or(DEFAULT_GAS_BUDGET);
+                let gas_price = gas_price.unwrap_or(self.gas_price);
+
+                let tx = self.sign_sponsor_txn(
+                    &aa_sender,
+                    sponsor,
+                    gas_payment,
+                    Some(move_authenticator),
+                    |sender, sponsor, gas| {
+                        TransactionData::new_programmable_allow_sponsor(
+                            sender,
+                            gas,
+                            ProgrammableTransaction {
+                                inputs: ptb_inputs,
+                                commands: ptb_commands,
+                            },
+                            gas_budget,
+                            gas_price,
+                            sponsor,
+                        )
+                    },
+                );
+
+                let summary = self.execute_txn(tx).await?;
+                let output = self.object_summary_output(&summary, /* summarize */ false);
+                Ok(output)
+            }
         }
     }
 
@@ -1239,6 +1275,92 @@ impl IotaTestAdapter {
 
     pub fn into_executor(self) -> Box<dyn TransactionalAdapter> {
         self.executor
+    }
+
+    fn prepare_ptb_data(
+        &mut self,
+        ptb_data: Option<NamedTempFile>,
+        ptb_inputs: Vec<ParsedValue<IotaExtraValueArgs>>,
+    ) -> anyhow::Result<(Vec<CallArg>, Vec<Command>)> {
+        let ptb_inputs = self
+            .compiled_state()
+            .resolve_args(ptb_inputs)?
+            .into_iter()
+            .map(|arg| arg.into_call_arg(self))
+            .collect::<anyhow::Result<Vec<CallArg>>>()?;
+
+        let ptb_cmds = {
+            let file = ptb_data
+                .ok_or_else(|| anyhow::anyhow!("Missing commands for programmable transaction"))?;
+            let contents = std::fs::read_to_string(file.path())?;
+            let commands = ParsedCommand::parse_vec(&contents)?;
+            let staged = &self.staged_modules;
+            let state = &self.compiled_state;
+            commands
+                .into_iter()
+                .map(|c| {
+                    c.into_command(
+                        &|p| {
+                            let modules = staged
+                                .get(&Symbol::from(p))?
+                                .modules
+                                .iter()
+                                .map(|m| {
+                                    let mut buf = vec![];
+                                    m.module
+                                        .serialize_with_version(m.module.version, &mut buf)
+                                        .unwrap();
+                                    buf
+                                })
+                                .collect();
+                            Some(modules)
+                        },
+                        &|s| Some(state.resolve_named_address(s)),
+                    )
+                })
+                .collect::<anyhow::Result<Vec<Command>>>()?
+        };
+        Ok((ptb_inputs, ptb_cmds))
+    }
+
+    /// Build a MoveAuthenticator.
+    /// Returns the Abstract Test Account and MoveAuthenticator.
+    fn prepare_move_authenticator_data(
+        &mut self,
+        authenticator_inputs: Vec<ParsedValue<IotaExtraValueArgs>>,
+        account: ParsedValue<IotaExtraValueArgs>,
+    ) -> anyhow::Result<(TestAccount, GenericSignature)> {
+        // Resolve authenticator inputs
+        let auth_inputs_resolved = self.compiled_state().resolve_args(authenticator_inputs)?;
+        let auth_inputs: Vec<CallArg> = auth_inputs_resolved
+            .into_iter()
+            .map(|arg| arg.into_call_arg(self))
+            .collect::<anyhow::Result<_>>()?;
+
+        let aa_arg = self
+            .compiled_state()
+            .resolve_args(vec![account])?
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("Missing account for MoveAuthenticator"))?;
+        let CallArg::Object(aa_arg) = aa_arg.into_call_arg(self)? else {
+            anyhow::bail!("abstract: account must be an object representing the abstract account");
+        };
+        let aa_sender_addr = aa_arg.id().into();
+
+        let account = TestAccount {
+            address: aa_sender_addr,
+            key_pair: None,
+            gas: aa_sender_addr.into(), // TODO: handle abstract account gas
+        };
+        Ok((
+            account,
+            GenericSignature::MoveAuthenticator(MoveAuthenticator::new_for_testing(
+                auth_inputs,
+                vec![],
+                CallArg::Object(aa_arg),
+            )),
+        ))
     }
 
     fn named_variables(&self) -> BTreeMap<String, String> {
@@ -1469,7 +1591,8 @@ impl IotaTestAdapter {
             Vec<ObjectRef>,
         ) -> TransactionData,
     ) -> Transaction {
-        self.sign_sponsor_txn(sender, None, vec![], move |sender, _, gas| {
+        let sender = self.get_sender(sender);
+        self.sign_sponsor_txn(sender, None, vec![], None, move |sender, _, gas| {
             txn_data(sender, gas)
         })
     }
@@ -1499,9 +1622,10 @@ impl IotaTestAdapter {
 
     fn sign_sponsor_txn(
         &self,
-        sender: Option<String>,
+        sender: &TestAccount,
         sponsor: Option<String>,
         payment: Vec<FakeID>,
+        aa_sig: Option<GenericSignature>,
         txn_data: impl FnOnce(
             // sender
             IotaAddress,
@@ -1511,19 +1635,27 @@ impl IotaTestAdapter {
             Vec<ObjectRef>,
         ) -> TransactionData,
     ) -> Transaction {
-        let sender = self.get_sender(sender);
         let sponsor = sponsor.map_or(sender, |a| self.get_sender(Some(a)));
 
         let payment_refs = self.get_payments(sponsor, payment);
 
         let data = txn_data(sender.address, sponsor.address, payment_refs);
 
-        if sender.address == sponsor.address {
-            to_sender_signed_transaction(data, &sender.key_pair)
+        if let Some(aa_sig) = aa_sig {
+            let sponsor_keypair = sponsor.key_pair.as_ref().map(|v| v as &dyn Signer<_>);
+            to_sender_signed_transaction_with_optional_sponsor(data, aa_sig, sponsor_keypair)
+        } else if sender.address == sponsor.address {
+            to_sender_signed_transaction(
+                data,
+                sender.key_pair.as_ref().expect("Sender key pair missing"),
+            )
         } else {
             to_sender_signed_transaction_with_multi_signers(
                 data,
-                vec![&sender.key_pair, &sponsor.key_pair],
+                vec![
+                    sender.key_pair.as_ref().expect("Sender key pair missing"),
+                    sponsor.key_pair.as_ref().expect("Sponsor key pair missing"),
+                ],
             )
         }
     }
@@ -1576,11 +1708,7 @@ impl IotaTestAdapter {
     }
 
     async fn execute_txn(&mut self, transaction: Transaction) -> anyhow::Result<TxnSummary> {
-        let with_shared = transaction
-            .data()
-            .intent_message()
-            .value
-            .contains_shared_object();
+        let with_shared = transaction.contains_shared_object();
         let (effects, error_opt) = self.executor.execute_txn(transaction).await?;
         let digest = effects.transaction_digest();
 
@@ -2209,7 +2337,7 @@ async fn init_val_fullnode_executor(
         );
         let test_account = TestAccount {
             address,
-            key_pair,
+            key_pair: Some(key_pair),
             gas: obj.id(),
         };
         objects.push(obj);
@@ -2337,7 +2465,7 @@ async fn init_sim_executor(
             name.to_owned(),
             TestAccount {
                 address: addr,
-                key_pair: kp,
+                key_pair: Some(kp),
                 gas: o.id(),
             },
         );
@@ -2349,7 +2477,7 @@ async fn init_sim_executor(
         .unwrap();
     let default_account = TestAccount {
         address: default_account_kp.0,
-        key_pair: default_account_kp.1,
+        key_pair: Some(default_account_kp.1),
         gas: o.id(),
     };
     objects.push(o.clone());
@@ -2358,7 +2486,7 @@ async fn init_sim_executor(
         let o = sim.store().owned_objects(v_addr).next().unwrap();
         let validator_account = TestAccount {
             address: v_addr,
-            key_pair: v_key,
+            key_pair: Some(v_key),
             gas: o.id(),
         };
         objects.push(o.clone());
@@ -2546,5 +2674,33 @@ impl ReadStore for IotaTestAdapter {
         Option<iota_types::messages_checkpoint::FullCheckpointContents>,
     > {
         self.executor.try_get_full_checkpoint_contents(digest)
+    }
+}
+
+/// Fill the compiled modules with authenticator metadata directly from
+/// function_infos
+fn fill_metadata(modules: &mut [MaybeNamedCompiledModule]) {
+    for m in modules.iter_mut() {
+        let module: &mut CompiledModule = &mut m.module;
+        let mut runtime_metadata = RuntimeModuleMetadata::default();
+
+        if let Some(fn_infos) = &m.function_infos {
+            for (_, name, info) in fn_infos.iter() {
+                // We only need authenticator version here
+                if let Some(version) = info.attributes.get_authenticator() {
+                    runtime_metadata.add_function_attribute(
+                        name.as_str().to_owned(),
+                        IotaAttribute::authenticator_attribute(version),
+                    );
+                }
+            }
+        }
+
+        if !runtime_metadata.is_empty() {
+            module.metadata.push(Metadata {
+                key: IOTA_METADATA_KEY.to_vec(),
+                value: RuntimeModuleMetadataWrapper::from(runtime_metadata).to_bcs_bytes(),
+            });
+        }
     }
 }

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -27,6 +27,7 @@
   - [`view-checkpoint`](#view-checkpoint)
   - [`run-graphql`](#run-graphql)
   - [`bench`](#bench)
+  - [`abstract`](#abstract)
 - [How `run_test` Compares a Move File With the Corresponding `.snap` File](#how-run_test-compares-a-move-file-with-the-corresponding-snap-file)
   - [Adapter Creation in `create_adapter`](#adapter-creation-in-create_adapter)
   - [Execution Process in `run_tasks_with_adapter`](#execution-process-in-run_tasks_with_adapter)
@@ -1414,6 +1415,180 @@ task 1 'publish'. lines 3-15:
 created: object(1,0), object(1,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 7220000,  storage_rebate: 0, non_refundable_storage_fee: 0
+```
+
+### `abstract`
+
+The `abstract` subcommand (`AbstractTransaction` in Rust) extends the capabilities of programmable transactions by allowing them to be executed through an Abstract Account (AA) authentication by a Move-based authenticator (`MoveAuthenticator`).
+Unlike programmable, where the sender directly signs the transaction with a system signature, abstract enables account abstraction — the sender is represented by a Abstract Account object itself.
+Doesn't support simulator mode.
+
+#### Syntax
+
+```
+//# abstract [OPTIONS]
+```
+
+#### Options
+
+```
+--account <ACCOUNT>: the sender of the abstract transaction. Must be an Abstract Account (AA) shared object.
+--sponsor <SPONSOR> (optional): account that pays for gas. If omitted, you must provide --gas-payment and that coin must be owned by the Abstract Account (AA).
+--gas-payment <OBJECT_ID>: coin object used to pay gas. Required when --sponsor is not provided.
+--auth-inputs <AUTH_INPUTS>: arguments to build the MoveAuthenticator(for instance - signature, public key etc).
+--ptb-inputs <PTB_INPUTS>: inputs passed to the PTB (Programmable Transaction Block) body.
+--gas-budget <GAS_BUDGET> (optional): maximum gas units for execution.
+--gas-price <GAS_PRICE> (optional): gas price per unit.
+```
+
+#### Example
+
+```move
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// simple authentication using abstract account
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish --sender A
+module test::abstract_account;
+
+use iota::account::{Self, AuthenticatorInfoV1};
+use iota::auth_context::AuthContext;
+use std::ascii;
+
+public struct AbstractAccount has key {
+    id: UID,
+}
+
+public fun create(
+    _public_key: vector<u8>,
+    authenticator: AuthenticatorInfoV1<AbstractAccount>,
+    ctx: &mut TxContext,
+): address {
+    let account = AbstractAccount { id: object::new(ctx) };
+
+    let account_address = object::id_address(&account);
+
+    account::create_account_v1(account, authenticator);
+
+    account_address
+}
+
+#[authenticator]
+public fun authenticate_hello_world(
+    _account: &AbstractAccount,
+    msg: ascii::String,
+    _auth_ctx: &AuthContext,
+    _ctx: &TxContext,
+) {
+    assert!(msg == ascii::string(b"HelloWorld"), 0);
+}
+
+//# programmable --sender A --inputs x"10" object(1,1) "abstract_account" "authenticate_hello_world" 7000000000
+//> 0: iota::account::create_auth_info_v1<test::abstract_account::AbstractAccount>(Input(1), Input(2), Input(3));
+//> 1: test::abstract_account::create(Input(0), Result(0));
+//> 2: SplitCoins(Gas, [Input(4)]);
+//> 3: TransferObjects([Result(2)], Result(1));
+
+//# view-object 2,0
+
+//# view-object 2,2
+
+//# abstract --account immshared(2,2) --gas-payment 2,0 --auth-inputs "HelloWorld" --ptb-inputs 100 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1));
+
+//# view-object 5,0
+```
+
+- Account (--account)
+  The immutable shared object that represents Abstract Account.
+- Gas Payment (--gas-payment)
+  Coin object that must be owned by the Abstract Account (AA).
+- PTB Inputs (--ptb-inputs)
+  These are inputs used inside the transaction body - for example, numeric values, objects, or addresses.
+  The PTB commands (//> ...) operate as in the programmable command.
+
+- object(1,1)
+  The `PackageMetadata` object carries information about function annotations, such as attributes
+
+`.snap` output:
+
+```
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 8-41:
+//# publish --sender A
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 11149200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 43-47:
+//# programmable --sender A --inputs x"10" object(1,1) "abstract_account" "authenticate_hello_world" 7000000000
+//> 0: iota::account::create_auth_info_v1<test::abstract_account::AbstractAccount>(Input(1), Input(2), Input(3));
+//> 1: test::abstract_account::create(Input(0), Result(0));
+//> 2: SplitCoins(Gas, [Input(4)]);
+//> 3: TransferObjects([Result(2)], Result(1));
+created: object(2,0), object(2,1), object(2,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6748800,  storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 3, line 49:
+//# view-object 2,0
+Owner: Account Address ( fake(2,2) )
+Version: 3
+Contents: iota::coin::Coin<iota::iota::IOTA> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    balance: iota::balance::Balance<iota::iota::IOTA> {
+        value: 7000000000u64,
+    },
+}
+
+task 4, line 51:
+//# view-object 2,2
+Owner: Shared( 3 )
+Version: 3
+Contents: test::abstract_account::AbstractAccount {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,2),
+        },
+    },
+}
+
+task 5, lines 53-55:
+//# abstract --account immshared(2,2) --gas-payment 2,0 --auth-inputs "HelloWorld" --ptb-inputs 100 @A
+created: object(5,0)
+mutated: object(2,0)
+unchanged_shared: object(2,2)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 6, line 57:
+//# view-object 5,0
+Owner: Account Address ( A )
+Version: 4
+Contents: iota::coin::Coin<iota::iota::IOTA> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(5,0),
+        },
+    },
+    balance: iota::balance::Balance<iota::iota::IOTA> {
+        value: 100u64,
+    },
+}
 ```
 
 ## How `run_test` Compares a Move File With the Corresponding `.snap` File

--- a/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
@@ -26,10 +26,11 @@ use move_command_line_common::{
 };
 use move_compiler::{
     FullyCompiledProgram,
-    compiled_unit::AnnotatedCompiledUnit,
+    compiled_unit::{AnnotatedCompiledUnit, FunctionInfo},
     diagnostics::{Diagnostics, warning_filters::WarningFiltersBuilder},
     editions::{Edition, Flavor},
-    shared::{NumericalAddress, PackageConfig, files::MappedFiles},
+    parser::ast::FunctionName,
+    shared::{NumericalAddress, PackageConfig, files::MappedFiles, unique_map::UniqueMap},
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -549,6 +550,7 @@ pub struct MaybeNamedCompiledModule {
     pub named_address: Option<Symbol>,
     pub module: CompiledModule,
     pub source_map: Option<SourceMap>,
+    pub function_infos: Option<UniqueMap<FunctionName, FunctionInfo>>,
 }
 
 pub async fn compile_any<'state, 'adapter: 'result, 'result, F, A, R>(
@@ -595,6 +597,7 @@ where
                         named_address: named_addr_opt,
                         module,
                         source_map,
+                        function_infos: Some(unit.function_infos),
                     }
                 })
                 .collect();
@@ -607,6 +610,7 @@ where
                     named_address: None,
                     module,
                     source_map: None,
+                    function_infos: None,
                 }],
                 None,
             )


### PR DESCRIPTION
# Description of change

Adds the support for creating package metadata in transacitonal test runner. 
This also adds the `abstract` command, that allows to generate test ptb with Move authenticators.
