### PR TITLE
feat(grpc): Add header in response on server side

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/v0/header.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/header.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_grpc_types::headers;
+use tonic::metadata::MetadataMap;
+
+/// Helper function to verify that all expected IOTA headers are present in the
+/// response metadata
+pub fn verify_iota_headers(metadata: &MetadataMap, operation_name: &str) {
+    let required_headers = [
+        headers::X_IOTA_CHAIN,
+        headers::X_IOTA_CHAIN_ID,
+        headers::X_IOTA_CHECKPOINT_HEIGHT,
+        headers::X_IOTA_EPOCH,
+        headers::X_IOTA_TIMESTAMP_MS,
+        headers::X_IOTA_TIMESTAMP,
+        headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT,
+        headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT_OBJECTS,
+        headers::X_IOTA_SERVER,
+    ];
+
+    for header_name in &required_headers {
+        assert!(
+            metadata.get(*header_name).is_some(),
+            "{operation_name} response should contain {header_name} header",
+        );
+    }
+}
+
+/// Helper function to parse a u64 header value
+pub fn parse_u64_header(metadata: &MetadataMap, header_name: &str) -> u64 {
+    metadata
+        .get(header_name)
+        .unwrap_or_else(|| panic!("{header_name} header should be present"))
+        .to_str()
+        .unwrap_or_else(|_| panic!("{header_name} header should be valid UTF-8"))
+        .parse()
+        .unwrap_or_else(|_| panic!("{header_name} header should be a valid u64"))
+}

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/header.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/header.rs
@@ -30,9 +30,7 @@ fn verify_iota_headers(metadata: &MetadataMap, operation_name: &str) {
     for header_name in &required_headers {
         assert!(
             metadata.get(*header_name).is_some(),
-            "{} response should contain {} header",
-            operation_name,
-            header_name
+            "{operation_name} response should contain {header_name} header",
         );
     }
 }
@@ -41,11 +39,11 @@ fn verify_iota_headers(metadata: &MetadataMap, operation_name: &str) {
 fn parse_u64_header(metadata: &MetadataMap, header_name: &str) -> u64 {
     metadata
         .get(header_name)
-        .unwrap_or_else(|| panic!("{} header should be present", header_name))
+        .unwrap_or_else(|| panic!("{header_name} header should be present"))
         .to_str()
-        .unwrap_or_else(|_| panic!("{} header should be valid UTF-8", header_name))
+        .unwrap_or_else(|_| panic!("{header_name} header should be valid UTF-8"))
         .parse()
-        .unwrap_or_else(|_| panic!("{} header should be a valid u64", header_name))
+        .unwrap_or_else(|_| panic!("{header_name} header should be a valid u64"))
 }
 
 #[sim_test]
@@ -80,13 +78,12 @@ async fn test_response_headers() {
         let checkpoint_height = parse_u64_header(metadata, headers::X_IOTA_CHECKPOINT_HEIGHT);
         assert!(
             checkpoint_height >= 10,
-            "checkpoint_height should be at least 10, got {}",
-            checkpoint_height
+            "checkpoint_height should be at least 10, got {checkpoint_height}",
         );
 
         // Verify epoch value
         let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
-        assert_eq!(epoch, 0, "epoch should be 0, got {}", epoch);
+        assert_eq!(epoch, 0, "epoch should be 0, got {epoch}");
     }
 
     // Test get_epoch
@@ -109,7 +106,7 @@ async fn test_response_headers() {
 
         // Verify epoch value
         let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
-        assert!(epoch >= 1, "epoch should be at least 1, got {}", epoch);
+        assert!(epoch >= 1, "epoch should be at least 1, got {epoch}");
     }
 
     // Test get_objects
@@ -133,7 +130,7 @@ async fn test_response_headers() {
 
         // Verify epoch value
         let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
-        assert!(epoch >= 2, "epoch should be at least 2, got {}", epoch);
+        assert!(epoch >= 2, "epoch should be at least 2, got {epoch}");
     }
 
     // Test get_transactions
@@ -157,7 +154,7 @@ async fn test_response_headers() {
 
         // Verify epoch value
         let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
-        assert!(epoch >= 3, "epoch should be at least 3, got {}", epoch);
+        assert!(epoch >= 3, "epoch should be at least 3, got {epoch}");
     }
 
     // Test get_checkpoint_data
@@ -185,7 +182,7 @@ async fn test_response_headers() {
 
         // Verify epoch value
         let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
-        assert!(epoch >= 4, "epoch should be at least 4, got {}", epoch);
+        assert!(epoch >= 4, "epoch should be at least 4, got {epoch}");
     }
 
     // Test stream_checkpoint_data
@@ -214,6 +211,6 @@ async fn test_response_headers() {
 
         // Verify epoch value
         let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
-        assert!(epoch >= 5, "epoch should be at least 5, got {}", epoch);
+        assert!(epoch >= 5, "epoch should be at least 5, got {epoch}");
     }
 }

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/header.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/header.rs
@@ -11,41 +11,8 @@ use iota_grpc_types::{
 };
 use iota_macros::sim_test;
 use test_cluster::TestClusterBuilder;
-use tonic::metadata::MetadataMap;
 
