### PR TITLE
feat(indexer): Make `persist_sequentially` more resilient to hanging

### DIFF
--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -4,7 +4,7 @@
 //! Types and associated logic to use while persisting
 //! data to the database.
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::Duration};
 
 use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
@@ -95,11 +95,16 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
                 return Ok(());
             }
 
+            let next_cp_present = unprocessed.contains_key(&next_cp_to_process);
+
             // Try to fetch new data tuple from the stream
-            if unprocessed.len() >= UNPROCESSED_CHECKPOINT_SIZE_LIMIT {
+            if unprocessed.len() >= UNPROCESSED_CHECKPOINT_SIZE_LIMIT && next_cp_present {
                 tracing::debug!(
-                    "Unprocessed checkpoint size reached limit {UNPROCESSED_CHECKPOINT_SIZE_LIMIT}, skip reading from stream..."
+                    "Unprocessed checkpoint size reached limit {UNPROCESSED_CHECKPOINT_SIZE_LIMIT} \
+                     at checkpoint {next_cp_to_process}. Current queue size: {}. Skip reading from stream...",
+                    unprocessed.len()
                 );
+                tokio::time::sleep(Duration::from_secs(1)).await;
             } else {
                 // Try to fetch new data tuple from the stream
                 match stream.next().now_or_never() {


### PR DESCRIPTION
# Description of change

Fixes `persist_sequentially` function that could potentially hang if buffer of checkpoints would be full, but we would be missing the next checkpoint to be processed.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/5873

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [x] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
