### PR TITLE
upstream(gRPC): gRPC supports TLS

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -297,6 +297,12 @@ pub struct GrpcApiConfig {
     /// in bytes.
     #[serde(default = "default_max_json_move_value_size")]
     pub max_json_move_value_size: usize,
+
+    /// TLS configuration for the gRPC server.
+    ///
+    /// If not provided, the gRPC server will use plain TCP without TLS.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tls: Option<TlsConfig>,
 }
 
 impl Default for GrpcApiConfig {
@@ -306,7 +312,33 @@ impl Default for GrpcApiConfig {
             checkpoint_broadcast_buffer_size: default_checkpoint_broadcast_buffer_size(),
             event_broadcast_buffer_size: default_event_broadcast_buffer_size(),
             max_json_move_value_size: default_max_json_move_value_size(),
+            tls: None,
         }
+    }
+}
+
+impl GrpcApiConfig {
+    pub fn tls_config(&self) -> Option<&TlsConfig> {
+        self.tls.as_ref()
+    }
+}
+
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct TlsConfig {
+    /// File path to a PEM formatted TLS certificate chain
+    cert: String,
+    /// File path to a PEM formatted TLS private key
+    key: String,
+}
+
+impl TlsConfig {
+    pub fn cert(&self) -> &str {
+        &self.cert
+    }
+
+    pub fn key(&self) -> &str {
+        &self.key
     }
 }
 

--- a/crates/iota-grpc-server/Cargo.toml
+++ b/crates/iota-grpc-server/Cargo.toml
@@ -22,7 +22,7 @@ tap.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-stream.workspace = true
 tokio-util.workspace = true
-tonic.workspace = true
+tonic = { workspace = true, features = ["tls-ring"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-grpc-server/src/server.rs
+++ b/crates/iota-grpc-server/src/server.rs
@@ -13,7 +13,7 @@ use iota_types::transaction_executor::TransactionExecutor;
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::TcpListenerStream;
 use tokio_util::sync::CancellationToken;
-use tonic::transport::Server;
+use tonic::transport::{Identity, Server, ServerTlsConfig};
 
 use crate::{
     GrpcCheckpointDataBroadcaster, GrpcCheckpointSummaryBroadcaster, GrpcReader, LedgerGrpcService,
@@ -94,19 +94,10 @@ pub async fn start_grpc_server(
         chain_id,
     );
 
-    // Create the server with proper address binding
-    let mut server_builder = Server::builder().add_service(
-        grpc_ledger_service::ledger_service_server::LedgerServiceServer::new(ledger_service),
-    );
-
-    // Add TransactionExecutionService if executor is provided
-    if let Some(executor) = executor {
-        let tx_service =
-            TransactionExecutionGrpcService::new(grpc_reader.clone(), executor, config.clone());
-        server_builder = server_builder.add_service(
-            grpc_tx_service::transaction_execution_service_server::TransactionExecutionServiceServer::new(tx_service),
-        );
-    }
+    // Create TransactionExecutionService if executor is provided
+    let tx_service = executor.map(|executor| {
+        TransactionExecutionGrpcService::new(grpc_reader.clone(), executor, config.clone())
+    });
 
     // Bind to the address to get the actual local address (especially important for
     // port 0)
@@ -120,18 +111,74 @@ pub async fn start_grpc_server(
     );
 
     // Spawn the server task with graceful shutdown
+    // TLS and non-TLS cases require different types, so we handle them separately
     let shutdown_token_for_server = shutdown_token.clone();
-    let server_handle = tokio::spawn(async move {
-        let result = server_builder
-            .serve_with_incoming_shutdown(
-                TcpListenerStream::new(listener),
-                shutdown_token_for_server.cancelled(),
+    let server_handle = if let Some(tls_config) = config.tls_config() {
+        // TLS case
+        let cert = std::fs::read_to_string(tls_config.cert()).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to read TLS cert file '{}': {}",
+                tls_config.cert(),
+                e
             )
-            .await;
+        })?;
+        let key = std::fs::read_to_string(tls_config.key()).map_err(|e| {
+            anyhow::anyhow!("failed to read TLS key file '{}': {}", tls_config.key(), e)
+        })?;
 
-        tracing::info!("gRPC server shutdown completed");
-        result
-    });
+        let identity = Identity::from_pem(cert, key);
+        let tls = ServerTlsConfig::new().identity(identity);
+
+        tracing::info!("gRPC server TLS enabled");
+
+        let mut router = Server::builder()
+            .tls_config(tls)
+            .map_err(|e| anyhow::anyhow!("failed to configure TLS: {}", e))?
+            .add_service(
+                grpc_ledger_service::ledger_service_server::LedgerServiceServer::new(
+                    ledger_service,
+                ),
+            );
+
+        if let Some(tx_service) = tx_service {
+            router = router.add_service(
+                grpc_tx_service::transaction_execution_service_server::TransactionExecutionServiceServer::new(tx_service),
+            );
+        }
+
+        // Drop the listener since tonic will rebind for TLS
+        drop(listener);
+
+        tokio::spawn(async move {
+            let result = router
+                .serve_with_shutdown(actual_addr, shutdown_token_for_server.cancelled())
+                .await;
+            tracing::info!("gRPC server shutdown completed");
+            result
+        })
+    } else {
+        // Non-TLS case
+        let mut router = Server::builder().add_service(
+            grpc_ledger_service::ledger_service_server::LedgerServiceServer::new(ledger_service),
+        );
+
+        if let Some(tx_service) = tx_service {
+            router = router.add_service(
+                grpc_tx_service::transaction_execution_service_server::TransactionExecutionServiceServer::new(tx_service),
+            );
+        }
+
+        tokio::spawn(async move {
+            let result = router
+                .serve_with_incoming_shutdown(
+                    TcpListenerStream::new(listener),
+                    shutdown_token_for_server.cancelled(),
+                )
+                .await;
+            tracing::info!("gRPC server shutdown completed");
+            result
+        })
+    };
 
     Ok(GrpcServerHandle {
         server_handle,

--- a/crates/iota-grpc-server/src/server.rs
+++ b/crates/iota-grpc-server/src/server.rs
@@ -110,11 +110,11 @@ pub async fn start_grpc_server(
         actual_addr
     );
 
-    // Spawn the server task with graceful shutdown
-    // TLS and non-TLS cases require different types, so we handle them separately
-    let shutdown_token_for_server = shutdown_token.clone();
-    let server_handle = if let Some(tls_config) = config.tls_config() {
-        // TLS case
+    // Build the router with services (common for both TLS and non-TLS)
+    let mut router_builder = Server::builder();
+
+    // Configure TLS if enabled
+    if let Some(tls_config) = config.tls_config() {
         let cert = std::fs::read_to_string(tls_config.cert()).map_err(|e| {
             anyhow::anyhow!(
                 "failed to read TLS cert file '{}': {}",
@@ -131,22 +131,28 @@ pub async fn start_grpc_server(
 
         tracing::info!("gRPC server TLS enabled");
 
-        let mut router = Server::builder()
+        router_builder = router_builder
             .tls_config(tls)
-            .map_err(|e| anyhow::anyhow!("failed to configure TLS: {}", e))?
-            .add_service(
-                grpc_ledger_service::ledger_service_server::LedgerServiceServer::new(
-                    ledger_service,
-                ),
-            );
+            .map_err(|e| anyhow::anyhow!("failed to configure TLS: {}", e))?;
+    }
 
-        if let Some(tx_service) = tx_service {
-            router = router.add_service(
-                grpc_tx_service::transaction_execution_service_server::TransactionExecutionServiceServer::new(tx_service),
-            );
-        }
+    // Add services to the router
+    let mut router = router_builder.add_service(
+        grpc_ledger_service::ledger_service_server::LedgerServiceServer::new(ledger_service),
+    );
 
-        // Drop the listener since tonic will rebind for TLS
+    if let Some(tx_service) = tx_service {
+        router = router.add_service(
+            grpc_tx_service::transaction_execution_service_server::TransactionExecutionServiceServer::new(tx_service),
+        );
+    }
+
+    // Spawn the server task with graceful shutdown
+    let shutdown_token_for_server = shutdown_token.clone();
+    let server_handle = if config.tls_config().is_some() {
+        // TLS case: tonic needs to control the entire transport stack for TLS,
+        // so we let it handle binding. We drop our pre-bound listener since
+        // tonic will create its own with proper TLS configuration.
         drop(listener);
 
         tokio::spawn(async move {
@@ -157,17 +163,7 @@ pub async fn start_grpc_server(
             result
         })
     } else {
-        // Non-TLS case
-        let mut router = Server::builder().add_service(
-            grpc_ledger_service::ledger_service_server::LedgerServiceServer::new(ledger_service),
-        );
-
-        if let Some(tx_service) = tx_service {
-            router = router.add_service(
-                grpc_tx_service::transaction_execution_service_server::TransactionExecutionServiceServer::new(tx_service),
-            );
-        }
-
+        // Non-TLS case: use the existing listener
         tokio::spawn(async move {
             let result = router
                 .serve_with_incoming_shutdown(


### PR DESCRIPTION
- Upstream range: [1.46.3, 1.47.1)
- Related commit:
https://github.com/MystenLabs/sui/commit/0316d747db35c796c5b3de099dfcedcafb0bb87d
  - Description: We port the TLS support for gRPC, but not for original http servers