### PR TITLE
feat: bump `iota` to `v1.13.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,7 +1841,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "const-str",
  "git-version",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "iota"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5489,7 +5489,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-sdk-types",
  "iota-simulator",
  "iota-source-validation",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5570,7 +5570,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "arrow-array 53.1.0",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -5663,7 +5663,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5716,7 +5716,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -5759,7 +5759,7 @@ dependencies = [
 
 [[package]]
 name = "iota-build-cache-server"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5801,7 +5801,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-move-build",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-sdk-types",
  "iota-swarm",
  "iota-swarm-config",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5842,7 +5842,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5871,7 +5871,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5972,7 +5972,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6027,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6122,7 +6122,7 @@ dependencies = [
  "iota-node",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-sdk-types",
  "iota-simulator",
  "iota-storage",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "serde_yaml",
 ]
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6208,7 +6208,7 @@ dependencies = [
  "iota-keys",
  "iota-metrics",
  "iota-network-stack",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-sdk-types",
  "iota-types",
  "parking_lot 0.12.3",
@@ -6232,7 +6232,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6252,7 +6252,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6270,7 +6270,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6291,7 +6291,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6341,7 +6341,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6351,7 +6351,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6359,7 +6359,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6372,7 +6372,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6447,7 +6447,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6460,14 +6460,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "axum 0.8.4",
 ]
 
 [[package]]
 name = "iota-grpc-client"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -6481,7 +6481,7 @@ dependencies = [
 
 [[package]]
 name = "iota-grpc-server"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6504,7 +6504,7 @@ dependencies = [
 
 [[package]]
 name = "iota-grpc-types"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "bcs",
  "iota-json-rpc-types",
@@ -6518,7 +6518,7 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "axum 0.8.4",
  "bytes",
@@ -6539,7 +6539,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6604,7 +6604,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-streaming"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -6638,7 +6638,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6713,7 +6713,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6732,7 +6732,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6751,7 +6751,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6770,7 +6770,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6804,7 +6804,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bip32",
@@ -6825,7 +6825,7 @@ dependencies = [
 
 [[package]]
 name = "iota-kvstore"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6864,7 +6864,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger-signer"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6872,7 +6872,7 @@ dependencies = [
  "bip32",
  "clap",
  "iota-ledger",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-sdk-types",
  "thiserror 1.0.64",
  "tokio",
@@ -6881,7 +6881,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6895,7 +6895,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-types",
  "move-core-types",
  "object_store 0.10.2",
@@ -6914,7 +6914,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -6924,7 +6924,7 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6936,7 +6936,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -6957,7 +6957,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -7021,7 +7021,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -7042,7 +7042,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "bin-version",
  "clap",
@@ -7075,7 +7075,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7087,7 +7087,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -7126,7 +7126,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anemo",
  "bcs",
@@ -7155,7 +7155,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7208,7 +7208,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7232,7 +7232,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7244,7 +7244,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-alt"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "move-package-alt",
  "serde",
@@ -7252,7 +7252,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7268,13 +7268,13 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -7284,7 +7284,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7305,7 +7305,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -7315,7 +7315,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "clap",
  "insta",
@@ -7330,7 +7330,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7339,7 +7339,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7354,7 +7354,7 @@ dependencies = [
  "hex",
  "hyper 1.4.1",
  "iota-metrics",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-tls",
  "iota-types",
  "itertools 0.13.0",
@@ -7382,7 +7382,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7398,7 +7398,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-transaction-checks",
  "iota-types",
  "jsonrpsee",
@@ -7427,7 +7427,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7456,7 +7456,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-kv"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7483,7 +7483,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7500,7 +7500,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-sdk-types",
  "iota-swarm-config",
  "iota-types",
@@ -7524,7 +7524,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7534,7 +7534,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-sdk-types",
  "iota-types",
  "itertools 0.13.0",
@@ -7589,7 +7589,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7654,7 +7654,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7676,7 +7676,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7710,7 +7710,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7737,7 +7737,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -7747,7 +7747,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -7769,7 +7769,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7784,7 +7784,7 @@ dependencies = [
  "iota-move",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-source-validation",
  "move-core-types",
  "move-package",
@@ -7805,7 +7805,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7856,7 +7856,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "bcs",
  "clap",
@@ -7884,7 +7884,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -7911,7 +7911,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anemo",
  "anyhow",
@@ -7939,7 +7939,7 @@ dependencies = [
 
 [[package]]
 name = "iota-synthetic-ingestion"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7956,12 +7956,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-sdk-types",
  "iota-types",
  "move-core-types",
@@ -7969,7 +7969,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7991,7 +7991,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -8013,7 +8013,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -8036,7 +8036,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8052,7 +8052,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -8065,7 +8065,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8110,7 +8110,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8184,7 +8184,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8212,7 +8212,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11562,7 +11562,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13544,7 +13544,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14340,7 +14340,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -14427,7 +14427,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -14445,7 +14445,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.13.1-rc",
+ "iota-sdk 1.13.1",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -15347,7 +15347,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -15419,7 +15419,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "bcs",
  "bincode",
@@ -15448,7 +15448,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -15458,7 +15458,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "serde",
  "thiserror 1.0.64",
@@ -15466,7 +15466,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "1.13.1-rc"
+version = "1.13.1"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "1.13.1-rc"
+version = "1.13.1"
 
 [workspace.metadata.cargo-udeps.ignore]
 normal = ["move-package-alt"]
@@ -222,7 +222,10 @@ debug = 0
 inherits = "simulator"
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(msim)', 'cfg(fail_points)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(msim)',
+  'cfg(fail_points)',
+] }
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
@@ -239,10 +242,28 @@ async-stream = "0.3.6"
 async-trait = "0.1.61"
 aws-config = "1.5.6"
 aws-sdk-dynamodb = "1.42"
-axum = { version = "0.8", default-features = false, features = ["tokio", "http2", "json", "matched-path", "original-uri", "form", "query", "ws", "macros"] }
+axum = { version = "0.8", default-features = false, features = [
+  "tokio",
+  "http2",
+  "json",
+  "matched-path",
+  "original-uri",
+  "form",
+  "query",
+  "ws",
+  "macros",
+] }
 axum-extra = { version = "0.10", features = ["typed-header"] }
-axum-server = { git = "https://github.com/bmwill/axum-server.git", rev = "f44323e271afdd1365fd0c8b0a4c0bbdf4956cb7", version = "0.6", default-features = false, features = ["tls-rustls"] }
-backoff = { version = "0.4.0", features = ["futures", "futures-core", "pin-project-lite", "tokio", "tokio_1"] }
+axum-server = { git = "https://github.com/bmwill/axum-server.git", rev = "f44323e271afdd1365fd0c8b0a4c0bbdf4956cb7", version = "0.6", default-features = false, features = [
+  "tls-rustls",
+] }
+backoff = { version = "0.4.0", features = [
+  "futures",
+  "futures-core",
+  "pin-project-lite",
+  "tokio",
+  "tokio_1",
+] }
 base64 = "0.21.2"
 base64-url = "2"
 bcs = "0.1.4"
@@ -261,7 +282,11 @@ colored = "2.0.0"
 comfy-table = "6.1.3"
 const-str = "0.5.3"
 coset = "0.3"
-criterion = { version = "0.5.0", features = ["async", "async_tokio", "html_reports"] }
+criterion = { version = "0.5.0", features = [
+  "async",
+  "async_tokio",
+  "html_reports",
+] }
 crossterm = "0.25.0"
 csv = "1.2.1"
 dashmap = "5.5.3"
@@ -276,7 +301,9 @@ expect-test = "1.4.0"
 eyre = "0.6.8"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
 fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
-fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", features = ["experimental"] }
+fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", features = [
+  "experimental",
+] }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto-zkp" }
 fdlimit = "0.2.1"
 flate2 = "1.0.28"
@@ -291,21 +318,44 @@ http = "1"
 http-body = "1"
 humantime = "2.1.0"
 hyper = "1"
-hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-roots", "http1", "http2", "ring", "tls12"] }
-hyper-util = { version = "0.1.4", features = ["tokio", "server-auto", "service"] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+  "webpki-roots",
+  "http1",
+  "http2",
+  "ring",
+  "tls12",
+] }
+hyper-util = { version = "0.1.4", features = [
+  "tokio",
+  "server-auto",
+  "service",
+] }
 im = "15"
 indexmap = { version = "2.11.0", features = ["serde"] }
 indicatif = "0.18.3"
 insta = { version = "1.21.1", features = ["redactions", "yaml", "json"] }
 integer-encoding = "3.0.1"
-iota-sdk-types = { package = "iota-sdk-types", git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "05608b7e4a5b96d85f84e1970a517f6f174beb8b", features = ["hash", "serde", "schemars"] }
+iota-sdk-types = { package = "iota-sdk-types", git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "05608b7e4a5b96d85f84e1970a517f6f174beb8b", features = [
+  "hash",
+  "serde",
+  "schemars",
+] }
 itertools = "0.13.0"
 json_to_table = { git = "https://github.com/zhiburt/tabled/", rev = "e449317a1c02eb6b29e409ad6617e5d9eb7b3bd4" }
-jsonrpsee = { version = "0.24", features = ["server", "macros", "client", "ws-client", "http-client"] }
+jsonrpsee = { version = "0.24", features = [
+  "server",
+  "macros",
+  "client",
+  "ws-client",
+  "http-client",
+] }
 leb128 = "0.2.5"
 lru = "0.12"
 mockall = "0.11.4"
-moka = { version = "0.12", default-features = false, features = ["sync", "atomic64"] }
+moka = { version = "0.12", default-features = false, features = [
+  "sync",
+  "atomic64",
+] }
 more-asserts = "0.3.1"
 msim = { git = "https://github.com/iotaledger/iota-sim.git", branch = "tokio-1.46.1", package = "msim" }
 nonempty = "0.9.0"
@@ -332,11 +382,25 @@ quote = "1.0.23"
 rand = "0.8.5"
 rayon = "1.5.3"
 regex = "1.7.1"
-reqwest = { version = "0.12", default-features = false, features = ["http2", "json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "http2",
+  "json",
+  "rustls-tls",
+] }
 roaring = "0.11.2"
-rocksdb = { version = "0.21.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"] }
+rocksdb = { version = "0.21.0", default-features = false, features = [
+  "snappy",
+  "lz4",
+  "zstd",
+  "zlib",
+  "multi-threaded-cf",
+] }
 rstest = "0.16.0"
-rustls = { version = "0.23.18", default-features = false, features = ["std", "tls12", "ring"] }
+rustls = { version = "0.23.18", default-features = false, features = [
+  "std",
+  "tls12",
+  "ring",
+] }
 schemars = { version = "0.8.21", features = ["either"] }
 scopeguard = "1.1"
 serde = { version = "1.0.144", features = ["derive", "rc"] }
@@ -364,7 +428,10 @@ thiserror = "1.0.40"
 # tokio is defined at a specific version to support patching with iota-sim
 # Do not upgrade without updating https://github.com/iotaledger/iota-sim first
 tokio = "1.46.1"
-tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "ring"] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+  "tls12",
+  "ring",
+] }
 tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 tokio-util = "0.7.10"
 toml = { version = "0.7.4", features = ["preserve_order"] }
@@ -374,10 +441,31 @@ tonic-health = "0.14"
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 tonic-rustls = "0.3.0"
-tower = { version = "0.4.12", features = ["full", "util", "timeout", "load-shed", "limit"] }
-tower-http = { version = "0.5", features = ["cors", "full", "trace", "set-header", "propagate-header"] }
+tower = { version = "0.4.12", features = [
+  "full",
+  "util",
+  "timeout",
+  "load-shed",
+  "limit",
+] }
+tower-http = { version = "0.5", features = [
+  "cors",
+  "full",
+  "trace",
+  "set-header",
+  "propagate-header",
+] }
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.15", default-features = false, features = ["std", "smallvec", "fmt", "ansi", "time", "json", "registry", "env-filter"] }
+tracing-subscriber = { version = "0.3.15", default-features = false, features = [
+  "std",
+  "smallvec",
+  "fmt",
+  "ansi",
+  "time",
+  "json",
+  "registry",
+  "env-filter",
+] }
 unescape = "0.1.0"
 url = "2.3.1"
 uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }
@@ -496,7 +584,9 @@ move-transactional-test-runner = { path = "external-crates/move/crates/move-tran
 move-unit-test = { path = "external-crates/move/crates/move-unit-test" }
 move-vm-config = { path = "external-crates/move/crates/move-vm-config" }
 move-vm-profiler = { path = "external-crates/move/crates/move-vm-profiler" }
-move-vm-test-utils = { path = "external-crates/move/crates/move-vm-test-utils/", features = ["tiered-gas"] }
+move-vm-test-utils = { path = "external-crates/move/crates/move-vm-test-utils/", features = [
+  "tiered-gas",
+] }
 prometheus-closure-metric = { path = "crates/prometheus-closure-metric" }
 simulacrum = { path = "crates/simulacrum" }
 starfish-config = { path = "crates/starfish/config" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,10 +222,7 @@ debug = 0
 inherits = "simulator"
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(msim)',
-  'cfg(fail_points)',
-] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(msim)', 'cfg(fail_points)'] }
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
@@ -242,28 +239,10 @@ async-stream = "0.3.6"
 async-trait = "0.1.61"
 aws-config = "1.5.6"
 aws-sdk-dynamodb = "1.42"
-axum = { version = "0.8", default-features = false, features = [
-  "tokio",
-  "http2",
-  "json",
-  "matched-path",
-  "original-uri",
-  "form",
-  "query",
-  "ws",
-  "macros",
-] }
+axum = { version = "0.8", default-features = false, features = ["tokio", "http2", "json", "matched-path", "original-uri", "form", "query", "ws", "macros"] }
 axum-extra = { version = "0.10", features = ["typed-header"] }
-axum-server = { git = "https://github.com/bmwill/axum-server.git", rev = "f44323e271afdd1365fd0c8b0a4c0bbdf4956cb7", version = "0.6", default-features = false, features = [
-  "tls-rustls",
-] }
-backoff = { version = "0.4.0", features = [
-  "futures",
-  "futures-core",
-  "pin-project-lite",
-  "tokio",
-  "tokio_1",
-] }
+axum-server = { git = "https://github.com/bmwill/axum-server.git", rev = "f44323e271afdd1365fd0c8b0a4c0bbdf4956cb7", version = "0.6", default-features = false, features = ["tls-rustls"] }
+backoff = { version = "0.4.0", features = ["futures", "futures-core", "pin-project-lite", "tokio", "tokio_1"] }
 base64 = "0.21.2"
 base64-url = "2"
 bcs = "0.1.4"
@@ -282,11 +261,7 @@ colored = "2.0.0"
 comfy-table = "6.1.3"
 const-str = "0.5.3"
 coset = "0.3"
-criterion = { version = "0.5.0", features = [
-  "async",
-  "async_tokio",
-  "html_reports",
-] }
+criterion = { version = "0.5.0", features = ["async", "async_tokio", "html_reports"] }
 crossterm = "0.25.0"
 csv = "1.2.1"
 dashmap = "5.5.3"
@@ -301,9 +276,7 @@ expect-test = "1.4.0"
 eyre = "0.6.8"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
 fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
-fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", features = [
-  "experimental",
-] }
+fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", features = ["experimental"] }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto-zkp" }
 fdlimit = "0.2.1"
 flate2 = "1.0.28"
@@ -318,44 +291,21 @@ http = "1"
 http-body = "1"
 humantime = "2.1.0"
 hyper = "1"
-hyper-rustls = { version = "0.27", default-features = false, features = [
-  "webpki-roots",
-  "http1",
-  "http2",
-  "ring",
-  "tls12",
-] }
-hyper-util = { version = "0.1.4", features = [
-  "tokio",
-  "server-auto",
-  "service",
-] }
+hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-roots", "http1", "http2", "ring", "tls12"] }
+hyper-util = { version = "0.1.4", features = ["tokio", "server-auto", "service"] }
 im = "15"
 indexmap = { version = "2.11.0", features = ["serde"] }
 indicatif = "0.18.3"
 insta = { version = "1.21.1", features = ["redactions", "yaml", "json"] }
 integer-encoding = "3.0.1"
-iota-sdk-types = { package = "iota-sdk-types", git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "05608b7e4a5b96d85f84e1970a517f6f174beb8b", features = [
-  "hash",
-  "serde",
-  "schemars",
-] }
+iota-sdk-types = { package = "iota-sdk-types", git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "05608b7e4a5b96d85f84e1970a517f6f174beb8b", features = ["hash", "serde", "schemars"] }
 itertools = "0.13.0"
 json_to_table = { git = "https://github.com/zhiburt/tabled/", rev = "e449317a1c02eb6b29e409ad6617e5d9eb7b3bd4" }
-jsonrpsee = { version = "0.24", features = [
-  "server",
-  "macros",
-  "client",
-  "ws-client",
-  "http-client",
-] }
+jsonrpsee = { version = "0.24", features = ["server", "macros", "client", "ws-client", "http-client"] }
 leb128 = "0.2.5"
 lru = "0.12"
 mockall = "0.11.4"
-moka = { version = "0.12", default-features = false, features = [
-  "sync",
-  "atomic64",
-] }
+moka = { version = "0.12", default-features = false, features = ["sync", "atomic64"] }
 more-asserts = "0.3.1"
 msim = { git = "https://github.com/iotaledger/iota-sim.git", branch = "tokio-1.46.1", package = "msim" }
 nonempty = "0.9.0"
@@ -382,25 +332,11 @@ quote = "1.0.23"
 rand = "0.8.5"
 rayon = "1.5.3"
 regex = "1.7.1"
-reqwest = { version = "0.12", default-features = false, features = [
-  "http2",
-  "json",
-  "rustls-tls",
-] }
+reqwest = { version = "0.12", default-features = false, features = ["http2", "json", "rustls-tls"] }
 roaring = "0.11.2"
-rocksdb = { version = "0.21.0", default-features = false, features = [
-  "snappy",
-  "lz4",
-  "zstd",
-  "zlib",
-  "multi-threaded-cf",
-] }
+rocksdb = { version = "0.21.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"] }
 rstest = "0.16.0"
-rustls = { version = "0.23.18", default-features = false, features = [
-  "std",
-  "tls12",
-  "ring",
-] }
+rustls = { version = "0.23.18", default-features = false, features = ["std", "tls12", "ring"] }
 schemars = { version = "0.8.21", features = ["either"] }
 scopeguard = "1.1"
 serde = { version = "1.0.144", features = ["derive", "rc"] }
@@ -428,10 +364,7 @@ thiserror = "1.0.40"
 # tokio is defined at a specific version to support patching with iota-sim
 # Do not upgrade without updating https://github.com/iotaledger/iota-sim first
 tokio = "1.46.1"
-tokio-rustls = { version = "0.26", default-features = false, features = [
-  "tls12",
-  "ring",
-] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "ring"] }
 tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 tokio-util = "0.7.10"
 toml = { version = "0.7.4", features = ["preserve_order"] }
@@ -441,31 +374,10 @@ tonic-health = "0.14"
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 tonic-rustls = "0.3.0"
-tower = { version = "0.4.12", features = [
-  "full",
-  "util",
-  "timeout",
-  "load-shed",
-  "limit",
-] }
-tower-http = { version = "0.5", features = [
-  "cors",
-  "full",
-  "trace",
-  "set-header",
-  "propagate-header",
-] }
+tower = { version = "0.4.12", features = ["full", "util", "timeout", "load-shed", "limit"] }
+tower-http = { version = "0.5", features = ["cors", "full", "trace", "set-header", "propagate-header"] }
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.15", default-features = false, features = [
-  "std",
-  "smallvec",
-  "fmt",
-  "ansi",
-  "time",
-  "json",
-  "registry",
-  "env-filter",
-] }
+tracing-subscriber = { version = "0.3.15", default-features = false, features = ["std", "smallvec", "fmt", "ansi", "time", "json", "registry", "env-filter"] }
 unescape = "0.1.0"
 url = "2.3.1"
 uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }
@@ -584,9 +496,7 @@ move-transactional-test-runner = { path = "external-crates/move/crates/move-tran
 move-unit-test = { path = "external-crates/move/crates/move-unit-test" }
 move-vm-config = { path = "external-crates/move/crates/move-vm-config" }
 move-vm-profiler = { path = "external-crates/move/crates/move-vm-profiler" }
-move-vm-test-utils = { path = "external-crates/move/crates/move-vm-test-utils/", features = [
-  "tiered-gas",
-] }
+move-vm-test-utils = { path = "external-crates/move/crates/move-vm-test-utils/", features = ["tiered-gas"] }
 prometheus-closure-metric = { path = "crates/prometheus-closure-metric" }
 simulacrum = { path = "crates/simulacrum" }
 starfish-config = { path = "crates/starfish/config" }

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "1.13.1-rc"
+    "version": "1.13.1"
   },
   "methods": [
     {


### PR DESCRIPTION
Bump iota to `v1.13.1` in preparation for Mainnet release.