### PR TITLE
fix(license): add `flamegraph-svg` to allowed gits and add CDDL license

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,8 @@ ci-clippy = "clippy --all-targets --all-features -- -D warnings"
 ci-license = "license-template --template .license_template --ignore .license_ignore"
 ci-udeps = "udeps --all-targets --backend=depinfo"
 ci-udeps-external = "udeps --all-targets --manifest-path external-crates/move/Cargo.toml --backend=depinfo"
+ci-deny-bans = "deny --manifest-path ./Cargo.toml check bans licenses sources --hide-inclusion-graph"
+ci-deny-advisories = "deny --manifest-path ./Cargo.toml check advisories --hide-inclusion-graph"
 
 [build]
 rustflags = ["-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]

--- a/deny.toml
+++ b/deny.toml
@@ -86,13 +86,13 @@ allow = [
   "ISC",
   "CC0-1.0",
   "0BSD",
-  "LicenseRef-ring",
   "Unlicense",
   "BSL-1.0",
   "Unicode-DFS-2016",
   "OpenSSL",
   "Unicode-3.0",
   "CDLA-Permissive-2.0",
+  "CDDL-1.0",
   # "Apache-2.0 WITH LLVM-exception",
 ]
 # The confidence threshold for detecting a license from license text.
@@ -221,6 +221,7 @@ allow-git = [
   "https://github.com/bmwill/openapiv3.git",
   "https://github.com/bmwill/axum-server.git",
   "https://github.com/iotaledger/iota-bigtable.git",
+  "https://github.com/iotaledger/flamegraph-svg.git",
 ]
 
 [sources.allow-org]


### PR DESCRIPTION
# Description of change

I created a new repo for the flamegraph code we copied and modified. It is licensed under CDDL license.

See https://github.com/iotaledger/flamegraph-svg

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes