### PR TITLE
upstream(iota): upgrade tests path delimiter issue

### DIFF
--- a/crates/iota/src/unit_tests/upgrade_compatibility_tests.rs
+++ b/crates/iota/src/unit_tests/upgrade_compatibility_tests.rs
@@ -306,11 +306,18 @@ fn get_packages(name: &str) -> (Vec<CompiledModule>, CompiledPackage, PathBuf) {
 
 /// Snapshots will differ on each machine, normalize to prevent test failures
 fn normalize_path(err_string: String) -> String {
-    // test
-    let re = regex::Regex::new(r"^(.*)┌─ .*(\/fixtures\/.*\.(move|toml):\d+:\d+)$").unwrap();
+    let re =
+        regex::Regex::new(r"^(.*?┌─ ).*?([\\/]fixtures[\\/].*\.(move|toml):\d+:\d+)$").unwrap();
+
     err_string
         .lines()
-        .map(|line| re.replace(line, "$1┌─ $2").into_owned())
+        .map(|line| {
+            re.replace(line, |caps: &regex::Captures| {
+                let normalized_path = caps[2].replace("\\", "/");
+                format!("{}{}", &caps[1], normalized_path)
+            })
+            .into_owned()
+        })
         .collect::<Vec<String>>()
         .join("\n")
 }


### PR DESCRIPTION
# Description of change

This fixes issues with Windows delimiter being used in the output of these tests, which makes the snapshots fail.

## Links to any relevant issues

Upstream PR: https://github.com/MystenLabs/sui/pull/24289

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes