### PR TITLE
feat(starfish): remove get_latest_rounds from network service

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -177,7 +177,7 @@ impl ConsensusAuthority {
         );
 
         let (core_dispatcher, core_thread_handle) =
-            ChannelCoreThreadDispatcher::start(context.clone(), &dag_state, core);
+            ChannelCoreThreadDispatcher::start(context.clone(), core);
         let core_dispatcher = Arc::new(core_dispatcher);
 
         let transactions_synchronizer = TransactionsSynchronizer::start(

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1008,31 +1008,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         Ok(result)
     }
 
-    async fn handle_get_latest_rounds(
-        &self,
-        _peer: AuthorityIndex,
-    ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
-        fail_point_async!("consensus-rpc-response");
-
-        let mut highest_received_rounds = self.core_dispatcher.highest_received_rounds();
-
-        let block_headers = self
-            .dag_state
-            .read()
-            .get_last_cached_block_header_per_authority(Round::MAX);
-        let highest_accepted_rounds = block_headers
-            .into_iter()
-            .map(|(block_headers, _)| block_headers.round())
-            .collect::<Vec<_>>();
-
-        // Own blocks do not go through the core dispatcher, so they need to be set
-        // separately.
-        highest_received_rounds[self.context.own_index] =
-            highest_accepted_rounds[self.context.own_index];
-
-        Ok((highest_received_rounds, highest_accepted_rounds))
-    }
-
     async fn handle_fetch_transactions(
         &self,
         peer: AuthorityIndex,
@@ -1367,7 +1342,7 @@ async fn make_recv_future<T: Clone>(
 #[cfg(test)]
 mod tests {
     use std::{
-        cmp::{max, min},
+        cmp::min,
         collections::{BTreeMap, BTreeSet},
         sync::Arc,
         time::Duration,
@@ -1970,171 +1945,8 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_handle_get_latest_rounds() {
-        // GIVEN
-        let rounds = 15;
-        let validators = 4;
-        let (context, key_pairs) = Context::new_for_test(validators);
-        let context = Arc::new(context);
-        let block_verifier = Arc::new(SignedBlockVerifier::new(
-            context.clone(),
-            Arc::new(crate::block_verifier::test::TxnSizeVerifier {}),
-        ));
-        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let store = Arc::new(MemStore::new(context.clone()));
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
-
-        let block_manager = BlockManager::new(context.clone(), dag_state.clone());
-        let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
-        let (signals, _signal_receivers) = CoreSignals::new(context.clone());
-        let (sender, _receiver) = unbounded_channel("consensus_output");
-        let leader_schedule = Arc::new(LeaderSchedule::from_store(
-            context.clone(),
-            dag_state.clone(),
-        ));
-        let commit_observer = CommitObserver::new(
-            context.clone(),
-            CommitConsumer::new(sender.clone(), 0),
-            dag_state.clone(),
-            store.clone(),
-            leader_schedule.clone(),
-        );
-
-        // we set sync_last_known_own_block to true and last known proposed round to
-        // rounds+5 so that core doesn't start to create its own new blocks,
-        // that would be different from the blocks created in dag builder
-        let mut core = Core::new(
-            context.clone(),
-            leader_schedule,
-            transaction_consumer,
-            block_manager,
-            true,
-            commit_observer,
-            signals,
-            key_pairs[context.own_index.value()].1.clone(),
-            dag_state.clone(),
-            true,
-        );
-        core.set_last_known_proposed_round(rounds + 5);
-
-        let core_dispatcher = Arc::new(FakeCoreThreadDispatcher {
-            core: Mutex::new(core),
-            highest_received_rounds: Mutex::new(vec![0; context.committee.size()]),
-        });
-
-        let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
-        let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
-        let network_client = Arc::new(FakeNetworkClient::default());
-
-        // Set up synchronizers
-        let transactions_synchronizer = TransactionsSynchronizer::start(
-            network_client.clone(),
-            context.clone(),
-            core_dispatcher.clone(),
-            dag_state.clone(),
-        );
-
-        let header_synchronizer = HeaderSynchronizer::start(
-            network_client,
-            context.clone(),
-            core_dispatcher.clone(),
-            commit_vote_monitor.clone(),
-            transactions_synchronizer.clone(),
-            block_verifier.clone(),
-            dag_state.clone(),
-            false,
-        );
-
-        // Create the authority service
-        let authority_service = Arc::new(AuthorityService::new(
-            context.clone(),
-            block_verifier,
-            commit_vote_monitor,
-            header_synchronizer,
-            transactions_synchronizer,
-            core_dispatcher.clone(),
-            rx_block_broadcast,
-            dag_state.clone(),
-            store.clone(),
-            tx_message_sender,
-            cordial_knowledge,
-        ));
-
-        // Set up DAG with blocks
-        let mut dag_builder = DagBuilder::new(context.clone());
-        dag_builder.layers(1..=rounds).build();
-        // dag_builder.persist_all_blocks(dag_state.clone());
-
-        // Get all block headers
-        let mut all_block_headers: Vec<Vec<VerifiedBlockHeader>> = vec![];
-        for round in 0..=rounds {
-            all_block_headers.push(dag_builder.block_headers(round..=round));
-        }
-
-        for round in 1..=rounds / 2 {
-            core_dispatcher
-                .add_block_headers(all_block_headers[round as usize].clone())
-                .await
-                .expect("block headers are expected to be added successfully");
-        }
-
-        let (received_rounds, accepted_rounds) = authority_service
-            .handle_get_latest_rounds(AuthorityIndex::new_for_test(1))
-            .await
-            .unwrap();
-        assert_eq!(
-            received_rounds,
-            [rounds / 2, rounds / 2, rounds / 2, rounds / 2]
-        );
-        assert_eq!(
-            accepted_rounds,
-            [rounds / 2, rounds / 2, rounds / 2, rounds / 2]
-        );
-
-        // Add header only for some validators so that received and accepted rounds are
-        // different
-        for round in rounds / 2 + 1..=rounds {
-            let headers = &all_block_headers[round as usize];
-            core_dispatcher
-                .add_block_headers(headers[..2].to_vec())
-                .await
-                .expect("block headers are expected to be added successfully");
-        }
-        let (received_rounds, accepted_rounds) = authority_service
-            .handle_get_latest_rounds(AuthorityIndex::new_for_test(1))
-            .await
-            .unwrap();
-        assert_eq!(
-            received_rounds,
-            [rounds / 2 + 1, rounds, rounds / 2, rounds / 2]
-        );
-        assert_eq!(
-            accepted_rounds,
-            [rounds / 2 + 1, rounds / 2 + 1, rounds / 2, rounds / 2]
-        );
-
-        for round in rounds / 2 + 1..=rounds {
-            let headers = &all_block_headers[round as usize];
-            core_dispatcher
-                .add_block_headers(headers[2..].to_vec())
-                .await
-                .expect("block headers are expected to be added successfully");
-        }
-
-        let (received_rounds, accepted_rounds) = authority_service
-            .handle_get_latest_rounds(AuthorityIndex::new_for_test(1))
-            .await
-            .unwrap();
-        assert_eq!(received_rounds, [rounds, rounds, rounds, rounds]);
-        assert_eq!(accepted_rounds, [rounds, rounds, rounds, rounds]);
-    }
-
     pub struct FakeCoreThreadDispatcher {
         core: Mutex<Core>,
-        highest_received_rounds: Mutex<Vec<u32>>,
     }
 
     #[async_trait]
@@ -2150,11 +1962,6 @@ mod tests {
             CoreError,
         > {
             let mut guard = self.core.lock();
-            let mut vec = self.highest_received_rounds.lock();
-            for block in blocks.iter() {
-                let entry = &mut vec[block.author()];
-                *entry = max(*entry, block.round());
-            }
             let _ = guard.add_blocks(blocks);
             Ok((BTreeSet::new(), BTreeMap::new()))
         }
@@ -2170,11 +1977,6 @@ mod tests {
             CoreError,
         > {
             let mut guard = self.core.lock();
-            let mut vec = self.highest_received_rounds.lock();
-            for block_header in block_headers.iter() {
-                let entry = &mut vec[block_header.author()];
-                *entry = max(*entry, block_header.round());
-            }
             let _ = guard.add_block_headers(block_headers);
             Ok((BTreeSet::new(), BTreeMap::new()))
         }
@@ -2239,11 +2041,6 @@ mod tests {
         fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
             unimplemented!("Unimplemented")
         }
-
-        fn highest_received_rounds(&self) -> Vec<Round> {
-            let guard = self.highest_received_rounds.lock();
-            guard.clone()
-        }
     }
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
@@ -2302,7 +2099,6 @@ mod tests {
 
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher {
             core: Mutex::new(core),
-            highest_received_rounds: vec![0; context.committee.size()].into(),
         });
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
@@ -2464,7 +2260,6 @@ mod tests {
 
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher {
             core: Mutex::new(core),
-            highest_received_rounds: vec![0; context.committee.size()].into(),
         });
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
@@ -2638,7 +2433,6 @@ mod tests {
 
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher {
             core: Mutex::new(core),
-            highest_received_rounds: vec![0; context.committee.size()].into(),
         });
 
         // Create a broadcast channel for new blocks
@@ -2961,7 +2755,6 @@ mod tests {
 
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher {
             core: Mutex::new(core),
-            highest_received_rounds: vec![0; context.committee.size()].into(),
         });
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
@@ -3102,7 +2895,6 @@ mod tests {
 
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher {
             core: Mutex::new(core),
-            highest_received_rounds: vec![0; context.committee.size()].into(),
         });
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
@@ -3268,7 +3060,6 @@ mod tests {
 
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher {
             core: Mutex::new(core),
-            highest_received_rounds: vec![0; context.committee.size()].into(),
         });
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
@@ -3457,7 +3248,6 @@ mod tests {
 
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher {
             core: Mutex::new(core),
-            highest_received_rounds: vec![0; context.committee.size()].into(),
         });
 
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -5,10 +5,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Debug,
-    sync::{
-        Arc,
-        atomic::{AtomicU32, Ordering},
-    },
+    sync::Arc,
 };
 
 use async_trait::async_trait;
@@ -16,21 +13,20 @@ use iota_metrics::{
     monitored_mpsc::{Receiver, Sender, WeakSender, channel},
     monitored_scope, spawn_logged_monitored_task,
 };
-use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
 use thiserror::Error;
 use tokio::sync::{oneshot, watch};
 use tracing::{info, warn};
 
 use crate::{
-    BlockHeaderAPI as _, CommittedSubDag, VerifiedBlockHeader,
+    CommittedSubDag, VerifiedBlockHeader,
     block_header::{BlockRef, Round, VerifiedBlock, VerifiedOwnShard, VerifiedTransactions},
     commit::CertifiedCommits,
     commit_observer::CommittedSubDagSource,
     context::Context,
     core::{Core, ReasonToCreateBlock},
     core_thread::CoreError::Shutdown,
-    dag_state::{DagState, TransactionSource},
+    dag_state::TransactionSource,
     error::{ConsensusError, ConsensusResult},
     transaction_ref::GenericTransactionRef,
 };
@@ -166,9 +162,6 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
     fn set_quorum_subscribers_exists(&self, exists: bool) -> Result<(), CoreError>;
 
     fn set_last_known_proposed_round(&self, round: Round) -> Result<(), CoreError>;
-
-    /// Returns the highest round received for each authority by Core.
-    fn highest_received_rounds(&self) -> Vec<Round>;
 }
 
 pub(crate) struct CoreThreadHandle {
@@ -313,30 +306,12 @@ pub(crate) struct ChannelCoreThreadDispatcher {
     sender: WeakSender<CoreThreadCommand>,
     tx_quorum_subscribers_exists: Arc<watch::Sender<bool>>,
     tx_last_known_proposed_round: Arc<watch::Sender<Round>>,
-    highest_received_rounds: Arc<Vec<AtomicU32>>,
 }
 
 impl ChannelCoreThreadDispatcher {
     /// Starts the core thread for the consensus authority and returns a
     /// dispatcher and handle for managing the core thread.
-    pub(crate) fn start(
-        context: Arc<Context>,
-        dag_state: &RwLock<DagState>,
-        core: Core,
-    ) -> (Self, CoreThreadHandle) {
-        // Initialize highest received rounds.
-        let highest_received_rounds = {
-            let dag_state = dag_state.read();
-            let highest_received_rounds = context
-                .committee
-                .authorities()
-                .map(|(index, _)| {
-                    AtomicU32::new(dag_state.get_last_block_header_for_authority(index).round())
-                })
-                .collect();
-
-            highest_received_rounds
-        };
+    pub(crate) fn start(context: Arc<Context>, core: Core) -> (Self, CoreThreadHandle) {
         let (sender, receiver) =
             channel("consensus_core_commands", CORE_THREAD_COMMANDS_CHANNEL_SIZE);
         let (tx_quorum_subscribers_exists, mut rx_quorum_subscribers_exists) =
@@ -371,7 +346,6 @@ impl ChannelCoreThreadDispatcher {
             sender: sender.downgrade(),
             tx_quorum_subscribers_exists: Arc::new(tx_quorum_subscribers_exists),
             tx_last_known_proposed_round: Arc::new(tx_last_known_proposed_round),
-            highest_received_rounds: Arc::new(highest_received_rounds),
         };
         let handle = CoreThreadHandle {
             join_handle,
@@ -405,9 +379,6 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         ),
         CoreError,
     > {
-        for block in &blocks {
-            self.highest_received_rounds[block.author()].fetch_max(block.round(), Ordering::AcqRel);
-        }
         let (sender, receiver) = oneshot::channel();
         self.send(CoreThreadCommand::AddBlocks(blocks, sender))
             .await;
@@ -471,12 +442,6 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         ),
         CoreError,
     > {
-        for commit in commits.commits() {
-            for block in commit.block_headers() {
-                self.highest_received_rounds[block.author()]
-                    .fetch_max(block.round(), Ordering::AcqRel);
-            }
-        }
         let (sender, receiver) = oneshot::channel();
         self.send(CoreThreadCommand::AddCertifiedCommits(commits, sender))
             .await;
@@ -522,13 +487,6 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         self.tx_last_known_proposed_round
             .send(round)
             .map_err(|e| Shutdown(e.to_string()))
-    }
-
-    fn highest_received_rounds(&self) -> Vec<Round> {
-        self.highest_received_rounds
-            .iter()
-            .map(|round| round.load(Ordering::Relaxed))
-            .collect()
     }
 }
 
@@ -707,10 +665,6 @@ pub(crate) mod tests {
             self.last_known_proposed_round.lock().push(round);
             Ok(())
         }
-
-        fn highest_received_rounds(&self) -> Vec<Round> {
-            unimplemented!()
-        }
     }
 
     #[tokio::test]
@@ -754,8 +708,7 @@ pub(crate) mod tests {
             false,
         );
 
-        let (core_dispatcher, handle) =
-            ChannelCoreThreadDispatcher::start(context, &dag_state, core);
+        let (core_dispatcher, handle) = ChannelCoreThreadDispatcher::start(context, core);
 
         // Now create some clones of the dispatcher
         let dispatcher_1 = core_dispatcher.clone();

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -2454,10 +2454,6 @@ mod tests {
         fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
             Ok(())
         }
-
-        fn highest_received_rounds(&self) -> Vec<Round> {
-            Vec::new()
-        }
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -209,13 +209,6 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         authorities: Vec<AuthorityIndex>,
     ) -> ConsensusResult<Vec<Bytes>>;
 
-    /// Handles the request to get the latest received & accepted rounds of all
-    /// authorities.
-    async fn handle_get_latest_rounds(
-        &self,
-        peer: AuthorityIndex,
-    ) -> ConsensusResult<(Vec<Round>, Vec<Round>)>;
-
     /// Handles the request to fetch transactions by references from the peer.
     /// The `fetch_mode` parameter controls whether results should be truncated
     /// to respect maximum transaction limits.

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -116,13 +116,6 @@ impl NetworkService for Mutex<TestService> {
         unimplemented!("Unimplemented")
     }
 
-    async fn handle_get_latest_rounds(
-        &self,
-        _peer: AuthorityIndex,
-    ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
-        unimplemented!("Unimplemented")
-    }
-
     async fn handle_fetch_transactions(
         &self,
         _peer: AuthorityIndex,

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -828,24 +828,10 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
 
     async fn get_latest_rounds(
         &self,
-        request: Request<GetLatestRoundsRequest>,
+        _request: Request<GetLatestRoundsRequest>,
     ) -> Result<Response<GetLatestRoundsResponse>, tonic::Status> {
-        let Some(peer_index) = request
-            .extensions()
-            .get::<PeerInfo>()
-            .map(|p| p.authority_index)
-        else {
-            return Err(tonic::Status::internal("PeerInfo not found"));
-        };
-        let (highest_received, highest_accepted) = self
-            .service
-            .handle_get_latest_rounds(peer_index)
-            .await
-            .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
-        Ok(Response::new(GetLatestRoundsResponse {
-            highest_received,
-            highest_accepted,
-        }))
+        error!("get_latest_rounds() is deprecated in starfish and should not be called");
+        unimplemented!();
     }
 
     type FetchTransactionsStream =

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -770,10 +770,6 @@ mod tests {
         fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
             unimplemented!()
         }
-
-        fn highest_received_rounds(&self) -> Vec<Round> {
-            unimplemented!()
-        }
     }
 
     ///  Prepare a batch of messages simulating the case:

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -2398,10 +2398,6 @@ mod tests {
         fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
             unimplemented!()
         }
-
-        fn highest_received_rounds(&self) -> Vec<Round> {
-            unimplemented!()
-        }
     }
 
     #[async_trait]


### PR DESCRIPTION
# Description of change
Remove `get_latest_rounds` method implementation from `ConsensusService` tonic API for `starfish`. Also clean up any methods and fields added to other structures that existed only to support this method. 

## Links to any relevant issues

fixes #9709.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
