### PR TITLE
feat(iota-indexer): add cache in `HttpRestKVClient`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6638,6 +6638,7 @@ dependencies = [
  "iota-types",
  "itertools 0.13.0",
  "jsonrpsee",
+ "moka",
  "move-binary-format",
  "move-core-types",
  "prometheus",

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -25,6 +25,7 @@ fastcrypto = { workspace = true, features = ["copy_key"] }
 futures.workspace = true
 itertools.workspace = true
 jsonrpsee.workspace = true
+moka.workspace = true
 prometheus.workspace = true
 rand = { workspace = true, optional = true }
 reqwest.workspace = true

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -142,11 +142,20 @@ pub struct HistoricFallbackOptions {
         help = "Experimental: Maximum number of concurrent batch requests to fallback KV store."
     )]
     pub fallback_kv_concurrent_fetches: usize,
+
+    #[arg(
+        long,
+        default_value_t = Self::DEFAULT_CACHE_SIZE,
+        env = "FALLBACK_KV_CACHE_SIZE",
+        help = "Experimental: Cache size for historic fallback."
+    )]
+    pub fallback_kv_cache_size: u64,
 }
 
 impl HistoricFallbackOptions {
     pub const DEFAULT_MULTI_FETCH_BATCH_SIZE: usize = 100;
     pub const DEFAULT_CONCURRENT_FETCHES: usize = 10;
+    pub const DEFAULT_CACHE_SIZE: u64 = 100_000;
 }
 
 impl Default for HistoricFallbackOptions {
@@ -155,6 +164,7 @@ impl Default for HistoricFallbackOptions {
             fallback_kv_url: None,
             fallback_kv_multi_fetch_batch_size: Self::DEFAULT_MULTI_FETCH_BATCH_SIZE,
             fallback_kv_concurrent_fetches: Self::DEFAULT_CONCURRENT_FETCHES,
+            fallback_kv_cache_size: Self::DEFAULT_CACHE_SIZE,
         }
     }
 }
@@ -438,8 +448,8 @@ pub mod deprecated {
 
     use crate::{
         config::{
-            Command, HistoricFallbackOptions, IndexerConfig, IngestionConfig, IngestionSources,
-            IotaNamesOptions, JsonRpcConfig, PruningOptions, SnapshotLagConfig,
+            Command, IndexerConfig, IngestionConfig, IngestionSources, IotaNamesOptions,
+            JsonRpcConfig, PruningOptions, SnapshotLagConfig,
         },
         db::ConnectionPoolConfig,
         errors::IndexerError,
@@ -644,7 +654,7 @@ pub mod deprecated {
                         old_conf.rpc_server_port,
                     ),
                     rpc_client_url: old_conf.rpc_client_url,
-                    historic_fallback_options: HistoricFallbackOptions::default(),
+                    historic_fallback_options: Default::default(),
                 })
             } else if old_conf.fullnode_sync_worker {
                 Command::Indexer {

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -3,8 +3,13 @@
 
 //! Module containing the client for interacting with the REST API KV server.
 
+use std::time::Duration;
+
 use bytes::Bytes;
-use futures::stream::{self, StreamExt};
+use futures::{
+    TryStreamExt, future,
+    stream::{self, StreamExt},
+};
 use iota_storage::http_key_value_store::{ItemType, Key};
 use iota_types::{
     base_types::{ObjectID, SequenceNumber},
@@ -16,6 +21,7 @@ use iota_types::{
     object::Object,
     transaction::Transaction,
 };
+use moka::sync::{Cache as MokaCache, CacheBuilder as MokaCacheBuilder};
 use reqwest::{
     Client, Url,
     header::{CONTENT_LENGTH, HeaderValue},
@@ -24,8 +30,12 @@ use serde::{Deserialize, Serialize};
 use tap::TapFallible;
 use tracing::{error, info, instrument, trace, warn};
 
-use crate::{IndexerError, errors::IndexerResult};
+use crate::{
+    IndexerError, errors::IndexerResult,
+    historical_fallback::metrics::HistoricalFallbackClientMetrics,
+};
 
+const CACHE_TIME_TO_IDLE: Duration = Duration::from_secs(600);
 /// Request payload for multi_get containing list of keys.
 #[derive(Serialize, Debug)]
 struct MultiGetRequest {
@@ -124,13 +134,17 @@ pub(crate) struct HttpRestKVClient {
     batch_size: usize,
     /// Maximum number of concurrent batch requests
     max_concurrent_batches: usize,
+    cache: MokaCache<Url, Bytes>,
+    metrics: HistoricalFallbackClientMetrics,
 }
 
 impl HttpRestKVClient {
     pub fn new(
         base_url: &str,
+        cache_size: u64,
         batch_size: usize,
         max_concurrent_batches: usize,
+        metrics: HistoricalFallbackClientMetrics,
     ) -> IndexerResult<Self> {
         info!(
             "creating HttpRestKVClient with base_url: {base_url}, batch_size: {batch_size}, max_concurrent_batches: {max_concurrent_batches}",
@@ -146,11 +160,17 @@ impl HttpRestKVClient {
 
         let base_url = Url::parse(&base_url)?;
 
+        let cache = MokaCacheBuilder::new(cache_size)
+            .time_to_idle(CACHE_TIME_TO_IDLE)
+            .build();
+
         Ok(Self {
             base_url,
             client,
             batch_size,
             max_concurrent_batches,
+            metrics,
+            cache,
         })
     }
 
@@ -159,21 +179,60 @@ impl HttpRestKVClient {
             return Ok(Vec::new());
         }
 
-        let requests: Vec<_> = keys
-            .chunks(self.batch_size)
-            .map(MultiGetRequest::try_from)
-            .collect::<Result<_, _>>()?;
+        // pre-allocate results with None. Cache hits will replace None with
+        // Some(value), and cache misses will remain None until we fetch them
+        // from the REST API.
+        let mut results = vec![None; keys.len()];
+        // track keys that missed the cache, preserving their original positions.
+        // Each entry is a tuple of (key, original_index) so we can merge fetched data
+        // back into the correct position in the results vector.
+        let mut missing = Vec::with_capacity(keys.len());
 
-        let mut results = stream::iter(requests)
-            .map(|request| self.fetch_batch(request))
-            .buffered(self.max_concurrent_batches);
-
-        let mut flattened = Vec::new();
-        while let Some(batch_result) = results.next().await {
-            flattened.extend(batch_result?);
+        for (index, key) in keys.iter().enumerate() {
+            let cache_key = self.get_url(key)?;
+            if let Some(bytes) = self.cache.get(&cache_key) {
+                trace!(
+                    "found cached data for url: {cache_key}, len: {}",
+                    bytes.len()
+                );
+                self.metrics.record_cache_hit(key.item_type());
+                results[index] = Some(bytes);
+            } else {
+                self.metrics.record_cache_miss(key.item_type());
+                missing.push((*key, index));
+            }
         }
 
-        Ok(flattened)
+        if !missing.is_empty() {
+            let missing_chunks = missing
+                .chunks(self.batch_size)
+                .map(|chunk| chunk.iter().map(|(key, _)| *key).collect())
+                .collect::<Vec<Vec<Key>>>();
+
+            let fetched_results = stream::iter(missing_chunks)
+                .map(|chunk| self.fetch_batch(chunk))
+                .buffered(self.max_concurrent_batches)
+                .try_fold(Vec::with_capacity(missing.len()), |mut acc, batch| {
+                    acc.extend(batch);
+                    future::ok(acc)
+                })
+                .await?;
+
+            // process fetched results: for each missing key that was successfully fetched
+            // that has non empty bytes, update the cache with the new data and
+            // populate the corresponding slot in results at original index
+            // position.
+            for (fetch_result, (key, index)) in fetched_results.into_iter().zip(missing.into_iter())
+            {
+                if let Some(bytes) = fetch_result.filter(|b| !b.is_empty()) {
+                    let cache_key = self.get_url(&key)?;
+                    self.cache.insert(cache_key, bytes.clone());
+                    results[index] = Some(bytes);
+                }
+            }
+        }
+
+        Ok(results)
     }
 
     async fn fetch_batch(&self, request: MultiGetRequest) -> IndexerResult<Vec<Option<Bytes>>> {

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -6,10 +6,7 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use futures::{
-    TryStreamExt, future,
-    stream::{self, StreamExt},
-};
+use futures::stream::{self, StreamExt};
 use iota_storage::http_key_value_store::{ItemType, Key};
 use iota_types::{
     base_types::{ObjectID, SequenceNumber},
@@ -134,7 +131,7 @@ pub(crate) struct HttpRestKVClient {
     batch_size: usize,
     /// Maximum number of concurrent batch requests
     max_concurrent_batches: usize,
-    cache: MokaCache<Url, Bytes>,
+    cache: MokaCache<Key, Bytes>,
     metrics: HistoricalFallbackClientMetrics,
 }
 
@@ -189,12 +186,8 @@ impl HttpRestKVClient {
         let mut missing = Vec::with_capacity(keys.len());
 
         for (index, key) in keys.iter().enumerate() {
-            let cache_key = self.get_url(key)?;
-            if let Some(bytes) = self.cache.get(&cache_key) {
-                trace!(
-                    "found cached data for url: {cache_key}, len: {}",
-                    bytes.len()
-                );
+            if let Some(bytes) = self.cache.get(key) {
+                trace!("found cached data for url: {key:?}, len: {}", bytes.len());
                 self.metrics.record_cache_hit(key.item_type());
                 results[index] = Some(bytes);
             } else {
@@ -203,32 +196,35 @@ impl HttpRestKVClient {
             }
         }
 
-        if !missing.is_empty() {
-            let missing_chunks = missing
-                .chunks(self.batch_size)
-                .map(|chunk| chunk.iter().map(|(key, _)| *key).collect())
-                .collect::<Vec<Vec<Key>>>();
+        if missing.is_empty() {
+            return Ok(results);
+        }
 
-            let fetched_results = stream::iter(missing_chunks)
-                .map(|chunk| self.fetch_batch(chunk))
-                .buffered(self.max_concurrent_batches)
-                .try_fold(Vec::with_capacity(missing.len()), |mut acc, batch| {
-                    acc.extend(batch);
-                    future::ok(acc)
-                })
-                .await?;
+        let missing_chunks = missing
+            .chunks(self.batch_size)
+            .map(|chunk| {
+                let keys = chunk.iter().map(|(key, _)| *key).collect::<Vec<Key>>();
+                MultiGetRequest::try_from(keys.as_slice())
+            })
+            .collect::<Result<Vec<MultiGetRequest>, IndexerError>>()?;
 
-            // process fetched results: for each missing key that was successfully fetched
-            // that has non empty bytes, update the cache with the new data and
-            // populate the corresponding slot in results at original index
-            // position.
-            for (fetch_result, (key, index)) in fetched_results.into_iter().zip(missing.into_iter())
-            {
-                if let Some(bytes) = fetch_result.filter(|b| !b.is_empty()) {
-                    let cache_key = self.get_url(&key)?;
-                    self.cache.insert(cache_key, bytes.clone());
-                    results[index] = Some(bytes);
-                }
+        let mut fetch_batch_stream = stream::iter(missing_chunks)
+            .map(|chunk| async move { self.fetch_batch(chunk).await })
+            .buffered(self.max_concurrent_batches);
+
+        let mut fetched_results = Vec::with_capacity(missing.len());
+        while let Some(batch_result) = fetch_batch_stream.next().await {
+            fetched_results.extend(batch_result?);
+        }
+
+        // process fetched results: for each missing key that was successfully fetched
+        // that has non empty bytes, update the cache with the new data and
+        // populate the corresponding slot in results at original index
+        // position.
+        for (fetch_result, (key, index)) in fetched_results.into_iter().zip(missing.into_iter()) {
+            if let Some(bytes) = fetch_result.filter(|b| !b.is_empty()) {
+                self.cache.insert(key, bytes.clone());
+                results[index] = Some(bytes);
             }
         }
 

--- a/crates/iota-indexer/src/historical_fallback/metrics.rs
+++ b/crates/iota-indexer/src/historical_fallback/metrics.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_storage::http_key_value_store::ItemType;
+use prometheus::{IntCounterVec, Registry, register_int_counter_vec_with_registry};
+
+#[derive(Clone)]
+pub struct HistoricalFallbackClientMetrics {
+    pub(crate) cache_hits: IntCounterVec,
+    pub(crate) cache_misses: IntCounterVec,
+}
+
+impl HistoricalFallbackClientMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            cache_hits: register_int_counter_vec_with_registry!(
+                "historical_fallback_cache_hits",
+                "Historical fallback cache hits",
+                &["resource"],
+                registry,
+            )
+            .unwrap(),
+            cache_misses: register_int_counter_vec_with_registry!(
+                "historical_fallback_cache_misses",
+                "Historical fallback cache misses",
+                &["resource"],
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+
+    pub(crate) fn record_cache_hit(&self, item_type: ItemType) {
+        self.cache_hits
+            .with_label_values(&[item_type.to_string()])
+            .inc();
+    }
+
+    pub(crate) fn record_cache_miss(&self, item_type: ItemType) {
+        self.cache_misses
+            .with_label_values(&[item_type.to_string()])
+            .inc();
+    }
+}

--- a/crates/iota-indexer/src/historical_fallback/mod.rs
+++ b/crates/iota-indexer/src/historical_fallback/mod.rs
@@ -10,4 +10,5 @@
 
 pub(crate) mod client;
 pub(crate) mod convert;
+pub(crate) mod metrics;
 pub(crate) mod reader;

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -25,6 +25,7 @@ use iota_types::{
     object::Object,
 };
 use itertools::{Either, Itertools, izip};
+use prometheus::Registry;
 
 use crate::{
     errors::{IndexerError, IndexerResult},
@@ -69,14 +70,14 @@ impl HistoricalFallbackReader {
         package_resolver: PackageResolver,
         fallback_kv_multi_fetch_batch_size: usize,
         fallback_kv_concurrent_fetches: usize,
-        metrics: HistoricalFallbackClientMetrics,
+        registry: &Registry,
     ) -> IndexerResult<Self> {
         let client = HttpRestKVClient::new(
             rest_kv_url,
             cache_size,
             fallback_kv_multi_fetch_batch_size,
             fallback_kv_concurrent_fetches,
-            metrics,
+            HistoricalFallbackClientMetrics::new(registry),
         )?;
         Ok(Self {
             client,

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -33,6 +33,7 @@ use crate::{
         convert::{
             HistoricalFallbackCheckpoint, HistoricalFallbackEvents, HistoricalFallbackTransaction,
         },
+        metrics::HistoricalFallbackClientMetrics,
     },
     models::{
         checkpoints::StoredCheckpoint, objects::StoredObject, transactions::StoredTransaction,
@@ -64,14 +65,18 @@ pub(crate) struct HistoricalFallbackReader {
 impl HistoricalFallbackReader {
     pub fn new(
         rest_kv_url: &str,
+        cache_size: u64,
         package_resolver: PackageResolver,
         fallback_kv_multi_fetch_batch_size: usize,
         fallback_kv_concurrent_fetches: usize,
+        metrics: HistoricalFallbackClientMetrics,
     ) -> IndexerResult<Self> {
         let client = HttpRestKVClient::new(
             rest_kv_url,
+            cache_size,
             fallback_kv_multi_fetch_batch_size,
             fallback_kv_concurrent_fetches,
+            metrics,
         )?;
         Ok(Self {
             client,

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -175,16 +175,19 @@ impl Indexer {
         let mut read = IndexerReader::new(connection_pool.clone());
 
         if let HistoricFallbackOptions {
-            fallback_kv_url: Some(url),
+            fallback_kv_url: Some(ref url),
             fallback_kv_multi_fetch_batch_size,
             fallback_kv_concurrent_fetches,
-        } = &config.historic_fallback_options
+            fallback_kv_cache_size,
+        } = config.historic_fallback_options
         {
             let historic_fallback_reader = HistoricalFallbackReader::new(
                 url.as_str(),
+                fallback_kv_cache_size,
                 read.package_resolver(),
-                *fallback_kv_multi_fetch_batch_size,
-                *fallback_kv_concurrent_fetches,
+                fallback_kv_multi_fetch_batch_size,
+                fallback_kv_concurrent_fetches,
+                metrics.historical_fallback_metrics.clone(),
             )?;
             info!("HistoricalFallbackReader initialized with URL: {url}");
             read.with_fallback_reader(historic_fallback_reader);

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -187,7 +187,7 @@ impl Indexer {
                 read.package_resolver(),
                 fallback_kv_multi_fetch_batch_size,
                 fallback_kv_concurrent_fetches,
-                metrics.historical_fallback_metrics.clone(),
+                registry,
             )?;
             info!("HistoricalFallbackReader initialized with URL: {url}");
             read.with_fallback_reader(historic_fallback_reader);

--- a/crates/iota-indexer/src/metrics.rs
+++ b/crates/iota-indexer/src/metrics.rs
@@ -12,6 +12,8 @@ use prometheus::{
 };
 use tracing::info;
 
+use crate::historical_fallback::metrics::HistoricalFallbackClientMetrics;
+
 const METRICS_ROUTE: &str = "/metrics";
 
 pub fn start_prometheus_server(
@@ -194,6 +196,7 @@ pub struct IndexerMetrics {
     pub optimistic_tx_with_missing_dependencies_count: IntCounter,
     pub optimistic_tx_with_missing_objects_counts: IntCounter,
     pub optimistic_tx_failed_db_writes_count: IntCounter,
+    pub historical_fallback_metrics: HistoricalFallbackClientMetrics,
 }
 
 impl IndexerMetrics {
@@ -923,6 +926,7 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
+            historical_fallback_metrics: HistoricalFallbackClientMetrics::new(registry),
         }
     }
 }

--- a/crates/iota-indexer/src/metrics.rs
+++ b/crates/iota-indexer/src/metrics.rs
@@ -12,8 +12,6 @@ use prometheus::{
 };
 use tracing::info;
 
-use crate::historical_fallback::metrics::HistoricalFallbackClientMetrics;
-
 const METRICS_ROUTE: &str = "/metrics";
 
 pub fn start_prometheus_server(
@@ -196,7 +194,6 @@ pub struct IndexerMetrics {
     pub optimistic_tx_with_missing_dependencies_count: IntCounter,
     pub optimistic_tx_with_missing_objects_counts: IntCounter,
     pub optimistic_tx_failed_db_writes_count: IntCounter,
-    pub historical_fallback_metrics: HistoricalFallbackClientMetrics,
 }
 
 impl IndexerMetrics {
@@ -926,7 +923,6 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
-            historical_fallback_metrics: HistoricalFallbackClientMetrics::new(registry),
         }
     }
 }

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -150,7 +150,7 @@ pub async fn start_test_indexer_impl(
         } => {
             let config = crate::config::JsonRpcConfig {
                 iota_names_options: IotaNamesOptions::default(),
-                historic_fallback_options: crate::config::HistoricFallbackOptions::default(),
+                historic_fallback_options: Default::default(),
                 rpc_address: reader_mode_rpc_url.parse().unwrap(),
                 rpc_client_url: rpc_url,
             };

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -375,7 +375,7 @@ fn start_indexer_reader(fullnode_rpc_url: impl Into<String>, database_name: Opti
 
     let config = JsonRpcConfig {
         iota_names_options: IotaNamesOptions::default(),
-        historic_fallback_options: iota_indexer::config::HistoricFallbackOptions::default(),
+        historic_fallback_options: Default::default(),
         rpc_address: SocketAddr::new(DEFAULT_INDEXER_IP.parse().unwrap(), port),
         rpc_client_url: fullnode_rpc_url.into(),
     };

--- a/crates/iota-storage/src/http_key_value_store.rs
+++ b/crates/iota-storage/src/http_key_value_store.rs
@@ -79,7 +79,19 @@ where
 
 /// Represents the supported items the REST API accepts when fetching the data
 /// based on Digest or Sequence number.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, strum::EnumString, strum::Display)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Deserialize,
+    strum::EnumString,
+    strum::Display,
+)]
 pub enum ItemType {
     #[strum(serialize = "tx")]
     #[serde(rename = "tx")]
@@ -104,7 +116,7 @@ pub enum ItemType {
     EventTransactionDigest,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Key {
     Transaction(TransactionDigest),
     TransactionEffects(TransactionDigest),


### PR DESCRIPTION
# Description of change

The following PR adds a caching layer to the `HttpRestKVClient`. The implementation is very similar to the one already implemented for the `HttpKVStore`.

## Links to any relevant issues

fixes #9501 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

Started the indexer reader and checked if the requests would be cached.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch does not affect the normal operation of the indexer. By default pruning is not enabled and also the fallback feature is enabled only if an additional CLI argument is provided during the startup. No further tests were conducted.
