### PR TITLE
fix(wallet): Properly filter ledger accounts in balance finder

### DIFF
--- a/apps/wallet/src/ui/app/pages/accounts/manage/accounts-finder/AccountsFinderIntroPage.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/manage/accounts-finder/AccountsFinderIntroPage.tsx
@@ -4,13 +4,11 @@
 import { useNavigate } from 'react-router-dom';
 import { Overlay } from '_components';
 import { useActiveAccount, useAppSelector } from '_hooks';
-import { getKey } from '_helpers';
+import { getSourceId } from '_helpers';
 import { Theme, useTheme } from '@iota/core';
 import { Button, ButtonType } from '@iota/apps-ui-kit';
 import BalanceFinderIntroImage from '_assets/images/balance_finder_intro.png';
 import BalanceFinderIntroDarkImage from '_assets/images/balance_finder_intro_darkmode.png';
-import { isLedgerAccountSerializedUI } from '_src/background/accounts/ledgerAccount';
-import { AllowedAccountSourceTypes } from '_src/ui/app/accounts-finder';
 import { useEffect, useState } from 'react';
 import { ExtensionViewType } from '_src/ui/app/redux/slices/app/appType';
 
@@ -24,14 +22,10 @@ export function AccountsFinderIntroPage() {
     );
 
     const skipActionAllowed = skipSeconds > 0;
-    const isLedgerAccount = activeAccount && isLedgerAccountSerializedUI(activeAccount);
-    const accountSourceId = activeAccount && getKey(activeAccount);
+    const accountSourceId = activeAccount && getSourceId(activeAccount);
     const imgSrc = theme === Theme.Dark ? BalanceFinderIntroDarkImage : BalanceFinderIntroImage;
 
-    const ledgerPath = `/accounts/manage/accounts-finder/${AllowedAccountSourceTypes.LedgerDerived}`;
-    const accountPath = isLedgerAccount
-        ? ledgerPath
-        : `/accounts/manage/accounts-finder/${accountSourceId}`;
+    const accountPath = `/accounts/manage/accounts-finder/${accountSourceId}`;
 
     useEffect(() => {
         if (!skipActionAllowed) return;

--- a/apps/wallet/src/ui/app/pages/accounts/manage/accounts-finder/AccountsFinderView.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/manage/accounts-finder/AccountsFinderView.tsx
@@ -17,7 +17,7 @@ import {
 import { AccountType, type SerializedUIAccount } from '_src/background/accounts/account';
 import { type SourceStrategyToFind } from '_src/shared/messaging/messages/payloads/accounts-finder';
 import { AllowedAccountSourceTypes } from '_src/ui/app/accounts-finder';
-import { getKey, getLedgerConnectionErrorMessage } from '_src/ui/app/helpers';
+import { getSourceId, getLedgerConnectionErrorMessage } from '_src/ui/app/helpers';
 import {
     useAccountSources,
     useAccounts,
@@ -116,7 +116,7 @@ export function AccountsFinderView(): JSX.Element {
         }
     }
 
-    const persistedAccounts = accounts?.filter((acc) => getKey(acc) === accountSourceId);
+    const persistedAccounts = accounts?.filter((acc) => getSourceId(acc) === accountSourceId);
     const isLocked =
         accountSource?.isLocked || (accountSourceId === AccountType.LedgerDerived && !password);
     const isLedgerLocked =


### PR DESCRIPTION
Closes https://github.com/iotaledger/iota/issues/9675

`getKey` is meant to be a UI util, for actual operations `getSourceId` must be used.