### PR TITLE
feat(graphql-rpc): add `Event.transactionBlock` field

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/event_connection/complexity.move
+++ b/crates/iota-graphql-e2e-tests/tests/event_connection/complexity.move
@@ -1,0 +1,109 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 17 --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use iota::event;
+
+    public struct EventA has copy, drop {
+        new_value: u64
+    }
+
+    public entry fun emit_100() {
+        let mut i = 0;
+        while (i < 100) {
+            event::emit(EventA { new_value: i });
+            i = i + 1;
+        }
+    }
+}
+
+//# run Test::M1::emit_100 --sender A
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  events(filter: { sender: "@{A}" }) {
+    nodes {
+      sendingModule {
+        name
+      }
+      json
+      bcs
+      transactionBlock {
+          digest
+      }
+    }
+  }
+}
+
+//# run-graphql
+# This should fail due to the complexity of the query.
+{
+  events(first: 50, filter: { sender: "@{A}" }) {
+    nodes {                               
+      sendingModule {                     
+        name                              
+      }
+      json                                
+      bcs                                 
+      transactionBlock {                  
+          digest                          
+          effects {                       
+              events(first: 50) {        
+                  nodes {                   
+                      transactionBlock {    
+                          digest
+                      }
+                  }
+              }
+          }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  transactionBlocks(filter: { signAddress: "@{A}" }) {
+    nodes {                     
+      effects{                  
+        events {               
+          edges {               
+            node {              
+              sendingModule {   
+                name            
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# This should fail due to the complexity of the query
+{
+  transactionBlocks(filter: { signAddress: "@{A}" }) {
+    nodes {                     
+      effects{                  
+        events {               
+          edges {               
+            node {              
+              sendingModule {   
+                name            
+              }
+              transactionBlock {
+                digest
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/event_connection/complexity.move
+++ b/crates/iota-graphql-e2e-tests/tests/event_connection/complexity.move
@@ -44,18 +44,18 @@ module Test::M1 {
 # This should fail due to the complexity of the query.
 {
   events(first: 50, filter: { sender: "@{A}" }) {
-    nodes {                               
-      sendingModule {                     
-        name                              
+    nodes {
+      sendingModule {
+        name
       }
-      json                                
-      bcs                                 
-      transactionBlock {                  
-          digest                          
-          effects {                       
-              events(first: 50) {        
-                  nodes {                   
-                      transactionBlock {    
+      json
+      bcs
+      transactionBlock {
+          digest
+          effects {
+              events(first: 50) {
+                  nodes {
+                      transactionBlock {
                           digest
                       }
                   }
@@ -69,13 +69,13 @@ module Test::M1 {
 //# run-graphql
 {
   transactionBlocks(filter: { signAddress: "@{A}" }) {
-    nodes {                     
-      effects{                  
-        events {               
-          edges {               
-            node {              
-              sendingModule {   
-                name            
+    nodes {
+      effects{
+        events {
+          edges {
+            node {
+              sendingModule {
+                name
               }
             }
           }
@@ -89,16 +89,157 @@ module Test::M1 {
 # This should fail due to the complexity of the query
 {
   transactionBlocks(filter: { signAddress: "@{A}" }) {
-    nodes {                     
-      effects{                  
-        events {               
-          edges {               
-            node {              
-              sendingModule {   
-                name            
+    nodes {
+      effects{
+        events {
+          edges {
+            node {
+              sendingModule {
+                name
               }
               transactionBlock {
                 digest
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  transactionBlocks(filter: { signAddress: "@{A}" }) {
+    nodes {
+      effects{
+        dependencies {
+            nodes {
+                digest
+                effects {
+                    events {
+                        edges {
+                            node {
+                                sendingModule {
+                                    name
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        events {
+          edges {
+            node {
+              sendingModule {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# This should fail due to the complexity of the query
+{
+  transactionBlocks(filter: { signAddress: "@{A}" }) {
+    nodes {
+      effects{
+        dependencies {
+            nodes {
+                digest
+                effects {
+                    events {
+                        edges {
+                            node {
+                                sendingModule {
+                                    name
+                                }
+                                transactionBlock {
+                                    digest
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        events {
+          edges {
+            node {
+              sendingModule {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  transactionBlocks(filter: { signAddress: "@{A}" }) {
+    nodes {
+      effects{
+        checkpoint {
+            transactionBlocks {
+                nodes {
+                  digest
+                }
+            }
+        }
+        events {
+          edges {
+            node {
+              sendingModule {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# This should fail due to the complexity of the query
+{
+  transactionBlocks(filter: { signAddress: "@{A}" }) {
+    nodes {
+      effects{
+        checkpoint {
+            transactionBlocks {
+                nodes {
+                  digest
+                  effects{
+                    events {
+                      edges {
+                        node {
+                          sendingModule {
+                            name
+                          }
+                          transactionBlock {
+                            digest
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+            }
+        }
+        events {
+          edges {
+            node {
+              sendingModule {
+                name
               }
             }
           }

--- a/crates/iota-graphql-e2e-tests/tests/event_connection/complexity.snap
+++ b/crates/iota-graphql-e2e-tests/tests/event_connection/complexity.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 8 tasks
+processed 12 tasks
 
 init:
 A: object(0,0)
@@ -444,6 +444,393 @@ Response: {
 }
 
 task 7, lines 88-109:
+//# run-graphql
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Query is too complex."
+    }
+  ]
+}
+
+task 8, lines 111-144:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "effects": {
+            "dependencies": {
+              "nodes": [
+                {
+                  "digest": "2T97RmNS4FSm8cVVQjhFaYobDxN9efZ2sJrgnBjNFqeP",
+                  "effects": {
+                    "events": {
+                      "edges": [
+                        {
+                          "node": {
+                            "sendingModule": {
+                              "name": "nft"
+                            }
+                          }
+                        },
+                        {
+                          "node": {
+                            "sendingModule": {
+                              "name": "nft"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "digest": "5Hb1xThFNfHqHXb8P35FdoFNWfudxSmwXDTRfRHMvHYL",
+                  "effects": {
+                    "events": {
+                      "edges": []
+                    }
+                  }
+                }
+              ]
+            },
+            "events": {
+              "edges": [
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 9, lines 146-183:
+//# run-graphql
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Query is too complex."
+    }
+  ]
+}
+
+task 10, lines 185-209:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "effects": {
+            "checkpoint": {
+              "transactionBlocks": {
+                "nodes": [
+                  {
+                    "digest": "5Hb1xThFNfHqHXb8P35FdoFNWfudxSmwXDTRfRHMvHYL"
+                  },
+                  {
+                    "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+                  }
+                ]
+              }
+            },
+            "events": {
+              "edges": [
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 11, lines 211-250:
 //# run-graphql
 Response: {
   "data": null,

--- a/crates/iota-graphql-e2e-tests/tests/event_connection/complexity.snap
+++ b/crates/iota-graphql-e2e-tests/tests/event_connection/complexity.snap
@@ -1,0 +1,455 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-21:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4841200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 23:
+//# run Test::M1::emit_100 --sender A
+events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [1, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [2, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [3, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [4, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [5, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [6, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [7, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [8, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [9, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [10, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [11, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [12, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [13, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [14, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [15, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [16, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [17, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [18, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [19, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [20, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [21, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [22, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [23, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [24, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [25, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [26, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [27, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [28, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [29, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [30, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [31, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [32, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [33, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [34, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [35, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [36, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [37, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [38, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [39, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [40, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [41, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [42, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [43, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [44, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [45, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [46, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [47, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [48, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [49, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [50, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [51, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [52, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [53, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [54, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [55, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [56, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [57, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [58, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [59, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [60, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [61, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [62, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [63, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [64, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [65, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [66, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [67, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [68, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [69, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [70, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [71, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [72, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [73, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [74, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [75, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [76, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [77, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [78, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [79, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [80, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [81, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [82, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [83, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [84, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [85, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [86, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [87, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [88, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [89, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [90, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [91, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [92, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [93, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [94, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [95, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [96, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [97, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [98, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [99, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 980400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 25:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 27-41:
+//# run-graphql
+Response: {
+  "data": {
+    "events": {
+      "nodes": [
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "0"
+          },
+          "bcs": "AAAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "1"
+          },
+          "bcs": "AQAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "2"
+          },
+          "bcs": "AgAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "3"
+          },
+          "bcs": "AwAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "4"
+          },
+          "bcs": "BAAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "5"
+          },
+          "bcs": "BQAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "6"
+          },
+          "bcs": "BgAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "7"
+          },
+          "bcs": "BwAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "8"
+          },
+          "bcs": "CAAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "9"
+          },
+          "bcs": "CQAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "10"
+          },
+          "bcs": "CgAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "11"
+          },
+          "bcs": "CwAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "12"
+          },
+          "bcs": "DAAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "13"
+          },
+          "bcs": "DQAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "14"
+          },
+          "bcs": "DgAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "15"
+          },
+          "bcs": "DwAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "16"
+          },
+          "bcs": "EAAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "17"
+          },
+          "bcs": "EQAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "18"
+          },
+          "bcs": "EgAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "19"
+          },
+          "bcs": "EwAAAAAAAAA=",
+          "transactionBlock": {
+            "digest": "FN31rqGck1n9bBEdgPZWoum1ZVQn64bgWAp2YPfgEmjj"
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 5, lines 43-67:
+//# run-graphql
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Query is too complex."
+    }
+  ]
+}
+
+task 6, lines 69-86:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "effects": {
+            "events": {
+              "edges": [
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 7, lines 88-109:
+//# run-graphql
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Query is too complex."
+    }
+  ]
+}

--- a/crates/iota-graphql-e2e-tests/tests/limits/output_node_estimation.snap
+++ b/crates/iota-graphql-e2e-tests/tests/limits/output_node_estimation.snap
@@ -433,6 +433,15 @@ Response: {
           "column": 21
         }
       ]
+    },
+    {
+      "message": "Failed to parse \"Int\": Invalid number",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ]
     }
   ]
 }

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -1281,6 +1281,15 @@ type Epoch {
 
 type Event {
 	"""
+	The transaction block that emitted this event. This information is only
+	available for events from transactions included in a checkpoint.
+	
+	For simulated transactions (e.g. dry run), or transactions that have
+	been just executed but not yet included in a checkpoint this returns
+	null.
+	"""
+	transactionBlock: TransactionBlock
+	"""
 	The Move module containing some function that when called by
 	a programmable transaction block (PTB) emitted this event.
 	For example, if a PTB invokes A::m1::foo, which internally

--- a/crates/iota-graphql-rpc/src/config.rs
+++ b/crates/iota-graphql-rpc/src/config.rs
@@ -14,6 +14,8 @@ use crate::functional_group::FunctionalGroup;
 
 pub(crate) const RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD: Duration = Duration::from_millis(10_000);
 pub(crate) const MAX_CONCURRENT_REQUESTS: usize = 1_000;
+pub(crate) const DEFAULT_PAGE_SIZE: u32 = 20;
+pub(crate) const MAX_PAGE_SIZE: u32 = 50;
 
 /// The combination of all configurations for the GraphQL service.
 #[GraphQLConfig]
@@ -499,8 +501,8 @@ impl Default for Limits {
             max_output_nodes: 100_000,
             max_query_payload_size: 5_000,
             max_db_query_cost: 20_000,
-            default_page_size: 20,
-            max_page_size: 50,
+            default_page_size: DEFAULT_PAGE_SIZE,
+            max_page_size: MAX_PAGE_SIZE,
             // This default was picked as the sum of pre- and post- quorum timeouts from
             // [`iota_core::authority_aggregator::TimeoutConfig`], with a 10% buffer.
             //

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -90,6 +90,8 @@ use crate::{
 /// The default allowed maximum lag between the current timestamp and the
 /// checkpoint timestamp.
 const DEFAULT_MAX_CHECKPOINT_LAG: Duration = Duration::from_secs(300);
+/// The maximum complexity allowed for native [`async_graphql`] checks.
+const MAX_COMPLEXITY: usize = 3000;
 
 pub(crate) struct Server {
     router: Router,
@@ -537,7 +539,7 @@ impl ServerBuilder {
 
 fn schema_builder() -> SchemaBuilder<Query, Mutation, Subscription> {
     async_graphql::Schema::build(Query, Mutation, Subscription)
-        .limit_complexity(6000)
+        .limit_complexity(MAX_COMPLEXITY)
         .register_output_type::<IMoveObject>()
         .register_output_type::<IObject>()
         .register_output_type::<IOwner>()

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -91,7 +91,7 @@ use crate::{
 /// checkpoint timestamp.
 const DEFAULT_MAX_CHECKPOINT_LAG: Duration = Duration::from_secs(300);
 /// The maximum complexity allowed for native [`async_graphql`] checks.
-const MAX_COMPLEXITY: usize = 3000;
+const MAX_COMPLEXITY: usize = 6000;
 
 pub(crate) struct Server {
     router: Router,

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -537,6 +537,7 @@ impl ServerBuilder {
 
 fn schema_builder() -> SchemaBuilder<Query, Mutation, Subscription> {
     async_graphql::Schema::build(Query, Mutation, Subscription)
+        .limit_complexity(6000)
         .register_output_type::<IMoveObject>()
         .register_output_type::<IObject>()
         .register_output_type::<IOwner>()

--- a/crates/iota-graphql-rpc/src/types/address.rs
+++ b/crates/iota-graphql-rpc/src/types/address.rs
@@ -5,6 +5,7 @@
 use async_graphql::{connection::Connection, *};
 
 use crate::{
+    config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     types::{
         balance::{self, Balance},
@@ -171,6 +172,9 @@ impl Address {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    #[graphql(
+        complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
+    )]
     async fn transaction_blocks(
         &self,
         ctx: &Context<'_>,

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -152,7 +152,6 @@ impl Checkpoint {
     }
 
     /// The epoch this checkpoint is part of.
-    #[graphql(complexity = 0)]
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
             ctx,

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -16,6 +16,7 @@ use iota_types::messages_checkpoint::CheckpointDigest;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     consistency::Checkpointed,
     data::{self, Conn, DataLoader, Db, DbConnection, QueryExecutor},
@@ -92,12 +93,14 @@ impl Checkpoint {
     /// in Base58. This hash can be used to verify checkpoint contents by
     /// checking signatures against the committee, Hashing contents to match
     /// digest, and checking that the previous checkpoint digest matches.
+    #[graphql(complexity = 0)]
     async fn digest(&self) -> Result<String> {
         Ok(self.digest_impl().extend()?.base58_encode())
     }
 
     /// This checkpoint's position in the total order of finalized checkpoints,
     /// agreed upon by consensus.
+    #[graphql(complexity = 0)]
     async fn sequence_number(&self) -> UInt53 {
         self.sequence_number_impl().into()
     }
@@ -105,17 +108,20 @@ impl Checkpoint {
     /// The timestamp at which the checkpoint is agreed to have happened
     /// according to consensus. Transactions that access time in this
     /// checkpoint will observe this timestamp.
+    #[graphql(complexity = 0)]
     async fn timestamp(&self) -> Result<DateTime> {
         DateTime::from_ms(self.stored.timestamp_ms).extend()
     }
 
     /// This is an aggregation of signatures from a quorum of validators for the
     /// checkpoint proposal.
+    #[graphql(complexity = 0)]
     async fn validator_signatures(&self) -> Base64 {
         Base64::from(&self.stored.validator_signature)
     }
 
     /// The digest of the checkpoint at the previous sequence number.
+    #[graphql(complexity = 0)]
     async fn previous_checkpoint_digest(&self) -> Option<String> {
         self.stored
             .previous_checkpoint_digest
@@ -125,6 +131,7 @@ impl Checkpoint {
 
     /// The total number of transaction blocks in the network by the end of this
     /// checkpoint.
+    #[graphql(complexity = 0)]
     async fn network_total_transactions(&self) -> Option<UInt53> {
         Some(self.network_total_transactions_impl().into())
     }
@@ -133,6 +140,7 @@ impl Checkpoint {
     /// storage fee accumulated during this epoch, up to and including this
     /// checkpoint. These values increase monotonically across checkpoints
     /// in the same epoch, and reset on epoch boundaries.
+    #[graphql(complexity = 0)]
     async fn rolling_gas_summary(&self) -> Option<GasCostSummary> {
         Some(GasCostSummary {
             computation_cost: self.stored.computation_cost as u64,
@@ -144,6 +152,7 @@ impl Checkpoint {
     }
 
     /// The epoch this checkpoint is part of.
+    #[graphql(complexity = 0)]
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
             ctx,
@@ -177,6 +186,9 @@ impl Checkpoint {
     ///
     /// By default, the scanning range consists of all transactions in this
     /// checkpoint.
+    #[graphql(
+        complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
+    )]
     async fn transaction_blocks(
         &self,
         ctx: &Context<'_>,

--- a/crates/iota-graphql-rpc/src/types/coin.rs
+++ b/crates/iota-graphql-rpc/src/types/coin.rs
@@ -10,6 +10,7 @@ use iota_indexer::{models::objects::StoredHistoryObject, types::OwnerType};
 use iota_types::{TypeTag, coin::Coin as NativeCoin};
 
 use crate::{
+    config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     consistency::{View, build_objects_query},
     data::{Db, QueryExecutor},
@@ -228,6 +229,9 @@ impl Coin {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    #[graphql(
+        complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
+    )]
     pub(crate) async fn received_transaction_blocks(
         &self,
         ctx: &Context<'_>,

--- a/crates/iota-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/iota-graphql-rpc/src/types/coin_metadata.rs
@@ -10,6 +10,7 @@ use iota_types::{
 };
 
 use crate::{
+    config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     context_data::db_data_provider::PgManager,
     data::Db,
@@ -220,6 +221,9 @@ impl CoinMetadata {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    #[graphql(
+        complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
+    )]
     pub(crate) async fn received_transaction_blocks(
         &self,
         ctx: &Context<'_>,

--- a/crates/iota-graphql-rpc/src/types/epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/epoch.rs
@@ -11,6 +11,7 @@ use iota_indexer::{models::epoch::QueryableEpochInfo, schema::epochs};
 use iota_types::messages_checkpoint::CheckpointCommitment as EpochCommitment;
 
 use crate::{
+    config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     context_data::db_data_provider::PgManager,
     data::{DataLoader, Db, DbConnection, QueryExecutor},
@@ -241,6 +242,9 @@ impl Epoch {
     ///
     /// By default, the scanning range consists of all transactions in this
     /// epoch.
+    #[graphql(
+        complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
+    )]
     async fn transaction_blocks(
         &self,
         ctx: &Context<'_>,

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -36,6 +36,7 @@ use crate::{
         date_time::DateTime,
         move_module::MoveModule,
         move_value::MoveValue,
+        transaction_block::{SeqKey, TransactionBlock},
     },
 };
 
@@ -44,6 +45,24 @@ mod filter;
 mod lookups;
 pub(crate) use cursor::Cursor;
 pub(crate) use filter::EventFilter;
+
+/// An event emitted in a transaction that has been checkpointed.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CheckpointedEventInfo {
+    /// The sequence number of the parent transaction.
+    tx_sequence_number: u64,
+    /// The timestamp of the parent transaction.
+    timestamp_ms: i64,
+}
+
+impl From<&StoredEvent> for CheckpointedEventInfo {
+    fn from(value: &StoredEvent) -> Self {
+        Self {
+            tx_sequence_number: value.tx_sequence_number as u64,
+            timestamp_ms: value.timestamp_ms,
+        }
+    }
+}
 
 /// An IOTA node emits one of the following events:
 /// Move event
@@ -54,7 +73,7 @@ pub(crate) use filter::EventFilter;
 /// Epoch change event
 #[derive(Clone, Debug)]
 pub(crate) struct Event {
-    pub stored: Option<StoredEvent>,
+    pub checkpointed_info: Option<CheckpointedEventInfo>,
     pub native: NativeEvent,
     /// The checkpoint sequence number this was viewed at.
     pub checkpoint_viewed_at: u64,
@@ -64,6 +83,21 @@ type Query<ST, GB> = data::Query<ST, events::table, GB>;
 
 #[Object]
 impl Event {
+    /// The transaction block that emitted this event. This information is only
+    /// available for events from transactions included in a checkpoint.
+    ///
+    /// For simulated transactions (e.g. dry run), or transactions that have
+    /// been just executed but not yet included in a checkpoint this returns
+    /// null.
+    async fn transaction_block(&self, ctx: &Context<'_>) -> Result<Option<TransactionBlock>> {
+        let Some(checkpointed) = &self.checkpointed_info else {
+            return Ok(None);
+        };
+        let key = SeqKey::new(checkpointed.tx_sequence_number, self.checkpoint_viewed_at);
+
+        TransactionBlock::query(ctx, key.into()).await.extend()
+    }
+
     /// The Move module containing some function that when called by
     /// a programmable transaction block (PTB) emitted this event.
     /// For example, if a PTB invokes A::m1::foo, which internally
@@ -94,8 +128,8 @@ impl Event {
 
     /// UTC timestamp in milliseconds since epoch (1/1/1970)
     async fn timestamp(&self) -> Result<Option<DateTime>, Error> {
-        if let Some(stored) = &self.stored {
-            Ok(Some(DateTime::from_ms(stored.timestamp_ms)?))
+        if let Some(checkpointed) = &self.checkpointed_info {
+            Ok(Some(DateTime::from_ms(checkpointed.timestamp_ms)?))
         } else {
             Ok(None)
         }
@@ -246,21 +280,12 @@ impl Event {
             ))
         })?;
 
-        let with_prefix = true;
-        let stored_event = StoredEvent {
-            tx_sequence_number: stored_tx.tx_sequence_number,
-            event_sequence_number: idx as i64,
-            transaction_digest: stored_tx.transaction_digest.clone(),
-            senders: vec![Some(native_event.sender.to_vec())],
-            package: native_event.package_id.to_vec(),
-            module: native_event.transaction_module.to_string(),
-            event_type: native_event.type_.to_canonical_string(with_prefix),
-            bcs: native_event.contents.clone(),
+        let checkpointed = CheckpointedEventInfo {
+            tx_sequence_number: stored_tx.tx_sequence_number as u64,
             timestamp_ms: stored_tx.timestamp_ms,
         };
-
         Ok(Self {
-            stored: Some(stored_event),
+            checkpointed_info: Some(checkpointed),
             native: native_event,
             checkpoint_viewed_at,
         })
@@ -273,6 +298,7 @@ impl Event {
         let Some(Some(sender_bytes)) = stored.senders.first() else {
             return Err(Error::Internal("No senders found for event".to_string()));
         };
+        let checkpointed = CheckpointedEventInfo::from(&stored);
         let sender = NativeIotaAddress::from_bytes(sender_bytes)
             .map_err(|e| Error::Internal(e.to_string()))?;
         let package_id =
@@ -283,7 +309,7 @@ impl Event {
             Identifier::from_str(&stored.module).map_err(|e| Error::Internal(e.to_string()))?;
         let contents = stored.bcs.clone();
         Ok(Event {
-            stored: Some(stored),
+            checkpointed_info: Some(checkpointed),
             native: NativeEvent {
                 sender,
                 package_id,
@@ -314,21 +340,8 @@ impl Event {
             ))
         })?;
 
-        let with_prefix = true;
-        let stored_event = StoredEvent {
-            tx_sequence_number: optimistic_tx.optimistic_sequence_number,
-            event_sequence_number: idx as i64,
-            transaction_digest: optimistic_tx.transaction_digest.clone(),
-            senders: vec![Some(native_event.sender.to_vec())],
-            package: native_event.package_id.to_vec(),
-            module: native_event.transaction_module.to_string(),
-            event_type: native_event.type_.to_canonical_string(with_prefix),
-            bcs: native_event.contents.clone(),
-            timestamp_ms: -1, // Optimistic transactions don't have timestamps yet
-        };
-
         Ok(Self {
-            stored: Some(stored_event),
+            checkpointed_info: None,
             native: native_event,
             checkpoint_viewed_at,
         })

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -105,7 +105,7 @@ impl Event {
     /// For example, if a PTB invokes A::m1::foo, which internally
     /// calls A::m2::emit_event to emit an event,
     /// the sending module would be A::m1.
-    #[graphql(complexity = 0)]
+    #[graphql(complexity = "child_complexity")]
     async fn sending_module(&self, ctx: &Context<'_>) -> Result<Option<MoveModule>> {
         MoveModule::query(
             ctx,
@@ -118,7 +118,7 @@ impl Event {
     }
 
     /// Address of the sender of the event
-    #[graphql(complexity = 0)]
+    #[graphql(complexity = "child_complexity")]
     async fn sender(&self) -> Result<Option<Address>> {
         if self.native.sender == NativeIotaAddress::ZERO {
             return Ok(None);

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -26,6 +26,7 @@ use iota_types::{
 use lookups::{add_bounds, select_emit_module, select_event_type, select_sender};
 
 use crate::{
+    config::DEFAULT_PAGE_SIZE,
     data::{self, Db, DbConnection, QueryExecutor},
     error::Error,
     query,
@@ -89,6 +90,7 @@ impl Event {
     /// For simulated transactions (e.g. dry run), or transactions that have
     /// been just executed but not yet included in a checkpoint this returns
     /// null.
+    #[graphql(complexity = "DEFAULT_PAGE_SIZE as usize * (1 + child_complexity)")]
     async fn transaction_block(&self, ctx: &Context<'_>) -> Result<Option<TransactionBlock>> {
         let Some(checkpointed) = &self.checkpointed_info else {
             return Ok(None);
@@ -103,6 +105,7 @@ impl Event {
     /// For example, if a PTB invokes A::m1::foo, which internally
     /// calls A::m2::emit_event to emit an event,
     /// the sending module would be A::m1.
+    #[graphql(complexity = 0)]
     async fn sending_module(&self, ctx: &Context<'_>) -> Result<Option<MoveModule>> {
         MoveModule::query(
             ctx,
@@ -115,6 +118,7 @@ impl Event {
     }
 
     /// Address of the sender of the event
+    #[graphql(complexity = 0)]
     async fn sender(&self) -> Result<Option<Address>> {
         if self.native.sender == NativeIotaAddress::ZERO {
             return Ok(None);
@@ -127,6 +131,7 @@ impl Event {
     }
 
     /// UTC timestamp in milliseconds since epoch (1/1/1970)
+    #[graphql(complexity = 0)]
     async fn timestamp(&self) -> Result<Option<DateTime>, Error> {
         if let Some(checkpointed) = &self.checkpointed_info {
             Ok(Some(DateTime::from_ms(checkpointed.timestamp_ms)?))

--- a/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
+++ b/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
@@ -36,6 +36,7 @@ use super::{
     uint53::UInt53,
 };
 use crate::{
+    config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     consistency::{View, build_objects_query},
     data::{Db, DbConnection, QueryExecutor},
@@ -270,6 +271,9 @@ impl NameRegistration {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    #[graphql(
+        complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
+    )]
     pub(crate) async fn received_transaction_blocks(
         &self,
         ctx: &Context<'_>,

--- a/crates/iota-graphql-rpc/src/types/move_object.rs
+++ b/crates/iota-graphql-rpc/src/types/move_object.rs
@@ -10,6 +10,7 @@ use iota_types::{
 };
 
 use crate::{
+    config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     data::Db,
     error::Error,
@@ -291,6 +292,9 @@ impl MoveObject {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    #[graphql(
+        complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
+    )]
     pub(crate) async fn received_transaction_blocks(
         &self,
         ctx: &Context<'_>,

--- a/crates/iota-graphql-rpc/src/types/move_package.rs
+++ b/crates/iota-graphql-rpc/src/types/move_package.rs
@@ -19,6 +19,7 @@ use iota_types::{is_system_package, move_package::MovePackage as NativeMovePacka
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     consistency::{Checkpointed, ConsistentNamedCursor},
     data::{DataLoader, Db, DbConnection, QueryExecutor},
@@ -382,6 +383,9 @@ impl MovePackage {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    #[graphql(
+        complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
+    )]
     pub(crate) async fn received_transaction_blocks(
         &self,
         ctx: &Context<'_>,

--- a/crates/iota-graphql-rpc/src/types/move_value.rs
+++ b/crates/iota-graphql-rpc/src/types/move_value.rs
@@ -41,9 +41,10 @@ const TYPE_UID: &IdentStr = ident_str!("UID");
 #[graphql(complex)]
 pub(crate) struct MoveValue {
     /// The value's Move type.
-    #[graphql(name = "type")]
+    #[graphql(name = "type", complexity = 0)]
     type_: MoveType,
     /// The BCS representation of this value, Base64 encoded.
+    #[graphql(complexity = 0)]
     bcs: Base64,
 }
 
@@ -100,6 +101,7 @@ pub(crate) struct MoveField {
 #[ComplexObject]
 impl MoveValue {
     /// Structured contents of a Move value.
+    #[graphql(complexity = 0)]
     async fn data(&self, ctx: &Context<'_>) -> Result<MoveData> {
         let resolver: &PackageResolver = ctx
             .data()
@@ -131,6 +133,7 @@ impl MoveValue {
     ///
     /// This form is offered as a less verbose convenience in cases where the
     /// layout of the type is known by the client.
+    #[graphql(complexity = 0)]
     async fn json(&self, ctx: &Context<'_>) -> Result<Json> {
         let resolver: &PackageResolver = ctx
             .data()

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -32,6 +32,7 @@ use move_core_types::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     consistency::{Checkpointed, View, build_objects_query},
     data::{DataLoader, Db, DbConnection, QueryExecutor, package_resolver::PackageResolver},
@@ -527,6 +528,9 @@ impl Object {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    #[graphql(
+        complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
+    )]
     pub(crate) async fn received_transaction_blocks(
         &self,
         ctx: &Context<'_>,

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -676,10 +676,9 @@ impl ObjectImpl<'_> {
             return Ok(None);
         };
         let digest = native.previous_transaction;
+        let key = transaction_block::DigestKey::new(digest.into(), self.0.checkpoint_viewed_at);
 
-        TransactionBlock::query(ctx, digest.into(), self.0.checkpoint_viewed_at)
-            .await
-            .extend()
+        TransactionBlock::query(ctx, key.into()).await.extend()
     }
 
     pub(crate) async fn storage_rebate(&self) -> Option<BigInt> {

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -384,9 +384,8 @@ impl Query {
         digest: Digest,
     ) -> Result<Option<TransactionBlock>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
-        TransactionBlock::query(ctx, digest, checkpoint)
-            .await
-            .extend()
+        let key = transaction_block::DigestKey::new(digest, checkpoint);
+        TransactionBlock::query(ctx, key.into()).await.extend()
     }
 
     /// The coin objects that exist in the network.

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -19,7 +19,7 @@ use move_core_types::account_address::AccountAddress;
 use serde::de::DeserializeOwned;
 
 use crate::{
-    config::ServiceConfig,
+    config::{DEFAULT_PAGE_SIZE, ServiceConfig},
     connection::ScanConnection,
     error::Error,
     mutation::Mutation,
@@ -466,6 +466,9 @@ impl Query {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    #[graphql(
+        complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
+    )]
     async fn transaction_blocks(
         &self,
         ctx: &Context<'_>,
@@ -495,6 +498,9 @@ impl Query {
     /// We currently do not support filtering by emitting module and event type
     /// at the same time so if both are provided in one filter, the query will
     /// error.
+    #[graphql(
+        complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
+    )]
     async fn events(
         &self,
         ctx: &Context<'_>,

--- a/crates/iota-graphql-rpc/src/types/stake.rs
+++ b/crates/iota-graphql-rpc/src/types/stake.rs
@@ -8,6 +8,7 @@ use iota_types::{base_types::MoveObjectType, governance::StakedIota as NativeSta
 use move_core_types::language_storage::StructTag;
 
 use crate::{
+    config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     context_data::db_data_provider::PgManager,
     data::Db,
@@ -237,6 +238,9 @@ impl StakedIota {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    #[graphql(
+        complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
+    )]
     pub(crate) async fn received_transaction_blocks(
         &self,
         ctx: &Context<'_>,

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -676,7 +676,7 @@ impl Loader<SeqKey> for Db {
             .map(|tx| (tx.tx_sequence_number, tx))
             .collect();
 
-        let mut results = HashMap::new();
+        let mut results = HashMap::with_capacity(keys.len());
         for key in keys {
             let Some(stored) = seq_num_to_tx.get(&(key.tx_sequence_number as i64)) else {
                 continue;

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -643,6 +643,60 @@ impl Loader<DigestKey> for Db {
     }
 }
 
+impl Loader<SeqKey> for Db {
+    type Value = TransactionBlock;
+    type Error = Error;
+
+    async fn load(&self, keys: &[SeqKey]) -> Result<HashMap<SeqKey, TransactionBlock>, Error> {
+        use transactions::dsl as tx;
+
+        let tx_seqs = keys
+            .iter()
+            .map(|k| k.tx_sequence_number as i64)
+            .collect::<Vec<_>>();
+        let transactions: Vec<StoredTransaction> = self
+            .execute(move |conn| {
+                conn.results(|| {
+                    tx::transactions
+                        .select(StoredTransaction::as_select())
+                        .filter(tx::tx_sequence_number.eq_any(tx_seqs.clone()))
+                })
+            })
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to fetch transactions: {e}")))?;
+
+        let seq_num_to_tx: HashMap<i64, StoredTransaction> = transactions
+            .into_iter()
+            .map(|tx| (tx.tx_sequence_number, tx))
+            .collect();
+
+        let mut results = HashMap::new();
+        for key in keys {
+            let Some(stored) = seq_num_to_tx.get(&(key.tx_sequence_number as i64)) else {
+                continue;
+            };
+
+            let checkpoint_viewed_at =
+                if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
+                    // Disable usage as a cursor, as the checkpoint is not in the available range
+                    UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER
+                } else {
+                    key.checkpoint_viewed_at
+                };
+
+            results.insert(
+                *key,
+                TransactionBlock {
+                    inner: TransactionBlockInner::try_from(stored.clone())?,
+                    checkpoint_viewed_at,
+                },
+            );
+        }
+
+        Ok(results)
+    }
+}
+
 impl TryFrom<StoredTransaction> for TransactionBlockInner {
     type Error = Error;
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -739,20 +739,20 @@ impl TryFrom<TransactionBlockEffects> for TransactionBlock {
         let checkpoint_viewed_at = effects.checkpoint_viewed_at;
         let inner = match effects.kind {
             TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {
-                TransactionBlockInner::try_from(stored_tx.clone())
+                TransactionBlockInner::try_from(stored_tx)
             }
             TransactionBlockEffectsKind::Executed { optimistic_tx, .. } => {
-                TransactionBlockInner::try_from(optimistic_tx.clone())
+                TransactionBlockInner::try_from(optimistic_tx)
             }
 
             TransactionBlockEffectsKind::DryRun {
                 tx_data,
-                native,
+                native: effects,
                 events,
             } => Ok(TransactionBlockInner::DryRun {
-                tx_data: tx_data.clone(),
-                effects: native.clone(),
-                events: events.clone(),
+                tx_data,
+                effects,
+                events,
             }),
         }?;
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -203,7 +203,7 @@ impl TransactionBlock {
 
     /// The address corresponding to the public key that signed this
     /// transaction. System transactions do not have senders.
-    #[graphql(complexity = 0)]
+    #[graphql(complexity = "child_complexity")]
     async fn sender(&self) -> Option<Address> {
         let sender = self.native().sender();
 
@@ -219,7 +219,7 @@ impl TransactionBlock {
     ///
     /// If the owner of the gas object(s) is not the same as the sender, the
     /// transaction block is a sponsored transaction block.
-    #[graphql(complexity = 0)]
+    #[graphql(complexity = "child_complexity")]
     async fn gas_input(&self, ctx: &Context<'_>) -> Option<GasInput> {
         let checkpoint_viewed_at =
             if matches!(self.inner, TransactionBlockInner::Checkpointed { .. })
@@ -243,7 +243,7 @@ impl TransactionBlock {
 
     /// The type of this transaction as well as the commands and/or parameters
     /// comprising the transaction of this kind.
-    #[graphql(complexity = 0)]
+    #[graphql(complexity = "child_complexity")]
     async fn kind(&self) -> Option<TransactionBlockKind> {
         Some(TransactionBlockKind::from(
             self.native().kind().clone(),
@@ -274,7 +274,7 @@ impl TransactionBlock {
     /// reference that sets a deadline after which validators will no longer
     /// consider the transaction valid. By default, there is no deadline for
     /// when a transaction must execute.
-    #[graphql(complexity = 0)]
+    #[graphql(complexity = "child_complexity")]
     async fn expiration(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         let TransactionExpiration::Epoch(id) = self.native().expiration() else {
             return Ok(None);

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -195,6 +195,7 @@ impl TransactionBlock {
     /// A 32-byte hash that uniquely identifies the transaction block contents,
     /// encoded in Base58. This serves as a unique id for the block on
     /// chain.
+    #[graphql(complexity = 0)]
     async fn digest(&self) -> Option<String> {
         self.native_signed_data()
             .map(|s| Base58::encode(s.digest()))
@@ -202,6 +203,7 @@ impl TransactionBlock {
 
     /// The address corresponding to the public key that signed this
     /// transaction. System transactions do not have senders.
+    #[graphql(complexity = 0)]
     async fn sender(&self) -> Option<Address> {
         let sender = self.native().sender();
 
@@ -217,6 +219,7 @@ impl TransactionBlock {
     ///
     /// If the owner of the gas object(s) is not the same as the sender, the
     /// transaction block is a sponsored transaction block.
+    #[graphql(complexity = 0)]
     async fn gas_input(&self, ctx: &Context<'_>) -> Option<GasInput> {
         let checkpoint_viewed_at =
             if matches!(self.inner, TransactionBlockInner::Checkpointed { .. })
@@ -240,6 +243,7 @@ impl TransactionBlock {
 
     /// The type of this transaction as well as the commands and/or parameters
     /// comprising the transaction of this kind.
+    #[graphql(complexity = 0)]
     async fn kind(&self) -> Option<TransactionBlockKind> {
         Some(TransactionBlockKind::from(
             self.native().kind().clone(),
@@ -249,6 +253,7 @@ impl TransactionBlock {
 
     /// A list of all signatures, Base64-encoded, from senders, and potentially
     /// the gas owner if this is a sponsored transaction.
+    #[graphql(complexity = 0)]
     async fn signatures(&self) -> Option<Vec<Base64>> {
         self.native_signed_data().map(|s| {
             s.tx_signatures()
@@ -260,6 +265,7 @@ impl TransactionBlock {
 
     /// The effects field captures the results to the chain of executing this
     /// transaction.
+    #[graphql(complexity = "child_complexity")]
     async fn effects(&self) -> Result<Option<TransactionBlockEffects>> {
         Ok(Some(self.clone().try_into().extend()?))
     }
@@ -268,6 +274,7 @@ impl TransactionBlock {
     /// reference that sets a deadline after which validators will no longer
     /// consider the transaction valid. By default, there is no deadline for
     /// when a transaction must execute.
+    #[graphql(complexity = 0)]
     async fn expiration(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         let TransactionExpiration::Epoch(id) = self.native().expiration() else {
             return Ok(None);
@@ -280,6 +287,7 @@ impl TransactionBlock {
 
     /// Serialized form of this transaction's `SenderSignedData`, BCS serialized
     /// and Base64 encoded.
+    #[graphql(complexity = 0)]
     async fn bcs(&self) -> Option<Base64> {
         match &self.inner {
             TransactionBlockInner::Checkpointed { stored_tx, .. } => {
@@ -306,6 +314,7 @@ impl TransactionBlock {
     ///
     /// Otherwise, it is recommended that you use
     /// `Query.isTransactionIndexedOnNode` for optimal performance.
+    #[graphql(complexity = 0)]
     async fn indexed_on_node(&self, ctx: &Context<'_>) -> Result<Option<bool>> {
         if self.inner.is_checkpointed() {
             return Ok(Some(true));

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -141,9 +141,53 @@ pub(crate) struct TransactionBlockCursor {
 /// `DataLoader` key for fetching a `TransactionBlock` by its digest, optionally
 /// constrained by a consistency cursor.
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-struct DigestKey {
+pub(crate) struct DigestKey {
     pub digest: Digest,
     pub checkpoint_viewed_at: u64,
+}
+
+impl DigestKey {
+    pub fn new(digest: Digest, checkpoint_viewed_at: u64) -> Self {
+        Self {
+            digest,
+            checkpoint_viewed_at,
+        }
+    }
+}
+
+/// `DataLoader` key for fetching a `TransactionBlock` by its sequence number,
+/// constrained by a consistency cursor.
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub(crate) struct SeqKey {
+    pub tx_sequence_number: u64,
+    pub checkpoint_viewed_at: u64,
+}
+
+impl SeqKey {
+    pub fn new(tx_sequence_number: u64, checkpoint_viewed_at: u64) -> Self {
+        Self {
+            tx_sequence_number,
+            checkpoint_viewed_at,
+        }
+    }
+}
+
+/// Filter for a point query of a TransactionBlock.
+pub(crate) enum TransactionBlockLookup {
+    ByDigest(DigestKey),
+    BySeq(SeqKey),
+}
+
+impl From<DigestKey> for TransactionBlockLookup {
+    fn from(key: DigestKey) -> Self {
+        TransactionBlockLookup::ByDigest(key)
+    }
+}
+
+impl From<SeqKey> for TransactionBlockLookup {
+    fn from(key: SeqKey) -> Self {
+        TransactionBlockLookup::BySeq(key)
+    }
 }
 
 #[Object]
@@ -305,16 +349,16 @@ impl TransactionBlock {
     /// checkpoint).
     pub(crate) async fn query(
         ctx: &Context<'_>,
-        digest: Digest,
-        checkpoint_viewed_at: u64,
+        key: TransactionBlockLookup,
     ) -> Result<Option<Self>, Error> {
         let DataLoader(loader) = ctx.data_unchecked();
-        loader
-            .load_one(DigestKey {
-                digest,
-                checkpoint_viewed_at,
-            })
-            .await
+        match key {
+            TransactionBlockLookup::ByDigest(digest_key) => loader.load_one(digest_key).await,
+            TransactionBlockLookup::BySeq(seq_key) => {
+                todo!()
+                // loader.load_one(seq_key).await
+            }
+        }
     }
 
     /// Look up multiple `TransactionBlock`s by their digests. Returns a map

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -352,10 +352,10 @@ impl TransactionBlock {
         }
     }
 
-    /// Look up a `TransactionBlock` in the database, by its transaction digest.
-    /// Treats it as if it is being viewed at the `checkpoint_viewed_at`
-    /// (e.g. the state of all relevant addresses will be at that
-    /// checkpoint).
+    /// Look up a `TransactionBlock` in the database, by its transaction digest
+    /// or sequence number. Treats it as if it is being viewed at the
+    /// `checkpoint_viewed_at` (e.g. the state of all relevant addresses
+    /// will be at that checkpoint).
     pub(crate) async fn query(
         ctx: &Context<'_>,
         key: TransactionBlockLookup,

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -354,10 +354,7 @@ impl TransactionBlock {
         let DataLoader(loader) = ctx.data_unchecked();
         match key {
             TransactionBlockLookup::ByDigest(digest_key) => loader.load_one(digest_key).await,
-            TransactionBlockLookup::BySeq(seq_key) => {
-                todo!()
-                // loader.load_one(seq_key).await
-            }
+            TransactionBlockLookup::BySeq(seq_key) => loader.load_one(seq_key).await,
         }
     }
 
@@ -676,14 +673,10 @@ impl Loader<SeqKey> for Db {
                 continue;
             };
 
-            let checkpoint_viewed_at =
-                if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
-                    // Disable usage as a cursor, as the checkpoint is not in the available range
-                    UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER
-                } else {
-                    key.checkpoint_viewed_at
-                };
-
+            let mut checkpoint_viewed_at = key.checkpoint_viewed_at;
+            if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
+                checkpoint_viewed_at = UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER;
+            }
             results.insert(
                 *key,
                 TransactionBlock {

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -446,7 +446,7 @@ impl TransactionBlockEffects {
                     Event::try_from_optimistic_transaction(optimistic_tx, c.ix, c.c).extend()?
                 }
                 TransactionBlockEffectsKind::DryRun { events, .. } => Event {
-                    stored: None,
+                    checkpointed_info: None,
                     native: events[c.ix].clone(),
                     checkpoint_viewed_at: c.c,
                 },

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -97,6 +97,7 @@ type CEvent = JsonCursor<ConsistentIndexCursor>;
 #[Object]
 impl TransactionBlockEffects {
     /// The transaction that ran to produce these effects.
+    #[graphql(complexity = "child_complexity")]
     async fn transaction_block(&self) -> Result<Option<TransactionBlock>> {
         Ok(Some(self.clone().try_into().extend()?))
     }
@@ -202,7 +203,7 @@ impl TransactionBlockEffects {
     }
 
     /// Transactions whose outputs this transaction depends upon.
-    #[graphql(complexity = 0)]
+    #[graphql(complexity = "child_complexity")]
     async fn dependencies(
         &self,
         ctx: &Context<'_>,
@@ -493,6 +494,7 @@ impl TransactionBlockEffects {
 
     /// The checkpoint this transaction was finalized in, if it is within the
     /// available range.
+    #[graphql(complexity = "child_complexity")]
     async fn checkpoint(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
         // If the transaction data is not a checkpointed transaction, it's not in the
         // checkpoint yet so we return None.

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -268,14 +268,14 @@ impl TransactionBlockEffects {
     }
 
     /// Effects to the gas object.
-    #[graphql(complexity = 0)]
+    #[graphql(complexity = "child_complexity")]
     async fn gas_effects(&self) -> Option<GasEffects> {
         Some(GasEffects::from(self.native(), self.checkpoint_viewed_at))
     }
 
     /// Shared objects that are referenced by but not changed by this
     /// transaction.
-    #[graphql(complexity = 0)]
+    #[graphql(complexity = "child_complexity")]
     async fn unchanged_shared_objects(
         &self,
         ctx: &Context<'_>,
@@ -315,7 +315,7 @@ impl TransactionBlockEffects {
     }
 
     /// The effect this transaction had on objects on-chain.
-    #[graphql(complexity = 0)]
+    #[graphql(complexity = "child_complexity")]
     async fn object_changes(
         &self,
         ctx: &Context<'_>,
@@ -362,7 +362,7 @@ impl TransactionBlockEffects {
 
     /// The effect this transaction had on the balances (sum of coin values per
     /// coin type) of addresses and objects.
-    #[graphql(complexity = 0)]
+    #[graphql(complexity = "child_complexity")]
     async fn balance_changes(
         &self,
         ctx: &Context<'_>,
@@ -481,7 +481,7 @@ impl TransactionBlockEffects {
     }
 
     /// The epoch this transaction was executed in.
-    #[graphql(complexity = 0)]
+    #[graphql(complexity = "child_complexity")]
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
             ctx,

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -17,6 +17,7 @@ use iota_types::{
 };
 
 use crate::{
+    config::DEFAULT_PAGE_SIZE,
     consistency::{ConsistentIndexCursor, UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER},
     data::package_resolver::PackageResolver,
     error::Error,
@@ -101,6 +102,7 @@ impl TransactionBlockEffects {
     }
 
     /// Whether the transaction executed successfully or not.
+    #[graphql(complexity = 0)]
     async fn status(&self) -> Option<ExecutionStatus> {
         Some(match self.native().status() {
             NativeExecutionStatus::Success => ExecutionStatus::Success,
@@ -111,6 +113,7 @@ impl TransactionBlockEffects {
     /// The latest version of all objects (apart from packages) that have been
     /// created or modified by this transaction, immediately following this
     /// transaction.
+    #[graphql(complexity = 0)]
     async fn lamport_version(&self) -> UInt53 {
         self.native().lamport_version().value().into()
     }
@@ -119,6 +122,7 @@ impl TransactionBlockEffects {
     /// If the error is a Move abort, the error message will be resolved to a
     /// human-readable form if possible, otherwise it will fall back to
     /// displaying the abort code and location.
+    #[graphql(complexity = 0)]
     async fn errors(&self, ctx: &Context<'_>) -> Result<Option<String>> {
         let resolver: &PackageResolver = ctx.data_unchecked();
 
@@ -198,6 +202,7 @@ impl TransactionBlockEffects {
     }
 
     /// Transactions whose outputs this transaction depends upon.
+    #[graphql(complexity = 0)]
     async fn dependencies(
         &self,
         ctx: &Context<'_>,
@@ -262,12 +267,14 @@ impl TransactionBlockEffects {
     }
 
     /// Effects to the gas object.
+    #[graphql(complexity = 0)]
     async fn gas_effects(&self) -> Option<GasEffects> {
         Some(GasEffects::from(self.native(), self.checkpoint_viewed_at))
     }
 
     /// Shared objects that are referenced by but not changed by this
     /// transaction.
+    #[graphql(complexity = 0)]
     async fn unchanged_shared_objects(
         &self,
         ctx: &Context<'_>,
@@ -307,6 +314,7 @@ impl TransactionBlockEffects {
     }
 
     /// The effect this transaction had on objects on-chain.
+    #[graphql(complexity = 0)]
     async fn object_changes(
         &self,
         ctx: &Context<'_>,
@@ -353,6 +361,7 @@ impl TransactionBlockEffects {
 
     /// The effect this transaction had on the balances (sum of coin values per
     /// coin type) of addresses and objects.
+    #[graphql(complexity = 0)]
     async fn balance_changes(
         &self,
         ctx: &Context<'_>,
@@ -409,6 +418,9 @@ impl TransactionBlockEffects {
     }
 
     /// Events emitted by this transaction block.
+    #[graphql(
+        complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
+    )]
     async fn events(
         &self,
         ctx: &Context<'_>,
@@ -459,6 +471,7 @@ impl TransactionBlockEffects {
 
     /// Timestamp corresponding to the checkpoint this transaction was finalized
     /// in.
+    #[graphql(complexity = 0)]
     async fn timestamp(&self) -> Result<Option<DateTime>, Error> {
         let TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } = &self.kind else {
             return Ok(None);
@@ -467,6 +480,7 @@ impl TransactionBlockEffects {
     }
 
     /// The epoch this transaction was executed in.
+    #[graphql(complexity = 0)]
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
             ctx,
@@ -499,6 +513,7 @@ impl TransactionBlockEffects {
     }
 
     /// Base64 encoded bcs serialization of the on-chain transaction effects.
+    #[graphql(complexity = 0)]
     async fn bcs(&self) -> Result<Base64> {
         let bytes = match &self.kind {
             TransactionBlockEffectsKind::Checkpointed { stored_tx, .. } => {

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -580,16 +580,13 @@ impl TryFrom<TransactionBlock> for TransactionBlockEffectsKind {
         match block.inner {
             TransactionBlockInner::Checkpointed { stored_tx, .. } => {
                 bcs::from_bytes(&stored_tx.raw_effects)
-                    .map(|native| TransactionBlockEffectsKind::Checkpointed {
-                        stored_tx: stored_tx.clone(),
-                        native,
-                    })
+                    .map(|native| TransactionBlockEffectsKind::Checkpointed { stored_tx, native })
                     .map_err(|e| {
                         Error::Internal(format!("Error deserializing transaction effects: {e}"))
                     })
             }
             TransactionBlockInner::Executed { optimistic_tx, .. } => {
-                TransactionBlockEffectsKind::try_from(optimistic_tx.clone())
+                TransactionBlockEffectsKind::try_from(optimistic_tx)
             }
 
             TransactionBlockInner::DryRun {

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/genesis.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/genesis.rs
@@ -97,7 +97,7 @@ impl GenesisTransaction {
             let native_event = self.native.events[cursor.ix].clone();
 
             let event = Event {
-                stored: None,
+                checkpointed_info: None,
                 native: native_event,
                 checkpoint_viewed_at: cursor.c,
             };

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1285,6 +1285,15 @@ type Epoch {
 
 type Event {
 	"""
+	The transaction block that emitted this event. This information is only
+	available for events from transactions included in a checkpoint.
+	
+	For simulated transactions (e.g. dry run), or transactions that have
+	been just executed but not yet included in a checkpoint this returns
+	null.
+	"""
+	transactionBlock: TransactionBlock
+	"""
 	The Move module containing some function that when called by
 	a programmable transaction block (PTB) emitted this event.
 	For example, if a PTB invokes A::m1::foo, which internally


### PR DESCRIPTION
# Description of change

This patch exposes the parent transaction of an event through the available event query paths.

As this introduces the possibility of recursive queries (e.g. `events -> tranasctionBlock -> events -> ...`, new complexity limits are introduced on the validation level exploiting [https://async-graphql.github.io/async-graphql/en/depth_and_complexity.html](async-graphql tooling) as opposed to the ad-hoc validation alredy present.

With the new limits, queries that try to recurse unnecessarily through the available query paths are rejected as "Too complex".

## Links to any relevant issues

Resolves #9402 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [x] GraphQL: :bulb:  A new field `Event.transactionBlock` is introduced that exposes the parent transaction of an event.
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
