### PR TITLE
fix(json-rpc,indexer): get delegated timelocked stake correctly

### DIFF
--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -240,10 +240,17 @@ impl GovernanceReadApi {
         let system_state_summary = self.get_latest_iota_system_state().await?;
         let epoch = system_state_summary.epoch();
 
+        let (candidate_rates, pending_rates) = tokio::try_join!(
+            self.candidate_validators_exchange_rate(&system_state_summary),
+            self.pending_validators_exchange_rate()
+        )?;
+
         let rates = self
             .exchange_rates(&system_state_summary)
             .await?
             .into_iter()
+            .chain(candidate_rates)
+            .chain(pending_rates)
             .map(|rates| (rates.pool_id, rates))
             .collect::<BTreeMap<_, _>>();
 

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -275,6 +275,10 @@ impl GovernanceReadApi {
         let rates = exchange_rates(&self.state, system_state_summary.epoch)
             .await?
             .into_iter()
+            // Try to find for any candidate validator exchange rate
+            .chain(candidate_validators_exchange_rate(&self.state)?)
+            // Try to find for any pending validator exchange rate
+            .chain(pending_validators_exchange_rate(&self.state)?)
             .map(|rates| (rates.pool_id, rates))
             .collect::<BTreeMap<_, _>>();
 


### PR DESCRIPTION
# Description of change

This patch includes exchange rates from pending and candidates validators while resolving exchange rates.

Following #3934 and #4313 

## Links to any relevant issues

Fixes #9676 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [x] JSON-RPC: :screwdriver: Fixes a bug in `iotax_getTimelockedStakes` where stakes added to pending or candidate validators would not get resolved and raise an error. 
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
