### PR TITLE
fix(move-cli): fix failing tests because `diff` returns unstable order on different machines

### DIFF
--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/args.exp
@@ -16,8 +16,8 @@ BUILDING A
 The following changes will be made.
 ============================================================
 
---- ./sources/address_migration.move
-+++ ./sources/address_migration.move
+--- ./sources/address_migration1.move
++++ ./sources/address_migration1.move
 @@ -1,2 +1,2 @@
 -address 0x2 {
 -module m {
@@ -29,8 +29,8 @@ The following changes will be made.
 @@ -6 +6 @@
 -}
 +/* } */
---- ./sources/address_migration1.move
-+++ ./sources/address_migration1.move
+--- ./sources/address_migration2.move
++++ ./sources/address_migration2.move
 @@ -1 +1 @@
 -address /* some inline comment */ 0x2 
 +/* address /* some inline comment */ 0x2 
@@ -45,13 +45,13 @@ The following changes will be made.
 @@ -8 +8 @@
 -/* an inline comment*/}
 +/* an inline comment*//* } */
---- ./sources/address_migration2.move
-+++ ./sources/address_migration2.move
+--- ./sources/address_migration3.move
++++ ./sources/address_migration3.move
 @@ -1 +1 @@
 -address 0x2{ module m {} module n {}}
 +/* address 0x2{ */ module 0x2::m {} module 0x2::n {}/* } */
---- ./sources/address_migration3.move
-+++ ./sources/address_migration3.move
+--- ./sources/address_migration4.move
++++ ./sources/address_migration4.move
 @@ -1,2 +1,2 @@
 -address A {
 -module m {
@@ -67,19 +67,19 @@ The following changes will be made.
 
 ============================================================
 Apply changes? (Y/n) 
-Updating "./sources/address_migration.move" . . .
 Updating "./sources/address_migration1.move" . . .
 Updating "./sources/address_migration2.move" . . .
 Updating "./sources/address_migration3.move" . . .
+Updating "./sources/address_migration4.move" . . .
 
 Changes complete
 Wrote patchfile out to: ./migration.patch
 
 Recorded edition in 'Move.toml'
 External Command `diff -r -s sources migration_sources`:
-Files sources/address_migration.move and migration_sources/address_migration.move are identical
 Files sources/address_migration1.move and migration_sources/address_migration1.move are identical
 Files sources/address_migration2.move and migration_sources/address_migration2.move are identical
 Files sources/address_migration3.move and migration_sources/address_migration3.move are identical
+Files sources/address_migration4.move and migration_sources/address_migration4.move are identical
 External Command `diff -s Move.toml Move.toml.expected`:
 Files Move.toml and Move.toml.expected are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration.move
@@ -1,6 +1,0 @@
-/* address 0x2 { */
-module 0x2::m {
-}
-module 0x2::n {
-}
-/* } */

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration1.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration1.move
@@ -1,8 +1,6 @@
-/* address /* some inline comment */ 0x2 
-// a line comment
-{ */
+/* address 0x2 { */
 module 0x2::m {
 }
 module 0x2::n {
 }
-/* an inline comment*//* } */
+/* } */

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration2.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration2.move
@@ -1,1 +1,8 @@
-/* address 0x2{ */ module 0x2::m {} module 0x2::n {}/* } */
+/* address /* some inline comment */ 0x2 
+// a line comment
+{ */
+module 0x2::m {
+}
+module 0x2::n {
+}
+/* an inline comment*//* } */

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration3.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration3.move
@@ -1,6 +1,1 @@
-/* address A { */
-module A::m {
-}
-module A::n {
-}
-/* } */
+/* address 0x2{ */ module 0x2::m {} module 0x2::n {}/* } */

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration4.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration4.move
@@ -1,0 +1,6 @@
+/* address A { */
+module A::m {
+}
+module A::n {
+}
+/* } */

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration1.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration1.move
@@ -1,8 +1,6 @@
-address /* some inline comment */ 0x2 
-// a line comment
-{
+address 0x2 {
 module m {
 }
 module n {
 }
-/* an inline comment*/}
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration2.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration2.move
@@ -1,1 +1,8 @@
-address 0x2{ module m {} module n {}}
+address /* some inline comment */ 0x2 
+// a line comment
+{
+module m {
+}
+module n {
+}
+/* an inline comment*/}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration3.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration3.move
@@ -1,6 +1,1 @@
-address A {
-module m {
-}
-module n {
-}
-}
+address 0x2{ module m {} module n {}}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration4.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration4.move
@@ -1,4 +1,4 @@
-address 0x2 {
+address A {
 module m {
 }
 module n {


### PR DESCRIPTION
# Description of change

The `move-cli` tests started failing because the order returned by the `diff` command was different in the CI.

```diff
-Files sources/address_migration.move and migration_sources/address_migration.move are identical
Files sources/address_migration1.move and migration_sources/address_migration1.move are identical
Files sources/address_migration2.move and migration_sources/address_migration2.move are identical
Files sources/address_migration3.move and migration_sources/address_migration3.move are identical
+Files sources/address_migration.move and migration_sources/address_migration.move are identical
```
I renamed the files (all bumped by +1).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes