### PR TITLE
fix(core): Remove `reexecute_local_checkpoints`

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -543,12 +543,17 @@ pub struct AuthorityEpochTables {
     /// Transactions that were executed in the current epoch.
     executed_in_epoch: DBMap<TransactionDigest, ()>,
 
+    // TODO: delete the deprecated tables in the next release
     #[allow(dead_code)]
+    #[deprecated]
     assigned_shared_object_versions: DBMap<TransactionKey, Vec<(ObjectID, SequenceNumber)>>,
+
     /// Next available shared object versions for each shared object.
     next_shared_object_versions: DBMap<ObjectID, SequenceNumber>,
 
-    // TODO: delete after DQ is rolled out
+    // TODO: delete the deprecated tables in the next release
+    #[allow(dead_code)]
+    #[deprecated]
     pub(crate) pending_execution: DBMap<TransactionDigest, TrustedExecutableTransaction>,
 
     /// Track which transactions have been processed in
@@ -568,7 +573,9 @@ pub struct AuthorityEpochTables {
     pending_consensus_transactions: DBMap<ConsensusTransactionKey, ConsensusTransaction>,
 
     /// this table is not used
+    // TODO: delete the deprecated tables in the next release
     #[allow(dead_code)]
+    #[deprecated]
     last_consensus_index: DBMap<(), ()>,
 
     /// The following table is used to store a single value (the corresponding
@@ -585,7 +592,9 @@ pub struct AuthorityEpochTables {
     /// Validators that have sent EndOfPublish message in this epoch
     end_of_publish: DBMap<AuthorityName, ()>,
 
+    // TODO: delete the deprecated tables in the next release
     #[allow(dead_code)]
+    #[deprecated]
     pending_checkpoints: DBMap<CheckpointHeight, PendingCheckpoint>,
 
     /// Checkpoint builder maintains internal list of transactions it included
@@ -603,7 +612,9 @@ pub struct AuthorityEpochTables {
         DBMap<(CheckpointSequenceNumber, u64), CheckpointSignatureMessage>,
 
     /// Deprecated - pending signatures are now stored in memory.
+    // TODO: delete the deprecated tables in the next release
     #[allow(dead_code)]
+    #[deprecated]
     user_signatures_for_checkpoints: DBMap<TransactionDigest, Vec<GenericSignature>>,
 
     /// Maps sequence number to checkpoint summary, used by CheckpointBuilder to

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -836,15 +836,6 @@ impl AuthorityEpochTables {
             .safe_iter()
             .collect::<Result<_, _>>()?)
     }
-
-    fn get_all_user_signatures_for_checkpoints(
-        &self,
-    ) -> IotaResult<HashMap<TransactionDigest, Vec<GenericSignature>>> {
-        Ok(self
-            .user_signatures_for_checkpoints
-            .safe_iter()
-            .collect::<Result<_, _>>()?)
-    }
 }
 
 pub(crate) const MUTEX_TABLE_SIZE: usize = 1024;
@@ -977,8 +968,7 @@ impl AuthorityPerEpochStore {
 
         let jwk_aggregator = Mutex::new(jwk_aggregator);
 
-        let consensus_output_cache =
-            ConsensusOutputCache::new(&epoch_start_configuration, &tables, metrics.clone());
+        let consensus_output_cache = ConsensusOutputCache::new(&tables, metrics.clone());
 
         let s = Arc::new(Self {
             name,
@@ -4118,20 +4108,14 @@ impl AuthorityPerEpochStore {
         &self,
         last: Option<CheckpointHeight>,
     ) -> IotaResult<Vec<(CheckpointHeight, PendingCheckpoint)>> {
-        let db_results = if !self
-            .epoch_start_config()
-            .is_data_quarantine_active_from_beginning_of_epoch()
-        {
-            // Reading from the db table is only needed when upgrading to data quarantining
-            // for the first time.
-            let tables = self.tables()?;
-            let db_iter = tables
-                .pending_checkpoints
-                .safe_iter_with_bounds(last.map(|height| height + 1), None);
-            db_iter.collect::<Result<Vec<(CheckpointHeight, PendingCheckpoint)>, _>>()?
-        } else {
-            vec![]
-        };
+        // Reading from the db table is only needed when upgrading to data quarantining
+        // for the first time.
+        let tables = self.tables()?;
+        let db_iter = tables
+            .pending_checkpoints
+            .safe_iter_with_bounds(last.map(|height| height + 1), None);
+        let db_results =
+            db_iter.collect::<Result<Vec<(CheckpointHeight, PendingCheckpoint)>, _>>()?;
 
         let mut quarantine_results = self
             .consensus_quarantine

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1496,16 +1496,6 @@ impl AuthorityPerEpochStore {
         Ok(result)
     }
 
-    /// Gets all pending certificates. Used during recovery.
-    pub fn all_pending_execution(&self) -> IotaResult<Vec<VerifiedExecutableTransaction>> {
-        Ok(self
-            .tables()?
-            .pending_execution
-            .unbounded_iter()
-            .map(|(_, cert)| cert.into())
-            .collect())
-    }
-
     /// Called when transaction outputs are committed to disk
     #[instrument(level = "trace", skip_all)]
     pub fn handle_finalized_checkpoint(

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -4108,29 +4108,10 @@ impl AuthorityPerEpochStore {
         &self,
         last: Option<CheckpointHeight>,
     ) -> IotaResult<Vec<(CheckpointHeight, PendingCheckpoint)>> {
-        // Reading from the db table is only needed when upgrading to data quarantining
-        // for the first time.
-        let tables = self.tables()?;
-        let db_iter = tables
-            .pending_checkpoints
-            .safe_iter_with_bounds(last.map(|height| height + 1), None);
-        let db_results =
-            db_iter.collect::<Result<Vec<(CheckpointHeight, PendingCheckpoint)>, _>>()?;
-
-        let mut quarantine_results = self
+        Ok(self
             .consensus_quarantine
             .read()
-            .get_pending_checkpoints(last);
-
-        // retain only the checkpoints with heights greater than the highest height in
-        // the db
-        if let Some(db_highest_height) = db_results.last().map(|(h, _)| h) {
-            quarantine_results.retain(|(h, _)| h > db_highest_height);
-        }
-
-        let mut db_results = db_results;
-        db_results.extend(quarantine_results);
-        Ok(db_results)
+            .get_pending_checkpoints(last))
     }
 
     pub fn pending_checkpoint_exists(&self, index: &CheckpointHeight) -> IotaResult<bool> {

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -365,11 +365,7 @@ pub(crate) struct ConsensusOutputCache {
 }
 
 impl ConsensusOutputCache {
-    pub(crate) fn new(
-        epoch_start_configuration: &EpochStartConfiguration,
-        tables: &AuthorityEpochTables,
-        metrics: Arc<EpochMetrics>,
-    ) -> Self {
+    pub(crate) fn new(tables: &AuthorityEpochTables, metrics: Arc<EpochMetrics>) -> Self {
         let deferred_transactions = tables
             .get_all_deferred_transactions()
             .expect("load deferred transactions cannot fail");
@@ -378,28 +374,12 @@ impl ConsensusOutputCache {
             .get_all_deferred_transactions_v2()
             .expect("load deferred transactions v2 cannot fail");
 
-        if !epoch_start_configuration.is_data_quarantine_active_from_beginning_of_epoch() {
-            let shared_version_assignments = Self::get_all_shared_version_assignments(tables);
-
-            let user_signatures_for_checkpoints = tables
-                .get_all_user_signatures_for_checkpoints()
-                .expect("load user signatures for checkpoints cannot fail");
-
-            Self {
-                shared_version_assignments: shared_version_assignments.into_iter().collect(),
-                deferred_transactions: Mutex::new(deferred_transactions),
-                deferred_transactions_v2: Mutex::new(deferred_transactions_v2),
-                user_signatures_for_checkpoints: Mutex::new(user_signatures_for_checkpoints),
-                metrics,
-            }
-        } else {
-            Self {
-                shared_version_assignments: Default::default(),
-                deferred_transactions: Mutex::new(deferred_transactions),
-                deferred_transactions_v2: Mutex::new(deferred_transactions_v2),
-                user_signatures_for_checkpoints: Default::default(),
-                metrics,
-            }
+        Self {
+            shared_version_assignments: Default::default(),
+            deferred_transactions: Mutex::new(deferred_transactions),
+            deferred_transactions_v2: Mutex::new(deferred_transactions_v2),
+            user_signatures_for_checkpoints: Default::default(),
+            metrics,
         }
     }
 
@@ -457,19 +437,6 @@ impl ConsensusOutputCache {
         self.metrics
             .shared_object_assignments_size
             .sub(removed_count as i64);
-    }
-
-    // Used to read pre-existing shared object versions from the database after a
-    // crash. TODO: remove this once all nodes have upgraded to
-    // data-quarantining.
-    fn get_all_shared_version_assignments(
-        tables: &AuthorityEpochTables,
-    ) -> Vec<(TransactionKey, Vec<(ObjectID, SequenceNumber)>)> {
-        tables
-            .assigned_shared_object_versions
-            .safe_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .expect("db error")
     }
 }
 

--- a/crates/iota-core/src/authority/epoch_start_configuration.rs
+++ b/crates/iota-core/src/authority/epoch_start_configuration.rs
@@ -49,15 +49,16 @@ pub trait EpochStartConfigTrait {
 // inconsistent with the released branch, and must be fixed.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum EpochFlag {
+    // The deprecated flags have all been in production for long enough that
+    // we have deleted the old code paths they were guarding.
+    // We retain them here in order not to break deserialization.
+    _DataQuarantineFromBeginningOfEpochDeprecated = 1,
+
     // When switching between different cache types mid-epoch, partial checkpoint transactions
     // might already be on disk. During lock initialization, we check if there is any existing
     // lock or not, depending on the used implementation. That's why we should not switch
     // mid-epoch.
     WritebackCacheEnabled = 0,
-
-    // This flag indicates whether data quarantining has been enabled from the
-    // beginning of the epoch.
-    DataQuarantineFromBeginningOfEpoch = 1,
 }
 
 impl EpochFlag {
@@ -72,7 +73,7 @@ impl EpochFlag {
     }
 
     fn default_flags_impl(cache_type: ExecutionCacheType) -> Vec<Self> {
-        let mut new_flags = vec![EpochFlag::DataQuarantineFromBeginningOfEpoch];
+        let mut new_flags = vec![];
 
         // Load cache type from env
         if matches!(cache_type.cache_type(), ExecutionCacheType::WritebackCache) {
@@ -89,8 +90,8 @@ impl fmt::Display for EpochFlag {
         // is used as metric key
         match self {
             EpochFlag::WritebackCacheEnabled => write!(f, "WritebackCacheEnabled"),
-            EpochFlag::DataQuarantineFromBeginningOfEpoch => {
-                write!(f, "DataQuarantineFromBeginningOfEpoch")
+            EpochFlag::_DataQuarantineFromBeginningOfEpochDeprecated => {
+                write!(f, "DataQuarantineFromBeginningOfEpoch (DEPRECATED)")
             }
         }
     }

--- a/crates/iota-core/src/authority/epoch_start_configuration.rs
+++ b/crates/iota-core/src/authority/epoch_start_configuration.rs
@@ -37,11 +37,6 @@ pub trait EpochStartConfigTrait {
             ExecutionCacheType::PassthroughCache
         }
     }
-
-    fn is_data_quarantine_active_from_beginning_of_epoch(&self) -> bool {
-        self.flags()
-            .contains(&EpochFlag::DataQuarantineFromBeginningOfEpoch)
-    }
 }
 
 // IMPORTANT: Assign explicit values to each variant to ensure that the values

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -30,7 +30,6 @@ use iota_types::{
     effects::{TransactionEffects, TransactionEffectsAPI},
     error::{IotaError, IotaResult},
     event::SystemEpochInfoEvent,
-    executable_transaction::VerifiedExecutableTransaction,
     gas::GasCostSummary,
     iota_system_state::{
         IotaSystemState, IotaSystemStateTrait,
@@ -871,124 +870,6 @@ impl CheckpointStore {
         self.delete_highest_executed_checkpoint_test_only()?;
         self.tables.watermarks.rocksdb.flush()?;
         Ok(())
-    }
-
-    /// TODO: this is only needed while upgrading from non-dataquarantine to
-    /// dataquarantine. After that it can be deleted.
-    ///
-    /// Re-executes all transactions from all local, uncertified checkpoints for
-    /// crash recovery. All transactions thus re-executed are guaranteed to
-    /// not have any missing dependencies, because we start from the highest
-    /// executed checkpoint, and proceed through checkpoints in order.
-    // tracking issue: https://github.com/iotaledger/iota/issues/8290
-    #[instrument(level = "debug", skip_all)]
-    pub async fn reexecute_local_checkpoints(
-        &self,
-        state: &AuthorityState,
-        epoch_store: &AuthorityPerEpochStore,
-    ) {
-        let epoch = epoch_store.epoch();
-        let highest_executed = self
-            .get_highest_executed_checkpoint_seq_number()
-            .expect("get_highest_executed_checkpoint_seq_number should not fail")
-            .unwrap_or(0);
-
-        let Ok(Some(highest_built)) = self.get_latest_locally_computed_checkpoint() else {
-            info!("no locally built checkpoints to verify");
-            return;
-        };
-
-        info!(
-            "rexecuting locally computed checkpoints for crash recovery from {} to {}",
-            highest_executed, highest_built
-        );
-
-        for seq in highest_executed + 1..=*highest_built.sequence_number() {
-            info!(?seq, "Re-executing locally computed checkpoint");
-            let Some(checkpoint) = self
-                .get_locally_computed_checkpoint(seq)
-                .expect("get_locally_computed_checkpoint should not fail")
-            else {
-                panic!("locally computed checkpoint {seq:?} not found");
-            };
-
-            let Some(contents) = self
-                .get_checkpoint_contents(&checkpoint.content_digest)
-                .expect("get_checkpoint_contents should not fail")
-            else {
-                panic!(
-                    "checkpoint contents not found for locally computed checkpoint {:?} (digest: {:?})",
-                    seq, checkpoint.content_digest
-                );
-            };
-
-            let cache = state.get_transaction_cache_reader();
-
-            let tx_digests: Vec<_> = contents.iter().map(|digests| digests.transaction).collect();
-            let fx_digests: Vec<_> = contents.iter().map(|digests| digests.effects).collect();
-            let txns = cache
-                .try_multi_get_transaction_blocks(&tx_digests)
-                .expect("try_multi_get_transaction_blocks should not fail");
-
-            let txns: Vec<_> = itertools::izip!(txns, tx_digests, fx_digests)
-                .filter_map(|(tx, digest, fx)| {
-                    if let Some(tx) = tx {
-                        Some((tx, fx))
-                    } else {
-                        info!(
-                            "transaction {:?} not found during checkpoint re-execution",
-                            digest
-                        );
-                        None
-                    }
-                })
-                // end of epoch transaction can only be executed by CheckpointExecutor
-                .filter(|(tx, _)| !tx.data().transaction_data().is_end_of_epoch_tx())
-                .map(|(tx, fx)| {
-                    (
-                        VerifiedExecutableTransaction::new_from_checkpoint(
-                            (*tx).clone(),
-                            epoch,
-                            seq,
-                        ),
-                        fx,
-                    )
-                })
-                .collect();
-
-            let tx_digests: Vec<_> = txns.iter().map(|(tx, _)| *tx.digest()).collect();
-
-            info!(
-                ?seq,
-                ?tx_digests,
-                "Re-executing transactions for locally built checkpoint"
-            );
-            // this will panic if any re-execution diverges from the previously recorded
-            // effects digest
-            state.enqueue_with_expected_effects_digest(txns, epoch_store);
-
-            // a task that logs every so often until it is cancelled
-            // This should normally finish very quickly, so seeing this log more than once
-            // or twice is likely a sign of a problem.
-            let waiting_logger = tokio::task::spawn(async move {
-                let mut interval = tokio::time::interval(Duration::from_secs(1));
-                loop {
-                    interval.tick().await;
-                    warn!(?seq, "Still waiting for re-execution to complete");
-                }
-            });
-
-            cache
-                .try_notify_read_executed_effects_digests(&tx_digests)
-                .await
-                .expect("notify_read_executed_effects_digests should not fail");
-
-            waiting_logger.abort();
-            waiting_logger.await.ok();
-            info!(?seq, "Re-execution completed for locally built checkpoint");
-        }
-
-        info!("Re-execution of locally built checkpoints completed");
     }
 }
 

--- a/crates/iota-core/src/transaction_manager.rs
+++ b/crates/iota-core/src/transaction_manager.rs
@@ -348,15 +348,13 @@ impl TransactionManager {
         tx_ready_certificates: UnboundedSender<PendingCertificate>,
         metrics: Arc<AuthorityMetrics>,
     ) -> TransactionManager {
-        let transaction_manager = TransactionManager {
+        TransactionManager {
             object_cache_read,
             transaction_cache_read,
             metrics: metrics.clone(),
             inner: RwLock::new(RwLock::new(Inner::new(epoch_store.epoch(), metrics))),
             tx_ready_certificates,
-        };
-        transaction_manager.enqueue(epoch_store.all_pending_execution().unwrap(), epoch_store);
-        transaction_manager
+        }
     }
 
     /// Enqueues certificates / verified transactions into TransactionManager.

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1440,15 +1440,6 @@ impl IotaNode {
             )
             .await;
 
-        if !epoch_store
-            .epoch_start_config()
-            .is_data_quarantine_active_from_beginning_of_epoch()
-        {
-            checkpoint_store
-                .reexecute_local_checkpoints(&state, &epoch_store)
-                .await;
-        }
-
         info!("Spawning checkpoint service");
         let checkpoint_service_tasks = checkpoint_service.spawn().await;
 


### PR DESCRIPTION
# Description of change

Remove `reexecute_local_checkpoints` from the `CheckpointStore`. This function was responsible for re-executing transactions from local checkpoints for crash recovery, but is no longer needed after the data quarantine upgrade. 

The `reexecute_local_checkpoints` removal is included in upstream commit https://github.com/MystenLabs/sui/commit/ebfbc0c22b6d2a27d1970cfae6ebfb80b327eb46


## Links to any relevant issues

Fixes #8290 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

