### PR TITLE
fix(indexer): Use "count_indexed_tx_global_orders_in_blocking_task"

### DIFF
--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -94,9 +94,13 @@ impl OptimisticTransactionExecutor {
         };
 
         backoff::future::retry(backoff, async || {
+            let digests: Vec<Vec<u8>> = expected_dependencies
+                .iter()
+                .map(|d| d.inner().to_vec())
+                .collect();
             let count = self
                 .read
-                .count_indexed_tx_global_orders_in_blocking_task(expected_dependencies.clone())
+                .count_indexed_tx_global_orders_in_blocking_task(digests.into_iter())
                 .await?;
             if count as usize != expected_dependencies.len() {
                 return Err(IndexerError::TransactionDependenciesNotIndexed)?;

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -721,8 +721,9 @@ impl IndexerReader {
                 .into_iter()
                 .map(|tx| tx.transaction_digest)
                 .collect::<HashSet<_>>();
-            let num_indexed =
-                self.count_indexed_tx_global_orders(optimistic_digests.into_iter())?;
+            let num_indexed = self
+                .count_indexed_tx_global_orders_in_blocking_task(optimistic_digests.into_iter())
+                .await?;
             if num_indexed as usize != num_optimistic {
                 return Ok(false);
             }
@@ -763,12 +764,10 @@ impl IndexerReader {
 
     pub(crate) async fn count_indexed_tx_global_orders_in_blocking_task(
         &self,
-        digests: HashSet<TransactionDigest>,
+        digests: impl Iterator<Item = Vec<u8>> + Send + 'static,
     ) -> Result<i64, IndexerError> {
-        self.spawn_blocking(move |this| {
-            this.count_indexed_tx_global_orders(digests.into_iter().map(|d| d.inner().to_vec()))
-        })
-        .await
+        self.spawn_blocking(move |this| this.count_indexed_tx_global_orders(digests))
+            .await
     }
 
     /// Fetches multiple transactions from the database.


### PR DESCRIPTION
# Description of change

This caused tests to be flaky, and randomly fail with 
```
called `Result::unwrap()` on an `Err` value: Transport(Http(Stream(hyper_util::client::legacy::Error(SendRequest, hyper::Error(IncompleteMessage)))))
```

the reason seemed to be:

```
thread 'tokio-runtime-worker' (42643488) panicked at crates/iota-indexer/src/read.rs:755:9:
you are calling a blocking DB operation directly on an async thread. Please use IndexerReader::spawn_blocking instead to move the operation to a blocking thread
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