-/// Helper function to verify that all expected IOTA headers are present in the
-/// response metadata
-fn verify_iota_headers(metadata: &MetadataMap, operation_name: &str) {
-    let required_headers = [
-        headers::X_IOTA_CHAIN,
-        headers::X_IOTA_CHAIN_ID,
-        headers::X_IOTA_CHECKPOINT_HEIGHT,
-        headers::X_IOTA_EPOCH,
-        headers::X_IOTA_TIMESTAMP_MS,
-        headers::X_IOTA_TIMESTAMP,
-        headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT,
-        headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT_OBJECTS,
-        headers::X_IOTA_SERVER,
-    ];
-
-    for header_name in &required_headers {
-        assert!(
-            metadata.get(*header_name).is_some(),
-            "{operation_name} response should contain {header_name} header",
-        );
-    }
-}
-
-/// Helper function to parse a u64 header value
-fn parse_u64_header(metadata: &MetadataMap, header_name: &str) -> u64 {
-    metadata
-        .get(header_name)
-        .unwrap_or_else(|| panic!("{header_name} header should be present"))
-        .to_str()
-        .unwrap_or_else(|_| panic!("{header_name} header should be valid UTF-8"))
-        .parse()
-        .unwrap_or_else(|_| panic!("{header_name} header should be a valid u64"))
-}
+use crate::v0::header::{parse_u64_header, verify_iota_headers};
 
 #[sim_test]
 async fn test_response_headers() {

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/header.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/header.rs
@@ -25,6 +25,7 @@ fn verify_iota_headers(metadata: &MetadataMap, operation_name: &str) {
         headers::X_IOTA_TIMESTAMP,
         headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT,
         headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT_OBJECTS,
+        headers::X_IOTA_SERVER,
     ];
 
     for header_name in &required_headers {

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/header.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/header.rs
@@ -1,0 +1,219 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_grpc_types::{
+    headers,
+    v0::ledger_service::{
+        CheckpointDataStreamRequest, GetCheckpointDataRequest, GetEpochRequest, GetObjectsRequest,
+        GetServiceInfoRequest, GetTransactionsRequest, get_checkpoint_data_request::CheckpointId,
+        ledger_service_client::LedgerServiceClient,
+    },
+};
+use iota_macros::sim_test;
+use test_cluster::TestClusterBuilder;
+use tonic::metadata::MetadataMap;
+
+/// Helper function to verify that all expected IOTA headers are present in the
+/// response metadata
+fn verify_iota_headers(metadata: &MetadataMap, operation_name: &str) {
+    let required_headers = [
+        headers::X_IOTA_CHAIN,
+        headers::X_IOTA_CHAIN_ID,
+        headers::X_IOTA_CHECKPOINT_HEIGHT,
+        headers::X_IOTA_EPOCH,
+        headers::X_IOTA_TIMESTAMP_MS,
+        headers::X_IOTA_TIMESTAMP,
+        headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT,
+        headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT_OBJECTS,
+    ];
+
+    for header_name in &required_headers {
+        assert!(
+            metadata.get(*header_name).is_some(),
+            "{} response should contain {} header",
+            operation_name,
+            header_name
+        );
+    }
+}
+
+/// Helper function to parse a u64 header value
+fn parse_u64_header(metadata: &MetadataMap, header_name: &str) -> u64 {
+    metadata
+        .get(header_name)
+        .unwrap_or_else(|| panic!("{} header should be present", header_name))
+        .to_str()
+        .unwrap_or_else(|_| panic!("{} header should be valid UTF-8", header_name))
+        .parse()
+        .unwrap_or_else(|_| panic!("{} header should be a valid u64", header_name))
+}
+
+#[sim_test]
+async fn test_response_headers() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .with_epoch_duration_ms(5000)
+        .build()
+        .await;
+
+    let mut grpc_client = LedgerServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    // Test get_service_info
+    {
+        test_cluster.wait_for_checkpoint(10, None).await;
+
+        let request = GetServiceInfoRequest { read_mask: None };
+
+        let response = grpc_client
+            .get_service_info(request)
+            .await
+            .expect("gRPC call to get_service_info");
+
+        let metadata = response.metadata();
+
+        // Verify all required headers are present
+        verify_iota_headers(metadata, "get_service_info");
+
+        // Verify checkpoint_height value
+        let checkpoint_height = parse_u64_header(metadata, headers::X_IOTA_CHECKPOINT_HEIGHT);
+        assert!(
+            checkpoint_height >= 10,
+            "checkpoint_height should be at least 10, got {}",
+            checkpoint_height
+        );
+
+        // Verify epoch value
+        let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
+        assert_eq!(epoch, 0, "epoch should be 0, got {}", epoch);
+    }
+
+    // Test get_epoch
+    {
+        test_cluster.wait_for_epoch(Some(2)).await;
+
+        let request = GetEpochRequest {
+            epoch: Some(1),
+            read_mask: None,
+        };
+        let response = grpc_client
+            .get_epoch(request)
+            .await
+            .expect("gRPC call to get_epoch");
+
+        let metadata = response.metadata();
+
+        // Verify all required headers are present
+        verify_iota_headers(metadata, "get_epoch");
+
+        // Verify epoch value
+        let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
+        assert!(epoch >= 1, "epoch should be at least 1, got {}", epoch);
+    }
+
+    // Test get_objects
+    {
+        test_cluster.wait_for_epoch(Some(3)).await;
+
+        let request = GetObjectsRequest {
+            requests: None,
+            read_mask: None,
+            max_message_size_bytes: None,
+        };
+
+        let stream = grpc_client
+            .get_objects(request)
+            .await
+            .expect("gRPC call to get_objects");
+
+        // Get metadata from the first response
+        let metadata = stream.metadata();
+        verify_iota_headers(metadata, "get_objects");
+
+        // Verify epoch value
+        let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
+        assert!(epoch >= 2, "epoch should be at least 2, got {}", epoch);
+    }
+
+    // Test get_transactions
+    {
+        test_cluster.wait_for_epoch(Some(4)).await;
+
+        let request = GetTransactionsRequest {
+            requests: None,
+            read_mask: None,
+            max_message_size_bytes: None,
+        };
+
+        let stream = grpc_client
+            .get_transactions(request)
+            .await
+            .expect("gRPC call to get_transactions");
+
+        // Get metadata from the response
+        let metadata = stream.metadata();
+        verify_iota_headers(metadata, "get_transactions");
+
+        // Verify epoch value
+        let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
+        assert!(epoch >= 3, "epoch should be at least 3, got {}", epoch);
+    }
+
+    // Test get_checkpoint_data
+    {
+        test_cluster.wait_for_epoch(Some(5)).await;
+
+        let request = GetCheckpointDataRequest {
+            checkpoint_id: Some(CheckpointId::Latest(true)),
+            checkpoint_read_mask: None,
+            transactions_filter: None,
+            transaction_read_mask: None,
+            events_filter: None,
+            event_read_mask: None,
+            max_message_size_bytes: None,
+        };
+
+        let stream = grpc_client
+            .get_checkpoint_data(request)
+            .await
+            .expect("gRPC call to get_checkpoint_data");
+
+        // Get metadata from the response
+        let metadata = stream.metadata();
+        verify_iota_headers(metadata, "get_checkpoint_data");
+
+        // Verify epoch value
+        let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
+        assert!(epoch >= 4, "epoch should be at least 4, got {}", epoch);
+    }
+
+    // Test stream_checkpoint_data
+    {
+        test_cluster.wait_for_epoch(Some(6)).await;
+
+        let request = CheckpointDataStreamRequest {
+            start_sequence_number: Some(1),
+            end_sequence_number: Some(2),
+            checkpoint_read_mask: None,
+            transactions_filter: None,
+            transaction_read_mask: None,
+            events_filter: None,
+            event_read_mask: None,
+            max_message_size_bytes: None,
+        };
+
+        let stream = grpc_client
+            .stream_checkpoint_data(request)
+            .await
+            .expect("gRPC call to stream_checkpoint_data");
+
+        // Get metadata from the response
+        let metadata = stream.metadata();
+        verify_iota_headers(metadata, "stream_checkpoint_data");
+
+        // Verify epoch value
+        let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
+        assert!(epoch >= 5, "epoch should be at least 5, got {}", epoch);
+    }
+}

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/mod.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/mod.rs
@@ -5,3 +5,4 @@ mod get_epoch;
 mod get_objects;
 mod get_service_info;
 mod get_transactions;
+mod header;

--- a/crates/iota-e2e-tests/tests/grpc/v0/mod.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+mod header;
 mod ledger_service;
 mod transaction_execution_service;
 

--- a/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/header.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/header.rs
@@ -1,0 +1,160 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_grpc_types::{
+    headers,
+    v0::{
+        bcs::BcsData,
+        signatures::{UserSignature, UserSignatures},
+        transaction::Transaction as ProtoTransaction,
+        transaction_execution_service::{
+            ExecuteTransactionRequest, SimulateTransactionRequest,
+            transaction_execution_service_client::TransactionExecutionServiceClient,
+        },
+    },
+};
+use iota_macros::sim_test;
+use iota_test_transaction_builder::make_transfer_iota_transaction;
+use iota_types::transaction::TransactionData;
+use test_cluster::TestClusterBuilder;
+use tonic::metadata::MetadataMap;
+
+/// Helper function to verify that all expected IOTA headers are present in the
+/// response metadata
+fn verify_iota_headers(metadata: &MetadataMap, operation_name: &str) {
+    let required_headers = [
+        headers::X_IOTA_CHAIN,
+        headers::X_IOTA_CHAIN_ID,
+        headers::X_IOTA_CHECKPOINT_HEIGHT,
+        headers::X_IOTA_EPOCH,
+        headers::X_IOTA_TIMESTAMP_MS,
+        headers::X_IOTA_TIMESTAMP,
+        headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT,
+        headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT_OBJECTS,
+    ];
+
+    for header_name in &required_headers {
+        assert!(
+            metadata.get(*header_name).is_some(),
+            "{} response should contain {} header",
+            operation_name,
+            header_name
+        );
+    }
+}
+
+/// Helper function to parse a u64 header value
+fn parse_u64_header(metadata: &MetadataMap, header_name: &str) -> u64 {
+    metadata
+        .get(header_name)
+        .unwrap_or_else(|| panic!("{} header should be present", header_name))
+        .to_str()
+        .unwrap_or_else(|_| panic!("{} header should be valid UTF-8", header_name))
+        .parse()
+        .unwrap_or_else(|_| panic!("{} header should be a valid u64", header_name))
+}
+
+#[sim_test]
+async fn test_response_headers() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .with_epoch_duration_ms(5000)
+        .build()
+        .await;
+
+    let mut client = TransactionExecutionServiceClient::connect(test_cluster.grpc_url())
+        .await
+        .unwrap();
+
+    let recipient = iota_types::base_types::IotaAddress::random_for_testing_only();
+    let amount = 9;
+
+    // Test execute_transaction
+    {
+        test_cluster.wait_for_epoch(Some(2)).await;
+
+        let txn =
+            make_transfer_iota_transaction(&test_cluster.wallet, Some(recipient), Some(amount))
+                .await;
+
+        let transaction = ProtoTransaction {
+            bcs: Some(BcsData {
+                data: bcs::to_bytes(txn.transaction_data()).unwrap().into(),
+            }),
+            ..Default::default()
+        };
+
+        let signatures = UserSignatures {
+            signatures: txn
+                .tx_signatures()
+                .iter()
+                .map(|s| UserSignature {
+                    bcs: Some(BcsData {
+                        data: s.as_ref().to_vec().into(),
+                    }),
+                })
+                .collect(),
+        };
+
+        let response = client
+            .execute_transaction(ExecuteTransactionRequest {
+                transaction: Some(transaction),
+                signatures: Some(signatures),
+                read_mask: None,
+            })
+            .await
+            .unwrap();
+
+        let metadata = response.metadata();
+        verify_iota_headers(metadata, "execute_transaction");
+
+        // Verify epoch value
+        let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
+        assert!(epoch >= 1, "epoch should be at least 1, got {}", epoch);
+    }
+
+    // Test simulate_transaction
+    {
+        test_cluster.wait_for_epoch(Some(3)).await;
+
+        let (sender, mut gas) = test_cluster.wallet.get_one_account().await.unwrap();
+        gas.sort_by_key(|object_ref| object_ref.0);
+        let obj_to_send = gas.first().unwrap();
+        let gas_obj = gas.last().unwrap();
+
+        // Build a simple transfer transaction with a very high gas budget
+        let tx_data = TransactionData::new_transfer(
+            recipient,
+            *obj_to_send,
+            sender,
+            *gas_obj,
+            1_000_000_000, // very high gas budget
+            1000,          // gas price
+        );
+
+        // Create the simulation request with gas estimation enabled
+        let transaction = ProtoTransaction {
+            bcs: Some(BcsData {
+                data: bcs::to_bytes(&tx_data).unwrap().into(),
+            }),
+            ..Default::default()
+        };
+
+        let request = SimulateTransactionRequest {
+            transaction: Some(transaction),
+            tx_checks: vec![],
+            estimate_gas_budget: Some(true),
+            read_mask: None,
+        };
+
+        // Simulate the transaction
+        let response = client.simulate_transaction(request).await.unwrap();
+
+        let metadata = response.metadata();
+        verify_iota_headers(metadata, "simulate_transaction");
+
+        // Verify epoch value
+        let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
+        assert!(epoch >= 2, "epoch should be at least 2, got {}", epoch);
+    }
+}

--- a/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/header.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/header.rs
@@ -17,41 +17,8 @@ use iota_macros::sim_test;
 use iota_test_transaction_builder::make_transfer_iota_transaction;
 use iota_types::transaction::TransactionData;
 use test_cluster::TestClusterBuilder;
-use tonic::metadata::MetadataMap;
 
-/// Helper function to verify that all expected IOTA headers are present in the
-/// response metadata
-fn verify_iota_headers(metadata: &MetadataMap, operation_name: &str) {
-    let required_headers = [
-        headers::X_IOTA_CHAIN,
-        headers::X_IOTA_CHAIN_ID,
-        headers::X_IOTA_CHECKPOINT_HEIGHT,
-        headers::X_IOTA_EPOCH,
-        headers::X_IOTA_TIMESTAMP_MS,
-        headers::X_IOTA_TIMESTAMP,
-        headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT,
-        headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT_OBJECTS,
-        headers::X_IOTA_SERVER,
-    ];
-
-    for header_name in &required_headers {
-        assert!(
-            metadata.get(*header_name).is_some(),
-            "{operation_name} response should contain {header_name} header",
-        );
-    }
-}
-
-/// Helper function to parse a u64 header value
-fn parse_u64_header(metadata: &MetadataMap, header_name: &str) -> u64 {
-    metadata
-        .get(header_name)
-        .unwrap_or_else(|| panic!("{header_name} header should be present"))
-        .to_str()
-        .unwrap_or_else(|_| panic!("{header_name} header should be valid UTF-8"))
-        .parse()
-        .unwrap_or_else(|_| panic!("{header_name} header should be a valid u64"))
-}
+use crate::v0::header::{parse_u64_header, verify_iota_headers};
 
 #[sim_test]
 async fn test_response_headers() {

--- a/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/header.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/header.rs
@@ -36,9 +36,7 @@ fn verify_iota_headers(metadata: &MetadataMap, operation_name: &str) {
     for header_name in &required_headers {
         assert!(
             metadata.get(*header_name).is_some(),
-            "{} response should contain {} header",
-            operation_name,
-            header_name
+            "{operation_name} response should contain {header_name} header",
         );
     }
 }
@@ -47,11 +45,11 @@ fn verify_iota_headers(metadata: &MetadataMap, operation_name: &str) {
 fn parse_u64_header(metadata: &MetadataMap, header_name: &str) -> u64 {
     metadata
         .get(header_name)
-        .unwrap_or_else(|| panic!("{} header should be present", header_name))
+        .unwrap_or_else(|| panic!("{header_name} header should be present"))
         .to_str()
-        .unwrap_or_else(|_| panic!("{} header should be valid UTF-8", header_name))
+        .unwrap_or_else(|_| panic!("{header_name} header should be valid UTF-8"))
         .parse()
-        .unwrap_or_else(|_| panic!("{} header should be a valid u64", header_name))
+        .unwrap_or_else(|_| panic!("{header_name} header should be a valid u64"))
 }
 
 #[sim_test]
@@ -110,7 +108,7 @@ async fn test_response_headers() {
 
         // Verify epoch value
         let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
-        assert!(epoch >= 1, "epoch should be at least 1, got {}", epoch);
+        assert!(epoch >= 1, "epoch should be at least 1, got {epoch}");
     }
 
     // Test simulate_transaction
@@ -155,6 +153,6 @@ async fn test_response_headers() {
 
         // Verify epoch value
         let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
-        assert!(epoch >= 2, "epoch should be at least 2, got {}", epoch);
+        assert!(epoch >= 2, "epoch should be at least 2, got {epoch}");
     }
 }

--- a/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/header.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/header.rs
@@ -31,6 +31,7 @@ fn verify_iota_headers(metadata: &MetadataMap, operation_name: &str) {
         headers::X_IOTA_TIMESTAMP,
         headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT,
         headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT_OBJECTS,
+        headers::X_IOTA_SERVER,
     ];
 
     for header_name in &required_headers {

--- a/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/mod.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/mod.rs
@@ -2,4 +2,5 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 mod execute;
+mod header;
 mod simulate;

--- a/crates/iota-grpc-client/src/response_ext.rs
+++ b/crates/iota-grpc-client/src/response_ext.rs
@@ -15,6 +15,7 @@ pub trait ResponseExt: sealed::Sealed {
     fn timestamp(&self) -> Option<&str>;
     fn lowest_available_checkpoint(&self) -> Option<u64>;
     fn lowest_available_checkpoint_objects(&self) -> Option<u64>;
+    fn server_version(&self) -> Option<&str>;
 }
 
 impl ResponseExt for http::header::HeaderMap {
@@ -63,6 +64,11 @@ impl ResponseExt for http::header::HeaderMap {
             .and_then(|h| h.to_str().ok())
             .and_then(|s| s.parse().ok())
     }
+
+    fn server_version(&self) -> Option<&str> {
+        self.get(headers::X_IOTA_SERVER)
+            .and_then(|h| h.to_str().ok())
+    }
 }
 
 impl ResponseExt for tonic::metadata::MetadataMap {
@@ -96,6 +102,10 @@ impl ResponseExt for tonic::metadata::MetadataMap {
 
     fn lowest_available_checkpoint_objects(&self) -> Option<u64> {
         self.as_ref().lowest_available_checkpoint_objects()
+    }
+
+    fn server_version(&self) -> Option<&str> {
+        self.as_ref().server_version()
     }
 }
 
@@ -131,6 +141,10 @@ impl<T> ResponseExt for tonic::Response<T> {
     fn lowest_available_checkpoint_objects(&self) -> Option<u64> {
         self.metadata().lowest_available_checkpoint_objects()
     }
+
+    fn server_version(&self) -> Option<&str> {
+        self.metadata().server_version()
+    }
 }
 
 impl ResponseExt for tonic::Status {
@@ -164,6 +178,10 @@ impl ResponseExt for tonic::Status {
 
     fn lowest_available_checkpoint_objects(&self) -> Option<u64> {
         self.metadata().lowest_available_checkpoint_objects()
+    }
+
+    fn server_version(&self) -> Option<&str> {
+        self.metadata().server_version()
     }
 }
 

--- a/crates/iota-grpc-server/src/ledger_service/get_service_info.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_service_info.rs
@@ -77,7 +77,7 @@ pub fn get_service_info(
     }
 
     if read_mask.contains(GetServiceInfoResponse::SERVER_FIELD.name) {
-        message.server = service.server_version.as_ref().map(ToString::to_string);
+        message.server = service.reader.server_version();
     }
 
     Ok(message)

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -86,7 +86,7 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
     > {
         let response = get_service_info::get_service_info(self, request.into_inner())
             .map(Response::new)
-            .map_err(|e| tonic::Status::from(e))?;
+            .map_err(tonic::Status::from)?;
         Ok(append_info_headers!(response, self.reader.clone()))
     }
 
@@ -96,7 +96,7 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
     ) -> std::result::Result<tonic::Response<Self::GetObjectsStream>, tonic::Status> {
         let response = get_objects::get_objects((*self.reader).clone(), request.into_inner())
             .map(|stream| Response::new(Box::pin(stream) as Self::GetObjectsStream))
-            .map_err(|e| tonic::Status::from(e))?;
+            .map_err(tonic::Status::from)?;
         Ok(append_info_headers!(response, self.reader.clone()))
     }
 
@@ -110,7 +110,7 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
             request.into_inner(),
         )
         .map(|stream| Response::new(Box::pin(stream) as Self::GetTransactionsStream))
-        .map_err(|e| tonic::Status::from(e))?;
+        .map_err(tonic::Status::from)?;
         Ok(append_info_headers!(response, self.reader.clone()))
     }
 
@@ -148,9 +148,7 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
         &self,
         request: Request<grpc_ledger_service::GetEpochRequest>,
     ) -> Result<Response<grpc_ledger_service::GetEpochResponse>, Status> {
-        let response = get_epoch::get_epoch(self, request.into_inner())
-            .map(Response::new)
-            .map_err(|e| Status::from(e))?;
+        let response = get_epoch::get_epoch(self, request.into_inner()).map(Response::new)?;
         Ok(append_info_headers!(response, self.reader.clone()))
     }
 }

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -84,31 +84,34 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
         tonic::Response<grpc_ledger_service::GetServiceInfoResponse>,
         tonic::Status,
     > {
-        get_service_info::get_service_info(self, request.into_inner())
+        let response = get_service_info::get_service_info(self, request.into_inner())
             .map(Response::new)
-            .map_err(Into::into)
+            .map_err(|e| tonic::Status::from(e))?;
+        Ok(append_info_headers!(response, self.reader.clone()))
     }
 
     async fn get_objects(
         &self,
         request: tonic::Request<grpc_ledger_service::GetObjectsRequest>,
     ) -> std::result::Result<tonic::Response<Self::GetObjectsStream>, tonic::Status> {
-        get_objects::get_objects((*self.reader).clone(), request.into_inner())
+        let response = get_objects::get_objects((*self.reader).clone(), request.into_inner())
             .map(|stream| Response::new(Box::pin(stream) as Self::GetObjectsStream))
-            .map_err(Into::into)
+            .map_err(|e| tonic::Status::from(e))?;
+        Ok(append_info_headers!(response, self.reader.clone()))
     }
 
     async fn get_transactions(
         &self,
         request: tonic::Request<grpc_ledger_service::GetTransactionsRequest>,
     ) -> std::result::Result<tonic::Response<Self::GetTransactionsStream>, tonic::Status> {
-        get_transactions::get_transactions(
+        let response = get_transactions::get_transactions(
             self.reader.clone(),
             self.config.clone(),
             request.into_inner(),
         )
         .map(|stream| Response::new(Box::pin(stream) as Self::GetTransactionsStream))
-        .map_err(Into::into)
+        .map_err(|e| tonic::Status::from(e))?;
+        Ok(append_info_headers!(response, self.reader.clone()))
     }
 
     /// Checkpoint operations
@@ -124,9 +127,8 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
         };
 
         // not implemented
-        Ok(Response::new(
-            Box::pin(stream) as Self::StreamCheckpointDataStream
-        ))
+        let response = Response::new(Box::pin(stream) as Self::StreamCheckpointDataStream);
+        Ok(append_info_headers!(response, self.reader.clone()))
     }
 
     async fn stream_checkpoint_data(
@@ -138,15 +140,17 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
         let end_sequence_number = req.end_sequence_number;
 
         let stream = self.stream_checkpoint_data(start_sequence_number, end_sequence_number);
-        Ok(Response::new(
-            Box::pin(stream) as Self::StreamCheckpointDataStream
-        ))
+        let response = Response::new(Box::pin(stream) as Self::StreamCheckpointDataStream);
+        Ok(append_info_headers!(response, self.reader.clone()))
     }
 
     async fn get_epoch(
         &self,
         request: Request<grpc_ledger_service::GetEpochRequest>,
     ) -> Result<Response<grpc_ledger_service::GetEpochResponse>, Status> {
-        get_epoch::get_epoch(self, request.into_inner()).map(Response::new)
+        let response = get_epoch::get_epoch(self, request.into_inner())
+            .map(Response::new)
+            .map_err(|e| Status::from(e))?;
+        Ok(append_info_headers!(response, self.reader.clone()))
     }
 }

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -24,7 +24,6 @@ pub struct LedgerGrpcService {
     pub cancellation_token: CancellationToken,
     pub chain_id: ChainIdentifier,
     pub chain: Chain,
-    pub server_version: Option<String>,
 }
 
 impl LedgerGrpcService {
@@ -35,7 +34,6 @@ impl LedgerGrpcService {
         checkpoint_data_broadcaster: GrpcCheckpointDataBroadcaster,
         cancellation_token: CancellationToken,
         chain_id: ChainIdentifier,
-        server_version: Option<String>,
     ) -> Self {
         Self {
             reader,
@@ -45,7 +43,6 @@ impl LedgerGrpcService {
             cancellation_token,
             chain_id,
             chain: chain_id.chain(),
-            server_version,
         }
     }
 }

--- a/crates/iota-grpc-server/src/lib.rs
+++ b/crates/iota-grpc-server/src/lib.rs
@@ -1,11 +1,14 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[macro_use]
+mod macros;
+
 // Modules
 pub mod constants;
 mod error;
 pub mod ledger_service;
-pub mod macros;
+pub mod response;
 pub mod server;
 pub mod transaction_execution_service;
 pub mod types;
@@ -13,6 +16,7 @@ pub mod utils;
 
 // Re-export commonly used types and traits
 pub use ledger_service::LedgerGrpcService;
+pub use response::append_info_headers;
 pub use server::{GrpcServerHandle, start_grpc_server};
 pub use transaction_execution_service::TransactionExecutionGrpcService;
 pub use types::{

--- a/crates/iota-grpc-server/src/macros.rs
+++ b/crates/iota-grpc-server/src/macros.rs
@@ -114,3 +114,20 @@ macro_rules! create_batching_stream {
         }
     };
 }
+
+/// Appends IOTA-specific metadata headers to a gRPC response.
+///
+/// This macro simplifies adding checkpoint and blockchain metadata headers
+/// to gRPC responses without repeating boilerplate code.
+/// Tonic does not currently support interceptors that can modify responses,
+/// so this macro provides a convenient way to append headers directly.
+///
+/// # Example
+/// ```ignore
+/// let response = Response::new(result);
+/// Ok(append_info_headers!(response, self.reader))
+/// ```
+#[macro_export]
+macro_rules! append_info_headers {
+    ($response:expr, $reader:expr) => {{ $crate::append_info_headers($reader, $response) }};
+}

--- a/crates/iota-grpc-server/src/response.rs
+++ b/crates/iota-grpc-server/src/response.rs
@@ -70,5 +70,12 @@ pub fn append_info_headers<T>(
         }
     }
 
+    if let Some(server_version) = grpc_reader
+        .server_version()
+        .and_then(|version| version.parse().ok())
+    {
+        headers.insert(headers::X_IOTA_SERVER, server_version);
+    }
+
     response
 }

--- a/crates/iota-grpc-server/src/response.rs
+++ b/crates/iota-grpc-server/src/response.rs
@@ -1,0 +1,74 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper for adding IOTA-specific metadata headers to gRPC responses
+
+use std::sync::Arc;
+
+use iota_grpc_types::headers;
+
+use crate::GrpcReader;
+
+/// Helper struct to add IOTA-specific metadata headers to responses
+/// Use this in service handlers to add checkpoint and blockchain metadata
+pub fn append_info_headers<T>(
+    grpc_reader: Arc<GrpcReader>,
+    mut response: tonic::Response<T>,
+) -> tonic::Response<T> {
+    let headers = response.metadata_mut();
+
+    if let Ok(chain_id) = grpc_reader.get_chain_identifier() {
+        if let Ok(chain_id) = chain_id.to_string().parse() {
+            headers.insert(headers::X_IOTA_CHAIN_ID, chain_id);
+        }
+
+        if let Ok(chain) = chain_id.chain().as_str().parse() {
+            headers.insert(headers::X_IOTA_CHAIN, chain);
+        }
+    }
+
+    if let Ok(latest_checkpoint) = grpc_reader.get_latest_checkpoint() {
+        if let Ok(height_value) = latest_checkpoint.sequence_number.to_string().parse() {
+            headers.insert(headers::X_IOTA_CHECKPOINT_HEIGHT, height_value);
+        }
+
+        if let Ok(epoch_value) = latest_checkpoint.epoch().to_string().parse() {
+            headers.insert(headers::X_IOTA_EPOCH, epoch_value);
+        }
+
+        if let Ok(timestamp_value) = latest_checkpoint.timestamp_ms.to_string().parse() {
+            headers.insert(headers::X_IOTA_TIMESTAMP_MS, timestamp_value);
+        }
+
+        if let Ok(duration) = latest_checkpoint
+            .timestamp()
+            .duration_since(std::time::UNIX_EPOCH)
+        {
+            if let Ok(timestamp_value) = duration.as_secs().to_string().parse() {
+                headers.insert(headers::X_IOTA_TIMESTAMP, timestamp_value);
+            }
+        }
+    }
+
+    // Add lowest available checkpoint header
+    if let Ok(lowest_checkpoint) = grpc_reader.get_lowest_available_checkpoint() {
+        if let Ok(lowest_value) = lowest_checkpoint.to_string().parse() {
+            response
+                .metadata_mut()
+                .insert(headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT, lowest_value);
+        }
+    }
+
+    // Add lowest available checkpoint objects header
+    if let Ok(lowest_objects) = grpc_reader.get_lowest_available_checkpoint_objects() {
+        if let Ok(lowest_objects_value) = lowest_objects.to_string().parse() {
+            response.metadata_mut().insert(
+                headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT_OBJECTS,
+                lowest_objects_value,
+            );
+        }
+    }
+
+    response
+}

