### PR TITLE
fix(flamegraphs): FlameSub layer always enable so that it doesn't block other layers

### DIFF
--- a/crates/telemetry-subscribers/src/flamegraph/tracing.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/tracing.rs
@@ -284,10 +284,12 @@ where
 {
     fn enabled(
         &self,
-        metadata: &tracing::Metadata<'_>,
+        _metadata: &tracing::Metadata<'_>,
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) -> bool {
-        self.enabled_metadata(metadata)
+        // When used as a Layer, we must return true for events to allow them to pass
+        // through to other layers.
+        true
     }
 
     fn on_new_span(


### PR DESCRIPTION
# Description of change

This PR fixes an issue causing FlameSub layer to block other tracing layers. With this fix FlameSub layer always enables other tracing_subscriber layers.
