### PR TITLE
upstream(iota): cross-platform write to file

### DIFF
--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -2,8 +2,6 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(not(target_os = "windows"))]
-use std::os::unix::fs::FileExt;
 #[cfg(target_os = "windows")]
 use std::os::windows::fs::FileExt;
 #[cfg(not(msim))]
@@ -13,7 +11,7 @@ use std::{
     env,
     fmt::Write,
     fs::{self, read_dir},
-    io::{self, Read},
+    io::{self, Read, Seek, SeekFrom, Write as IoWrite},
     net::SocketAddr,
     path::{Path, PathBuf},
     str, thread,
@@ -2557,10 +2555,10 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
         ),
     );
     let new = lines.join("\n");
-    #[cfg(target_os = "windows")]
-    move_toml.seek_write(new.as_bytes(), 0).unwrap();
-    #[cfg(not(target_os = "windows"))]
-    move_toml.write_at(new.as_bytes(), 0).unwrap();
+
+    move_toml.seek(SeekFrom::Start(0))?;
+    move_toml.set_len(0)?; // Truncate the file
+    move_toml.write_all(new.as_bytes())?;
 
     // Now run the upgrade
     let build_config = BuildConfig::new_for_testing().config;
@@ -2858,10 +2856,9 @@ async fn test_package_management_on_upgrade_command_conflict() -> Result<(), any
     lines.insert(idx + 1, "published-at = \"0xbad\"".to_string());
     let new = lines.join("\n");
 
-    #[cfg(target_os = "windows")]
-    move_toml.seek_write(new.as_bytes(), 0).unwrap();
-    #[cfg(not(target_os = "windows"))]
-    move_toml.write_at(new.as_bytes(), 0).unwrap();
+    move_toml.seek(SeekFrom::Start(0))?;
+    move_toml.set_len(0)?; // Truncate the file
+    move_toml.write_all(new.as_bytes())?;
 
     // Create a new build config for the upgrade. Initialize its lock file to the
     // package we published.


### PR DESCRIPTION
# Description of change

>This PR fixes an issue where the write_to method is only specific on unix machines. This was blocking Windows machines from running sui crate tests.

We already fixed this in the past but this cross-platform version is slightly better and correctly truncates the file.

## Links to any relevant issues

Upstream PR: https://github.com/MystenLabs/sui/pull/24291

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