--- a/crates/iota-grpc-server/src/response.rs
+++ b/crates/iota-grpc-server/src/response.rs
@@ -29,41 +29,38 @@ pub fn append_info_headers<T>(
     }
 
     if let Ok(latest_checkpoint) = grpc_reader.get_latest_checkpoint() {
-        if let Ok(height_value) = latest_checkpoint.sequence_number.to_string().parse() {
-            headers.insert(headers::X_IOTA_CHECKPOINT_HEIGHT, height_value);
-        }
-
         if let Ok(epoch_value) = latest_checkpoint.epoch().to_string().parse() {
             headers.insert(headers::X_IOTA_EPOCH, epoch_value);
+        }
+
+        if let Ok(height_value) = latest_checkpoint.sequence_number.to_string().parse() {
+            headers.insert(headers::X_IOTA_CHECKPOINT_HEIGHT, height_value);
         }
 
         if let Ok(timestamp_value) = latest_checkpoint.timestamp_ms.to_string().parse() {
             headers.insert(headers::X_IOTA_TIMESTAMP_MS, timestamp_value);
         }
 
-        if let Ok(duration) = latest_checkpoint
-            .timestamp()
-            .duration_since(std::time::UNIX_EPOCH)
-        {
-            if let Ok(timestamp_value) = duration.as_secs().to_string().parse() {
-                headers.insert(headers::X_IOTA_TIMESTAMP, timestamp_value);
-            }
-        }
+        headers.insert(
+            headers::X_IOTA_TIMESTAMP,
+            iota_grpc_types::proto::timestamp_ms_to_proto(latest_checkpoint.timestamp_ms)
+                .to_string()
+                .try_into()
+                .expect("timestamp is a valid MetadataValue<Ascii>"),
+        );
     }
 
     // Add lowest available checkpoint header
     if let Ok(lowest_checkpoint) = grpc_reader.get_lowest_available_checkpoint() {
         if let Ok(lowest_value) = lowest_checkpoint.to_string().parse() {
-            response
-                .metadata_mut()
-                .insert(headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT, lowest_value);
+            headers.insert(headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT, lowest_value);
         }
     }
 
     // Add lowest available checkpoint objects header
     if let Ok(lowest_objects) = grpc_reader.get_lowest_available_checkpoint_objects() {
         if let Ok(lowest_objects_value) = lowest_objects.to_string().parse() {
-            response.metadata_mut().insert(
+            headers.insert(
                 headers::X_IOTA_LOWEST_AVAILABLE_CHECKPOINT_OBJECTS,
                 lowest_objects_value,
             );

--- a/crates/iota-grpc-server/src/server.rs
+++ b/crates/iota-grpc-server/src/server.rs
@@ -73,7 +73,6 @@ pub async fn start_grpc_server(
     config: iota_config::node::GrpcApiConfig,
     shutdown_token: CancellationToken,
     chain_id: iota_types::digests::ChainIdentifier,
-    server_version: Option<String>,
 ) -> Result<GrpcServerHandle> {
     // Create broadcast channels
     let (checkpoint_summary_tx, _) = broadcast::channel(config.checkpoint_broadcast_buffer_size);
@@ -93,7 +92,6 @@ pub async fn start_grpc_server(
         checkpoint_data_broadcaster.clone(),
         shutdown_token.clone(),
         chain_id,
-        server_version,
     );
 
     // Create the server with proper address binding

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -65,7 +65,7 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         )
         .await
         .map(Response::new)
-        .map_err(|e| tonic::Status::from(e))?;
+        .map_err(tonic::Status::from)?;
         Ok(append_info_headers!(response, self.reader.clone()))
     }
 
@@ -81,7 +81,7 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         )
         .await
         .map(Response::new)
-        .map_err(|e| tonic::Status::from(e))?;
+        .map_err(tonic::Status::from)?;
         Ok(append_info_headers!(response, self.reader.clone()))
     }
 }

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -57,7 +57,7 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         &self,
         request: Request<ExecuteTransactionRequest>,
     ) -> Result<Response<ExecuteTransactionResponse>, tonic::Status> {
-        execute_transaction(
+        let response = execute_transaction(
             &self.reader,
             &self.executor,
             &self.config,
@@ -65,14 +65,15 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         )
         .await
         .map(Response::new)
-        .map_err(Into::into)
+        .map_err(|e| tonic::Status::from(e))?;
+        Ok(append_info_headers!(response, self.reader.clone()))
     }
 
     async fn simulate_transaction(
         &self,
         request: Request<SimulateTransactionRequest>,
     ) -> Result<Response<SimulateTransactionResponse>, tonic::Status> {
-        simulate::simulate_transaction(
+        let response = simulate::simulate_transaction(
             &self.reader,
             &self.executor,
             &self.config,
@@ -80,7 +81,8 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         )
         .await
         .map(Response::new)
-        .map_err(Into::into)
+        .map_err(|e| tonic::Status::from(e))?;
+        Ok(append_info_headers!(response, self.reader.clone()))
     }
 }
 

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -403,19 +403,31 @@ impl GrpcStateReader for RestStateReaderAdapter {
 #[derive(Clone)]
 pub struct GrpcReader {
     state_reader: Arc<dyn GrpcStateReader>,
+    server_version: Option<String>,
 }
 
 impl GrpcReader {
-    pub fn new(state_reader: Arc<dyn GrpcStateReader>) -> Self {
-        Self { state_reader }
+    pub fn new(state_reader: Arc<dyn GrpcStateReader>, server_version: Option<String>) -> Self {
+        Self {
+            state_reader,
+            server_version,
+        }
     }
 
-    pub fn from_rest_state_reader(state_reader: Arc<dyn RestStateReader>) -> Self {
+    pub fn from_rest_state_reader(
+        state_reader: Arc<dyn RestStateReader>,
+        server_version: Option<String>,
+    ) -> Self {
         Self {
             state_reader: Arc::new(RestStateReaderAdapter {
                 inner: state_reader,
             }),
+            server_version,
         }
+    }
+
+    pub fn server_version(&self) -> Option<String> {
+        self.server_version.clone()
     }
 
     pub fn get_chain_identifier(&self) -> anyhow::Result<iota_types::digests::ChainIdentifier> {

--- a/crates/iota-grpc-server/tests_ignored/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests_ignored/checkpoint_stream.rs
@@ -382,7 +382,7 @@ async fn test_server_and_client_setup<I: Iterator<Item = u64>>(
     let mock = Arc::new(MockRestStateReader::new_from_iter(checkpoint_range));
     let checkpoints = mock.checkpoints.clone();
     let cancellation_token = tokio_util::sync::CancellationToken::new();
-    let grpc_reader = Arc::new(GrpcReader::from_rest_state_reader(mock));
+    let grpc_reader = Arc::new(GrpcReader::from_rest_state_reader(mock, None));
 
     let localhost = local_ip_utils::localhost_for_testing();
     let grpc_port = local_ip_utils::get_available_port(&localhost);

--- a/crates/iota-grpc-types/src/headers.rs
+++ b/crates/iota-grpc-types/src/headers.rs
@@ -40,3 +40,6 @@ pub const X_IOTA_TIMESTAMP_MS: &str = "x-iota-timestamp-ms";
 ///
 /// [RFC 3339]: https://www.ietf.org/rfc/rfc3339.txt
 pub const X_IOTA_TIMESTAMP: &str = "x-iota-timestamp";
+
+/// Server version string
+pub const X_IOTA_SERVER: &str = "x-iota-server";

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2455,7 +2455,10 @@ async fn build_grpc_server(
     let shutdown_token = CancellationToken::new();
 
     // Create GrpcReader
-    let grpc_reader = Arc::new(GrpcReader::from_rest_state_reader(rest_read_store));
+    let grpc_reader = Arc::new(GrpcReader::from_rest_state_reader(
+        rest_read_store,
+        Some(env!("CARGO_PKG_VERSION").to_string()),
+    ));
 
     // Get the subscription handler from the state for event streaming
     let event_subscriber =
@@ -2470,7 +2473,6 @@ async fn build_grpc_server(
         grpc_config.clone(),
         shutdown_token,
         chain_id,
-        Some(env!("CARGO_PKG_VERSION").to_string()),
     )
     .await?;
 


### PR DESCRIPTION
# Description of change

This pull request introduces IOTA-specific metadata headers to all gRPC responses in both the Ledger and Transaction Execution services. It does so by implementing a new helper function and macro for appending these headers, then updating all relevant service endpoints to use this mechanism. Since tonic does not support interceptor to modify a response, we need to go with macro and apply it to all methods.


## Links to any relevant issues

Close #9623 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
