### PR TITLE
feat(indexer): Multiget requests in HttpRestKVClient

### DIFF
--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -126,6 +126,37 @@ pub struct HistoricFallbackOptions {
         help = "Experimental: REST KV store URL for historic fallback. Depends on the iota-rest-kv API which is still being finalized."
     )]
     pub fallback_kv_url: Option<Url>,
+
+    #[arg(
+        long,
+        default_value_t = Self::DEFAULT_MULTI_FETCH_BATCH_SIZE,
+        env = "FALLBACK_KV_MULTI_FETCH_BATCH_SIZE",
+        help = "Experimental: Maximum number of keys per batch request to fallback KV store."
+    )]
+    pub fallback_kv_multi_fetch_batch_size: usize,
+
+    #[arg(
+        long,
+        default_value_t = Self::DEFAULT_CONCURRENT_FETCHES,
+        env = "FALLBACK_KV_CONCURRENT_FETCHES",
+        help = "Experimental: Maximum number of concurrent batch requests to fallback KV store."
+    )]
+    pub fallback_kv_concurrent_fetches: usize,
+}
+
+impl HistoricFallbackOptions {
+    pub const DEFAULT_MULTI_FETCH_BATCH_SIZE: usize = 100;
+    pub const DEFAULT_CONCURRENT_FETCHES: usize = 10;
+}
+
+impl Default for HistoricFallbackOptions {
+    fn default() -> Self {
+        Self {
+            fallback_kv_url: None,
+            fallback_kv_multi_fetch_batch_size: Self::DEFAULT_MULTI_FETCH_BATCH_SIZE,
+            fallback_kv_concurrent_fetches: Self::DEFAULT_CONCURRENT_FETCHES,
+        }
+    }
 }
 
 #[derive(Args, Debug, Default, Clone)]
@@ -613,9 +644,7 @@ pub mod deprecated {
                         old_conf.rpc_server_port,
                     ),
                     rpc_client_url: old_conf.rpc_client_url,
-                    historic_fallback_options: HistoricFallbackOptions {
-                        fallback_kv_url: None,
-                    },
+                    historic_fallback_options: HistoricFallbackOptions::default(),
                 })
             } else if old_conf.fullnode_sync_worker {
                 Command::Indexer {

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -94,8 +94,7 @@ impl HttpRestKVClient {
         max_concurrent_batches: usize,
     ) -> IndexerResult<Self> {
         info!(
-            "creating HttpRestKVClient with base_url: {}, batch_size: {}, max_concurrent_batches: {}",
-            base_url, batch_size, max_concurrent_batches
+            "creating HttpRestKVClient with base_url: {base_url}, batch_size: {batch_size}, max_concurrent_batches: {max_concurrent_batches}",
         );
 
         let client = Client::builder().http2_prior_knowledge().build()?;
@@ -133,11 +132,9 @@ impl HttpRestKVClient {
             .map(|chunk| chunk.to_vec())
             .collect();
 
-        let results = stream::iter(chunks)
+        let mut results = stream::iter(chunks)
             .map(|chunk| self.fetch_batch(chunk))
             .buffered(self.max_concurrent_batches);
-
-        futures::pin_mut!(results);
 
         let mut flattened = Vec::new();
         while let Some(batch_result) = results.next().await {

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -3,11 +3,9 @@
 
 //! Module containing the client for interacting with the REST API KV server.
 
-use std::str::FromStr;
-
 use bytes::Bytes;
 use futures::stream::{self, StreamExt};
-use iota_storage::http_key_value_store::Key;
+use iota_storage::http_key_value_store::{ItemType, Key};
 use iota_types::{
     base_types::{ObjectID, SequenceNumber},
     digests::{CheckpointDigest, TransactionDigest},
@@ -31,8 +29,49 @@ use crate::{IndexerError, errors::IndexerResult};
 /// Request payload for multi_get containing list of keys.
 #[derive(Serialize, Debug)]
 struct MultiGetRequest {
+    /// The item type for all keys in this request.
+    /// Not serialized - used only for URL construction.
+    #[serde(skip)]
+    item_type: ItemType,
     /// List of base64url-encoded keys to retrieve.
     keys: Vec<String>,
+}
+
+impl TryFrom<&[Key]> for MultiGetRequest {
+    type Error = IndexerError;
+
+    /// Creates a new MultiGetRequest from a slice of keys.
+    /// All keys must be the same enum variant.
+    ///
+    /// # Errors
+    /// Returns an error if keys are empty or if keys are different enum
+    /// variants.
+    fn try_from(keys: &[Key]) -> Result<Self, Self::Error> {
+        if keys.is_empty() {
+            return Err(IndexerError::InvalidArgument(
+                "Cannot create MultiGetRequest with empty keys".to_string(),
+            ));
+        }
+
+        let expected_discriminant = std::mem::discriminant(&keys[0]);
+        let (item_type, _) = keys[0].to_path_elements();
+
+        let mut encoded_keys = Vec::with_capacity(keys.len());
+        for key in keys {
+            if std::mem::discriminant(key) != expected_discriminant {
+                return Err(IndexerError::NotSupported(
+                    "MultiGetRequest with heterogenous Key variants are not supported.".to_string(),
+                ));
+            }
+            let (_, encoded_key) = key.to_path_elements();
+            encoded_keys.push(encoded_key);
+        }
+
+        Ok(Self {
+            item_type,
+            keys: encoded_keys,
+        })
+    }
 }
 
 pub(crate) trait KeyValueStoreClient {
@@ -115,13 +154,6 @@ impl HttpRestKVClient {
         })
     }
 
-    #[allow(dead_code)]
-    fn get_url(&self, key: &Key) -> IndexerResult<Url> {
-        let (item_type, digest) = key.to_path_elements();
-        let joined = self.base_url.join(&format!("{item_type}/{digest}"))?;
-        Ok(Url::from_str(joined.as_str())?)
-    }
-
     async fn multi_fetch(&self, keys: Vec<Key>) -> IndexerResult<Vec<Option<Bytes>>> {
         if keys.is_empty() {
             return Ok(Vec::new());
@@ -133,7 +165,7 @@ impl HttpRestKVClient {
             .collect();
 
         let mut results = stream::iter(chunks)
-            .map(|chunk| self.fetch_batch(chunk))
+            .map(|chunk| async move { self.fetch_batch(&chunk).await })
             .buffered(self.max_concurrent_batches);
 
         let mut flattened = Vec::new();
@@ -144,19 +176,9 @@ impl HttpRestKVClient {
         Ok(flattened)
     }
 
-    async fn fetch_batch(&self, keys: Vec<Key>) -> IndexerResult<Vec<Option<Bytes>>> {
-        // Extract item_type from the first key (all keys should be the same type)
-        let item_type = keys[0].item_type().to_string();
-        let url = self.base_url.join(&item_type)?;
-
-        let encoded_keys: Vec<String> = keys
-            .iter()
-            .map(|key| {
-                let (_, encoded) = key.to_path_elements();
-                encoded
-            })
-            .collect();
-        let payload = MultiGetRequest { keys: encoded_keys };
+    async fn fetch_batch(&self, keys: &[Key]) -> IndexerResult<Vec<Option<Bytes>>> {
+        let payload = MultiGetRequest::try_from(keys)?;
+        let url = self.base_url.join(&payload.item_type.to_string())?;
 
         trace!(
             "fetching batch of {} keys from url: {url}",
@@ -184,31 +206,6 @@ impl HttpRestKVClient {
         bcs::from_bytes::<Vec<Option<Bytes>>>(&bytes).map_err(|e| {
             IndexerError::Serde(format!("failed to deserialize multi_get response: {e:?}"))
         })
-    }
-
-    #[allow(dead_code)]
-    async fn fetch(&self, key: Key) -> IndexerResult<Option<Bytes>> {
-        let url = self.get_url(&key)?;
-
-        trace!("fetching url: {url}");
-
-        let resp = self.client.get(url.clone()).send().await?;
-        trace!(
-            "got response {} for url: {url}, len: {:?}",
-            resp.status(),
-            resp.headers()
-                .get(CONTENT_LENGTH)
-                .unwrap_or(&HeaderValue::from_static("0"))
-        );
-
-        // return None for non-2xx responses.
-        if !resp.status().is_success() {
-            return Ok(None);
-        }
-
-        let bytes = resp.bytes().await?;
-        // map the bytes to Some only if non-empty.
-        Ok((!bytes.is_empty()).then_some(bytes))
     }
 }
 

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -22,11 +22,18 @@ use reqwest::{
     Client, Url,
     header::{CONTENT_LENGTH, HeaderValue},
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tap::TapFallible;
 use tracing::{error, info, instrument, trace, warn};
 
-use crate::errors::IndexerResult;
+use crate::{IndexerError, errors::IndexerResult};
+
+/// Request payload for multi_get containing list of keys.
+#[derive(Serialize, Debug)]
+struct MultiGetRequest {
+    /// List of base64url-encoded keys to retrieve.
+    keys: Vec<String>,
+}
 
 pub(crate) trait KeyValueStoreClient {
     async fn multi_get_transactions(
@@ -74,11 +81,22 @@ pub(crate) trait KeyValueStoreClient {
 pub(crate) struct HttpRestKVClient {
     base_url: Url,
     client: Client,
+    /// Maximum number of keys per batch request
+    batch_size: usize,
+    /// Maximum number of concurrent batch requests
+    max_concurrent_batches: usize,
 }
 
 impl HttpRestKVClient {
-    pub fn new(base_url: &str) -> IndexerResult<Self> {
-        info!("creating HttpRestKVClient with base_url: {}", base_url);
+    pub fn new(
+        base_url: &str,
+        batch_size: usize,
+        max_concurrent_batches: usize,
+    ) -> IndexerResult<Self> {
+        info!(
+            "creating HttpRestKVClient with base_url: {}, batch_size: {}, max_concurrent_batches: {}",
+            base_url, batch_size, max_concurrent_batches
+        );
 
         let client = Client::builder().http2_prior_knowledge().build()?;
 
@@ -90,28 +108,88 @@ impl HttpRestKVClient {
 
         let base_url = Url::parse(&base_url)?;
 
-        Ok(Self { base_url, client })
+        Ok(Self {
+            base_url,
+            client,
+            batch_size,
+            max_concurrent_batches,
+        })
     }
 
+    #[allow(dead_code)]
     fn get_url(&self, key: &Key) -> IndexerResult<Url> {
         let (item_type, digest) = key.to_path_elements();
         let joined = self.base_url.join(&format!("{item_type}/{digest}"))?;
         Ok(Url::from_str(joined.as_str())?)
     }
 
-    async fn multi_fetch(&self, uris: Vec<Key>) -> Vec<IndexerResult<Option<Bytes>>> {
-        if uris.is_empty() {
-            return Vec::new();
+    async fn multi_fetch(&self, keys: Vec<Key>) -> IndexerResult<Vec<Option<Bytes>>> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
         }
-        let len = uris.len();
-        stream::iter(uris)
-            .map(|url| self.fetch(url))
-            // len must be greater than 0, otherwise it will enter a deadlock.
-            .buffered(len)
-            .collect()
-            .await
+
+        let chunks: Vec<Vec<Key>> = keys
+            .chunks(self.batch_size)
+            .map(|chunk| chunk.to_vec())
+            .collect();
+
+        let results = stream::iter(chunks)
+            .map(|chunk| self.fetch_batch(chunk))
+            .buffered(self.max_concurrent_batches);
+
+        futures::pin_mut!(results);
+
+        let mut flattened = Vec::new();
+        while let Some(batch_result) = results.next().await {
+            flattened.extend(batch_result?);
+        }
+
+        Ok(flattened)
     }
 
+    async fn fetch_batch(&self, keys: Vec<Key>) -> IndexerResult<Vec<Option<Bytes>>> {
+        // Extract item_type from the first key (all keys should be the same type)
+        let item_type = keys[0].item_type().to_string();
+        let url = self.base_url.join(&item_type)?;
+
+        let encoded_keys: Vec<String> = keys
+            .iter()
+            .map(|key| {
+                let (_, encoded) = key.to_path_elements();
+                encoded
+            })
+            .collect();
+        let payload = MultiGetRequest { keys: encoded_keys };
+
+        trace!(
+            "fetching batch of {} keys from url: {url}",
+            payload.keys.len()
+        );
+
+        let resp = self.client.post(url.clone()).json(&payload).send().await?;
+
+        trace!(
+            "got response {} for url: {url}, len: {:?}",
+            resp.status(),
+            resp.headers()
+                .get(CONTENT_LENGTH)
+                .unwrap_or(&HeaderValue::from_static("0"))
+        );
+
+        if !resp.status().is_success() {
+            return Err(IndexerError::HistoricalFallbackStorageError(format!(
+                "multi_fetch request failed with status: {}",
+                resp.status()
+            )));
+        }
+
+        let bytes = resp.bytes().await?;
+        bcs::from_bytes::<Vec<Option<Bytes>>>(&bytes).map_err(|e| {
+            IndexerError::Serde(format!("failed to deserialize multi_get response: {e:?}"))
+        })
+    }
+
+    #[allow(dead_code)]
     async fn fetch(&self, key: Key) -> IndexerResult<Option<Bytes>> {
         let url = self.get_url(&key)?;
 
@@ -152,21 +230,6 @@ where
         .ok()
 }
 
-fn map_fetch<'a, K>(fetch: (&'a IndexerResult<Option<Bytes>>, &'a K)) -> Option<(&'a Bytes, &'a K)>
-where
-    K: std::fmt::Debug,
-{
-    let (fetch, key) = fetch;
-    match fetch {
-        Ok(Some(bytes)) => Some((bytes, key)),
-        Ok(None) => None,
-        Err(err) => {
-            warn!("Error fetching key: {key:?}, error: {err:?}");
-            None
-        }
-    }
-}
-
 fn deser_check_digest<T, D>(
     digest: &D,
     bytes: &Bytes,
@@ -198,13 +261,12 @@ impl KeyValueStoreClient for HttpRestKVClient {
             .map(|tx| Key::Transaction(*tx))
             .collect::<Vec<_>>();
 
-        let fetches = self.multi_fetch(keys).await;
+        let fetches = self.multi_fetch(keys).await?;
         let txn_results = fetches
             .iter()
             .zip(transaction_digests.iter())
-            .map(map_fetch)
-            .map(|maybe_bytes| {
-                maybe_bytes.and_then(|(bytes, digest)| {
+            .map(|(fetch, digest)| {
+                fetch.as_ref().and_then(|bytes| {
                     deser_check_digest(digest, bytes, |tx: &Transaction| *tx.digest())
                 })
             })
@@ -223,13 +285,12 @@ impl KeyValueStoreClient for HttpRestKVClient {
             .map(|fx| Key::TransactionEffects(*fx))
             .collect::<Vec<_>>();
 
-        let fetches = self.multi_fetch(keys).await;
+        let fetches = self.multi_fetch(keys).await?;
         let fx_results = fetches
             .iter()
             .zip(transaction_digests.iter())
-            .map(map_fetch)
-            .map(|maybe_bytes| {
-                maybe_bytes.and_then(|(bytes, digest)| {
+            .map(|(fetch, digest)| {
+                fetch.as_ref().and_then(|bytes| {
                     deser_check_digest(digest, bytes, |fx: &TransactionEffects| {
                         *fx.transaction_digest()
                     })
@@ -250,15 +311,15 @@ impl KeyValueStoreClient for HttpRestKVClient {
             .map(|digest| Key::TransactionToCheckpoint(*digest))
             .collect::<Vec<_>>();
 
-        let fetches = self.multi_fetch(keys).await;
+        let fetches = self.multi_fetch(keys).await?;
 
         let results = fetches
             .iter()
             .zip(transaction_digests.iter())
-            .map(map_fetch)
-            .map(|maybe_bytes| {
-                maybe_bytes
-                    .and_then(|(bytes, key)| deser::<_, CheckpointSequenceNumber>(&key, bytes))
+            .map(|(fetch, digest)| {
+                fetch
+                    .as_ref()
+                    .and_then(|bytes| deser::<_, CheckpointSequenceNumber>(&digest, bytes))
             })
             .collect::<Vec<_>>();
 
@@ -274,14 +335,14 @@ impl KeyValueStoreClient for HttpRestKVClient {
             .iter()
             .map(|digest| Key::EventsByTransactionDigest(*digest))
             .collect::<Vec<_>>();
-        Ok(self
-            .multi_fetch(keys)
-            .await
+        let fetches = self.multi_fetch(keys).await?;
+        Ok(fetches
             .iter()
             .zip(transaction_digests.iter())
-            .map(map_fetch)
-            .map(|maybe_bytes| {
-                maybe_bytes.and_then(|(bytes, key)| deser::<_, TransactionEvents>(&key, bytes))
+            .map(|(fetch, digest)| {
+                fetch
+                    .as_ref()
+                    .and_then(|bytes| deser::<_, TransactionEvents>(&digest, bytes))
             })
             .collect::<Vec<_>>())
     }
@@ -296,15 +357,15 @@ impl KeyValueStoreClient for HttpRestKVClient {
             .map(|cp| Key::CheckpointSummary(*cp))
             .collect::<Vec<_>>();
 
-        let fetches = self.multi_fetch(keys).await;
+        let fetches = self.multi_fetch(keys).await?;
 
         let summaries_results = fetches
             .iter()
             .zip(checkpoint_sequence_numbers.iter())
-            .map(map_fetch)
-            .map(|maybe_bytes| {
-                maybe_bytes
-                    .and_then(|(bytes, seq)| deser::<_, CertifiedCheckpointSummary>(seq, bytes))
+            .map(|(fetch, seq)| {
+                fetch
+                    .as_ref()
+                    .and_then(|bytes| deser::<_, CertifiedCheckpointSummary>(seq, bytes))
             })
             .collect::<Vec<_>>();
 
@@ -321,14 +382,15 @@ impl KeyValueStoreClient for HttpRestKVClient {
             .map(|cp| Key::CheckpointContents(*cp))
             .collect::<Vec<_>>();
 
-        let fetches = self.multi_fetch(keys).await;
+        let fetches = self.multi_fetch(keys).await?;
 
         let contents_results = fetches
             .iter()
             .zip(checkpoint_sequence_numbers.iter())
-            .map(map_fetch)
-            .map(|maybe_bytes| {
-                maybe_bytes.and_then(|(bytes, seq)| deser::<_, CheckpointContents>(seq, bytes))
+            .map(|(fetch, seq)| {
+                fetch
+                    .as_ref()
+                    .and_then(|bytes| deser::<_, CheckpointContents>(seq, bytes))
             })
             .collect::<Vec<_>>();
 
@@ -345,14 +407,13 @@ impl KeyValueStoreClient for HttpRestKVClient {
             .map(|cp| Key::CheckpointSummaryByDigest(*cp))
             .collect::<Vec<_>>();
 
-        let fetches = self.multi_fetch(keys).await;
+        let fetches = self.multi_fetch(keys).await?;
 
         let summaries_by_digest_results = fetches
             .iter()
             .zip(checkpoint_digests.iter())
-            .map(map_fetch)
-            .map(|maybe_bytes| {
-                maybe_bytes.and_then(|(bytes, digest)| {
+            .map(|(fetch, digest)| {
+                fetch.as_ref().and_then(|bytes| {
                     deser_check_digest(digest, bytes, |s: &CertifiedCheckpointSummary| *s.digest())
                 })
             })
@@ -371,13 +432,12 @@ impl KeyValueStoreClient for HttpRestKVClient {
             .map(|(object_id, version)| Key::ObjectKey(*object_id, *version))
             .collect::<Vec<_>>();
 
-        let fetches = self.multi_fetch(keys).await;
+        let fetches = self.multi_fetch(keys).await?;
 
         let objects = fetches
             .iter()
             .zip(object_refs.iter())
-            .map(map_fetch)
-            .map(|maybe_bytes| maybe_bytes.and_then(|(bytes, object_ref)| deser(object_ref, bytes)))
+            .map(|(fetch, object_ref)| fetch.as_ref().and_then(|bytes| deser(object_ref, bytes)))
             .collect::<Vec<_>>();
 
         Ok(objects)

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -159,13 +159,13 @@ impl HttpRestKVClient {
             return Ok(Vec::new());
         }
 
-        let chunks: Vec<Vec<Key>> = keys
+        let requests: Vec<_> = keys
             .chunks(self.batch_size)
-            .map(|chunk| chunk.to_vec())
-            .collect();
+            .map(MultiGetRequest::try_from)
+            .collect::<Result<_, _>>()?;
 
-        let mut results = stream::iter(chunks)
-            .map(|chunk| async move { self.fetch_batch(&chunk).await })
+        let mut results = stream::iter(requests)
+            .map(|request| self.fetch_batch(request))
             .buffered(self.max_concurrent_batches);
 
         let mut flattened = Vec::new();
@@ -176,16 +176,15 @@ impl HttpRestKVClient {
         Ok(flattened)
     }
 
-    async fn fetch_batch(&self, keys: &[Key]) -> IndexerResult<Vec<Option<Bytes>>> {
-        let payload = MultiGetRequest::try_from(keys)?;
-        let url = self.base_url.join(&payload.item_type.to_string())?;
+    async fn fetch_batch(&self, request: MultiGetRequest) -> IndexerResult<Vec<Option<Bytes>>> {
+        let url = self.base_url.join(&request.item_type.to_string())?;
 
         trace!(
             "fetching batch of {} keys from url: {url}",
-            payload.keys.len()
+            request.keys.len()
         );
 
-        let resp = self.client.post(url.clone()).json(&payload).send().await?;
+        let resp = self.client.post(url.clone()).json(&request).send().await?;
 
         trace!(
             "got response {} for url: {url}, len: {:?}",

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -62,8 +62,17 @@ pub(crate) struct HistoricalFallbackReader {
 }
 
 impl HistoricalFallbackReader {
-    pub fn new(rest_kv_url: &str, package_resolver: PackageResolver) -> IndexerResult<Self> {
-        let client = HttpRestKVClient::new(rest_kv_url)?;
+    pub fn new(
+        rest_kv_url: &str,
+        package_resolver: PackageResolver,
+        fallback_kv_multi_fetch_batch_size: usize,
+        fallback_kv_concurrent_fetches: usize,
+    ) -> IndexerResult<Self> {
+        let client = HttpRestKVClient::new(
+            rest_kv_url,
+            fallback_kv_multi_fetch_batch_size,
+            fallback_kv_concurrent_fetches,
+        )?;
         Ok(Self {
             client,
             package_resolver,

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -13,7 +13,9 @@ use tracing::{info, warn};
 
 use crate::{
     build_json_rpc_server,
-    config::{IngestionConfig, JsonRpcConfig, RetentionConfig, SnapshotLagConfig},
+    config::{
+        HistoricFallbackOptions, IngestionConfig, JsonRpcConfig, RetentionConfig, SnapshotLagConfig,
+    },
     db::ConnectionPool,
     errors::IndexerError,
     historical_fallback::reader::HistoricalFallbackReader,
@@ -172,10 +174,19 @@ impl Indexer {
 
         let mut read = IndexerReader::new(connection_pool.clone());
 
-        if let Some(fallback_kv_url) = &config.historic_fallback_options.fallback_kv_url {
-            let historic_fallback_reader =
-                HistoricalFallbackReader::new(fallback_kv_url.as_str(), read.package_resolver())?;
-            info!("HistoricalFallbackReader initialized with URL: {fallback_kv_url}");
+        if let HistoricFallbackOptions {
+            fallback_kv_url: Some(url),
+            fallback_kv_multi_fetch_batch_size,
+            fallback_kv_concurrent_fetches,
+        } = &config.historic_fallback_options
+        {
+            let historic_fallback_reader = HistoricalFallbackReader::new(
+                url.as_str(),
+                read.package_resolver(),
+                *fallback_kv_multi_fetch_batch_size,
+                *fallback_kv_concurrent_fetches,
+            )?;
+            info!("HistoricalFallbackReader initialized with URL: {url}");
             read.with_fallback_reader(historic_fallback_reader);
         } else {
             info!("No config for HistoricalFallbackReader provided, skipping...");

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -150,9 +150,7 @@ pub async fn start_test_indexer_impl(
         } => {
             let config = crate::config::JsonRpcConfig {
                 iota_names_options: IotaNamesOptions::default(),
-                historic_fallback_options: crate::config::HistoricFallbackOptions {
-                    fallback_kv_url: None,
-                },
+                historic_fallback_options: crate::config::HistoricFallbackOptions::default(),
                 rpc_address: reader_mode_rpc_url.parse().unwrap(),
                 rpc_client_url: rpc_url,
             };

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -375,9 +375,7 @@ fn start_indexer_reader(fullnode_rpc_url: impl Into<String>, database_name: Opti
 
     let config = JsonRpcConfig {
         iota_names_options: IotaNamesOptions::default(),
-        historic_fallback_options: iota_indexer::config::HistoricFallbackOptions {
-            fallback_kv_url: None,
-        },
+        historic_fallback_options: iota_indexer::config::HistoricFallbackOptions::default(),
         rpc_address: SocketAddr::new(DEFAULT_INDEXER_IP.parse().unwrap(), port),
         rpc_client_url: fullnode_rpc_url.into(),
     };


### PR DESCRIPTION
# Description of change

Improved implementation of the client so that it uses [multi-get](https://github.com/iotaledger/iota/issues/9413) requests in multi_fetch instead of calling fetch multiple times in a loop.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9467

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

Tested by running rest-kv and indexer locally, and checking that fallback queries use batching properly.