### PR TITLE
chore(ci): fix typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -46,6 +46,10 @@ transferer = "transferrer"
 # not in the correction dictionary
 checkpoitn = "checkpoint"
 typ = "typ"
+# crates
+bimap = "bimap"
+# plurals
+pendings = "pendings"
 
 [default.extend-identifiers]
 numer = "numer"

--- a/crates/iota-network/src/randomness/mod.rs
+++ b/crates/iota-network/src/randomness/mod.rs
@@ -646,7 +646,7 @@ impl RandomnessEventLoop {
         // Try to verify the aggregated signature all at once. (Should work in the happy
         // path.)
         if ThresholdBls12381MinSig::verify(vss_pk.c0(), &round.signature_message(), &sig).is_err() {
-            // If verifiation fails, some of the inputs must be invalid. We have to go
+            // If verification fails, some of the inputs must be invalid. We have to go
             // through one-by-one to find which.
             // TODO: add test for individual sig verification.
             self.received_partial_sigs

--- a/crates/iota-rosetta/src/account.rs
+++ b/crates/iota-rosetta/src/account.rs
@@ -65,7 +65,7 @@ pub async fn balance(
                     balances: balances_first,
                 });
             } else {
-                // retry logic needs to be aaded
+                // retry logic needs to be added
                 retry_attempts -= 1;
             }
         }

--- a/crates/iota-types/src/unit_tests/messages_tests.rs
+++ b/crates/iota-types/src/unit_tests/messages_tests.rs
@@ -305,7 +305,7 @@ fn test_auth_sig_commit_to_wrong_epoch_id_fail() {
     );
     let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
 
-    // Auth signtaure commits to epoch 0 verifies ok.
+    // Auth signature commits to epoch 0 verifies ok.
     let sig = AuthoritySignature::new_secure(
         &IntentMessage::new(
             Intent::iota_app(IntentScope::SenderSignedTransaction),
@@ -318,7 +318,7 @@ fn test_auth_sig_commit_to_wrong_epoch_id_fail() {
     assert!(res.is_ok());
     assert!(obligation.verify_all().is_ok());
 
-    // Auth signtaure commits to epoch 1 fails to verify.
+    // Auth signature commits to epoch 1 fails to verify.
     let mut obligation = VerificationObligation::default();
     let idx1 = obligation.add_message(
         &message,

--- a/docs/content/developer/iota-identity/how-tos/post-quantum.mdx
+++ b/docs/content/developer/iota-identity/how-tos/post-quantum.mdx
@@ -323,7 +323,7 @@ JwtCredentialValidatorHybrid::with_signature_verifiers(EdDSAJwsVerifier::default
 
 ## Security Considerations
 
-Although VCs and VPs secured through PQC signatures would indeed be resiliant against quantum 
+Although VCs and VPs secured through PQC signatures would indeed be resilient against quantum 
 attacks, it is important to consider the security of the issuer's DID Document as well. If the DID 
 document, containing a signature's verification method, were to be compromised, the ability to 
 verify all signatures that rely on it would be compromised as well.


### PR DESCRIPTION
# Description of change

Fix new typos after updating the runner image's typos-cli to `v1.42.0`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
