### PR TITLE
fix(iota-core): feature gate misbehavior reports

### DIFF
--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -123,19 +123,22 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
                 .set(checkpoint_seq as i64);
         }
 
-        // We also send misbehavior reports to consensus at this point. Misbehavior
-        // reports containing proofs of misbehaviour can be send whenever the
-        // misbehavior is detected, but we choose to send the ones that include only
-        // unprovable counts at this point, due to periodicity reasons and to ensure a
-        // (approximate) synchronization with the score updates.
-        let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
-        let transaction = ConsensusTransaction::new_misbehavior_report(
-            epoch_store.name,
-            &misbehavior_report,
-            checkpoint_seq,
-        );
-        self.sender
-            .submit_to_consensus(&[transaction], epoch_store)?;
+        // If scoring is enabled in protocol config, we also send misbehavior reports to
+        // consensus at this point. Misbehavior reports containing proofs of
+        // misbehaviour can be send whenever the misbehavior is detected, but we
+        // choose to send the ones that include only unprovable counts at this
+        // point, due to periodicity reasons and to ensure a (approximate)
+        // synchronization with the score updates.
+        if epoch_store.protocol_config().calculate_validator_scores() {
+            let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
+            let transaction = ConsensusTransaction::new_misbehavior_report(
+                epoch_store.name,
+                &misbehavior_report,
+                checkpoint_seq,
+            );
+            self.sender
+                .submit_to_consensus(&[transaction], epoch_store)?;
+        }
 
         if checkpoint_timestamp >= self.next_reconfiguration_timestamp_ms {
             // close_epoch is ok if called multiple times


### PR DESCRIPTION
# Description of change

Use the `calculate_validator_scores` feature flag to decide whether to issue misbehavior reports. This is necessary to ensure backwards compatibility and pass the split cluster tests.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
