### PR TITLE
refactor(json-rpc)!: rename view callArgs to arguments

### DIFF
--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -122,7 +122,7 @@ impl WriteApiServer for WriteApi {
         &self,
         function_name: String,
         type_args: Option<Vec<IotaTypeTag>>,
-        call_args: Vec<IotaJsonValue>,
+        arguments: Vec<IotaJsonValue>,
     ) -> RpcResult<IotaMoveViewCallResults> {
         let MoveFunctionName {
             package,
@@ -137,7 +137,7 @@ impl WriteApiServer for WriteApi {
                 &module,
                 &function,
                 type_args.unwrap_or_default(),
-                call_args,
+                arguments,
             )
             .await
             .map_err(IndexerError::from)?;
@@ -204,7 +204,7 @@ impl WriteApiServer for OptimisticWriteApi {
         &self,
         function_name: String,
         type_args: Option<Vec<IotaTypeTag>>,
-        call_args: Vec<IotaJsonValue>,
+        arguments: Vec<IotaJsonValue>,
     ) -> RpcResult<IotaMoveViewCallResults> {
         let chain = self
             .optimistic_tx_executor
@@ -221,7 +221,7 @@ impl WriteApiServer for OptimisticWriteApi {
         }
 
         self.write_api
-            .view_function_call(function_name, type_args, call_args)
+            .view_function_call(function_name, type_args, arguments)
             .await
     }
 }

--- a/crates/iota-json-rpc-api/src/write.rs
+++ b/crates/iota-json-rpc-api/src/write.rs
@@ -52,7 +52,7 @@ pub trait WriteApi {
         /// The fully qualified function name `<package_id>::<module_name>::<function_name>`. E.g.  `0x3::iota_system::get_total_iota_supply`.
         function_name: String,
         type_args: Option<Vec<IotaTypeTag>>,
-        call_args: Vec<IotaJsonValue>,
+        arguments: Vec<IotaJsonValue>,
     ) -> RpcResult<IotaMoveViewCallResults>;
 
     /// Runs the transaction in dev-inspect mode. Which allows for nearly any

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -368,7 +368,7 @@ impl WriteApiServer for TransactionExecutionApi {
         &self,
         function_name: String,
         type_args: Option<Vec<IotaTypeTag>>,
-        call_args: Vec<IotaJsonValue>,
+        arguments: Vec<IotaJsonValue>,
     ) -> RpcResult<IotaMoveViewCallResults> {
         let chain = self
             .state
@@ -395,7 +395,7 @@ impl WriteApiServer for TransactionExecutionApi {
                 &module,
                 &function,
                 type_args.unwrap_or_default(),
-                call_args,
+                arguments,
             )
             .await
             .map_err(Error::from)?;

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -3277,7 +3277,7 @@
           }
         },
         {
-          "name": "call_args",
+          "name": "arguments",
           "required": true,
           "schema": {
             "type": "array",


### PR DESCRIPTION
# Description of change

Rename `callArgs -> arguments` in `iota_view` JSON-RPC parameters to comply with IIP5.

## Links to any relevant issues

Fixes #9670 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [x] JSON-RPC: :warning: Renames `iota_view` parameter `callArgs` to `arguments` to comply with IIP 5. `iota_view` is still in alpha, so the API is not yet stable.
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
