### PR TITLE
fix(tooling-ci): Inject apps backend into published SDK

### DIFF
--- a/.github/workflows/changesets_publish.yml
+++ b/.github/workflows/changesets_publish.yml
@@ -17,6 +17,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.ta
 env:
   IOTA_NETWORKS: ${{ secrets.CHANGESETS_IOTA_NETWORKS }}
   DEFAULT_NETWORK: ${{ secrets.CHANGESETS_DEFAULT_NETWORK }}
+  APPS_BACKEND: ${{ secrets.CHANGESETS_APPS_BACKEND }}
   NPM_TOKEN: ""
 
 permissions:


### PR DESCRIPTION
# Description of change

Published SDK are using the apps backend URL from `.env.default`. This injects it from github secrets.


