### PR TITLE
feat(aws): orchestrator improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5670,6 +5670,7 @@ dependencies = [
  "aws-runtime",
  "aws-sdk-ec2",
  "aws-smithy-runtime-api",
+ "chrono",
  "clap",
  "color-eyre",
  "crossterm 0.25.0",

--- a/crates/iota-aws-orchestrator/Cargo.toml
+++ b/crates/iota-aws-orchestrator/Cargo.toml
@@ -13,6 +13,7 @@ aws-config = "1.5.6"
 aws-runtime = "1.4"
 aws-sdk-ec2 = "1.72"
 aws-smithy-runtime-api = "1.7"
+chrono.workspace = true
 clap.workspace = true
 color-eyre = "0.6"
 crossterm.workspace = true

--- a/crates/iota-aws-orchestrator/assets/plot.py
+++ b/crates/iota-aws-orchestrator/assets/plot.py
@@ -245,7 +245,7 @@ class Plotter:
 
     def _load_measurement_data(self, filename):
         measurements = []
-        files = glob(os.path.join(self.data_directory, filename))
+        files = glob(os.path.join(self.data_directory, '**', filename), recursive=True)
         for file in files:
             print(f'Loading file {file}...')
             with open(file, 'r') as f:
@@ -259,7 +259,7 @@ class Plotter:
     def _file_format(self, shared_objects_ratio, faults, nodes, load):
         use_ip = self.parameters.use_internal_ip_address
         use_ip = '*' if use_ip is None else 'true' if use_ip else 'false'
-        return f'measurements-{shared_objects_ratio}-{faults}-{nodes}-{load}-{use_ip}.json'
+        return f'measurements-{shared_objects_ratio}-{faults}-{nodes}-{load}-{use_ip}-*.json'
 
     def plot_latency_throughput(self):
         plot_lines_data = []

--- a/crates/iota-aws-orchestrator/src/measurement.rs
+++ b/crates/iota-aws-orchestrator/src/measurement.rs
@@ -2,13 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::HashMap,
-    fs,
-    io::BufRead,
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::{collections::HashMap, fs, io::BufRead, path::Path, time::Duration};
 
 use prettytable::{Table, row};
 use prometheus_parse::Scrape;
@@ -355,8 +349,9 @@ impl<T: BenchmarkType> MeasurementsCollection<T> {
     /// Save the collection of measurements as a json file.
     pub fn save<P: AsRef<Path>>(&self, path: P) {
         let json = serde_json::to_string_pretty(self).expect("Cannot serialize metrics");
-        let mut file = PathBuf::from(path.as_ref());
-        file.push(format!("measurements-{:?}.json", self.parameters));
+        let file = path
+            .as_ref()
+            .join(format!("measurements-{:?}.json", self.parameters));
         fs::write(file, json).unwrap();
     }
 

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use chrono;
 use tokio::time::{self, Instant};
 
 use crate::{
@@ -602,9 +603,14 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
 
         let results_directory = &self.settings.results_dir;
         let commit = &self.settings.repository.commit;
-        let path: PathBuf = [results_directory, &format!("results-{commit}").into()]
-            .iter()
-            .collect();
+        let timestamp = chrono::Local::now().format("%y%m%d_%H%M%S");
+        let path: PathBuf = [
+            results_directory,
+            &format!("results-{commit}").into(),
+            &format!("{timestamp}").into(),
+        ]
+        .iter()
+        .collect();
         fs::create_dir_all(&path).expect("Failed to create log directory");
         aggregator.save(&path);
 

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -338,31 +338,8 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
     pub async fn update(&self) -> TestbedResult<()> {
         display::action("Updating all instances");
 
-        // Update all active instances.
         let commit = &self.settings.repository.commit;
-        let git_update_command = [
-            &format!("git fetch origin {commit} --force"),
-            &format!("(git reset --hard origin/{commit} || git checkout --force {commit})"),
-            "git clean -fd -e target",
-        ]
-        .join(" && ");
-
-        let id = "git update";
         let repo_name = self.settings.repository_name();
-        let context = CommandContext::new()
-            .run_background(id.into())
-            .with_execute_from_path(repo_name.clone().into());
-
-        // Execute and wait for the git update command on all instances (including
-        // metrics)
-        display::action(format!("update command: {git_update_command}"));
-        self.ssh_manager
-            .execute(self.instances(), git_update_command, context)
-            .await?;
-        self.ssh_manager
-            .wait_for_command(self.instances(), id, CommandStatus::Terminated)
-            .await?;
-
         let build_groups = self.settings.build_groups();
 
         // Check if build cache is enabled
@@ -378,6 +355,28 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
                 )
                 .await?;
         } else {
+            let git_update_command = [
+                &format!("git fetch origin {commit} --force"),
+                &format!("(git reset --hard origin/{commit} || git checkout --force {commit})"),
+                "git clean -fd -e target",
+            ]
+            .join(" && ");
+
+            let id = "git update";
+            let context = CommandContext::new()
+                .run_background(id.into())
+                .with_execute_from_path(repo_name.clone().into());
+
+            // Execute and wait for the git update command on all instances (including
+            // metrics)
+            display::action(format!("update command: {git_update_command}"));
+            self.ssh_manager
+                .execute(self.instances(), git_update_command, context)
+                .await?;
+            self.ssh_manager
+                .wait_for_command(self.instances(), id, CommandStatus::Terminated)
+                .await?;
+
             self.update_with_local_build(build_groups).await?;
         }
 

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -539,6 +539,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
     /// Collect metrics from the load generators.
     pub async fn run(
         &self,
+        benchmark_dir: &Path,
         parameters: &BenchmarkParameters<T>,
     ) -> TestbedResult<MeasurementsCollection<T>> {
         display::action(format!(
@@ -601,24 +602,16 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             }
         }
 
-        let results_directory = &self.settings.results_dir;
-        let commit = &self.settings.repository.commit;
-        let timestamp = chrono::Local::now().format("%y%m%d_%H%M%S");
-        let path: PathBuf = [
-            results_directory,
-            &format!("results-{commit}").into(),
-            &format!("{timestamp}").into(),
-        ]
-        .iter()
-        .collect();
-        fs::create_dir_all(&path).expect("Failed to create log directory");
-        aggregator.save(&path);
+        aggregator.save(benchmark_dir);
 
         if self.settings.enable_flamegraph {
+            let flamegraphs_dir = benchmark_dir.join("flamegraphs");
+            fs::create_dir_all(&flamegraphs_dir).expect("Failed to create flamegraphs directory");
+
             self.fetch_flamegraphs(
                 parameters,
                 self.instances_without_metrics().clone(),
-                &path,
+                &flamegraphs_dir,
                 "?svg=true",
                 "flamegraph",
             )
@@ -633,7 +626,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
                 self.fetch_flamegraphs(
                     parameters,
                     self.instances_without_metrics().clone(),
-                    &path,
+                    &flamegraphs_dir,
                     "?svg=true&mem=true",
                     "flamegraph-alloc",
                 )
@@ -674,20 +667,10 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
     }
 
     /// Download the log files from the nodes and clients.
-    pub async fn download_logs(
-        &self,
-        parameters: &BenchmarkParameters<T>,
-    ) -> TestbedResult<LogsAnalyzer> {
-        // Create a log sub-directory for this run.
-        let commit = &self.settings.repository.commit;
-        let path: PathBuf = [
-            &self.settings.logs_dir,
-            &format!("logs-{commit}").into(),
-            &format!("logs-{parameters:?}").into(),
-        ]
-        .iter()
-        .collect();
-        fs::create_dir_all(&path).expect("Failed to create log directory");
+    pub async fn download_logs(&self, benchmark_dir: &Path) -> TestbedResult<LogsAnalyzer> {
+        // Create a logs sub-directory for this run.
+        let path = benchmark_dir.join("logs");
+        fs::create_dir_all(&path).expect("Failed to create logs directory");
 
         // NOTE: Our ssh library does not seem to be able to transfers files in parallel
         // reliably.
@@ -701,10 +684,8 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             let connection = self.ssh_manager.connect(instance.ssh_address()).await?;
             let client_log_content = connection.download("client.log").await?;
 
-            let client_log_file = [path.clone(), format!("client-{i}.log").into()]
-                .iter()
-                .collect::<PathBuf>();
-            fs::write(&client_log_file, client_log_content.as_bytes())
+            let client_log_file = path.join(format!("client-{i}.log"));
+            fs::write(client_log_file, client_log_content.as_bytes())
                 .expect("Cannot write log file");
 
             let mut log_parser = LogsAnalyzer::default();
@@ -720,10 +701,8 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             let connection = self.ssh_manager.connect(instance.ssh_address()).await?;
             let node_log_content = connection.download("node.log").await?;
 
-            let node_log_file = [path.clone(), format!("node-{i}.log").into()]
-                .iter()
-                .collect::<PathBuf>();
-            fs::write(&node_log_file, node_log_content.as_bytes()).expect("Cannot write log file");
+            let node_log_file = path.join(format!("node-{i}.log"));
+            fs::write(node_log_file, node_log_content.as_bytes()).expect("Cannot write log file");
 
             let mut log_parser = LogsAnalyzer::default();
             log_parser.set_node_errors(&node_log_content);
@@ -746,6 +725,9 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         // Cleanup the testbed (in case the previous run was not completed).
         self.cleanup(true).await?;
 
+        let commit: PathBuf = self.settings.repository.commit.replace("/", "_").into();
+        let timestamp = chrono::Local::now().format("%y%m%d_%H%M%S");
+
         // Update the software on all instances.
         if !self.skip_testbed_update {
             self.install().await?;
@@ -761,8 +743,18 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             display::config("Parameters", &parameters);
             display::newline();
 
+            let benchmark_dir: PathBuf = [
+                &self.settings.results_dir,
+                &commit,
+                &format!("{timestamp}-{parameters:?}").into(),
+            ]
+            .iter()
+            .collect();
+
             // Cleanup the testbed (in case the previous run was not completed).
             self.cleanup(true).await?;
+            // Create benchmark directory.
+            fs::create_dir_all(&benchmark_dir).expect("Failed to create benchmark directory");
             // Start the instance monitoring tools.
             self.start_monitoring(&parameters).await?;
 
@@ -780,7 +772,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
 
             // Wait for the benchmark to terminate. Then save the results and print a
             // summary.
-            let aggregator = self.run(&parameters).await?;
+            let aggregator = self.run(&benchmark_dir, &parameters).await?;
             aggregator.display_summary();
             generator.register_result(aggregator);
             // drop(monitor);
@@ -790,7 +782,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
 
             // Download the log files.
             if self.log_processing {
-                let error_counter = self.download_logs(&parameters).await?;
+                let error_counter = self.download_logs(&benchmark_dir).await?;
                 error_counter.print_summary();
             }
 

--- a/crates/iota-aws-orchestrator/src/settings.rs
+++ b/crates/iota-aws-orchestrator/src/settings.rs
@@ -197,13 +197,9 @@ pub struct Settings {
     #[serde(default)]
     pub use_fullnode_for_execution: bool,
     /// The directory (on the local machine) where to save benchmarks
-    /// measurements.
+    /// results.
     #[serde(default = "default_results_dir")]
     pub results_dir: PathBuf,
-    /// The directory (on the local machine) where to download logs files from
-    /// the instances.
-    #[serde(default = "default_logs_dir")]
-    pub logs_dir: PathBuf,
     /// Binary build configuration.
     #[serde(default)]
     pub build_configs: HashMap<String, BinaryBuildConfig>,
@@ -220,10 +216,6 @@ fn default_results_dir() -> PathBuf {
     ["./", "results"].iter().collect()
 }
 
-fn default_logs_dir() -> PathBuf {
-    ["./", "logs"].iter().collect()
-}
-
 impl Settings {
     /// Load the settings from a json file.
     pub fn load<P>(path: P) -> SettingsResult<Self>
@@ -236,7 +228,6 @@ impl Settings {
             let settings: Settings = serde_json::from_slice(data.as_bytes())?;
 
             fs::create_dir_all(&settings.results_dir)?;
-            fs::create_dir_all(&settings.logs_dir)?;
 
             Ok(settings)
         };
@@ -381,7 +372,6 @@ impl Settings {
             working_dir: "/path/to/working_dir".into(),
             use_fullnode_for_execution: false,
             results_dir: "results".into(),
-            logs_dir: "logs".into(),
             build_configs: HashMap::new(),
             enable_flamegraph: false,
         }

--- a/crates/iota-aws-orchestrator/src/ssh.rs
+++ b/crates/iota-aws-orchestrator/src/ssh.rs
@@ -51,6 +51,8 @@ pub struct CommandContext {
     pub path: Option<PathBuf>,
     /// The log file to redirect all stdout and stderr.
     pub log_file: Option<PathBuf>,
+    /// The number of retries before giving up to execute the command.
+    pub retries: usize,
 }
 
 impl CommandContext {
@@ -60,6 +62,7 @@ impl CommandContext {
             background: None,
             path: None,
             log_file: None,
+            retries: 0,
         }
     }
 
@@ -78,6 +81,12 @@ impl CommandContext {
     /// Set the log file where to redirect stdout and stderr.
     pub fn with_log_file(mut self, path: PathBuf) -> Self {
         self.log_file = Some(path);
+        self
+    }
+
+    /// Set the number of retries before giving up to execute the command.
+    pub fn with_retries(mut self, retries: usize) -> Self {
+        self.retries = retries;
         self
     }
 
@@ -209,34 +218,24 @@ impl SshConnectionManager {
                 let context = context.clone();
 
                 tokio::spawn(async move {
+                    let connection = ssh_manager.connect(instance.ssh_address()).await?;
+
                     let command_str = command.into();
                     let mut consecutive_errors = 0;
                     loop {
-                        match ssh_manager.connect(instance.ssh_address()).await {
-                            Ok(connection) => {
-                                // success resets the error streak
-                                consecutive_errors = 0;
-                                match connection.execute(context.apply(command_str.clone())).await {
-                                    Ok(output) => {
-                                        return Ok(output);
-                                    }
-                                    Err(err) => {
-                                        consecutive_errors += 1;
-                                        if consecutive_errors >= 5 {
-                                            return Err(err);
-                                        }
-                                    }
-                                }
+                        match connection.execute(context.apply(command_str.clone())).await {
+                            Ok(output) => {
+                                return Ok(output);
                             }
                             Err(err) => {
                                 consecutive_errors += 1;
-                                if consecutive_errors >= 5 {
+                                if consecutive_errors > context.retries {
                                     return Err(err);
                                 }
                             }
                         }
 
-                        sleep(Duration::from_secs(5)).await;
+                        sleep(Self::RETRY_DELAY).await;
                     }
                 })
             })
@@ -294,7 +293,7 @@ impl SshConnectionManager {
             sleep(Self::RETRY_DELAY).await;
 
             if self
-                .execute_per_instance(instances.clone(), CommandContext::default())
+                .execute_per_instance(instances.clone(), CommandContext::default().with_retries(5))
                 .await
                 .is_ok()
             {
@@ -310,7 +309,7 @@ impl SshConnectionManager {
     {
         let ssh_command = format!("(tmux kill-session -t {command_id} || true)");
         let targets = instances.into_iter().map(|x| (x, ssh_command.clone()));
-        self.execute_per_instance(targets, CommandContext::default())
+        self.execute_per_instance(targets, CommandContext::default().with_retries(5))
             .await?;
         Ok(())
     }


### PR DESCRIPTION
# Description of change

This PR fixes some issues with the `iota-aws-orchestrator`:
- simplify and reorganize results directory structure as follows: `<results_dir>/<commit>/<timestamp>-<params>/`, `logs` and `flamegraphs` are placed into respective subfolders; this allows to keep the results of multiple benchmark runs with the same parameters.
- Fix the retry logic and add new `with_retries` to `CommandContext`
- Do not clone the repository if the build cache is used. It's not needed.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes