### PR TITLE
upstream(iota): move protocol config fetch to `--verify-compatibility` flag

### DIFF
--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -991,17 +991,6 @@ impl IotaClientCommands {
                 let client = context.get_client().await?;
                 let read_api = client.read_api();
                 let chain_id = read_api.get_chain_identifier().await.ok();
-                let protocol_version = read_api.get_protocol_config(None).await?.protocol_version;
-                let protocol_config = ProtocolConfig::get_for_version(
-                    protocol_version,
-                    match chain_id
-                        .as_ref()
-                        .and_then(ChainIdentifier::from_chain_short_id)
-                    {
-                        Some(chain_id) => chain_id.chain(),
-                        None => Chain::Unknown,
-                    },
-                );
 
                 check_protocol_version_and_warn(read_api).await?;
 
@@ -1037,11 +1026,11 @@ impl IotaClientCommands {
                 .await;
 
                 // Restore original ID, then check result.
-                if let (Some(chain_id), Some(previous_id)) = (chain_id, previous_id) {
+                if let (Some(chain_id), Some(previous_id)) = (&chain_id, previous_id) {
                     let _ = iota_package_management::set_package_id(
                         &package_path,
                         build_config.install_dir.clone(),
-                        &chain_id,
+                        chain_id,
                         previous_id,
                     )?;
                 }
@@ -1057,6 +1046,28 @@ impl IotaClientCommands {
                 let dep_ids = compiled_package.get_published_dependencies_ids();
 
                 if verify_compatibility {
+                    let protocol_version =
+                        read_api.get_protocol_config(None).await?.protocol_version;
+
+                    ensure!(
+                        ProtocolVersion::MAX >= protocol_version,
+                        "On-chain protocol version ({}) is ahead of the latest known version ({}) in the CLI.\
+                        Please update the CLI to the latest version if you want to use --verify-compatibility flag.",
+                        protocol_version.as_u64(),
+                        ProtocolVersion::MAX.as_u64()
+                    );
+
+                    let protocol_config = ProtocolConfig::get_for_version(
+                        protocol_version,
+                        match chain_id
+                            .as_ref()
+                            .and_then(ChainIdentifier::from_chain_short_id)
+                        {
+                            Some(chain_id) => chain_id.chain(),
+                            None => Chain::Unknown,
+                        },
+                    );
+
                     check_compatibility(
                         read_api,
                         package_id,


### PR DESCRIPTION
# Description of change

This PR fixes the issue for upgrade compatibility checks which appears when trying to do an upgrade with an older CLI than the current protocol version on the network, but without passing the `--verify-compatibility` flag. The code is moved in the if branch as `--verify-compatibility` is false by default.

## Links to any relevant issues

Upstream PR: https://github.com/MystenLabs/sui/pull/23433

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Fixed a bug where an upgrade command would terminate early if the CLI binary is not at the same protocol version or newer than the network.
- [ ] Rust SDK:
- [ ] REST API:
