### PR TITLE
feat(consensus): reinitialize consensus components after fast commit sync work

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -1173,6 +1173,11 @@ mod tests {
             max_round_first
         );
 
+        // Let the validator operate for a while to ensure sufficient data is written to storage.
+        // This helps ensure proper initialization on the next restart.
+        tracing::info!("Letting authority {} operate for 10 seconds before second crash...", stopped_index);
+        sleep(Duration::from_secs(10)).await;
+
         // === Second crash: Stop authority 0 again ===
         tracing::info!("=== Second crash: Stopping authority {} again ===", stopped_index);
         authorities.remove(stopped_index).stop().await;

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -18,7 +18,7 @@ use crate::{
     block_verifier::SignedBlockVerifier,
     commit_observer::CommitObserver,
     commit_syncer::{
-        CommitSyncer, CommitSyncerHandle, fast::FastCommitSyncer, regular::RegularCommitSyncer,
+        CommitSyncerHandle, fast::FastCommitSyncer, regular::RegularCommitSyncer,
     },
     commit_vote_monitor::CommitVoteMonitor,
     context::{Clock, Context},

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -1099,17 +1099,19 @@ mod tests {
         consumer_monitors[stopped_index] = monitor;
         authorities.insert(stopped_index, authority);
 
-        // Let it run to observe sync behavior in logs
-        // Look for: "[fast_commit_sync] Checking to schedule fetches"
-        let start_time = Instant::now();
+        // First recovery: Let authority 0 catch up and create blocks
+        // Wait until authority 0 is within 50 rounds of other authorities (or timeout after 120s)
+        tracing::info!("=== First recovery: waiting for authority 0 to catch up ===");
         let mut last_committed_index = [0; NUM_AUTHORITIES];
         let mut last_round_committed_blocks = [0; NUM_AUTHORITIES];
+        let start_time = Instant::now();
+        let max_wait = Duration::from_secs(120);
+        let catch_up_threshold = 50;
         loop {
-            if start_time.elapsed() > Duration::from_secs(60) {
+            if start_time.elapsed() > max_wait {
                 break;
             }
             for (index, receiver) in output_receivers.iter_mut().enumerate() {
-                // Manually update the commit consumer monitor with the highest handled commit
                 let deadline = Instant::now() + Duration::from_millis(25);
                 while Instant::now() < deadline {
                     let remaining = deadline - Instant::now();
@@ -1119,19 +1121,151 @@ mod tests {
                         for block_ref in &committed_subdag.base.committed_header_refs {
                             if block_ref.round > GENESIS_ROUND {
                                 let author_index = block_ref.author;
-                                last_round_committed_blocks[author_index] =
-                                    max(last_round_committed_blocks[author_index], block_ref.round);
+                                last_round_committed_blocks[author_index] = max(
+                                    last_round_committed_blocks[author_index],
+                                    block_ref.round,
+                                );
                             }
                         }
 
                         let commit_index = committed_subdag.commit_ref.index;
-                        assert!(last_committed_index[index] < commit_index);
-                        last_committed_index[index] = commit_index;
-                        consumer_monitors[index].set_highest_handled_commit(commit_index);
+                        // Only update if this is a new commit (handles replay during recovery)
+                        if commit_index > last_committed_index[index] {
+                            last_committed_index[index] = commit_index;
+                            consumer_monitors[index].set_highest_handled_commit(commit_index);
+                        }
                     } else {
-                        // If we time out, we assume that no new dags were committed.
                         break;
                     }
+                }
+            }
+            // Check if authority 0 has caught up
+            let max_round = *last_round_committed_blocks.iter().max().unwrap_or(&0);
+            if last_round_committed_blocks[stopped_index] > 0
+                && last_round_committed_blocks[stopped_index] + catch_up_threshold >= max_round
+            {
+                tracing::info!(
+                    "Authority {} caught up: round {} vs max {}",
+                    stopped_index,
+                    last_round_committed_blocks[stopped_index],
+                    max_round
+                );
+                break;
+            }
+        }
+
+        // Verify authority 0 caught up after first fast sync
+        tracing::info!(
+            "After first recovery - Last committed block rounds per authority: {:?}",
+            last_round_committed_blocks
+        );
+        let max_round_first = *last_round_committed_blocks.iter().max().unwrap();
+        assert!(
+            last_round_committed_blocks[stopped_index] > 0,
+            "Authority {} should have created blocks after first fast sync",
+            stopped_index
+        );
+        assert!(
+            last_round_committed_blocks[stopped_index] + catch_up_threshold >= max_round_first,
+            "Authority {} should be caught up after first fast sync. Its round {} is too far behind max {}",
+            stopped_index,
+            last_round_committed_blocks[stopped_index],
+            max_round_first
+        );
+
+        // === Second crash: Stop authority 0 again ===
+        tracing::info!("=== Second crash: Stopping authority {} again ===", stopped_index);
+        authorities.remove(stopped_index).stop().await;
+
+        // Wait to widen gap again
+        tracing::info!("Waiting 10 seconds to widen the commit gap again...");
+        sleep(Duration::from_secs(10)).await;
+
+        // === Second recovery: Restart authority 0 again ===
+        tracing::info!(
+            "=== Second recovery: Restarting authority {}. FastCommitSyncer should activate again ===",
+            stopped_index
+        );
+        let parameters = Parameters {
+            db_path: temp_dirs[stopped_index].path().to_path_buf(),
+            dag_state_cached_rounds: 5,
+            commit_sync_parallel_fetches: 2,
+            commit_sync_batch_size: 10,
+            commit_sync_gap_threshold: 50,
+            fast_commit_sync_batch_size: 20,
+            sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            ..Default::default()
+        };
+        let (authority, receiver, monitor) = make_authority_with_params(
+            committee.to_authority_index(stopped_index).unwrap(),
+            &temp_dirs[stopped_index],
+            committee.clone(),
+            keypairs.clone(),
+            boot_counters[stopped_index],
+            protocol_config.clone(),
+            parameters,
+        )
+        .await;
+        boot_counters[stopped_index] += 1;
+        output_receivers[stopped_index] = receiver;
+        consumer_monitors[stopped_index] = monitor;
+        authorities.insert(stopped_index, authority);
+
+        // Second recovery: Let authority 0 catch up again
+        // Wait until authority 0 is within 50 rounds of other authorities (or timeout after 120s)
+        tracing::info!("=== Second recovery: waiting for authority 0 to catch up again ===");
+        // Reset tracking for the stopped authority since it will replay commits from recovery
+        let round_before_second_sync = last_round_committed_blocks[stopped_index];
+        last_committed_index[stopped_index] = 0;
+        let start_time = Instant::now();
+        loop {
+            if start_time.elapsed() > max_wait {
+                break;
+            }
+            for (index, receiver) in output_receivers.iter_mut().enumerate() {
+                let deadline = Instant::now() + Duration::from_millis(25);
+                while Instant::now() < deadline {
+                    let remaining = deadline - Instant::now();
+                    if let Ok(Some(committed_subdag)) =
+                        tokio::time::timeout(remaining, receiver.recv()).await
+                    {
+                        for block_ref in &committed_subdag.base.committed_header_refs {
+                            if block_ref.round > GENESIS_ROUND {
+                                let author_index = block_ref.author;
+                                last_round_committed_blocks[author_index] = max(
+                                    last_round_committed_blocks[author_index],
+                                    block_ref.round,
+                                );
+                            }
+                        }
+
+                        let commit_index = committed_subdag.commit_ref.index;
+                        // Only update if this is a new commit (handles replay during recovery)
+                        if commit_index > last_committed_index[index] {
+                            last_committed_index[index] = commit_index;
+                            consumer_monitors[index].set_highest_handled_commit(commit_index);
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+            // Check if authority 0 has caught up (or made progress)
+            let max_round = *last_round_committed_blocks.iter().max().unwrap_or(&0);
+            let made_progress = last_round_committed_blocks[stopped_index] > round_before_second_sync;
+            let is_close = last_round_committed_blocks[stopped_index] + catch_up_threshold >= max_round;
+
+            if made_progress {
+                tracing::info!(
+                    "Authority {} made progress after second sync: round {} (was {}) vs max {}",
+                    stopped_index,
+                    last_round_committed_blocks[stopped_index],
+                    round_before_second_sync,
+                    max_round
+                );
+                if is_close {
+                    tracing::info!("Authority {} is close enough to max, breaking early", stopped_index);
+                    break;
                 }
             }
         }
@@ -1146,25 +1280,26 @@ mod tests {
             "Test complete. Check logs for [fast_commit_sync] and [commit_sync] messages."
         );
 
-        // Verify authority 0 created blocks after fast sync completed
+        // Verify authority 0 created blocks after second fast sync
         tracing::info!(
-            "Last committed block rounds per authority: {:?}",
+            "After second recovery - Last committed block rounds per authority: {:?}",
             last_round_committed_blocks
         );
         assert!(
-            last_round_committed_blocks[stopped_index] > 0,
-            "Authority {} should have created blocks after fast sync, but last_round_committed_blocks[{}] = {}",
+            last_round_committed_blocks[stopped_index] > round_before_second_sync,
+            "Authority {} should have created new blocks after second fast sync. Round before: {}, after: {}",
             stopped_index,
-            stopped_index,
+            round_before_second_sync,
             last_round_committed_blocks[stopped_index]
         );
 
         // Verify authority 0's last committed block round is reasonably close to other authorities
-        // (within 100 rounds), proving it's participating in consensus after sync
+        // (within 200 rounds to allow for slower catch-up on second restart)
+        let second_recovery_threshold = 200;
         let max_round = *last_round_committed_blocks.iter().max().unwrap();
         assert!(
-            last_round_committed_blocks[stopped_index] + 100 >= max_round,
-            "Authority {} should be caught up after fast sync. Its last round {} is too far behind max round {}",
+            last_round_committed_blocks[stopped_index] + second_recovery_threshold >= max_round,
+            "Authority {} should be caught up after second fast sync. Its last round {} is too far behind max round {}",
             stopped_index,
             last_round_committed_blocks[stopped_index],
             max_round

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -1262,7 +1262,6 @@ mod tests {
             last_processed_before_second_restart,
         )
         .await;
-        boot_counters[stopped_index] += 1;
         output_receivers[stopped_index] = receiver;
         consumer_monitors[stopped_index] = monitor;
         authorities.insert(stopped_index, authority);

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -1010,7 +1010,9 @@ mod tests {
     /// gap-based syncer selection.
     #[tokio::test(flavor = "current_thread")]
     async fn test_fast_commit_syncer_on_restart() {
-        telemetry_subscribers::init_for_testing();
+        let _guards = telemetry_subscribers::TelemetryConfig::new()
+            .with_log_level("debug")
+            .init();
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);
 
@@ -1142,6 +1144,30 @@ mod tests {
 
         tracing::info!(
             "Test complete. Check logs for [fast_commit_sync] and [commit_sync] messages."
+        );
+
+        // Verify authority 0 created blocks after fast sync completed
+        tracing::info!(
+            "Last committed block rounds per authority: {:?}",
+            last_round_committed_blocks
+        );
+        assert!(
+            last_round_committed_blocks[stopped_index] > 0,
+            "Authority {} should have created blocks after fast sync, but last_round_committed_blocks[{}] = {}",
+            stopped_index,
+            stopped_index,
+            last_round_committed_blocks[stopped_index]
+        );
+
+        // Verify authority 0's last committed block round is reasonably close to other authorities
+        // (within 100 rounds), proving it's participating in consensus after sync
+        let max_round = *last_round_committed_blocks.iter().max().unwrap();
+        assert!(
+            last_round_committed_blocks[stopped_index] + 100 >= max_round,
+            "Authority {} should be caught up after fast sync. Its last round {} is too far behind max round {}",
+            stopped_index,
+            last_round_committed_blocks[stopped_index],
+            max_round
         );
     }
 }

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -1014,7 +1014,7 @@ mod tests {
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);
 
-        const NUM_AUTHORITIES: usize = 8;
+        const NUM_AUTHORITIES: usize = 4;
         const COMMIT_GAP_THRESHOLD: u32 = 50;
         const CATCH_UP_THRESHOLD: u32 = 50;
         const SECOND_RECOVERY_THRESHOLD: u32 = 200;
@@ -1028,7 +1028,7 @@ mod tests {
             .collect();
 
         let mut authorities = Vec::with_capacity(NUM_AUTHORITIES);
-        let mut boot_counters = vec![0u64; NUM_AUTHORITIES];
+        let mut boot_counters = [0u64; NUM_AUTHORITIES];
         let mut consumer_monitors = Vec::with_capacity(NUM_AUTHORITIES);
         let mut output_receivers = Vec::with_capacity(NUM_AUTHORITIES);
 
@@ -1067,15 +1067,55 @@ mod tests {
             consumer_monitors.push(monitor);
         }
 
-        sleep(Duration::from_secs(10)).await;
+        // Drain receivers during initial operation to track commits
+        let start_time = Instant::now();
+        let mut initial_committed_index = vec![0u32; NUM_AUTHORITIES];
+        while start_time.elapsed() < Duration::from_secs(10) {
+            for (index, receiver) in output_receivers.iter_mut().enumerate() {
+                while let Ok(committed_subdag) = receiver.try_recv() {
+                    let commit_index = committed_subdag.commit_ref.index;
+                    if commit_index > initial_committed_index[index] {
+                        initial_committed_index[index] = commit_index;
+                        consumer_monitors[index].set_highest_handled_commit(commit_index);
+                    }
+                }
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+        eprintln!("\n=== INITIAL OPERATION (10s) ===");
+        eprintln!("initial_committed_index (all authorities): {:?}", initial_committed_index);
 
         // First crash: stop authority 0
         let stopped_index: usize = 0;
+        eprintln!("\n=== PHASE 1: FIRST CRASH ===");
+        eprintln!("Authority 0 highest_handled_commit before stop: {}", consumer_monitors[stopped_index].highest_handled_commit());
         authorities.remove(stopped_index).stop().await;
-        sleep(Duration::from_secs(10)).await;
+
+        // Drain other authorities while authority 0 is stopped
+        let start_time = Instant::now();
+        let mut commits_while_stopped = vec![0u32; NUM_AUTHORITIES];
+        while start_time.elapsed() < Duration::from_secs(10) {
+            for (index, receiver) in output_receivers.iter_mut().enumerate() {
+                if index == stopped_index {
+                    continue; // Skip stopped authority
+                }
+                while let Ok(committed_subdag) = receiver.try_recv() {
+                    let commit_index = committed_subdag.commit_ref.index;
+                    if commit_index > commits_while_stopped[index] {
+                        commits_while_stopped[index] = commit_index;
+                        consumer_monitors[index].set_highest_handled_commit(commit_index);
+                    }
+                }
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+        eprintln!("\n=== WHILE AUTH 0 STOPPED (10s) ===");
+        eprintln!("commits_while_stopped (other authorities): {:?}", commits_while_stopped);
 
         // First recovery: restart authority 0
         let last_processed_before_restart = consumer_monitors[stopped_index].highest_handled_commit();
+        eprintln!("\n=== PHASE 2: FIRST RECOVERY ===");
+        eprintln!("last_processed_before_restart: {}", last_processed_before_restart);
         let parameters = Parameters {
             db_path: temp_dirs[stopped_index].path().to_path_buf(),
             dag_state_cached_rounds: 5,
@@ -1151,6 +1191,10 @@ mod tests {
         }
 
         let max_round_first = *last_round_committed_blocks.iter().max().unwrap();
+        eprintln!("\n=== AFTER FIRST RECOVERY CAUGHT UP ===");
+        eprintln!("last_committed_index (all authorities): {:?}", last_committed_index);
+        eprintln!("last_round_committed_blocks (all authorities): {:?}", last_round_committed_blocks);
+        eprintln!("max_round_first: {}", max_round_first);
         assert!(
             last_round_committed_blocks[stopped_index] > 0,
             "Authority should have created blocks after first fast sync"
@@ -1160,14 +1204,54 @@ mod tests {
             "Authority should be caught up after first fast sync"
         );
 
-        sleep(Duration::from_secs(10)).await;
+        // Drain receivers during normal operation after first recovery
+        let start_time = Instant::now();
+        let mut commits_after_first_recovery = vec![0u32; NUM_AUTHORITIES];
+        while start_time.elapsed() < Duration::from_secs(10) {
+            for (index, receiver) in output_receivers.iter_mut().enumerate() {
+                while let Ok(committed_subdag) = receiver.try_recv() {
+                    let commit_index = committed_subdag.commit_ref.index;
+                    if commit_index > commits_after_first_recovery[index] {
+                        commits_after_first_recovery[index] = commit_index;
+                        consumer_monitors[index].set_highest_handled_commit(commit_index);
+                    }
+                }
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+        eprintln!("\n=== NORMAL OPERATION AFTER FIRST RECOVERY (10s) ===");
+        eprintln!("commits_after_first_recovery (all authorities): {:?}", commits_after_first_recovery);
 
         // Second crash: stop authority 0 again
+        eprintln!("\n=== PHASE 3: SECOND CRASH ===");
+        eprintln!("Authority 0 highest_handled_commit before second stop: {}", consumer_monitors[stopped_index].highest_handled_commit());
         authorities.remove(stopped_index).stop().await;
-        sleep(Duration::from_secs(10)).await;
+
+        // Drain other authorities while authority 0 is stopped (second time)
+        let start_time = Instant::now();
+        let mut commits_while_stopped_2 = vec![0u32; NUM_AUTHORITIES];
+        while start_time.elapsed() < Duration::from_secs(10) {
+            for (index, receiver) in output_receivers.iter_mut().enumerate() {
+                if index == stopped_index {
+                    continue;
+                }
+                while let Ok(committed_subdag) = receiver.try_recv() {
+                    let commit_index = committed_subdag.commit_ref.index;
+                    if commit_index > commits_while_stopped_2[index] {
+                        commits_while_stopped_2[index] = commit_index;
+                        consumer_monitors[index].set_highest_handled_commit(commit_index);
+                    }
+                }
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+        eprintln!("\n=== WHILE AUTH 0 STOPPED SECOND TIME (10s) ===");
+        eprintln!("commits_while_stopped_2 (other authorities): {:?}", commits_while_stopped_2);
 
         // Second recovery: restart authority 0 again
         let last_processed_before_second_restart = consumer_monitors[stopped_index].highest_handled_commit();
+        eprintln!("\n=== PHASE 4: SECOND RECOVERY ===");
+        eprintln!("last_processed_before_second_restart: {}", last_processed_before_second_restart);
 
         let parameters = Parameters {
             db_path: temp_dirs[stopped_index].path().to_path_buf(),
@@ -1251,12 +1335,18 @@ mod tests {
             authority.stop().await;
         }
 
+        eprintln!("\n=== FINAL STATE AFTER SECOND RECOVERY ===");
+        eprintln!("last_committed_index (all authorities): {:?}", last_committed_index);
+        eprintln!("last_round_committed_blocks (all authorities): {:?}", last_round_committed_blocks);
+        eprintln!("round_before_second_sync: {}", round_before_second_sync);
+
         // Verify authority 0 made progress and caught up after second recovery
         assert!(
             last_round_committed_blocks[stopped_index] > round_before_second_sync,
             "Authority should have created new blocks after second fast sync"
         );
         let max_round = *last_round_committed_blocks.iter().max().unwrap();
+        eprintln!("max_round (final): {}", max_round);
         assert!(
             last_round_committed_blocks[stopped_index] + SECOND_RECOVERY_THRESHOLD >= max_round,
             "Authority should be caught up after second fast sync"
@@ -1277,14 +1367,38 @@ mod tests {
             .unwrap_or(0);
 
         let mut mismatches = Vec::new();
+        let mut mismatch_details = Vec::new();
+
         for commit_idx in overall_min..=overall_max {
+            // Collect all (authority -> values) observations for this commit.
             let mut commit_data: Vec<(usize, CommitDigest, BlockRef)> = Vec::new();
+            let mut missing = Vec::new();
             for (auth_idx, commits) in authority_commits.iter().enumerate() {
                 if let Some((digest, leader)) = commits.get(&commit_idx) {
                     commit_data.push((auth_idx, *digest, *leader));
+                } else {
+                    missing.push(auth_idx);
                 }
             }
 
+            // If fewer than 2 authorities have data for this commit index, we can't
+            // establish divergence (current test semantics). Still record missing
+            // for debugging if we later find mismatches elsewhere.
+            if commit_data.len() < 2 {
+                continue;
+            }
+
+            // Group authorities by digest and leader for better diagnostics.
+            use std::collections::BTreeMap;
+            let mut by_digest: BTreeMap<CommitDigest, Vec<usize>> = BTreeMap::new();
+            let mut by_leader: BTreeMap<BlockRef, Vec<usize>> = BTreeMap::new();
+            for (auth_idx, digest, leader) in &commit_data {
+                by_digest.entry(*digest).or_default().push(*auth_idx);
+                by_leader.entry(*leader).or_default().push(*auth_idx);
+            }
+
+            // Preserve the old pairwise mismatch summarization, but also attach
+            // full observed values.
             if commit_data.len() >= 2 {
                 let (first_auth, first_digest, first_leader) = commit_data[0];
                 for &(auth_idx, digest, leader) in &commit_data[1..] {
@@ -1300,13 +1414,60 @@ mod tests {
                     }
                 }
             }
+
+            if by_digest.len() > 1 || by_leader.len() > 1 {
+                let mut detail = String::new();
+                detail.push_str(&format!("Commit {commit_idx} mismatch details:\n"));
+
+                if by_digest.len() > 1 {
+                    detail.push_str("  Digests observed:\n");
+                    for (digest, auths) in &by_digest {
+                        detail.push_str(&format!("    {digest:?}: authorities {auths:?}\n"));
+                    }
+                } else {
+                    // Keep a single-line summary for consistency.
+                    let (digest, auths) = by_digest.iter().next().unwrap();
+                    detail.push_str(&format!(
+                        "  Digest consistent: {digest:?} (authorities {auths:?})\n"
+                    ));
+                }
+
+                if by_leader.len() > 1 {
+                    detail.push_str("  Leaders observed:\n");
+                    for (leader, auths) in &by_leader {
+                        detail.push_str(&format!("    {leader:?}: authorities {auths:?}\n"));
+                    }
+                } else {
+                    let (leader, auths) = by_leader.iter().next().unwrap();
+                    detail.push_str(&format!(
+                        "  Leader consistent: {leader:?} (authorities {auths:?})\n"
+                    ));
+                }
+
+                // Helpful to see who didn't report this commit index at all.
+                if !missing.is_empty() {
+                    detail.push_str(&format!("  Missing authorities: {missing:?}\n"));
+                }
+
+                mismatch_details.push(detail);
+            }
+        }
+
+        // Print all mismatch details (if any) before the assert so failures are
+        // actionable in CI logs.
+        if !mismatch_details.is_empty() {
+            eprintln!("\n=== COMMIT SEQUENCE DIVERGENCE DETAILS ===");
+            for d in &mismatch_details {
+                eprintln!("{d}");
+            }
         }
 
         assert!(
             mismatches.is_empty(),
             "Commit sequence divergence detected - {} mismatches found. \
-            This indicates the fast sync authority has a different leader schedule than other authorities.",
-            mismatches.len()
+            This indicates the fast sync authority has a different leader schedule than other authorities.\n\n{}",
+            mismatches.len(),
+            mismatches.join("\n")
         );
     }
 }

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -390,7 +390,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        CommittedSubDag, block_header::GENESIS_ROUND, transaction::NoopTransactionVerifier,
+        CommittedSubDag, block_header::GENESIS_ROUND, commit::CommitIndex,
+        transaction::NoopTransactionVerifier,
     };
 
     #[rstest]
@@ -968,6 +969,7 @@ mod tests {
         boot_counter: u64,
         protocol_config: ProtocolConfig,
         parameters: Parameters,
+        last_processed_commit_index: CommitIndex,
     ) -> (
         ConsensusAuthority,
         UnboundedReceiver<CommittedSubDag>,
@@ -980,7 +982,7 @@ mod tests {
         let network_keypair = keypairs[index].0.clone();
 
         let (sender, receiver) = unbounded_channel("consensus_output");
-        let commit_consumer = CommitConsumer::new(sender, 0);
+        let commit_consumer = CommitConsumer::new(sender, last_processed_commit_index);
 
         let consensus_consumer_monitor = commit_consumer.monitor();
 
@@ -1003,18 +1005,20 @@ mod tests {
         (authority, receiver, consensus_consumer_monitor)
     }
 
-    /// Test that FastCommitSyncer activates when a node restarts with a large
-    /// commit gap. This test is for log analysis - observe logs to verify
-    /// gap-based syncer selection.
+    /// Test that FastCommitSyncer does not cause consensus divergence after restart.
+    /// Verifies that all authorities agree on the same commit sequence (digest and leader)
+    /// even when one authority uses fast sync to catch up after crashes.
     #[tokio::test(flavor = "current_thread")]
     async fn test_fast_commit_syncer_on_restart() {
-        let _guards = telemetry_subscribers::TelemetryConfig::new()
-            .with_log_level("debug")
-            .init();
+        telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);
 
-        const NUM_AUTHORITIES: usize = 4;
+        const NUM_AUTHORITIES: usize = 8;
+        const COMMIT_GAP_THRESHOLD: u32 = 50;
+        const CATCH_UP_THRESHOLD: u32 = 50;
+        const SECOND_RECOVERY_THRESHOLD: u32 = 200;
+
         let (committee, keypairs) = local_committee_and_keys(0, vec![1; NUM_AUTHORITIES]);
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         protocol_config.set_consensus_transaction_ref_for_testing(true);
@@ -1024,18 +1028,24 @@ mod tests {
             .collect();
 
         let mut authorities = Vec::with_capacity(NUM_AUTHORITIES);
-        let mut boot_counters = [0u64; NUM_AUTHORITIES];
+        let mut boot_counters = vec![0u64; NUM_AUTHORITIES];
         let mut consumer_monitors = Vec::with_capacity(NUM_AUTHORITIES);
         let mut output_receivers = Vec::with_capacity(NUM_AUTHORITIES);
 
-        // Start all authorities with low gap threshold (50 commits)
+        use std::collections::HashMap;
+        use crate::commit::{CommitDigest, CommitIndex};
+        use crate::block_header::BlockRef;
+        let mut authority_commits: Vec<HashMap<CommitIndex, (CommitDigest, BlockRef)>> =
+            vec![HashMap::new(); NUM_AUTHORITIES];
+
+        // Start all authorities
         for (index, _) in committee.authorities() {
             let parameters = Parameters {
                 db_path: temp_dirs[index.value()].path().to_path_buf(),
                 dag_state_cached_rounds: 5,
                 commit_sync_parallel_fetches: 2,
                 commit_sync_batch_size: 10,
-                commit_sync_gap_threshold: 50,
+                commit_sync_gap_threshold: COMMIT_GAP_THRESHOLD,
                 fast_commit_sync_batch_size: 20,
                 sync_last_known_own_block_timeout: Duration::from_millis(2_000),
                 ..Default::default()
@@ -1048,6 +1058,7 @@ mod tests {
                 boot_counters[index],
                 protocol_config.clone(),
                 parameters,
+                0,
             )
             .await;
             boot_counters[index] += 1;
@@ -1056,28 +1067,21 @@ mod tests {
             consumer_monitors.push(monitor);
         }
 
-        tracing::info!("All authorities started. Running for 3 minutes to accumulate commits...");
-
-        // Let network run for some time to accumulate commits
         sleep(Duration::from_secs(10)).await;
 
-        // Stop authority 0
+        // First crash: stop authority 0
         let stopped_index: usize = 0;
-        tracing::info!("Stopping authority {stopped_index}...");
         authorities.remove(stopped_index).stop().await;
-
-        // Wait more to widen gap
-        tracing::info!("Waiting 10 seconds to widen the commit gap...");
         sleep(Duration::from_secs(10)).await;
 
-        // Restart the stopped authority
-        tracing::info!("Restarting authority {stopped_index}. FastCommitSyncer should activate...");
+        // First recovery: restart authority 0
+        let last_processed_before_restart = consumer_monitors[stopped_index].highest_handled_commit();
         let parameters = Parameters {
             db_path: temp_dirs[stopped_index].path().to_path_buf(),
             dag_state_cached_rounds: 5,
             commit_sync_parallel_fetches: 2,
             commit_sync_batch_size: 10,
-            commit_sync_gap_threshold: 50,
+            commit_sync_gap_threshold: COMMIT_GAP_THRESHOLD,
             fast_commit_sync_batch_size: 20,
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             ..Default::default()
@@ -1090,6 +1094,7 @@ mod tests {
             boot_counters[stopped_index],
             protocol_config.clone(),
             parameters,
+            last_processed_before_restart,
         )
         .await;
         boot_counters[stopped_index] += 1;
@@ -1097,15 +1102,11 @@ mod tests {
         consumer_monitors[stopped_index] = monitor;
         authorities.insert(stopped_index, authority);
 
-        // First recovery: Let authority 0 catch up and create blocks
-        // Wait until authority 0 is within 50 rounds of other authorities (or timeout
-        // after 120s)
-        tracing::info!("=== First recovery: waiting for authority 0 to catch up ===");
-        let mut last_committed_index = [0; NUM_AUTHORITIES];
-        let mut last_round_committed_blocks = [0; NUM_AUTHORITIES];
+        // Wait for authority 0 to catch up after first recovery
+        let mut last_committed_index = vec![0; NUM_AUTHORITIES];
+        let mut last_round_committed_blocks = vec![0; NUM_AUTHORITIES];
         let start_time = Instant::now();
         let max_wait = Duration::from_secs(120);
-        let catch_up_threshold = 50;
         loop {
             if start_time.elapsed() > max_wait {
                 break;
@@ -1126,7 +1127,11 @@ mod tests {
                         }
 
                         let commit_index = committed_subdag.commit_ref.index;
-                        // Only update if this is a new commit (handles replay during recovery)
+                        let commit_digest = committed_subdag.commit_ref.digest;
+                        let leader = committed_subdag.leader;
+
+                        authority_commits[index].insert(commit_index, (commit_digest, leader));
+
                         if commit_index > last_committed_index[index] {
                             last_committed_index[index] = commit_index;
                             consumer_monitors[index].set_highest_handled_commit(commit_index);
@@ -1136,70 +1141,40 @@ mod tests {
                     }
                 }
             }
-            // Check if authority 0 has caught up
+
             let max_round = *last_round_committed_blocks.iter().max().unwrap_or(&0);
             if last_round_committed_blocks[stopped_index] > 0
-                && last_round_committed_blocks[stopped_index] + catch_up_threshold >= max_round
+                && last_round_committed_blocks[stopped_index] + CATCH_UP_THRESHOLD >= max_round
             {
-                tracing::info!(
-                    "Authority {} caught up: round {} vs max {}",
-                    stopped_index,
-                    last_round_committed_blocks[stopped_index],
-                    max_round
-                );
                 break;
             }
         }
 
-        // Verify authority 0 caught up after first fast sync
-        tracing::info!(
-            "After first recovery - Last committed block rounds per authority: {:?}",
-            last_round_committed_blocks
-        );
         let max_round_first = *last_round_committed_blocks.iter().max().unwrap();
         assert!(
             last_round_committed_blocks[stopped_index] > 0,
-            "Authority {} should have created blocks after first fast sync",
-            stopped_index
+            "Authority should have created blocks after first fast sync"
         );
         assert!(
-            last_round_committed_blocks[stopped_index] + catch_up_threshold >= max_round_first,
-            "Authority {} should be caught up after first fast sync. Its round {} is too far behind max {}",
-            stopped_index,
-            last_round_committed_blocks[stopped_index],
-            max_round_first
+            last_round_committed_blocks[stopped_index] + CATCH_UP_THRESHOLD >= max_round_first,
+            "Authority should be caught up after first fast sync"
         );
 
-        // Let the validator operate for a while to ensure sufficient data is written to
-        // storage. This helps ensure proper initialization on the next restart.
-        tracing::info!(
-            "Letting authority {} operate for 10 seconds before second crash...",
-            stopped_index
-        );
         sleep(Duration::from_secs(10)).await;
 
-        // === Second crash: Stop authority 0 again ===
-        tracing::info!(
-            "=== Second crash: Stopping authority {} again ===",
-            stopped_index
-        );
+        // Second crash: stop authority 0 again
         authorities.remove(stopped_index).stop().await;
-
-        // Wait to widen gap again
-        tracing::info!("Waiting 10 seconds to widen the commit gap again...");
         sleep(Duration::from_secs(10)).await;
 
-        // === Second recovery: Restart authority 0 again ===
-        tracing::info!(
-            "=== Second recovery: Restarting authority {}. FastCommitSyncer should activate again ===",
-            stopped_index
-        );
+        // Second recovery: restart authority 0 again
+        let last_processed_before_second_restart = consumer_monitors[stopped_index].highest_handled_commit();
+
         let parameters = Parameters {
             db_path: temp_dirs[stopped_index].path().to_path_buf(),
             dag_state_cached_rounds: 5,
             commit_sync_parallel_fetches: 2,
             commit_sync_batch_size: 10,
-            commit_sync_gap_threshold: 50,
+            commit_sync_gap_threshold: COMMIT_GAP_THRESHOLD,
             fast_commit_sync_batch_size: 20,
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             ..Default::default()
@@ -1212,6 +1187,7 @@ mod tests {
             boot_counters[stopped_index],
             protocol_config.clone(),
             parameters,
+            last_processed_before_second_restart,
         )
         .await;
         boot_counters[stopped_index] += 1;
@@ -1219,12 +1195,7 @@ mod tests {
         consumer_monitors[stopped_index] = monitor;
         authorities.insert(stopped_index, authority);
 
-        // Second recovery: Let authority 0 catch up again
-        // Wait until authority 0 is within 50 rounds of other authorities (or timeout
-        // after 120s)
-        tracing::info!("=== Second recovery: waiting for authority 0 to catch up again ===");
-        // Reset tracking for the stopped authority since it will replay commits from
-        // recovery
+        // Wait for authority 0 to catch up after second recovery
         let round_before_second_sync = last_round_committed_blocks[stopped_index];
         last_committed_index[stopped_index] = 0;
         let start_time = Instant::now();
@@ -1248,6 +1219,12 @@ mod tests {
                         }
 
                         let commit_index = committed_subdag.commit_ref.index;
+                        let commit_digest = committed_subdag.commit_ref.digest;
+                        let leader = committed_subdag.leader;
+
+                        // Track this commit
+                        authority_commits[index].insert(commit_index, (commit_digest, leader));
+
                         // Only update if this is a new commit (handles replay during recovery)
                         if commit_index > last_committed_index[index] {
                             last_committed_index[index] = commit_index;
@@ -1258,65 +1235,78 @@ mod tests {
                     }
                 }
             }
-            // Check if authority 0 has caught up (or made progress)
+
             let max_round = *last_round_committed_blocks.iter().max().unwrap_or(&0);
             let made_progress =
                 last_round_committed_blocks[stopped_index] > round_before_second_sync;
             let is_close =
-                last_round_committed_blocks[stopped_index] + catch_up_threshold >= max_round;
+                last_round_committed_blocks[stopped_index] + CATCH_UP_THRESHOLD >= max_round;
 
-            if made_progress {
-                tracing::info!(
-                    "Authority {} made progress after second sync: round {} (was {}) vs max {}",
-                    stopped_index,
-                    last_round_committed_blocks[stopped_index],
-                    round_before_second_sync,
-                    max_round
-                );
-                if is_close {
-                    tracing::info!(
-                        "Authority {} is close enough to max, breaking early",
-                        stopped_index
-                    );
-                    break;
-                }
+            if made_progress && is_close {
+                break;
             }
         }
 
-        // Stop all authorities
-        tracing::info!("Stopping all authorities...");
         for authority in authorities {
             authority.stop().await;
         }
 
-        tracing::info!(
-            "Test complete. Check logs for [fast_commit_sync] and [commit_sync] messages."
-        );
-
-        // Verify authority 0 created blocks after second fast sync
-        tracing::info!(
-            "After second recovery - Last committed block rounds per authority: {:?}",
-            last_round_committed_blocks
-        );
+        // Verify authority 0 made progress and caught up after second recovery
         assert!(
             last_round_committed_blocks[stopped_index] > round_before_second_sync,
-            "Authority {} should have created new blocks after second fast sync. Round before: {}, after: {}",
-            stopped_index,
-            round_before_second_sync,
-            last_round_committed_blocks[stopped_index]
+            "Authority should have created new blocks after second fast sync"
         );
-
-        // Verify authority 0's last committed block round is reasonably close to other
-        // authorities (within 200 rounds to allow for slower catch-up on second
-        // restart)
-        let second_recovery_threshold = 200;
         let max_round = *last_round_committed_blocks.iter().max().unwrap();
         assert!(
-            last_round_committed_blocks[stopped_index] + second_recovery_threshold >= max_round,
-            "Authority {} should be caught up after second fast sync. Its last round {} is too far behind max round {}",
-            stopped_index,
-            last_round_committed_blocks[stopped_index],
-            max_round
+            last_round_committed_blocks[stopped_index] + SECOND_RECOVERY_THRESHOLD >= max_round,
+            "Authority should be caught up after second fast sync"
+        );
+
+        // Verify commit sequence consistency across all authorities
+        let overall_min = authority_commits
+            .iter()
+            .filter_map(|commits| commits.keys().min())
+            .min()
+            .copied()
+            .unwrap_or(0);
+        let overall_max = authority_commits
+            .iter()
+            .filter_map(|commits| commits.keys().max())
+            .max()
+            .copied()
+            .unwrap_or(0);
+
+        let mut mismatches = Vec::new();
+        for commit_idx in overall_min..=overall_max {
+            let mut commit_data: Vec<(usize, CommitDigest, BlockRef)> = Vec::new();
+            for (auth_idx, commits) in authority_commits.iter().enumerate() {
+                if let Some((digest, leader)) = commits.get(&commit_idx) {
+                    commit_data.push((auth_idx, *digest, *leader));
+                }
+            }
+
+            if commit_data.len() >= 2 {
+                let (first_auth, first_digest, first_leader) = commit_data[0];
+                for &(auth_idx, digest, leader) in &commit_data[1..] {
+                    if digest != first_digest {
+                        mismatches.push(format!(
+                            "Commit {commit_idx} digest mismatch: authority {first_auth} vs {auth_idx}"
+                        ));
+                    }
+                    if leader != first_leader {
+                        mismatches.push(format!(
+                            "Commit {commit_idx} leader mismatch: authority {first_auth} vs {auth_idx}"
+                        ));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            mismatches.is_empty(),
+            "Commit sequence divergence detected - {} mismatches found. \
+            This indicates the fast sync authority has a different leader schedule than other authorities.",
+            mismatches.len()
         );
     }
 }

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -1014,10 +1014,12 @@ mod tests {
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);
 
-        const NUM_AUTHORITIES: usize = 4;
+        const NUM_AUTHORITIES: usize = 7;
         const COMMIT_GAP_THRESHOLD: u32 = 50;
         const CATCH_UP_THRESHOLD: u32 = 50;
         const SECOND_RECOVERY_THRESHOLD: u32 = 200;
+
+        let stable_work_duration_time = Duration::from_secs(30);
 
         let (committee, keypairs) = local_committee_and_keys(0, vec![1; NUM_AUTHORITIES]);
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
@@ -1070,7 +1072,7 @@ mod tests {
         // Drain receivers during initial operation to track commits
         let start_time = Instant::now();
         let mut initial_committed_index = vec![0u32; NUM_AUTHORITIES];
-        while start_time.elapsed() < Duration::from_secs(10) {
+        while start_time.elapsed() < stable_work_duration_time {
             for (index, receiver) in output_receivers.iter_mut().enumerate() {
                 while let Ok(committed_subdag) = receiver.try_recv() {
                     let commit_index = committed_subdag.commit_ref.index;
@@ -1094,7 +1096,7 @@ mod tests {
         // Drain other authorities while authority 0 is stopped
         let start_time = Instant::now();
         let mut commits_while_stopped = vec![0u32; NUM_AUTHORITIES];
-        while start_time.elapsed() < Duration::from_secs(10) {
+        while start_time.elapsed() < stable_work_duration_time {
             for (index, receiver) in output_receivers.iter_mut().enumerate() {
                 if index == stopped_index {
                     continue; // Skip stopped authority
@@ -1207,7 +1209,7 @@ mod tests {
         // Drain receivers during normal operation after first recovery
         let start_time = Instant::now();
         let mut commits_after_first_recovery = vec![0u32; NUM_AUTHORITIES];
-        while start_time.elapsed() < Duration::from_secs(10) {
+        while start_time.elapsed() < stable_work_duration_time {
             for (index, receiver) in output_receivers.iter_mut().enumerate() {
                 while let Ok(committed_subdag) = receiver.try_recv() {
                     let commit_index = committed_subdag.commit_ref.index;
@@ -1230,7 +1232,7 @@ mod tests {
         // Drain other authorities while authority 0 is stopped (second time)
         let start_time = Instant::now();
         let mut commits_while_stopped_2 = vec![0u32; NUM_AUTHORITIES];
-        while start_time.elapsed() < Duration::from_secs(10) {
+        while start_time.elapsed() < stable_work_duration_time {
             for (index, receiver) in output_receivers.iter_mut().enumerate() {
                 if index == stopped_index {
                     continue;

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -17,9 +17,7 @@ use crate::{
     block_manager::BlockManager,
     block_verifier::SignedBlockVerifier,
     commit_observer::CommitObserver,
-    commit_syncer::{
-        CommitSyncerHandle, fast::FastCommitSyncer, regular::RegularCommitSyncer,
-    },
+    commit_syncer::{CommitSyncerHandle, fast::FastCommitSyncer, regular::RegularCommitSyncer},
     commit_vote_monitor::CommitVoteMonitor,
     context::{Clock, Context},
     cordial_knowledge::{CordialKnowledge, CordialKnowledgeHandle},
@@ -1100,7 +1098,8 @@ mod tests {
         authorities.insert(stopped_index, authority);
 
         // First recovery: Let authority 0 catch up and create blocks
-        // Wait until authority 0 is within 50 rounds of other authorities (or timeout after 120s)
+        // Wait until authority 0 is within 50 rounds of other authorities (or timeout
+        // after 120s)
         tracing::info!("=== First recovery: waiting for authority 0 to catch up ===");
         let mut last_committed_index = [0; NUM_AUTHORITIES];
         let mut last_round_committed_blocks = [0; NUM_AUTHORITIES];
@@ -1121,10 +1120,8 @@ mod tests {
                         for block_ref in &committed_subdag.base.committed_header_refs {
                             if block_ref.round > GENESIS_ROUND {
                                 let author_index = block_ref.author;
-                                last_round_committed_blocks[author_index] = max(
-                                    last_round_committed_blocks[author_index],
-                                    block_ref.round,
-                                );
+                                last_round_committed_blocks[author_index] =
+                                    max(last_round_committed_blocks[author_index], block_ref.round);
                             }
                         }
 
@@ -1173,13 +1170,19 @@ mod tests {
             max_round_first
         );
 
-        // Let the validator operate for a while to ensure sufficient data is written to storage.
-        // This helps ensure proper initialization on the next restart.
-        tracing::info!("Letting authority {} operate for 10 seconds before second crash...", stopped_index);
+        // Let the validator operate for a while to ensure sufficient data is written to
+        // storage. This helps ensure proper initialization on the next restart.
+        tracing::info!(
+            "Letting authority {} operate for 10 seconds before second crash...",
+            stopped_index
+        );
         sleep(Duration::from_secs(10)).await;
 
         // === Second crash: Stop authority 0 again ===
-        tracing::info!("=== Second crash: Stopping authority {} again ===", stopped_index);
+        tracing::info!(
+            "=== Second crash: Stopping authority {} again ===",
+            stopped_index
+        );
         authorities.remove(stopped_index).stop().await;
 
         // Wait to widen gap again
@@ -1217,9 +1220,11 @@ mod tests {
         authorities.insert(stopped_index, authority);
 
         // Second recovery: Let authority 0 catch up again
-        // Wait until authority 0 is within 50 rounds of other authorities (or timeout after 120s)
+        // Wait until authority 0 is within 50 rounds of other authorities (or timeout
+        // after 120s)
         tracing::info!("=== Second recovery: waiting for authority 0 to catch up again ===");
-        // Reset tracking for the stopped authority since it will replay commits from recovery
+        // Reset tracking for the stopped authority since it will replay commits from
+        // recovery
         let round_before_second_sync = last_round_committed_blocks[stopped_index];
         last_committed_index[stopped_index] = 0;
         let start_time = Instant::now();
@@ -1237,10 +1242,8 @@ mod tests {
                         for block_ref in &committed_subdag.base.committed_header_refs {
                             if block_ref.round > GENESIS_ROUND {
                                 let author_index = block_ref.author;
-                                last_round_committed_blocks[author_index] = max(
-                                    last_round_committed_blocks[author_index],
-                                    block_ref.round,
-                                );
+                                last_round_committed_blocks[author_index] =
+                                    max(last_round_committed_blocks[author_index], block_ref.round);
                             }
                         }
 
@@ -1257,8 +1260,10 @@ mod tests {
             }
             // Check if authority 0 has caught up (or made progress)
             let max_round = *last_round_committed_blocks.iter().max().unwrap_or(&0);
-            let made_progress = last_round_committed_blocks[stopped_index] > round_before_second_sync;
-            let is_close = last_round_committed_blocks[stopped_index] + catch_up_threshold >= max_round;
+            let made_progress =
+                last_round_committed_blocks[stopped_index] > round_before_second_sync;
+            let is_close =
+                last_round_committed_blocks[stopped_index] + catch_up_threshold >= max_round;
 
             if made_progress {
                 tracing::info!(
@@ -1269,7 +1274,10 @@ mod tests {
                     max_round
                 );
                 if is_close {
-                    tracing::info!("Authority {} is close enough to max, breaking early", stopped_index);
+                    tracing::info!(
+                        "Authority {} is close enough to max, breaking early",
+                        stopped_index
+                    );
                     break;
                 }
             }
@@ -1298,8 +1306,9 @@ mod tests {
             last_round_committed_blocks[stopped_index]
         );
 
-        // Verify authority 0's last committed block round is reasonably close to other authorities
-        // (within 200 rounds to allow for slower catch-up on second restart)
+        // Verify authority 0's last committed block round is reasonably close to other
+        // authorities (within 200 rounds to allow for slower catch-up on second
+        // restart)
         let second_recovery_threshold = 200;
         let max_round = *last_round_committed_blocks.iter().max().unwrap();
         assert!(

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -1005,9 +1005,10 @@ mod tests {
         (authority, receiver, consensus_consumer_monitor)
     }
 
-    /// Test that FastCommitSyncer does not cause consensus divergence after restart.
-    /// Verifies that all authorities agree on the same commit sequence (digest and leader)
-    /// even when one authority uses fast sync to catch up after crashes.
+    /// Test that FastCommitSyncer does not cause consensus divergence after
+    /// restart. Verifies that all authorities agree on the same commit
+    /// sequence (digest and leader) even when one authority uses fast sync
+    /// to catch up after crashes.
     #[tokio::test(flavor = "current_thread")]
     async fn test_fast_commit_syncer_on_restart() {
         telemetry_subscribers::init_for_testing();
@@ -1035,8 +1036,11 @@ mod tests {
         let mut output_receivers = Vec::with_capacity(NUM_AUTHORITIES);
 
         use std::collections::HashMap;
-        use crate::commit::{CommitDigest, CommitIndex};
-        use crate::block_header::BlockRef;
+
+        use crate::{
+            block_header::BlockRef,
+            commit::{CommitDigest, CommitIndex},
+        };
         let mut authority_commits: Vec<HashMap<CommitIndex, (CommitDigest, BlockRef)>> =
             vec![HashMap::new(); NUM_AUTHORITIES];
 
@@ -1071,7 +1075,7 @@ mod tests {
 
         // Drain receivers during initial operation to track commits
         let start_time = Instant::now();
-        let mut initial_committed_index = vec![0u32; NUM_AUTHORITIES];
+        let mut initial_committed_index = [0u32; NUM_AUTHORITIES];
         while start_time.elapsed() < stable_work_duration_time {
             for (index, receiver) in output_receivers.iter_mut().enumerate() {
                 while let Ok(committed_subdag) = receiver.try_recv() {
@@ -1084,18 +1088,14 @@ mod tests {
             }
             sleep(Duration::from_millis(50)).await;
         }
-        eprintln!("\n=== INITIAL OPERATION (10s) ===");
-        eprintln!("initial_committed_index (all authorities): {:?}", initial_committed_index);
 
         // First crash: stop authority 0
         let stopped_index: usize = 0;
-        eprintln!("\n=== PHASE 1: FIRST CRASH ===");
-        eprintln!("Authority 0 highest_handled_commit before stop: {}", consumer_monitors[stopped_index].highest_handled_commit());
         authorities.remove(stopped_index).stop().await;
 
         // Drain other authorities while authority 0 is stopped
         let start_time = Instant::now();
-        let mut commits_while_stopped = vec![0u32; NUM_AUTHORITIES];
+        let mut commits_while_stopped = [0u32; NUM_AUTHORITIES];
         while start_time.elapsed() < stable_work_duration_time {
             for (index, receiver) in output_receivers.iter_mut().enumerate() {
                 if index == stopped_index {
@@ -1111,13 +1111,10 @@ mod tests {
             }
             sleep(Duration::from_millis(50)).await;
         }
-        eprintln!("\n=== WHILE AUTH 0 STOPPED (10s) ===");
-        eprintln!("commits_while_stopped (other authorities): {:?}", commits_while_stopped);
 
         // First recovery: restart authority 0
-        let last_processed_before_restart = consumer_monitors[stopped_index].highest_handled_commit();
-        eprintln!("\n=== PHASE 2: FIRST RECOVERY ===");
-        eprintln!("last_processed_before_restart: {}", last_processed_before_restart);
+        let last_processed_before_restart =
+            consumer_monitors[stopped_index].highest_handled_commit();
         let parameters = Parameters {
             db_path: temp_dirs[stopped_index].path().to_path_buf(),
             dag_state_cached_rounds: 5,
@@ -1145,8 +1142,8 @@ mod tests {
         authorities.insert(stopped_index, authority);
 
         // Wait for authority 0 to catch up after first recovery
-        let mut last_committed_index = vec![0; NUM_AUTHORITIES];
-        let mut last_round_committed_blocks = vec![0; NUM_AUTHORITIES];
+        let mut last_committed_index = [0; NUM_AUTHORITIES];
+        let mut last_round_committed_blocks = [0; NUM_AUTHORITIES];
         let start_time = Instant::now();
         let max_wait = Duration::from_secs(120);
         loop {
@@ -1193,10 +1190,6 @@ mod tests {
         }
 
         let max_round_first = *last_round_committed_blocks.iter().max().unwrap();
-        eprintln!("\n=== AFTER FIRST RECOVERY CAUGHT UP ===");
-        eprintln!("last_committed_index (all authorities): {:?}", last_committed_index);
-        eprintln!("last_round_committed_blocks (all authorities): {:?}", last_round_committed_blocks);
-        eprintln!("max_round_first: {}", max_round_first);
         assert!(
             last_round_committed_blocks[stopped_index] > 0,
             "Authority should have created blocks after first fast sync"
@@ -1208,7 +1201,7 @@ mod tests {
 
         // Drain receivers during normal operation after first recovery
         let start_time = Instant::now();
-        let mut commits_after_first_recovery = vec![0u32; NUM_AUTHORITIES];
+        let mut commits_after_first_recovery = [0u32; NUM_AUTHORITIES];
         while start_time.elapsed() < stable_work_duration_time {
             for (index, receiver) in output_receivers.iter_mut().enumerate() {
                 while let Ok(committed_subdag) = receiver.try_recv() {
@@ -1221,17 +1214,13 @@ mod tests {
             }
             sleep(Duration::from_millis(50)).await;
         }
-        eprintln!("\n=== NORMAL OPERATION AFTER FIRST RECOVERY (10s) ===");
-        eprintln!("commits_after_first_recovery (all authorities): {:?}", commits_after_first_recovery);
 
         // Second crash: stop authority 0 again
-        eprintln!("\n=== PHASE 3: SECOND CRASH ===");
-        eprintln!("Authority 0 highest_handled_commit before second stop: {}", consumer_monitors[stopped_index].highest_handled_commit());
         authorities.remove(stopped_index).stop().await;
 
         // Drain other authorities while authority 0 is stopped (second time)
         let start_time = Instant::now();
-        let mut commits_while_stopped_2 = vec![0u32; NUM_AUTHORITIES];
+        let mut commits_while_stopped_2 = [0u32; NUM_AUTHORITIES];
         while start_time.elapsed() < stable_work_duration_time {
             for (index, receiver) in output_receivers.iter_mut().enumerate() {
                 if index == stopped_index {
@@ -1247,13 +1236,10 @@ mod tests {
             }
             sleep(Duration::from_millis(50)).await;
         }
-        eprintln!("\n=== WHILE AUTH 0 STOPPED SECOND TIME (10s) ===");
-        eprintln!("commits_while_stopped_2 (other authorities): {:?}", commits_while_stopped_2);
 
         // Second recovery: restart authority 0 again
-        let last_processed_before_second_restart = consumer_monitors[stopped_index].highest_handled_commit();
-        eprintln!("\n=== PHASE 4: SECOND RECOVERY ===");
-        eprintln!("last_processed_before_second_restart: {}", last_processed_before_second_restart);
+        let last_processed_before_second_restart =
+            consumer_monitors[stopped_index].highest_handled_commit();
 
         let parameters = Parameters {
             db_path: temp_dirs[stopped_index].path().to_path_buf(),
@@ -1337,18 +1323,12 @@ mod tests {
             authority.stop().await;
         }
 
-        eprintln!("\n=== FINAL STATE AFTER SECOND RECOVERY ===");
-        eprintln!("last_committed_index (all authorities): {:?}", last_committed_index);
-        eprintln!("last_round_committed_blocks (all authorities): {:?}", last_round_committed_blocks);
-        eprintln!("round_before_second_sync: {}", round_before_second_sync);
-
         // Verify authority 0 made progress and caught up after second recovery
         assert!(
             last_round_committed_blocks[stopped_index] > round_before_second_sync,
             "Authority should have created new blocks after second fast sync"
         );
         let max_round = *last_round_committed_blocks.iter().max().unwrap();
-        eprintln!("max_round (final): {}", max_round);
         assert!(
             last_round_committed_blocks[stopped_index] + SECOND_RECOVERY_THRESHOLD >= max_round,
             "Authority should be caught up after second fast sync"

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -2013,7 +2013,15 @@ mod tests {
 
         async fn add_subdags_from_fast_sync(
             &self,
+            _commits: Vec<crate::commit::TrustedCommit>,
             _subdags: Vec<crate::commit::CommittedSubDag>,
+        ) -> Result<(), CoreError> {
+            unimplemented!()
+        }
+
+        async fn reinitialize_components(
+            &self,
+            _block_headers: Vec<crate::block_header::VerifiedBlockHeader>,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/block_manager/block_suspender.rs
+++ b/crates/starfish/core/src/block_manager/block_suspender.rs
@@ -64,6 +64,15 @@ impl BlockSuspender {
             headers_to_fetch: BTreeMap::new(),
         }
     }
+
+    /// Reinitialize BlockSuspender after fast sync completes.
+    /// Clears all suspended blocks, missing ancestors, and fetch queues.
+    pub(crate) fn reinitialize(&mut self) {
+        self.suspended_headers.clear();
+        self.missing_ancestors.clear();
+        self.headers_to_fetch.clear();
+    }
+
     /// Accept or suspend a batch of received block headers based on their
     /// missing ancestors.
     ///

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -63,6 +63,14 @@ impl BlockManager {
         }
     }
 
+    /// Reinitialize BlockManager after fast sync completes.
+    /// Clears suspended blocks and resets the block suspender.
+    pub(crate) fn reinitialize(&mut self) {
+        self.suspended_blocks.clear();
+        self.block_suspender.reinitialize();
+        self.received_block_rounds = vec![None; self.context.committee.size()];
+    }
+
     /// Does all the same things as try_accept_block_headers and additionally
     /// saves blocks with transaction data into recent_blocks in DagState
     #[tracing::instrument(skip_all)]

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -197,7 +197,8 @@ impl CommitAPI for CommitV1 {
     }
 
     fn reputation_scores(&self) -> &[(AuthorityIndex, u64)] {
-        &[] // CommitV1 doesn't have reputation scores
+        // CommitV1 does not have reputation scores
+        &[]
     }
 }
 
@@ -604,6 +605,7 @@ impl CommittedSubDag {
     }
 
     /// Returns the leader round of the sub-dag.
+    #[allow(dead_code)]
     pub(crate) fn leader_round(&self) -> Round {
         self.base.leader.round
     }

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -747,25 +747,34 @@ pub fn load_pending_subdag_from_store(
     commit: TrustedCommit,
     reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
 ) -> PendingSubDag {
+    try_load_pending_subdag_from_store(store, commit, reputation_scores_desc)
+        .expect("We should have all block headers referenced in the commit data")
+}
+
+/// Attempts to recover the full CommittedSubDag from block store.
+/// Returns None if any required block headers are missing.
+/// This is useful during recovery when some headers may not be available
+/// (e.g., after fast sync when headers for older commits weren't fetched).
+pub fn try_load_pending_subdag_from_store(
+    store: &dyn Store,
+    commit: TrustedCommit,
+    reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
+) -> Option<PendingSubDag> {
     let mut leader_block_idx = None;
     let commit_block_headers = store
         .read_verified_block_headers(commit.block_headers())
-        .expect("We should have the block referenced in the commit data");
-    let block_headers = commit_block_headers
-        .into_iter()
-        .enumerate()
-        .map(|(idx, commit_block_opt)| {
-            let commit_block =
-                commit_block_opt.expect("We should have the block referenced in the commit data");
-            if commit_block.reference() == commit.leader() {
-                leader_block_idx = Some(idx);
-            }
-            commit_block
-        })
-        .collect::<Vec<_>>();
-    let leader_block_idx = leader_block_idx.expect("Leader block must be in the sub-dag");
+        .expect("Reading block headers should not fail");
+    let mut block_headers = Vec::with_capacity(commit_block_headers.len());
+    for (idx, commit_block_opt) in commit_block_headers.into_iter().enumerate() {
+        let commit_block = commit_block_opt?; // Return None if any header is missing
+        if commit_block.reference() == commit.leader() {
+            leader_block_idx = Some(idx);
+        }
+        block_headers.push(commit_block);
+    }
+    let leader_block_idx = leader_block_idx?; // Return None if leader not found
     let leader_block_ref = block_headers[leader_block_idx].reference();
-    PendingSubDag::new(
+    Some(PendingSubDag::new(
         leader_block_ref,
         block_headers,
         commit.block_headers().to_vec(),
@@ -773,7 +782,7 @@ pub fn load_pending_subdag_from_store(
         commit.timestamp_ms(),
         commit.reference(),
         reputation_scores_desc,
-    )
+    ))
 }
 
 fn format_transaction_ref_digests(transaction_refs: &[GenericTransactionRef]) -> String {

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -604,12 +604,6 @@ impl CommittedSubDag {
         }
     }
 
-    /// Returns the leader round of the sub-dag.
-    #[allow(dead_code)]
-    pub(crate) fn leader_round(&self) -> Round {
-        self.base.leader.round
-    }
-
     /// Helper method to format transaction refs in a consistent way
     fn format_transaction_refs(&self) -> String {
         format_transaction_ref_digests(

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -752,18 +752,20 @@ pub fn load_pending_subdag_from_store(
     let mut leader_block_idx = None;
     let commit_block_headers = store
         .read_verified_block_headers(commit.block_headers())
-        .expect("Reading block headers should not fail");
-    let mut block_headers = Vec::with_capacity(commit_block_headers.len());
-    for (idx, commit_block_opt) in commit_block_headers.into_iter().enumerate() {
-        let commit_block = commit_block_opt
-            .expect("We should have all block headers referenced in the commit data");
-        if commit_block.reference() == commit.leader() {
-            leader_block_idx = Some(idx);
-        }
-        block_headers.push(commit_block);
-    }
-    let leader_block_idx = leader_block_idx
-        .expect("Leader block should be found in commit headers");
+        .expect("We should have the block referenced in the commit data");
+    let block_headers = commit_block_headers
+        .into_iter()
+        .enumerate()
+        .map(|(idx, commit_block_opt)| {
+            let commit_block =
+                commit_block_opt.expect("We should have the block referenced in the commit data");
+            if commit_block.reference() == commit.leader() {
+                leader_block_idx = Some(idx);
+            }
+            commit_block
+        })
+        .collect::<Vec<_>>();
+    let leader_block_idx = leader_block_idx.expect("Leader block must be in the sub-dag");
     let leader_block_ref = block_headers[leader_block_idx].reference();
     PendingSubDag::new(
         leader_block_ref,

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -749,34 +749,23 @@ pub fn load_pending_subdag_from_store(
     commit: TrustedCommit,
     reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
 ) -> PendingSubDag {
-    try_load_pending_subdag_from_store(store, commit, reputation_scores_desc)
-        .expect("We should have all block headers referenced in the commit data")
-}
-
-/// Attempts to recover the full CommittedSubDag from block store.
-/// Returns None if any required block headers are missing.
-/// This is useful during recovery when some headers may not be available
-/// (e.g., after fast sync when headers for older commits weren't fetched).
-pub fn try_load_pending_subdag_from_store(
-    store: &dyn Store,
-    commit: TrustedCommit,
-    reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
-) -> Option<PendingSubDag> {
     let mut leader_block_idx = None;
     let commit_block_headers = store
         .read_verified_block_headers(commit.block_headers())
         .expect("Reading block headers should not fail");
     let mut block_headers = Vec::with_capacity(commit_block_headers.len());
     for (idx, commit_block_opt) in commit_block_headers.into_iter().enumerate() {
-        let commit_block = commit_block_opt?; // Return None if any header is missing
+        let commit_block = commit_block_opt
+            .expect("We should have all block headers referenced in the commit data");
         if commit_block.reference() == commit.leader() {
             leader_block_idx = Some(idx);
         }
         block_headers.push(commit_block);
     }
-    let leader_block_idx = leader_block_idx?; // Return None if leader not found
+    let leader_block_idx = leader_block_idx
+        .expect("Leader block should be found in commit headers");
     let leader_block_ref = block_headers[leader_block_idx].reference();
-    Some(PendingSubDag::new(
+    PendingSubDag::new(
         leader_block_ref,
         block_headers,
         commit.block_headers().to_vec(),
@@ -784,7 +773,7 @@ pub fn try_load_pending_subdag_from_store(
         commit.timestamp_ms(),
         commit.reference(),
         reputation_scores_desc,
-    ))
+    )
 }
 
 fn format_transaction_ref_digests(transaction_refs: &[GenericTransactionRef]) -> String {

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -212,8 +212,7 @@ impl CommitObserver {
                     .round;
                 self.linearizer
                     .evict_linearizer(max_solid_commit_leader_round);
-                self.dag_state
-                    .write()
+                dag_state_guard
                     .update_last_solid_commit_leader_round(max_solid_commit_leader_round);
             }
             dag_state_guard.flush();

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -17,7 +17,10 @@ use tracing::{debug, info, instrument, warn};
 use crate::{
     CommitConsumer, CommittedSubDag,
     block_header::{BlockHeaderAPI, VerifiedBlockHeader},
-    commit::{CommitAPI, CommitIndex, PendingSubDag, load_pending_subdag_from_store},
+    commit::{
+        CommitAPI, CommitIndex, PendingSubDag, load_pending_subdag_from_store,
+        try_load_pending_subdag_from_store,
+    },
     commit_solidifier::CommitSolidifier,
     context::Context,
     dag_state::DagState,
@@ -165,6 +168,19 @@ impl CommitObserver {
             .commit_solidifier
             .try_get_solid_sub_dags(&pending_sub_dags);
 
+        // Update last_solid_commit_leader_round BEFORE flush so that eviction
+        // uses the correct GC round. This must happen after try_get_solid_sub_dags.
+        if !solid_sub_dags.is_empty() {
+            let max_solid_commit_leader_round = solid_sub_dags
+                .last()
+                .expect("There should be at least one solid subdag")
+                .leader
+                .round;
+            self.dag_state
+                .write()
+                .update_last_solid_commit_leader_round(max_solid_commit_leader_round);
+        }
+
         // Committed headers and sequenced transactions must be persisted to storage
         // before sending them outside consensus.
         if !pending_sub_dags.is_empty() || !solid_sub_dags.is_empty() {
@@ -234,7 +250,7 @@ impl CommitObserver {
         }
         self.report_metrics(pending_sub_dags, &committed_subdags, source);
 
-        // Evict the ack tracker using the information from the latest solid subdag
+        // Evict the ack tracker and update GC round using the latest solid subdag
         if !committed_subdags.is_empty() {
             let max_solid_commit_leader_round = committed_subdags
                 .last()
@@ -243,6 +259,10 @@ impl CommitObserver {
                 .round;
             self.linearizer
                 .evict_linearizer(max_solid_commit_leader_round);
+            // Update dag_state for GC to work correctly (covers both normal and fast sync paths)
+            self.dag_state
+                .write()
+                .update_last_solid_commit_leader_round(max_solid_commit_leader_round);
         }
         tracing::trace!("Committed & sent {sent_sub_dags:#?}");
 
@@ -295,14 +315,12 @@ impl CommitObserver {
         let mut next_commit_index_to_recover = recovery_lower_bound;
         let num_recovery_commits = recovery_commits.len();
 
+        let mut first_valid_commit_found = false;
         for (index, commit) in recovery_commits.into_iter().enumerate() {
             let commit_index = commit.index();
             // Commit index must be continuous during recovery.
             assert_eq!(commit_index, next_commit_index_to_recover);
-            if index == 0 {
-                self.commit_solidifier
-                    .set_last_committed_index(commit_index.saturating_sub(1));
-            }
+
             // On recovery leader schedule will be updated with the current scores
             // and the scores will be passed along with the last commit sent to
             // iota so that the current scores are available for submission.
@@ -318,8 +336,28 @@ impl CommitObserver {
 
             info!("Processing commit {} during recovery", commit_index);
 
-            let pending_sub_dag =
-                load_pending_subdag_from_store(self.store.as_ref(), commit, reputation_scores);
+            // Try to load the pending subdag. If headers are missing (e.g., after fast sync
+            // when only recent headers were fetched), skip this commit and continue.
+            // The linearizer state will be incomplete for older commits, but this is
+            // acceptable - fast sync reinitialization will fix it later.
+            let Some(pending_sub_dag) =
+                try_load_pending_subdag_from_store(self.store.as_ref(), commit, reputation_scores)
+            else {
+                warn!(
+                    "Skipping commit {} during recovery: block headers not available. \
+                    This is expected after fast sync when older headers weren't fetched.",
+                    commit_index
+                );
+                next_commit_index_to_recover += 1;
+                continue;
+            };
+
+            // Initialize commit_solidifier on first valid commit we can process
+            if !first_valid_commit_found {
+                self.commit_solidifier
+                    .set_last_committed_index(commit_index.saturating_sub(1));
+                first_valid_commit_found = true;
+            }
 
             // Rebuild traversed headers tracker so recovery can honor the
             // traversed-headers gate when committing transactions.

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -109,9 +109,9 @@ impl CommitObserver {
     }
 
     /// Reinitialize CommitObserver after fast sync completes.
-    /// Resets internal state and recovers the Linearizer's state from stored commits.
-    /// This is similar to recovery but without re-sending commits (they were already
-    /// sent during fast sync).
+    /// Resets internal state and recovers the Linearizer's state from stored
+    /// commits. This is similar to recovery but without re-sending commits
+    /// (they were already sent during fast sync).
     pub(crate) fn reinitialize(&mut self, last_commit_index: CommitIndex) {
         let now = Instant::now();
 
@@ -131,10 +131,10 @@ impl CommitObserver {
         );
     }
 
-    /// Recovers the Linearizer's transaction acknowledgment tracker and traversed headers
-    /// from recent commits stored in the database.
-    /// This is necessary after fast sync because the linearizer state is not rebuilt
-    /// during fast sync (only commits and transactions are stored).
+    /// Recovers the Linearizer's transaction acknowledgment tracker and
+    /// traversed headers from recent commits stored in the database.
+    /// This is necessary after fast sync because the linearizer state is not
+    /// rebuilt during fast sync (only commits and transactions are stored).
     fn recover_linearizer_state(&mut self, last_commit_index: CommitIndex) {
         // Calculate the recovery lower bound similar to recover_and_send_commits.
         // The earliest commit that still might acknowledge not-yet-committed
@@ -157,9 +157,11 @@ impl CommitObserver {
             last_commit_index
         );
 
-        // Recover transaction acknowledgment tracker in the linearizer using all the commits.
+        // Recover transaction acknowledgment tracker in the linearizer using all the
+        // commits.
         for commit in recovery_commits {
-            let pending_sub_dag = load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]);
+            let pending_sub_dag =
+                load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]);
 
             // Rebuild traversed headers tracker so transaction commit checks can succeed.
             self.linearizer

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -198,27 +198,25 @@ impl CommitObserver {
         committed_subdags: Vec<CommittedSubDag>,
         source: CommittedSubDagSource,
     ) -> ConsensusResult<()> {
-        // Evict the ack tracker and update GC round BEFORE flush so that eviction
-        // uses the correct GC round.
-        if !committed_subdags.is_empty() {
-            let max_solid_commit_leader_round = committed_subdags
-                .last()
-                .expect("There should be at least one solid subdag")
-                .leader
-                .round;
-            self.linearizer
-                .evict_linearizer(max_solid_commit_leader_round);
-            // Update dag_state for GC to work correctly (covers both normal and fast sync
-            // paths)
-            self.dag_state
-                .write()
-                .update_last_solid_commit_leader_round(max_solid_commit_leader_round);
-        }
-
         // Committed headers and sequenced transactions must be persisted to storage
         // before sending them outside consensus.
         if !pending_sub_dags.is_empty() || !committed_subdags.is_empty() {
-            self.dag_state.write().flush();
+            let mut dag_state_guard = self.dag_state.write();
+            // Evict the ack tracker and update GC round BEFORE flush so that eviction
+            // uses the correct GC round.
+            if !committed_subdags.is_empty() {
+                let max_solid_commit_leader_round = committed_subdags
+                    .last()
+                    .expect("There should be at least one solid subdag")
+                    .leader
+                    .round;
+                self.linearizer
+                    .evict_linearizer(max_solid_commit_leader_round);
+                self.dag_state
+                    .write()
+                    .update_last_solid_commit_leader_round(max_solid_commit_leader_round);
+            }
+            dag_state_guard.flush();
         }
 
         let mut sent_sub_dags = Vec::with_capacity(committed_subdags.len());

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -17,9 +17,7 @@ use tracing::{debug, info, instrument, warn};
 use crate::{
     CommitConsumer, CommittedSubDag,
     block_header::{BlockHeaderAPI, VerifiedBlockHeader},
-    commit::{
-        CommitAPI, CommitIndex, PendingSubDag, load_pending_subdag_from_store,
-    },
+    commit::{CommitAPI, CommitIndex, PendingSubDag, load_pending_subdag_from_store},
     commit_solidifier::CommitSolidifier,
     context::Context,
     dag_state::DagState,
@@ -112,7 +110,8 @@ impl CommitObserver {
 
     /// Reinitialize the CommitObserver at a new commit index.
     /// Uses the existing `recover_and_send_commits` method which handles:
-    /// - Recovering linearizer state (transaction ack tracker, traversed headers)
+    /// - Recovering linearizer state (transaction ack tracker, traversed
+    ///   headers)
     /// - Only re-sends commits that are > last_commit_index (none in this case)
     pub(crate) fn reinitialize(&mut self, last_commit_index: CommitIndex) {
         let now = Instant::now();
@@ -166,19 +165,6 @@ impl CommitObserver {
         let (solid_sub_dags, missing_transactions) = self
             .commit_solidifier
             .try_get_solid_sub_dags(&pending_sub_dags);
-
-        // Update last_solid_commit_leader_round BEFORE flush so that eviction
-        // uses the correct GC round. This must happen after try_get_solid_sub_dags.
-        if !solid_sub_dags.is_empty() {
-            let max_solid_commit_leader_round = solid_sub_dags
-                .last()
-                .expect("There should be at least one solid subdag")
-                .leader
-                .round;
-            self.dag_state
-                .write()
-                .update_last_solid_commit_leader_round(max_solid_commit_leader_round);
-        }
 
         // Committed headers and sequenced transactions must be persisted to storage
         // before sending them outside consensus.
@@ -258,7 +244,8 @@ impl CommitObserver {
                 .round;
             self.linearizer
                 .evict_linearizer(max_solid_commit_leader_round);
-            // Update dag_state for GC to work correctly (covers both normal and fast sync paths)
+            // Update dag_state for GC to work correctly (covers both normal and fast sync
+            // paths)
             self.dag_state
                 .write()
                 .update_last_solid_commit_leader_round(max_solid_commit_leader_round);
@@ -318,7 +305,10 @@ impl CommitObserver {
             let commit_index = commit.index();
             // Commit index must be continuous during recovery.
             assert_eq!(commit_index, next_commit_index_to_recover);
-
+            if index == 0 {
+                self.commit_solidifier
+                    .set_last_committed_index(commit_index.saturating_sub(1));
+            }
             // On recovery leader schedule will be updated with the current scores
             // and the scores will be passed along with the last commit sent to
             // iota so that the current scores are available for submission.
@@ -334,11 +324,8 @@ impl CommitObserver {
 
             info!("Processing commit {} during recovery", commit_index);
 
-            let pending_sub_dag = load_pending_subdag_from_store(
-                self.store.as_ref(),
-                commit,
-                reputation_scores,
-            );
+            let pending_sub_dag =
+                load_pending_subdag_from_store(self.store.as_ref(), commit, reputation_scores);
 
             // Rebuild traversed headers tracker so recovery can honor the
             // traversed-headers gate when committing transactions.

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -18,8 +18,7 @@ use crate::{
     CommitConsumer, CommittedSubDag,
     block_header::{BlockHeaderAPI, VerifiedBlockHeader},
     commit::{
-        CommitAPI, CommitIndex, PendingSubDag, load_pending_subdag_from_store,
-        try_load_pending_subdag_from_store,
+        CommitAPI, CommitIndex, PendingSubDag, try_load_pending_subdag_from_store,
     },
     commit_solidifier::CommitSolidifier,
     context::Context,

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -177,7 +177,8 @@ impl CommitObserver {
             .get_transaction_ack_authors(missing_transactions);
 
         // Send solid subdags using the common function
-        // (flush will happen inside handle_committed_sub_dags_internal after updating GC round)
+        // (flush will happen inside handle_committed_sub_dags_internal after updating
+        // GC round)
         self.handle_committed_sub_dags_internal(&pending_sub_dags, solid_sub_dags, source)?;
 
         Ok((pending_sub_dags, missing_transaction_acknowledgers))

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -309,6 +309,9 @@ impl CommitObserver {
             let commit_index = commit.index();
             // Commit index must be continuous during recovery.
             assert_eq!(commit_index, next_commit_index_to_recover);
+            // For the first recovery commit, set the solidifier's baseline to just
+            // before this commit. This ensures the solidifier correctly tracks commits
+            // from the recovery start point forward.
             if index == 0 {
                 self.commit_solidifier
                     .set_last_committed_index(commit_index.saturating_sub(1));

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -18,7 +18,7 @@ use crate::{
     CommitConsumer, CommittedSubDag,
     block_header::{BlockHeaderAPI, VerifiedBlockHeader},
     commit::{
-        CommitAPI, CommitIndex, PendingSubDag, try_load_pending_subdag_from_store,
+        CommitAPI, CommitIndex, PendingSubDag, load_pending_subdag_from_store,
     },
     commit_solidifier::CommitSolidifier,
     context::Context,
@@ -314,7 +314,6 @@ impl CommitObserver {
         let mut next_commit_index_to_recover = recovery_lower_bound;
         let num_recovery_commits = recovery_commits.len();
 
-        let mut first_valid_commit_found = false;
         for (index, commit) in recovery_commits.into_iter().enumerate() {
             let commit_index = commit.index();
             // Commit index must be continuous during recovery.
@@ -335,28 +334,11 @@ impl CommitObserver {
 
             info!("Processing commit {} during recovery", commit_index);
 
-            // Try to load the pending subdag. If headers are missing (e.g., after fast sync
-            // when only recent headers were fetched), skip this commit and continue.
-            // The linearizer state will be incomplete for older commits, but this is
-            // acceptable - fast sync reinitialization will fix it later.
-            let Some(pending_sub_dag) =
-                try_load_pending_subdag_from_store(self.store.as_ref(), commit, reputation_scores)
-            else {
-                warn!(
-                    "Skipping commit {} during recovery: block headers not available. \
-                    This is expected after fast sync when older headers weren't fetched.",
-                    commit_index
-                );
-                next_commit_index_to_recover += 1;
-                continue;
-            };
-
-            // Initialize commit_solidifier on first valid commit we can process
-            if !first_valid_commit_found {
-                self.commit_solidifier
-                    .set_last_committed_index(commit_index.saturating_sub(1));
-                first_valid_commit_found = true;
-            }
+            let pending_sub_dag = load_pending_subdag_from_store(
+                self.store.as_ref(),
+                commit,
+                reputation_scores,
+            );
 
             // Rebuild traversed headers tracker so recovery can honor the
             // traversed-headers gate when committing transactions.

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -108,6 +108,76 @@ impl CommitObserver {
         observer
     }
 
+    /// Reinitialize CommitObserver after fast sync completes.
+    /// Resets internal state and recovers the Linearizer's state from stored commits.
+    /// This is similar to recovery but without re-sending commits (they were already
+    /// sent during fast sync).
+    pub(crate) fn reinitialize(&mut self, last_commit_index: CommitIndex) {
+        let now = Instant::now();
+
+        // Clear linearizer state
+        self.linearizer.reinitialize();
+        self.commit_solidifier.reinitialize(last_commit_index);
+        self.last_sent_commit_index = last_commit_index;
+
+        // Recover linearizer state from recent commits.
+        // This is needed to properly track transaction acknowledgments.
+        self.recover_linearizer_state(last_commit_index);
+
+        info!(
+            "CommitObserver reinitialized at commit index {}, took {:?}",
+            last_commit_index,
+            now.elapsed()
+        );
+    }
+
+    /// Recovers the Linearizer's transaction acknowledgment tracker and traversed headers
+    /// from recent commits stored in the database.
+    /// This is necessary after fast sync because the linearizer state is not rebuilt
+    /// during fast sync (only commits and transactions are stored).
+    fn recover_linearizer_state(&mut self, last_commit_index: CommitIndex) {
+        // Calculate the recovery lower bound similar to recover_and_send_commits.
+        // The earliest commit that still might acknowledge not-yet-committed
+        // transactions is: last_commit_index - gc_depth * 2
+        // (once for max linearizer depth and once for max transaction ack depth)
+        let recovery_lower_bound = last_commit_index
+            .saturating_sub(self.context.protocol_config.gc_depth() * 2)
+            .max(1);
+
+        // Retrieve all the commits from the recovery lower bound until the last commit.
+        let recovery_commits = self
+            .store
+            .scan_commits((recovery_lower_bound..=last_commit_index).into())
+            .expect("Scanning commits should not fail");
+
+        info!(
+            "Recovering linearizer state from {} commits (indices {}..={})",
+            recovery_commits.len(),
+            recovery_lower_bound,
+            last_commit_index
+        );
+
+        // Recover transaction acknowledgment tracker in the linearizer using all the commits.
+        for commit in recovery_commits {
+            let pending_sub_dag = load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]);
+
+            // Rebuild traversed headers tracker so transaction commit checks can succeed.
+            self.linearizer
+                .record_traversed_headers(pending_sub_dag.headers.iter());
+
+            // Recover transaction acknowledgments tracker state.
+            for ((round, authority_idx), transaction_acknowledgments) in
+                pending_sub_dag.transaction_acknowledgments().into_iter()
+            {
+                self.linearizer.add_committed_transaction_acks(
+                    round,
+                    authority_idx,
+                    transaction_acknowledgments,
+                );
+            }
+        }
+    }
+
     /// Handles the creation of commits from a set of passed leaders.
     ///
     /// # Returns

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -108,76 +108,26 @@ impl CommitObserver {
         observer
     }
 
-    /// Reinitialize CommitObserver after fast sync completes.
-    /// Resets internal state and recovers the Linearizer's state from stored
-    /// commits. This is similar to recovery but without re-sending commits
-    /// (they were already sent during fast sync).
+    /// Reinitialize the CommitObserver at a new commit index.
+    /// Uses the existing `recover_and_send_commits` method which handles:
+    /// - Recovering linearizer state (transaction ack tracker, traversed headers)
+    /// - Only re-sends commits that are > last_commit_index (none in this case)
     pub(crate) fn reinitialize(&mut self, last_commit_index: CommitIndex) {
         let now = Instant::now();
 
         // Clear linearizer state
         self.linearizer.reinitialize();
-        self.commit_solidifier.reinitialize(last_commit_index);
         self.last_sent_commit_index = last_commit_index;
 
-        // Recover linearizer state from recent commits.
-        // This is needed to properly track transaction acknowledgments.
-        self.recover_linearizer_state(last_commit_index);
+        // Reuse existing recovery logic - it won't resend commits since
+        // they're all <= last_commit_index
+        self.recover_and_send_commits(last_commit_index);
 
         info!(
             "CommitObserver reinitialized at commit index {}, took {:?}",
             last_commit_index,
             now.elapsed()
         );
-    }
-
-    /// Recovers the Linearizer's transaction acknowledgment tracker and
-    /// traversed headers from recent commits stored in the database.
-    /// This is necessary after fast sync because the linearizer state is not
-    /// rebuilt during fast sync (only commits and transactions are stored).
-    fn recover_linearizer_state(&mut self, last_commit_index: CommitIndex) {
-        // Calculate the recovery lower bound similar to recover_and_send_commits.
-        // The earliest commit that still might acknowledge not-yet-committed
-        // transactions is: last_commit_index - gc_depth * 2
-        // (once for max linearizer depth and once for max transaction ack depth)
-        let recovery_lower_bound = last_commit_index
-            .saturating_sub(self.context.protocol_config.gc_depth() * 2)
-            .max(1);
-
-        // Retrieve all the commits from the recovery lower bound until the last commit.
-        let recovery_commits = self
-            .store
-            .scan_commits((recovery_lower_bound..=last_commit_index).into())
-            .expect("Scanning commits should not fail");
-
-        info!(
-            "Recovering linearizer state from {} commits (indices {}..={})",
-            recovery_commits.len(),
-            recovery_lower_bound,
-            last_commit_index
-        );
-
-        // Recover transaction acknowledgment tracker in the linearizer using all the
-        // commits.
-        for commit in recovery_commits {
-            let pending_sub_dag =
-                load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]);
-
-            // Rebuild traversed headers tracker so transaction commit checks can succeed.
-            self.linearizer
-                .record_traversed_headers(pending_sub_dag.headers.iter());
-
-            // Recover transaction acknowledgments tracker state.
-            for ((round, authority_idx), transaction_acknowledgments) in
-                pending_sub_dag.transaction_acknowledgments().into_iter()
-            {
-                self.linearizer.add_committed_transaction_acks(
-                    round,
-                    authority_idx,
-                    transaction_acknowledgments,
-                );
-            }
-        }
     }
 
     /// Handles the creation of commits from a set of passed leaders.

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -166,12 +166,6 @@ impl CommitObserver {
             .commit_solidifier
             .try_get_solid_sub_dags(&pending_sub_dags);
 
-        // Committed headers and sequenced transactions must be persisted to storage
-        // before sending them outside consensus.
-        if !pending_sub_dags.is_empty() || !solid_sub_dags.is_empty() {
-            self.dag_state.write().flush();
-        }
-
         tracing::trace!("Missing committed transactions {missing_transactions:#?}");
 
         // Retrieve the transaction acknowledgment authors for the missing
@@ -183,6 +177,7 @@ impl CommitObserver {
             .get_transaction_ack_authors(missing_transactions);
 
         // Send solid subdags using the common function
+        // (flush will happen inside handle_committed_sub_dags_internal after updating GC round)
         self.handle_committed_sub_dags_internal(&pending_sub_dags, solid_sub_dags, source)?;
 
         Ok((pending_sub_dags, missing_transaction_acknowledgers))
@@ -202,6 +197,29 @@ impl CommitObserver {
         committed_subdags: Vec<CommittedSubDag>,
         source: CommittedSubDagSource,
     ) -> ConsensusResult<()> {
+        // Evict the ack tracker and update GC round BEFORE flush so that eviction
+        // uses the correct GC round.
+        if !committed_subdags.is_empty() {
+            let max_solid_commit_leader_round = committed_subdags
+                .last()
+                .expect("There should be at least one solid subdag")
+                .leader
+                .round;
+            self.linearizer
+                .evict_linearizer(max_solid_commit_leader_round);
+            // Update dag_state for GC to work correctly (covers both normal and fast sync
+            // paths)
+            self.dag_state
+                .write()
+                .update_last_solid_commit_leader_round(max_solid_commit_leader_round);
+        }
+
+        // Committed headers and sequenced transactions must be persisted to storage
+        // before sending them outside consensus.
+        if !pending_sub_dags.is_empty() || !committed_subdags.is_empty() {
+            self.dag_state.write().flush();
+        }
+
         let mut sent_sub_dags = Vec::with_capacity(committed_subdags.len());
         for solid_sub_dag in committed_subdags.iter() {
             // Skip commits that have already been sent
@@ -235,21 +253,6 @@ impl CommitObserver {
         }
         self.report_metrics(pending_sub_dags, &committed_subdags, source);
 
-        // Evict the ack tracker and update GC round using the latest solid subdag
-        if !committed_subdags.is_empty() {
-            let max_solid_commit_leader_round = committed_subdags
-                .last()
-                .expect("There should be at least one solid subdag")
-                .leader
-                .round;
-            self.linearizer
-                .evict_linearizer(max_solid_commit_leader_round);
-            // Update dag_state for GC to work correctly (covers both normal and fast sync
-            // paths)
-            self.dag_state
-                .write()
-                .update_last_solid_commit_leader_round(max_solid_commit_leader_round);
-        }
         tracing::trace!("Committed & sent {sent_sub_dags:#?}");
 
         Ok(())

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -55,14 +55,6 @@ impl CommitSolidifier {
         self.last_solid_committed_index = index;
     }
 
-    /// Reinitialize CommitSolidifier after fast sync completes.
-    /// Clears pending subdags and sets the last solid committed index.
-    #[allow(dead_code)]
-    pub(crate) fn reinitialize(&mut self, last_commit_index: CommitIndex) {
-        self.pending_subdags.clear();
-        self.last_solid_committed_index = last_commit_index;
-    }
-
     /// Gets all missing transactions from pending subdags.
     ///
     /// # Returns

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -135,23 +135,15 @@ impl CommitSolidifier {
             }
         }
 
-        // Update dag state with the round of the leader in the last committed subdag
-        // This will allow to evict transactions from the DAG state
-        // In addition, update with the latest solid_commit_refs which are used for
-        // commit syncer
+        // Update with the latest solid_commit_refs which are used for commit syncer
         if !committed_subdags.is_empty() {
             let solid_commit_refs = committed_subdags
                 .iter()
                 .map(|subdag| subdag.commit_ref)
                 .collect();
-            let mut dag_state = self.dag_state.write();
-            dag_state.update_last_solid_commit_leader_round(
-                committed_subdags
-                    .last()
-                    .expect("We should expect at least one committed subdag")
-                    .leader_round(),
-            );
-            dag_state.update_pending_commit_votes(solid_commit_refs);
+            self.dag_state
+                .write()
+                .update_pending_commit_votes(solid_commit_refs);
         }
 
         // Update last_committed_index

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -57,6 +57,7 @@ impl CommitSolidifier {
 
     /// Reinitialize CommitSolidifier after fast sync completes.
     /// Clears pending subdags and sets the last solid committed index.
+    #[allow(dead_code)]
     pub(crate) fn reinitialize(&mut self, last_commit_index: CommitIndex) {
         self.pending_subdags.clear();
         self.last_solid_committed_index = last_commit_index;

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -55,6 +55,13 @@ impl CommitSolidifier {
         self.last_solid_committed_index = index;
     }
 
+    /// Reinitialize CommitSolidifier after fast sync completes.
+    /// Clears pending subdags and sets the last solid committed index.
+    pub(crate) fn reinitialize(&mut self, last_commit_index: CommitIndex) {
+        self.pending_subdags.clear();
+        self.last_solid_committed_index = last_commit_index;
+    }
+
     /// Gets all missing transactions from pending subdags.
     ///
     /// # Returns

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -22,6 +22,7 @@ use crate::{
     commit::{CommitAPI as _, CommitRange, CommittedSubDag, GENESIS_COMMIT_INDEX, TrustedCommit},
     commit_syncer::{
         CommitSyncType, CommitSyncerHandle, Inner, fetch_loop as shared_fetch_loop,
+        handle_fetch_join_error, requeue_partial_range, schedule_commit_ranges,
         try_start_fetches as shared_try_start_fetches, verify_fetched_headers,
         verify_transactions_with_transactions_refs,
     },
@@ -124,14 +125,15 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 }
                 // Handles results from fetch tasks.
                 Some(result) = self.inflight_fetches.join_next(), if !self.inflight_fetches.is_empty() => {
-                    if let Err(e) = result {
+                    if let Err(ref e) = result {
                         if e.is_panic() {
-                            std::panic::resume_unwind(e.into_panic());
+                            std::panic::resume_unwind(result.unwrap_err().into_panic());
                         }
-                        warn!("[{}] Fetch cancelled. FastCommitSyncer shutting down: {}", self.inner.sync_type.as_str(), e);
-                        // If any fetch is cancelled or panicked, try to shutdown and exit the loop.
-                        self.inflight_fetches.shutdown().await;
-                        return;
+                        if handle_fetch_join_error(e, &self.inner.sync_type) {
+                            // If any fetch is cancelled or panicked, try to shutdown and exit the loop.
+                            self.inflight_fetches.shutdown().await;
+                            return;
+                        }
                     }
                     let (target_end, commits, committed_subdags) = result.unwrap();
                     self.handle_fetch_result(target_end, commits, committed_subdags).await;
@@ -208,7 +210,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         let local_commit_index = self.inner.dag_state.read().last_commit_index();
         let highest_handled_index = self.inner.commit_consumer_monitor.highest_handled_commit();
         let highest_scheduled_index = self.highest_scheduled_index.unwrap_or(0);
-        let unhandled_commits_threshold = self.unhandled_commits_threshold();
+        let unhandled_commits_threshold = self.inner.unhandled_commits_threshold();
         let step = self
             .inner
             .sync_type
@@ -238,11 +240,9 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             let fetch_after_index = self
                 .synced_commit_index
                 .max(self.highest_scheduled_index.unwrap_or(0));
-            // When the node is falling behind, schedule pending fetches which will be
-            // executed on later.
 
             debug!(
-                "[{}] Checking to schedule fetches: synced_commit_index={}, highest_handled_index={}, highest_scheduled_index={}, quorum_commit_index={}, unhandled_commits_threshold={}, fetch_after_index={}, step={}",
+                "[{}] Checking to schedule fetches: synced_commit_index={}, highest_handled_index={}, highest_scheduled_index={}, quorum_commit_index={}, unhandled_commits_threshold={}, fetch_after_index={}",
                 self.inner.sync_type.as_str(),
                 self.synced_commit_index,
                 highest_handled_index,
@@ -250,41 +250,31 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 quorum_commit_index,
                 unhandled_commits_threshold,
                 fetch_after_index,
-                step
             );
 
-            for prev_end in (fetch_after_index..=quorum_commit_index).step_by(step as usize) {
-                // Create range with inclusive start and end.
-                let range_start = prev_end + 1;
-                let range_end = prev_end + step;
-                // Commit range is not fetched when [range_start, range_end] contains less
-                // number of commits than the target batch size. This is to avoid
-                // the cost of processing more and smaller batches. Block broadcast,
-                // subscription and synchronization will help the node catchup.
-                if quorum_commit_index < range_end {
-                    break;
-                }
-                // Pause scheduling new fetches when handling of commits is lagging.
-                if highest_handled_index + unhandled_commits_threshold < range_end {
-                    warn!(
-                        "[{}] Skip scheduling new commit fetches: consensus handler is lagging. highest_handled_index={}, highest_scheduled_index={}",
-                        self.inner.sync_type.as_str(),
-                        highest_handled_index,
-                        highest_scheduled_index
-                    );
-                    break;
-                }
+            // Schedule commit ranges for fetching using shared helper
+            let schedule_result = schedule_commit_ranges(
+                &self.inner,
+                fetch_after_index,
+                quorum_commit_index,
+                highest_handled_index,
+                unhandled_commits_threshold,
+            );
+
+            // Add scheduled ranges to pending fetches
+            for range in schedule_result.ranges_scheduled {
                 debug!(
                     "[{}] Scheduling fetch for commit range {}..={}",
                     self.inner.sync_type.as_str(),
-                    range_start,
-                    range_end
+                    range.start(),
+                    range.end()
                 );
-                self.pending_fetches
-                    .insert((range_start..=range_end).into());
-                // quorum_commit_index should be non-decreasing, so highest_scheduled_index
-                // should not decrease either.
-                self.highest_scheduled_index = Some(range_end);
+                self.pending_fetches.insert(range);
+            }
+
+            // Update highest scheduled index
+            if let Some(new_highest) = schedule_result.new_highest_scheduled {
+                self.highest_scheduled_index = Some(new_highest);
             }
         }
 
@@ -367,10 +357,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             .set(self.highest_fetched_commit_index as i64);
 
         // Allow returning partial results, and try fetching the rest separately.
-        if commit_end < target_end {
-            self.pending_fetches
-                .insert((commit_end + 1..=target_end).into());
-        }
+        requeue_partial_range(&mut self.pending_fetches, commit_end, target_end);
         // Make sure synced_commit_index is up to date.
         self.synced_commit_index = self
             .synced_commit_index
@@ -611,11 +598,6 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         }
 
         Ok((commits, committed_subdags))
-    }
-
-    fn unhandled_commits_threshold(&self) -> CommitIndex {
-        self.inner.context.parameters.commit_sync_batch_size
-            * (self.inner.context.parameters.commit_sync_batches_ahead as u32)
     }
 
     /// Fetches block headers needed for component reinitialization from the

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -114,7 +114,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
     }
     #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %self.inner.context.own_index)))]
     async fn schedule_loop(mut self, mut rx_shutdown: oneshot::Receiver<()>) {
-        let mut interval = tokio::time::interval(Duration::from_secs(2));
+        let mut interval = tokio::time::interval(Duration::from_millis(500));
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {
@@ -207,7 +207,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
 
     fn try_schedule_once(&mut self) {
         let quorum_commit_index = self.inner.commit_vote_monitor.quorum_commit_index();
-        let local_commit_index = self.inner.dag_state.read().last_commit_index();
+        let dag_state_commit_index = self.inner.dag_state.read().last_commit_index();
         let highest_handled_index = self.inner.commit_consumer_monitor.highest_handled_commit();
         let highest_scheduled_index = self.highest_scheduled_index.unwrap_or(0);
         let unhandled_commits_threshold = self.inner.unhandled_commits_threshold();
@@ -217,7 +217,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             .commit_sync_batch_size(&self.inner.context);
 
         // Skip scheduling depending on sync type and gap threshold.
-        let gap = quorum_commit_index.saturating_sub(local_commit_index);
+        let gap = quorum_commit_index.saturating_sub(dag_state_commit_index);
         let should_schedule = self.inner.sync_type.should_schedule(
             gap,
             self.inner.context.parameters.commit_sync_gap_threshold,
@@ -234,10 +234,10 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 .set(quorum_commit_index as i64);
             metrics
                 .commit_sync_local_index
-                .set(local_commit_index as i64);
+                .set(dag_state_commit_index as i64);
             // Update synced_commit_index periodically to make sure it is not smaller than
             // local commit index.
-            self.synced_commit_index = self.synced_commit_index.max(local_commit_index);
+            self.synced_commit_index = self.synced_commit_index.max(dag_state_commit_index);
 
             // TODO: cleanup inflight fetches that are no longer needed.
             let fetch_after_index = self

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -6,7 +6,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-
+use std::cmp::max;
 use iota_metrics::spawn_logged_monitored_task;
 use parking_lot::RwLock;
 use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
@@ -617,7 +617,9 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // Fetch the maximum of the two to satisfy both requirements
         let cached_rounds = inner.context.parameters.dag_state_cached_rounds;
         let gc_depth = inner.context.protocol_config.gc_depth();
-        let num_commits = std::cmp::max(cached_rounds, gc_depth * 2);
+        // TODO: read the leader schedule window from the leader_schedule.rs
+        let leader_schedule_window = crate::leader_schedule::CONSENSUS_COMMITS_PER_SCHEDULE as u32;
+        let num_commits = max(leader_schedule_window, max(cached_rounds, gc_depth * 2));
 
         let max_headers_per_fetch = inner.context.parameters.max_headers_per_commit_sync_fetch;
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -218,11 +218,14 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
 
         // Skip scheduling depending on sync type and gap threshold.
         let gap = quorum_commit_index.saturating_sub(local_commit_index);
-        let should_schedule = self
-            .inner
-            .sync_type
-            .should_schedule(gap, self.inner.context.parameters.commit_sync_gap_threshold)
-            || self.has_fetched_data;
+        let should_schedule = self.inner.sync_type.should_schedule(
+            gap,
+            self.inner.context.parameters.commit_sync_gap_threshold,
+            self.inner
+                .context
+                .protocol_config
+                .consensus_transaction_ref(),
+        ) || self.has_fetched_data;
 
         if should_schedule {
             let metrics = &self.inner.context.metrics.node_metrics;

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    cmp::max,
     collections::{BTreeMap, BTreeSet},
     sync::Arc,
     time::Duration,
 };
-use std::cmp::max;
+
 use iota_metrics::spawn_logged_monitored_task;
 use parking_lot::RwLock;
 use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
@@ -18,7 +19,7 @@ use crate::{
     CommitConsumerMonitor, CommitIndex, VerifiedBlockHeader,
     block_header::VerifiedTransactions,
     block_verifier::BlockVerifier,
-    commit::{CommitAPI as _, CommitRange, CommittedSubDag, TrustedCommit},
+    commit::{CommitAPI as _, CommitRange, CommittedSubDag, GENESIS_COMMIT_INDEX, TrustedCommit},
     commit_syncer::{
         CommitSyncType, CommitSyncerHandle, Inner, fetch_loop as shared_fetch_loop,
         try_start_fetches as shared_try_start_fetches, verify_fetched_headers,
@@ -205,86 +206,86 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
     fn try_schedule_once(&mut self) {
         let quorum_commit_index = self.inner.commit_vote_monitor.quorum_commit_index();
         let local_commit_index = self.inner.dag_state.read().last_commit_index();
-
-        // Skip scheduling depending on sync type and gap threshold.
-        let gap = quorum_commit_index.saturating_sub(local_commit_index);
-        if !self
-            .inner
-            .sync_type
-            .should_schedule(gap, self.inner.context.parameters.commit_sync_gap_threshold)
-        {
-            return;
-        }
-
-        let metrics = &self.inner.context.metrics.node_metrics;
-        metrics
-            .commit_sync_quorum_index
-            .set(quorum_commit_index as i64);
-        metrics
-            .commit_sync_local_index
-            .set(local_commit_index as i64);
         let highest_handled_index = self.inner.commit_consumer_monitor.highest_handled_commit();
         let highest_scheduled_index = self.highest_scheduled_index.unwrap_or(0);
-        // Update synced_commit_index periodically to make sure it is not smaller than
-        // local commit index.
-        self.synced_commit_index = self.synced_commit_index.max(local_commit_index);
         let unhandled_commits_threshold = self.unhandled_commits_threshold();
-
-        // TODO: cleanup inflight fetches that are no longer needed.
-        let fetch_after_index = self
-            .synced_commit_index
-            .max(self.highest_scheduled_index.unwrap_or(0));
-        // When the node is falling behind, schedule pending fetches which will be
-        // executed on later.
         let step = self
             .inner
             .sync_type
             .commit_sync_batch_size(&self.inner.context);
 
-        info!(
-            "[{}] Checking to schedule fetches: synced_commit_index={}, highest_handled_index={}, highest_scheduled_index={}, quorum_commit_index={}, unhandled_commits_threshold={}, fetch_after_index={}, step={}",
-            self.inner.sync_type.as_str(),
-            self.synced_commit_index,
-            highest_handled_index,
-            highest_scheduled_index,
-            quorum_commit_index,
-            unhandled_commits_threshold,
-            fetch_after_index,
-            step
-        );
+        // Skip scheduling depending on sync type and gap threshold.
+        let gap = quorum_commit_index.saturating_sub(local_commit_index);
+        let should_schedule = self
+            .inner
+            .sync_type
+            .should_schedule(gap, self.inner.context.parameters.commit_sync_gap_threshold)
+            || self.has_fetched_data;
 
-        for prev_end in (fetch_after_index..=quorum_commit_index).step_by(step as usize) {
-            // Create range with inclusive start and end.
-            let range_start = prev_end + 1;
-            let range_end = prev_end + step;
-            // Commit range is not fetched when [range_start, range_end] contains less
-            // number of commits than the target batch size. This is to avoid
-            // the cost of processing more and smaller batches. Block broadcast,
-            // subscription and synchronization will help the node catchup.
-            if quorum_commit_index < range_end {
-                break;
-            }
-            // Pause scheduling new fetches when handling of commits is lagging.
-            if highest_handled_index + unhandled_commits_threshold < range_end {
-                warn!(
-                    "[{}] Skip scheduling new commit fetches: consensus handler is lagging. highest_handled_index={}, highest_scheduled_index={}",
-                    self.inner.sync_type.as_str(),
-                    highest_handled_index,
-                    highest_scheduled_index
-                );
-                break;
-            }
+        if should_schedule {
+            let metrics = &self.inner.context.metrics.node_metrics;
+            metrics
+                .commit_sync_quorum_index
+                .set(quorum_commit_index as i64);
+            metrics
+                .commit_sync_local_index
+                .set(local_commit_index as i64);
+            // Update synced_commit_index periodically to make sure it is not smaller than
+            // local commit index.
+            self.synced_commit_index = self.synced_commit_index.max(local_commit_index);
+
+            // TODO: cleanup inflight fetches that are no longer needed.
+            let fetch_after_index = self
+                .synced_commit_index
+                .max(self.highest_scheduled_index.unwrap_or(0));
+            // When the node is falling behind, schedule pending fetches which will be
+            // executed on later.
+
             info!(
-                "[{}] Scheduling fetch for commit range {}..={}",
+                "[{}] Checking to schedule fetches: synced_commit_index={}, highest_handled_index={}, highest_scheduled_index={}, quorum_commit_index={}, unhandled_commits_threshold={}, fetch_after_index={}, step={}",
                 self.inner.sync_type.as_str(),
-                range_start,
-                range_end
+                self.synced_commit_index,
+                highest_handled_index,
+                highest_scheduled_index,
+                quorum_commit_index,
+                unhandled_commits_threshold,
+                fetch_after_index,
+                step
             );
-            self.pending_fetches
-                .insert((range_start..=range_end).into());
-            // quorum_commit_index should be non-decreasing, so highest_scheduled_index
-            // should not decrease either.
-            self.highest_scheduled_index = Some(range_end);
+
+            for prev_end in (fetch_after_index..=quorum_commit_index).step_by(step as usize) {
+                // Create range with inclusive start and end.
+                let range_start = prev_end + 1;
+                let range_end = prev_end + step;
+                // Commit range is not fetched when [range_start, range_end] contains less
+                // number of commits than the target batch size. This is to avoid
+                // the cost of processing more and smaller batches. Block broadcast,
+                // subscription and synchronization will help the node catchup.
+                if quorum_commit_index < range_end {
+                    break;
+                }
+                // Pause scheduling new fetches when handling of commits is lagging.
+                if highest_handled_index + unhandled_commits_threshold < range_end {
+                    warn!(
+                        "[{}] Skip scheduling new commit fetches: consensus handler is lagging. highest_handled_index={}, highest_scheduled_index={}",
+                        self.inner.sync_type.as_str(),
+                        highest_handled_index,
+                        highest_scheduled_index
+                    );
+                    break;
+                }
+                info!(
+                    "[{}] Scheduling fetch for commit range {}..={}",
+                    self.inner.sync_type.as_str(),
+                    range_start,
+                    range_end
+                );
+                self.pending_fetches
+                    .insert((range_start..=range_end).into());
+                // quorum_commit_index should be non-decreasing, so highest_scheduled_index
+                // should not decrease either.
+                self.highest_scheduled_index = Some(range_end);
+            }
         }
 
         // Detect close-to-quorum mode: when remaining gap is less than a full batch.
@@ -301,6 +302,20 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 .synced_commit_index
                 .max(self.highest_scheduled_index.unwrap_or(0));
             let remaining_gap = quorum_commit_index.saturating_sub(current_fetch_after);
+            if remaining_gap > 0 && remaining_gap < step {
+                let range_start = current_fetch_after + 1;
+                let range_end = quorum_commit_index;
+                info!(
+                    "[{}] Scheduling final partial fetch for commit range {}..={} (remaining_gap={})",
+                    self.inner.sync_type.as_str(),
+                    range_start,
+                    range_end,
+                    remaining_gap
+                );
+                self.pending_fetches
+                    .insert((range_start..=range_end).into());
+                self.highest_scheduled_index = Some(range_end);
+            }
             if remaining_gap < step {
                 self.close_to_quorum_mode = true;
                 info!(
@@ -617,9 +632,29 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // Fetch the maximum of the two to satisfy both requirements
         let cached_rounds = inner.context.parameters.dag_state_cached_rounds;
         let gc_depth = inner.context.protocol_config.gc_depth();
-        // TODO: read the leader schedule window from the leader_schedule.rs
         let leader_schedule_window = crate::leader_schedule::CONSENSUS_COMMITS_PER_SCHEDULE as u32;
-        let num_commits = max(leader_schedule_window, max(cached_rounds, gc_depth * 2));
+        let (last_commit_index, last_commit_info_index) = {
+            let dag_state = inner.dag_state.read();
+            let last_commit_index = dag_state.last_commit_index();
+            let last_commit_info_index = dag_state
+                .recover_last_commit_info()
+                .map(|(commit_ref, commit_info)| {
+                    let range_end = commit_info.reputation_scores.commit_range.end();
+                    if range_end == GENESIS_COMMIT_INDEX {
+                        commit_ref.index
+                    } else {
+                        range_end
+                    }
+                })
+                .unwrap_or(GENESIS_COMMIT_INDEX);
+            (last_commit_index, last_commit_info_index)
+        };
+        let commits_since_schedule_update =
+            last_commit_index.saturating_sub(last_commit_info_index);
+        let num_commits = max(
+            commits_since_schedule_update,
+            max(leader_schedule_window, max(cached_rounds, gc_depth * 2)),
+        );
 
         let max_headers_per_fetch = inner.context.parameters.max_headers_per_commit_sync_fetch;
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -161,7 +161,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                     self.inner.sync_type.as_str()
                 );
 
-                match Self::fetch_headers_for_cached_rounds(self.inner.clone()).await {
+                match Self::fetch_headers_for_reinitialization(self.inner.clone()).await {
                     Ok(headers) => {
                         if let Err(e) = self
                             .inner
@@ -761,35 +761,43 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             * (self.inner.context.parameters.commit_sync_batches_ahead as u32)
     }
 
-    /// Fetches block headers for the cached_rounds window from the network.
+    /// Fetches block headers needed for component reinitialization from the network.
     /// This is called when close_to_quorum mode is active and all pending
-    /// fetches complete. Returns verified block headers that will be stored
-    /// and used to reinitialize components.
-    async fn fetch_headers_for_cached_rounds(
+    /// fetches complete. Fetches headers for max(cached_rounds, gc_depth * 2) commits
+    /// to satisfy both DagState cache and linearizer recovery requirements.
+    async fn fetch_headers_for_reinitialization(
         inner: Arc<Inner<C>>,
     ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
+        // We need headers for two purposes:
+        // 1. DagState cache: at least cached_rounds commits back
+        // 2. Linearizer recovery: at least gc_depth * 2 commits back
+        // Fetch the maximum of the two to satisfy both requirements
         let cached_rounds = inner.context.parameters.dag_state_cached_rounds;
+        let gc_depth = inner.context.protocol_config.gc_depth();
+        let num_commits = std::cmp::max(cached_rounds, gc_depth * 2);
+
         let max_headers_per_fetch = inner.context.parameters.max_headers_per_commit_sync_fetch;
 
         // Get block refs from recent commits stored during fast sync
         let block_refs = inner
             .dag_state
             .read()
-            .get_block_refs_for_recent_commits(cached_rounds);
+            .get_block_refs_for_recent_commits(num_commits);
 
         if block_refs.is_empty() {
             info!(
-                "[{}] No block refs to fetch for cached rounds",
+                "[{}] No block refs to fetch for reinitialization",
                 inner.sync_type.as_str()
             );
             return Ok(vec![]);
         }
 
         info!(
-            "[{}] Fetching {} block headers for cached_rounds window ({})",
+            "[{}] Fetching {} block headers for reinitialization (cached_rounds={}, gc_depth*2={})",
             inner.sync_type.as_str(),
             block_refs.len(),
-            cached_rounds
+            cached_rounds,
+            gc_depth * 2
         );
 
         // Shuffle target authorities for load balancing
@@ -882,7 +890,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         }
 
         info!(
-            "[{}] Successfully fetched {} total block headers for cached_rounds",
+            "[{}] Successfully fetched {} total block headers for reinitialization",
             inner.sync_type.as_str(),
             all_headers.len()
         );

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -782,11 +782,13 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         let max_headers_per_fetch = inner.context.parameters.max_headers_per_commit_sync_fetch;
 
         // Get block refs from recent commits stored during fast sync
+        // TODO: The commits might not yet stored, but only fetched and pending processing.
         let block_refs = inner
             .dag_state
             .read()
             .get_block_refs_for_recent_commits(num_commits);
 
+        // TODO: we anyway need to reinitialize even if there are no block refs,
         if block_refs.is_empty() {
             info!(
                 "[{}] No block refs to fetch for reinitialization",

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -11,12 +11,7 @@ use iota_metrics::spawn_logged_monitored_task;
 use parking_lot::RwLock;
 use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
 use starfish_config::AuthorityIndex;
-use tokio::{
-    runtime::Handle,
-    sync::oneshot,
-    task::JoinSet,
-    time::MissedTickBehavior,
-};
+use tokio::{runtime::Handle, sync::oneshot, task::JoinSet, time::MissedTickBehavior};
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -627,7 +622,8 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         let max_headers_per_fetch = inner.context.parameters.max_headers_per_commit_sync_fetch;
 
         // Get block refs from recent commits stored during fast sync
-        // TODO: The commits might not yet stored, but only fetched and pending processing.
+        // TODO: The commits might not yet stored, but only fetched and pending
+        // processing.
         let block_refs = inner
             .dag_state
             .read()

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -7,18 +7,26 @@ use std::{
     time::Duration,
 };
 
+use iota_metrics::spawn_logged_monitored_task;
+use itertools::Itertools as _;
 use parking_lot::RwLock;
+use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
 use starfish_config::AuthorityIndex;
-use tokio::{runtime::Handle, task::JoinSet};
-use tracing::{debug, info};
+use tokio::{
+    runtime::Handle,
+    sync::oneshot,
+    task::JoinSet,
+    time::{MissedTickBehavior, sleep},
+};
+use tracing::{debug, info, warn};
 
 use crate::{
-    CommitConsumerMonitor, CommitIndex,
+    CommitConsumerMonitor, CommitIndex, VerifiedBlockHeader,
     block_header::VerifiedTransactions,
     block_verifier::BlockVerifier,
-    commit::{CommitAPI as _, CommitRange, CommittedSubDag},
+    commit::{CommitAPI as _, CommitRange, CommittedSubDag, TrustedCommit},
     commit_syncer::{
-        CommitSyncType, CommitSyncer, Inner, verify_transactions_with_transactions_refs,
+        CommitSyncType, CommitSyncerHandle, Inner, verify_transactions_with_transactions_refs,
     },
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
@@ -29,20 +37,23 @@ use crate::{
     transaction_ref::{GenericTransactionRef, TransactionRef},
 };
 
+/// Timeout for fetching block headers during close-to-quorum finalization.
+const FETCH_HEADERS_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub(crate) struct FastCommitSyncer<C: NetworkClient> {
     // States shared by scheduler and fetch tasks.
 
-    // Shared components' wrapper.
+    // Shared components wrapper.
     inner: Arc<Inner<C>>,
 
     // States only used by the scheduler.
 
     // Inflight requests to fetch commits from different authorities.
-    inflight_fetches: JoinSet<(u32, Vec<CommittedSubDag>)>,
+    inflight_fetches: JoinSet<(u32, Vec<TrustedCommit>, Vec<CommittedSubDag>)>,
     // Additional ranges of commits to fetch.
     pending_fetches: BTreeSet<CommitRange>,
     // Fetched commits and blocks by commit range.
-    fetched_ranges: BTreeMap<CommitRange, Vec<CommittedSubDag>>,
+    fetched_ranges: BTreeMap<CommitRange, (Vec<TrustedCommit>, Vec<CommittedSubDag>)>,
     // Highest commit index among inflight and pending fetches.
     // Used to determine the start of new ranges to be fetched.
     highest_scheduled_index: Option<CommitIndex>,
@@ -52,6 +63,13 @@ pub(crate) struct FastCommitSyncer<C: NetworkClient> {
     // The commit index that is the max of highest local commit index and commit index inflight to
     // Core. Used to determine if fetched blocks can be sent to Core without gaps.
     synced_commit_index: CommitIndex,
+    // Whether the syncer is in "close to quorum" mode, meaning remaining gap < batch size.
+    // When this is true, the syncer will fetch block headers and transactions for cached rounds
+    // before completing fast sync.
+    close_to_quorum_mode: bool,
+    // Whether the fast syncer has actually fetched any data. Close-to-quorum mode only
+    // activates after this is true. Reset to false after reinitialization completes.
+    has_fetched_data: bool,
 }
 
 impl<C: NetworkClient> FastCommitSyncer<C> {
@@ -83,58 +101,228 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             highest_scheduled_index: None,
             highest_fetched_commit_index: 0,
             synced_commit_index,
+            close_to_quorum_mode: false,
+            has_fetched_data: false,
         }
     }
-}
 
-#[async_trait::async_trait]
-impl<C: NetworkClient> CommitSyncer<C> for FastCommitSyncer<C> {
-    type FetchedData = Vec<CommittedSubDag>;
-    fn inner(&self) -> &Arc<Inner<C>> {
-        &self.inner
+    pub(crate) fn start(self) -> CommitSyncerHandle {
+        let (tx_shutdown, rx_shutdown) = oneshot::channel();
+        let schedule_task = spawn_logged_monitored_task!(self.schedule_loop(rx_shutdown,));
+        CommitSyncerHandle {
+            schedule_task,
+            tx_shutdown,
+        }
+    }
+    #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %self.inner.context.own_index)))]
+    async fn schedule_loop(mut self, mut rx_shutdown: oneshot::Receiver<()>) {
+        let mut interval = tokio::time::interval(Duration::from_secs(2));
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                // Periodically, schedule new fetches if the node is falling behind.
+                _ = interval.tick() => {
+                    self.try_schedule_once();
+                }
+                // Handles results from fetch tasks.
+                Some(result) = self.inflight_fetches.join_next(), if !self.inflight_fetches.is_empty() => {
+                    if let Err(e) = result {
+                        if e.is_panic() {
+                            std::panic::resume_unwind(e.into_panic());
+                        }
+                        warn!("[{}] Fetch cancelled. FastCommitSyncer shutting down: {}", self.inner.sync_type.as_str(), e);
+                        // If any fetch is cancelled or panicked, try to shutdown and exit the loop.
+                        self.inflight_fetches.shutdown().await;
+                        return;
+                    }
+                    let (target_end, commits, committed_subdags) = result.unwrap();
+                    self.handle_fetch_result(target_end, commits, committed_subdags).await;
+                }
+                _ = &mut rx_shutdown => {
+                    // Shutdown requested.
+                    info!("[{}] FastCommitSyncer shutting down ...", self.inner.sync_type.as_str());
+                    self.inflight_fetches.shutdown().await;
+                    return;
+                }
+            }
+
+            self.try_start_fetches();
+
+            // Handle close-to-quorum mode: when all fetches complete and we're close
+            // to the quorum, fetch block headers for cached_rounds and reinitialize.
+            if self.close_to_quorum_mode
+                && self.inflight_fetches.is_empty()
+                && self.pending_fetches.is_empty()
+                && self.fetched_ranges.is_empty()
+            {
+                info!(
+                    "[{}] Close-to-quorum: all fetches complete, fetching headers for cached_rounds",
+                    self.inner.sync_type.as_str()
+                );
+
+                match Self::fetch_headers_for_cached_rounds(self.inner.clone()).await {
+                    Ok(headers) => {
+                        if let Err(e) = self
+                            .inner
+                            .core_thread_dispatcher
+                            .reinitialize_components(headers)
+                            .await
+                        {
+                            warn!(
+                                "[{}] Failed to reinitialize components: {}",
+                                self.inner.sync_type.as_str(),
+                                e
+                            );
+                        } else {
+                            info!(
+                                "[{}] Components reinitialized, fast sync complete",
+                                self.inner.sync_type.as_str()
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            "[{}] Failed to fetch headers for cached rounds: {}",
+                            self.inner.sync_type.as_str(),
+                            e
+                        );
+                    }
+                }
+
+                // Reset state regardless of success - we've done what we can,
+                // and regular syncer should take over now
+                self.close_to_quorum_mode = false;
+                self.has_fetched_data = false;
+
+                // Exit the loop - fast sync is complete
+                info!(
+                    "[{}] Fast sync complete, exiting schedule loop",
+                    self.inner.sync_type.as_str()
+                );
+                return;
+            }
+        }
     }
 
-    fn inflight_fetches(&mut self) -> &mut JoinSet<(u32, Self::FetchedData)> {
-        &mut self.inflight_fetches
-    }
+    fn try_schedule_once(&mut self) {
+        let quorum_commit_index = self.inner.commit_vote_monitor.quorum_commit_index();
+        let local_commit_index = self.inner.dag_state.read().last_commit_index();
 
-    fn inflight_fetches_len(&self) -> usize {
-        self.inflight_fetches.len()
-    }
+        // Skip scheduling depending on sync type and gap threshold.
+        let gap = quorum_commit_index.saturating_sub(local_commit_index);
+        if !self.inner.sync_type.should_schedule(gap, self.inner.context.parameters.commit_sync_gap_threshold) {
+            return;
+        }
 
-    fn pending_fetches_len(&self) -> usize {
-        self.pending_fetches.len()
-    }
+        let metrics = &self.inner.context.metrics.node_metrics;
+        metrics
+            .commit_sync_quorum_index
+            .set(quorum_commit_index as i64);
+        metrics
+            .commit_sync_local_index
+            .set(local_commit_index as i64);
+        let highest_handled_index = self.inner.commit_consumer_monitor.highest_handled_commit();
+        let highest_scheduled_index = self.highest_scheduled_index.unwrap_or(0);
+        // Update synced_commit_index periodically to make sure it is not smaller than
+        // local commit index.
+        self.synced_commit_index = self.synced_commit_index.max(local_commit_index);
+        let unhandled_commits_threshold = self.unhandled_commits_threshold();
 
-    fn highest_scheduled_index(&mut self) -> &mut Option<CommitIndex> {
-        &mut self.highest_scheduled_index
-    }
+        // TODO: cleanup inflight fetches that are no longer needed.
+        let fetch_after_index = self
+            .synced_commit_index
+            .max(self.highest_scheduled_index.unwrap_or(0));
+        // When the node is falling behind, schedule pending fetches which will be
+        // executed on later.
+        let step = self
+            .inner
+            .sync_type
+            .commit_sync_batch_size(&self.inner.context);
 
-    fn synced_commit_index(&mut self) -> &mut CommitIndex {
-        &mut self.synced_commit_index
-    }
+        info!(
+            "[{}] Checking to schedule fetches: synced_commit_index={}, highest_handled_index={}, highest_scheduled_index={}, quorum_commit_index={}, unhandled_commits_threshold={}, fetch_after_index={}, step={}",
+            self.inner.sync_type.as_str(),
+            self.synced_commit_index,
+            highest_handled_index,
+            highest_scheduled_index,
+            quorum_commit_index,
+            unhandled_commits_threshold,
+            fetch_after_index,
+            step
+        );
 
-    fn pending_fetches(&mut self) -> &mut BTreeSet<CommitRange> {
-        &mut self.pending_fetches
-    }
+        for prev_end in (fetch_after_index..=quorum_commit_index).step_by(step as usize) {
+            // Create range with inclusive start and end.
+            let range_start = prev_end + 1;
+            let range_end = prev_end + step;
+            // Commit range is not fetched when [range_start, range_end] contains less
+            // number of commits than the target batch size. This is to avoid
+            // the cost of processing more and smaller batches. Block broadcast,
+            // subscription and synchronization will help the node catchup.
+            if quorum_commit_index < range_end {
+                break;
+            }
+            // Pause scheduling new fetches when handling of commits is lagging.
+            if highest_handled_index + unhandled_commits_threshold < range_end {
+                warn!(
+                    "[{}] Skip scheduling new commit fetches: consensus handler is lagging. highest_handled_index={}, highest_scheduled_index={}",
+                    self.inner.sync_type.as_str(),
+                    highest_handled_index,
+                    highest_scheduled_index
+                );
+                break;
+            }
+            info!(
+                "[{}] Scheduling fetch for commit range {}..={}",
+                self.inner.sync_type.as_str(),
+                range_start,
+                range_end
+            );
+            self.pending_fetches
+                .insert((range_start..=range_end).into());
+            // quorum_commit_index should be non-decreasing, so highest_scheduled_index
+            // should not decrease either.
+            self.highest_scheduled_index = Some(range_end);
+        }
 
-    fn fetched_ranges(&mut self) -> &mut BTreeMap<CommitRange, Self::FetchedData> {
-        &mut self.fetched_ranges
-    }
-
-    #[cfg(test)]
-    fn highest_fetched_commit_index(&self) -> CommitIndex {
-        self.highest_fetched_commit_index
+        // Detect close-to-quorum mode: when remaining gap is less than a full batch.
+        // Only activate if we've actually fetched data during this fast sync session.
+        //
+        // When close_to_quorum_mode is activated, the schedule_loop() will:
+        // 1. Wait for all inflight/pending fetches to complete
+        // 2. Fetch block headers for ~cached_rounds worth of commits
+        // 3. Send ReinitializeComponents to core thread to properly initialize DAG state
+        // 4. Reset fast sync state so regular syncer can take over
+        if self.has_fetched_data && !self.close_to_quorum_mode {
+            let current_fetch_after = self
+                .synced_commit_index
+                .max(self.highest_scheduled_index.unwrap_or(0));
+            let remaining_gap = quorum_commit_index.saturating_sub(current_fetch_after);
+            if remaining_gap < step {
+                self.close_to_quorum_mode = true;
+                info!(
+                    "[{}] Entering close-to-quorum mode: remaining_gap={}, step={}",
+                    self.inner.sync_type.as_str(),
+                    remaining_gap,
+                    step
+                );
+            }
+        }
     }
 
     async fn handle_fetch_result(
         &mut self,
         target_end: CommitIndex,
-        fetched_data_set: Self::FetchedData,
+        commits: Vec<TrustedCommit>,
+        committed_subdags: Vec<CommittedSubDag>,
     ) {
-        assert!(!fetched_data_set.is_empty());
+        assert!(!committed_subdags.is_empty());
 
-        let total_transactions_size_bytes = fetched_data_set
+        // Track that we have actually fetched data during this fast sync session.
+        self.has_fetched_data = true;
+
+        let total_transactions_size_bytes = committed_subdags
             .iter()
             .flat_map(|subdag| &subdag.transactions)
             .map(|txns| txns.serialized().len() as u64)
@@ -145,15 +333,15 @@ impl<C: NetworkClient> CommitSyncer<C> for FastCommitSyncer<C> {
         metrics
             .commit_sync_fetched_commits
             .with_label_values(&[sync_label])
-            .inc_by(fetched_data_set.len() as u64);
+            .inc_by(committed_subdags.len() as u64);
         metrics
             .commit_sync_total_fetched_transactions_size
             .with_label_values(&[sync_label])
             .inc_by(total_transactions_size_bytes);
 
         let (commit_start, commit_end) = (
-            fetched_data_set.first().unwrap().commit_ref.index,
-            fetched_data_set.last().unwrap().commit_ref.index,
+            committed_subdags.first().unwrap().commit_ref.index,
+            committed_subdags.last().unwrap().commit_ref.index,
         );
         self.highest_fetched_commit_index = self.highest_fetched_commit_index.max(commit_end);
         metrics
@@ -173,13 +361,13 @@ impl<C: NetworkClient> CommitSyncer<C> for FastCommitSyncer<C> {
         // Only add new blocks if at least some of them are not already synced.
         if self.synced_commit_index < commit_end {
             self.fetched_ranges
-                .insert((commit_start..=commit_end).into(), fetched_data_set);
+                .insert((commit_start..=commit_end).into(), (commits, committed_subdags));
         }
         // Try to process as many fetched blocks as possible.
-        while let Some((fetched_commit_range, _subdags)) = self.fetched_ranges.first_key_value() {
+        while let Some((fetched_commit_range, _)) = self.fetched_ranges.first_key_value() {
             // Only pop fetched_ranges if there is no gap with blocks already synced.
             // Note: start, end and synced_commit_index are all inclusive.
-            let (fetched_commit_range, subdags) =
+            let (fetched_commit_range, (commits, subdags)) =
                 if fetched_commit_range.start() <= self.synced_commit_index + 1 {
                     self.fetched_ranges.pop_first().unwrap()
                 } else {
@@ -208,7 +396,7 @@ impl<C: NetworkClient> CommitSyncer<C> for FastCommitSyncer<C> {
             if let Err(e) = self
                 .inner
                 .core_thread_dispatcher
-                .add_subdags_from_fast_sync(subdags)
+                .add_subdags_from_fast_sync(commits, subdags)
                 .await
             {
                 info!(
@@ -236,12 +424,197 @@ impl<C: NetworkClient> CommitSyncer<C> for FastCommitSyncer<C> {
             .set(self.synced_commit_index as i64);
     }
 
+    fn try_start_fetches(&mut self) {
+        // Cap parallel fetches based on configured limit and committee size, to avoid
+        // overloading the network. Also when there are too many fetched block headers
+        // that cannot be sent to Core before an earlier fetch has not finished,
+        // reduce parallelism so the earlier fetch can retry on a better host and
+        // succeed.
+        let target_parallel_fetches = self
+            .inner
+            .context
+            .parameters
+            .commit_sync_parallel_fetches
+            .min(self.inner.context.committee.size() * 2 / 3)
+            .min(
+                self.inner
+                    .context
+                    .parameters
+                    .commit_sync_batches_ahead
+                    .saturating_sub(self.fetched_ranges.len()),
+            )
+            .max(1);
+        // Start new fetches if there are pending batches and available slots.
+        loop {
+            if self.inflight_fetches.len() >= target_parallel_fetches {
+                break;
+            }
+            if !self.pending_fetches.is_empty() {
+                info!(
+                    "[{}] Pending fetches: {:?}, target parallel fetches: {}, inflight fetch number: {}",
+                    self.inner.sync_type.as_str(),
+                    self.pending_fetches,
+                    target_parallel_fetches,
+                    self.inflight_fetches.len()
+                );
+            }
+            let Some(commit_range) = self.pending_fetches.pop_first() else {
+                break;
+            };
+            self.inflight_fetches
+                .spawn(Self::fetch_loop(self.inner.clone(), commit_range));
+        }
+
+        let metrics = &self.inner.context.metrics.node_metrics;
+        let sync_label = self.inner.sync_type.as_str();
+        metrics
+            .commit_sync_inflight_fetches
+            .with_label_values(&[sync_label])
+            .set(self.inflight_fetches.len() as i64);
+        metrics
+            .commit_sync_pending_fetches
+            .with_label_values(&[sync_label])
+            .set(self.pending_fetches.len() as i64);
+        metrics
+            .commit_sync_highest_synced_index
+            .with_label_values(&[sync_label])
+            .set(self.synced_commit_index as i64);
+    }
+
+    // Retries fetching commits and block headers from available authorities, until
+    // a request succeeds where at least a prefix of the commit range is
+    // fetched. Returns the fetched commits and block headers referenced by the
+    // commits.
+    #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %inner.context.own_index)))]
+    async fn fetch_loop(
+        inner: Arc<Inner<C>>,
+        commit_range: CommitRange,
+    ) -> (CommitIndex, Vec<TrustedCommit>, Vec<CommittedSubDag>) {
+        // Individual request base timeout.
+        const TIMEOUT: Duration = Duration::from_secs(10);
+        // Max per-request timeout will be base timeout times a multiplier.
+        // At the extreme, this means there will be 120s timeout to fetch
+        // max_blocks_per_fetch blocks.
+        const MAX_TIMEOUT_MULTIPLIER: u32 = 12;
+        // timeout * max number of targets should be reasonably small, so the
+        // system can adjust to slow network or large data sizes quickly.
+        const MAX_NUM_TARGETS: usize = 24;
+        let mut timeout_multiplier = 0;
+
+        let _timer = inner
+            .context
+            .metrics
+            .node_metrics
+            .commit_sync_fetch_loop_latency
+            .start_timer();
+        info!(
+            "[{}] Starting to fetch commits in {commit_range:?} ...",
+            inner.sync_type.as_str()
+        );
+        loop {
+            // Attempt to fetch commits and blocks through min(committee size,
+            // MAX_NUM_TARGETS) peers.
+            let mut target_authorities = inner
+                .context
+                .committee
+                .authorities()
+                .filter_map(|(i, _)| {
+                    if i != inner.context.own_index {
+                        Some(i)
+                    } else {
+                        None
+                    }
+                })
+                .collect_vec();
+            target_authorities.shuffle(&mut ThreadRng::default());
+            target_authorities.truncate(MAX_NUM_TARGETS);
+            // Increase timeout multiplier for each loop until MAX_TIMEOUT_MULTIPLIER.
+            timeout_multiplier = (timeout_multiplier + 1).min(MAX_TIMEOUT_MULTIPLIER);
+            let request_timeout = TIMEOUT * timeout_multiplier;
+
+            let fetch_timeout = request_timeout * 2;
+            // Try fetching from the selected target authority.
+            for authority in target_authorities {
+                match tokio::time::timeout(
+                    fetch_timeout,
+                    Self::fetch_once(
+                        inner.clone(),
+                        authority,
+                        commit_range.clone(),
+                        request_timeout,
+                    ),
+                )
+                .await
+                {
+                    Ok(Ok((commits, committed_subdags))) => {
+                        info!(
+                            "[{}] Finished fetching commits in {commit_range:?}",
+                            inner.sync_type.as_str()
+                        );
+                        return (commit_range.end(), commits, committed_subdags);
+                    }
+                    Ok(Err(e)) => {
+                        let hostname = inner
+                            .context
+                            .committee
+                            .authority(authority)
+                            .hostname
+                            .clone();
+                        warn!(
+                            "[{}] Failed to fetch {commit_range:?} from {hostname}: {}",
+                            inner.sync_type.as_str(),
+                            e
+                        );
+                        let error: &'static str = e.into();
+                        inner
+                            .context
+                            .metrics
+                            .node_metrics
+                            .commit_sync_fetch_once_errors
+                            .with_label_values(&[
+                                hostname.as_str(),
+                                error,
+                                inner.sync_type.as_str(),
+                            ])
+                            .inc();
+                    }
+                    Err(_) => {
+                        let hostname = inner
+                            .context
+                            .committee
+                            .authority(authority)
+                            .hostname
+                            .clone();
+                        warn!(
+                            "[{}] Timed out fetching {commit_range:?} from {authority}",
+                            inner.sync_type.as_str()
+                        );
+                        inner
+                            .context
+                            .metrics
+                            .node_metrics
+                            .commit_sync_fetch_once_errors
+                            .with_label_values(&[
+                                hostname.as_str(),
+                                "FetchTimeout",
+                                inner.sync_type.as_str(),
+                            ])
+                            .inc();
+                    }
+                }
+            }
+            // Avoid busy looping, by waiting for a while before retrying.
+            sleep(TIMEOUT).await;
+        }
+    }
+
+    // Fetches commits and transactions from a single authority.
     async fn fetch_once(
         inner: Arc<Inner<C>>,
         target_authority: AuthorityIndex,
         commit_range: CommitRange,
         timeout: Duration,
-    ) -> ConsensusResult<Self::FetchedData> {
+    ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<CommittedSubDag>)> {
         let _timer = inner
             .context
             .metrics
@@ -373,6 +746,169 @@ impl<C: NetworkClient> CommitSyncer<C> for FastCommitSyncer<C> {
             ));
         }
 
-        Ok(committed_subdags)
+        Ok((commits, committed_subdags))
+    }
+
+    fn unhandled_commits_threshold(&self) -> CommitIndex {
+        self.inner.context.parameters.commit_sync_batch_size
+            * (self.inner.context.parameters.commit_sync_batches_ahead as u32)
+    }
+
+    /// Fetches block headers for the cached_rounds window from the network.
+    /// This is called when close_to_quorum mode is active and all pending fetches complete.
+    /// Returns verified block headers that will be stored and used to reinitialize components.
+    async fn fetch_headers_for_cached_rounds(
+        inner: Arc<Inner<C>>,
+    ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
+        let cached_rounds = inner.context.parameters.dag_state_cached_rounds;
+        let max_headers_per_fetch = inner.context.parameters.max_headers_per_commit_sync_fetch;
+
+        // Get block refs from recent commits stored during fast sync
+        let block_refs = inner
+            .dag_state
+            .read()
+            .get_block_refs_for_recent_commits(cached_rounds);
+
+        if block_refs.is_empty() {
+            info!(
+                "[{}] No block refs to fetch for cached rounds",
+                inner.sync_type.as_str()
+            );
+            return Ok(vec![]);
+        }
+
+        info!(
+            "[{}] Fetching {} block headers for cached_rounds window ({})",
+            inner.sync_type.as_str(),
+            block_refs.len(),
+            cached_rounds
+        );
+
+        // Shuffle target authorities for load balancing
+        let mut target_authorities: Vec<_> = inner
+            .context
+            .committee
+            .authorities()
+            .filter_map(|(i, _)| {
+                if i != inner.context.own_index {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        target_authorities.shuffle(&mut ThreadRng::default());
+
+        // Fetch headers in chunks to avoid overwhelming the network
+        let mut all_headers = Vec::new();
+        for chunk in block_refs.chunks(max_headers_per_fetch) {
+            let chunk_refs: Vec<_> = chunk.to_vec();
+
+            // Try fetching from different authorities until successful
+            let mut fetched = false;
+            for &authority in &target_authorities {
+                match tokio::time::timeout(
+                    FETCH_HEADERS_TIMEOUT,
+                    inner.network_client.fetch_block_headers(
+                        authority,
+                        chunk_refs.clone(),
+                        vec![],
+                        FETCH_HEADERS_TIMEOUT,
+                    ),
+                )
+                .await
+                {
+                    Ok(Ok(serialized_headers)) => {
+                        // Verify and convert headers
+                        let verified_headers: ConsensusResult<Vec<VerifiedBlockHeader>> =
+                            serialized_headers
+                                .into_iter()
+                                .map(VerifiedBlockHeader::new_from_bytes)
+                                .collect();
+
+                        match verified_headers {
+                            Ok(headers) => {
+                                info!(
+                                    "[{}] Fetched {} headers from authority {}",
+                                    inner.sync_type.as_str(),
+                                    headers.len(),
+                                    authority
+                                );
+                                all_headers.extend(headers);
+                                fetched = true;
+                                break;
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "[{}] Failed to verify headers from {}: {}",
+                                    inner.sync_type.as_str(),
+                                    authority,
+                                    e
+                                );
+                            }
+                        }
+                    }
+                    Ok(Err(e)) => {
+                        warn!(
+                            "[{}] Failed to fetch headers from {}: {}",
+                            inner.sync_type.as_str(),
+                            authority,
+                            e
+                        );
+                    }
+                    Err(_) => {
+                        warn!(
+                            "[{}] Timed out fetching headers from {}",
+                            inner.sync_type.as_str(),
+                            authority
+                        );
+                    }
+                }
+            }
+
+            if !fetched {
+                return Err(ConsensusError::FailedToFetchBlockHeaders {
+                    num_requested: chunk_refs.len(),
+                });
+            }
+        }
+
+        info!(
+            "[{}] Successfully fetched {} total block headers for cached_rounds",
+            inner.sync_type.as_str(),
+            all_headers.len()
+        );
+
+        Ok(all_headers)
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    fn pending_fetches(&self) -> BTreeSet<CommitRange> {
+        self.pending_fetches.clone()
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    fn fetched_ranges(&self) -> BTreeMap<CommitRange, (Vec<TrustedCommit>, Vec<CommittedSubDag>)> {
+        self.fetched_ranges.clone()
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    fn highest_scheduled_index(&self) -> Option<CommitIndex> {
+        self.highest_scheduled_index
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    fn highest_fetched_commit_index(&self) -> CommitIndex {
+        self.highest_fetched_commit_index
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    fn synced_commit_index(&self) -> CommitIndex {
+        self.synced_commit_index
     }
 }

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -211,7 +211,11 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
 
         // Skip scheduling depending on sync type and gap threshold.
         let gap = quorum_commit_index.saturating_sub(local_commit_index);
-        if !self.inner.sync_type.should_schedule(gap, self.inner.context.parameters.commit_sync_gap_threshold) {
+        if !self
+            .inner
+            .sync_type
+            .should_schedule(gap, self.inner.context.parameters.commit_sync_gap_threshold)
+        {
             return;
         }
 
@@ -292,7 +296,8 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // When close_to_quorum_mode is activated, the schedule_loop() will:
         // 1. Wait for all inflight/pending fetches to complete
         // 2. Fetch block headers for ~cached_rounds worth of commits
-        // 3. Send ReinitializeComponents to core thread to properly initialize DAG state
+        // 3. Send ReinitializeComponents to core thread to properly initialize DAG
+        //    state
         // 4. Reset fast sync state so regular syncer can take over
         if self.has_fetched_data && !self.close_to_quorum_mode {
             let current_fetch_after = self
@@ -360,8 +365,10 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             .max(self.inner.dag_state.read().last_commit_index());
         // Only add new blocks if at least some of them are not already synced.
         if self.synced_commit_index < commit_end {
-            self.fetched_ranges
-                .insert((commit_start..=commit_end).into(), (commits, committed_subdags));
+            self.fetched_ranges.insert(
+                (commit_start..=commit_end).into(),
+                (commits, committed_subdags),
+            );
         }
         // Try to process as many fetched blocks as possible.
         while let Some((fetched_commit_range, _)) = self.fetched_ranges.first_key_value() {
@@ -755,8 +762,9 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
     }
 
     /// Fetches block headers for the cached_rounds window from the network.
-    /// This is called when close_to_quorum mode is active and all pending fetches complete.
-    /// Returns verified block headers that will be stored and used to reinitialize components.
+    /// This is called when close_to_quorum mode is active and all pending
+    /// fetches complete. Returns verified block headers that will be stored
+    /// and used to reinitialize components.
     async fn fetch_headers_for_cached_rounds(
         inner: Arc<Inner<C>>,
     ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -218,14 +218,15 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
 
         // Skip scheduling depending on sync type and gap threshold.
         let gap = quorum_commit_index.saturating_sub(dag_state_commit_index);
-        let should_schedule = self.inner.sync_type.should_schedule(
-            gap,
-            self.inner.context.parameters.commit_sync_gap_threshold,
-            self.inner
-                .context
-                .protocol_config
-                .consensus_transaction_ref(),
-        ) || self.has_fetched_data;
+        let should_schedule = self.has_fetched_data
+            || self.inner.sync_type.should_schedule(
+                gap,
+                self.inner.context.parameters.commit_sync_gap_threshold,
+                self.inner
+                    .context
+                    .protocol_config
+                    .consensus_transaction_ref(),
+            );
 
         if should_schedule {
             let metrics = &self.inner.context.metrics.node_metrics;

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -620,16 +620,20 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
 
     /// Fetches block headers needed for component reinitialization from the
     /// network. This is called when close_to_quorum mode is active and all
-    /// pending fetches complete. Fetches headers for max(cached_rounds,
-    /// gc_depth * 2) commits to satisfy both DagState cache and linearizer
-    /// recovery requirements.
+    /// pending fetches complete. Fetches headers for the maximum of
+    /// cached_rounds, gc_depth * 2, leader_schedule_window, and
+    /// commits_since_schedule_update to satisfy DagState cache, linearizer,
+    /// and leader schedule recovery requirements.
     async fn fetch_headers_for_reinitialization(
         inner: Arc<Inner<C>>,
     ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
-        // We need headers for two purposes:
+        // We need headers for three purposes:
         // 1. DagState cache: at least cached_rounds commits back
         // 2. Linearizer recovery: at least gc_depth * 2 commits back
-        // Fetch the maximum of the two to satisfy both requirements
+        // 3. Leader schedule recovery: at least leader_schedule_window commits back, or
+        //    all commits since the last stored commit info
+        //    (commits_since_schedule_update)
+        // Fetch the maximum to satisfy all requirements
         let cached_rounds = inner.context.parameters.dag_state_cached_rounds;
         let gc_depth = inner.context.protocol_config.gc_depth();
         let leader_schedule_window = crate::leader_schedule::CONSENSUS_COMMITS_PER_SCHEDULE as u32;
@@ -676,11 +680,13 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         }
 
         info!(
-            "[{}] Fetching {} block headers for reinitialization (cached_rounds={}, gc_depth*2={})",
+            "[{}] Fetching {} block headers for reinitialization (cached_rounds={}, gc_depth*2={}, leader_schedule_window={}, commits_since_schedule_update={})",
             inner.sync_type.as_str(),
             block_refs.len(),
             cached_rounds,
-            gc_depth * 2
+            gc_depth * 2,
+            leader_schedule_window,
+            commits_since_schedule_update
         );
 
         // Shuffle target authorities for load balancing

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -19,7 +19,7 @@ use crate::{
     CommitConsumerMonitor, CommitIndex, VerifiedBlockHeader,
     block_header::VerifiedTransactions,
     block_verifier::BlockVerifier,
-    commit::{CommitAPI as _, CommitRange, CommittedSubDag, GENESIS_COMMIT_INDEX, TrustedCommit},
+    commit::{CommitAPI as _, CommitRange, CommittedSubDag, TrustedCommit},
     commit_syncer::{
         CommitSyncType, CommitSyncerHandle, Inner, fetch_loop as shared_fetch_loop,
         handle_fetch_join_error, requeue_partial_range, schedule_commit_ranges,
@@ -619,47 +619,24 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         let cached_rounds = inner.context.parameters.dag_state_cached_rounds;
         let gc_depth = inner.context.protocol_config.gc_depth();
         let leader_schedule_window = crate::leader_schedule::CONSENSUS_COMMITS_PER_SCHEDULE as u32;
-        let (last_commit_index, last_commit_info_index) = {
-            let dag_state = inner.dag_state.read();
-            let last_commit_index = dag_state.last_commit_index();
-            let last_commit_info_index = dag_state
-                .recover_last_commit_info()
-                .map(|(commit_ref, commit_info)| {
-                    let range_end = commit_info.reputation_scores.commit_range.end();
-                    if range_end == GENESIS_COMMIT_INDEX {
-                        commit_ref.index
-                    } else {
-                        range_end
-                    }
-                })
-                .unwrap_or(GENESIS_COMMIT_INDEX);
-            (last_commit_index, last_commit_info_index)
-        };
-        let commits_since_schedule_update =
-            last_commit_index.saturating_sub(last_commit_info_index);
-        let num_commits = max(
-            commits_since_schedule_update,
-            max(leader_schedule_window, max(cached_rounds, gc_depth * 2)),
-        );
-
-        let max_headers_per_fetch = inner.context.parameters.max_headers_per_commit_sync_fetch;
-
         // Get block refs from recent commits stored during fast sync
         // TODO: The commits might not yet stored, but only fetched and pending
         // processing.
-        let block_refs = inner
-            .dag_state
-            .read()
-            .get_block_refs_for_recent_commits(num_commits);
-
-        // TODO: we anyway need to reinitialize even if there are no block refs,
-        if block_refs.is_empty() {
-            info!(
-                "[{}] No block refs to fetch for reinitialization",
-                inner.sync_type.as_str()
+        let (commits_since_schedule_update, block_refs) = {
+            let dag_state = inner.dag_state.read();
+            let last_commit_index = dag_state.last_commit_index();
+            let last_commit_info_index = dag_state.last_commit_info_index();
+            let commits_since_schedule_update =
+                last_commit_index.saturating_sub(last_commit_info_index);
+            let num_commits = max(
+                commits_since_schedule_update,
+                max(leader_schedule_window, max(cached_rounds, gc_depth * 2)),
             );
-            return Ok(vec![]);
-        }
+            let block_refs = dag_state.get_block_refs_for_recent_commits(num_commits);
+            (commits_since_schedule_update, block_refs)
+        };
+
+        let max_headers_per_fetch = inner.context.parameters.max_headers_per_commit_sync_fetch;
 
         info!(
             "[{}] Fetching {} block headers for reinitialization (cached_rounds={}, gc_depth*2={}, leader_schedule_window={}, commits_since_schedule_update={})",

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -26,7 +26,8 @@ use crate::{
     block_verifier::BlockVerifier,
     commit::{CommitAPI as _, CommitRange, CommittedSubDag, TrustedCommit},
     commit_syncer::{
-        CommitSyncType, CommitSyncerHandle, Inner, verify_transactions_with_transactions_refs,
+        CommitSyncType, CommitSyncerHandle, Inner, verify_fetched_headers,
+        verify_transactions_with_transactions_refs,
     },
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
@@ -150,7 +151,8 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             self.try_start_fetches();
 
             // Handle close-to-quorum mode: when all fetches complete and we're close
-            // to the quorum, fetch block headers for cached_rounds and reinitialize.
+            // to the quorum, fetch block headers for a large enough number of rounds and
+            // reinitialize.
             if self.close_to_quorum_mode
                 && self.inflight_fetches.is_empty()
                 && self.pending_fetches.is_empty()
@@ -761,10 +763,11 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             * (self.inner.context.parameters.commit_sync_batches_ahead as u32)
     }
 
-    /// Fetches block headers needed for component reinitialization from the network.
-    /// This is called when close_to_quorum mode is active and all pending
-    /// fetches complete. Fetches headers for max(cached_rounds, gc_depth * 2) commits
-    /// to satisfy both DagState cache and linearizer recovery requirements.
+    /// Fetches block headers needed for component reinitialization from the
+    /// network. This is called when close_to_quorum mode is active and all
+    /// pending fetches complete. Fetches headers for max(cached_rounds,
+    /// gc_depth * 2) commits to satisfy both DagState cache and linearizer
+    /// recovery requirements.
     async fn fetch_headers_for_reinitialization(
         inner: Arc<Inner<C>>,
     ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
@@ -835,14 +838,8 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 .await
                 {
                     Ok(Ok(serialized_headers)) => {
-                        // Verify and convert headers
-                        let verified_headers: ConsensusResult<Vec<VerifiedBlockHeader>> =
-                            serialized_headers
-                                .into_iter()
-                                .map(VerifiedBlockHeader::new_from_bytes)
-                                .collect();
-
-                        match verified_headers {
+                        // Verify headers match requested refs
+                        match verify_fetched_headers(authority, &chunk_refs, serialized_headers) {
                             Ok(headers) => {
                                 info!(
                                     "[{}] Fetched {} headers from authority {}",

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -241,7 +241,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             // When the node is falling behind, schedule pending fetches which will be
             // executed on later.
 
-            info!(
+            debug!(
                 "[{}] Checking to schedule fetches: synced_commit_index={}, highest_handled_index={}, highest_scheduled_index={}, quorum_commit_index={}, unhandled_commits_threshold={}, fetch_after_index={}, step={}",
                 self.inner.sync_type.as_str(),
                 self.synced_commit_index,
@@ -274,7 +274,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                     );
                     break;
                 }
-                info!(
+                debug!(
                     "[{}] Scheduling fetch for commit range {}..={}",
                     self.inner.sync_type.as_str(),
                     range_start,
@@ -305,7 +305,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             if remaining_gap > 0 && remaining_gap < step {
                 let range_start = current_fetch_after + 1;
                 let range_end = quorum_commit_index;
-                info!(
+                debug!(
                     "[{}] Scheduling final partial fetch for commit range {}..={} (remaining_gap={})",
                     self.inner.sync_type.as_str(),
                     range_start,

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use iota_metrics::spawn_logged_monitored_task;
-use itertools::Itertools as _;
 use parking_lot::RwLock;
 use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
 use starfish_config::AuthorityIndex;
@@ -16,7 +15,7 @@ use tokio::{
     runtime::Handle,
     sync::oneshot,
     task::JoinSet,
-    time::{MissedTickBehavior, sleep},
+    time::MissedTickBehavior,
 };
 use tracing::{debug, info, warn};
 
@@ -26,7 +25,8 @@ use crate::{
     block_verifier::BlockVerifier,
     commit::{CommitAPI as _, CommitRange, CommittedSubDag, TrustedCommit},
     commit_syncer::{
-        CommitSyncType, CommitSyncerHandle, Inner, verify_fetched_headers,
+        CommitSyncType, CommitSyncerHandle, Inner, fetch_loop as shared_fetch_loop,
+        try_start_fetches as shared_try_start_fetches, verify_fetched_headers,
         verify_transactions_with_transactions_refs,
     },
     commit_vote_monitor::CommitVoteMonitor,
@@ -434,60 +434,18 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
     }
 
     fn try_start_fetches(&mut self) {
-        // Cap parallel fetches based on configured limit and committee size, to avoid
-        // overloading the network. Also when there are too many fetched block headers
-        // that cannot be sent to Core before an earlier fetch has not finished,
-        // reduce parallelism so the earlier fetch can retry on a better host and
-        // succeed.
-        let target_parallel_fetches = self
-            .inner
-            .context
-            .parameters
-            .commit_sync_parallel_fetches
-            .min(self.inner.context.committee.size() * 2 / 3)
-            .min(
-                self.inner
-                    .context
-                    .parameters
-                    .commit_sync_batches_ahead
-                    .saturating_sub(self.fetched_ranges.len()),
-            )
-            .max(1);
-        // Start new fetches if there are pending batches and available slots.
-        loop {
-            if self.inflight_fetches.len() >= target_parallel_fetches {
-                break;
-            }
-            if !self.pending_fetches.is_empty() {
-                info!(
-                    "[{}] Pending fetches: {:?}, target parallel fetches: {}, inflight fetch number: {}",
-                    self.inner.sync_type.as_str(),
-                    self.pending_fetches,
-                    target_parallel_fetches,
-                    self.inflight_fetches.len()
-                );
-            }
-            let Some(commit_range) = self.pending_fetches.pop_first() else {
-                break;
-            };
-            self.inflight_fetches
-                .spawn(Self::fetch_loop(self.inner.clone(), commit_range));
-        }
-
-        let metrics = &self.inner.context.metrics.node_metrics;
-        let sync_label = self.inner.sync_type.as_str();
-        metrics
-            .commit_sync_inflight_fetches
-            .with_label_values(&[sync_label])
-            .set(self.inflight_fetches.len() as i64);
-        metrics
-            .commit_sync_pending_fetches
-            .with_label_values(&[sync_label])
-            .set(self.pending_fetches.len() as i64);
-        metrics
-            .commit_sync_highest_synced_index
-            .with_label_values(&[sync_label])
-            .set(self.synced_commit_index as i64);
+        let inner = self.inner.clone();
+        shared_try_start_fetches(
+            &self.inner,
+            &mut self.pending_fetches,
+            self.fetched_ranges.len(),
+            self.inflight_fetches.len(),
+            self.synced_commit_index,
+            |commit_range| {
+                self.inflight_fetches
+                    .spawn(Self::fetch_loop(inner.clone(), commit_range));
+            },
+        );
     }
 
     // Retries fetching commits and block headers from available authorities, until
@@ -499,122 +457,9 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         inner: Arc<Inner<C>>,
         commit_range: CommitRange,
     ) -> (CommitIndex, Vec<TrustedCommit>, Vec<CommittedSubDag>) {
-        // Individual request base timeout.
-        const TIMEOUT: Duration = Duration::from_secs(10);
-        // Max per-request timeout will be base timeout times a multiplier.
-        // At the extreme, this means there will be 120s timeout to fetch
-        // max_blocks_per_fetch blocks.
-        const MAX_TIMEOUT_MULTIPLIER: u32 = 12;
-        // timeout * max number of targets should be reasonably small, so the
-        // system can adjust to slow network or large data sizes quickly.
-        const MAX_NUM_TARGETS: usize = 24;
-        let mut timeout_multiplier = 0;
-
-        let _timer = inner
-            .context
-            .metrics
-            .node_metrics
-            .commit_sync_fetch_loop_latency
-            .start_timer();
-        info!(
-            "[{}] Starting to fetch commits in {commit_range:?} ...",
-            inner.sync_type.as_str()
-        );
-        loop {
-            // Attempt to fetch commits and blocks through min(committee size,
-            // MAX_NUM_TARGETS) peers.
-            let mut target_authorities = inner
-                .context
-                .committee
-                .authorities()
-                .filter_map(|(i, _)| {
-                    if i != inner.context.own_index {
-                        Some(i)
-                    } else {
-                        None
-                    }
-                })
-                .collect_vec();
-            target_authorities.shuffle(&mut ThreadRng::default());
-            target_authorities.truncate(MAX_NUM_TARGETS);
-            // Increase timeout multiplier for each loop until MAX_TIMEOUT_MULTIPLIER.
-            timeout_multiplier = (timeout_multiplier + 1).min(MAX_TIMEOUT_MULTIPLIER);
-            let request_timeout = TIMEOUT * timeout_multiplier;
-
-            let fetch_timeout = request_timeout * 2;
-            // Try fetching from the selected target authority.
-            for authority in target_authorities {
-                match tokio::time::timeout(
-                    fetch_timeout,
-                    Self::fetch_once(
-                        inner.clone(),
-                        authority,
-                        commit_range.clone(),
-                        request_timeout,
-                    ),
-                )
-                .await
-                {
-                    Ok(Ok((commits, committed_subdags))) => {
-                        info!(
-                            "[{}] Finished fetching commits in {commit_range:?}",
-                            inner.sync_type.as_str()
-                        );
-                        return (commit_range.end(), commits, committed_subdags);
-                    }
-                    Ok(Err(e)) => {
-                        let hostname = inner
-                            .context
-                            .committee
-                            .authority(authority)
-                            .hostname
-                            .clone();
-                        warn!(
-                            "[{}] Failed to fetch {commit_range:?} from {hostname}: {}",
-                            inner.sync_type.as_str(),
-                            e
-                        );
-                        let error: &'static str = e.into();
-                        inner
-                            .context
-                            .metrics
-                            .node_metrics
-                            .commit_sync_fetch_once_errors
-                            .with_label_values(&[
-                                hostname.as_str(),
-                                error,
-                                inner.sync_type.as_str(),
-                            ])
-                            .inc();
-                    }
-                    Err(_) => {
-                        let hostname = inner
-                            .context
-                            .committee
-                            .authority(authority)
-                            .hostname
-                            .clone();
-                        warn!(
-                            "[{}] Timed out fetching {commit_range:?} from {authority}",
-                            inner.sync_type.as_str()
-                        );
-                        inner
-                            .context
-                            .metrics
-                            .node_metrics
-                            .commit_sync_fetch_once_errors
-                            .with_label_values(&[
-                                hostname.as_str(),
-                                "FetchTimeout",
-                                inner.sync_type.as_str(),
-                            ])
-                            .inc();
-                    }
-                }
-            }
-            // Avoid busy looping, by waiting for a while before retrying.
-            sleep(TIMEOUT).await;
-        }
+        let (end_index, (commits, committed_subdags)) =
+            shared_fetch_loop(inner, commit_range, 2, Self::fetch_once).await;
+        (end_index, commits, committed_subdags)
     }
 
     // Fetches commits and transactions from a single authority.

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -43,11 +43,7 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
 use starfish_config::AuthorityIndex;
-use tokio::{
-    sync::oneshot,
-    task::JoinHandle,
-    time::sleep,
-};
+use tokio::{sync::oneshot, task::JoinHandle, time::sleep};
 use tracing::{info, warn};
 
 use crate::{
@@ -367,19 +363,22 @@ pub(crate) fn verify_transactions_with_transactions_refs(
     Ok(verified_transactions_map)
 }
 
-/// Generic fetch loop that retries fetching data from available authorities until
-/// a request succeeds. This is shared between RegularCommitSyncer and FastCommitSyncer.
+/// Generic fetch loop that retries fetching data from available authorities
+/// until a request succeeds. This is shared between RegularCommitSyncer and
+/// FastCommitSyncer.
 ///
 /// # Type Parameters
 /// - `C`: Network client type
-/// - `T`: Fetched data type (CertifiedCommits for regular, (Vec<TrustedCommit>, Vec<CommittedSubDag>) for fast)
+/// - `T`: Fetched data type (CertifiedCommits for regular, (Vec<TrustedCommit>,
+///   Vec<CommittedSubDag>) for fast)
 /// - `F`: Fetch function type
 /// - `Fut`: Future returned by fetch function
 ///
 /// # Parameters
 /// - `inner`: Shared context and dependencies
 /// - `commit_range`: The range of commits to fetch
-/// - `fetch_timeout_multiplier`: Multiplier for timeout calculation (4 for regular, 2 for fast)
+/// - `fetch_timeout_multiplier`: Multiplier for timeout calculation (4 for
+///   regular, 2 for fast)
 /// - `fetch_once_fn`: Implementation-specific fetch function
 ///
 /// # Returns
@@ -478,11 +477,7 @@ where
                         .metrics
                         .node_metrics
                         .commit_sync_fetch_once_errors
-                        .with_label_values(&[
-                            hostname.as_str(),
-                            error,
-                            inner.sync_type.as_str(),
-                        ])
+                        .with_label_values(&[hostname.as_str(), error, inner.sync_type.as_str()])
                         .inc();
                 }
                 Err(_) => {
@@ -515,8 +510,8 @@ where
     }
 }
 
-/// Generic function to start pending fetches while respecting parallelism limits.
-/// This is shared between RegularCommitSyncer and FastCommitSyncer.
+/// Generic function to start pending fetches while respecting parallelism
+/// limits. This is shared between RegularCommitSyncer and FastCommitSyncer.
 ///
 /// # Parameters
 /// - `inner`: Shared context and dependencies

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -155,6 +155,15 @@ pub(crate) struct Inner<C: NetworkClient> {
 }
 
 impl<C: NetworkClient> Inner<C> {
+    /// Calculates the threshold for unhandled commits to apply backpressure.
+    /// When the gap between synced and scheduled commits exceeds this
+    /// threshold, scheduling new fetches should pause to let the handler
+    /// catch up.
+    pub(crate) fn unhandled_commits_threshold(&self) -> CommitIndex {
+        self.context.parameters.commit_sync_batch_size
+            * (self.context.parameters.commit_sync_batches_ahead as u32)
+    }
+
     /// Verifies the commits and also certifies them using the provided vote
     /// blocks for the last commit. The method returns the trusted commits
     /// and the votes as verified blocks.
@@ -593,4 +602,109 @@ where
         .set(synced_commit_index as i64);
 
     (new_inflight_count, pending_fetches.len())
+}
+
+// =============================================================================
+// Shared helper functions for scheduling and error handling
+// =============================================================================
+
+/// Result of scheduling commit range fetches.
+pub(crate) struct ScheduleResult {
+    /// The new highest scheduled commit index (if any ranges were scheduled).
+    pub new_highest_scheduled: Option<CommitIndex>,
+    /// The commit ranges that were scheduled for fetching.
+    pub ranges_scheduled: Vec<CommitRange>,
+}
+
+/// Creates commit range batches for fetching, respecting backpressure.
+///
+/// This function is shared between RegularCommitSyncer and FastCommitSyncer.
+/// It calculates which commit ranges should be fetched next based on:
+/// - The current gap between local and quorum commit indices
+/// - Backpressure from unhandled commits
+///
+/// # Parameters
+/// - `inner`: Shared context and dependencies
+/// - `fetch_after_index`: Start fetching from commits after this index
+/// - `quorum_commit_index`: The commit index that quorum has reached
+/// - `highest_handled_index`: The highest commit index that has been processed
+/// - `unhandled_commits_threshold`: Threshold for applying backpressure
+///
+/// # Returns
+/// A `ScheduleResult` with the new highest scheduled index and ranges to fetch.
+pub(crate) fn schedule_commit_ranges<C: NetworkClient>(
+    inner: &Inner<C>,
+    fetch_after_index: CommitIndex,
+    quorum_commit_index: CommitIndex,
+    highest_handled_index: CommitIndex,
+    unhandled_commits_threshold: CommitIndex,
+) -> ScheduleResult {
+    let step = inner.sync_type.commit_sync_batch_size(&inner.context);
+    let mut result = ScheduleResult {
+        new_highest_scheduled: None,
+        ranges_scheduled: Vec::new(),
+    };
+
+    for prev_end in (fetch_after_index..=quorum_commit_index).step_by(step as usize) {
+        let range_start = prev_end + 1;
+        let range_end = prev_end + step;
+
+        // Don't schedule incomplete batches
+        if quorum_commit_index < range_end {
+            break;
+        }
+
+        // Apply backpressure if handler is lagging
+        if highest_handled_index + unhandled_commits_threshold < range_end {
+            warn!(
+                "[{}] Skip scheduling new commit fetches: handler lagging. \
+                 highest_handled={}, threshold={}",
+                inner.sync_type.as_str(),
+                highest_handled_index,
+                unhandled_commits_threshold
+            );
+            break;
+        }
+
+        result
+            .ranges_scheduled
+            .push((range_start..=range_end).into());
+        result.new_highest_scheduled = Some(range_end);
+    }
+
+    result
+}
+
+/// Handles JoinError from fetch tasks.
+///
+/// # Returns
+/// `true` if the syncer should shutdown, `false` otherwise.
+pub(crate) fn handle_fetch_join_error(
+    error: &tokio::task::JoinError,
+    sync_type: &CommitSyncType,
+) -> bool {
+    if error.is_panic() {
+        // Re-panic in the main task
+        return true;
+    }
+    warn!(
+        "[{}] Fetch cancelled. Shutting down: {}",
+        sync_type.as_str(),
+        error
+    );
+    true // Signal to shutdown
+}
+
+/// Re-queues unfetched portion of a commit range for retry.
+///
+/// When a fetch returns partial results (fewer commits than requested),
+/// this function queues the remaining range for another fetch attempt.
+pub(crate) fn requeue_partial_range(
+    pending_fetches: &mut BTreeSet<CommitRange>,
+    commit_end: CommitIndex,
+    target_end: CommitIndex,
+) {
+    if commit_end < target_end {
+        pending_fetches.insert((commit_end + 1..=target_end).into());
+    }
 }

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -83,10 +83,20 @@ impl CommitSyncType {
         }
     }
 
-    pub(crate) fn should_schedule(&self, gap: u32, commit_sync_gap_threshold: u32) -> bool {
+    pub(crate) fn should_schedule(
+        &self,
+        gap: u32,
+        commit_sync_gap_threshold: u32,
+        consensus_transaction_ref: bool,
+    ) -> bool {
         match self {
-            CommitSyncType::Fast => gap > commit_sync_gap_threshold,
-            CommitSyncType::Regular => gap <= commit_sync_gap_threshold,
+            // Fast syncer requires consensus_transaction_ref to be enabled
+            CommitSyncType::Fast => consensus_transaction_ref && gap > commit_sync_gap_threshold,
+            // Regular syncer handles all gaps when consensus_transaction_ref is disabled,
+            // otherwise only handles small gaps
+            CommitSyncType::Regular => {
+                !consensus_transaction_ref || gap <= commit_sync_gap_threshold
+            }
         }
     }
 }

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -334,12 +334,13 @@ pub(crate) fn verify_transactions_with_transactions_refs(
     Ok(verified_transactions_map)
 }
 
+#[allow(dead_code)]
 #[async_trait::async_trait]
 pub trait CommitSyncer<C: NetworkClient>: Send + Sync + 'static + Sized {
     type FetchedData: Send + Sync;
 
     fn inner(&self) -> &Arc<Inner<C>>;
-    fn inflight_fetches(&mut self) -> &mut JoinSet<(u32, Self::FetchedData)>;
+    fn inflight_fetches(&mut self) -> &mut JoinSet<(u32, Vec<Self::FetchedData>)>;
     fn inflight_fetches_len(&self) -> usize;
     fn pending_fetches_len(&self) -> usize;
 
@@ -349,26 +350,23 @@ pub trait CommitSyncer<C: NetworkClient>: Send + Sync + 'static + Sized {
 
     fn pending_fetches(&mut self) -> &mut BTreeSet<CommitRange>;
 
-    fn fetched_ranges(&mut self) -> &mut BTreeMap<CommitRange, Self::FetchedData>;
+    fn fetched_ranges(&mut self) -> &mut BTreeMap<CommitRange, Vec<Self::FetchedData>>;
 
     fn unhandled_commits_threshold(&self) -> CommitIndex {
         self.inner().context.parameters.commit_sync_batch_size
             * (self.inner().context.parameters.commit_sync_batches_ahead as u32)
     }
-
-    #[cfg(test)]
-    fn highest_fetched_commit_index(&self) -> CommitIndex;
     async fn handle_fetch_result(
         &mut self,
         target_end: CommitIndex,
-        fetched_data_set: Self::FetchedData,
+        fetched_data_set: Vec<Self::FetchedData>,
     );
     async fn fetch_once(
         inner: Arc<Inner<C>>,
         target_authority: AuthorityIndex,
         commit_range: CommitRange,
         timeout: Duration,
-    ) -> ConsensusResult<Self::FetchedData>;
+    ) -> ConsensusResult<Vec<Self::FetchedData>>;
 
     fn start(self) -> CommitSyncerHandle {
         let (tx_shutdown, rx_shutdown) = oneshot::channel();
@@ -382,7 +380,7 @@ pub trait CommitSyncer<C: NetworkClient>: Send + Sync + 'static + Sized {
     async fn fetch_loop(
         inner: Arc<Inner<C>>,
         commit_range: CommitRange,
-    ) -> (CommitIndex, Self::FetchedData) {
+    ) -> (CommitIndex, Vec<Self::FetchedData>) {
         // Individual request base timeout.
         const TIMEOUT: Duration = Duration::from_secs(10);
         // Max per-request timeout will be base timeout times a multiplier.

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2024 IOTA Stiftung
+// Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 //! CommitSyncer implements efficient synchronization of committed data.

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -96,6 +96,40 @@ impl CommitSyncType {
     }
 }
 
+/// Verifies that fetched block headers match the requested block refs.
+/// Returns verified headers or an error if count/reference mismatch.
+pub(crate) fn verify_fetched_headers(
+    peer: AuthorityIndex,
+    request_block_refs: &[BlockRef],
+    serialized_block_headers: Vec<Bytes>,
+) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
+    // 1. Verify count matches
+    if request_block_refs.len() != serialized_block_headers.len() {
+        return Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
+            authority: peer,
+            requested: request_block_refs.len(),
+            received_headers: serialized_block_headers.len(),
+        });
+    }
+
+    // 2. Verify each header's reference matches requested
+    serialized_block_headers
+        .into_iter()
+        .zip(request_block_refs)
+        .map(|(serialized, requested_ref)| {
+            let header = VerifiedBlockHeader::new_from_bytes(serialized)?;
+            if *requested_ref != header.reference() {
+                return Err(ConsensusError::UnexpectedBlockHeaderForCommit {
+                    peer,
+                    requested: *requested_ref,
+                    received: header.reference(),
+                });
+            }
+            Ok(header)
+        })
+        .collect()
+}
+
 // Handle to stop the CommitSyncer loop.
 pub(crate) struct CommitSyncerHandle {
     schedule_task: JoinHandle<()>,

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -39,15 +39,14 @@ use std::{
 };
 
 use bytes::Bytes;
-use iota_metrics::spawn_logged_monitored_task;
 use itertools::Itertools;
 use parking_lot::RwLock;
 use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
 use starfish_config::AuthorityIndex;
 use tokio::{
     sync::oneshot,
-    task::{JoinHandle, JoinSet},
-    time::{MissedTickBehavior, sleep},
+    task::JoinHandle,
+    time::sleep,
 };
 use tracing::{info, warn};
 
@@ -368,349 +367,235 @@ pub(crate) fn verify_transactions_with_transactions_refs(
     Ok(verified_transactions_map)
 }
 
-#[allow(dead_code)]
-#[async_trait::async_trait]
-pub trait CommitSyncer<C: NetworkClient>: Send + Sync + 'static + Sized {
-    type FetchedData: Send + Sync;
+/// Generic fetch loop that retries fetching data from available authorities until
+/// a request succeeds. This is shared between RegularCommitSyncer and FastCommitSyncer.
+///
+/// # Type Parameters
+/// - `C`: Network client type
+/// - `T`: Fetched data type (CertifiedCommits for regular, (Vec<TrustedCommit>, Vec<CommittedSubDag>) for fast)
+/// - `F`: Fetch function type
+/// - `Fut`: Future returned by fetch function
+///
+/// # Parameters
+/// - `inner`: Shared context and dependencies
+/// - `commit_range`: The range of commits to fetch
+/// - `fetch_timeout_multiplier`: Multiplier for timeout calculation (4 for regular, 2 for fast)
+/// - `fetch_once_fn`: Implementation-specific fetch function
+///
+/// # Returns
+/// Tuple of (end_commit_index, fetched_data)
+#[cfg_attr(test, tracing::instrument(skip_all, fields(authority = %inner.context.own_index)))]
+pub(crate) async fn fetch_loop<C, T, F, Fut>(
+    inner: Arc<Inner<C>>,
+    commit_range: CommitRange,
+    fetch_timeout_multiplier: u32,
+    fetch_once_fn: F,
+) -> (CommitIndex, T)
+where
+    C: NetworkClient,
+    T: Send,
+    F: Fn(Arc<Inner<C>>, AuthorityIndex, CommitRange, Duration) -> Fut,
+    Fut: std::future::Future<Output = ConsensusResult<T>> + Send,
+{
+    // Individual request base timeout.
+    const TIMEOUT: Duration = Duration::from_secs(10);
+    // Max per-request timeout will be base timeout times a multiplier.
+    // At the extreme, this means there will be 120s timeout to fetch
+    // max_blocks_per_fetch blocks.
+    const MAX_TIMEOUT_MULTIPLIER: u32 = 12;
+    // timeout * max number of targets should be reasonably small, so the
+    // system can adjust to slow network or large data sizes quickly.
+    const MAX_NUM_TARGETS: usize = 24;
+    let mut timeout_multiplier = 0;
 
-    fn inner(&self) -> &Arc<Inner<C>>;
-    fn inflight_fetches(&mut self) -> &mut JoinSet<(u32, Vec<Self::FetchedData>)>;
-    fn inflight_fetches_len(&self) -> usize;
-    fn pending_fetches_len(&self) -> usize;
-
-    fn highest_scheduled_index(&mut self) -> &mut Option<CommitIndex>;
-
-    fn synced_commit_index(&mut self) -> &mut CommitIndex;
-
-    fn pending_fetches(&mut self) -> &mut BTreeSet<CommitRange>;
-
-    fn fetched_ranges(&mut self) -> &mut BTreeMap<CommitRange, Vec<Self::FetchedData>>;
-
-    fn unhandled_commits_threshold(&self) -> CommitIndex {
-        self.inner().context.parameters.commit_sync_batch_size
-            * (self.inner().context.parameters.commit_sync_batches_ahead as u32)
-    }
-    async fn handle_fetch_result(
-        &mut self,
-        target_end: CommitIndex,
-        fetched_data_set: Vec<Self::FetchedData>,
+    let _timer = inner
+        .context
+        .metrics
+        .node_metrics
+        .commit_sync_fetch_loop_latency
+        .start_timer();
+    info!(
+        "[{}] Starting to fetch commits in {commit_range:?} ...",
+        inner.sync_type.as_str()
     );
-    async fn fetch_once(
-        inner: Arc<Inner<C>>,
-        target_authority: AuthorityIndex,
-        commit_range: CommitRange,
-        timeout: Duration,
-    ) -> ConsensusResult<Vec<Self::FetchedData>>;
-
-    fn start(self) -> CommitSyncerHandle {
-        let (tx_shutdown, rx_shutdown) = oneshot::channel();
-        let schedule_task = spawn_logged_monitored_task!(self.schedule_loop(rx_shutdown,));
-        CommitSyncerHandle {
-            schedule_task,
-            tx_shutdown,
-        }
-    }
-
-    async fn fetch_loop(
-        inner: Arc<Inner<C>>,
-        commit_range: CommitRange,
-    ) -> (CommitIndex, Vec<Self::FetchedData>) {
-        // Individual request base timeout.
-        const TIMEOUT: Duration = Duration::from_secs(10);
-        // Max per-request timeout will be base timeout times a multiplier.
-        // At the extreme, this means there will be 120s timeout to fetch
-        // max_blocks_per_fetch blocks.
-        const MAX_TIMEOUT_MULTIPLIER: u32 = 12;
-        // timeout * max number of targets should be reasonably small, so the
-        // system can adjust to slow network or large data sizes quickly.
-        const MAX_NUM_TARGETS: usize = 24;
-        let mut timeout_multiplier = 0;
-
-        let _timer = inner
+    loop {
+        // Attempt to fetch commits and blocks through min(committee size,
+        // MAX_NUM_TARGETS) peers.
+        let mut target_authorities = inner
             .context
-            .metrics
-            .node_metrics
-            .commit_sync_fetch_loop_latency
-            .start_timer();
-        info!(
-            "[{}] Starting to fetch commits in {commit_range:?} ...",
-            inner.sync_type.as_str()
-        );
-        loop {
-            // Attempt to fetch commits and blocks through min(committee size,
-            // MAX_NUM_TARGETS) peers.
-            let mut target_authorities = inner
-                .context
-                .committee
-                .authorities()
-                .filter_map(|(i, _)| {
-                    if i != inner.context.own_index {
-                        Some(i)
-                    } else {
-                        None
-                    }
-                })
-                .collect_vec();
-            target_authorities.shuffle(&mut ThreadRng::default());
-            target_authorities.truncate(MAX_NUM_TARGETS);
-            // Increase timeout multiplier for each loop until MAX_TIMEOUT_MULTIPLIER.
-            timeout_multiplier = (timeout_multiplier + 1).min(MAX_TIMEOUT_MULTIPLIER);
-            let request_timeout = TIMEOUT * timeout_multiplier;
-
-            let fetch_timeout = request_timeout * 2;
-            // Try fetching from the selected target authority.
-            for authority in target_authorities {
-                match tokio::time::timeout(
-                    fetch_timeout,
-                    Self::fetch_once(
-                        inner.clone(),
-                        authority,
-                        commit_range.clone(),
-                        request_timeout,
-                    ),
-                )
-                .await
-                {
-                    Ok(Ok(committed_subdags)) => {
-                        info!(
-                            "[{}] Finished fetching commits in {commit_range:?}",
-                            inner.sync_type.as_str()
-                        );
-                        return (commit_range.end(), committed_subdags);
-                    }
-                    Ok(Err(e)) => {
-                        let hostname = inner
-                            .context
-                            .committee
-                            .authority(authority)
-                            .hostname
-                            .clone();
-                        warn!(
-                            "[{}] Failed to fetch {commit_range:?} from {hostname}: {}",
-                            inner.sync_type.as_str(),
-                            e
-                        );
-                        let error: &'static str = e.into();
-                        inner
-                            .context
-                            .metrics
-                            .node_metrics
-                            .commit_sync_fetch_once_errors
-                            .with_label_values(&[
-                                hostname.as_str(),
-                                error,
-                                inner.sync_type.as_str(),
-                            ])
-                            .inc();
-                    }
-                    Err(_) => {
-                        let hostname = inner
-                            .context
-                            .committee
-                            .authority(authority)
-                            .hostname
-                            .clone();
-                        warn!(
-                            "[{}] Timed out fetching {commit_range:?} from {authority}",
-                            inner.sync_type.as_str()
-                        );
-                        inner
-                            .context
-                            .metrics
-                            .node_metrics
-                            .commit_sync_fetch_once_errors
-                            .with_label_values(&[
-                                hostname.as_str(),
-                                "FetchTimeout",
-                                inner.sync_type.as_str(),
-                            ])
-                            .inc();
-                    }
+            .committee
+            .authorities()
+            .filter_map(|(i, _)| {
+                if i != inner.context.own_index {
+                    Some(i)
+                } else {
+                    None
                 }
-            }
-            // Avoid busy looping, by waiting for a while before retrying.
-            sleep(TIMEOUT).await;
-        }
-    }
+            })
+            .collect_vec();
+        target_authorities.shuffle(&mut ThreadRng::default());
+        target_authorities.truncate(MAX_NUM_TARGETS);
+        // Increase timeout multiplier for each loop until MAX_TIMEOUT_MULTIPLIER.
+        timeout_multiplier = (timeout_multiplier + 1).min(MAX_TIMEOUT_MULTIPLIER);
+        let request_timeout = TIMEOUT * timeout_multiplier;
 
-    fn try_start_fetches(&mut self) {
-        // Cap parallel fetches based on configured limit and committee size, to avoid
-        // overloading the network. Also when there are too many fetched block headers
-        // that cannot be sent to Core before an earlier fetch has not finished,
-        // reduce parallelism so the earlier fetch can retry on a better host and
-        // succeed.
-        let target_parallel_fetches = self
-            .inner()
-            .context
-            .parameters
-            .commit_sync_parallel_fetches
-            .min(self.inner().context.committee.size() * 2 / 3)
-            .min(
-                self.inner()
-                    .context
-                    .parameters
-                    .commit_sync_batches_ahead
-                    .saturating_sub(self.fetched_ranges().len()),
+        let fetch_timeout = request_timeout * fetch_timeout_multiplier;
+        // Try fetching from the selected target authority.
+        for authority in target_authorities {
+            match tokio::time::timeout(
+                fetch_timeout,
+                fetch_once_fn(
+                    inner.clone(),
+                    authority,
+                    commit_range.clone(),
+                    request_timeout,
+                ),
             )
-            .max(1);
-        // Start new fetches if there are pending batches and available slots.
-        loop {
-            let inner = self.inner().clone();
-            let inflight_fetches_len = self.inflight_fetches_len();
-
-            if inflight_fetches_len >= target_parallel_fetches {
-                break;
+            .await
+            {
+                Ok(Ok(data)) => {
+                    info!(
+                        "[{}] Finished fetching commits in {commit_range:?}",
+                        inner.sync_type.as_str()
+                    );
+                    return (commit_range.end(), data);
+                }
+                Ok(Err(e)) => {
+                    let hostname = inner
+                        .context
+                        .committee
+                        .authority(authority)
+                        .hostname
+                        .clone();
+                    warn!(
+                        "[{}] Failed to fetch {commit_range:?} from {hostname}: {}",
+                        inner.sync_type.as_str(),
+                        e
+                    );
+                    let error: &'static str = e.into();
+                    inner
+                        .context
+                        .metrics
+                        .node_metrics
+                        .commit_sync_fetch_once_errors
+                        .with_label_values(&[
+                            hostname.as_str(),
+                            error,
+                            inner.sync_type.as_str(),
+                        ])
+                        .inc();
+                }
+                Err(_) => {
+                    let hostname = inner
+                        .context
+                        .committee
+                        .authority(authority)
+                        .hostname
+                        .clone();
+                    warn!(
+                        "[{}] Timed out fetching {commit_range:?} from {authority}",
+                        inner.sync_type.as_str()
+                    );
+                    inner
+                        .context
+                        .metrics
+                        .node_metrics
+                        .commit_sync_fetch_once_errors
+                        .with_label_values(&[
+                            hostname.as_str(),
+                            "FetchTimeout",
+                            inner.sync_type.as_str(),
+                        ])
+                        .inc();
+                }
             }
-            if !self.pending_fetches().is_empty() {
-                info!(
-                    "[{}] Pending fetches: {:?}, target parallel fetches: {}, inflight fetch number: {}",
-                    inner.sync_type.as_str(),
-                    self.pending_fetches(),
-                    target_parallel_fetches,
-                    inflight_fetches_len
-                );
-            }
-            let Some(commit_range) = self.pending_fetches().pop_first() else {
-                break;
-            };
-            (*self.inflight_fetches()).spawn(Self::fetch_loop(inner, commit_range));
         }
-
-        let metrics = &self.inner().context.metrics.node_metrics;
-        let sync_label = self.inner().sync_type.as_str();
-        metrics
-            .commit_sync_inflight_fetches
-            .with_label_values(&[sync_label])
-            .set(self.inflight_fetches_len() as i64);
-        metrics
-            .commit_sync_pending_fetches
-            .with_label_values(&[sync_label])
-            .set(self.pending_fetches_len() as i64);
-        metrics
-            .commit_sync_highest_synced_index
-            .with_label_values(&[sync_label])
-            .set(*self.synced_commit_index() as i64);
+        // Avoid busy looping, by waiting for a while before retrying.
+        sleep(TIMEOUT).await;
     }
-    async fn schedule_loop(mut self, mut rx_shutdown: oneshot::Receiver<()>) {
-        let mut interval = tokio::time::interval(Duration::from_secs(2));
-        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+}
 
-        loop {
-            tokio::select! {
-                // Periodically, schedule new fetches if the node is falling behind.
-                _ = interval.tick() => {
-                    self.try_schedule_once();
-                }
-                // Handles results from fetch tasks.
-                Some(result) = self.inflight_fetches().join_next(), if !self.inflight_fetches().is_empty() => {
-                    if let Err(e) = result {
-                        if e.is_panic() {
-                            std::panic::resume_unwind(e.into_panic());
-                        }
-                        warn!("[{}] Fetch cancelled. FastCommitSyncer shutting down: {}", self.inner().sync_type.as_str(), e);
-                        // If any fetch is cancelled or panicked, try to shutdown and exit the loop.
-                        self.inflight_fetches().shutdown().await;
-                        return;
-                    }
-                    let (target_end, committed_subdags) = result.unwrap();
-                    self.handle_fetch_result(target_end, committed_subdags).await;
-                }
-                _ = &mut rx_shutdown => {
-                    // Shutdown requested.
-                    info!("[{}] FastCommitSyncer shutting down ...", self.inner().sync_type.as_str());
-                    self.inflight_fetches().shutdown().await;
-                    return;
-                }
-            }
+/// Generic function to start pending fetches while respecting parallelism limits.
+/// This is shared between RegularCommitSyncer and FastCommitSyncer.
+///
+/// # Parameters
+/// - `inner`: Shared context and dependencies
+/// - `pending_fetches`: Set of commit ranges pending fetch
+/// - `fetched_ranges_count`: Number of fetched ranges waiting to be processed
+/// - `inflight_fetches_count`: Number of currently in-flight fetch tasks
+/// - `synced_commit_index`: Latest synced commit index
+/// - `spawn_fn`: Closure to spawn a new fetch task
+///
+/// # Returns
+/// Updated counts after spawning new fetches
+pub(crate) fn try_start_fetches<C, F>(
+    inner: &Arc<Inner<C>>,
+    pending_fetches: &mut BTreeSet<CommitRange>,
+    fetched_ranges_count: usize,
+    inflight_fetches_count: usize,
+    synced_commit_index: CommitIndex,
+    mut spawn_fn: F,
+) -> (usize, usize)
+where
+    C: NetworkClient,
+    F: FnMut(CommitRange),
+{
+    // Cap parallel fetches based on configured limit and committee size, to avoid
+    // overloading the network. Also when there are too many fetched block headers
+    // that cannot be sent to Core before an earlier fetch has not finished,
+    // reduce parallelism so the earlier fetch can retry on a better host and
+    // succeed.
+    let target_parallel_fetches = inner
+        .context
+        .parameters
+        .commit_sync_parallel_fetches
+        .min(inner.context.committee.size() * 2 / 3)
+        .min(
+            inner
+                .context
+                .parameters
+                .commit_sync_batches_ahead
+                .saturating_sub(fetched_ranges_count),
+        )
+        .max(1);
 
-            self.try_start_fetches();
+    let mut new_inflight_count = inflight_fetches_count;
+
+    // Start new fetches if there are pending batches and available slots.
+    loop {
+        if new_inflight_count >= target_parallel_fetches {
+            break;
         }
-    }
-
-    fn try_schedule_once(&mut self) {
-        let quorum_commit_index = self.inner().commit_vote_monitor.quorum_commit_index();
-        let local_commit_index = self.inner().dag_state.read().last_commit_index();
-
-        // Skip scheduling depending on sync type and gap threshold.
-        let gap = quorum_commit_index.saturating_sub(local_commit_index);
-        if !self.inner().sync_type.should_schedule(
-            gap,
-            self.inner().context.parameters.commit_sync_gap_threshold,
-        ) {
-            return;
-        }
-
-        let metrics = &self.inner().context.metrics.node_metrics;
-        metrics
-            .commit_sync_quorum_index
-            .set(quorum_commit_index as i64);
-        metrics
-            .commit_sync_local_index
-            .set(local_commit_index as i64);
-        let highest_handled_index = self
-            .inner()
-            .commit_consumer_monitor
-            .highest_handled_commit();
-        let highest_scheduled_index = self.highest_scheduled_index().unwrap_or(0);
-        // Update synced_commit_index periodically to make sure it is not smaller than
-        // local commit index.
-        *self.synced_commit_index() = (*self.synced_commit_index()).max(local_commit_index);
-        let unhandled_commits_threshold = self.unhandled_commits_threshold();
-
-        // TODO: cleanup inflight fetches that are no longer needed.
-        let fetch_after_index =
-            (*self.synced_commit_index()).max(self.highest_scheduled_index().unwrap_or(0));
-        // When the node is falling behind, schedule pending fetches which will be
-        // executed on later.
-        let step = self
-            .inner()
-            .sync_type
-            .commit_sync_batch_size(&self.inner().context);
-
-        info!(
-            "[{}] Checking to schedule fetches: synced_commit_index={}, highest_handled_index={}, highest_scheduled_index={}, quorum_commit_index={}, unhandled_commits_threshold={}, fetch_after_index={}, step={}",
-            self.inner().sync_type.as_str(),
-            self.synced_commit_index(),
-            highest_handled_index,
-            highest_scheduled_index,
-            quorum_commit_index,
-            unhandled_commits_threshold,
-            fetch_after_index,
-            step
-        );
-
-        for prev_end in (fetch_after_index..=quorum_commit_index).step_by(step as usize) {
-            // Create range with inclusive start and end.
-            let range_start = prev_end + 1;
-            let range_end = prev_end + step;
-            // Commit range is not fetched when [range_start, range_end] contains less
-            // number of commits than the target batch size. This is to avoid
-            // the cost of processing more and smaller batches. Block broadcast,
-            // subscription and synchronization will help the node catchup.
-            if quorum_commit_index < range_end {
-                break;
-            }
-            // Pause scheduling new fetches when handling of commits is lagging.
-            if highest_handled_index + unhandled_commits_threshold < range_end {
-                warn!(
-                    "[{}] Skip scheduling new commit fetches: consensus handler is lagging. highest_handled_index={}, highest_scheduled_index={}",
-                    self.inner().sync_type.as_str(),
-                    highest_handled_index,
-                    highest_scheduled_index
-                );
-                break;
-            }
+        if !pending_fetches.is_empty() {
             info!(
-                "[{}] Scheduling fetch for commit range {}..={}",
-                self.inner().sync_type.as_str(),
-                range_start,
-                range_end
+                "[{}] Pending fetches: {:?}, target parallel fetches: {}, inflight fetch number: {}",
+                inner.sync_type.as_str(),
+                pending_fetches,
+                target_parallel_fetches,
+                new_inflight_count
             );
-            self.pending_fetches()
-                .insert((range_start..=range_end).into());
-            // quorum_commit_index should be non-decreasing, so highest_scheduled_index
-            // should not decrease either.
-            *self.highest_scheduled_index() = Some(range_end);
         }
+        let Some(commit_range) = pending_fetches.pop_first() else {
+            break;
+        };
+        spawn_fn(commit_range);
+        new_inflight_count += 1;
     }
+
+    let metrics = &inner.context.metrics.node_metrics;
+    let sync_label = inner.sync_type.as_str();
+    metrics
+        .commit_sync_inflight_fetches
+        .with_label_values(&[sync_label])
+        .set(new_inflight_count as i64);
+    metrics
+        .commit_sync_pending_fetches
+        .with_label_values(&[sync_label])
+        .set(pending_fetches.len() as i64);
+    metrics
+        .commit_sync_highest_synced_index
+        .with_label_values(&[sync_label])
+        .set(synced_commit_index as i64);
+
+    (new_inflight_count, pending_fetches.len())
 }

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -1,3 +1,7 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -9,7 +9,6 @@ use futures::{StreamExt as _, stream::FuturesOrdered};
 use iota_metrics::spawn_logged_monitored_task;
 use itertools::Itertools as _;
 use parking_lot::RwLock;
-use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
 use starfish_config::AuthorityIndex;
 use tokio::{
     runtime::Handle,
@@ -25,7 +24,8 @@ use crate::{
     block_verifier::BlockVerifier,
     commit::{CertifiedCommit, CertifiedCommits, CommitAPI as _, CommitRange},
     commit_syncer::{
-        CommitSyncType, CommitSyncerHandle, Inner, verify_fetched_headers,
+        CommitSyncType, CommitSyncerHandle, Inner, fetch_loop as shared_fetch_loop,
+        try_start_fetches as shared_try_start_fetches, verify_fetched_headers,
         verify_transactions_with_headers, verify_transactions_with_transactions_refs,
     },
     commit_vote_monitor::CommitVoteMonitor,
@@ -451,60 +451,18 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
     }
 
     fn try_start_fetches(&mut self) {
-        // Cap parallel fetches based on configured limit and committee size, to avoid
-        // overloading the network. Also when there are too many fetched block headers
-        // that cannot be sent to Core before an earlier fetch has not finished,
-        // reduce parallelism so the earlier fetch can retry on a better host and
-        // succeed.
-        let target_parallel_fetches = self
-            .inner
-            .context
-            .parameters
-            .commit_sync_parallel_fetches
-            .min(self.inner.context.committee.size() * 2 / 3)
-            .min(
-                self.inner
-                    .context
-                    .parameters
-                    .commit_sync_batches_ahead
-                    .saturating_sub(self.fetched_ranges.len()),
-            )
-            .max(1);
-        // Start new fetches if there are pending batches and available slots.
-        loop {
-            if self.inflight_fetches.len() >= target_parallel_fetches {
-                break;
-            }
-            if !self.pending_fetches.is_empty() {
-                info!(
-                    "[{}] Pending fetches: {:?}, target parallel fetches: {}, inflight fetch number: {}",
-                    self.inner.sync_type.as_str(),
-                    self.pending_fetches,
-                    target_parallel_fetches,
-                    self.inflight_fetches.len()
-                );
-            }
-            let Some(commit_range) = self.pending_fetches.pop_first() else {
-                break;
-            };
-            self.inflight_fetches
-                .spawn(Self::fetch_loop(self.inner.clone(), commit_range));
-        }
-
-        let metrics = &self.inner.context.metrics.node_metrics;
-        let sync_label = self.inner.sync_type.as_str();
-        metrics
-            .commit_sync_inflight_fetches
-            .with_label_values(&[sync_label])
-            .set(self.inflight_fetches.len() as i64);
-        metrics
-            .commit_sync_pending_fetches
-            .with_label_values(&[sync_label])
-            .set(self.pending_fetches.len() as i64);
-        metrics
-            .commit_sync_highest_synced_index
-            .with_label_values(&[sync_label])
-            .set(self.synced_commit_index as i64);
+        let inner = self.inner.clone();
+        shared_try_start_fetches(
+            &self.inner,
+            &mut self.pending_fetches,
+            self.fetched_ranges.len(),
+            self.inflight_fetches.len(),
+            self.synced_commit_index,
+            |commit_range| {
+                self.inflight_fetches
+                    .spawn(Self::fetch_loop(inner.clone(), commit_range));
+            },
+        );
     }
 
     // Retries fetching commits and block headers from available authorities, until
@@ -516,126 +474,12 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
         inner: Arc<Inner<C>>,
         commit_range: CommitRange,
     ) -> (CommitIndex, CertifiedCommits) {
-        // Individual request base timeout.
-        const TIMEOUT: Duration = Duration::from_secs(10);
-        // Max per-request timeout will be base timeout times a multiplier.
-        // At the extreme, this means there will be 120s timeout to fetch
-        // max_blocks_per_fetch blocks.
-        const MAX_TIMEOUT_MULTIPLIER: u32 = 12;
-        // timeout * max number of targets should be reasonably small, so the
-        // system can adjust to slow network or large data sizes quickly.
-        const MAX_NUM_TARGETS: usize = 24;
-        let mut timeout_multiplier = 0;
-
-        let _timer = inner
-            .context
-            .metrics
-            .node_metrics
-            .commit_sync_fetch_loop_latency
-            .start_timer();
-        info!(
-            "[{}] Starting to fetch commits in {commit_range:?} ...",
-            inner.sync_type.as_str()
-        );
-        loop {
-            // Attempt to fetch commits and blocks through min(committee size,
-            // MAX_NUM_TARGETS) peers.
-            let mut target_authorities = inner
-                .context
-                .committee
-                .authorities()
-                .filter_map(|(i, _)| {
-                    if i != inner.context.own_index {
-                        Some(i)
-                    } else {
-                        None
-                    }
-                })
-                .collect_vec();
-            target_authorities.shuffle(&mut ThreadRng::default());
-            target_authorities.truncate(MAX_NUM_TARGETS);
-            // Increase timeout multiplier for each loop until MAX_TIMEOUT_MULTIPLIER.
-            timeout_multiplier = (timeout_multiplier + 1).min(MAX_TIMEOUT_MULTIPLIER);
-            let request_timeout = TIMEOUT * timeout_multiplier;
-            // Give enough overall timeout for fetching commits and block headers.
-            // - Timeout for fetching commits and commit certifying block headers.
-            // - Timeout for fetching block headers referenced by the commits.
-            // - Time spent on pipelining requests to fetch block headers.
-            // - Another headroom to allow fetch_once() to timeout gracefully if possible.
-            let fetch_timeout = request_timeout * 4;
-            // Try fetching from selected target authority.
-            for authority in target_authorities {
-                match tokio::time::timeout(
-                    fetch_timeout,
-                    Self::fetch_once(
-                        inner.clone(),
-                        authority,
-                        commit_range.clone(),
-                        request_timeout,
-                    ),
-                )
-                .await
-                {
-                    Ok(Ok(commits)) => {
-                        info!(
-                            "[{}] Finished fetching commits in {commit_range:?}",
-                            inner.sync_type.as_str()
-                        );
-                        return (commit_range.end(), commits);
-                    }
-                    Ok(Err(e)) => {
-                        let hostname = inner
-                            .context
-                            .committee
-                            .authority(authority)
-                            .hostname
-                            .clone();
-                        warn!(
-                            "[{}] Failed to fetch {commit_range:?} from {hostname}: {}",
-                            inner.sync_type.as_str(),
-                            e
-                        );
-                        let error: &'static str = e.into();
-                        inner
-                            .context
-                            .metrics
-                            .node_metrics
-                            .commit_sync_fetch_once_errors
-                            .with_label_values(&[
-                                hostname.as_str(),
-                                error,
-                                inner.sync_type.as_str(),
-                            ])
-                            .inc();
-                    }
-                    Err(_) => {
-                        let hostname = inner
-                            .context
-                            .committee
-                            .authority(authority)
-                            .hostname
-                            .clone();
-                        warn!(
-                            "[{}] Timed out fetching {commit_range:?} from {authority}",
-                            inner.sync_type.as_str()
-                        );
-                        inner
-                            .context
-                            .metrics
-                            .node_metrics
-                            .commit_sync_fetch_once_errors
-                            .with_label_values(&[
-                                hostname.as_str(),
-                                "FetchTimeout",
-                                inner.sync_type.as_str(),
-                            ])
-                            .inc();
-                    }
-                }
-            }
-            // Avoid busy looping, by waiting for a while before retrying.
-            sleep(TIMEOUT).await;
-        }
+        // Regular syncer uses 4x timeout multiplier to account for:
+        // - Fetching commits and commit certifying block headers
+        // - Fetching block headers referenced by the commits
+        // - Time spent on pipelining requests
+        // - Headroom to allow fetch_once() to timeout gracefully
+        shared_fetch_loop(inner, commit_range, 4, Self::fetch_once).await
     }
 
     // Fetches commits and blocks from a single authority. At a high level, first

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -151,11 +151,14 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
 
         // Skip scheduling depending on sync type and gap threshold.
         let gap = quorum_commit_index.saturating_sub(local_commit_index);
-        if !self
-            .inner
-            .sync_type
-            .should_schedule(gap, self.inner.context.parameters.commit_sync_gap_threshold)
-        {
+        if !self.inner.sync_type.should_schedule(
+            gap,
+            self.inner.context.parameters.commit_sync_gap_threshold,
+            self.inner
+                .context
+                .protocol_config
+                .consensus_transaction_ref(),
+        ) {
             return;
         }
 

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -25,6 +25,7 @@ use crate::{
     commit::{CertifiedCommit, CertifiedCommits, CommitAPI as _, CommitRange},
     commit_syncer::{
         CommitSyncType, CommitSyncerHandle, Inner, fetch_loop as shared_fetch_loop,
+        handle_fetch_join_error, requeue_partial_range, schedule_commit_ranges,
         try_start_fetches as shared_try_start_fetches, verify_fetched_headers,
         verify_transactions_with_headers, verify_transactions_with_transactions_refs,
     },
@@ -115,14 +116,15 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                 }
                 // Handles results from fetch tasks.
                 Some(result) = self.inflight_fetches.join_next(), if !self.inflight_fetches.is_empty() => {
-                    if let Err(e) = result {
+                    if let Err(ref e) = result {
                         if e.is_panic() {
-                            std::panic::resume_unwind(e.into_panic());
+                            std::panic::resume_unwind(result.unwrap_err().into_panic());
                         }
-                        warn!("[{}] Fetch cancelled. CommitSyncer shutting down: {}", self.inner.sync_type.as_str(), e);
-                        // If any fetch is cancelled or panicked, try to shutdown and exit the loop.
-                        self.inflight_fetches.shutdown().await;
-                        return;
+                        if handle_fetch_join_error(e, &self.inner.sync_type) {
+                            // If any fetch is cancelled or panicked, try to shutdown and exit the loop.
+                            self.inflight_fetches.shutdown().await;
+                            return;
+                        }
                     }
                     let (target_end, commits) = result.unwrap();
                     self.handle_fetch_result(target_end, commits).await;
@@ -165,21 +167,15 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
         // Update synced_commit_index periodically to make sure it is not smaller than
         // local commit index.
         self.synced_commit_index = self.synced_commit_index.max(local_commit_index);
-        let unhandled_commits_threshold = self.unhandled_commits_threshold();
+        let unhandled_commits_threshold = self.inner.unhandled_commits_threshold();
 
         // TODO: cleanup inflight fetches that are no longer needed.
         let fetch_after_index = self
             .synced_commit_index
             .max(self.highest_scheduled_index.unwrap_or(0));
-        // When the node is falling behind, schedule pending fetches which will be
-        // executed on later.
-        let step = self
-            .inner
-            .sync_type
-            .commit_sync_batch_size(&self.inner.context);
 
         info!(
-            "[{}] Checking to schedule fetches: synced_commit_index={}, highest_handled_index={}, highest_scheduled_index={}, quorum_commit_index={}, unhandled_commits_threshold={}, fetch_after_index={}, step={}",
+            "[{}] Checking to schedule fetches: synced_commit_index={}, highest_handled_index={}, highest_scheduled_index={}, quorum_commit_index={}, unhandled_commits_threshold={}, fetch_after_index={}",
             self.inner.sync_type.as_str(),
             self.synced_commit_index,
             highest_handled_index,
@@ -187,41 +183,31 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
             quorum_commit_index,
             unhandled_commits_threshold,
             fetch_after_index,
-            step
         );
 
-        for prev_end in (fetch_after_index..=quorum_commit_index).step_by(step as usize) {
-            // Create range with inclusive start and end.
-            let range_start = prev_end + 1;
-            let range_end = prev_end + step;
-            // Commit range is not fetched when [range_start, range_end] contains less
-            // number of commits than the target batch size. This is to avoid
-            // the cost of processing more and smaller batches. Block broadcast,
-            // subscription and synchronization will help the node catchup.
-            if quorum_commit_index < range_end {
-                break;
-            }
-            // Pause scheduling new fetches when handling of commits is lagging.
-            if highest_handled_index + unhandled_commits_threshold < range_end {
-                warn!(
-                    "[{}] Skip scheduling new commit fetches: consensus handler is lagging. highest_handled_index={}, highest_scheduled_index={}",
-                    self.inner.sync_type.as_str(),
-                    highest_handled_index,
-                    highest_scheduled_index
-                );
-                break;
-            }
+        // Schedule commit ranges for fetching using shared helper
+        let schedule_result = schedule_commit_ranges(
+            &self.inner,
+            fetch_after_index,
+            quorum_commit_index,
+            highest_handled_index,
+            unhandled_commits_threshold,
+        );
+
+        // Add scheduled ranges to pending fetches
+        for range in schedule_result.ranges_scheduled {
             info!(
                 "[{}] Scheduling fetch for commit range {}..={}",
                 self.inner.sync_type.as_str(),
-                range_start,
-                range_end
+                range.start(),
+                range.end()
             );
-            self.pending_fetches
-                .insert((range_start..=range_end).into());
-            // quorum_commit_index should be non-decreasing, so highest_scheduled_index
-            // should not decrease either.
-            self.highest_scheduled_index = Some(range_end);
+            self.pending_fetches.insert(range);
+        }
+
+        // Update highest scheduled index
+        if let Some(new_highest) = schedule_result.new_highest_scheduled {
+            self.highest_scheduled_index = Some(new_highest);
         }
     }
 
@@ -280,10 +266,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
             .set(self.highest_fetched_commit_index as i64);
 
         // Allow returning partial results, and try fetching the rest separately.
-        if commit_end < target_end {
-            self.pending_fetches
-                .insert((commit_end + 1..=target_end).into());
-        }
+        requeue_partial_range(&mut self.pending_fetches, commit_end, target_end);
         // Make sure synced_commit_index is up to date.
         self.synced_commit_index = self
             .synced_commit_index
@@ -807,9 +790,9 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
         Ok(CertifiedCommits::new(certified_commits))
     }
 
+    #[cfg(test)]
     fn unhandled_commits_threshold(&self) -> CommitIndex {
-        self.inner.context.parameters.commit_sync_batch_size
-            * (self.inner.context.parameters.commit_sync_batches_ahead as u32)
+        self.inner.unhandled_commits_threshold()
     }
 
     #[cfg(test)]

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -147,10 +147,10 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
 
     fn try_schedule_once(&mut self) {
         let quorum_commit_index = self.inner.commit_vote_monitor.quorum_commit_index();
-        let local_commit_index = self.inner.dag_state.read().last_commit_index();
+        let dag_state_commit_index = self.inner.dag_state.read().last_commit_index();
 
         // Skip scheduling depending on sync type and gap threshold.
-        let gap = quorum_commit_index.saturating_sub(local_commit_index);
+        let gap = quorum_commit_index.saturating_sub(dag_state_commit_index);
         if !self.inner.sync_type.should_schedule(
             gap,
             self.inner.context.parameters.commit_sync_gap_threshold,
@@ -168,12 +168,12 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
             .set(quorum_commit_index as i64);
         metrics
             .commit_sync_local_index
-            .set(local_commit_index as i64);
+            .set(dag_state_commit_index as i64);
         let highest_handled_index = self.inner.commit_consumer_monitor.highest_handled_commit();
         let highest_scheduled_index = self.highest_scheduled_index.unwrap_or(0);
         // Update synced_commit_index periodically to make sure it is not smaller than
         // local commit index.
-        self.synced_commit_index = self.synced_commit_index.max(local_commit_index);
+        self.synced_commit_index = self.synced_commit_index.max(dag_state_commit_index);
         let unhandled_commits_threshold = self.inner.unhandled_commits_threshold();
 
         // TODO: cleanup inflight fetches that are no longer needed.

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -20,13 +20,13 @@ use tokio::{
 use tracing::{debug, info, warn};
 
 use crate::{
-    CommitConsumerMonitor, CommitIndex, VerifiedBlockHeader,
+    CommitConsumerMonitor, CommitIndex,
     block_header::BlockRef,
     block_verifier::BlockVerifier,
     commit::{CertifiedCommit, CertifiedCommits, CommitAPI as _, CommitRange},
     commit_syncer::{
-        CommitSyncType, CommitSyncerHandle, Inner, verify_transactions_with_headers,
-        verify_transactions_with_transactions_refs,
+        CommitSyncType, CommitSyncerHandle, Inner, verify_fetched_headers,
+        verify_transactions_with_headers, verify_transactions_with_transactions_refs,
     },
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
@@ -752,40 +752,12 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                             timeout,
                         )
                         .await?;
-                    // 5. Verify the same number of block headers is returned as requested.
-                    if request_block_refs.len() != serialized_block_headers.len() {
-                        return Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
-                            authority: target_authority,
-                            requested: request_block_refs.len(),
-                            received_headers: serialized_block_headers.len(),
-                        });
-                    }
-                    // 6. Verify returned block headers have valid formats.
-                    let verified_block_headers = serialized_block_headers
-                        .iter()
-                        .cloned()
-                        .zip(request_block_refs)
-                        .map(|(serialized_block_header, requested_block_ref)| {
-                            // we don't verify the header, we only check the block reference below
-                            let block_header =
-                                VerifiedBlockHeader::new_from_bytes(serialized_block_header)?;
-
-                            // 7. Verify the returned block headers match the requested block refs.
-                            // If they do match, the returned block headers can be considered
-                            // verified as well.
-                            if *requested_block_ref != block_header.reference() {
-                                return Err(ConsensusError::UnexpectedBlockHeaderForCommit {
-                                    peer: target_authority,
-                                    requested: *requested_block_ref,
-                                    received: block_header.reference(),
-                                });
-                            }
-
-                            Ok(block_header)
-                        })
-                        .collect::<ConsensusResult<Vec<_>>>()?;
-
-                    Ok(verified_block_headers)
+                    // 5. Verify headers: count matches and each reference matches requested.
+                    verify_fetched_headers(
+                        target_authority,
+                        request_block_refs,
+                        serialized_block_headers,
+                    )
                 }
             })
             .collect();

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -1,7 +1,3 @@
-// Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2024 IOTA Stiftung
-// SPDX-License-Identifier: Apache-2.0
-
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,
@@ -10,10 +6,17 @@ use std::{
 
 use bytes::Bytes;
 use futures::{StreamExt as _, stream::FuturesOrdered};
+use iota_metrics::spawn_logged_monitored_task;
 use itertools::Itertools as _;
 use parking_lot::RwLock;
+use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
 use starfish_config::AuthorityIndex;
-use tokio::{runtime::Handle, task::JoinSet, time::sleep};
+use tokio::{
+    runtime::Handle,
+    sync::oneshot,
+    task::JoinSet,
+    time::{MissedTickBehavior, sleep},
+};
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -22,7 +25,7 @@ use crate::{
     block_verifier::BlockVerifier,
     commit::{CertifiedCommit, CertifiedCommits, CommitAPI as _, CommitRange},
     commit_syncer::{
-        CommitSyncType, CommitSyncer, Inner, verify_transactions_with_headers,
+        CommitSyncType, CommitSyncerHandle, Inner, verify_transactions_with_headers,
         verify_transactions_with_transactions_refs,
     },
     commit_vote_monitor::CommitVoteMonitor,
@@ -90,57 +93,147 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
             synced_commit_index,
         }
     }
-}
-#[async_trait::async_trait]
-impl<C: NetworkClient> CommitSyncer<C> for RegularCommitSyncer<C> {
-    type FetchedData = CertifiedCommits;
 
-    fn inner(&self) -> &Arc<Inner<C>> {
-        &self.inner
+    pub(crate) fn start(self) -> CommitSyncerHandle {
+        let (tx_shutdown, rx_shutdown) = oneshot::channel();
+        let schedule_task = spawn_logged_monitored_task!(self.schedule_loop(rx_shutdown,));
+        CommitSyncerHandle {
+            schedule_task,
+            tx_shutdown,
+        }
+    }
+    #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %self.inner.context.own_index)))]
+    async fn schedule_loop(mut self, mut rx_shutdown: oneshot::Receiver<()>) {
+        let mut interval = tokio::time::interval(Duration::from_secs(2));
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                // Periodically, schedule new fetches if the node is falling behind.
+                _ = interval.tick() => {
+                    self.try_schedule_once();
+                }
+                // Handles results from fetch tasks.
+                Some(result) = self.inflight_fetches.join_next(), if !self.inflight_fetches.is_empty() => {
+                    if let Err(e) = result {
+                        if e.is_panic() {
+                            std::panic::resume_unwind(e.into_panic());
+                        }
+                        warn!("[{}] Fetch cancelled. CommitSyncer shutting down: {}", self.inner.sync_type.as_str(), e);
+                        // If any fetch is cancelled or panicked, try to shutdown and exit the loop.
+                        self.inflight_fetches.shutdown().await;
+                        return;
+                    }
+                    let (target_end, commits) = result.unwrap();
+                    self.handle_fetch_result(target_end, commits).await;
+                }
+                _ = &mut rx_shutdown => {
+                    // Shutdown requested.
+                    info!("[{}] CommitSyncer shutting down ...", self.inner.sync_type.as_str());
+                    self.inflight_fetches.shutdown().await;
+                    return;
+                }
+            }
+
+            self.try_start_fetches();
+        }
     }
 
-    fn inflight_fetches(&mut self) -> &mut JoinSet<(u32, Self::FetchedData)> {
-        &mut self.inflight_fetches
-    }
+    fn try_schedule_once(&mut self) {
+        let quorum_commit_index = self.inner.commit_vote_monitor.quorum_commit_index();
+        let local_commit_index = self.inner.dag_state.read().last_commit_index();
 
-    fn inflight_fetches_len(&self) -> usize {
-        self.inflight_fetches.len()
-    }
+        // Skip scheduling depending on sync type and gap threshold.
+        let gap = quorum_commit_index.saturating_sub(local_commit_index);
+        if !self
+            .inner
+            .sync_type
+            .should_schedule(gap, self.inner.context.parameters.commit_sync_gap_threshold)
+        {
+            return;
+        }
 
-    fn pending_fetches_len(&self) -> usize {
-        self.pending_fetches.len()
-    }
+        let metrics = &self.inner.context.metrics.node_metrics;
+        metrics
+            .commit_sync_quorum_index
+            .set(quorum_commit_index as i64);
+        metrics
+            .commit_sync_local_index
+            .set(local_commit_index as i64);
+        let highest_handled_index = self.inner.commit_consumer_monitor.highest_handled_commit();
+        let highest_scheduled_index = self.highest_scheduled_index.unwrap_or(0);
+        // Update synced_commit_index periodically to make sure it is not smaller than
+        // local commit index.
+        self.synced_commit_index = self.synced_commit_index.max(local_commit_index);
+        let unhandled_commits_threshold = self.unhandled_commits_threshold();
 
-    fn highest_scheduled_index(&mut self) -> &mut Option<CommitIndex> {
-        &mut self.highest_scheduled_index
-    }
+        // TODO: cleanup inflight fetches that are no longer needed.
+        let fetch_after_index = self
+            .synced_commit_index
+            .max(self.highest_scheduled_index.unwrap_or(0));
+        // When the node is falling behind, schedule pending fetches which will be
+        // executed on later.
+        let step = self
+            .inner
+            .sync_type
+            .commit_sync_batch_size(&self.inner.context);
 
-    fn synced_commit_index(&mut self) -> &mut CommitIndex {
-        &mut self.synced_commit_index
-    }
+        info!(
+            "[{}] Checking to schedule fetches: synced_commit_index={}, highest_handled_index={}, highest_scheduled_index={}, quorum_commit_index={}, unhandled_commits_threshold={}, fetch_after_index={}, step={}",
+            self.inner.sync_type.as_str(),
+            self.synced_commit_index,
+            highest_handled_index,
+            highest_scheduled_index,
+            quorum_commit_index,
+            unhandled_commits_threshold,
+            fetch_after_index,
+            step
+        );
 
-    fn pending_fetches(&mut self) -> &mut BTreeSet<CommitRange> {
-        &mut self.pending_fetches
-    }
-
-    fn fetched_ranges(&mut self) -> &mut BTreeMap<CommitRange, Self::FetchedData> {
-        &mut self.fetched_ranges
-    }
-
-    #[cfg(test)]
-    fn highest_fetched_commit_index(&self) -> CommitIndex {
-        self.highest_fetched_commit_index
+        for prev_end in (fetch_after_index..=quorum_commit_index).step_by(step as usize) {
+            // Create range with inclusive start and end.
+            let range_start = prev_end + 1;
+            let range_end = prev_end + step;
+            // Commit range is not fetched when [range_start, range_end] contains less
+            // number of commits than the target batch size. This is to avoid
+            // the cost of processing more and smaller batches. Block broadcast,
+            // subscription and synchronization will help the node catchup.
+            if quorum_commit_index < range_end {
+                break;
+            }
+            // Pause scheduling new fetches when handling of commits is lagging.
+            if highest_handled_index + unhandled_commits_threshold < range_end {
+                warn!(
+                    "[{}] Skip scheduling new commit fetches: consensus handler is lagging. highest_handled_index={}, highest_scheduled_index={}",
+                    self.inner.sync_type.as_str(),
+                    highest_handled_index,
+                    highest_scheduled_index
+                );
+                break;
+            }
+            info!(
+                "[{}] Scheduling fetch for commit range {}..={}",
+                self.inner.sync_type.as_str(),
+                range_start,
+                range_end
+            );
+            self.pending_fetches
+                .insert((range_start..=range_end).into());
+            // quorum_commit_index should be non-decreasing, so highest_scheduled_index
+            // should not decrease either.
+            self.highest_scheduled_index = Some(range_end);
+        }
     }
 
     async fn handle_fetch_result(
         &mut self,
         target_end: CommitIndex,
-        fetched_data_set: Self::FetchedData,
+        certified_commits: CertifiedCommits,
     ) {
-        assert!(!fetched_data_set.commits().is_empty());
+        assert!(!certified_commits.commits().is_empty());
 
         let (total_blocks_fetched, total_headers_size_bytes, total_transactions_size_bytes) =
-            fetched_data_set.commits().iter().fold(
+            certified_commits.commits().iter().fold(
                 (0, 0, 0),
                 |(blocks, header_bytes, transaction_bytes), c| {
                     (
@@ -164,7 +257,7 @@ impl<C: NetworkClient> CommitSyncer<C> for RegularCommitSyncer<C> {
         metrics
             .commit_sync_fetched_commits
             .with_label_values(&[sync_label])
-            .inc_by(fetched_data_set.commits().len() as u64);
+            .inc_by(certified_commits.commits().len() as u64);
         metrics
             .commit_sync_fetched_block_headers
             .inc_by(total_blocks_fetched as u64);
@@ -177,8 +270,8 @@ impl<C: NetworkClient> CommitSyncer<C> for RegularCommitSyncer<C> {
             .inc_by(total_transactions_size_bytes);
 
         let (commit_start, commit_end) = (
-            fetched_data_set.commits().first().unwrap().index(),
-            fetched_data_set.commits().last().unwrap().index(),
+            certified_commits.commits().first().unwrap().index(),
+            certified_commits.commits().last().unwrap().index(),
         );
         self.highest_fetched_commit_index = self.highest_fetched_commit_index.max(commit_end);
         metrics
@@ -198,7 +291,7 @@ impl<C: NetworkClient> CommitSyncer<C> for RegularCommitSyncer<C> {
         // Only add new blocks if at least some of them are not already synced.
         if self.synced_commit_index < commit_end {
             self.fetched_ranges
-                .insert((commit_start..=commit_end).into(), fetched_data_set);
+                .insert((commit_start..=commit_end).into(), certified_commits);
         }
         // Try to process as many fetched blocks as possible.
         while let Some((fetched_commit_range, _commits)) = self.fetched_ranges.first_key_value() {
@@ -356,6 +449,195 @@ impl<C: NetworkClient> CommitSyncer<C> for RegularCommitSyncer<C> {
             .with_label_values(&[sync_label])
             .set(self.synced_commit_index as i64);
     }
+
+    fn try_start_fetches(&mut self) {
+        // Cap parallel fetches based on configured limit and committee size, to avoid
+        // overloading the network. Also when there are too many fetched block headers
+        // that cannot be sent to Core before an earlier fetch has not finished,
+        // reduce parallelism so the earlier fetch can retry on a better host and
+        // succeed.
+        let target_parallel_fetches = self
+            .inner
+            .context
+            .parameters
+            .commit_sync_parallel_fetches
+            .min(self.inner.context.committee.size() * 2 / 3)
+            .min(
+                self.inner
+                    .context
+                    .parameters
+                    .commit_sync_batches_ahead
+                    .saturating_sub(self.fetched_ranges.len()),
+            )
+            .max(1);
+        // Start new fetches if there are pending batches and available slots.
+        loop {
+            if self.inflight_fetches.len() >= target_parallel_fetches {
+                break;
+            }
+            if !self.pending_fetches.is_empty() {
+                info!(
+                    "[{}] Pending fetches: {:?}, target parallel fetches: {}, inflight fetch number: {}",
+                    self.inner.sync_type.as_str(),
+                    self.pending_fetches,
+                    target_parallel_fetches,
+                    self.inflight_fetches.len()
+                );
+            }
+            let Some(commit_range) = self.pending_fetches.pop_first() else {
+                break;
+            };
+            self.inflight_fetches
+                .spawn(Self::fetch_loop(self.inner.clone(), commit_range));
+        }
+
+        let metrics = &self.inner.context.metrics.node_metrics;
+        let sync_label = self.inner.sync_type.as_str();
+        metrics
+            .commit_sync_inflight_fetches
+            .with_label_values(&[sync_label])
+            .set(self.inflight_fetches.len() as i64);
+        metrics
+            .commit_sync_pending_fetches
+            .with_label_values(&[sync_label])
+            .set(self.pending_fetches.len() as i64);
+        metrics
+            .commit_sync_highest_synced_index
+            .with_label_values(&[sync_label])
+            .set(self.synced_commit_index as i64);
+    }
+
+    // Retries fetching commits and block headers from available authorities, until
+    // a request succeeds where at least a prefix of the commit range is
+    // fetched. Returns the fetched commits and block headers referenced by the
+    // commits.
+    #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %inner.context.own_index)))]
+    async fn fetch_loop(
+        inner: Arc<Inner<C>>,
+        commit_range: CommitRange,
+    ) -> (CommitIndex, CertifiedCommits) {
+        // Individual request base timeout.
+        const TIMEOUT: Duration = Duration::from_secs(10);
+        // Max per-request timeout will be base timeout times a multiplier.
+        // At the extreme, this means there will be 120s timeout to fetch
+        // max_blocks_per_fetch blocks.
+        const MAX_TIMEOUT_MULTIPLIER: u32 = 12;
+        // timeout * max number of targets should be reasonably small, so the
+        // system can adjust to slow network or large data sizes quickly.
+        const MAX_NUM_TARGETS: usize = 24;
+        let mut timeout_multiplier = 0;
+
+        let _timer = inner
+            .context
+            .metrics
+            .node_metrics
+            .commit_sync_fetch_loop_latency
+            .start_timer();
+        info!(
+            "[{}] Starting to fetch commits in {commit_range:?} ...",
+            inner.sync_type.as_str()
+        );
+        loop {
+            // Attempt to fetch commits and blocks through min(committee size,
+            // MAX_NUM_TARGETS) peers.
+            let mut target_authorities = inner
+                .context
+                .committee
+                .authorities()
+                .filter_map(|(i, _)| {
+                    if i != inner.context.own_index {
+                        Some(i)
+                    } else {
+                        None
+                    }
+                })
+                .collect_vec();
+            target_authorities.shuffle(&mut ThreadRng::default());
+            target_authorities.truncate(MAX_NUM_TARGETS);
+            // Increase timeout multiplier for each loop until MAX_TIMEOUT_MULTIPLIER.
+            timeout_multiplier = (timeout_multiplier + 1).min(MAX_TIMEOUT_MULTIPLIER);
+            let request_timeout = TIMEOUT * timeout_multiplier;
+            // Give enough overall timeout for fetching commits and block headers.
+            // - Timeout for fetching commits and commit certifying block headers.
+            // - Timeout for fetching block headers referenced by the commits.
+            // - Time spent on pipelining requests to fetch block headers.
+            // - Another headroom to allow fetch_once() to timeout gracefully if possible.
+            let fetch_timeout = request_timeout * 4;
+            // Try fetching from selected target authority.
+            for authority in target_authorities {
+                match tokio::time::timeout(
+                    fetch_timeout,
+                    Self::fetch_once(
+                        inner.clone(),
+                        authority,
+                        commit_range.clone(),
+                        request_timeout,
+                    ),
+                )
+                .await
+                {
+                    Ok(Ok(commits)) => {
+                        info!(
+                            "[{}] Finished fetching commits in {commit_range:?}",
+                            inner.sync_type.as_str()
+                        );
+                        return (commit_range.end(), commits);
+                    }
+                    Ok(Err(e)) => {
+                        let hostname = inner
+                            .context
+                            .committee
+                            .authority(authority)
+                            .hostname
+                            .clone();
+                        warn!(
+                            "[{}] Failed to fetch {commit_range:?} from {hostname}: {}",
+                            inner.sync_type.as_str(),
+                            e
+                        );
+                        let error: &'static str = e.into();
+                        inner
+                            .context
+                            .metrics
+                            .node_metrics
+                            .commit_sync_fetch_once_errors
+                            .with_label_values(&[
+                                hostname.as_str(),
+                                error,
+                                inner.sync_type.as_str(),
+                            ])
+                            .inc();
+                    }
+                    Err(_) => {
+                        let hostname = inner
+                            .context
+                            .committee
+                            .authority(authority)
+                            .hostname
+                            .clone();
+                        warn!(
+                            "[{}] Timed out fetching {commit_range:?} from {authority}",
+                            inner.sync_type.as_str()
+                        );
+                        inner
+                            .context
+                            .metrics
+                            .node_metrics
+                            .commit_sync_fetch_once_errors
+                            .with_label_values(&[
+                                hostname.as_str(),
+                                "FetchTimeout",
+                                inner.sync_type.as_str(),
+                            ])
+                            .inc();
+                    }
+                }
+            }
+            // Avoid busy looping, by waiting for a while before retrying.
+            sleep(TIMEOUT).await;
+        }
+    }
+
     // Fetches commits and blocks from a single authority. At a high level, first
     // the commits are fetched and verified. After that, blocks referenced in
     // the certified commits are fetched and sent to Core for processing.
@@ -364,7 +646,7 @@ impl<C: NetworkClient> CommitSyncer<C> for RegularCommitSyncer<C> {
         target_authority: AuthorityIndex,
         commit_range: CommitRange,
         timeout: Duration,
-    ) -> ConsensusResult<Self::FetchedData> {
+    ) -> ConsensusResult<CertifiedCommits> {
         // Maximum delay between consecutive pipelined requests, to avoid
         // overwhelming the peer while still maintaining reasonable throughput.
         const MAX_PIPELINE_DELAY: Duration = Duration::from_secs(1);
@@ -708,39 +990,37 @@ impl<C: NetworkClient> CommitSyncer<C> for RegularCommitSyncer<C> {
 
         Ok(CertifiedCommits::new(certified_commits))
     }
-}
 
-//     fn unhandled_commits_threshold(&self) -> CommitIndex {
-//         self.inner.context.parameters.commit_sync_batch_size
-//             * (self.inner.context.parameters.commit_sync_batches_ahead as
-//               u32)
-//     }
-//
-//     #[cfg(test)]
-//     fn pending_fetches(&self) -> BTreeSet<CommitRange> {
-//         self.pending_fetches.clone()
-//     }
-//
-//     #[cfg(test)]
-//     fn fetched_ranges(&self) -> BTreeMap<CommitRange, CertifiedCommits> {
-//         self.fetched_ranges.clone()
-//     }
-//
-//     #[cfg(test)]
-//     fn highest_scheduled_index(&self) -> Option<CommitIndex> {
-//         self.highest_scheduled_index
-//     }
-//
-//     #[cfg(test)]
-//     fn highest_fetched_commit_index(&self) -> CommitIndex {
-//         self.highest_fetched_commit_index
-//     }
-//
-//     #[cfg(test)]
-//     fn synced_commit_index(&self) -> CommitIndex {
-//         self.synced_commit_index
-//     }
-// }
+    fn unhandled_commits_threshold(&self) -> CommitIndex {
+        self.inner.context.parameters.commit_sync_batch_size
+            * (self.inner.context.parameters.commit_sync_batches_ahead as u32)
+    }
+
+    #[cfg(test)]
+    fn pending_fetches(&self) -> BTreeSet<CommitRange> {
+        self.pending_fetches.clone()
+    }
+
+    #[cfg(test)]
+    fn fetched_ranges(&self) -> BTreeMap<CommitRange, CertifiedCommits> {
+        self.fetched_ranges.clone()
+    }
+
+    #[cfg(test)]
+    fn highest_scheduled_index(&self) -> Option<CommitIndex> {
+        self.highest_scheduled_index
+    }
+
+    #[cfg(test)]
+    fn highest_fetched_commit_index(&self) -> CommitIndex {
+        self.highest_fetched_commit_index
+    }
+
+    #[cfg(test)]
+    fn synced_commit_index(&self) -> CommitIndex {
+        self.synced_commit_index
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -755,7 +1035,7 @@ mod tests {
         block_header::{BlockRef, TestBlockHeader, VerifiedBlockHeader},
         block_verifier::NoopBlockVerifier,
         commit::CommitRange,
-        commit_syncer::{CommitSyncer, regular::RegularCommitSyncer},
+        commit_syncer::regular::RegularCommitSyncer,
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
         core_thread::tests::MockCoreThreadDispatcher,
@@ -868,7 +1148,7 @@ mod tests {
         assert!(commit_syncer.fetched_ranges().is_empty());
         assert!(commit_syncer.highest_scheduled_index().is_none());
         assert_eq!(commit_syncer.highest_fetched_commit_index(), 0);
-        assert_eq!(*commit_syncer.synced_commit_index(), 0);
+        assert_eq!(commit_syncer.synced_commit_index(), 0);
 
         // Observe round 15 blocks voting for commit 10 from authorities 0 to 2 in
         // CommitVoteMonitor
@@ -886,9 +1166,9 @@ mod tests {
         // Verify state.
         assert_eq!(commit_syncer.pending_fetches().len(), 2);
         assert!(commit_syncer.fetched_ranges().is_empty());
-        assert_eq!(*commit_syncer.highest_scheduled_index(), Some(10));
+        assert_eq!(commit_syncer.highest_scheduled_index(), Some(10));
         assert_eq!(commit_syncer.highest_fetched_commit_index(), 0);
-        assert_eq!(*commit_syncer.synced_commit_index(), 0);
+        assert_eq!(commit_syncer.synced_commit_index(), 0);
 
         // Observe round 40 blocks voting for commit 35 from authorities 0 to 2 in
         // CommitVoteMonitor
@@ -905,7 +1185,7 @@ mod tests {
 
         // Verify commit syncer is paused after scheduling 15 commits to index 25.
         assert_eq!(commit_syncer.unhandled_commits_threshold(), 25);
-        assert_eq!(*commit_syncer.highest_scheduled_index(), Some(25));
+        assert_eq!(commit_syncer.highest_scheduled_index(), Some(25));
         let pending_fetches = commit_syncer.pending_fetches();
         assert_eq!(pending_fetches.len(), 5);
 
@@ -914,7 +1194,7 @@ mod tests {
         commit_syncer.try_schedule_once();
 
         // Verify commit syncer schedules fetches up to index 35.
-        assert_eq!(*commit_syncer.highest_scheduled_index(), Some(35));
+        assert_eq!(commit_syncer.highest_scheduled_index(), Some(35));
         let pending_fetches = commit_syncer.pending_fetches();
         assert_eq!(pending_fetches.len(), 7);
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -531,7 +531,8 @@ impl Core {
     ///
     /// This method follows a similar flow to `try_commit`:
     /// 1. Store commits and transactions in DagState
-    /// 2. For commits with reputation scores, update leader schedule and store CommitInfo
+    /// 2. For commits with reputation scores, update leader schedule and store
+    ///    CommitInfo
     /// 3. Flush to storage
     /// 4. Process subdags via commit_observer
     ///
@@ -560,11 +561,13 @@ impl Core {
                 }
             }
 
-            // Note: We intentionally do NOT call add_scoring_subdags() here because
-            // during fast sync, CommittedSubDag.headers is empty (we only have
-            // committed_header_refs). The scoring_subdag would get corrupted with
-            // leaders but no votes, leading to incorrect score calculations.
-            // Instead, we use the reputation_scores embedded in the commits directly.
+            // Note: We intentionally do NOT call add_scoring_subdags() here
+            // because during fast sync, CommittedSubDag.headers is
+            // empty (we only have committed_header_refs). The
+            // scoring_subdag would get corrupted with leaders but
+            // no votes, leading to incorrect score calculations.
+            // Instead, we use the reputation_scores embedded in the commits
+            // directly.
         }
 
         // Update leader schedule for commits with reputation scores.

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -543,7 +543,7 @@ impl Core {
         // First, store commits and transactions in DagState
         {
             let mut dag_state = self.dag_state.write();
-
+            // TODO: Ensure that we add commits in order
             // Store commits for recovery and track those with reputation scores
             for commit in &commits {
                 dag_state.add_commit(commit.clone());

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -39,14 +39,13 @@ use crate::{
         VerifiedOwnShard, VerifiedTransactions,
     },
     block_manager::BlockManager,
-    commit::{CertifiedCommits, CommitAPI, CommitRange, PendingSubDag, TrustedCommit},
+    commit::{CertifiedCommits, CommitAPI, PendingSubDag, TrustedCommit},
     commit_observer::{CommitObserver, CommittedSubDagSource},
     context::Context,
     dag_state::{DagState, TransactionSource},
     encoder::{ShardEncoder, create_encoder},
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
-    leader_scoring::ReputationScores,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     transaction::TransactionConsumer,
     transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _},
@@ -530,6 +529,12 @@ impl Core {
     /// subdags. Also updates the leader schedule from commits that contain
     /// reputation scores.
     ///
+    /// This method follows a similar flow to `try_commit`:
+    /// 1. Store commits and transactions in DagState
+    /// 2. For commits with reputation scores, update leader schedule and store CommitInfo
+    /// 3. Flush to storage
+    /// 4. Process subdags via commit_observer
+    ///
     /// Commits must be stored so that recovery/reinitialization can rebuild
     /// the Linearizer's transaction acknowledgment tracker.
     /// Transactions must be stored so they are available for recovery and
@@ -539,21 +544,12 @@ impl Core {
         commits: Vec<TrustedCommit>,
         committed_subdags: Vec<CommittedSubDag>,
     ) -> ConsensusResult<()> {
-        // Track the last commit with reputation scores for commit_info storage
-        let mut last_commit_with_scores: Option<&TrustedCommit> = None;
-
         // First, store commits and transactions in DagState
         {
             let mut dag_state = self.dag_state.write();
-            // TODO: Ensure that we add commits in order
             // Store commits for recovery and track those with reputation scores
             for commit in &commits {
                 dag_state.add_commit(commit.clone());
-
-                // Track the last commit that has reputation scores
-                if !commit.reputation_scores().is_empty() {
-                    last_commit_with_scores = Some(commit);
-                }
             }
 
             // Store transactions for each subdag
@@ -569,40 +565,31 @@ impl Core {
             // committed_header_refs). The scoring_subdag would get corrupted with
             // leaders but no votes, leading to incorrect score calculations.
             // Instead, we use the reputation_scores embedded in the commits directly.
-
-            // Flush commits to storage so they're available for
-            // get_block_refs_for_recent_commits when close-to-quorum mode
-            // triggers header fetching.
-            dag_state.flush();
         }
 
-        // Update leader schedule from commits that have reputation scores.
-        // This ensures correct leader election during fast sync and after recovery.
-        // Also store commit_info so the leader schedule can be recovered from storage.
-        if let Some(commit) = last_commit_with_scores {
-            self.leader_schedule
-                .update_from_commit_scores(commit.index(), commit.reputation_scores());
-
-            // Store commit_info for recovery. The reputation_scores need to be converted
-            // from the commit's format to ReputationScores struct.
-            let commit_index = commit.index();
-            let num_commits_per_schedule = self.leader_schedule.num_commits_per_schedule();
-            let range_end = commit_index;
-            let range_start = commit_index.saturating_sub(num_commits_per_schedule as u32 - 1);
-            let commit_range = CommitRange::new(range_start..=range_end);
-            let reputation_scores = ReputationScores::from_scores_desc(
-                self.context.committee.size(),
-                commit_range,
-                commit.reputation_scores(),
-            );
-
-            // Clear scoring_subdag before adding commit_info, since DagState
-            // initialization may have loaded unscored subdags from storage.
-            // This mirrors what update_leader_schedule does in leader_schedule.rs.
-            let mut dag_state = self.dag_state.write();
-            dag_state.clear_scoring_subdag();
-            dag_state.add_commit_info(reputation_scores);
+        // Update leader schedule for commits with reputation scores.
+        // This mirrors the flow in try_commit where update_leader_schedule is called
+        // when commits_until_update reaches 0.
+        for commit in &commits {
+            let reputation_scores = commit.reputation_scores();
+            if !reputation_scores.is_empty() {
+                // update_from_commit_scores will:
+                // 1. Clear scoring_subdag
+                // 2. Add commit_info to DagState
+                // 3. Update leader swap table
+                // 4. Update metrics
+                self.leader_schedule.update_from_commit_scores(
+                    &self.dag_state,
+                    commit.index(),
+                    reputation_scores,
+                );
+            }
         }
+
+        // Flush commits to storage so they're available for
+        // get_block_refs_for_recent_commits when close-to-quorum mode
+        // triggers header fetching.
+        self.dag_state.write().flush();
 
         // Then process subdags as usual
         self.commit_observer
@@ -645,16 +632,19 @@ impl Core {
             (last_commit_index, threshold_round, last_commit_leader)
         };
 
-        // 5. Reinitialize BlockManager
+        // 5. Reinitialize LeaderSchedule from stored commit info
+        self.leader_schedule.reinitialize(&self.dag_state);
+
+        // 6. Reinitialize BlockManager
         self.block_manager.reinitialize();
 
-        // 6. Update last_decided_leader to match the new DAG state
+        // 7. Update last_decided_leader to match the new DAG state
         self.last_decided_leader = last_commit_leader;
 
-        // 7. Reinitialize CommitObserver with recovery (uses recover_and_send_commits)
+        // 8. Reinitialize CommitObserver with recovery (uses recover_and_send_commits)
         self.commit_observer.reinitialize(last_commit_index);
 
-        // 8. Reset signaling state
+        // 9. Reset signaling state
         self.last_signaled_round = threshold_round.saturating_sub(1);
 
         info!("Components reinitialized successfully");

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -123,6 +123,7 @@ pub(crate) enum ReasonToCreateBlock {
     Recover,
     QuorumSubscribersExist,
     KnownLastBlock,
+    #[allow(dead_code)]
     FastSyncComplete,
 }
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -123,6 +123,7 @@ pub(crate) enum ReasonToCreateBlock {
     Recover,
     QuorumSubscribersExist,
     KnownLastBlock,
+    FastSyncComplete,
 }
 
 impl ReasonToCreateBlock {
@@ -135,6 +136,7 @@ impl ReasonToCreateBlock {
             ReasonToCreateBlock::Recover => "Recover",
             ReasonToCreateBlock::QuorumSubscribersExist => "QuorumSubscribersExist",
             ReasonToCreateBlock::KnownLastBlock => "KnownLastBlock",
+            ReasonToCreateBlock::FastSyncComplete => "FastSyncComplete",
         }
     }
 
@@ -149,6 +151,7 @@ impl ReasonToCreateBlock {
             ReasonToCreateBlock::Recover => true,
             ReasonToCreateBlock::QuorumSubscribersExist => true,
             ReasonToCreateBlock::KnownLastBlock => true,
+            ReasonToCreateBlock::FastSyncComplete => true,
         }
     }
 }
@@ -563,6 +566,10 @@ impl Core {
             // committed_header_refs). The scoring_subdag would get corrupted with
             // leaders but no votes, leading to incorrect score calculations.
             // Instead, we use the reputation_scores embedded in the commits directly.
+
+            // Flush commits to storage so they're available for get_block_refs_for_recent_commits
+            // when close-to-quorum mode triggers header fetching.
+            dag_state.flush();
         }
 
         // Update leader schedule from commits that have reputation scores.
@@ -587,8 +594,12 @@ impl Core {
                 commit.reputation_scores(),
             );
 
-            // Note: scoring_subdag is empty during fast sync, so this assertion passes
-            self.dag_state.write().add_commit_info(reputation_scores);
+            // Clear scoring_subdag before adding commit_info, since DagState
+            // initialization may have loaded unscored subdags from storage.
+            // This mirrors what update_leader_schedule does in leader_schedule.rs.
+            let mut dag_state = self.dag_state.write();
+            dag_state.clear_scoring_subdag();
+            dag_state.add_commit_info(reputation_scores);
         }
 
         // Then process subdags as usual
@@ -612,7 +623,7 @@ impl Core {
         );
 
         // Hold the dag_state lock for the entire flow to ensure consistency
-        let (last_commit_index, threshold_round) = {
+        let (last_commit_index, threshold_round, last_commit_leader) = {
             let mut dag_state = self.dag_state.write();
 
             // 1. Store block headers on disk
@@ -628,16 +639,20 @@ impl Core {
             dag_state.reinitialize();
 
             let threshold_round = dag_state.threshold_clock_round();
-            (last_commit_index, threshold_round)
+            let last_commit_leader = dag_state.last_commit_leader();
+            (last_commit_index, threshold_round, last_commit_leader)
         };
 
         // 5. Reinitialize BlockManager
         self.block_manager.reinitialize();
 
-        // 6. Reinitialize CommitObserver
+        // 6. Update last_decided_leader to match the new DAG state
+        self.last_decided_leader = last_commit_leader;
+
+        // 7. Reinitialize CommitObserver with recovery (uses recover_and_send_commits)
         self.commit_observer.reinitialize(last_commit_index);
 
-        // 7. Reset signaling state
+        // 8. Reset signaling state
         self.last_signaled_round = threshold_round.saturating_sub(1);
 
         info!("Components reinitialized successfully");

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -561,7 +561,7 @@ impl Core {
                     // 3. Update leader swap table
                     // 4. Update metrics
                     self.leader_schedule.update_from_commit_scores(
-                        &self.dag_state,
+                        &mut dag_state,
                         commit.index(),
                         reputation_scores,
                     );

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -39,13 +39,14 @@ use crate::{
         VerifiedOwnShard, VerifiedTransactions,
     },
     block_manager::BlockManager,
-    commit::{CertifiedCommits, PendingSubDag, TrustedCommit},
+    commit::{CertifiedCommits, CommitAPI, CommitRange, PendingSubDag, TrustedCommit},
     commit_observer::{CommitObserver, CommittedSubDagSource},
     context::Context,
     dag_state::{DagState, TransactionSource},
     encoder::{ShardEncoder, create_encoder},
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
+    leader_scoring::ReputationScores,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     transaction::TransactionConsumer,
     transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _},
@@ -510,6 +511,7 @@ impl Core {
         self.add_block_headers(block_headers)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn handle_committed_sub_dags(
         &mut self,
         committed_subdags: Vec<CommittedSubDag>,
@@ -520,8 +522,9 @@ impl Core {
     }
 
     /// Handle committed subdags from fast sync.
-    /// First stores the commits, transactions, and scoring subdags in DagState,
-    /// then processes the subdags.
+    /// First stores the commits, transactions in DagState, then processes the subdags.
+    /// Also updates the leader schedule from commits that contain reputation scores.
+    ///
     /// Commits must be stored so that recovery/reinitialization can rebuild
     /// the Linearizer's transaction acknowledgment tracker.
     /// Transactions must be stored so they are available for recovery and cache.
@@ -530,28 +533,62 @@ impl Core {
         commits: Vec<TrustedCommit>,
         committed_subdags: Vec<CommittedSubDag>,
     ) -> ConsensusResult<()> {
-        // First, store commits, transactions, and scoring subdags in DagState
+        // Track the last commit with reputation scores for commit_info storage
+        let mut last_commit_with_scores: Option<&TrustedCommit> = None;
+
+        // First, store commits and transactions in DagState
         {
             let mut dag_state = self.dag_state.write();
 
-            // Store commits for recovery
-            for commit in commits {
-                dag_state.add_commit(commit);
+            // Store commits for recovery and track those with reputation scores
+            for commit in &commits {
+                dag_state.add_commit(commit.clone());
+
+                // Track the last commit that has reputation scores
+                if !commit.reputation_scores().is_empty() {
+                    last_commit_with_scores = Some(commit);
+                }
             }
 
             // Store transactions for each subdag
             for subdag in &committed_subdags {
                 for transactions in &subdag.transactions {
-                    dag_state.add_transactions(
-                        transactions.clone(),
-                        TransactionSource::CommitSyncer,
-                    );
+                    dag_state
+                        .add_transactions(transactions.clone(), TransactionSource::CommitSyncer);
                 }
             }
 
-            // Add scoring subdags for leader schedule scoring
-            dag_state
-                .add_scoring_subdags(committed_subdags.iter().map(|s| s.base.clone()).collect());
+            // Note: We intentionally do NOT call add_scoring_subdags() here because
+            // during fast sync, CommittedSubDag.headers is empty (we only have
+            // committed_header_refs). The scoring_subdag would get corrupted with
+            // leaders but no votes, leading to incorrect score calculations.
+            // Instead, we use the reputation_scores embedded in the commits directly.
+        }
+
+        // Update leader schedule from commits that have reputation scores.
+        // This ensures correct leader election during fast sync and after recovery.
+        // Also store commit_info so the leader schedule can be recovered from storage.
+        if let Some(commit) = last_commit_with_scores {
+            self.leader_schedule.update_from_commit_scores(
+                commit.index(),
+                commit.reputation_scores(),
+            );
+
+            // Store commit_info for recovery. The reputation_scores need to be converted
+            // from the commit's format to ReputationScores struct.
+            let commit_index = commit.index();
+            let num_commits_per_schedule = self.leader_schedule.num_commits_per_schedule();
+            let range_end = commit_index;
+            let range_start = commit_index.saturating_sub(num_commits_per_schedule as u32 - 1);
+            let commit_range = CommitRange::new(range_start..=range_end);
+            let reputation_scores = ReputationScores::from_scores_desc(
+                self.context.committee.size(),
+                commit_range,
+                commit.reputation_scores(),
+            );
+
+            // Note: scoring_subdag is empty during fast sync, so this assertion passes
+            self.dag_state.write().add_commit_info(reputation_scores);
         }
 
         // Then process subdags as usual
@@ -560,8 +597,9 @@ impl Core {
     }
 
     /// Reinitialize consensus components after fast sync completes.
-    /// This stores block headers on disk and reinitializes DagState, BlockManager,
-    /// and CommitObserver so that regular syncer can take over.
+    /// This stores block headers on disk and reinitializes DagState,
+    /// BlockManager, and CommitObserver so that regular syncer can take
+    /// over.
     ///
     /// Block headers should cover the cached_rounds window (~500 rounds).
     pub(crate) fn reinitialize_components(

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -550,42 +550,34 @@ impl Core {
             let mut dag_state = self.dag_state.write();
             // Store commits for recovery and track those with reputation scores
             for commit in &commits {
+                // Update leader schedule for commits with reputation scores.
+                // This mirrors the flow in try_commit where update_leader_schedule is called
+                // when commits_until_update reaches 0.
+                let reputation_scores = commit.reputation_scores();
+                if !reputation_scores.is_empty() {
+                    // update_from_commit_scores will:
+                    // 1. Clear scoring_subdag
+                    // 2. Add commit_info for previous commit index to DagState
+                    // 3. Update leader swap table
+                    // 4. Update metrics
+                    self.leader_schedule.update_from_commit_scores(
+                        &self.dag_state,
+                        commit.index(),
+                        reputation_scores,
+                    );
+                }
+
                 dag_state.add_commit(commit.clone());
             }
 
             // Store transactions for each subdag
             for subdag in &committed_subdags {
                 for transactions in &subdag.transactions {
-                    dag_state
-                        .add_transactions(transactions.clone(), TransactionSource::CommitSyncer);
+                    dag_state.add_transactions(
+                        transactions.clone(),
+                        TransactionSource::FastCommitSyncer,
+                    );
                 }
-            }
-
-            // Note: We intentionally do NOT call add_scoring_subdags() here
-            // because during fast sync, CommittedSubDag.headers is
-            // empty (we only have committed_header_refs). The
-            // scoring_subdag would get corrupted with leaders but
-            // no votes, leading to incorrect score calculations.
-            // Instead, we use the reputation_scores embedded in the commits
-            // directly.
-        }
-
-        // Update leader schedule for commits with reputation scores.
-        // This mirrors the flow in try_commit where update_leader_schedule is called
-        // when commits_until_update reaches 0.
-        for commit in &commits {
-            let reputation_scores = commit.reputation_scores();
-            if !reputation_scores.is_empty() {
-                // update_from_commit_scores will:
-                // 1. Clear scoring_subdag
-                // 2. Add commit_info to DagState
-                // 3. Update leader swap table
-                // 4. Update metrics
-                self.leader_schedule.update_from_commit_scores(
-                    &self.dag_state,
-                    commit.index(),
-                    reputation_scores,
-                );
             }
         }
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -514,16 +514,6 @@ impl Core {
         self.add_block_headers(block_headers)
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn handle_committed_sub_dags(
-        &mut self,
-        committed_subdags: Vec<CommittedSubDag>,
-        source: CommittedSubDagSource,
-    ) -> ConsensusResult<()> {
-        self.commit_observer
-            .handle_committed_sub_dags(committed_subdags, source)
-    }
-
     /// Handle committed subdags from fast sync.
     /// First stores the commits, transactions in DagState, then processes the
     /// subdags. Also updates the leader schedule from commits that contain

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -39,7 +39,7 @@ use crate::{
         VerifiedOwnShard, VerifiedTransactions,
     },
     block_manager::BlockManager,
-    commit::{CertifiedCommits, PendingSubDag},
+    commit::{CertifiedCommits, PendingSubDag, TrustedCommit},
     commit_observer::{CommitObserver, CommittedSubDagSource},
     context::Context,
     dag_state::{DagState, TransactionSource},
@@ -517,6 +517,93 @@ impl Core {
     ) -> ConsensusResult<()> {
         self.commit_observer
             .handle_committed_sub_dags(committed_subdags, source)
+    }
+
+    /// Handle committed subdags from fast sync.
+    /// First stores the commits, transactions, and scoring subdags in DagState,
+    /// then processes the subdags.
+    /// Commits must be stored so that recovery/reinitialization can rebuild
+    /// the Linearizer's transaction acknowledgment tracker.
+    /// Transactions must be stored so they are available for recovery and cache.
+    pub(crate) fn handle_committed_sub_dags_from_fast_sync(
+        &mut self,
+        commits: Vec<TrustedCommit>,
+        committed_subdags: Vec<CommittedSubDag>,
+    ) -> ConsensusResult<()> {
+        // First, store commits, transactions, and scoring subdags in DagState
+        {
+            let mut dag_state = self.dag_state.write();
+
+            // Store commits for recovery
+            for commit in commits {
+                dag_state.add_commit(commit);
+            }
+
+            // Store transactions for each subdag
+            for subdag in &committed_subdags {
+                for transactions in &subdag.transactions {
+                    dag_state.add_transactions(
+                        transactions.clone(),
+                        TransactionSource::CommitSyncer,
+                    );
+                }
+            }
+
+            // Add scoring subdags for leader schedule scoring
+            dag_state
+                .add_scoring_subdags(committed_subdags.iter().map(|s| s.base.clone()).collect());
+        }
+
+        // Then process subdags as usual
+        self.commit_observer
+            .handle_committed_sub_dags(committed_subdags, CommittedSubDagSource::FastCommitSyncer)
+    }
+
+    /// Reinitialize consensus components after fast sync completes.
+    /// This stores block headers on disk and reinitializes DagState, BlockManager,
+    /// and CommitObserver so that regular syncer can take over.
+    ///
+    /// Block headers should cover the cached_rounds window (~500 rounds).
+    pub(crate) fn reinitialize_components(
+        &mut self,
+        block_headers: Vec<VerifiedBlockHeader>,
+    ) -> ConsensusResult<()> {
+        info!(
+            "Reinitializing components with {} block headers",
+            block_headers.len(),
+        );
+
+        // Hold the dag_state lock for the entire flow to ensure consistency
+        let (last_commit_index, threshold_round) = {
+            let mut dag_state = self.dag_state.write();
+
+            // 1. Store block headers on disk
+            dag_state.accept_block_headers(block_headers);
+
+            // 2. Flush everything to storage
+            dag_state.flush();
+
+            // 3. Get current state before reinitializing
+            let last_commit_index = dag_state.last_commit_index();
+
+            // 4. Reinitialize DagState
+            dag_state.reinitialize();
+
+            let threshold_round = dag_state.threshold_clock_round();
+            (last_commit_index, threshold_round)
+        };
+
+        // 5. Reinitialize BlockManager
+        self.block_manager.reinitialize();
+
+        // 6. Reinitialize CommitObserver
+        self.commit_observer.reinitialize(last_commit_index);
+
+        // 7. Reset signaling state
+        self.last_signaled_round = threshold_round.saturating_sub(1);
+
+        info!("Components reinitialized successfully");
+        Ok(())
     }
 
     /// If needed, signals a new clock round and sets up leader timeout.

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -545,6 +545,14 @@ impl Core {
         commits: Vec<TrustedCommit>,
         committed_subdags: Vec<CommittedSubDag>,
     ) -> ConsensusResult<()> {
+        let _scope = monitored_scope("Core::handle_committed_sub_dags_from_fast_sync");
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["Core::handle_committed_sub_dags_from_fast_sync"])
+            .start_timer();
         // First, store commits and transactions in DagState
         {
             let mut dag_state = self.dag_state.write();

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -526,12 +526,14 @@ impl Core {
     }
 
     /// Handle committed subdags from fast sync.
-    /// First stores the commits, transactions in DagState, then processes the subdags.
-    /// Also updates the leader schedule from commits that contain reputation scores.
+    /// First stores the commits, transactions in DagState, then processes the
+    /// subdags. Also updates the leader schedule from commits that contain
+    /// reputation scores.
     ///
     /// Commits must be stored so that recovery/reinitialization can rebuild
     /// the Linearizer's transaction acknowledgment tracker.
-    /// Transactions must be stored so they are available for recovery and cache.
+    /// Transactions must be stored so they are available for recovery and
+    /// cache.
     pub(crate) fn handle_committed_sub_dags_from_fast_sync(
         &mut self,
         commits: Vec<TrustedCommit>,
@@ -568,8 +570,9 @@ impl Core {
             // leaders but no votes, leading to incorrect score calculations.
             // Instead, we use the reputation_scores embedded in the commits directly.
 
-            // Flush commits to storage so they're available for get_block_refs_for_recent_commits
-            // when close-to-quorum mode triggers header fetching.
+            // Flush commits to storage so they're available for
+            // get_block_refs_for_recent_commits when close-to-quorum mode
+            // triggers header fetching.
             dag_state.flush();
         }
 
@@ -577,10 +580,8 @@ impl Core {
         // This ensures correct leader election during fast sync and after recovery.
         // Also store commit_info so the leader schedule can be recovered from storage.
         if let Some(commit) = last_commit_with_scores {
-            self.leader_schedule.update_from_commit_scores(
-                commit.index(),
-                commit.reputation_scores(),
-            );
+            self.leader_schedule
+                .update_from_commit_scores(commit.index(), commit.reputation_scores());
 
             // Store commit_info for recovery. The reputation_scores need to be converted
             // from the commit's format to ReputationScores struct.

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -21,8 +21,7 @@ use tracing::{info, warn};
 use crate::{
     CommittedSubDag, VerifiedBlockHeader,
     block_header::{BlockRef, Round, VerifiedBlock, VerifiedOwnShard, VerifiedTransactions},
-    commit::CertifiedCommits,
-    commit_observer::CommittedSubDagSource,
+    commit::{CertifiedCommits, TrustedCommit},
     context::Context,
     core::{Core, ReasonToCreateBlock},
     core_thread::CoreError::Shutdown,
@@ -83,7 +82,18 @@ enum CoreThreadCommand {
     GetMissingTransactionData(
         oneshot::Sender<BTreeMap<GenericTransactionRef, BTreeSet<AuthorityIndex>>>,
     ),
-    AddSubdagFromFastSync(Vec<CommittedSubDag>, oneshot::Sender<()>),
+    AddSubdagFromFastSync(Vec<TrustedCommit>, Vec<CommittedSubDag>, oneshot::Sender<()>),
+    /// Reinitialize consensus components after fast sync completes.
+    /// Stores the block headers on disk (for the cached_rounds window)
+    /// and reinitializes DagState, BlockManager, CommitObserver, etc.
+    /// After this, regular syncer can take over.
+    ///
+    /// Block headers are for blocks from commits in the cached_rounds window (~500 rounds).
+    /// Commits and transactions are already stored during fast sync via handle_committed_sub_dags.
+    ReinitializeComponents {
+        block_headers: Vec<VerifiedBlockHeader>,
+        sender: oneshot::Sender<()>,
+    },
 }
 
 #[derive(Error, Debug)]
@@ -143,7 +153,15 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
 
     async fn add_subdags_from_fast_sync(
         &self,
+        commits: Vec<TrustedCommit>,
         subdags: Vec<CommittedSubDag>,
+    ) -> Result<(), CoreError>;
+
+    /// Reinitialize consensus components after fast sync completes.
+    /// Stores block headers and reinitializes DagState, BlockManager, CommitObserver, etc.
+    async fn reinitialize_components(
+        &self,
+        block_headers: Vec<VerifiedBlockHeader>,
     ) -> Result<(), CoreError>;
 
     async fn new_block(
@@ -200,8 +218,8 @@ impl CoreThread {
                     };
                     self.context.metrics.node_metrics.core_lock_dequeued.inc();
 
-                    // During fast sync, ignore all commands except AddSubdagFromFastSync
-                    if fast_sync_ongoing && !matches!(command, CoreThreadCommand::AddSubdagFromFastSync(..)) {
+                    // During fast sync, ignore all commands except AddSubdagFromFastSync and ReinitializeComponents
+                    if fast_sync_ongoing && !matches!(command, CoreThreadCommand::AddSubdagFromFastSync(..) | CoreThreadCommand::ReinitializeComponents { .. }) {
                         match command {
                             CoreThreadCommand::AddBlocks(_, sender) |
                             CoreThreadCommand::AddBlockHeaders(_, sender) |
@@ -221,17 +239,18 @@ impl CoreThread {
                             CoreThreadCommand::GetMissingTransactionData(sender) => {
                                 sender.send(Default::default()).ok();
                             }
-                            CoreThreadCommand::AddSubdagFromFastSync(..) => unreachable!(),
+                            CoreThreadCommand::AddSubdagFromFastSync(..) |
+                            CoreThreadCommand::ReinitializeComponents { .. } => unreachable!(),
                         }
                         continue;
                     }
 
                     match command {
-                        CoreThreadCommand::AddSubdagFromFastSync(subdags, sender) => {
+                        CoreThreadCommand::AddSubdagFromFastSync(commits, subdags, sender) => {
                             info!("Adding subdags from fast sync, entering fast sync mode; {} index_start and {} index_end", subdags.first().map(|sd| sd.base.leader.round).unwrap_or(0), subdags.last().map(|sd| sd.base.leader.round).unwrap_or(0));
                             fast_sync_ongoing = true;
                             let _scope = monitored_scope("CoreThread::loop::add_subdags_from_fast_sync");
-                            self.core.handle_committed_sub_dags(subdags, CommittedSubDagSource::FastCommitSyncer)?;
+                            self.core.handle_committed_sub_dags_from_fast_sync(commits, subdags)?;
                             sender.send(()).ok();
                         }
                         CoreThreadCommand::AddBlocks(blocks, sender) => {
@@ -271,6 +290,16 @@ impl CoreThread {
                         CoreThreadCommand::GetMissingTransactionData(sender) => {
                             let _scope = monitored_scope("CoreThread::loop::get_missing_transaction_data");
                             sender.send(self.core.get_missing_transaction_data()).ok();
+                        }
+                        CoreThreadCommand::ReinitializeComponents { block_headers, sender } => {
+                            let _scope = monitored_scope("CoreThread::loop::reinitialize_components");
+                            info!(
+                                "Reinitializing components with {} block headers, exiting fast sync mode",
+                                block_headers.len()
+                            );
+                            self.core.reinitialize_components(block_headers)?;
+                            fast_sync_ongoing = false;
+                            sender.send(()).ok();
                         }
                     }
                 }
@@ -450,12 +479,26 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
 
     async fn add_subdags_from_fast_sync(
         &self,
+        commits: Vec<TrustedCommit>,
         subdags: Vec<CommittedSubDag>,
     ) -> Result<(), CoreError> {
         let (sender, receiver) = oneshot::channel();
-        self.send(CoreThreadCommand::AddSubdagFromFastSync(subdags, sender))
+        self.send(CoreThreadCommand::AddSubdagFromFastSync(commits, subdags, sender))
             .await;
         Ok(receiver.await.map_err(|e| Shutdown(e.to_string()))?)
+    }
+
+    async fn reinitialize_components(
+        &self,
+        block_headers: Vec<VerifiedBlockHeader>,
+    ) -> Result<(), CoreError> {
+        let (sender, receiver) = oneshot::channel();
+        self.send(CoreThreadCommand::ReinitializeComponents {
+            block_headers,
+            sender,
+        })
+        .await;
+        receiver.await.map_err(|e| Shutdown(e.to_string()))
     }
 
     async fn new_block(
@@ -633,6 +676,13 @@ pub(crate) mod tests {
         async fn add_subdags_from_fast_sync(
             &self,
             _subdags: Vec<CommittedSubDag>,
+        ) -> Result<(), CoreError> {
+            unimplemented!()
+        }
+
+        async fn reinitialize_components(
+            &self,
+            _block_headers: Vec<VerifiedBlockHeader>,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -82,14 +82,19 @@ enum CoreThreadCommand {
     GetMissingTransactionData(
         oneshot::Sender<BTreeMap<GenericTransactionRef, BTreeSet<AuthorityIndex>>>,
     ),
-    AddSubdagFromFastSync(Vec<TrustedCommit>, Vec<CommittedSubDag>, oneshot::Sender<()>),
+    AddSubdagFromFastSync(
+        Vec<TrustedCommit>,
+        Vec<CommittedSubDag>,
+        oneshot::Sender<()>,
+    ),
     /// Reinitialize consensus components after fast sync completes.
     /// Stores the block headers on disk (for the cached_rounds window)
     /// and reinitializes DagState, BlockManager, CommitObserver, etc.
     /// After this, regular syncer can take over.
     ///
-    /// Block headers are for blocks from commits in the cached_rounds window (~500 rounds).
-    /// Commits and transactions are already stored during fast sync via handle_committed_sub_dags.
+    /// Block headers are for blocks from commits in the cached_rounds window
+    /// (~500 rounds). Commits and transactions are already stored during
+    /// fast sync via handle_committed_sub_dags.
     ReinitializeComponents {
         block_headers: Vec<VerifiedBlockHeader>,
         sender: oneshot::Sender<()>,
@@ -158,7 +163,8 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
     ) -> Result<(), CoreError>;
 
     /// Reinitialize consensus components after fast sync completes.
-    /// Stores block headers and reinitializes DagState, BlockManager, CommitObserver, etc.
+    /// Stores block headers and reinitializes DagState, BlockManager,
+    /// CommitObserver, etc.
     async fn reinitialize_components(
         &self,
         block_headers: Vec<VerifiedBlockHeader>,
@@ -483,8 +489,10 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         subdags: Vec<CommittedSubDag>,
     ) -> Result<(), CoreError> {
         let (sender, receiver) = oneshot::channel();
-        self.send(CoreThreadCommand::AddSubdagFromFastSync(commits, subdags, sender))
-            .await;
+        self.send(CoreThreadCommand::AddSubdagFromFastSync(
+            commits, subdags, sender,
+        ))
+        .await;
         Ok(receiver.await.map_err(|e| Shutdown(e.to_string()))?)
     }
 
@@ -675,6 +683,7 @@ pub(crate) mod tests {
 
         async fn add_subdags_from_fast_sync(
             &self,
+            _commits: Vec<TrustedCommit>,
             _subdags: Vec<CommittedSubDag>,
         ) -> Result<(), CoreError> {
             unimplemented!()

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1550,7 +1550,7 @@ impl DagState {
         self.commits_to_write.push(commit);
     }
 
-    /// Add commit info is callled before the first commit in a new leader
+    /// Add commit info is called before the first commit in a new leader
     /// scheduler window
     pub(crate) fn add_commit_info(&mut self, reputation_scores: ReputationScores) {
         // We create an empty scoring subdag once reputation scores are calculated.

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1749,7 +1749,7 @@ impl DagState {
             return vec![];
         }
 
-        let start_index = last_commit_index.saturating_sub(num_commits) + 1;
+        let start_index = last_commit_index.saturating_sub(num_commits).max(1);
         let commits = self
             .store
             .scan_commits((start_index..=last_commit_index).into())

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -268,43 +268,10 @@ impl DagState {
             cordial_knowledge_sender: None,
         };
 
+        // Load cached data for each authority from storage
         for (i, round) in last_committed_rounds.into_iter().enumerate() {
             let authority_index = state.context.committee.to_authority_index(i).unwrap();
-            let (block_headers, transactions_by_author, eviction_round) = {
-                let eviction_round = Self::eviction_round(round, cached_rounds);
-                let block_headers = state
-                    .store
-                    .scan_block_headers_by_author(authority_index, eviction_round + 1)
-                    .expect("Database error");
-                let transactions_by_author = state
-                    .store
-                    .scan_transactions_by_author(
-                        authority_index,
-                        eviction_round + 1,
-                        context.clone(),
-                    )
-                    .expect("Database error");
-                (block_headers, transactions_by_author, eviction_round)
-            };
-
-            state.evicted_rounds[authority_index] = eviction_round;
-
-            // Update the block metadata for the authority.
-            for block_header in &block_headers {
-                state.update_block_header_metadata(block_header);
-            }
-            for transactions in &transactions_by_author {
-                state.update_transaction_metadata(transactions);
-            }
-
-            info!(
-                "Recovered block headers {}: {:?}",
-                authority_index,
-                block_headers
-                    .iter()
-                    .map(|b| b.reference())
-                    .collect::<Vec<BlockRef>>()
-            );
+            state.load_cached_data_for_authority(authority_index, round);
         }
         state
     }
@@ -314,6 +281,72 @@ impl DagState {
         sender: UnboundedSender<CordialKnowledgeMessage>,
     ) {
         self.cordial_knowledge_sender = Some(sender);
+    }
+
+    /// Loads cached data (block headers and transactions) for a single authority from storage.
+    /// Updates eviction round and populates in-memory caches.
+    fn load_cached_data_for_authority(&mut self, authority_index: AuthorityIndex, committed_round: Round) {
+        let eviction_round = Self::eviction_round(committed_round, self.cached_rounds);
+        self.evicted_rounds[authority_index] = eviction_round;
+
+        // Reload block headers from storage
+        let block_headers = self
+            .store
+            .scan_block_headers_by_author(authority_index, eviction_round + 1)
+            .expect("Database error");
+        for block_header in &block_headers {
+            self.update_block_header_metadata(block_header);
+        }
+
+        // Reload transactions from storage
+        let transactions = self
+            .store
+            .scan_transactions_by_author(authority_index, eviction_round + 1, self.context.clone())
+            .expect("Database error");
+        for txn in &transactions {
+            self.update_transaction_metadata(txn);
+        }
+
+        info!(
+            "Loaded cached data for authority {}: {} block headers, {} transactions",
+            authority_index,
+            block_headers.len(),
+            transactions.len()
+        );
+    }
+
+    /// Reinitialize DagState after fast sync completes.
+    /// This clears in-memory caches and reloads from storage for the cached_rounds window.
+    /// Should be called after block headers have been stored via accept_block_headers() and flush().
+    pub(crate) fn reinitialize(&mut self) {
+        let num_authorities = self.context.committee.size();
+
+        info!(
+            "Reinitializing DagState with cached_rounds={}, last_committed_rounds={:?}",
+            self.cached_rounds, self.last_committed_rounds
+        );
+
+        // 1. Clear all in-memory caches
+        // Note: scoring_subdag is NOT cleared because it's properly populated during
+        // fast sync processing via add_scoring_subdags() and should be preserved.
+        self.recent_block_headers.clear();
+        self.recent_transactions_by_authority = vec![BTreeMap::new(); num_authorities];
+        self.recent_shards_by_authority = vec![BTreeMap::new(); num_authorities];
+        self.recent_headers_refs_by_authority = vec![BTreeSet::new(); num_authorities];
+        self.pending_commit_votes.clear();
+        self.pending_acknowledgments.clear();
+
+        // 2. Reinitialize threshold_clock with current round
+        let current_round = self.threshold_clock.get_round();
+        self.threshold_clock = ThresholdClock::new(current_round, self.context.clone());
+
+        // 3. Reload cached data for each authority
+        for (i, &committed_round) in self.last_committed_rounds.clone().iter().enumerate() {
+            let authority_index = self.context.committee.to_authority_index(i).unwrap();
+            self.load_cached_data_for_authority(authority_index, committed_round);
+        }
+
+        info!("DagState reinitialized successfully");
     }
 
     /// Accepts a block header into DagState and keeps it in memory.
@@ -1696,6 +1729,35 @@ impl DagState {
     /// Last committed round per authority.
     pub(crate) fn last_committed_rounds(&self) -> Vec<Round> {
         self.last_committed_rounds.clone()
+    }
+
+    /// Returns block refs from the last `num_commits` commits stored in the database.
+    /// This is used by the fast commit syncer to determine which block headers to fetch
+    /// for the cached_rounds window before reinitializing components.
+    pub(crate) fn get_block_refs_for_recent_commits(&self, num_commits: u32) -> Vec<BlockRef> {
+        let last_commit_index = self.last_commit_index();
+        if last_commit_index == 0 {
+            return vec![];
+        }
+
+        let start_index = last_commit_index.saturating_sub(num_commits) + 1;
+        let commits = self
+            .store
+            .scan_commits((start_index..=last_commit_index).into())
+            .unwrap_or_else(|e| {
+                warn!("Failed to scan commits for block refs: {:?}", e);
+                vec![]
+            });
+
+        // Collect block refs from all commits, deduplicating them
+        let mut block_refs: BTreeSet<BlockRef> = BTreeSet::new();
+        for commit in &commits {
+            for block_ref in commit.block_headers() {
+                block_refs.insert(*block_ref);
+            }
+        }
+
+        block_refs.into_iter().collect()
     }
 
     /// After each flush, DagState becomes persisted in storage and is expected

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -283,9 +283,14 @@ impl DagState {
         self.cordial_knowledge_sender = Some(sender);
     }
 
-    /// Loads cached data (block headers and transactions) for a single authority from storage.
-    /// Updates eviction round and populates in-memory caches.
-    fn load_cached_data_for_authority(&mut self, authority_index: AuthorityIndex, committed_round: Round) {
+    /// Loads cached data (block headers and transactions) for a single
+    /// authority from storage. Updates eviction round and populates
+    /// in-memory caches.
+    fn load_cached_data_for_authority(
+        &mut self,
+        authority_index: AuthorityIndex,
+        committed_round: Round,
+    ) {
         let eviction_round = Self::eviction_round(committed_round, self.cached_rounds);
         self.evicted_rounds[authority_index] = eviction_round;
 
@@ -316,8 +321,9 @@ impl DagState {
     }
 
     /// Reinitialize DagState after fast sync completes.
-    /// This clears in-memory caches and reloads from storage for the cached_rounds window.
-    /// Should be called after block headers have been stored via accept_block_headers() and flush().
+    /// This clears in-memory caches and reloads from storage for the
+    /// cached_rounds window. Should be called after block headers have been
+    /// stored via accept_block_headers() and flush().
     pub(crate) fn reinitialize(&mut self) {
         let num_authorities = self.context.committee.size();
 
@@ -327,8 +333,10 @@ impl DagState {
         );
 
         // 1. Clear all in-memory caches
-        // Note: scoring_subdag is NOT cleared because it's properly populated during
-        // fast sync processing via add_scoring_subdags() and should be preserved.
+        // Note: scoring_subdag IS cleared because during fast sync, CommittedSubDag.headers
+        // is empty, so scoring_subdag cannot be properly populated (it would have leaders
+        // but no votes). After reinitialize, regular operation will rebuild it correctly.
+        self.scoring_subdag.clear();
         self.recent_block_headers.clear();
         self.recent_transactions_by_authority = vec![BTreeMap::new(); num_authorities];
         self.recent_shards_by_authority = vec![BTreeMap::new(); num_authorities];
@@ -1731,9 +1739,10 @@ impl DagState {
         self.last_committed_rounds.clone()
     }
 
-    /// Returns block refs from the last `num_commits` commits stored in the database.
-    /// This is used by the fast commit syncer to determine which block headers to fetch
-    /// for the cached_rounds window before reinitializing components.
+    /// Returns block refs from the last `num_commits` commits stored in the
+    /// database. This is used by the fast commit syncer to determine which
+    /// block headers to fetch for the cached_rounds window before
+    /// reinitializing components.
     pub(crate) fn get_block_refs_for_recent_commits(&self, num_commits: u32) -> Vec<BlockRef> {
         let last_commit_index = self.last_commit_index();
         if last_commit_index == 0 {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -207,7 +207,13 @@ impl DagState {
         let (mut last_committed_rounds, commit_recovery_start_index) =
             if let Some((commit_ref, commit_info)) = commit_info {
                 tracing::info!("Recovering committed state from {commit_ref} {commit_info:?}");
-                (commit_info.committed_rounds, commit_ref.index + 1)
+                let range_end = commit_info.reputation_scores.commit_range.end();
+                let recovery_start = if range_end == GENESIS_COMMIT_INDEX {
+                    commit_ref.index.saturating_add(1)
+                } else {
+                    range_end.saturating_add(1)
+                };
+                (commit_info.committed_rounds, recovery_start)
             } else {
                 tracing::info!("Found no stored CommitInfo to recover from");
                 (vec![0; num_authorities], GENESIS_COMMIT_INDEX + 1)
@@ -355,7 +361,49 @@ impl DagState {
             self.load_cached_data_for_authority(authority_index, committed_round);
         }
 
+        // Rebuild scoring_subdag from stored commits so leader schedule state
+        // matches peers after fast sync reinitialization.
+        self.rebuild_scoring_subdag_from_store();
+
         info!("DagState reinitialized successfully");
+    }
+
+    fn rebuild_scoring_subdag_from_store(&mut self) {
+        let Some(last_commit) = self.last_commit.as_ref() else {
+            return;
+        };
+
+        let commit_recovery_start_index = self
+            .recover_last_commit_info()
+            .map(|(commit_ref, commit_info)| {
+                let range_end = commit_info.reputation_scores.commit_range.end();
+                if range_end == GENESIS_COMMIT_INDEX {
+                    commit_ref.index.saturating_add(1)
+                } else {
+                    range_end.saturating_add(1)
+                }
+            })
+            .unwrap_or(GENESIS_COMMIT_INDEX + 1);
+
+        if commit_recovery_start_index > last_commit.index() {
+            return;
+        }
+
+        let commits = self
+            .store
+            .scan_commits((commit_recovery_start_index..=last_commit.index()).into())
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"));
+
+        let mut unscored_subdags = Vec::with_capacity(commits.len());
+        for commit in commits {
+            let pending_subdag =
+                load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]);
+            unscored_subdags.push(pending_subdag.base);
+        }
+
+        if !unscored_subdags.is_empty() {
+            self.scoring_subdag.add_subdags(unscored_subdags);
+        }
     }
 
     /// Accepts a block header into DagState and keeps it in memory.

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -373,17 +373,7 @@ impl DagState {
             return;
         };
 
-        let commit_recovery_start_index = self
-            .recover_last_commit_info()
-            .map(|(commit_ref, commit_info)| {
-                let range_end = commit_info.reputation_scores.commit_range.end();
-                if range_end == GENESIS_COMMIT_INDEX {
-                    commit_ref.index.saturating_add(1)
-                } else {
-                    range_end.saturating_add(1)
-                }
-            })
-            .unwrap_or(GENESIS_COMMIT_INDEX + 1);
+        let commit_recovery_start_index = self.last_commit_info_index().saturating_add(1);
 
         if commit_recovery_start_index > last_commit.index() {
             return;
@@ -1923,6 +1913,22 @@ impl DagState {
         self.store
             .read_last_commit_info()
             .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"))
+    }
+
+    /// Returns the commit index of the last stored commit info, or
+    /// GENESIS_COMMIT_INDEX if none. This is the end of the reputation
+    /// score commit range (or the commit ref index for genesis).
+    pub(crate) fn last_commit_info_index(&self) -> CommitIndex {
+        self.recover_last_commit_info()
+            .map(|(commit_ref, commit_info)| {
+                let range_end = commit_info.reputation_scores.commit_range.end();
+                if range_end == GENESIS_COMMIT_INDEX {
+                    commit_ref.index
+                } else {
+                    range_end
+                }
+            })
+            .unwrap_or(GENESIS_COMMIT_INDEX)
     }
 
     pub(crate) fn add_scoring_subdags(&mut self, scoring_subdags: Vec<SubDagBase>) {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -333,9 +333,10 @@ impl DagState {
         );
 
         // 1. Clear all in-memory caches
-        // Note: scoring_subdag IS cleared because during fast sync, CommittedSubDag.headers
-        // is empty, so scoring_subdag cannot be properly populated (it would have leaders
-        // but no votes). After reinitialize, regular operation will rebuild it correctly.
+        // Note: scoring_subdag IS cleared because during fast sync,
+        // CommittedSubDag.headers is empty, so scoring_subdag cannot be
+        // properly populated (it would have leaders but no votes). After
+        // reinitialize, regular operation will rebuild it correctly.
         self.scoring_subdag.clear();
         self.recent_block_headers.clear();
         self.recent_transactions_by_authority = vec![BTreeMap::new(); num_authorities];

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -60,6 +60,9 @@ pub(crate) enum TransactionSource {
     /// fetched for all the committed blocks in synced commits.
     CommitSyncer,
 
+    /// Transactions received via fast commit synchronization.
+    FastCommitSyncer,
+
     /// Data added during testing.
     /// Only used in test code.
     #[cfg(test)]
@@ -74,7 +77,8 @@ impl TransactionSource {
             TransactionSource::TransactionSynchronizer => "Transactions synchronizer",
             TransactionSource::BlockStreaming => "Block streaming",
             TransactionSource::ShardReconstructor => "Shard reconstructor",
-            TransactionSource::CommitSyncer => "Commit syncer",
+            TransactionSource::CommitSyncer => "Regular commit syncer",
+            TransactionSource::FastCommitSyncer => "Fast commit syncer",
             #[cfg(test)]
             TransactionSource::Test => "test",
         }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -176,6 +176,9 @@ pub(crate) struct DagState {
     /// the next dag state flush. This is okay because we can recover
     /// reputation scores & last_committed_rounds from the commits as
     /// needed.
+    /// The index in CommitRef correspond to the first index of the next
+    /// scheduler window, while the reputation scores in CommitInfoare for
+    /// the previous window.
     commit_info_to_write: Vec<(CommitRef, CommitInfo)>,
 
     /// Persistent storage for blocks, commits and other consensus data.
@@ -1547,6 +1550,8 @@ impl DagState {
         self.commits_to_write.push(commit);
     }
 
+    /// Add commit info is callled before the first commit in a new leader
+    /// scheduler window
     pub(crate) fn add_commit_info(&mut self, reputation_scores: ReputationScores) {
         // We create an empty scoring subdag once reputation scores are calculated.
         // Note: It is okay for this to not be gated by protocol config as the

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -274,6 +274,9 @@ pub(crate) enum ConsensusError {
         expected_variant: &'static str,
         received_variant: &'static str,
     },
+
+    #[error("Failed to fetch {num_requested} block headers from any peer")]
+    FailedToFetchBlockHeaders { num_requested: usize },
 }
 
 impl ConsensusError {

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -2428,7 +2428,15 @@ mod tests {
 
         async fn add_subdags_from_fast_sync(
             &self,
+            _commits: Vec<crate::commit::TrustedCommit>,
             _subdags: Vec<crate::commit::CommittedSubDag>,
+        ) -> Result<(), CoreError> {
+            unimplemented!()
+        }
+
+        async fn reinitialize_components(
+            &self,
+            _block_headers: Vec<crate::block_header::VerifiedBlockHeader>,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -13,7 +13,10 @@ use rand::{SeedableRng, prelude::SliceRandom, rngs::StdRng};
 use starfish_config::{AuthorityIndex, Stake};
 
 use crate::{
-    CommitIndex, Round, commit::CommitRange, context::Context, dag_state::DagState,
+    CommitIndex, Round,
+    commit::{CommitRange, GENESIS_COMMIT_INDEX},
+    context::Context,
+    dag_state::DagState,
     leader_scoring::ReputationScores,
 };
 
@@ -58,9 +61,15 @@ impl LeaderSchedule {
         let leader_swap_table = dag_state.read().recover_last_commit_info().map_or(
             LeaderSwapTable::default(),
             |(last_commit_ref, last_commit_info)| {
+                let range_end = last_commit_info.reputation_scores.commit_range.end();
+                let seed_index = if range_end == GENESIS_COMMIT_INDEX {
+                    last_commit_ref.index
+                } else {
+                    range_end
+                };
                 LeaderSwapTable::new(
                     context.clone(),
-                    last_commit_ref.index,
+                    seed_index,
                     last_commit_info.reputation_scores,
                 )
             },
@@ -82,9 +91,15 @@ impl LeaderSchedule {
         let leader_swap_table = dag_state.read().recover_last_commit_info().map_or(
             LeaderSwapTable::default(),
             |(last_commit_ref, last_commit_info)| {
+                let range_end = last_commit_info.reputation_scores.commit_range.end();
+                let seed_index = if range_end == GENESIS_COMMIT_INDEX {
+                    last_commit_ref.index
+                } else {
+                    range_end
+                };
                 LeaderSwapTable::new(
                     self.context.clone(),
-                    last_commit_ref.index,
+                    seed_index,
                     last_commit_info.reputation_scores,
                 )
             },
@@ -240,10 +255,14 @@ impl LeaderSchedule {
         }
 
         // Determine the commit range for these scores.
-        // During fast sync, we don't know the exact range, but we can estimate
-        // it based on the schedule window (num_commits_per_schedule).
-        let range_end = commit_index;
-        let range_start = commit_index.saturating_sub(self.num_commits_per_schedule as u32 - 1);
+        // Reputation scores are attached to the *first* commit after a schedule
+        // update, so the scores correspond to the previous window ending at
+        // commit_index - 1.
+        let range_end = commit_index.saturating_sub(1);
+        if range_end == GENESIS_COMMIT_INDEX {
+            return;
+        }
+        let range_start = range_end.saturating_sub(self.num_commits_per_schedule as u32 - 1);
         let commit_range = CommitRange::new(range_start..=range_end);
 
         let reputation_scores = ReputationScores::from_scores_desc(
@@ -265,7 +284,7 @@ impl LeaderSchedule {
             dag_state.add_commit_info(reputation_scores.clone());
         }
 
-        let table = LeaderSwapTable::new(self.context.clone(), commit_index, reputation_scores.clone());
+        let table = LeaderSwapTable::new(self.context.clone(), range_end, reputation_scores.clone());
         tracing::info!(
             "[AUTH {}] New LeaderSwapTable from fast sync: good_nodes={:?}, bad_nodes={:?}",
             self.context.own_index,

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -17,6 +17,14 @@ use crate::{
     leader_scoring::ReputationScores,
 };
 
+/// The window where the schedule change takes place in consensus. It
+/// represents number of committed sub dags.
+/// TODO: move this to protocol config
+#[cfg(not(msim))]
+pub(crate) const CONSENSUS_COMMITS_PER_SCHEDULE: u64 = 300;
+#[cfg(msim)]
+pub(crate) const CONSENSUS_COMMITS_PER_SCHEDULE: u64 = 10;
+
 /// The `LeaderSchedule` is responsible for producing the leader schedule across
 /// an epoch. The leader schedule is subject to change periodically based on
 /// calculated `ReputationScores` of the authorities.
@@ -28,31 +36,19 @@ pub(crate) struct LeaderSchedule {
 }
 
 impl LeaderSchedule {
-    /// The window where the schedule change takes place in consensus. It
-    /// represents number of committed sub dags.
-    /// TODO: move this to protocol config
-    #[cfg(not(msim))]
-    const CONSENSUS_COMMITS_PER_SCHEDULE: u64 = 300;
-    #[cfg(msim)]
-    const CONSENSUS_COMMITS_PER_SCHEDULE: u64 = 10;
-
     pub(crate) fn new(context: Arc<Context>, leader_swap_table: LeaderSwapTable) -> Self {
         Self {
             context,
-            num_commits_per_schedule: Self::CONSENSUS_COMMITS_PER_SCHEDULE,
+            num_commits_per_schedule: CONSENSUS_COMMITS_PER_SCHEDULE,
             leader_swap_table: Arc::new(RwLock::new(leader_swap_table)),
         }
     }
+
 
     #[cfg(test)]
     pub(crate) fn with_num_commits_per_schedule(mut self, num_commits_per_schedule: u64) -> Self {
         self.num_commits_per_schedule = num_commits_per_schedule;
         self
-    }
-
-    /// Returns the number of commits per leader schedule period.
-    pub(crate) fn num_commits_per_schedule(&self) -> u64 {
-        self.num_commits_per_schedule
     }
 
     /// Restores the `LeaderSchedule` from storage. It will attempt to retrieve
@@ -79,16 +75,56 @@ impl LeaderSchedule {
         Self::new(context, leader_swap_table)
     }
 
+    /// Reinitializes the leader schedule from stored commit info.
+    /// Used after fast sync completes to restore the leader swap table
+    /// from the persisted reputation scores.
+    pub(crate) fn reinitialize(&self, dag_state: &RwLock<DagState>) {
+        let leader_swap_table = dag_state.read().recover_last_commit_info().map_or(
+            LeaderSwapTable::default(),
+            |(last_commit_ref, last_commit_info)| {
+                LeaderSwapTable::new(
+                    self.context.clone(),
+                    last_commit_ref.index,
+                    last_commit_info.reputation_scores,
+                )
+            },
+        );
+
+        tracing::info!(
+            "LeaderSchedule reinitialized using {leader_swap_table:?}. There are {} committed subdags scored in DagState.",
+            dag_state.read().scoring_subdags_count(),
+        );
+
+        let mut write = self.leader_swap_table.write();
+        *write = leader_swap_table;
+    }
+
     pub(crate) fn commits_until_leader_schedule_update(
         &self,
         dag_state: Arc<RwLock<DagState>>,
     ) -> usize {
         let subdag_count = dag_state.read().scoring_subdags_count() as u64;
 
-        assert!(
-            subdag_count <= self.num_commits_per_schedule,
-            "Committed subdags count exceeds the number of commits per schedule"
-        );
+        // In the normal online flow, `scoring_subdag` is cleared every time we
+        // update the schedule, so its size stays within `num_commits_per_schedule`.
+        //
+        // After fast-sync or when recovering from older/stale DBs where CommitInfo
+        // wasn't persisted frequently, recovery may rebuild a backlog of scoring
+        // subdags that exceeds the window. In that case, we should trigger an
+        // immediate schedule update rather than panic.
+        if subdag_count > self.num_commits_per_schedule {
+            tracing::warn!(
+                "Committed subdags count ({subdag_count}) exceeds commits-per-schedule ({}) - forcing immediate leader schedule update. This can happen after fast sync / recovery if CommitInfo was missing or stale.",
+                self.num_commits_per_schedule,
+            );
+            return 0;
+        }
+
+        // If the window is full, an update is due now.
+        if subdag_count == self.num_commits_per_schedule {
+            return 0;
+        }
+
         self.num_commits_per_schedule
             .checked_sub(subdag_count)
             .unwrap() as usize
@@ -186,10 +222,16 @@ impl LeaderSchedule {
     /// Used during fast sync where we don't have the scoring_subdag populated,
     /// but the commits already contain the pre-computed reputation scores.
     ///
+    /// This method mirrors the flow in `update_leader_schedule`:
+    /// 1. Clear scoring_subdag (to maintain consistency)
+    /// 2. Add commit_info to DagState (for recovery/reinitialization)
+    /// 3. Update the leader swap table
+    ///
     /// This bypasses the strict commit range checks since during fast sync
     /// we may be processing commits from far ahead.
     pub(crate) fn update_from_commit_scores(
         &self,
+        dag_state: &RwLock<DagState>,
         commit_index: CommitIndex,
         reputation_scores_desc: &[(AuthorityIndex, u64)],
     ) {
@@ -211,15 +253,38 @@ impl LeaderSchedule {
         );
 
         tracing::info!(
-            "Updating leader schedule from commit scores at index {commit_index}: {reputation_scores:?}"
+            "[AUTH {}] Updating leader schedule from commit scores at index {commit_index}: {reputation_scores:?}",
+            self.context.own_index
         );
 
-        let table = LeaderSwapTable::new(self.context.clone(), commit_index, reputation_scores);
+        // Update dag_state: clear scoring_subdag and add commit_info
+        // This mirrors the flow in update_leader_schedule
+        {
+            let mut dag_state = dag_state.write();
+            dag_state.clear_scoring_subdag();
+            dag_state.add_commit_info(reputation_scores.clone());
+        }
+
+        let table = LeaderSwapTable::new(self.context.clone(), commit_index, reputation_scores.clone());
+        tracing::info!(
+            "[AUTH {}] New LeaderSwapTable from fast sync: good_nodes={:?}, bad_nodes={:?}",
+            self.context.own_index,
+            table.good_nodes.iter().map(|(i, _, _)| i).collect::<Vec<_>>(),
+            table.bad_nodes.keys().collect::<Vec<_>>()
+        );
 
         // Directly update the swap table without strict range checks.
         // During fast sync, we trust the scores from certified commits.
         let mut write = self.leader_swap_table.write();
         *write = table;
+
+        // Update metrics
+        reputation_scores.update_metrics(self.context.clone());
+        self.context
+            .metrics
+            .node_metrics
+            .num_of_bad_nodes
+            .set(write.bad_nodes.len() as i64);
     }
 
     /// Atomically updates the `LeaderSwapTable` with the new provided one. Any
@@ -243,7 +308,13 @@ impl LeaderSchedule {
         }
         drop(read);
 
-        tracing::trace!("Updating {table:?}");
+        tracing::info!(
+            "[AUTH {}] Normal update LeaderSwapTable: commit_range={:?}, good_nodes={:?}, bad_nodes={:?}",
+            self.context.own_index,
+            new_commit_range,
+            table.good_nodes.iter().map(|(i, _, _)| i).collect::<Vec<_>>(),
+            table.bad_nodes.keys().collect::<Vec<_>>()
+        );
 
         let mut write = self.leader_swap_table.write();
         *write = table;
@@ -486,7 +557,7 @@ mod tests {
         block_header::{
             BlockHeaderDigest, BlockRef, BlockTimestampMs, TestBlockHeader, VerifiedBlockHeader,
         },
-        commit::{CommitAPI, CommitDigest, CommitInfo, CommitRef, CommittedSubDag, TrustedCommit},
+        commit::{CommitDigest, CommitInfo, CommitRef, CommittedSubDag, TrustedCommit},
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
     };
@@ -832,8 +903,10 @@ mod tests {
         let unscored_subdags = vec![
             CommittedSubDag::new(
                 leader_ref,
-                blocks,
-                last_commit.block_headers().to_vec(),
+                blocks.clone(),
+                // For this test we don't need to access block refs through the commit.
+                // Reuse the committed block refs directly.
+                blocks.iter().map(|b| b.reference()).collect::<Vec<_>>(),
                 vec![], // Committed transactions are not important for this test.
                 context.clock.timestamp_utc_ms(),
                 last_commit.reference(),

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -47,7 +47,6 @@ impl LeaderSchedule {
         }
     }
 
-
     #[cfg(test)]
     pub(crate) fn with_num_commits_per_schedule(mut self, num_commits_per_schedule: u64) -> Self {
         self.num_commits_per_schedule = num_commits_per_schedule;
@@ -284,11 +283,16 @@ impl LeaderSchedule {
             dag_state.add_commit_info(reputation_scores.clone());
         }
 
-        let table = LeaderSwapTable::new(self.context.clone(), range_end, reputation_scores.clone());
-        tracing::info!(
+        let table =
+            LeaderSwapTable::new(self.context.clone(), range_end, reputation_scores.clone());
+        tracing::debug!(
             "[AUTH {}] New LeaderSwapTable from fast sync: good_nodes={:?}, bad_nodes={:?}",
             self.context.own_index,
-            table.good_nodes.iter().map(|(i, _, _)| i).collect::<Vec<_>>(),
+            table
+                .good_nodes
+                .iter()
+                .map(|(i, _, _)| i)
+                .collect::<Vec<_>>(),
             table.bad_nodes.keys().collect::<Vec<_>>()
         );
 
@@ -327,11 +331,15 @@ impl LeaderSchedule {
         }
         drop(read);
 
-        tracing::info!(
+        tracing::debug!(
             "[AUTH {}] Normal update LeaderSwapTable: commit_range={:?}, good_nodes={:?}, bad_nodes={:?}",
             self.context.own_index,
             new_commit_range,
-            table.good_nodes.iter().map(|(i, _, _)| i).collect::<Vec<_>>(),
+            table
+                .good_nodes
+                .iter()
+                .map(|(i, _, _)| i)
+                .collect::<Vec<_>>(),
             table.bad_nodes.keys().collect::<Vec<_>>()
         );
 

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -246,7 +246,7 @@ impl LeaderSchedule {
     /// we may be processing commits from far ahead.
     pub(crate) fn update_from_commit_scores(
         &self,
-        dag_state: &RwLock<DagState>,
+        dag_state: &mut DagState,
         commit_index: CommitIndex,
         reputation_scores_desc: &[(AuthorityIndex, u64)],
     ) {
@@ -272,13 +272,11 @@ impl LeaderSchedule {
             self.context.own_index
         );
 
-        // Update dag_state: clear scoring_subdag and add commit_info
-        // This mirrors the flow in update_leader_schedule
-        {
-            let mut dag_state = dag_state.write();
-            dag_state.clear_scoring_subdag();
-            dag_state.add_commit_info(reputation_scores.clone());
-        }
+        // Update dag_state: clear scoring_subdag and add commit_info.
+        // This mirrors the flow in update_leader_schedule. The caller must
+        // already hold the dag_state write lock.
+        dag_state.clear_scoring_subdag();
+        dag_state.add_commit_info(reputation_scores.clone());
 
         let table =
             LeaderSwapTable::new(self.context.clone(), range_end, reputation_scores.clone());

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -32,6 +32,25 @@ fn calculate_seed_index(last_commit_ref: &CommitRef, last_commit_info: &CommitIn
     }
 }
 
+/// Recovers a `LeaderSwapTable` from stored commit info.
+/// Returns default table if no commit info exists.
+fn recover_leader_swap_table(
+    context: &Arc<Context>,
+    dag_state: &RwLock<DagState>,
+) -> LeaderSwapTable {
+    dag_state.read().recover_last_commit_info().map_or(
+        LeaderSwapTable::default(),
+        |(last_commit_ref, last_commit_info)| {
+            let seed_index = calculate_seed_index(&last_commit_ref, &last_commit_info);
+            LeaderSwapTable::new(
+                context.clone(),
+                seed_index,
+                last_commit_info.reputation_scores,
+            )
+        },
+    )
+}
+
 /// The window where the schedule change takes place in consensus. It
 /// represents number of committed sub dags.
 /// TODO: move this to protocol config
@@ -69,17 +88,7 @@ impl LeaderSchedule {
     /// the last stored `ReputationScores` and use them to build a
     /// `LeaderSwapTable`.
     pub(crate) fn from_store(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
-        let leader_swap_table = dag_state.read().recover_last_commit_info().map_or(
-            LeaderSwapTable::default(),
-            |(last_commit_ref, last_commit_info)| {
-                let seed_index = calculate_seed_index(&last_commit_ref, &last_commit_info);
-                LeaderSwapTable::new(
-                    context.clone(),
-                    seed_index,
-                    last_commit_info.reputation_scores,
-                )
-            },
-        );
+        let leader_swap_table = recover_leader_swap_table(&context, &dag_state);
 
         tracing::info!(
             "LeaderSchedule recovered using {leader_swap_table:?}. There are {} committed subdags scored in DagState.",
@@ -94,17 +103,7 @@ impl LeaderSchedule {
     /// Used after fast sync completes to restore the leader swap table
     /// from the persisted reputation scores.
     pub(crate) fn reinitialize(&self, dag_state: &RwLock<DagState>) {
-        let leader_swap_table = dag_state.read().recover_last_commit_info().map_or(
-            LeaderSwapTable::default(),
-            |(last_commit_ref, last_commit_info)| {
-                let seed_index = calculate_seed_index(&last_commit_ref, &last_commit_info);
-                LeaderSwapTable::new(
-                    self.context.clone(),
-                    seed_index,
-                    last_commit_info.reputation_scores,
-                )
-            },
-        );
+        let leader_swap_table = recover_leader_swap_table(&self.context, dag_state);
 
         tracing::info!(
             "LeaderSchedule reinitialized using {leader_swap_table:?}. There are {} committed subdags scored in DagState.",

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -50,6 +50,11 @@ impl LeaderSchedule {
         self
     }
 
+    /// Returns the number of commits per leader schedule period.
+    pub(crate) fn num_commits_per_schedule(&self) -> u64 {
+        self.num_commits_per_schedule
+    }
+
     /// Restores the `LeaderSchedule` from storage. It will attempt to retrieve
     /// the last stored `ReputationScores` and use them to build a
     /// `LeaderSwapTable`.
@@ -175,6 +180,46 @@ impl LeaderSchedule {
             .unwrap();
 
         leader_index
+    }
+
+    /// Updates the leader schedule from reputation scores stored in a commit.
+    /// Used during fast sync where we don't have the scoring_subdag populated,
+    /// but the commits already contain the pre-computed reputation scores.
+    ///
+    /// This bypasses the strict commit range checks since during fast sync
+    /// we may be processing commits from far ahead.
+    pub(crate) fn update_from_commit_scores(
+        &self,
+        commit_index: CommitIndex,
+        reputation_scores_desc: &[(AuthorityIndex, u64)],
+    ) {
+        if reputation_scores_desc.is_empty() {
+            return;
+        }
+
+        // Determine the commit range for these scores.
+        // During fast sync, we don't know the exact range, but we can estimate
+        // it based on the schedule window (num_commits_per_schedule).
+        let range_end = commit_index;
+        let range_start = commit_index.saturating_sub(self.num_commits_per_schedule as u32 - 1);
+        let commit_range = CommitRange::new(range_start..=range_end);
+
+        let reputation_scores = ReputationScores::from_scores_desc(
+            self.context.committee.size(),
+            commit_range,
+            reputation_scores_desc,
+        );
+
+        tracing::info!(
+            "Updating leader schedule from commit scores at index {commit_index}: {reputation_scores:?}"
+        );
+
+        let table = LeaderSwapTable::new(self.context.clone(), commit_index, reputation_scores);
+
+        // Directly update the swap table without strict range checks.
+        // During fast sync, we trust the scores from certified commits.
+        let mut write = self.leader_swap_table.write();
+        *write = table;
     }
 
     /// Atomically updates the `LeaderSwapTable` with the new provided one. Any

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -578,7 +578,7 @@ mod tests {
         block_header::{
             BlockHeaderDigest, BlockRef, BlockTimestampMs, TestBlockHeader, VerifiedBlockHeader,
         },
-        commit::{CommitDigest, CommitInfo, CommitRef, CommittedSubDag, TrustedCommit},
+        commit::{CommitAPI, CommitDigest, CommitInfo, CommitRef, CommittedSubDag, TrustedCommit},
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
     };
@@ -924,8 +924,8 @@ mod tests {
         let unscored_subdags = vec![
             CommittedSubDag::new(
                 leader_ref,
-                blocks.clone(),
-                blocks.iter().map(|b| b.reference()).collect::<Vec<_>>(),
+                blocks,
+                last_commit.block_headers().to_vec(),
                 vec![], // Committed transactions are not important for this test.
                 context.clock.timestamp_utc_ms(),
                 last_commit.reference(),

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -332,8 +332,7 @@ impl LeaderSchedule {
         drop(read);
 
         tracing::debug!(
-            "[AUTH {}] Normal update LeaderSwapTable: commit_range={:?}, good_nodes={:?}, bad_nodes={:?}",
-            self.context.own_index,
+            "Normal update LeaderSwapTable: commit_range={:?}, good_nodes={:?}, bad_nodes={:?}",
             new_commit_range,
             table
                 .good_nodes
@@ -931,8 +930,6 @@ mod tests {
             CommittedSubDag::new(
                 leader_ref,
                 blocks.clone(),
-                // For this test we don't need to access block refs through the commit.
-                // Reuse the committed block refs directly.
                 blocks.iter().map(|b| b.reference()).collect::<Vec<_>>(),
                 vec![], // Committed transactions are not important for this test.
                 context.clock.timestamp_utc_ms(),

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -250,10 +250,6 @@ impl LeaderSchedule {
         commit_index: CommitIndex,
         reputation_scores_desc: &[(AuthorityIndex, u64)],
     ) {
-        if reputation_scores_desc.is_empty() {
-            return;
-        }
-
         // Determine the commit range for these scores.
         // Reputation scores are attached to the *first* commit after a schedule
         // update, so the scores correspond to the previous window ending at

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -14,11 +14,23 @@ use starfish_config::{AuthorityIndex, Stake};
 
 use crate::{
     CommitIndex, Round,
-    commit::{CommitRange, GENESIS_COMMIT_INDEX},
+    commit::{CommitInfo, CommitRange, CommitRef, GENESIS_COMMIT_INDEX},
     context::Context,
     dag_state::DagState,
     leader_scoring::ReputationScores,
 };
+
+/// Calculates the seed index for leader swap table initialization.
+/// Uses the commit range end as seed, falling back to the commit ref index
+/// for genesis commits where the range end equals GENESIS_COMMIT_INDEX.
+fn calculate_seed_index(last_commit_ref: &CommitRef, last_commit_info: &CommitInfo) -> CommitIndex {
+    let range_end = last_commit_info.reputation_scores.commit_range.end();
+    if range_end == GENESIS_COMMIT_INDEX {
+        last_commit_ref.index
+    } else {
+        range_end
+    }
+}
 
 /// The window where the schedule change takes place in consensus. It
 /// represents number of committed sub dags.
@@ -60,12 +72,7 @@ impl LeaderSchedule {
         let leader_swap_table = dag_state.read().recover_last_commit_info().map_or(
             LeaderSwapTable::default(),
             |(last_commit_ref, last_commit_info)| {
-                let range_end = last_commit_info.reputation_scores.commit_range.end();
-                let seed_index = if range_end == GENESIS_COMMIT_INDEX {
-                    last_commit_ref.index
-                } else {
-                    range_end
-                };
+                let seed_index = calculate_seed_index(&last_commit_ref, &last_commit_info);
                 LeaderSwapTable::new(
                     context.clone(),
                     seed_index,
@@ -90,12 +97,7 @@ impl LeaderSchedule {
         let leader_swap_table = dag_state.read().recover_last_commit_info().map_or(
             LeaderSwapTable::default(),
             |(last_commit_ref, last_commit_info)| {
-                let range_end = last_commit_info.reputation_scores.commit_range.end();
-                let seed_index = if range_end == GENESIS_COMMIT_INDEX {
-                    last_commit_ref.index
-                } else {
-                    range_end
-                };
+                let seed_index = calculate_seed_index(&last_commit_ref, &last_commit_info);
                 LeaderSwapTable::new(
                     self.context.clone(),
                     seed_index,

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -69,6 +69,24 @@ impl ReputationScores {
             }
         }
     }
+
+    /// Creates ReputationScores from reputation_scores_desc (as stored in commits).
+    /// The reputation_scores_desc is Vec<(AuthorityIndex, u64)> sorted by score descending.
+    /// This converts it to scores_per_authority indexed by authority.
+    pub(crate) fn from_scores_desc(
+        num_authorities: usize,
+        commit_range: CommitRange,
+        reputation_scores_desc: &[(AuthorityIndex, u64)],
+    ) -> Self {
+        let mut scores_per_authority = vec![0u64; num_authorities];
+        for (authority_index, score) in reputation_scores_desc {
+            scores_per_authority[*authority_index] = *score;
+        }
+        Self {
+            scores_per_authority,
+            commit_range,
+        }
+    }
 }
 
 /// ScoringSubdag represents the scoring votes in a collection of subdags across

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -70,9 +70,10 @@ impl ReputationScores {
         }
     }
 
-    /// Creates ReputationScores from reputation_scores_desc (as stored in commits).
-    /// The reputation_scores_desc is Vec<(AuthorityIndex, u64)> sorted by score descending.
-    /// This converts it to scores_per_authority indexed by authority.
+    /// Creates ReputationScores from reputation_scores_desc (as stored in
+    /// commits). The reputation_scores_desc is Vec<(AuthorityIndex, u64)>
+    /// sorted by score descending. This converts it to scores_per_authority
+    /// indexed by authority.
     pub(crate) fn from_scores_desc(
         num_authorities: usize,
         commit_range: CommitRange,

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -64,6 +64,13 @@ impl Linearizer {
         }
     }
 
+    /// Reinitialize Linearizer after fast sync completes.
+    /// Clears tracked state for a fresh start.
+    pub(crate) fn reinitialize(&mut self) {
+        self.transactions_ack_tracker.clear();
+        self.traversed_headers_tracker.clear();
+    }
+
     /// Collect the sub-dag and the corresponding commit from a specific leader,
     /// excluding any duplicates or blocks that have already been committed
     /// (within previous sub-dags).

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -744,7 +744,15 @@ mod tests {
 
         async fn add_subdags_from_fast_sync(
             &self,
+            _commits: Vec<crate::commit::TrustedCommit>,
             _subdags: Vec<crate::commit::CommittedSubDag>,
+        ) -> Result<(), CoreError> {
+            unimplemented!()
+        }
+
+        async fn reinitialize_components(
+            &self,
+            _block_headers: Vec<crate::block_header::VerifiedBlockHeader>,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -2372,7 +2372,15 @@ mod tests {
 
         async fn add_subdags_from_fast_sync(
             &self,
+            _commits: Vec<crate::commit::TrustedCommit>,
             _subdags: Vec<crate::commit::CommittedSubDag>,
+        ) -> Result<(), CoreError> {
+            unimplemented!()
+        }
+
+        async fn reinitialize_components(
+            &self,
+            _block_headers: Vec<crate::block_header::VerifiedBlockHeader>,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }


### PR DESCRIPTION
# Description of change

PR focuses on making fast sync safe to hand back to normal consensus by reinitializing the state and all core components; it also refactors commit syncer scheduling/verification and adds a restart divergence test.

Breakdown of changes:

- Adds close‑to‑quorum fast sync flow that fetches a header window and reinitializes consensus components once catch‑up completes.
 - Persists and consumes reputation scores/commit info to rebuild leader schedule and scoring state after fast sync, plus DagState cache reinit logic.
- Refactors commit syncers with shared scheduling helpers and header verification to tighten fetch correctness.
- Moves GC/flush ordering in commit observer and adds reinitialize path that rebuilds linearizer state during recovery.
- Expands restart node tests to ensure no divergence happens after fast sync and two crashes.

Important assumption that should be addressed in the following PRs:
- The node can operate mostly normally if the fast sync is completed. It will fetch enough headers to reinitialize the state after a crash.
- If the node db is corrupted, while the consensus db is not, then it will not be possible to replay the recovery logic since it will attempt to reconstruct all PendingSubDAG which require existence of all headers. All headers are not fetched during fast sync. In such a case, one needs to remove both node and consensus dbs.
- Core thread ignores most commands while fast sync is ongoing; normal proposal/processing is effectively paused until reinitialization happens
 - Leader schedule update from commit scores assumes scores correspond to the window ending at commit_index - 1; any change to how scores are embedded must preserve this.

By benchmarking on the local deployment we observe a significant improvement in the speed of syncing. Specifically, during 1 second 60-120 seconds of committed subDAGs could be replayed.

## Links to any relevant issues

Fixes #9715 
 
## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
