### PR TITLE
fix(dashboard): Fix vesting unit tests

### DIFF
--- a/apps/wallet-dashboard/lib/utils/vesting/vesting.spec.ts
+++ b/apps/wallet-dashboard/lib/utils/vesting/vesting.spec.ts
@@ -95,7 +95,7 @@ describe('build supply increase staker vesting portfolio', () => {
         const vestingPortfolio = buildVestingPortfolio(lastPayout!, Date.now());
 
         expect(vestingPortfolio.length).toEqual(
-            getSupplyIncreaseVestingPayoutsCount(SupplyIncreaseUserType.Staker),
+            getSupplyIncreaseVestingPayoutsCount(SupplyIncreaseUserType.Entity),
         );
     });
 
@@ -114,7 +114,7 @@ describe('build supply increase staker vesting portfolio', () => {
 
         const vestingPortfolio = buildVestingPortfolio(lastPayout!, Date.now());
         expect(vestingPortfolio.length).toEqual(
-            getSupplyIncreaseVestingPayoutsCount(SupplyIncreaseUserType.Staker),
+            getSupplyIncreaseVestingPayoutsCount(SupplyIncreaseUserType.Entity),
         );
     });
 });


### PR DESCRIPTION
# Description of change

Since the staker period is over (October) and we are approaching the end of 2025, the test logic is now failing as it assumes the mock vesting schedule, built from current date, last payout will be <2025 for `staker`.

To fix we simply consider the built vesting schedule is for `Entity` (4 years vesting) 


