### PR TITLE
feat(simulacrum): add simulacrum server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -93,6 +93,7 @@
 /crates/iota-verifier-transactional-tests/ @iotaledger/vm-language
 /crates/prometheus-closure-metric/ @iotaledger/node
 /crates/simulacrum/ @iotaledger/vm-language
+/crates/simulacrum-server/ @iotaledger/node
 /crates/starfish/ @iotaledger/consensus
 /crates/telemetry-subscribers/ @iotaledger/core-protocol
 /crates/transaction-fuzzer/ @iotaledger/node @iotaledger/vm-language

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,7 +92,7 @@
 /crates/iota-upgrade-compatibility-transactional-tests/ @iotaledger/vm-language
 /crates/iota-verifier-transactional-tests/ @iotaledger/vm-language
 /crates/prometheus-closure-metric/ @iotaledger/node
-/crates/simulacrum/ @iotaledger/vm-language
+/crates/simulacrum/ @iotaledger/node @iotaledger/vm-language
 /crates/simulacrum-server/ @iotaledger/node
 /crates/starfish/ @iotaledger/consensus
 /crates/telemetry-subscribers/ @iotaledger/core-protocol

--- a/.github/crates-filters.yml
+++ b/.github/crates-filters.yml
@@ -188,6 +188,8 @@ prometheus-closure-metric:
   - "crates/prometheus-closure-metric/**"
 simulacrum:
   - "crates/simulacrum/**"
+simulacrum-server:
+  - "crates/simulacrum-server/**"
 telemetry-subscribers:
   - "crates/telemetry-subscribers/**"
 test-cluster:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13691,6 +13691,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "simulacrum-server"
+version = "1.15.0-alpha"
+dependencies = [
+ "anyhow",
+ "axum 0.8.4",
+ "clap",
+ "futures",
+ "http 1.3.1",
+ "iota-config",
+ "iota-execution",
+ "iota-faucet",
+ "iota-grpc-server",
+ "iota-json-rpc-types",
+ "iota-protocol-config",
+ "iota-swarm-config",
+ "iota-types",
+ "move-core-types",
+ "rand 0.8.5",
+ "serde",
+ "simulacrum",
+ "tokio",
+ "tokio-util 0.7.12",
+ "tower 0.4.13",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13678,6 +13678,7 @@ dependencies = [
  "fastcrypto",
  "iota-config",
  "iota-execution",
+ "iota-grpc-server",
  "iota-protocol-config",
  "iota-storage",
  "iota-swarm-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13695,6 +13695,7 @@ name = "simulacrum-server"
 version = "1.15.0-alpha"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum 0.8.4",
  "clap",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13675,6 +13675,7 @@ name = "simulacrum"
 version = "1.15.0-alpha"
 dependencies = [
  "anyhow",
+ "async-trait",
  "fastcrypto",
  "iota-config",
  "iota-execution",
@@ -13689,6 +13690,7 @@ dependencies = [
  "move-core-types",
  "prometheus",
  "rand 0.8.5",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,7 @@ members = [
   "crates/iota-verifier-transactional-tests",
   "crates/prometheus-closure-metric",
   "crates/simulacrum",
+  "crates/simulacrum-server",
   "crates/starfish/config",
   "crates/starfish/core",
   "crates/starfish/simtests",
@@ -501,6 +502,7 @@ move-vm-profiler = { path = "external-crates/move/crates/move-vm-profiler" }
 move-vm-test-utils = { path = "external-crates/move/crates/move-vm-test-utils/", features = ["tiered-gas"] }
 prometheus-closure-metric = { path = "crates/prometheus-closure-metric" }
 simulacrum = { path = "crates/simulacrum" }
+simulacrum-server = { path = "crates/simulacrum-server" }
 starfish-config = { path = "crates/starfish/config" }
 starfish-core = { path = "crates/starfish/core" }
 starfish-simtests = { path = "crates/starfish/simtests" }

--- a/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
@@ -212,7 +212,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn test_transaction_handler() -> anyhow::Result<()> {
-        let mut sim = Simulacrum::new();
+        let sim = Simulacrum::new();
 
         // Execute a simple transaction.
         let transfer_recipient = IotaAddress::random_for_testing_only();

--- a/crates/iota-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/iota-graphql-rpc/tests/e2e_tests.rs
@@ -82,7 +82,7 @@ mod tests {
     async fn prep_executor_cluster() -> (ConnectionConfig, ExecutorCluster) {
         let rng = StdRng::from_seed([12; 32]);
         let data_ingestion_path = tempdir().unwrap().keep();
-        let mut sim = Simulacrum::new_with_rng(rng);
+        let sim = Simulacrum::new_with_rng(rng);
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
         sim.create_checkpoint();
@@ -152,7 +152,7 @@ mod tests {
     #[serial]
     async fn test_simple_client_simulator_cluster() {
         let rng = StdRng::from_seed([12; 32]);
-        let mut sim = Simulacrum::new_with_rng(rng);
+        let sim = Simulacrum::new_with_rng(rng);
         let data_ingestion_path = tempdir().unwrap().keep();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
@@ -160,9 +160,7 @@ mod tests {
         sim.create_checkpoint();
 
         let genesis_checkpoint_digest1 = *sim
-            .store()
-            .get_checkpoint_by_sequence_number(0)
-            .unwrap()
+            .with_store(|store| store.get_checkpoint_by_sequence_number(0).cloned().unwrap())
             .digest();
 
         let chain_id_actual = format!("{}", ChainIdentifier::from(genesis_checkpoint_digest1));

--- a/crates/iota-graphql-rpc/tests/examples_validation_tests.rs
+++ b/crates/iota-graphql-rpc/tests/examples_validation_tests.rs
@@ -144,7 +144,7 @@ mod tests {
     async fn good_examples_within_limits() {
         let rng = StdRng::from_seed([12; 32]);
         let data_ingestion_path = tempdir().unwrap().keep();
-        let mut sim = Simulacrum::new_with_rng(rng);
+        let sim = Simulacrum::new_with_rng(rng);
         let (mut max_nodes, mut max_output_nodes, mut max_depth, mut max_payload) = (0, 0, 0, 0);
 
         sim.set_data_ingestion_path(data_ingestion_path.clone());
@@ -211,7 +211,7 @@ mod tests {
     async fn bad_examples_fail() {
         let rng = StdRng::from_seed([12; 32]);
         let data_ingestion_path = tempdir().unwrap().keep();
-        let mut sim = Simulacrum::new_with_rng(rng);
+        let sim = Simulacrum::new_with_rng(rng);
         let (mut max_nodes, mut max_output_nodes, mut max_depth, mut max_payload) = (0, 0, 0, 0);
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -56,7 +56,7 @@ mod ingestion_tests {
     #[tokio::test]
     pub async fn checkpoint_objects_ingestion() -> Result<(), IndexerError> {
         let tempdir = tempdir().unwrap();
-        let mut sim = Simulacrum::new();
+        let sim = Simulacrum::new();
         let data_ingestion_path = tempdir.path().to_path_buf();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
@@ -80,7 +80,7 @@ mod ingestion_tests {
 
     #[tokio::test]
     pub async fn transaction_table() -> Result<(), IndexerError> {
-        let mut sim = Simulacrum::new();
+        let sim = Simulacrum::new();
         let data_ingestion_path = tempdir().unwrap().keep();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
@@ -131,7 +131,7 @@ mod ingestion_tests {
 
     #[tokio::test]
     pub async fn object_type() -> Result<(), IndexerError> {
-        let mut sim = Simulacrum::new();
+        let sim = Simulacrum::new();
         let data_ingestion_path = tempdir().unwrap().keep();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
@@ -184,7 +184,7 @@ mod ingestion_tests {
     #[tokio::test]
     pub async fn objects_snapshot() -> Result<(), IndexerError> {
         let tempdir = tempdir().unwrap();
-        let mut sim = Simulacrum::new();
+        let sim = Simulacrum::new();
         let data_ingestion_path = tempdir.path().to_path_buf();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
@@ -260,7 +260,7 @@ mod ingestion_tests {
 
     #[tokio::test]
     pub async fn tx_global_order_table() -> Result<(), IndexerError> {
-        let mut sim = Simulacrum::new();
+        let sim = Simulacrum::new();
         let data_ingestion_path = tempdir().unwrap().keep();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
@@ -316,7 +316,7 @@ mod ingestion_tests {
 
     #[tokio::test]
     pub async fn tx_global_order_table_on_conflict_do_nothing() -> Result<(), IndexerError> {
-        let mut sim = Simulacrum::new();
+        let sim = Simulacrum::new();
         let data_ingestion_path = tempdir().unwrap().keep();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
@@ -390,7 +390,7 @@ mod ingestion_tests {
     #[tokio::test]
     pub async fn test_insert_large_batch_tx_indices() -> Result<(), IndexerError> {
         let tempdir = tempdir().unwrap();
-        let mut sim = Simulacrum::new();
+        let sim = Simulacrum::new();
         let data_ingestion_path = tempdir.path().to_path_buf();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
@@ -427,7 +427,7 @@ mod ingestion_tests {
     #[tokio::test]
     pub async fn test_insert_large_batch_event_indices() -> Result<(), IndexerError> {
         let tempdir = tempdir().unwrap();
-        let mut sim = Simulacrum::new();
+        let sim = Simulacrum::new();
         let data_ingestion_path = tempdir.path().to_path_buf();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
@@ -457,7 +457,7 @@ mod ingestion_tests {
     #[tokio::test]
     pub async fn test_epoch_boundary() -> Result<(), IndexerError> {
         let tempdir = tempdir().unwrap();
-        let mut sim = Simulacrum::new();
+        let sim = Simulacrum::new();
         let data_ingestion_path = tempdir.path().to_path_buf();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 

--- a/crates/iota-synthetic-ingestion/src/synthetic_ingestion.rs
+++ b/crates/iota-synthetic-ingestion/src/synthetic_ingestion.rs
@@ -68,7 +68,7 @@ pub async fn generate_ingestion(config: Config) -> Result<()> {
     } = config;
 
     // Simulacrum will generate `0.chk` as the genesis checkpoint.
-    let mut sim = Simulacrum::new();
+    let sim = Simulacrum::new();
     sim.set_data_ingestion_path(ingestion_dir.clone());
 
     let gas_price = sim.reference_gas_price();

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -462,26 +462,27 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
         tx_digest: &TransactionDigest,
         _limit: usize,
     ) -> IotaResult<Vec<Event>> {
-        Ok(self
-            .store()
-            .get_transaction_events_by_tx_digest(tx_digest)
-            .map(|x| x.data)
-            .unwrap_or_default())
+        Ok(self.with_store(|store| {
+            store
+                .get_transaction_events_by_tx_digest(tx_digest)
+                .map(|x| x.data)
+                .unwrap_or_default()
+        }))
     }
 
     async fn create_checkpoint(&mut self) -> anyhow::Result<VerifiedCheckpoint> {
-        Ok(self.create_checkpoint())
+        Ok(Simulacrum::create_checkpoint(self))
     }
 
     async fn advance_clock(
         &mut self,
         duration: std::time::Duration,
     ) -> anyhow::Result<TransactionEffects> {
-        Ok(self.advance_clock(duration))
+        Ok(Simulacrum::advance_clock(self, duration))
     }
 
     async fn advance_epoch(&mut self) -> anyhow::Result<()> {
-        self.advance_epoch();
+        Simulacrum::advance_epoch(self);
         Ok(())
     }
 
@@ -490,7 +491,7 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
         address: IotaAddress,
         amount: u64,
     ) -> anyhow::Result<TransactionEffects> {
-        self.request_gas(address, amount)
+        Simulacrum::request_gas(self, address, amount)
     }
 
     async fn get_active_validator_addresses(&self) -> IotaResult<Vec<IotaAddress>> {

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -64,7 +64,7 @@ pub struct PersistedStoreInner {
     events_tx_digest_index: DBMap<TransactionDigest, TransactionEventsDigest>,
 
     // Committee data
-    epoch_to_committee: DBMap<(), Vec<Committee>>,
+    epoch_to_committee: DBMap<EpochId, Committee>,
 
     // Epoch data
     last_checkpoints_per_epoch: DBMap<EpochId, CheckpointSequenceNumber>,
@@ -257,27 +257,21 @@ impl SimulatorStore for PersistedStore {
     }
 
     fn insert_committee(&mut self, committee: Committee) {
-        let epoch = committee.epoch as usize;
+        let epoch = committee.epoch();
 
-        let mut committees = self
+        let committees = self
             .read_write
             .epoch_to_committee
-            .get(&())
-            .expect("Fatal: DB read failed")
-            .unwrap_or_default();
+            .get(&epoch)
+            .expect("Fatal: DB read failed");
 
-        if committees.get(epoch).is_some() {
+        if committees.is_some() {
             return;
         }
 
-        if committees.len() == epoch {
-            committees.push(committee);
-        } else {
-            panic!("committee was inserted into EpochCommitteeMap out of order");
-        }
         self.read_write
             .epoch_to_committee
-            .insert(&(), &committees)
+            .insert(&epoch, &committee)
             .expect("Fatal: DB write failed");
     }
 
@@ -483,9 +477,8 @@ impl ReadStore for PersistedStore {
         Ok(self
             .read_write
             .epoch_to_committee
-            .get(&())
+            .get(&epoch)
             .expect("Fatal: DB read failed")
-            .and_then(|committees| committees.get(epoch as usize).cloned())
             .map(std::sync::Arc::new))
     }
 
@@ -658,9 +651,8 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
         Ok(self
             .inner
             .epoch_to_committee
-            .get(&())
+            .get(&epoch)
             .expect("Fatal: DB read failed")
-            .and_then(|committees| committees.get(epoch as usize).cloned())
             .map(std::sync::Arc::new))
     }
 

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -554,7 +554,7 @@ impl ReadStore for PersistedStore {
         &self,
         _sequence_number: CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<Option<CheckpointContents>> {
-        todo!()
+        unimplemented!()
     }
 
     fn try_get_transaction(
@@ -598,7 +598,7 @@ impl ReadStore for PersistedStore {
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::FullCheckpointContents>,
     > {
-        todo!()
+        unimplemented!()
     }
 
     fn try_get_full_checkpoint_contents(
@@ -607,7 +607,7 @@ impl ReadStore for PersistedStore {
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::FullCheckpointContents>,
     > {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -66,6 +66,9 @@ pub struct PersistedStoreInner {
     // Committee data
     epoch_to_committee: DBMap<(), Vec<Committee>>,
 
+    // Epoch data
+    last_checkpoints_per_epoch: DBMap<EpochId, CheckpointSequenceNumber>,
+
     // Object data
     live_objects: DBMap<ObjectID, SequenceNumber>,
     objects: DBMap<ObjectID, BTreeMap<SequenceNumber, Object>>,
@@ -164,25 +167,6 @@ impl PersistedStore {
 }
 
 impl SimulatorStore for PersistedStore {
-    fn get_checkpoint_by_sequence_number(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Option<VerifiedCheckpoint> {
-        self.read_write
-            .checkpoints
-            .get(&sequence_number)
-            .expect("Fatal: DB read failed")
-            .map(|checkpoint| checkpoint.into())
-    }
-
-    fn get_checkpoint_by_digest(&self, digest: &CheckpointDigest) -> Option<VerifiedCheckpoint> {
-        self.read_write
-            .checkpoint_digest_to_sequence_number
-            .get(digest)
-            .expect("Fatal: DB read failed")
-            .and_then(|sequence_number| self.get_checkpoint_by_sequence_number(sequence_number))
-    }
-
     fn get_highest_checkpoint(&self) -> Option<VerifiedCheckpoint> {
         self.read_write
             .checkpoints
@@ -192,49 +176,6 @@ impl SimulatorStore for PersistedStore {
             .transpose()
             .expect("failed to fetch highest checkpoint")
             .map(|(_, checkpoint)| checkpoint.into())
-    }
-
-    fn get_checkpoint_contents(
-        &self,
-        digest: &CheckpointContentsDigest,
-    ) -> Option<CheckpointContents> {
-        self.read_write
-            .checkpoint_contents
-            .get(digest)
-            .expect("Fatal: DB read failed")
-    }
-
-    fn get_committee_by_epoch(&self, epoch: EpochId) -> Option<Committee> {
-        self.read_write
-            .epoch_to_committee
-            .get(&())
-            .expect("Fatal: DB read failed")
-            .and_then(|committees| committees.get(epoch as usize).cloned())
-    }
-
-    fn get_transaction(&self, digest: &TransactionDigest) -> Option<VerifiedTransaction> {
-        self.read_write
-            .transactions
-            .get(digest)
-            .expect("Fatal: DB read failed")
-            .map(|transaction| transaction.into())
-    }
-
-    fn get_transaction_effects(&self, digest: &TransactionDigest) -> Option<TransactionEffects> {
-        self.read_write
-            .effects
-            .get(digest)
-            .expect("Fatal: DB read failed")
-    }
-
-    fn get_transaction_events(
-        &self,
-        digest: &TransactionEventsDigest,
-    ) -> Option<TransactionEvents> {
-        self.read_write
-            .events
-            .get(digest)
-            .expect("Fatal: DB read failed")
     }
 
     fn get_transaction_events_by_tx_digest(
@@ -279,6 +220,13 @@ impl SimulatorStore for PersistedStore {
             .expect("clock should exist")
             .to_rust()
             .expect("clock object should deserialize")
+    }
+
+    fn get_last_checkpoint_of_epoch(&self, epoch: EpochId) -> Option<CheckpointSequenceNumber> {
+        self.read_write
+            .last_checkpoints_per_epoch
+            .get(&epoch)
+            .expect("Fatal: DB read failed")
     }
 
     fn owned_objects(&self, owner: IotaAddress) -> Box<dyn Iterator<Item = Object> + '_> {
@@ -408,6 +356,17 @@ impl SimulatorStore for PersistedStore {
     fn backing_store(&self) -> &dyn iota_types::storage::BackingStore {
         self
     }
+
+    fn update_last_checkpoint_of_epoch(
+        &mut self,
+        epoch: EpochId,
+        last_checkpoint: CheckpointSequenceNumber,
+    ) {
+        self.read_write
+            .last_checkpoints_per_epoch
+            .insert(&epoch, &last_checkpoint)
+            .expect("Fatal: DB write failed");
+    }
 }
 
 impl BackingPackageStore for PersistedStore {
@@ -516,6 +475,149 @@ impl ObjectStore for PersistedStore {
     }
 }
 
+impl ReadStore for PersistedStore {
+    fn try_get_committee(
+        &self,
+        epoch: EpochId,
+    ) -> iota_types::storage::error::Result<Option<std::sync::Arc<Committee>>> {
+        Ok(self
+            .read_write
+            .epoch_to_committee
+            .get(&())
+            .expect("Fatal: DB read failed")
+            .and_then(|committees| committees.get(epoch as usize).cloned())
+            .map(std::sync::Arc::new))
+    }
+
+    fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
+        self.read_write
+            .checkpoints
+            .reversed_safe_iter_with_bounds(None, None)
+            .expect("failed to fetch highest checkpoint")
+            .next()
+            .transpose()
+            .expect("failed to fetch highest checkpoint")
+            .map(|(_, checkpoint)| checkpoint.into())
+            .ok_or(IotaError::UserInput {
+                error: UserInputError::LatestCheckpointSequenceNumberNotFound,
+            })
+            .map_err(iota_types::storage::error::Error::custom)
+    }
+
+    fn try_get_highest_verified_checkpoint(
+        &self,
+    ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
+        self.try_get_latest_checkpoint()
+    }
+
+    fn try_get_highest_synced_checkpoint(
+        &self,
+    ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
+        self.try_get_latest_checkpoint()
+    }
+
+    fn try_get_lowest_available_checkpoint(
+        &self,
+    ) -> iota_types::storage::error::Result<CheckpointSequenceNumber> {
+        Ok(0)
+    }
+
+    fn try_get_checkpoint_by_digest(
+        &self,
+        digest: &CheckpointDigest,
+    ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
+        Ok(self
+            .read_write
+            .checkpoint_digest_to_sequence_number
+            .get(digest)
+            .expect("Fatal: DB read failed")
+            .and_then(|sequence_number| self.get_checkpoint_by_sequence_number(sequence_number)))
+    }
+
+    fn try_get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
+        Ok(self
+            .read_write
+            .checkpoints
+            .get(&sequence_number)
+            .expect("Fatal: DB read failed")
+            .map(|checkpoint| checkpoint.into()))
+    }
+
+    fn try_get_checkpoint_contents_by_digest(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> iota_types::storage::error::Result<Option<CheckpointContents>> {
+        Ok(self
+            .read_write
+            .checkpoint_contents
+            .get(digest)
+            .expect("Fatal: DB read failed"))
+    }
+
+    fn try_get_checkpoint_contents_by_sequence_number(
+        &self,
+        _sequence_number: CheckpointSequenceNumber,
+    ) -> iota_types::storage::error::Result<Option<CheckpointContents>> {
+        todo!()
+    }
+
+    fn try_get_transaction(
+        &self,
+        tx_digest: &TransactionDigest,
+    ) -> iota_types::storage::error::Result<Option<Arc<VerifiedTransaction>>> {
+        let tx = self
+            .read_write
+            .transactions
+            .get(tx_digest)
+            .expect("Fatal: DB read failed")
+            .map(|transaction| transaction.into());
+        Ok(tx.map(Arc::new))
+    }
+
+    fn try_get_transaction_effects(
+        &self,
+        tx_digest: &TransactionDigest,
+    ) -> iota_types::storage::error::Result<Option<TransactionEffects>> {
+        Ok(self
+            .read_write
+            .effects
+            .get(tx_digest)
+            .expect("Fatal: DB read failed"))
+    }
+
+    fn try_get_events(
+        &self,
+        event_digest: &TransactionEventsDigest,
+    ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
+        Ok(self
+            .read_write
+            .events
+            .get(event_digest)
+            .expect("Fatal: DB read failed"))
+    }
+
+    fn try_get_full_checkpoint_contents_by_sequence_number(
+        &self,
+        _sequence_number: CheckpointSequenceNumber,
+    ) -> iota_types::storage::error::Result<
+        Option<iota_types::messages_checkpoint::FullCheckpointContents>,
+    > {
+        todo!()
+    }
+
+    fn try_get_full_checkpoint_contents(
+        &self,
+        _digest: &CheckpointContentsDigest,
+    ) -> iota_types::storage::error::Result<
+        Option<iota_types::messages_checkpoint::FullCheckpointContents>,
+    > {
+        todo!()
+    }
+}
+
 impl ObjectStore for PersistedStoreInnerReadOnlyWrapper {
     fn try_get_object(
         &self,
@@ -551,9 +653,15 @@ impl ObjectStore for PersistedStoreInnerReadOnlyWrapper {
 impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
     fn try_get_committee(
         &self,
-        _epoch: EpochId,
+        epoch: EpochId,
     ) -> iota_types::storage::error::Result<Option<std::sync::Arc<Committee>>> {
-        todo!()
+        Ok(self
+            .inner
+            .epoch_to_committee
+            .get(&())
+            .expect("Fatal: DB read failed")
+            .and_then(|committees| committees.get(epoch as usize).cloned())
+            .map(std::sync::Arc::new))
     }
 
     fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
@@ -788,8 +896,8 @@ mod tests {
         );
 
         assert_ne!(
-            chain1.with_store(|store| store.get_committee_by_epoch(0)),
-            chain3.with_store(|store| store.get_committee_by_epoch(0)),
+            chain1.with_store(|store| store.get_committee(0)),
+            chain3.with_store(|store| store.get_committee(0)),
         );
     }
 }

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -760,9 +760,7 @@ mod tests {
             None,
         );
         let genesis_checkpoint_digest1 = *chain1
-            .store()
-            .get_checkpoint_by_sequence_number(0)
-            .unwrap()
+            .with_store(|store| store.get_checkpoint_by_sequence_number(0).unwrap())
             .digest();
 
         let rng = StdRng::from_seed([9; 32]);
@@ -774,9 +772,7 @@ mod tests {
             None,
         );
         let genesis_checkpoint_digest2 = *chain2
-            .store()
-            .get_checkpoint_by_sequence_number(0)
-            .unwrap()
+            .with_store(|store| store.get_checkpoint_by_sequence_number(0).unwrap())
             .digest();
 
         assert_eq!(genesis_checkpoint_digest1, genesis_checkpoint_digest2);
@@ -792,8 +788,8 @@ mod tests {
         );
 
         assert_ne!(
-            chain1.store().get_committee_by_epoch(0),
-            chain3.store().get_committee_by_epoch(0),
+            chain1.with_store(|store| store.get_committee_by_epoch(0)),
+            chain3.with_store(|store| store.get_committee_by_epoch(0)),
         );
     }
 }

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -2328,39 +2328,43 @@ async fn init_sim_executor(
     sim.set_data_ingestion_path(data_ingestion_path.clone());
 
     // Get the actual object values from the simulator
-    for (name, (addr, kp)) in account_kps {
-        let o = sim.with_store(|store| store.owned_objects(addr).next().unwrap());
-        objects.push(o.clone());
-        account_objects.insert(name.clone(), o.id());
+    let default_account = sim.with_store(|store| {
+        for (name, (addr, kp)) in account_kps {
+            let o = store.owned_objects(addr).next().unwrap();
+            objects.push(o.clone());
+            account_objects.insert(name.clone(), o.id());
 
-        accounts.insert(
-            name.to_owned(),
-            TestAccount {
-                address: addr,
-                key_pair: kp,
-                gas: o.id(),
-            },
-        );
-    }
-    let o = sim.with_store(|store| store.owned_objects(default_account_kp.0).next().unwrap());
-    let default_account = TestAccount {
-        address: default_account_kp.0,
-        key_pair: default_account_kp.1,
-        gas: o.id(),
-    };
-    objects.push(o.clone());
-
-    if let (Some(v_addr), Some(v_key)) = (validator_addr, validator_key) {
-        let o = sim.with_store(|store| store.owned_objects(v_addr).next().unwrap());
-        let validator_account = TestAccount {
-            address: v_addr,
-            key_pair: v_key,
+            accounts.insert(
+                name.to_owned(),
+                TestAccount {
+                    address: addr,
+                    key_pair: kp,
+                    gas: o.id(),
+                },
+            );
+        }
+        let o = store.owned_objects(default_account_kp.0).next().unwrap();
+        let default_account = TestAccount {
+            address: default_account_kp.0,
+            key_pair: default_account_kp.1,
             gas: o.id(),
         };
         objects.push(o.clone());
-        account_objects.insert("validator_0".to_string(), o.id());
-        accounts.insert("validator_0".to_string(), validator_account);
-    }
+
+        if let (Some(v_addr), Some(v_key)) = (validator_addr, validator_key) {
+            let o = store.owned_objects(v_addr).next().unwrap();
+            let validator_account = TestAccount {
+                address: v_addr,
+                key_pair: v_key,
+                gas: o.id(),
+            };
+            objects.push(o.clone());
+            account_objects.insert("validator_0".to_string(), o.id());
+            accounts.insert("validator_0".to_string(), validator_account);
+        }
+
+        default_account
+    });
 
     let sim = Box::new(sim);
     update_named_address_mapping(

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -88,6 +88,7 @@ use move_transactional_test_runner::{
 use move_vm_runtime::session::SerializedReturnValues;
 use once_cell::sync::Lazy;
 use rand::{Rng, SeedableRng, rngs::StdRng};
+use simulacrum::SimulatorStore;
 use tempfile::{NamedTempFile, tempdir};
 
 use crate::{
@@ -2314,22 +2315,21 @@ async fn init_sim_executor(
     // Create the simulator with the specific account configs, which also crates
     // objects
 
-    let (mut sim, read_replica) =
-        PersistedStore::new_sim_replica_with_protocol_version_and_accounts(
-            rng,
-            DEFAULT_CHAIN_START_TIMESTAMP,
-            protocol_config.version,
-            acc_cfgs,
-            key_copy.map(|q| vec![q]),
-            reference_gas_price,
-            None,
-        );
+    let (sim, read_replica) = PersistedStore::new_sim_replica_with_protocol_version_and_accounts(
+        rng,
+        DEFAULT_CHAIN_START_TIMESTAMP,
+        protocol_config.version,
+        acc_cfgs,
+        key_copy.map(|q| vec![q]),
+        reference_gas_price,
+        None,
+    );
 
     sim.set_data_ingestion_path(data_ingestion_path.clone());
 
     // Get the actual object values from the simulator
     for (name, (addr, kp)) in account_kps {
-        let o = sim.store().owned_objects(addr).next().unwrap();
+        let o = sim.with_store(|store| store.owned_objects(addr).next().unwrap());
         objects.push(o.clone());
         account_objects.insert(name.clone(), o.id());
 
@@ -2342,11 +2342,7 @@ async fn init_sim_executor(
             },
         );
     }
-    let o = sim
-        .store()
-        .owned_objects(default_account_kp.0)
-        .next()
-        .unwrap();
+    let o = sim.with_store(|store| store.owned_objects(default_account_kp.0).next().unwrap());
     let default_account = TestAccount {
         address: default_account_kp.0,
         key_pair: default_account_kp.1,
@@ -2355,7 +2351,7 @@ async fn init_sim_executor(
     objects.push(o.clone());
 
     if let (Some(v_addr), Some(v_key)) = (validator_addr, validator_key) {
-        let o = sim.store().owned_objects(v_addr).next().unwrap();
+        let o = sim.with_store(|store| store.owned_objects(v_addr).next().unwrap());
         let validator_account = TestAccount {
             address: v_addr,
             key_pair: v_key,

--- a/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
+++ b/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
@@ -51,7 +51,7 @@ pub trait EpochStartSystemStateTrait {
 /// db tables to store the new version. This is OK because we only store one
 /// copy of this as part of EpochStartConfiguration for the most recent epoch in
 /// the db.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[enum_dispatch(EpochStartSystemStateTrait)]
 pub enum EpochStartSystemState {
     V1(EpochStartSystemStateV1),
@@ -135,7 +135,7 @@ impl EpochStartSystemState {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct EpochStartSystemStateV1 {
     epoch: EpochId,
     protocol_version: u64,
@@ -353,7 +353,7 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct EpochStartSystemStateV2 {
     v1: EpochStartSystemStateV1,
     active_validators: Vec<EpochStartValidatorInfoV1>,

--- a/crates/iota-types/src/transaction_executor.rs
+++ b/crates/iota-types/src/transaction_executor.rs
@@ -16,7 +16,7 @@ use crate::{
     transaction::TransactionData,
 };
 
-/// Trait to define the interface for how the REST service interacts with a a
+/// Trait to define the interface for how the REST service interacts with a
 /// QuorumDriver or a simulated transaction executor.
 #[async_trait::async_trait]
 pub trait TransactionExecutor: Send + Sync {

--- a/crates/simulacrum-server/Cargo.toml
+++ b/crates/simulacrum-server/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 # external dependencies
 anyhow.workspace = true
+async-trait.workspace = true
 axum.workspace = true
 clap.workspace = true
 futures.workspace = true

--- a/crates/simulacrum-server/Cargo.toml
+++ b/crates/simulacrum-server/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "simulacrum-server"
+version.workspace = true
+authors = ["IOTA Foundation <info@iota.org>"]
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[[bin]]
+name = "simulacrum-server"
+path = "src/main.rs"
+
+[dependencies]
+# external dependencies
+anyhow.workspace = true
+axum.workspace = true
+clap.workspace = true
+futures.workspace = true
+http.workspace = true
+rand.workspace = true
+serde.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+tower.workspace = true
+tower-http.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+uuid.workspace = true
+
+# internal dependencies
+iota-config.workspace = true
+iota-execution.workspace = true
+iota-faucet.workspace = true
+iota-grpc-server.workspace = true
+iota-json-rpc-types.workspace = true
+iota-protocol-config.workspace = true
+iota-swarm-config.workspace = true
+iota-types.workspace = true
+move-core-types.workspace = true
+simulacrum.workspace = true

--- a/crates/simulacrum-server/README.md
+++ b/crates/simulacrum-server/README.md
@@ -1,0 +1,56 @@
+# Simulacrum Server
+
+A gRPC and REST API server for IOTA Simulacrum that allows external clients to interact with a simulated IOTA blockchain.
+
+## Features
+
+- **REST API**: Full control interface for managing the simulacrum
+- **gRPC API**: High-performance streaming interface
+- **Command-line Interface**: Configurable server settings
+
+## Quick Start
+
+### Build and Run
+
+```bash
+# Run with default settings
+cargo run --bin simulacrum-server
+
+# Run with custom configuration
+cargo run --bin simulacrum-server -- \
+    --rest-address 127.0.0.1:8080 \
+    --grpc-address 127.0.0.1:9000 \
+    --initial-checkpoints 5
+```
+
+### Command Line Options
+
+- `--grpc-address`: gRPC server address (default: 127.0.0.1:9000)
+- `--rest-address`: REST API server address (default: 127.0.0.1:8080)
+- `--initial-checkpoints`: Number of checkpoints to create on startup (default: 0)
+- `--chain-start-timestamp-ms`: Chain start timestamp in milliseconds
+
+## REST API Endpoints
+
+### Status
+
+- `GET /status` - Detailed simulacrum status
+
+### Checkpoint Management
+
+- `GET /checkpoint` - Get the latest checkpoint
+- `POST /checkpoint/create` - Create a new checkpoint
+- `POST /checkpoint/create_multiple` - Create multiple checkpoints
+
+### Time and Epoch Control
+
+- `POST /clock/advance` - Advance the simulacrum clock
+- `POST /epoch/advance` - Advance to the next epoch
+
+## API Examples
+
+Run the included demo script to see all endpoints in action:
+
+```bash
+./examples/rest_api_demo.sh
+```

--- a/crates/simulacrum-server/README.md
+++ b/crates/simulacrum-server/README.md
@@ -6,6 +6,7 @@ A gRPC and REST API server for IOTA Simulacrum that allows external clients to i
 
 - **REST API**: Full control interface for managing the simulacrum
 - **gRPC API**: High-performance streaming interface
+- **Faucet Service**: Request gas tokens for testing
 - **Command-line Interface**: Configurable server settings
 
 ## Quick Start
@@ -29,6 +30,9 @@ cargo run --bin simulacrum-server -- \
 - `--rest-address`: REST API server address (default: 127.0.0.1:8080)
 - `--initial-checkpoints`: Number of checkpoints to create on startup (default: 0)
 - `--chain-start-timestamp-ms`: Chain start timestamp in milliseconds
+- `--faucet-request-amount`: Faucet request amount in nanos (default: 1_000_000_000 = 1 IOTA)
+- `--accounts`: Accounts to create in the format "address:amount,address:amount..."
+- `--data-ingestion-path`: Path to store data ingestion files
 
 ## REST API Endpoints
 
@@ -46,6 +50,12 @@ cargo run --bin simulacrum-server -- \
 
 - `POST /clock/advance` - Advance the simulacrum clock
 - `POST /epoch/advance` - Advance to the next epoch
+
+### Faucet
+
+- `GET /faucet/` - Faucet health check
+- `POST /faucet/gas` - Request gas tokens
+- `POST /faucet/v1/gas` - Request gas tokens (batch endpoint)
 
 ## API Examples
 

--- a/crates/simulacrum-server/README.md
+++ b/crates/simulacrum-server/README.md
@@ -5,7 +5,7 @@ A gRPC and REST API server for IOTA Simulacrum that allows external clients to i
 ## Features
 
 - **REST API**: Full control interface for managing the simulacrum
-- **gRPC API**: High-performance streaming interface
+- **gRPC API**: High-performance node interface
 - **Faucet Service**: Request gas tokens for testing
 - **Command-line Interface**: Configurable server settings
 

--- a/crates/simulacrum-server/examples/rest_api_demo.sh
+++ b/crates/simulacrum-server/examples/rest_api_demo.sh
@@ -7,68 +7,63 @@ BASE_URL="http://127.0.0.1:8080"
 echo "=== Simulacrum Server REST API Demo ==="
 echo ""
 
-# Check health
-echo "1. Checking server health..."
-curl -s "$BASE_URL/health" | jq '.'
-echo ""
-
 # Get status
-echo "2. Getting simulacrum status..."
+echo "1. Getting simulacrum status..."
 curl -s "$BASE_URL/status" | jq '.'
 echo ""
 
 # Get current checkpoint
-echo "3. Getting current checkpoint..."
+echo "2. Getting current checkpoint..."
 curl -s "$BASE_URL/checkpoint" | jq '.'
 echo ""
 
 # Create a checkpoint
-echo "4. Creating a new checkpoint..."
+echo "3. Creating a new checkpoint..."
 curl -s -X POST "$BASE_URL/checkpoint/create" | jq '.'
 echo ""
 
 # Advance clock
-echo "5. Advancing clock by 5 seconds..."
+echo "4. Advancing clock by 5 seconds..."
 curl -s -X POST "$BASE_URL/clock/advance" \
   -H "Content-Type: application/json" \
   -d '{"duration_ms": 5000}' | jq '.'
 echo ""
 
 # Create multiple checkpoints
-echo "6. Creating 3 checkpoints with 2 second intervals..."
+echo "5. Creating 3 checkpoints with 2 second intervals..."
 curl -s -X POST "$BASE_URL/checkpoint/create_multiple" \
   -H "Content-Type: application/json" \
   -d '{"count": 3, "interval_ms": 2000}' | jq '.'
 echo ""
 
 # Advance to next epoch
-echo "7. Advancing to next epoch with checkpoint..."
+echo "6. Advancing to next epoch with checkpoint..."
 curl -s -X POST "$BASE_URL/epoch/advance" \
   -H "Content-Type: application/json" \
   -d '{"create_checkpoint": true}' | jq '.'
 echo ""
 
 # Test faucet health
-echo "8. Checking faucet health..."
+echo "7. Checking faucet health..."
 curl -s "$BASE_URL/faucet/" | jq '.'
 echo ""
 
 # Request gas from faucet (requires a valid IOTA address)
-echo "9. Requesting gas from faucet..."
+echo "8. Requesting gas from faucet..."
 curl -s -X POST "$BASE_URL/faucet/gas" \
   -H "Content-Type: application/json" \
   -d '{"FixedAmountRequest": {"recipient": "0x0000000000000000000000000000000000000000000000000000000000000000"}}' | jq '.'
 echo ""
 
 # Request gas from faucet (batch endpoint)
-echo "10. Requesting gas from faucet (batch)..."
+echo "9. Requesting gas from faucet (batch)..."
 curl -s -X POST "$BASE_URL/faucet/v1/gas" \
   -H "Content-Type: application/json" \
   -d '{"FixedAmountRequest": {"recipient": "0x0000000000000000000000000000000000000000000000000000000000000000"}}' | jq '.'
 echo ""
 
 # Final status check
-echo "11. Final status check..."
+echo "10. Final status check..."
 curl -s "$BASE_URL/status" | jq '.'
 echo ""
 

--- a/crates/simulacrum-server/examples/rest_api_demo.sh
+++ b/crates/simulacrum-server/examples/rest_api_demo.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Example script demonstrating how to use the Simulacrum Server REST API
+
+BASE_URL="http://127.0.0.1:8080"
+
+echo "=== Simulacrum Server REST API Demo ==="
+echo ""
+
+# Check health
+echo "1. Checking server health..."
+curl -s "$BASE_URL/health" | jq '.'
+echo ""
+
+# Get status
+echo "2. Getting simulacrum status..."
+curl -s "$BASE_URL/status" | jq '.'
+echo ""
+
+# Get current checkpoint
+echo "3. Getting current checkpoint..."
+curl -s "$BASE_URL/checkpoint" | jq '.'
+echo ""
+
+# Create a checkpoint
+echo "4. Creating a new checkpoint..."
+curl -s -X POST "$BASE_URL/checkpoint/create" | jq '.'
+echo ""
+
+# Advance clock
+echo "5. Advancing clock by 5 seconds..."
+curl -s -X POST "$BASE_URL/clock/advance" \
+  -H "Content-Type: application/json" \
+  -d '{"duration_ms": 5000}' | jq '.'
+echo ""
+
+# Create multiple checkpoints
+echo "6. Creating 3 checkpoints with 2 second intervals..."
+curl -s -X POST "$BASE_URL/checkpoint/create_multiple" \
+  -H "Content-Type: application/json" \
+  -d '{"count": 3, "interval_ms": 2000}' | jq '.'
+echo ""
+
+# Advance to next epoch
+echo "7. Advancing to next epoch with checkpoint..."
+curl -s -X POST "$BASE_URL/epoch/advance" \
+  -H "Content-Type: application/json" \
+  -d '{"create_checkpoint": true}' | jq '.'
+echo ""
+
+# Test faucet health
+echo "8. Checking faucet health..."
+curl -s "$BASE_URL/faucet/" | jq '.'
+echo ""
+
+# Request gas from faucet (requires a valid IOTA address)
+echo "9. Requesting gas from faucet..."
+curl -s -X POST "$BASE_URL/faucet/gas" \
+  -H "Content-Type: application/json" \
+  -d '{"FixedAmountRequest": {"recipient": "0x0000000000000000000000000000000000000000000000000000000000000000"}}' | jq '.'
+echo ""
+
+# Request gas from faucet (batch endpoint)
+echo "10. Requesting gas from faucet (batch)..."
+curl -s -X POST "$BASE_URL/faucet/v1/gas" \
+  -H "Content-Type: application/json" \
+  -d '{"FixedAmountRequest": {"recipient": "0x0000000000000000000000000000000000000000000000000000000000000000"}}' | jq '.'
+echo ""
+
+# Final status check
+echo "11. Final status check..."
+curl -s "$BASE_URL/status" | jq '.'
+echo ""
+
+echo "=== Demo Complete ==="

--- a/crates/simulacrum-server/src/faucet.rs
+++ b/crates/simulacrum-server/src/faucet.rs
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Faucet module for Simulacrum Server
+//!
+//! This module provides faucet functionality for requesting gas tokens,
+//! using the same types and endpoints as the iota-faucet crate.
+
+use axum::{
+    Router,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Json},
+    routing::{get, post},
+};
+use iota_faucet::{
+    BatchFaucetResponse, CoinInfo, FaucetError, FaucetReceipt, FaucetRequest, FaucetResponse,
+};
+use iota_types::effects::TransactionEffectsAPI;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::rest_api::AppState;
+
+/// Health check endpoint for faucet
+pub async fn health() -> Result<Json<&'static str>, StatusCode> {
+    Ok(Json("OK"))
+}
+
+/// Internal function that handles the actual gas request logic
+async fn request_gas_internal(
+    state: &AppState,
+    recipient: iota_types::base_types::IotaAddress,
+) -> Result<FaucetReceipt, String> {
+    let amount = state.faucet_request_amount;
+
+    info!(
+        "Faucet request for {} NANOS to address: {}",
+        amount, recipient
+    );
+
+    let mut simulacrum = state.simulacrum.lock().await;
+
+    // Request gas from the faucet
+    let gas_result = simulacrum.request_gas(recipient, amount);
+
+    match gas_result {
+        Ok(effects) => {
+            info!(
+                "Gas request successful, effects: {:?}",
+                effects.summary_for_debug()
+            );
+
+            // Create a checkpoint to finalize the transaction
+            let checkpoint = simulacrum.create_checkpoint();
+
+            // Extract created gas objects from effects
+            let mut sent_coins = Vec::new();
+            for (obj_ref, _) in effects.created().iter() {
+                sent_coins.push(CoinInfo {
+                    amount,
+                    id: obj_ref.0, // Extract ObjectID from ObjectRef tuple
+                    transfer_tx_digest: *effects.transaction_digest(),
+                });
+            }
+
+            let receipt = FaucetReceipt { sent: sent_coins };
+
+            info!(
+                "Faucet request completed successfully for address: {}, checkpoint: {}",
+                recipient,
+                checkpoint.sequence_number()
+            );
+
+            Ok(receipt)
+        }
+        Err(err) => {
+            warn!("Failed to request gas: {:?}", err);
+            Err(format!("Failed to request gas: {}", err))
+        }
+    }
+}
+
+/// Main faucet gas request handler matching iota-faucet endpoints
+pub async fn request_gas(
+    State(state): State<AppState>,
+    Json(payload): Json<FaucetRequest>,
+) -> impl IntoResponse {
+    match payload {
+        FaucetRequest::FixedAmountRequest(request) => {
+            match request_gas_internal(&state, request.recipient).await {
+                Ok(receipt) => (StatusCode::CREATED, Json(FaucetResponse::from(receipt))),
+                Err(err) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(FaucetResponse {
+                        error: Some(err),
+                        transferred_gas_objects: vec![],
+                    }),
+                ),
+            }
+        }
+        FaucetRequest::GetBatchSendStatusRequest(_) => {
+            // Batch operations not supported in simulacrum
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(FaucetResponse {
+                    error: Some("Batch operations not supported in simulacrum".to_string()),
+                    transferred_gas_objects: vec![],
+                }),
+            )
+        }
+    }
+}
+
+pub async fn batch_request_gas(
+    State(state): State<AppState>,
+    Json(payload): Json<FaucetRequest>,
+) -> impl IntoResponse {
+    let FaucetRequest::FixedAmountRequest(request) = payload else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(BatchFaucetResponse::from(FaucetError::Internal(
+                "Input Error.".to_string(),
+            ))),
+        );
+    };
+
+    match request_gas_internal(&state, request.recipient).await {
+        Ok(_receipt) => (
+            StatusCode::CREATED,
+            Json(BatchFaucetResponse {
+                task: Some(Uuid::new_v4().to_string()),
+                error: None,
+            }),
+        ),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(BatchFaucetResponse::from(FaucetError::Internal(err))),
+        ),
+    }
+}
+
+/// Add faucet routes matching iota-faucet endpoints
+pub fn add_faucet_routes() -> Router<AppState> {
+    Router::new()
+        .route("/", get(health))
+        .route("/gas", post(request_gas))
+        .route("/v1/gas", post(batch_request_gas))
+}

--- a/crates/simulacrum-server/src/faucet.rs
+++ b/crates/simulacrum-server/src/faucet.rs
@@ -39,7 +39,7 @@ async fn request_gas_internal(
         amount, recipient
     );
 
-    let mut simulacrum = state.simulacrum.lock().await;
+    let simulacrum = state.simulacrum.as_ref();
 
     // Request gas from the faucet
     let gas_result = simulacrum.request_gas(recipient, amount);

--- a/crates/simulacrum-server/src/grpc_server.rs
+++ b/crates/simulacrum-server/src/grpc_server.rs
@@ -9,15 +9,11 @@ use anyhow::Result;
 use iota_grpc_server::{GrpcReader, GrpcServerHandle, start_grpc_server};
 use iota_types::{
     digests::{ChainIdentifier, CheckpointDigest},
-    effects::TransactionEffectsAPI,
-    quorum_driver_types::{
-        ExecuteTransactionRequestV1, ExecuteTransactionResponseV1, FinalizedEffects,
-        QuorumDriverError,
-    },
-    transaction::TransactionData,
-    transaction_executor::{SimulateTransactionResult, TransactionExecutor, VmChecks},
+    transaction_executor::TransactionExecutor as TransactionExecutorTrait,
 };
-use simulacrum::{Simulacrum, state_reader::SimulacrumGrpcReader};
+use simulacrum::{
+    Simulacrum, state_reader::SimulacrumGrpcReader, transaction_executor::TransactionExecutor,
+};
 
 // Dummy event subscriber for simulacrum (events not supported)
 // TODO: add support for events in simulacrum?
@@ -33,104 +29,6 @@ impl iota_grpc_server::types::EventSubscriber for DummyEventSubscriber {
     }
 }
 
-/// Transaction executor implementation for simulacrum
-/// This allows transaction execution and simulation via gRPC without requiring
-/// quorum consensus
-pub struct SimulacrumTransactionExecutor {
-    simulacrum: Arc<Simulacrum>,
-}
-
-impl SimulacrumTransactionExecutor {
-    pub fn new(simulacrum: Arc<Simulacrum>) -> Self {
-        Self { simulacrum }
-    }
-}
-
-#[async_trait::async_trait]
-impl TransactionExecutor for SimulacrumTransactionExecutor {
-    async fn execute_transaction(
-        &self,
-        request: ExecuteTransactionRequestV1,
-        _client_addr: Option<std::net::SocketAddr>,
-    ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
-        let simulacrum = &*self.simulacrum;
-
-        // Execute the transaction directly (it's already a Transaction type)
-        let (effects, _execution_error) = simulacrum
-            .execute_transaction(request.transaction.clone())
-            .map_err(|e| {
-                QuorumDriverError::QuorumDriverInternal(iota_types::error::IotaError::Unknown(
-                    e.to_string(),
-                ))
-            })?;
-
-        // Create a checkpoint to finalize the transaction
-        let checkpoint = simulacrum.create_checkpoint();
-
-        tracing::debug!(
-            tx_digest = ?effects.transaction_digest(),
-            checkpoint = checkpoint.sequence_number(),
-            "Transaction executed and finalized in simulacrum"
-        );
-
-        // For simulacrum, we create a dummy certified effects since there's no real
-        // validator consensus. We use
-        // CertifiedTransactionEffects::new_from_data_and_sig with empty
-        // signatures.
-        let (test_committee, _) = iota_types::committee::Committee::new_simple_test_committee();
-        let effects_cert = iota_types::effects::CertifiedTransactionEffects::new_from_data_and_sig(
-            effects.clone(),
-            iota_types::crypto::AuthorityQuorumSignInfo::new_from_auth_sign_infos(
-                vec![],
-                &test_committee,
-            )
-            .unwrap(),
-        );
-        let verified_effects =
-            iota_types::effects::VerifiedCertifiedTransactionEffects::new_unchecked(effects_cert);
-
-        // Build response
-        let response = ExecuteTransactionResponseV1 {
-            effects: FinalizedEffects::new_from_effects_cert(verified_effects.into()),
-            events: if request.include_events {
-                // TODO: get events from simulacrum store
-                None
-            } else {
-                None
-            },
-            input_objects: if request.include_input_objects {
-                // TODO: get input objects from simulacrum store
-                None
-            } else {
-                None
-            },
-            output_objects: if request.include_output_objects {
-                // TODO: get output objects from simulacrum store
-                None
-            } else {
-                None
-            },
-            auxiliary_data: if request.include_auxiliary_data {
-                // TODO: get auxiliary data
-                None
-            } else {
-                None
-            },
-        };
-
-        Ok(response)
-    }
-
-    fn simulate_transaction(
-        &self,
-        transaction: TransactionData,
-        checks: VmChecks,
-    ) -> Result<SimulateTransactionResult, iota_types::error::IotaError> {
-        // Simulacrum is already thread-safe, no locking needed
-        self.simulacrum.simulate_transaction(transaction, checks)
-    }
-}
-
 /// Start a gRPC server for the given simulacrum instance
 pub async fn start_simulacrum_grpc_server(
     simulacrum: Arc<Simulacrum>,
@@ -141,10 +39,9 @@ pub async fn start_simulacrum_grpc_server(
 
     // Create a transaction executor for simulacrum to enable transaction execution
     // and simulation via gRPC
-    let executor = Some(
-        Arc::new(SimulacrumTransactionExecutor::new(simulacrum.clone()))
-            as Arc<dyn TransactionExecutor>,
-    );
+    let executor =
+        Some(Arc::new(TransactionExecutor::new(simulacrum.clone()))
+            as Arc<dyn TransactionExecutorTrait>);
 
     let simulacrum_reader = Arc::new(SimulacrumGrpcReader::new(simulacrum.clone(), chain_id));
     let grpc_reader = Arc::new(GrpcReader::new(simulacrum_reader, None));
@@ -174,13 +71,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_grpc_server_startup_with_mutex() {
-        let mut simulacrum = Simulacrum::new();
+        let sim = Simulacrum::new();
 
         // Create some checkpoints
-        simulacrum.advance_clock(Duration::from_secs(1));
-        simulacrum.create_checkpoint();
+        sim.advance_clock(Duration::from_secs(1));
+        sim.create_checkpoint();
 
-        let simulacrum = Arc::new(simulacrum);
+        let simulacrum = Arc::new(sim);
 
         // Start gRPC server with test configuration using test utilities
         let address = local_ip_utils::new_local_tcp_socket_for_testing();

--- a/crates/simulacrum-server/src/grpc_server.rs
+++ b/crates/simulacrum-server/src/grpc_server.rs
@@ -6,19 +6,26 @@
 use std::sync::Arc;
 
 use anyhow::Result;
+#[allow(unused_imports)]
+use async_trait::async_trait;
 use iota_grpc_server::{GrpcReader, GrpcServerHandle, GrpcStateReader, start_grpc_server};
 use iota_types::{
     TypeTag,
     base_types::{ObjectID, VersionNumber},
     committee::Committee,
     digests::{ChainIdentifier, CheckpointDigest, TransactionDigest, TransactionEventsDigest},
-    effects::{TransactionEffects, TransactionEvents},
+    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     full_checkpoint_content::CheckpointData,
     iota_system_state::IotaSystemState,
     messages_checkpoint::CertifiedCheckpointSummary,
     object::Object,
+    quorum_driver_types::{
+        ExecuteTransactionRequestV1, ExecuteTransactionResponseV1, FinalizedEffects,
+        QuorumDriverError,
+    },
     storage::EpochInfo,
-    transaction::VerifiedTransaction,
+    transaction::{TransactionData, VerifiedTransaction},
+    transaction_executor::{SimulateTransactionResult, TransactionExecutor, VmChecks},
 };
 use move_core_types::annotated_value::MoveTypeLayout;
 use simulacrum::Simulacrum;
@@ -192,6 +199,108 @@ impl GrpcStateReader for SimulacrumGrpcReader {
     }
 }
 
+/// Transaction executor implementation for simulacrum
+/// This allows transaction execution and simulation via gRPC without requiring
+/// quorum consensus
+pub struct SimulacrumTransactionExecutor {
+    simulacrum: Arc<tokio::sync::Mutex<Simulacrum>>,
+}
+
+impl SimulacrumTransactionExecutor {
+    pub fn new(simulacrum: Arc<tokio::sync::Mutex<Simulacrum>>) -> Self {
+        Self { simulacrum }
+    }
+}
+
+#[async_trait::async_trait]
+impl TransactionExecutor for SimulacrumTransactionExecutor {
+    async fn execute_transaction(
+        &self,
+        request: ExecuteTransactionRequestV1,
+        _client_addr: Option<std::net::SocketAddr>,
+    ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
+        let mut simulacrum = self.simulacrum.lock().await;
+
+        // Execute the transaction directly (it's already a Transaction type)
+        let (effects, _execution_error) = simulacrum
+            .execute_transaction(request.transaction.clone())
+            .map_err(|e| {
+                QuorumDriverError::QuorumDriverInternal(iota_types::error::IotaError::Unknown(
+                    e.to_string(),
+                ))
+            })?;
+
+        // Create a checkpoint to finalize the transaction
+        let checkpoint = simulacrum.create_checkpoint();
+
+        tracing::debug!(
+            tx_digest = ?effects.transaction_digest(),
+            checkpoint = checkpoint.sequence_number(),
+            "Transaction executed and finalized in simulacrum"
+        );
+
+        // For simulacrum, we create a dummy certified effects since there's no real
+        // validator consensus. We use
+        // CertifiedTransactionEffects::new_from_data_and_sig with empty
+        // signatures.
+        let (test_committee, _) = iota_types::committee::Committee::new_simple_test_committee();
+        let effects_cert = iota_types::effects::CertifiedTransactionEffects::new_from_data_and_sig(
+            effects.clone(),
+            iota_types::crypto::AuthorityQuorumSignInfo::new_from_auth_sign_infos(
+                vec![],
+                &test_committee,
+            )
+            .unwrap(),
+        );
+        let verified_effects =
+            iota_types::effects::VerifiedCertifiedTransactionEffects::new_unchecked(effects_cert);
+
+        // Build response
+        let response = ExecuteTransactionResponseV1 {
+            effects: FinalizedEffects::new_from_effects_cert(verified_effects.into()),
+            events: if request.include_events {
+                // TODO: get events from simulacrum store
+                None
+            } else {
+                None
+            },
+            input_objects: if request.include_input_objects {
+                // TODO: get input objects from simulacrum store
+                None
+            } else {
+                None
+            },
+            output_objects: if request.include_output_objects {
+                // TODO: get output objects from simulacrum store
+                None
+            } else {
+                None
+            },
+            auxiliary_data: if request.include_auxiliary_data {
+                // TODO: get auxiliary data
+                None
+            } else {
+                None
+            },
+        };
+
+        Ok(response)
+    }
+
+    fn simulate_transaction(
+        &self,
+        transaction: TransactionData,
+        checks: VmChecks,
+    ) -> Result<SimulateTransactionResult, iota_types::error::IotaError> {
+        // This is a synchronous call, so we need to use blocking
+        let rt = tokio::runtime::Handle::current();
+        let simulacrum = rt.block_on(self.simulacrum.lock());
+
+        // Use the simulacrum's simulate_transaction method
+        simulacrum.simulate_transaction(transaction, checks)
+    }
+}
+
 /// Start a gRPC server for the given simulacrum instance
 pub async fn start_simulacrum_grpc_server(
     simulacrum: Arc<tokio::sync::Mutex<Simulacrum>>,
@@ -200,14 +309,12 @@ pub async fn start_simulacrum_grpc_server(
 ) -> Result<GrpcServerHandle> {
     let chain_id = ChainIdentifier::from(CheckpointDigest::default());
 
-    // TODO: find a way to convert from Executor to TransactionExecutor (I guess we
-    // need some simple implementation of the TransactionOrchestrator without
-    // consensus)
-    // let rt = tokio::runtime::Handle::current();
-    // let simulacrum_tmp = rt.block_on(simulacrum.lock());
-    // let executor = simulacrum_tmp.executor();
-    // drop(simulacrum_tmp);
-    let executor = None;
+    // Create a transaction executor for simulacrum to enable transaction execution
+    // and simulation via gRPC
+    let executor = Some(
+        Arc::new(SimulacrumTransactionExecutor::new(simulacrum.clone()))
+            as Arc<dyn TransactionExecutor>,
+    );
 
     let simulacrum_reader = Arc::new(SimulacrumGrpcReader::new(simulacrum, chain_id));
     let grpc_reader = Arc::new(GrpcReader::new(simulacrum_reader, None));

--- a/crates/simulacrum-server/src/grpc_server.rs
+++ b/crates/simulacrum-server/src/grpc_server.rs
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! gRPC streaming server for Simulacrum
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use iota_grpc_server::{GrpcReader, GrpcServerHandle, GrpcStateReader, start_grpc_server};
+use iota_types::{
+    TypeTag,
+    base_types::{ObjectID, VersionNumber},
+    committee::Committee,
+    digests::{ChainIdentifier, CheckpointDigest, TransactionDigest, TransactionEventsDigest},
+    effects::{TransactionEffects, TransactionEvents},
+    full_checkpoint_content::CheckpointData,
+    iota_system_state::IotaSystemState,
+    messages_checkpoint::CertifiedCheckpointSummary,
+    object::Object,
+    storage::EpochInfo,
+    transaction::VerifiedTransaction,
+};
+use move_core_types::annotated_value::MoveTypeLayout;
+use simulacrum::Simulacrum;
+
+// Dummy event subscriber for simulacrum (events not supported)
+// TODO: add support for events in simulacrum?
+struct DummyEventSubscriber;
+
+impl iota_grpc_server::types::EventSubscriber for DummyEventSubscriber {
+    fn subscribe_events(
+        &self,
+        _filter: iota_json_rpc_types::EventFilter,
+    ) -> Box<dyn futures::Stream<Item = iota_json_rpc_types::IotaEvent> + Send + Unpin> {
+        // Return an empty stream
+        Box::new(Box::pin(futures::stream::empty()))
+    }
+}
+
+/// GrpcStateReader implementation that works with a mutex-protected Simulacrum
+/// This allows sharing the same simulacrum instance between REST and gRPC APIs
+pub struct SimulacrumGrpcReader {
+    simulacrum: Arc<tokio::sync::Mutex<Simulacrum>>,
+    chain_id: ChainIdentifier,
+}
+
+impl SimulacrumGrpcReader {
+    pub fn new(simulacrum: Arc<tokio::sync::Mutex<Simulacrum>>, chain_id: ChainIdentifier) -> Self {
+        Self {
+            simulacrum,
+            chain_id,
+        }
+    }
+}
+
+impl GrpcStateReader for SimulacrumGrpcReader {
+    fn get_chain_identifier(&self) -> Result<ChainIdentifier> {
+        Ok(self.chain_id)
+    }
+
+    fn get_latest_checkpoint_sequence_number(&self) -> Option<u64> {
+        let rt = tokio::runtime::Handle::current();
+        let simulacrum = rt.block_on(self.simulacrum.lock());
+
+        simulacrum
+            .store()
+            .get_highest_checkpoint()
+            .map(|checkpoint| *checkpoint.sequence_number())
+    }
+
+    fn get_checkpoint_summary(&self, seq: u64) -> Option<CertifiedCheckpointSummary> {
+        let rt = tokio::runtime::Handle::current();
+        let simulacrum = rt.block_on(self.simulacrum.lock());
+
+        simulacrum
+            .store()
+            .get_checkpoint_by_sequence_number(seq)
+            .map(CertifiedCheckpointSummary::from)
+    }
+
+    fn get_checkpoint_data(&self, seq: u64) -> Option<CheckpointData> {
+        let rt = tokio::runtime::Handle::current();
+        let simulacrum = rt.block_on(self.simulacrum.lock());
+
+        let checkpoint = simulacrum.store().get_checkpoint_by_sequence_number(seq)?;
+        let contents = simulacrum
+            .store()
+            .get_checkpoint_contents(&checkpoint.content_digest)?;
+
+        Some(CheckpointData {
+            checkpoint_summary: CertifiedCheckpointSummary::from(checkpoint),
+            checkpoint_contents: contents,
+            // TODO: we should return the transactions as well
+            transactions: vec![],
+        })
+    }
+
+    fn get_epoch_last_checkpoint(&self, epoch: u64) -> Result<Option<CertifiedCheckpointSummary>> {
+        let rt = tokio::runtime::Handle::current();
+        let simulacrum = rt.block_on(self.simulacrum.lock());
+
+        // Simple implementation for simulacrum - find the last checkpoint of the given
+        // epoch
+        let latest_seq = simulacrum
+            .store()
+            .get_highest_checkpoint()
+            .map(|checkpoint| *checkpoint.sequence_number())
+            .unwrap_or(0);
+
+        // TODO: optimize that by storing epoch -> last checkpoint mapping
+        for seq in (0..=latest_seq).rev() {
+            if let Some(checkpoint) = simulacrum.store().get_checkpoint_by_sequence_number(seq) {
+                if checkpoint.epoch() == epoch {
+                    return Ok(Some(CertifiedCheckpointSummary::from(checkpoint)));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    fn get_lowest_available_checkpoint(&self) -> Result<u64> {
+        // Simulacrum starts from checkpoint 0
+        Ok(0)
+    }
+
+    fn get_lowest_available_checkpoint_objects(&self) -> Result<u64> {
+        // Simulacrum has all objects from the beginning
+        Ok(0)
+    }
+
+    fn get_object(&self, _object_id: &ObjectID) -> Option<Object> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        None
+    }
+
+    fn get_object_by_key(&self, _object_id: &ObjectID, _version: VersionNumber) -> Option<Object> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        None
+    }
+
+    fn get_committee(&self, _epoch: u64) -> Result<Option<Arc<Committee>>> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        Ok(None)
+    }
+
+    fn get_system_state(&self) -> Result<IotaSystemState> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        Err(anyhow::anyhow!("System state not available in simulacrum"))
+    }
+
+    fn get_epoch_info(&self, _epoch: u64) -> Option<EpochInfo> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        None
+    }
+
+    fn get_type_layout(&self, _type_tag: &TypeTag) -> Result<Option<MoveTypeLayout>> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        Ok(None)
+    }
+
+    fn get_transaction(&self, _digest: &TransactionDigest) -> Option<Arc<VerifiedTransaction>> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        None
+    }
+
+    fn get_transaction_effects(&self, _digest: &TransactionDigest) -> Option<TransactionEffects> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        None
+    }
+
+    fn get_transaction_events(
+        &self,
+        _digest: &TransactionEventsDigest,
+    ) -> Option<TransactionEvents> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        None
+    }
+
+    fn get_transaction_checkpoint(&self, _digest: &TransactionDigest) -> Option<u64> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        None
+    }
+}
+
+/// Start a gRPC server for the given simulacrum instance
+pub async fn start_simulacrum_grpc_server(
+    simulacrum: Arc<tokio::sync::Mutex<Simulacrum>>,
+    config: iota_config::node::GrpcApiConfig,
+    shutdown_token: tokio_util::sync::CancellationToken,
+) -> Result<GrpcServerHandle> {
+    let chain_id = ChainIdentifier::from(CheckpointDigest::default());
+
+    // TODO: find a way to convert from Executor to TransactionExecutor (I guess we
+    // need some simple implementation of the TransactionOrchestrator without
+    // consensus)
+    // let rt = tokio::runtime::Handle::current();
+    // let simulacrum_tmp = rt.block_on(simulacrum.lock());
+    // let executor = simulacrum_tmp.executor();
+    // drop(simulacrum_tmp);
+    let executor = None;
+
+    let simulacrum_reader = Arc::new(SimulacrumGrpcReader::new(simulacrum, chain_id));
+    let grpc_reader = Arc::new(GrpcReader::new(simulacrum_reader, None));
+
+    // TODO: add if needed
+    let event_subscriber: Option<Arc<dyn iota_grpc_server::types::EventSubscriber>> = None;
+
+    start_grpc_server(
+        grpc_reader,
+        event_subscriber.unwrap_or_else(|| Arc::new(DummyEventSubscriber)),
+        executor,
+        config,
+        shutdown_token,
+        chain_id,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use iota_config::local_ip_utils;
+    use simulacrum::Simulacrum;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_grpc_server_startup_with_mutex() {
+        let mut simulacrum = Simulacrum::new();
+
+        // Create some checkpoints
+        simulacrum.advance_clock(Duration::from_secs(1));
+        simulacrum.create_checkpoint();
+
+        let simulacrum = Arc::new(tokio::sync::Mutex::new(simulacrum));
+
+        // Start gRPC server with test configuration using test utilities
+        let address = local_ip_utils::new_local_tcp_socket_for_testing();
+        let config = iota_config::node::GrpcApiConfig {
+            address,
+            ..Default::default()
+        };
+        let shutdown_token = tokio_util::sync::CancellationToken::new();
+
+        let server_handle =
+            start_simulacrum_grpc_server(simulacrum, config, shutdown_token.clone())
+                .await
+                .unwrap();
+
+        // Verify server handle was created with proper address resolution
+        assert!(server_handle.address().ip().is_loopback());
+        assert!(server_handle.address().port() > 0);
+
+        // Shutdown
+        shutdown_token.cancel();
+        server_handle.shutdown().await.unwrap();
+    }
+}

--- a/crates/simulacrum-server/src/grpc_server.rs
+++ b/crates/simulacrum-server/src/grpc_server.rs
@@ -51,6 +51,7 @@ pub async fn start_simulacrum_grpc_server(
 
     start_grpc_server(
         grpc_reader,
+        #[allow(clippy::unnecessary_literal_unwrap)]
         event_subscriber.unwrap_or_else(|| Arc::new(DummyEventSubscriber)),
         executor,
         config,

--- a/crates/simulacrum-server/src/grpc_server.rs
+++ b/crates/simulacrum-server/src/grpc_server.rs
@@ -6,29 +6,18 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use async_trait::async_trait;
-use iota_grpc_server::{GrpcReader, GrpcServerHandle, GrpcStateReader, start_grpc_server};
+use iota_grpc_server::{GrpcReader, GrpcServerHandle, start_grpc_server};
 use iota_types::{
-    TypeTag,
-    base_types::{ObjectID, VersionNumber},
-    committee::Committee,
-    digests::{ChainIdentifier, CheckpointDigest, TransactionDigest, TransactionEventsDigest},
-    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
-    full_checkpoint_content::CheckpointData,
-    iota_system_state::IotaSystemState,
-    messages_checkpoint::CertifiedCheckpointSummary,
-    object::Object,
+    digests::{ChainIdentifier, CheckpointDigest},
+    effects::TransactionEffectsAPI,
     quorum_driver_types::{
         ExecuteTransactionRequestV1, ExecuteTransactionResponseV1, FinalizedEffects,
         QuorumDriverError,
     },
-    storage::EpochInfo,
-    transaction::{TransactionData, VerifiedTransaction},
+    transaction::TransactionData,
     transaction_executor::{SimulateTransactionResult, TransactionExecutor, VmChecks},
 };
-use move_core_types::annotated_value::MoveTypeLayout;
-use simulacrum::Simulacrum;
+use simulacrum::{Simulacrum, state_reader::SimulacrumGrpcReader};
 
 // Dummy event subscriber for simulacrum (events not supported)
 // TODO: add support for events in simulacrum?
@@ -44,170 +33,15 @@ impl iota_grpc_server::types::EventSubscriber for DummyEventSubscriber {
     }
 }
 
-/// GrpcStateReader implementation that works with a mutex-protected Simulacrum
-/// This allows sharing the same simulacrum instance between REST and gRPC APIs
-pub struct SimulacrumGrpcReader {
-    simulacrum: Arc<tokio::sync::Mutex<Simulacrum>>,
-    chain_id: ChainIdentifier,
-}
-
-impl SimulacrumGrpcReader {
-    pub fn new(simulacrum: Arc<tokio::sync::Mutex<Simulacrum>>, chain_id: ChainIdentifier) -> Self {
-        Self {
-            simulacrum,
-            chain_id,
-        }
-    }
-}
-
-impl GrpcStateReader for SimulacrumGrpcReader {
-    fn get_chain_identifier(&self) -> Result<ChainIdentifier> {
-        Ok(self.chain_id)
-    }
-
-    fn get_latest_checkpoint_sequence_number(&self) -> Option<u64> {
-        let rt = tokio::runtime::Handle::current();
-        let simulacrum = rt.block_on(self.simulacrum.lock());
-
-        simulacrum
-            .store()
-            .get_highest_checkpoint()
-            .map(|checkpoint| *checkpoint.sequence_number())
-    }
-
-    fn get_checkpoint_summary(&self, seq: u64) -> Option<CertifiedCheckpointSummary> {
-        let rt = tokio::runtime::Handle::current();
-        let simulacrum = rt.block_on(self.simulacrum.lock());
-
-        simulacrum
-            .store()
-            .get_checkpoint_by_sequence_number(seq)
-            .map(CertifiedCheckpointSummary::from)
-    }
-
-    fn get_checkpoint_data(&self, seq: u64) -> Option<CheckpointData> {
-        let rt = tokio::runtime::Handle::current();
-        let simulacrum = rt.block_on(self.simulacrum.lock());
-
-        let checkpoint = simulacrum.store().get_checkpoint_by_sequence_number(seq)?;
-        let contents = simulacrum
-            .store()
-            .get_checkpoint_contents(&checkpoint.content_digest)?;
-
-        Some(CheckpointData {
-            checkpoint_summary: CertifiedCheckpointSummary::from(checkpoint),
-            checkpoint_contents: contents,
-            // TODO: we should return the transactions as well
-            transactions: vec![],
-        })
-    }
-
-    fn get_epoch_last_checkpoint(&self, epoch: u64) -> Result<Option<CertifiedCheckpointSummary>> {
-        let rt = tokio::runtime::Handle::current();
-        let simulacrum = rt.block_on(self.simulacrum.lock());
-
-        // Simple implementation for simulacrum - find the last checkpoint of the given
-        // epoch
-        let latest_seq = simulacrum
-            .store()
-            .get_highest_checkpoint()
-            .map(|checkpoint| *checkpoint.sequence_number())
-            .unwrap_or(0);
-
-        // TODO: optimize that by storing epoch -> last checkpoint mapping
-        for seq in (0..=latest_seq).rev() {
-            if let Some(checkpoint) = simulacrum.store().get_checkpoint_by_sequence_number(seq) {
-                if checkpoint.epoch() == epoch {
-                    return Ok(Some(CertifiedCheckpointSummary::from(checkpoint)));
-                }
-            }
-        }
-        Ok(None)
-    }
-
-    fn get_lowest_available_checkpoint(&self) -> Result<u64> {
-        // Simulacrum starts from checkpoint 0
-        Ok(0)
-    }
-
-    fn get_lowest_available_checkpoint_objects(&self) -> Result<u64> {
-        // Simulacrum has all objects from the beginning
-        Ok(0)
-    }
-
-    fn get_object(&self, _object_id: &ObjectID) -> Option<Object> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        None
-    }
-
-    fn get_object_by_key(&self, _object_id: &ObjectID, _version: VersionNumber) -> Option<Object> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        None
-    }
-
-    fn get_committee(&self, _epoch: u64) -> Result<Option<Arc<Committee>>> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        Ok(None)
-    }
-
-    fn get_system_state(&self) -> Result<IotaSystemState> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        Err(anyhow::anyhow!("System state not available in simulacrum"))
-    }
-
-    fn get_epoch_info(&self, _epoch: u64) -> Option<EpochInfo> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        None
-    }
-
-    fn get_type_layout(&self, _type_tag: &TypeTag) -> Result<Option<MoveTypeLayout>> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        Ok(None)
-    }
-
-    fn get_transaction(&self, _digest: &TransactionDigest) -> Option<Arc<VerifiedTransaction>> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        None
-    }
-
-    fn get_transaction_effects(&self, _digest: &TransactionDigest) -> Option<TransactionEffects> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        None
-    }
-
-    fn get_transaction_events(
-        &self,
-        _digest: &TransactionEventsDigest,
-    ) -> Option<TransactionEvents> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        None
-    }
-
-    fn get_transaction_checkpoint(&self, _digest: &TransactionDigest) -> Option<u64> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        None
-    }
-}
-
 /// Transaction executor implementation for simulacrum
 /// This allows transaction execution and simulation via gRPC without requiring
 /// quorum consensus
 pub struct SimulacrumTransactionExecutor {
-    simulacrum: Arc<tokio::sync::Mutex<Simulacrum>>,
+    simulacrum: Arc<Simulacrum>,
 }
 
 impl SimulacrumTransactionExecutor {
-    pub fn new(simulacrum: Arc<tokio::sync::Mutex<Simulacrum>>) -> Self {
+    pub fn new(simulacrum: Arc<Simulacrum>) -> Self {
         Self { simulacrum }
     }
 }
@@ -219,7 +53,7 @@ impl TransactionExecutor for SimulacrumTransactionExecutor {
         request: ExecuteTransactionRequestV1,
         _client_addr: Option<std::net::SocketAddr>,
     ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
-        let mut simulacrum = self.simulacrum.lock().await;
+        let simulacrum = &*self.simulacrum;
 
         // Execute the transaction directly (it's already a Transaction type)
         let (effects, _execution_error) = simulacrum
@@ -292,18 +126,14 @@ impl TransactionExecutor for SimulacrumTransactionExecutor {
         transaction: TransactionData,
         checks: VmChecks,
     ) -> Result<SimulateTransactionResult, iota_types::error::IotaError> {
-        // This is a synchronous call, so we need to use blocking
-        let rt = tokio::runtime::Handle::current();
-        let simulacrum = rt.block_on(self.simulacrum.lock());
-
-        // Use the simulacrum's simulate_transaction method
-        simulacrum.simulate_transaction(transaction, checks)
+        // Simulacrum is already thread-safe, no locking needed
+        self.simulacrum.simulate_transaction(transaction, checks)
     }
 }
 
 /// Start a gRPC server for the given simulacrum instance
 pub async fn start_simulacrum_grpc_server(
-    simulacrum: Arc<tokio::sync::Mutex<Simulacrum>>,
+    simulacrum: Arc<Simulacrum>,
     config: iota_config::node::GrpcApiConfig,
     shutdown_token: tokio_util::sync::CancellationToken,
 ) -> Result<GrpcServerHandle> {
@@ -316,7 +146,7 @@ pub async fn start_simulacrum_grpc_server(
             as Arc<dyn TransactionExecutor>,
     );
 
-    let simulacrum_reader = Arc::new(SimulacrumGrpcReader::new(simulacrum, chain_id));
+    let simulacrum_reader = Arc::new(SimulacrumGrpcReader::new(simulacrum.clone(), chain_id));
     let grpc_reader = Arc::new(GrpcReader::new(simulacrum_reader, None));
 
     // TODO: add if needed
@@ -350,7 +180,7 @@ mod tests {
         simulacrum.advance_clock(Duration::from_secs(1));
         simulacrum.create_checkpoint();
 
-        let simulacrum = Arc::new(tokio::sync::Mutex::new(simulacrum));
+        let simulacrum = Arc::new(simulacrum);
 
         // Start gRPC server with test configuration using test utilities
         let address = local_ip_utils::new_local_tcp_socket_for_testing();

--- a/crates/simulacrum-server/src/grpc_server.rs
+++ b/crates/simulacrum-server/src/grpc_server.rs
@@ -8,8 +8,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use iota_grpc_server::{GrpcReader, GrpcServerHandle, start_grpc_server};
 use iota_types::{
-    digests::{ChainIdentifier, CheckpointDigest},
-    transaction_executor::TransactionExecutor as TransactionExecutorTrait,
+    storage::RestStateReader, transaction_executor::TransactionExecutor as TransactionExecutorTrait,
 };
 use simulacrum::{
     Simulacrum, state_reader::SimulacrumGrpcReader, transaction_executor::TransactionExecutor,
@@ -35,7 +34,9 @@ pub async fn start_simulacrum_grpc_server(
     config: iota_config::node::GrpcApiConfig,
     shutdown_token: tokio_util::sync::CancellationToken,
 ) -> Result<GrpcServerHandle> {
-    let chain_id = ChainIdentifier::from(CheckpointDigest::default());
+    let chain_id = simulacrum
+        .get_chain_identifier()
+        .expect("chain identifier should be set");
 
     // Create a transaction executor for simulacrum to enable transaction execution
     // and simulation via gRPC

--- a/crates/simulacrum-server/src/lib.rs
+++ b/crates/simulacrum-server/src/lib.rs
@@ -9,6 +9,6 @@ pub mod faucet;
 pub mod grpc_server;
 pub mod rest_api;
 
-pub use grpc_server::{SimulacrumGrpcReader, start_simulacrum_grpc_server};
+pub use grpc_server::start_simulacrum_grpc_server;
 pub use rest_api::{AppState, create_router};
 pub use simulacrum::{Simulacrum, store::SimulatorStore};

--- a/crates/simulacrum-server/src/lib.rs
+++ b/crates/simulacrum-server/src/lib.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Simulacrum Server Library
+//!
+//! This crate provides both gRPC and REST API servers for IOTA Simulacrum.
+
+pub mod faucet;
+pub mod grpc_server;
+pub mod rest_api;
+
+pub use grpc_server::{SimulacrumGrpcReader, start_simulacrum_grpc_server};
+pub use rest_api::{AppState, create_router};
+pub use simulacrum::{Simulacrum, store::SimulatorStore};

--- a/crates/simulacrum-server/src/main.rs
+++ b/crates/simulacrum-server/src/main.rs
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Simulacrum Server Binary
+//! This binary provides a gRPC and REST API server for a simulacrum instance.
+//! It allows external clients to interact with a simulated IOTA blockchain.
+
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+use anyhow::Result;
+use clap::Parser;
+use iota_swarm_config::genesis_config::AccountConfig;
+use simulacrum::Simulacrum;
+use tokio::signal;
+use tokio_util::sync::CancellationToken;
+use tower::ServiceBuilder;
+use tracing::{error, info, level_filters::LevelFilter, warn};
+
+mod faucet;
+mod grpc_server;
+mod rest_api;
+
+use rest_api::AppState;
+use tracing_subscriber::EnvFilter;
+
+/// Command line arguments for the simulacrum server
+#[derive(Parser, Debug)]
+#[command(
+    name = "simulacrum-server",
+    about = "A gRPC and REST API server to simulate the IOTA blockchain"
+)]
+struct Args {
+    /// gRPC server address
+    #[arg(long, default_value = "127.0.0.1:9000")]
+    grpc_address: SocketAddr,
+
+    /// REST API server address
+    #[arg(long, default_value = "127.0.0.1:8080")]
+    rest_address: SocketAddr,
+
+    /// Initial number of checkpoints to create on startup
+    #[arg(long, default_value = "0")]
+    initial_checkpoints: u64,
+
+    /// Chain start timestamp in milliseconds
+    #[arg(long)]
+    chain_start_timestamp_ms: Option<u64>,
+
+    /// Faucet request amount in nanos (default: 1_000_000_000 = 1 IOTA)
+    #[arg(long, default_value = "1000000000")]
+    faucet_request_amount: u64,
+
+    /// Accounts to create in the format "address:amount,address:amount..."
+    #[arg(long)]
+    accounts: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize tracing
+    let subscriber = ::tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("unable to initialize logging");
+
+    let args = Args::parse();
+
+    info!("Starting Simulacrum Server");
+    info!("REST address: {}", args.rest_address);
+    info!("gRPC address: {}", args.grpc_address);
+
+    // Create simulacrum instance
+    info!(
+        "Creating simulacrum with chain start timestamp: {}",
+        args.chain_start_timestamp_ms.unwrap_or_default()
+    );
+
+    // Parse accounts from command line argument
+    let mut account_configs = if let Some(accounts_str) = args.accounts {
+        let pairs: Vec<&str> = accounts_str.split(',').collect();
+        info!("Creating {} accounts", pairs.len());
+        
+        pairs
+            .iter()
+            .filter_map(|pair| {
+                let parts: Vec<&str> = pair.split(':').collect();
+                if parts.len() != 2 {
+                    panic!("Invalid account format '{pair}', expected 'address:amount'");
+                }
+                
+                let address = match parts[0].parse::<iota_types::base_types::IotaAddress>() {
+                    Ok(addr) => addr,
+                    Err(e) => {
+                        panic!("Invalid address '{}': {e}", parts[0]);
+                    }
+                };
+                
+                let amount = match parts[1].parse::<u64>() {
+                    Ok(amt) => amt,
+                    Err(e) => {
+                        panic!("Invalid amount '{}': {e}", parts[1]);
+                    }
+                };
+                
+                Some(AccountConfig {
+                    address: Some(address),
+                    gas_amounts: vec![amount],
+                })
+            })
+            .collect()
+    } else {
+        info!("No accounts specified");
+        vec![]
+    };
+
+    // create an account for the faucet
+    let faucet_account = AccountConfig {
+        address: None,
+        gas_amounts: vec![10_000_000_000],
+    };
+    account_configs.insert(0, faucet_account); // ensure faucet account is first
+
+    let mut simulacrum = Simulacrum::new_with_protocol_version_and_accounts(
+        rand::rngs::OsRng,
+        args.chain_start_timestamp_ms.unwrap_or_default(),
+        iota_protocol_config::ProtocolVersion::MAX,
+        account_configs,
+    );
+
+    // Create initial checkpoints if requested
+    if args.initial_checkpoints > 0 {
+        info!("Creating {} initial checkpoints", args.initial_checkpoints);
+        for i in 0..args.initial_checkpoints {
+            simulacrum.advance_clock(Duration::from_secs(1));
+            let checkpoint = simulacrum.create_checkpoint();
+            info!(
+                "Created initial checkpoint {}: sequence {}",
+                i + 1,
+                checkpoint.sequence_number()
+            );
+        }
+    }
+
+    let simulacrum = Arc::new(tokio::sync::Mutex::new(simulacrum));
+    let app_state = AppState {
+        simulacrum: simulacrum.clone(),
+        faucet_request_amount: args.faucet_request_amount,
+    };
+
+    // Start gRPC server
+    let shutdown_token = CancellationToken::new();
+    let grpc_handle = {
+        info!("Starting gRPC server on {}", args.grpc_address);
+
+        let grpc_config = iota_config::node::GrpcApiConfig {
+            address: args.grpc_address,
+            ..Default::default()
+        };
+
+        match grpc_server::start_simulacrum_grpc_server(
+            simulacrum.clone(),
+            grpc_config,
+            shutdown_token.clone(),
+        )
+        .await
+        {
+            Ok(handle) => {
+                info!("gRPC server started successfully on {}", handle.address());
+                Some(handle)
+            }
+            Err(e) => {
+                panic!("Failed to start gRPC server: {e}");
+            }
+        }
+    };
+
+    // Start REST API server
+    let rest_handle = {
+        info!("Starting REST API server on {}", args.rest_address);
+
+        let router = rest_api::create_router(app_state)
+            .layer(ServiceBuilder::new().layer(axum::middleware::from_fn(
+            |req: axum::http::Request<axum::body::Body>, next: axum::middleware::Next| async move {
+                let start = std::time::Instant::now();
+                let method = req.method().clone();
+                let uri = req.uri().clone();
+
+                let response = next.run(req).await;
+                let elapsed = start.elapsed();
+
+                tracing::debug!("{method} {uri} took {elapsed:?}");
+                response
+            },
+        )));
+
+        let listener = tokio::net::TcpListener::bind(args.rest_address).await?;
+
+        Some(tokio::spawn(async move {
+            info!("REST API server listening on {}", args.rest_address);
+            if let Err(e) = axum::serve(listener, router).await {
+                error!("REST API server error: {}", e);
+            }
+        }))
+    };
+
+    info!("Simulacrum Server started successfully");
+    info!("");
+    info!("Available REST endpoints:");
+    info!("  GET  /status                     - Simulacrum status");
+    info!("  GET  /checkpoint                 - Get latest checkpoint");
+    info!("  POST /checkpoint/create          - Create a new checkpoint");
+    info!("  POST /checkpoint/create_multiple - Create multiple checkpoints");
+    info!("  POST /clock/advance              - Advance simulacrum clock");
+    info!("  POST /epoch/advance              - Advance to next epoch");
+    info!("");
+
+    // Wait for shutdown signal
+    match signal::ctrl_c().await {
+        Ok(()) => {
+            info!("Received shutdown signal, stopping servers...");
+        }
+        Err(err) => {
+            warn!("Failed to listen for shutdown signal: {err}");
+        }
+    }
+
+    // Shutdown servers
+    shutdown_token.cancel();
+
+    if let Some(handle) = rest_handle {
+        handle.abort();
+        info!("REST API server stopped");
+    }
+
+    if let Some(handle) = grpc_handle {
+        if let Err(e) = handle.shutdown().await {
+            warn!("Error shutting down gRPC server: {}", e);
+        }
+        info!("gRPC server stopped");
+    }
+
+    info!("Simulacrum Server stopped");
+    Ok(())
+}

--- a/crates/simulacrum-server/src/main.rs
+++ b/crates/simulacrum-server/src/main.rs
@@ -10,6 +10,7 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use anyhow::Result;
 use clap::Parser;
 use iota_swarm_config::genesis_config::AccountConfig;
+use iota_types::digests::{ChainIdentifier, CheckpointDigest};
 use simulacrum::Simulacrum;
 use tokio::signal;
 use tokio_util::sync::CancellationToken;
@@ -159,6 +160,7 @@ async fn main() -> Result<()> {
     let app_state = AppState {
         simulacrum: simulacrum.clone(),
         faucet_request_amount: args.faucet_request_amount,
+        chain_id: ChainIdentifier::from(CheckpointDigest::default()).to_string(),
     };
 
     // Start gRPC server

--- a/crates/simulacrum-server/src/main.rs
+++ b/crates/simulacrum-server/src/main.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<()> {
     let mut account_configs = if let Some(accounts_str) = args.accounts {
         let pairs: Vec<&str> = accounts_str.split(',').collect();
         info!("Creating {} accounts", pairs.len());
-        
+
         pairs
             .iter()
             .filter_map(|pair| {
@@ -91,21 +91,21 @@ async fn main() -> Result<()> {
                 if parts.len() != 2 {
                     panic!("Invalid account format '{pair}', expected 'address:amount'");
                 }
-                
+
                 let address = match parts[0].parse::<iota_types::base_types::IotaAddress>() {
                     Ok(addr) => addr,
                     Err(e) => {
                         panic!("Invalid address '{}': {e}", parts[0]);
                     }
                 };
-                
+
                 let amount = match parts[1].parse::<u64>() {
                     Ok(amt) => amt,
                     Err(e) => {
                         panic!("Invalid amount '{}': {e}", parts[1]);
                     }
                 };
-                
+
                 Some(AccountConfig {
                     address: Some(address),
                     gas_amounts: vec![amount],

--- a/crates/simulacrum-server/src/main.rs
+++ b/crates/simulacrum-server/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<()> {
 
         pairs
             .iter()
-            .filter_map(|pair| {
+            .map(|pair| {
                 let parts: Vec<&str> = pair.split(':').collect();
                 if parts.len() != 2 {
                     panic!("Invalid account format '{pair}', expected 'address:amount'");
@@ -110,10 +110,10 @@ async fn main() -> Result<()> {
                     }
                 };
 
-                Some(AccountConfig {
+                AccountConfig {
                     address: Some(address),
                     gas_amounts: vec![amount],
-                })
+                }
             })
             .collect()
     } else {

--- a/crates/simulacrum-server/src/main.rs
+++ b/crates/simulacrum-server/src/main.rs
@@ -53,6 +53,10 @@ struct Args {
     /// Accounts to create in the format "address:amount,address:amount..."
     #[arg(long)]
     accounts: Option<String>,
+
+    /// Path to store data ingestion files
+    #[arg(long)]
+    data_ingestion_path: Option<String>,
 }
 
 #[tokio::main]
@@ -124,12 +128,18 @@ async fn main() -> Result<()> {
     };
     account_configs.insert(0, faucet_account); // ensure faucet account is first
 
-    let mut simulacrum = Simulacrum::new_with_protocol_version_and_accounts(
+    let simulacrum = Simulacrum::new_with_protocol_version_and_accounts(
         rand::rngs::OsRng,
         args.chain_start_timestamp_ms.unwrap_or_default(),
         iota_protocol_config::ProtocolVersion::MAX,
         account_configs,
     );
+
+    // Set data ingestion path if provided
+    if let Some(path) = args.data_ingestion_path {
+        info!("Setting data ingestion path to: {}", path);
+        simulacrum.set_data_ingestion_path(path.into());
+    }
 
     // Create initial checkpoints if requested
     if args.initial_checkpoints > 0 {
@@ -145,7 +155,7 @@ async fn main() -> Result<()> {
         }
     }
 
-    let simulacrum = Arc::new(tokio::sync::Mutex::new(simulacrum));
+    let simulacrum = Arc::new(simulacrum);
     let app_state = AppState {
         simulacrum: simulacrum.clone(),
         faucet_request_amount: args.faucet_request_amount,

--- a/crates/simulacrum-server/src/main.rs
+++ b/crates/simulacrum-server/src/main.rs
@@ -10,7 +10,7 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use anyhow::Result;
 use clap::Parser;
 use iota_swarm_config::genesis_config::AccountConfig;
-use iota_types::digests::{ChainIdentifier, CheckpointDigest};
+use iota_types::storage::RestStateReader;
 use simulacrum::Simulacrum;
 use tokio::signal;
 use tokio_util::sync::CancellationToken;
@@ -160,7 +160,10 @@ async fn main() -> Result<()> {
     let app_state = AppState {
         simulacrum: simulacrum.clone(),
         faucet_request_amount: args.faucet_request_amount,
-        chain_id: ChainIdentifier::from(CheckpointDigest::default()).to_string(),
+        chain_id: simulacrum
+            .get_chain_identifier()
+            .expect("chain identifier should be set")
+            .to_string(),
     };
 
     // Start gRPC server

--- a/crates/simulacrum-server/src/main.rs
+++ b/crates/simulacrum-server/src/main.rs
@@ -124,7 +124,7 @@ async fn main() -> Result<()> {
     // create an account for the faucet
     let faucet_account = AccountConfig {
         address: None,
-        gas_amounts: vec![10_000_000_000],
+        gas_amounts: vec![100_000_000_000_000],
     };
     account_configs.insert(0, faucet_account); // ensure faucet account is first
 

--- a/crates/simulacrum-server/src/rest_api.rs
+++ b/crates/simulacrum-server/src/rest_api.rs
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! REST API module for Simulacrum Server
+//!
+//! This module provides REST endpoints for controlling and querying the
+//! simulacrum.
+
+use std::{borrow::Cow, sync::Arc, time::Duration};
+
+use axum::{
+    BoxError, Extension, Json, Router,
+    error_handling::HandleErrorLayer,
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+};
+use http::Method;
+use serde::{Deserialize, Serialize};
+use simulacrum::Simulacrum;
+use tower::ServiceBuilder;
+use tower_http::cors::{Any, CorsLayer};
+use tracing::info;
+
+use crate::faucet;
+
+/// Application state shared between REST handlers
+#[derive(Clone)]
+pub struct AppState {
+    pub simulacrum: Arc<tokio::sync::Mutex<Simulacrum>>,
+    pub faucet_request_amount: u64,
+}
+
+/// REST API response types
+#[derive(Serialize)]
+pub struct SimulacrumStatus {
+    pub chain_id: String,
+    pub current_epoch: u64,
+    pub highest_checkpoint: Option<u64>,
+    pub timestamp_ms: u64,
+    pub reference_gas_price: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CheckpointResponse {
+    pub sequence_number: u64,
+    pub epoch: u64,
+    pub timestamp_ms: u64,
+    pub network_total_transactions: u64,
+    pub content_digest: String,
+}
+
+#[derive(Deserialize)]
+pub struct AdvanceClockRequest {
+    pub duration_ms: u64,
+}
+
+#[derive(Deserialize)]
+pub struct AdvanceEpochRequest {
+    #[serde(default)]
+    pub create_checkpoint: bool,
+}
+
+#[derive(Deserialize)]
+pub struct CreateCheckpointsRequest {
+    pub count: u64,
+    #[serde(default = "default_interval_ms")]
+    pub interval_ms: u64,
+}
+
+fn default_interval_ms() -> u64 {
+    1000 // 1 second default
+}
+
+#[derive(Serialize)]
+pub struct AdvanceClockResponse {
+    pub new_timestamp_ms: u64,
+    pub advanced_by_ms: u64,
+}
+
+#[derive(Serialize)]
+pub struct AdvanceEpochResponse {
+    pub new_epoch: u64,
+    pub checkpoint: Option<CheckpointResponse>,
+}
+
+#[derive(Serialize)]
+pub struct CreateCheckpointsResponse {
+    pub created_count: u64,
+    pub checkpoints: Vec<CheckpointResponse>,
+}
+
+/// Helper function to convert a checkpoint to response format
+pub fn checkpoint_to_response(
+    checkpoint: &iota_types::messages_checkpoint::VerifiedCheckpoint,
+) -> CheckpointResponse {
+    let checkpoint_data = checkpoint.data();
+    CheckpointResponse {
+        sequence_number: *checkpoint.sequence_number(),
+        epoch: checkpoint.epoch(),
+        timestamp_ms: checkpoint_data.timestamp_ms,
+        network_total_transactions: checkpoint_data.network_total_transactions,
+        content_digest: checkpoint_data.content_digest.to_string(),
+    }
+}
+
+/// REST API handlers
+pub async fn get_status(
+    State(state): State<AppState>,
+) -> Result<Json<SimulacrumStatus>, StatusCode> {
+    let simulacrum = state.simulacrum.lock().await;
+
+    let highest_checkpoint = simulacrum
+        .store()
+        .get_highest_checkpoint()
+        .map(|cp| *cp.sequence_number());
+
+    let current_epoch = simulacrum
+        .store()
+        .get_highest_checkpoint()
+        .map(|cp| cp.epoch())
+        .unwrap_or(0);
+
+    let timestamp_ms = simulacrum.store().get_clock().timestamp_ms();
+    let reference_gas_price = simulacrum.reference_gas_price();
+
+    let response = SimulacrumStatus {
+        // we should pass the chain ID here as well.
+        chain_id: "simulacrum".to_string(),
+        current_epoch,
+        highest_checkpoint,
+        timestamp_ms,
+        reference_gas_price,
+    };
+
+    Ok(Json(response))
+}
+
+pub async fn get_checkpoint(
+    State(state): State<AppState>,
+) -> Result<Json<CheckpointResponse>, StatusCode> {
+    let simulacrum = state.simulacrum.lock().await;
+    let checkpoint = simulacrum
+        .store()
+        .get_highest_checkpoint()
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let response = checkpoint_to_response(&checkpoint);
+    Ok(Json(response))
+}
+
+pub async fn create_checkpoint(
+    State(state): State<AppState>,
+) -> Result<Json<CheckpointResponse>, StatusCode> {
+    let mut simulacrum = state.simulacrum.lock().await;
+    let checkpoint = simulacrum.create_checkpoint();
+
+    let response = checkpoint_to_response(&checkpoint);
+
+    info!(
+        "Created checkpoint {} in epoch {} with {} transactions",
+        checkpoint.sequence_number(),
+        checkpoint.epoch(),
+        checkpoint.data().network_total_transactions
+    );
+
+    Ok(Json(response))
+}
+
+pub async fn create_checkpoints(
+    State(state): State<AppState>,
+    Json(request): Json<CreateCheckpointsRequest>,
+) -> Result<Json<CreateCheckpointsResponse>, StatusCode> {
+    if request.count == 0 {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let mut simulacrum = state.simulacrum.lock().await;
+    let mut checkpoints = Vec::new();
+
+    for i in 0..request.count {
+        if i > 0 {
+            // Advance clock between checkpoints
+            simulacrum.advance_clock(Duration::from_millis(request.interval_ms));
+        }
+
+        let checkpoint = simulacrum.create_checkpoint();
+        checkpoints.push(checkpoint_to_response(&checkpoint));
+    }
+
+    info!(
+        "Created {} checkpoints with {}ms intervals",
+        request.count, request.interval_ms
+    );
+
+    let response = CreateCheckpointsResponse {
+        created_count: request.count,
+        checkpoints,
+    };
+
+    Ok(Json(response))
+}
+
+pub async fn advance_clock(
+    State(state): State<AppState>,
+    Json(request): Json<AdvanceClockRequest>,
+) -> Result<Json<AdvanceClockResponse>, StatusCode> {
+    let mut simulacrum = state.simulacrum.lock().await;
+
+    let old_timestamp = simulacrum.store().get_clock().timestamp_ms();
+    simulacrum.advance_clock(Duration::from_millis(request.duration_ms));
+    let new_timestamp = simulacrum.store().get_clock().timestamp_ms();
+
+    let response = AdvanceClockResponse {
+        new_timestamp_ms: new_timestamp,
+        advanced_by_ms: new_timestamp - old_timestamp,
+    };
+
+    info!(
+        "Advanced clock by {} ms, new timestamp: {} ms",
+        response.advanced_by_ms, response.new_timestamp_ms
+    );
+
+    Ok(Json(response))
+}
+
+pub async fn advance_epoch(
+    State(state): State<AppState>,
+    Json(request): Json<AdvanceEpochRequest>,
+) -> Result<Json<AdvanceEpochResponse>, StatusCode> {
+    let mut simulacrum = state.simulacrum.lock().await;
+
+    let old_epoch = simulacrum
+        .store()
+        .get_highest_checkpoint()
+        .map(|cp| cp.epoch())
+        .unwrap_or(0);
+    simulacrum.advance_epoch();
+    let new_epoch = simulacrum
+        .store()
+        .get_highest_checkpoint()
+        .map(|cp| cp.epoch())
+        .unwrap_or(0);
+
+    let checkpoint = if request.create_checkpoint {
+        let cp = simulacrum.create_checkpoint();
+        Some(checkpoint_to_response(&cp))
+    } else {
+        None
+    };
+
+    let response = AdvanceEpochResponse {
+        new_epoch,
+        checkpoint,
+    };
+
+    info!(
+        "Advanced epoch from {} to {}, created checkpoint: {}",
+        old_epoch, new_epoch, request.create_checkpoint
+    );
+
+    Ok(Json(response))
+}
+
+async fn handle_error(error: BoxError) -> impl IntoResponse {
+    if error.is::<tower::load_shed::error::Overloaded>() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Cow::from("service is overloaded, please try again later"),
+        );
+    }
+
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Cow::from(format!("Unhandled internal error: {error}")),
+    )
+}
+
+/// Create the REST API router
+pub fn create_router(state: AppState) -> Router {
+    let cors = CorsLayer::new()
+        .allow_methods(vec![Method::GET, Method::POST])
+        .allow_headers(Any)
+        .allow_origin(Any);
+
+    // Configuration values
+    let request_buffer_size = 1000;
+    let concurrency_limit = 1;
+
+    Router::new()
+        .route("/status", get(get_status))
+        .route("/checkpoint", get(get_checkpoint))
+        .route("/checkpoint/create", post(create_checkpoint))
+        .route("/checkpoint/create_multiple", post(create_checkpoints))
+        .route("/clock/advance", post(advance_clock))
+        .route("/epoch/advance", post(advance_epoch))
+        .nest("/faucet", faucet::add_faucet_routes())
+        .with_state(state.clone())
+        .layer(
+            ServiceBuilder::new()
+                .layer(HandleErrorLayer::new(handle_error))
+                .layer(cors)
+                .load_shed()
+                .buffer(request_buffer_size)
+                .concurrency_limit(concurrency_limit)
+                .layer(Extension(state.clone()))
+                .into_inner(),
+        )
+}

--- a/crates/simulacrum-server/src/rest_api.rs
+++ b/crates/simulacrum-server/src/rest_api.rs
@@ -114,7 +114,7 @@ pub async fn get_status(
 
     let highest_verified_checkpoint = simulacrum.get_highest_verified_checkpoint();
     let highest_verified_checkpoint_data = highest_verified_checkpoint.data();
-    let highest_checkpoint = Some(highest_verified_checkpoint_data.sequence_number().clone());
+    let highest_checkpoint = Some(*highest_verified_checkpoint_data.sequence_number());
     let current_epoch = highest_verified_checkpoint_data.epoch;
 
     let timestamp_ms = simulacrum.with_store(|store| store.get_clock().timestamp_ms());

--- a/crates/simulacrum-server/src/rest_api.rs
+++ b/crates/simulacrum-server/src/rest_api.rs
@@ -17,6 +17,7 @@ use axum::{
     routing::{get, post},
 };
 use http::Method;
+use iota_types::storage::ReadStore;
 use serde::{Deserialize, Serialize};
 use simulacrum::Simulacrum;
 use tower::ServiceBuilder;
@@ -28,7 +29,7 @@ use crate::faucet;
 /// Application state shared between REST handlers
 #[derive(Clone)]
 pub struct AppState {
-    pub simulacrum: Arc<tokio::sync::Mutex<Simulacrum>>,
+    pub simulacrum: Arc<Simulacrum>,
     pub faucet_request_amount: u64,
 }
 
@@ -109,20 +110,14 @@ pub fn checkpoint_to_response(
 pub async fn get_status(
     State(state): State<AppState>,
 ) -> Result<Json<SimulacrumStatus>, StatusCode> {
-    let simulacrum = state.simulacrum.lock().await;
+    let simulacrum = state.simulacrum.as_ref();
 
-    let highest_checkpoint = simulacrum
-        .store()
-        .get_highest_checkpoint()
-        .map(|cp| *cp.sequence_number());
+    let highest_verified_checkpoint = simulacrum.get_highest_verified_checkpoint();
+    let highest_verified_checkpoint_data = highest_verified_checkpoint.data();
+    let highest_checkpoint = Some(highest_verified_checkpoint_data.sequence_number().clone());
+    let current_epoch = highest_verified_checkpoint_data.epoch;
 
-    let current_epoch = simulacrum
-        .store()
-        .get_highest_checkpoint()
-        .map(|cp| cp.epoch())
-        .unwrap_or(0);
-
-    let timestamp_ms = simulacrum.store().get_clock().timestamp_ms();
+    let timestamp_ms = simulacrum.with_store(|store| store.get_clock().timestamp_ms());
     let reference_gas_price = simulacrum.reference_gas_price();
 
     let response = SimulacrumStatus {
@@ -140,20 +135,17 @@ pub async fn get_status(
 pub async fn get_checkpoint(
     State(state): State<AppState>,
 ) -> Result<Json<CheckpointResponse>, StatusCode> {
-    let simulacrum = state.simulacrum.lock().await;
-    let checkpoint = simulacrum
-        .store()
-        .get_highest_checkpoint()
-        .ok_or(StatusCode::NOT_FOUND)?;
+    let simulacrum = state.simulacrum.as_ref();
+    let highest_verified_checkpoint = simulacrum.get_highest_verified_checkpoint();
 
-    let response = checkpoint_to_response(&checkpoint);
+    let response = checkpoint_to_response(&highest_verified_checkpoint);
     Ok(Json(response))
 }
 
 pub async fn create_checkpoint(
     State(state): State<AppState>,
 ) -> Result<Json<CheckpointResponse>, StatusCode> {
-    let mut simulacrum = state.simulacrum.lock().await;
+    let simulacrum = state.simulacrum.as_ref();
     let checkpoint = simulacrum.create_checkpoint();
 
     let response = checkpoint_to_response(&checkpoint);
@@ -176,7 +168,7 @@ pub async fn create_checkpoints(
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    let mut simulacrum = state.simulacrum.lock().await;
+    let simulacrum = state.simulacrum.as_ref();
     let mut checkpoints = Vec::new();
 
     for i in 0..request.count {
@@ -206,11 +198,11 @@ pub async fn advance_clock(
     State(state): State<AppState>,
     Json(request): Json<AdvanceClockRequest>,
 ) -> Result<Json<AdvanceClockResponse>, StatusCode> {
-    let mut simulacrum = state.simulacrum.lock().await;
+    let simulacrum = state.simulacrum.as_ref();
 
-    let old_timestamp = simulacrum.store().get_clock().timestamp_ms();
+    let old_timestamp = simulacrum.with_store(|store| store.get_clock().timestamp_ms());
     simulacrum.advance_clock(Duration::from_millis(request.duration_ms));
-    let new_timestamp = simulacrum.store().get_clock().timestamp_ms();
+    let new_timestamp = simulacrum.with_store(|store| store.get_clock().timestamp_ms());
 
     let response = AdvanceClockResponse {
         new_timestamp_ms: new_timestamp,
@@ -229,19 +221,13 @@ pub async fn advance_epoch(
     State(state): State<AppState>,
     Json(request): Json<AdvanceEpochRequest>,
 ) -> Result<Json<AdvanceEpochResponse>, StatusCode> {
-    let mut simulacrum = state.simulacrum.lock().await;
+    let simulacrum = state.simulacrum.as_ref();
 
-    let old_epoch = simulacrum
-        .store()
-        .get_highest_checkpoint()
-        .map(|cp| cp.epoch())
-        .unwrap_or(0);
+    let old_epoch = simulacrum.get_highest_verified_checkpoint().data().epoch;
+
     simulacrum.advance_epoch();
-    let new_epoch = simulacrum
-        .store()
-        .get_highest_checkpoint()
-        .map(|cp| cp.epoch())
-        .unwrap_or(0);
+
+    let new_epoch = simulacrum.get_highest_verified_checkpoint().data().epoch;
 
     let checkpoint = if request.create_checkpoint {
         let cp = simulacrum.create_checkpoint();

--- a/crates/simulacrum-server/src/rest_api.rs
+++ b/crates/simulacrum-server/src/rest_api.rs
@@ -31,6 +31,7 @@ use crate::faucet;
 pub struct AppState {
     pub simulacrum: Arc<Simulacrum>,
     pub faucet_request_amount: u64,
+    pub chain_id: String,
 }
 
 /// REST API response types
@@ -121,8 +122,7 @@ pub async fn get_status(
     let reference_gas_price = simulacrum.reference_gas_price();
 
     let response = SimulacrumStatus {
-        // we should pass the chain ID here as well.
-        chain_id: "simulacrum".to_string(),
+        chain_id: state.chain_id.clone(),
         current_epoch,
         highest_checkpoint,
         timestamp_ms,

--- a/crates/simulacrum/Cargo.toml
+++ b/crates/simulacrum/Cargo.toml
@@ -16,6 +16,7 @@ rand.workspace = true
 # internal dependencies
 iota-config.workspace = true
 iota-execution.workspace = true
+iota-grpc-server.workspace = true
 iota-protocol-config.workspace = true
 iota-storage.workspace = true
 iota-swarm-config.workspace = true

--- a/crates/simulacrum/Cargo.toml
+++ b/crates/simulacrum/Cargo.toml
@@ -9,9 +9,11 @@ publish = false
 [dependencies]
 # external dependencies
 anyhow.workspace = true
+async-trait.workspace = true
 fastcrypto.workspace = true
 prometheus.workspace = true
 rand.workspace = true
+tracing.workspace = true
 
 # internal dependencies
 iota-config.workspace = true

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -11,16 +11,22 @@ use iota_config::{
 use iota_execution::Executor;
 use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use iota_types::{
+    base_types::ObjectID,
     committee::{Committee, EpochId},
-    effects::TransactionEffects,
+    digests::TransactionDigest,
+    effects::{TransactionEffects, TransactionEffectsAPI},
+    error::IotaResult,
     gas::IotaGasStatus,
+    gas_coin::NANOS_PER_IOTA,
     inner_temporary_store::InnerTemporaryStore,
     iota_system_state::{
         IotaSystemState, IotaSystemStateTrait,
         epoch_start_iota_system_state::{EpochStartSystemState, EpochStartSystemStateTrait},
     },
     metrics::{BytecodeVerifierMetrics, LimitsMetrics},
-    transaction::{TransactionDataAPI, VerifiedTransaction},
+    object::{MoveObject, Object, Owner},
+    transaction::{ObjectReadResult, TransactionData, TransactionDataAPI, VerifiedTransaction},
+    transaction_executor::{SimulateTransactionResult, VmChecks},
 };
 
 use crate::SimulatorStore;
@@ -156,5 +162,118 @@ impl EpochState {
             tx_digest,
             &mut None,
         ))
+    }
+
+    /// Simulate a transaction without committing changes.
+    /// This is similar to execute_transaction but:
+    /// - Takes TransactionData instead of VerifiedTransaction (no signature
+    ///   required)
+    /// - Takes VmChecks parameter to control validation strictness
+    /// - Returns SimulateTransactionResult with input/output objects
+    /// - Creates a mock gas object if none provided
+    pub fn simulate_transaction(
+        &self,
+        store: &dyn SimulatorStore,
+        deny_config: &TransactionDenyConfig,
+        verifier_signing_config: &VerifierSigningConfig,
+        mut transaction: TransactionData,
+        checks: VmChecks,
+    ) -> IotaResult<SimulateTransactionResult> {
+        // Cheap validity checks for a transaction, including input size limits.
+        transaction.validity_check_no_gas_check(&self.protocol_config)?;
+
+        let input_object_kinds = transaction.input_objects()?;
+        let receiving_object_refs = transaction.receiving_objects();
+
+        // Check if some transaction elements are denied
+        iota_transaction_checks::deny::check_transaction_for_signing(
+            &transaction,
+            &[],
+            &input_object_kinds,
+            &receiving_object_refs,
+            deny_config,
+            store,
+        )?;
+
+        // Load input and receiving objects
+        let (mut input_objects, receiving_objects) = store.read_objects_for_synchronous_execution(
+            &transaction.digest(),
+            &input_object_kinds,
+            &receiving_object_refs,
+        )?;
+
+        // Create a mock gas object if one was not provided
+        const SIMULATION_GAS_COIN_VALUE: u64 = 1_000_000_000 * NANOS_PER_IOTA; // 1B IOTA
+        let mock_gas_id = if transaction.gas().is_empty() {
+            let mock_gas_object = Object::new_move(
+                MoveObject::new_gas_coin(1.into(), ObjectID::MAX, SIMULATION_GAS_COIN_VALUE),
+                Owner::AddressOwner(transaction.gas_data().owner),
+                TransactionDigest::genesis_marker(),
+            );
+            let mock_gas_object_ref = mock_gas_object.compute_object_reference();
+            transaction.gas_data_mut().payment = vec![mock_gas_object_ref];
+            input_objects.push(ObjectReadResult::new_from_gas_object(&mock_gas_object));
+            Some(mock_gas_object.id())
+        } else {
+            None
+        };
+
+        // Checks enabled -> DRY-RUN (simulating a real TX)
+        // Checks disabled -> DEV-INSPECT (more relaxed Move VM checks)
+        let (gas_status, checked_input_objects) = if checks.enabled() {
+            iota_transaction_checks::check_transaction_input(
+                &self.protocol_config,
+                self.epoch_start_state.reference_gas_price(),
+                &transaction,
+                input_objects,
+                &receiving_objects,
+                &self.bytecode_verifier_metrics,
+                verifier_signing_config,
+            )?
+        } else {
+            let checked_input_objects = iota_transaction_checks::check_dev_inspect_input(
+                &self.protocol_config,
+                transaction.kind(),
+                input_objects,
+                receiving_objects,
+            )?;
+            let gas_status = IotaGasStatus::new(
+                transaction.gas_budget(),
+                transaction.gas_price(),
+                self.epoch_start_state.reference_gas_price(),
+                &self.protocol_config,
+            )?;
+
+            (gas_status, checked_input_objects)
+        };
+
+        // Execute the simulation
+        let (kind, signer, gas_coins) = transaction.execution_parts();
+        let (inner_temp_store, _, effects, execution_result) =
+            self.executor.dev_inspect_transaction(
+                store.backing_store(),
+                &self.protocol_config,
+                self.limits_metrics.clone(),
+                false,           // expensive_checks
+                &HashSet::new(), // certificate_deny_set
+                &self.epoch_start_state.epoch(),
+                self.epoch_start_state.epoch_start_timestamp_ms(),
+                checked_input_objects,
+                gas_coins,
+                gas_status,
+                kind,
+                signer,
+                transaction.digest(),
+                checks.disabled(),
+            );
+
+        Ok(SimulateTransactionResult {
+            input_objects: inner_temp_store.input_objects,
+            output_objects: inner_temp_store.written,
+            events: effects.events_digest().map(|_| inner_temp_store.events),
+            effects,
+            execution_result,
+            mock_gas_id,
+        })
     }
 }

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -90,6 +90,10 @@ impl EpochState {
         &self.protocol_config
     }
 
+    pub fn executor(&self) -> Arc<dyn Executor + Send + Sync> {
+        self.executor.clone()
+    }
+
     pub fn execute_transaction(
         &self,
         store: &dyn SimulatorStore,

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -84,8 +84,8 @@ impl EpochState {
         &self.committee
     }
 
-    pub fn epoch_start_state(&self) -> &EpochStartSystemState {
-        &self.epoch_start_state
+    pub fn epoch_start_state(&self) -> EpochStartSystemState {
+        self.epoch_start_state.clone()
     }
 
     pub fn protocol_version(&self) -> ProtocolVersion {
@@ -94,10 +94,6 @@ impl EpochState {
 
     pub fn protocol_config(&self) -> &ProtocolConfig {
         &self.protocol_config
-    }
-
-    pub fn executor(&self) -> Arc<dyn Executor + Send + Sync> {
-        self.executor.clone()
     }
 
     pub fn execute_transaction(

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -408,7 +408,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     ///
     /// # fn main() {
     /// let mut simulacrum = Simulacrum::new();
-    /// let address = IotaAddress::generate(simulacrum.rng());
+    /// let address = simulacrum.with_rng(|rng| IotaAddress::generate(rng));
     /// simulacrum.request_gas(address, NANOS_PER_IOTA).unwrap();
     ///
     /// // `account` now has a Coin<IOTA> object with single IOTA in it.

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -23,6 +23,7 @@ use iota_config::{
     genesis, transaction_deny_config::TransactionDenyConfig,
     verifier_signing_config::VerifierSigningConfig,
 };
+use iota_execution::Executor;
 use iota_protocol_config::ProtocolVersion;
 use iota_storage::blob::{Blob, BlobEncoding};
 use iota_swarm_config::{
@@ -89,6 +90,10 @@ impl Simulacrum {
     #[expect(clippy::new_without_default)]
     pub fn new() -> Self {
         Self::new_with_rng(OsRng)
+    }
+
+    pub fn executor(&self) -> Arc<dyn Executor + Send + Sync> {
+        self.epoch_state.executor()
     }
 }
 
@@ -345,7 +350,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         // For right now we'll just use the first account as the `faucet` account. We
         // may want to explicitly cordon off the faucet account from the rest of
         // the accounts though.
-        let (sender, key) = self.keystore().accounts().next().unwrap();
+        let (sender, key) = self.keystore().accounts().next().ok_or_else(|| anyhow!("no accounts available in keystore"))?;
         let object = self
             .store()
             .owned_objects(*sender)

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -343,7 +343,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
 
         inner.store.insert_checkpoint(checkpoint.clone());
         inner.store.insert_checkpoint_contents(contents.clone());
-        self.process_data_ingestion_locked(&mut inner, checkpoint, contents)
+        self.process_data_ingestion_locked(&inner, checkpoint, contents)
             .unwrap();
         inner.epoch_state = new_epoch_state;
     }
@@ -462,7 +462,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         let contents = inner
             .store
             .get_checkpoint_contents(&checkpoint.content_digest);
-        self.process_data_ingestion_locked(&mut inner, checkpoint, contents.unwrap())
+        self.process_data_ingestion_locked(&inner, checkpoint, contents.unwrap())
             .unwrap();
     }
 

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -263,15 +263,11 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     /// This creates and executes a ConsensusCommitPrologue transaction which
     /// advances the chain Clock by the provided duration.
     pub fn advance_clock(&self, duration: std::time::Duration) -> TransactionEffects {
-        let epoch;
-        let round;
-        let timestamp_ms;
-        {
-            let mut inner = self.inner.write().unwrap();
-            epoch = inner.epoch_state.epoch();
-            round = inner.epoch_state.next_consensus_round();
-            timestamp_ms = inner.store.get_clock().timestamp_ms() + duration.as_millis() as u64;
-        }
+        let mut inner = self.inner.write().unwrap();
+        let epoch = inner.epoch_state.epoch();
+        let round = inner.epoch_state.next_consensus_round();
+        let timestamp_ms = inner.store.get_clock().timestamp_ms() + duration.as_millis() as u64;
+        drop(inner);
 
         let consensus_commit_prologue_transaction =
             VerifiedTransaction::new_consensus_commit_prologue_v1(
@@ -297,45 +293,26 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     /// NOTE: This function does not currently support updating the protocol
     /// version or the system packages
     pub fn advance_epoch(&self) {
-        let (
-            current_epoch,
-            next_epoch,
-            next_epoch_protocol_version,
-            storage_cost,
-            computation_cost,
-            computation_cost_burned,
-            storage_rebate,
-            non_refundable_storage_fee,
-            epoch_start_timestamp_ms,
-        ) = {
-            let inner = self.inner.read().unwrap();
-            let current_epoch = inner.epoch_state.epoch();
-            let next_epoch = current_epoch + 1;
-            let next_epoch_protocol_version = inner.epoch_state.protocol_version();
-            let gas_cost_summary = inner.checkpoint_builder.epoch_rolling_gas_cost_summary();
-            let epoch_start_timestamp_ms = inner.store.get_clock().timestamp_ms();
-            (
-                current_epoch,
-                next_epoch,
-                next_epoch_protocol_version,
-                gas_cost_summary.storage_cost,
-                gas_cost_summary.computation_cost,
-                gas_cost_summary.computation_cost_burned,
-                gas_cost_summary.storage_rebate,
-                gas_cost_summary.non_refundable_storage_fee,
-                epoch_start_timestamp_ms,
-            )
-        };
+        let inner = self.inner.read().unwrap();
+        let current_epoch = inner.epoch_state.epoch();
+        let next_epoch = current_epoch + 1;
+        let next_epoch_protocol_version = inner.epoch_state.protocol_version();
+        let gas_cost_summary = inner
+            .checkpoint_builder
+            .epoch_rolling_gas_cost_summary()
+            .clone();
+        let epoch_start_timestamp_ms = inner.store.get_clock().timestamp_ms();
+        drop(inner);
 
         let next_epoch_system_package_bytes = vec![];
         let kinds = vec![EndOfEpochTransactionKind::new_change_epoch_v3(
             next_epoch,
             next_epoch_protocol_version,
-            storage_cost,
-            computation_cost,
-            computation_cost_burned,
-            storage_rebate,
-            non_refundable_storage_fee,
+            gas_cost_summary.storage_cost,
+            gas_cost_summary.computation_cost,
+            gas_cost_summary.computation_cost_burned,
+            gas_cost_summary.storage_rebate,
+            gas_cost_summary.non_refundable_storage_fee,
             epoch_start_timestamp_ms,
             next_epoch_system_package_bytes,
             vec![],
@@ -645,18 +622,13 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::CheckpointContents>,
     > {
-        self.with_store(|store| {
-            let checkpoint = store.get_checkpoint_by_sequence_number(sequence_number);
-
-            match checkpoint {
-                None => Ok(None),
-                Some(checkpoint) => {
-                    let contents_digest = checkpoint.content_digest;
-                    let contents = store.get_checkpoint_contents_by_digest(&contents_digest);
-                    Ok(contents)
-                }
-            }
-        })
+        Ok(self.with_store(|store| {
+            store
+                .get_checkpoint_by_sequence_number(sequence_number)
+                .and_then(|checkpoint| {
+                    store.get_checkpoint_contents_by_digest(&checkpoint.content_digest)
+                })
+        }))
     }
 
     fn try_get_transaction(
@@ -687,24 +659,15 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
         Option<iota_types::messages_checkpoint::FullCheckpointContents>,
     > {
         self.with_store(|store| {
-            let checkpoint = store.get_checkpoint_by_sequence_number(sequence_number);
-
-            match checkpoint {
-                None => Ok(None),
-                Some(checkpoint) => {
-                    let contents_digest = checkpoint.content_digest;
-                    let contents = store.get_checkpoint_contents_by_digest(&contents_digest);
-
-                    if let Some(contents) = contents {
-                        iota_types::messages_checkpoint::FullCheckpointContents::try_from_checkpoint_contents(
-                            store,
-                            contents,
-                        )
-                    } else {
-                        Ok(None)
-                    }
-                }
-            }
+            store
+                .try_get_checkpoint_by_sequence_number(sequence_number)?
+                .and_then(|chk| store.get_checkpoint_contents_by_digest(&chk.content_digest))
+                .map_or(Ok(None), |contents| {
+                    iota_types::messages_checkpoint::FullCheckpointContents::try_from_checkpoint_contents(
+                        store,
+                        contents.clone(),
+                    )
+                })
         })
     }
 
@@ -715,15 +678,13 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
         Option<iota_types::messages_checkpoint::FullCheckpointContents>,
     > {
         self.with_store(|store| {
-            let contents = match store.get_checkpoint_contents_by_digest(digest) {
-                Some(c) => c,
-                None => return Ok(None),
-            };
-
-            iota_types::messages_checkpoint::FullCheckpointContents::try_from_checkpoint_contents(
-                store,
-                contents.clone(),
-            )
+            store.get_checkpoint_contents_by_digest(digest)
+            .map_or(Ok(None), |contents| {
+                iota_types::messages_checkpoint::FullCheckpointContents::try_from_checkpoint_contents(
+                    self,
+                    contents.clone(),
+                )
+            })
         })
     }
 }

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -13,9 +13,14 @@
 //! [`Simulacrum`]: crate::Simulacrum
 
 mod epoch_state;
+pub mod state_reader;
 pub mod store;
 
-use std::{num::NonZeroUsize, path::PathBuf, sync::Arc};
+use std::{
+    num::NonZeroUsize,
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
 
 use anyhow::{Result, anyhow};
 use fastcrypto::traits::Signer;
@@ -23,7 +28,6 @@ use iota_config::{
     genesis, transaction_deny_config::TransactionDenyConfig,
     verifier_signing_config::VerifierSigningConfig,
 };
-use iota_execution::Executor;
 use iota_protocol_config::ProtocolVersion;
 use iota_storage::blob::{Blob, BlobEncoding};
 use iota_swarm_config::{
@@ -33,7 +37,7 @@ use iota_swarm_config::{
 use iota_types::{
     base_types::{AuthorityName, IotaAddress, ObjectID, VersionNumber},
     committee::Committee,
-    crypto::AuthoritySignature,
+    crypto::{AuthoritySignature, KeypairTraits},
     digests::ConsensusCommitDigest,
     effects::TransactionEffects,
     error::ExecutionError,
@@ -68,6 +72,14 @@ use self::{epoch_state::EpochState, store::in_mem_store::KeyStore};
 ///
 /// [mod]: index.html
 pub struct Simulacrum<R = OsRng, Store: SimulatorStore = InMemoryStore> {
+    // Mutable state protected by RwLock for thread-safe interior mutability
+    inner: RwLock<SimulacrumInner<R, Store>>,
+    // Immutable config - can be accessed directly
+    deny_config: TransactionDenyConfig,
+    verifier_signing_config: VerifierSigningConfig,
+}
+
+struct SimulacrumInner<R, Store: SimulatorStore> {
     rng: R,
     keystore: KeyStore,
     #[expect(unused)]
@@ -77,11 +89,7 @@ pub struct Simulacrum<R = OsRng, Store: SimulatorStore = InMemoryStore> {
 
     // Epoch specific data
     epoch_state: EpochState,
-
-    // Other
-    deny_config: TransactionDenyConfig,
     data_ingestion_path: Option<PathBuf>,
-    verifier_signing_config: VerifierSigningConfig,
 }
 
 impl Simulacrum {
@@ -90,10 +98,6 @@ impl Simulacrum {
     #[expect(clippy::new_without_default)]
     pub fn new() -> Self {
         Self::new_with_rng(OsRng)
-    }
-
-    pub fn executor(&self) -> Arc<dyn Executor + Send + Sync> {
-        self.epoch_state.executor()
     }
 }
 
@@ -155,15 +159,17 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         let epoch_state = EpochState::new(genesis.iota_system_object());
 
         Self {
-            rng,
-            keystore,
-            genesis: genesis.clone(),
-            store,
-            checkpoint_builder,
-            epoch_state,
             deny_config: TransactionDenyConfig::default(),
             verifier_signing_config: VerifierSigningConfig::default(),
-            data_ingestion_path: None,
+            inner: RwLock::new(SimulacrumInner {
+                rng,
+                keystore,
+                genesis: genesis.clone(),
+                store,
+                checkpoint_builder,
+                epoch_state,
+                data_ingestion_path: None,
+            }),
         }
     }
 
@@ -181,15 +187,16 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     /// time `create_checkpoint` is called) and the corresponding
     /// TransactionEffects are returned.
     pub fn execute_transaction(
-        &mut self,
+        &self,
         transaction: Transaction,
     ) -> anyhow::Result<(TransactionEffects, Option<ExecutionError>)> {
+        let mut inner = self.inner.write().unwrap();
         let transaction = transaction
-            .try_into_verified_for_testing(self.epoch_state.epoch(), &VerifyParams::default())?;
+            .try_into_verified_for_testing(inner.epoch_state.epoch(), &VerifyParams::default())?;
 
         let (inner_temporary_store, _, effects, execution_error_opt) =
-            self.epoch_state.execute_transaction(
-                &self.store,
+            inner.epoch_state.execute_transaction(
+                &inner.store,
                 &self.deny_config,
                 &self.verifier_signing_config,
                 &transaction,
@@ -199,7 +206,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
             written, events, ..
         } = inner_temporary_store;
 
-        self.store.insert_executed_transaction(
+        inner.store.insert_executed_transaction(
             transaction.clone(),
             effects.clone(),
             events,
@@ -207,7 +214,8 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         );
 
         // Insert into checkpoint builder
-        self.checkpoint_builder
+        inner
+            .checkpoint_builder
             .push_transaction(transaction, effects.clone());
         Ok((effects, execution_error_opt.err()))
     }
@@ -220,8 +228,9 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         checks: iota_types::transaction_executor::VmChecks,
     ) -> iota_types::error::IotaResult<iota_types::transaction_executor::SimulateTransactionResult>
     {
-        self.epoch_state.simulate_transaction(
-            &self.store,
+        let inner = self.inner.read().unwrap();
+        inner.epoch_state.simulate_transaction(
+            &inner.store,
             &self.deny_config,
             &self.verifier_signing_config,
             transaction,
@@ -231,14 +240,18 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
 
     /// Creates the next Checkpoint using the Transactions enqueued since the
     /// last checkpoint was created.
-    pub fn create_checkpoint(&mut self) -> VerifiedCheckpoint {
-        let committee = CommitteeWithKeys::new(&self.keystore, self.epoch_state.committee());
-        let (checkpoint, contents, _) = self
-            .checkpoint_builder
-            .build(&committee, self.store.get_clock().timestamp_ms());
-        self.store.insert_checkpoint(checkpoint.clone());
-        self.store.insert_checkpoint_contents(contents.clone());
-        self.process_data_ingestion(checkpoint.clone(), contents)
+    pub fn create_checkpoint(&self) -> VerifiedCheckpoint {
+        let mut inner = self.inner.write().unwrap();
+        let (checkpoint, contents) = {
+            let committee = CommitteeWithKeys::new(&inner.keystore, inner.epoch_state.committee());
+            let timestamp_ms = inner.store.get_clock().timestamp_ms();
+            let (checkpoint, contents, _) =
+                inner.checkpoint_builder.build(&committee, timestamp_ms);
+            (checkpoint, contents)
+        };
+        inner.store.insert_checkpoint(checkpoint.clone());
+        inner.store.insert_checkpoint_contents(contents.clone());
+        self.process_data_ingestion_locked(&inner, checkpoint.clone(), contents)
             .unwrap();
         checkpoint
     }
@@ -247,10 +260,16 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     ///
     /// This creates and executes a ConsensusCommitPrologue transaction which
     /// advances the chain Clock by the provided duration.
-    pub fn advance_clock(&mut self, duration: std::time::Duration) -> TransactionEffects {
-        let epoch = self.epoch_state.epoch();
-        let round = self.epoch_state.next_consensus_round();
-        let timestamp_ms = self.store.get_clock().timestamp_ms() + duration.as_millis() as u64;
+    pub fn advance_clock(&self, duration: std::time::Duration) -> TransactionEffects {
+        let epoch;
+        let round;
+        let timestamp_ms;
+        {
+            let mut inner = self.inner.write().unwrap();
+            epoch = inner.epoch_state.epoch();
+            round = inner.epoch_state.next_consensus_round();
+            timestamp_ms = inner.store.get_clock().timestamp_ms() + duration.as_millis() as u64;
+        }
 
         let consensus_commit_prologue_transaction =
             VerifiedTransaction::new_consensus_commit_prologue_v1(
@@ -275,11 +294,12 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     ///
     /// NOTE: This function does not currently support updating the protocol
     /// version or the system packages
-    pub fn advance_epoch(&mut self) {
-        let next_epoch = self.epoch_state.epoch() + 1;
-        let next_epoch_protocol_version = self.epoch_state.protocol_version();
-        let gas_cost_summary = self.checkpoint_builder.epoch_rolling_gas_cost_summary();
-        let epoch_start_timestamp_ms = self.store.get_clock().timestamp_ms();
+    pub fn advance_epoch(&self) {
+        let inner = self.inner.write().unwrap();
+        let next_epoch = inner.epoch_state.epoch() + 1;
+        let next_epoch_protocol_version = inner.epoch_state.protocol_version();
+        let gas_cost_summary = inner.checkpoint_builder.epoch_rolling_gas_cost_summary();
+        let epoch_start_timestamp_ms = inner.store.get_clock().timestamp_ms();
         let next_epoch_system_package_bytes = vec![];
 
         let kinds = vec![EndOfEpochTransactionKind::new_change_epoch_v3(
@@ -296,10 +316,12 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         )];
 
         let tx = VerifiedTransaction::new_end_of_epoch_transaction(kinds);
+        drop(inner);
         self.execute_transaction(tx.into())
             .expect("advancing the epoch cannot fail");
 
-        let new_epoch_state = EpochState::new(self.store.get_system_state());
+        let mut inner = self.inner.write().unwrap();
+        let new_epoch_state = EpochState::new(inner.store.get_system_state());
         let end_of_epoch_data = EndOfEpochData {
             next_epoch_committee: new_epoch_state.committee().voting_rights.clone(),
             next_epoch_protocol_version,
@@ -307,45 +329,70 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
             // Do not simulate supply changes for now.
             epoch_supply_change: 0,
         };
-        let committee = CommitteeWithKeys::new(&self.keystore, self.epoch_state.committee());
-        let (checkpoint, contents, _) = self.checkpoint_builder.build_end_of_epoch(
-            &committee,
-            self.store.get_clock().timestamp_ms(),
-            next_epoch,
-            end_of_epoch_data,
-        );
+        let (checkpoint, contents, _) = {
+            let committee = CommitteeWithKeys::new(&inner.keystore, inner.epoch_state.committee());
+            let timestamp_ms = inner.store.get_clock().timestamp_ms();
+            inner.checkpoint_builder.build_end_of_epoch(
+                &committee,
+                timestamp_ms,
+                next_epoch,
+                end_of_epoch_data,
+            )
+        };
 
-        self.store.insert_checkpoint(checkpoint.clone());
-        self.store.insert_checkpoint_contents(contents.clone());
-        self.process_data_ingestion(checkpoint, contents).unwrap();
-        self.epoch_state = new_epoch_state;
+        inner.store.insert_checkpoint(checkpoint.clone());
+        inner.store.insert_checkpoint_contents(contents.clone());
+        self.process_data_ingestion_locked(&mut inner, checkpoint, contents)
+            .unwrap();
+        inner.epoch_state = new_epoch_state;
     }
 
-    pub fn store(&self) -> &dyn SimulatorStore {
-        &self.store
-    }
-
-    pub fn keystore(&self) -> &KeyStore {
-        &self.keystore
-    }
-
-    pub fn epoch_start_state(&self) -> &EpochStartSystemState {
-        self.epoch_state.epoch_start_state()
-    }
-
-    /// Return a handle to the internally held RNG.
+    /// Execute a function with read access to the store.
     ///
-    /// Returns a handle to the RNG used to create this Simulacrum for use as a
-    /// source of randomness. Using a seeded RNG to build a Simulacrum and
-    /// then utilizing the stored RNG as a source of randomness can lead to
-    /// a fully deterministic chain evolution.
-    pub fn rng(&mut self) -> &mut R {
-        &mut self.rng
+    /// This provides thread-safe access to the underlying store by locking it
+    /// for the duration of the closure execution.
+    pub fn with_store<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&S) -> T,
+    {
+        let inner = self.inner.read().unwrap();
+        f(&inner.store)
+    }
+
+    /// Execute a function with read access to the keystore.
+    ///
+    /// This provides thread-safe access to the keystore by locking it
+    /// for the duration of the closure execution.
+    pub fn with_keystore<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&KeyStore) -> T,
+    {
+        let inner = self.inner.read().unwrap();
+        f(&inner.keystore)
+    }
+
+    pub fn epoch_start_state(&self) -> EpochStartSystemState {
+        let inner = self.inner.read().unwrap();
+        inner.epoch_state.epoch_start_state()
+    }
+
+    /// Execute a function with mutable access to the internally held RNG.
+    ///
+    /// Provides mutable access to the RNG used to create this Simulacrum for
+    /// use as a source of randomness. Using a seeded RNG to build a
+    /// Simulacrum and then utilizing the stored RNG as a source of
+    /// randomness can lead to a fully deterministic chain evolution.
+    pub fn with_rng<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&mut R) -> T,
+    {
+        let mut inner = self.inner.write().unwrap();
+        f(&mut inner.rng)
     }
 
     /// Return the reference gas price for the current epoch
     pub fn reference_gas_price(&self) -> u64 {
-        self.epoch_state.reference_gas_price()
+        self.inner.read().unwrap().epoch_state.reference_gas_price()
     }
 
     /// Request that `amount` Nanos be sent to `address` from a faucet account.
@@ -363,20 +410,23 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     /// // ...
     /// # }
     /// ```
-    pub fn request_gas(&mut self, address: IotaAddress, amount: u64) -> Result<TransactionEffects> {
+    pub fn request_gas(&self, address: IotaAddress, amount: u64) -> Result<TransactionEffects> {
         // For right now we'll just use the first account as the `faucet` account. We
         // may want to explicitly cordon off the faucet account from the rest of
         // the accounts though.
-        let (sender, key) = self
-            .keystore()
-            .accounts()
-            .next()
-            .ok_or_else(|| anyhow!("no accounts available in keystore"))?;
+        let (sender, key) = self.with_keystore(|keystore| -> Result<(IotaAddress, _)> {
+            let (s, k) = keystore
+                .accounts()
+                .next()
+                .ok_or_else(|| anyhow!("no accounts available in keystore"))?;
+            Ok((*s, k.copy()))
+        })?;
+
         let object = self
-            .store()
-            .owned_objects(*sender)
-            .find(|object| {
-                object.is_gas_coin() && object.get_coin_value_unsafe() > amount + NANOS_PER_IOTA
+            .with_store(|store| {
+                store.owned_objects(sender).find(|object| {
+                    object.is_gas_coin() && object.get_coin_value_unsafe() > amount + NANOS_PER_IOTA
+                })
             })
             .ok_or_else(|| {
                 anyhow!("unable to find a coin with enough to satisfy request for {amount} Nanos")
@@ -384,7 +434,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
 
         let gas_data = iota_types::transaction::GasData {
             payment: vec![object.compute_object_reference()],
-            owner: *sender,
+            owner: sender,
             price: self.reference_gas_price(),
             budget: NANOS_PER_IOTA,
         };
@@ -398,19 +448,20 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
 
         let kind = iota_types::transaction::TransactionKind::ProgrammableTransaction(pt);
         let tx_data =
-            iota_types::transaction::TransactionData::new_with_gas_data(kind, *sender, gas_data);
-        let tx = Transaction::from_data_and_signer(tx_data, vec![key]);
+            iota_types::transaction::TransactionData::new_with_gas_data(kind, sender, gas_data);
+        let tx = Transaction::from_data_and_signer(tx_data, vec![&key]);
 
         self.execute_transaction(tx).map(|x| x.0)
     }
 
-    pub fn set_data_ingestion_path(&mut self, data_ingestion_path: PathBuf) {
-        self.data_ingestion_path = Some(data_ingestion_path);
-        let checkpoint = self.store.get_checkpoint_by_sequence_number(0).unwrap();
-        let contents = self
+    pub fn set_data_ingestion_path(&self, data_ingestion_path: PathBuf) {
+        let mut inner = self.inner.write().unwrap();
+        inner.data_ingestion_path = Some(data_ingestion_path);
+        let checkpoint = inner.store.get_checkpoint_by_sequence_number(0).unwrap();
+        let contents = inner
             .store
             .get_checkpoint_contents(&checkpoint.content_digest);
-        self.process_data_ingestion(checkpoint, contents.unwrap())
+        self.process_data_ingestion_locked(&mut inner, checkpoint, contents.unwrap())
             .unwrap();
     }
 
@@ -419,18 +470,23 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     /// generated checkpoint has the exact sequence number provided. This
     /// can be useful to generate checkpoints with specific sequence
     /// numbers. Monotonicity of checkpoint numbers is enforced strictly.
-    pub fn override_next_checkpoint_number(&mut self, number: CheckpointSequenceNumber) {
-        let committee = CommitteeWithKeys::new(&self.keystore, self.epoch_state.committee());
-        self.checkpoint_builder
+    pub fn override_next_checkpoint_number(&self, number: CheckpointSequenceNumber) {
+        let mut inner = self.inner.write().unwrap();
+        let committee = CommitteeWithKeys::new(&inner.keystore, inner.epoch_state.committee());
+        inner
+            .checkpoint_builder
             .override_next_checkpoint_number(number, &committee);
     }
 
-    fn process_data_ingestion(
+    /// Creates a CheckpointData structure from the provided checkpoint and
+    /// contents and writes it to disk if "data_ingestion_path" is set.
+    fn process_data_ingestion_locked(
         &self,
+        inner: &SimulacrumInner<R, S>,
         checkpoint: VerifiedCheckpoint,
         checkpoint_contents: CheckpointContents,
     ) -> anyhow::Result<()> {
-        if let Some(path) = &self.data_ingestion_path {
+        if let Some(path) = &inner.data_ingestion_path {
             let file_name = format!("{}.chk", checkpoint.sequence_number);
             let checkpoint_data = self.try_get_checkpoint_data(checkpoint, checkpoint_contents)?;
             std::fs::create_dir_all(path)?;
@@ -441,31 +497,31 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     }
 }
 
-pub struct CommitteeWithKeys<'a> {
-    keystore: &'a KeyStore,
-    committee: &'a Committee,
+pub struct CommitteeWithKeys {
+    keystore: KeyStore,
+    committee: Committee,
 }
 
-impl<'a> CommitteeWithKeys<'a> {
-    fn new(keystore: &'a KeyStore, committee: &'a Committee) -> Self {
+impl CommitteeWithKeys {
+    fn new(keystore: &KeyStore, committee: &Committee) -> Self {
         Self {
-            keystore,
-            committee,
+            keystore: keystore.clone(),
+            committee: committee.clone(),
         }
     }
 
     pub fn keystore(&self) -> &KeyStore {
-        self.keystore
+        &self.keystore
     }
 }
 
-impl ValidatorKeypairProvider for CommitteeWithKeys<'_> {
+impl ValidatorKeypairProvider for CommitteeWithKeys {
     fn get_validator_key(&self, name: &AuthorityName) -> &dyn Signer<AuthoritySignature> {
         self.keystore.validator(name).unwrap()
     }
 
     fn get_committee(&self) -> &Committee {
-        self.committee
+        &self.committee
     }
 }
 
@@ -474,7 +530,7 @@ impl<T, V: store::SimulatorStore> ObjectStore for Simulacrum<T, V> {
         &self,
         object_id: &ObjectID,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
-        Ok(store::SimulatorStore::get_object(&self.store, object_id))
+        self.with_store(|store| store.try_get_object(object_id))
     }
 
     fn try_get_object_by_key(
@@ -482,7 +538,7 @@ impl<T, V: store::SimulatorStore> ObjectStore for Simulacrum<T, V> {
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
-        self.store.try_get_object_by_key(object_id, version)
+        self.with_store(|store| store.try_get_object_by_key(object_id, version))
     }
 }
 
@@ -495,7 +551,7 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
     }
 
     fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        Ok(self.store().get_highest_checkpoint().unwrap())
+        Ok(self.with_store(|store| store.get_highest_checkpoint().unwrap()))
     }
 
     fn try_get_highest_verified_checkpoint(
@@ -523,16 +579,14 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
         &self,
         digest: &iota_types::messages_checkpoint::CheckpointDigest,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
-        Ok(self.store().get_checkpoint_by_digest(digest))
+        Ok(self.with_store(|store| store.get_checkpoint_by_digest(digest)))
     }
 
     fn try_get_checkpoint_by_sequence_number(
         &self,
         sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
-        Ok(self
-            .store()
-            .get_checkpoint_by_sequence_number(sequence_number))
+        Ok(self.with_store(|store| store.get_checkpoint_by_sequence_number(sequence_number)))
     }
 
     fn try_get_checkpoint_contents_by_digest(
@@ -541,7 +595,7 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::CheckpointContents>,
     > {
-        Ok(self.store().get_checkpoint_contents(digest))
+        Ok(self.with_store(|store| store.get_checkpoint_contents(digest)))
     }
 
     fn try_get_checkpoint_contents_by_sequence_number(
@@ -557,21 +611,23 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
         &self,
         tx_digest: &iota_types::digests::TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<Arc<VerifiedTransaction>>> {
-        Ok(self.store().get_transaction(tx_digest).map(Arc::new))
+        Ok(self
+            .with_store(|store| store.get_transaction(tx_digest))
+            .map(Arc::new))
     }
 
     fn try_get_transaction_effects(
         &self,
         tx_digest: &iota_types::digests::TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEffects>> {
-        Ok(self.store().get_transaction_effects(tx_digest))
+        Ok(self.with_store(|store| store.get_transaction_effects(tx_digest)))
     }
 
     fn try_get_events(
         &self,
         event_digest: &iota_types::digests::TransactionEventsDigest,
     ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEvents>> {
-        Ok(self.store().get_transaction_events(event_digest))
+        Ok(self.with_store(|store| store.get_transaction_events(event_digest)))
     }
 
     fn try_get_full_checkpoint_contents_by_sequence_number(
@@ -604,8 +660,7 @@ impl<T: Send + Sync, V: store::SimulatorStore + Send + Sync> RestStateReader for
         &self,
     ) -> iota_types::storage::error::Result<iota_types::digests::ChainIdentifier> {
         Ok(self
-            .store()
-            .get_checkpoint_by_sequence_number(0)
+            .with_store(|store| store.get_checkpoint_by_sequence_number(0))
             .unwrap()
             .digest()
             .to_owned()
@@ -639,17 +694,21 @@ impl Simulacrum {
     /// iota-test-transaction-builder by defining a trait
     /// that both WalletContext and Simulacrum implement. Then we can remove
     /// this function.
-    pub fn transfer_txn(&mut self, recipient: IotaAddress) -> (Transaction, u64) {
-        let (sender, key) = self.keystore().accounts().next().unwrap();
-        let sender = *sender;
+    pub fn transfer_txn(&self, recipient: IotaAddress) -> (Transaction, u64) {
+        let (sender, key) = self.with_keystore(|keystore| {
+            let (s, k) = keystore.accounts().next().unwrap();
+            (*s, k.copy())
+        });
 
-        let object = self
-            .store()
-            .owned_objects(sender)
-            .find(|object| object.is_gas_coin())
-            .unwrap();
-        let gas_coin = GasCoin::try_from(&object).unwrap();
-        let transfer_amount = gas_coin.value() / 2;
+        let (object, gas_coin_value) = self.with_store(|store| {
+            let object = store
+                .owned_objects(sender)
+                .find(|object| object.is_gas_coin())
+                .unwrap();
+            let gas_coin = GasCoin::try_from(object).unwrap();
+            (object.clone(), gas_coin.value())
+        });
+        let transfer_amount = gas_coin_value / 2;
 
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
@@ -665,7 +724,7 @@ impl Simulacrum {
             budget: 1_000_000_000,
         };
         let tx_data = TransactionData::new_with_gas_data(kind, sender, gas_data);
-        let tx = Transaction::from_data_and_signer(tx_data, vec![key]);
+        let tx = Transaction::from_data_and_signer(tx_data, vec![&key]);
         (tx, transfer_amount)
     }
 }
@@ -686,19 +745,13 @@ mod tests {
     fn deterministic_genesis() {
         let rng = StdRng::from_seed([9; 32]);
         let chain1 = Simulacrum::new_with_rng(rng);
-        let genesis_checkpoint_digest1 = *chain1
-            .store()
-            .get_checkpoint_by_sequence_number(0)
-            .unwrap()
-            .digest();
+        let genesis_checkpoint_digest1 = chain1
+            .with_store(|store| *store.get_checkpoint_by_sequence_number(0).unwrap().digest());
 
         let rng = StdRng::from_seed([9; 32]);
         let chain2 = Simulacrum::new_with_rng(rng);
-        let genesis_checkpoint_digest2 = *chain2
-            .store()
-            .get_checkpoint_by_sequence_number(0)
-            .unwrap()
-            .digest();
+        let genesis_checkpoint_digest2 = chain2
+            .with_store(|store| *store.get_checkpoint_by_sequence_number(0).unwrap().digest());
 
         assert_eq!(genesis_checkpoint_digest1, genesis_checkpoint_digest2);
 
@@ -706,10 +759,9 @@ mod tests {
         let rng = StdRng::from_seed([0; 32]);
         let chain3 = Simulacrum::new_with_rng(rng);
 
-        assert_ne!(
-            chain1.store().get_committee_by_epoch(0),
-            chain3.store().get_committee_by_epoch(0),
-        );
+        let committee1 = chain1.with_store(|store| store.get_committee_by_epoch(0));
+        let committee3 = chain3.with_store(|store| store.get_committee_by_epoch(0));
+        assert_ne!(committee1, committee3);
     }
 
     #[test]
@@ -717,18 +769,25 @@ mod tests {
         let steps = 10;
         let mut chain = Simulacrum::new();
 
-        let clock = chain.store().get_clock();
-        let start_time_ms = clock.timestamp_ms();
-        println!("clock: {clock:#?}");
+        let start_time_ms = chain.with_store(|store| {
+            let clock = store.get_clock();
+            println!("clock: {clock:#?}");
+            clock.timestamp_ms()
+        });
+
         for _ in 0..steps {
             chain.advance_clock(Duration::from_millis(1));
             chain.create_checkpoint();
-            let clock = chain.store().get_clock();
-            println!("clock: {clock:#?}");
+            chain.with_store(|store| {
+                let clock = store.get_clock();
+                println!("clock: {clock:#?}");
+            });
         }
-        let end_time_ms = chain.store().get_clock().timestamp_ms();
+        let end_time_ms = chain.with_store(|store| store.get_clock().timestamp_ms());
         assert_eq!(end_time_ms - start_time_ms, steps);
-        dbg!(chain.store().get_highest_checkpoint());
+        chain.with_store(|store| {
+            dbg!(store.get_highest_checkpoint());
+        });
     }
 
     #[test]
@@ -736,16 +795,18 @@ mod tests {
         let steps = 10;
         let mut chain = Simulacrum::new();
 
-        let start_epoch = chain.store.get_highest_checkpoint().unwrap().epoch;
+        let start_epoch = chain.with_store(|store| store.get_highest_checkpoint().unwrap().epoch);
         for i in 0..steps {
             chain.advance_epoch();
             chain.advance_clock(Duration::from_millis(1));
             chain.create_checkpoint();
             println!("{i}");
         }
-        let end_epoch = chain.store.get_highest_checkpoint().unwrap().epoch;
+        let end_epoch = chain.with_store(|store| store.get_highest_checkpoint().unwrap().epoch);
         assert_eq!(end_epoch - start_epoch, steps);
-        dbg!(chain.store().get_highest_checkpoint());
+        chain.with_store(|store| {
+            dbg!(store.get_highest_checkpoint());
+        });
     }
 
     #[test]
@@ -759,23 +820,25 @@ mod tests {
         let gas_summary = effects.gas_cost_summary();
         let gas_paid = gas_summary.net_gas_usage();
 
-        assert_eq!(
-            (transfer_amount as i64 - gas_paid) as u64,
-            store::SimulatorStore::get_object(sim.store(), &gas_id)
-                .and_then(|object| GasCoin::try_from(&object).ok())
-                .unwrap()
-                .value()
-        );
+        sim.with_store(|store| {
+            assert_eq!(
+                (transfer_amount as i64 - gas_paid) as u64,
+                store::SimulatorStore::get_object(store, &gas_id)
+                    .and_then(|object| GasCoin::try_from(&object).ok())
+                    .unwrap()
+                    .value()
+            );
 
-        assert_eq!(
-            transfer_amount,
-            sim.store()
-                .owned_objects(recipient)
-                .next()
-                .and_then(|object| GasCoin::try_from(&object).ok())
-                .unwrap()
-                .value()
-        );
+            assert_eq!(
+                transfer_amount,
+                store
+                    .owned_objects(recipient)
+                    .next()
+                    .and_then(|object| GasCoin::try_from(&object).ok())
+                    .unwrap()
+                    .value()
+            );
+        });
 
         let checkpoint = sim.create_checkpoint();
 

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -212,6 +212,23 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         Ok((effects, execution_error_opt.err()))
     }
 
+    /// Simulate a transaction without committing changes.
+    /// This is useful for testing transaction behavior without modifying state.
+    pub fn simulate_transaction(
+        &self,
+        transaction: TransactionData,
+        checks: iota_types::transaction_executor::VmChecks,
+    ) -> iota_types::error::IotaResult<iota_types::transaction_executor::SimulateTransactionResult>
+    {
+        self.epoch_state.simulate_transaction(
+            &self.store,
+            &self.deny_config,
+            &self.verifier_signing_config,
+            transaction,
+            checks,
+        )
+    }
+
     /// Creates the next Checkpoint using the Transactions enqueued since the
     /// last checkpoint was created.
     pub fn create_checkpoint(&mut self) -> VerifiedCheckpoint {
@@ -350,7 +367,11 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         // For right now we'll just use the first account as the `faucet` account. We
         // may want to explicitly cordon off the faucet account from the rest of
         // the accounts though.
-        let (sender, key) = self.keystore().accounts().next().ok_or_else(|| anyhow!("no accounts available in keystore"))?;
+        let (sender, key) = self
+            .keystore()
+            .accounts()
+            .next()
+            .ok_or_else(|| anyhow!("no accounts available in keystore"))?;
         let object = self
             .store()
             .owned_objects(*sender)

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -465,7 +465,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         let checkpoint = inner.store.get_checkpoint_by_sequence_number(0).unwrap();
         let contents = inner
             .store
-            .get_checkpoint_contents(&checkpoint.content_digest);
+            .get_checkpoint_contents_by_digest(&checkpoint.content_digest);
         self.process_data_ingestion_locked(&inner, checkpoint, contents.unwrap())
             .unwrap();
     }
@@ -562,13 +562,13 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
     fn try_get_highest_verified_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        todo!()
+        Ok(self.with_store(|store| store.get_highest_checkpoint().unwrap()))
     }
 
     fn try_get_highest_synced_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        todo!()
+        Ok(self.with_store(|store| store.get_highest_checkpoint().unwrap()))
     }
 
     fn try_get_lowest_available_checkpoint(
@@ -600,25 +600,34 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::CheckpointContents>,
     > {
-        Ok(self.with_store(|store| store.get_checkpoint_contents(digest)))
+        Ok(self.with_store(|store| store.get_checkpoint_contents_by_digest(digest)))
     }
 
     fn try_get_checkpoint_contents_by_sequence_number(
         &self,
-        _sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
+        sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::CheckpointContents>,
     > {
-        todo!()
+        self.with_store(|store| {
+            let checkpoint = store.get_checkpoint_by_sequence_number(sequence_number);
+
+            match checkpoint {
+                None => Ok(None),
+                Some(checkpoint) => {
+                    let contents_digest = checkpoint.content_digest;
+                    let contents = store.get_checkpoint_contents_by_digest(&contents_digest);
+                    Ok(contents)
+                }
+            }
+        })
     }
 
     fn try_get_transaction(
         &self,
         tx_digest: &iota_types::digests::TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<Arc<VerifiedTransaction>>> {
-        Ok(self
-            .with_store(|store| store.get_transaction(tx_digest))
-            .map(Arc::new))
+        Ok(self.with_store(|store| store.get_transaction(tx_digest)))
     }
 
     fn try_get_transaction_effects(
@@ -632,25 +641,54 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
         &self,
         event_digest: &iota_types::digests::TransactionEventsDigest,
     ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEvents>> {
-        Ok(self.with_store(|store| store.get_transaction_events(event_digest)))
+        Ok(self.with_store(|store| store.get_events(event_digest)))
     }
 
     fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
-        _sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
+        sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::FullCheckpointContents>,
     > {
-        todo!()
+        self.with_store(|store| {
+            let checkpoint = store.get_checkpoint_by_sequence_number(sequence_number);
+
+            match checkpoint {
+                None => Ok(None),
+                Some(checkpoint) => {
+                    let contents_digest = checkpoint.content_digest;
+                    let contents = store.get_checkpoint_contents_by_digest(&contents_digest);
+
+                    if let Some(contents) = contents {
+                        iota_types::messages_checkpoint::FullCheckpointContents::try_from_checkpoint_contents(
+                            store,
+                            contents,
+                        )
+                    } else {
+                        Ok(None)
+                    }
+                }
+            }
+        })
     }
 
     fn try_get_full_checkpoint_contents(
         &self,
-        _digest: &iota_types::messages_checkpoint::CheckpointContentsDigest,
+        digest: &iota_types::messages_checkpoint::CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::FullCheckpointContents>,
     > {
-        todo!()
+        self.with_store(|store| {
+            let contents = match store.get_checkpoint_contents_by_digest(digest) {
+                Some(c) => c,
+                None => return Ok(None),
+            };
+
+            iota_types::messages_checkpoint::FullCheckpointContents::try_from_checkpoint_contents(
+                store,
+                contents.clone(),
+            )
+        })
     }
 }
 
@@ -674,9 +712,13 @@ impl<T: Send + Sync, V: store::SimulatorStore + Send + Sync> RestStateReader for
 
     fn get_epoch_last_checkpoint(
         &self,
-        _epoch_id: iota_types::committee::EpochId,
+        epoch_id: iota_types::committee::EpochId,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
-        todo!()
+        Ok(self.with_store(|store| {
+            store
+                .get_last_checkpoint_of_epoch(epoch_id)
+                .and_then(|seq| self.get_checkpoint_by_sequence_number(seq))
+        }))
     }
 
     fn indexes(&self) -> Option<&dyn iota_types::storage::RestIndexes> {

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -740,7 +740,7 @@ impl<T: Send + Sync, V: store::SimulatorStore + Send + Sync> RestStateReader for
     ) -> iota_types::storage::error::Result<iota_types::digests::ChainIdentifier> {
         Ok(self
             .with_store(|store| store.get_checkpoint_by_sequence_number(0))
-            .unwrap()
+            .expect("lowest available checkpoint should exist")
             .digest()
             .to_owned()
             .into())

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -297,7 +297,8 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     /// version or the system packages
     pub fn advance_epoch(&self) {
         let inner = self.inner.write().unwrap();
-        let next_epoch = inner.epoch_state.epoch() + 1;
+        let current_epoch = inner.epoch_state.epoch();
+        let next_epoch = current_epoch + 1;
         let next_epoch_protocol_version = inner.epoch_state.protocol_version();
         let gas_cost_summary = inner.checkpoint_builder.epoch_rolling_gas_cost_summary();
         let epoch_start_timestamp_ms = inner.store.get_clock().timestamp_ms();
@@ -343,6 +344,9 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
 
         inner.store.insert_checkpoint(checkpoint.clone());
         inner.store.insert_checkpoint_contents(contents.clone());
+        inner
+            .store
+            .update_last_checkpoint_of_epoch(current_epoch, *checkpoint.sequence_number());
         self.process_data_ingestion_locked(&inner, checkpoint, contents)
             .unwrap();
         inner.epoch_state = new_epoch_state;

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -242,17 +242,18 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     /// Creates the next Checkpoint using the Transactions enqueued since the
     /// last checkpoint was created.
     pub fn create_checkpoint(&self) -> VerifiedCheckpoint {
-        let mut inner = self.inner.write().unwrap();
         let (checkpoint, contents) = {
+            let mut inner = self.inner.write().unwrap();
             let committee = CommitteeWithKeys::new(&inner.keystore, inner.epoch_state.committee());
             let timestamp_ms = inner.store.get_clock().timestamp_ms();
             let (checkpoint, contents, _) =
                 inner.checkpoint_builder.build(&committee, timestamp_ms);
+            inner.store.insert_checkpoint(checkpoint.clone());
+            inner.store.insert_checkpoint_contents(contents.clone());
             (checkpoint, contents)
         };
-        inner.store.insert_checkpoint(checkpoint.clone());
-        inner.store.insert_checkpoint_contents(contents.clone());
-        self.process_data_ingestion_locked(&inner, checkpoint.clone(), contents)
+        // Release lock before expensive data ingestion operation
+        self.process_data_ingestion(checkpoint.clone(), contents)
             .unwrap();
         checkpoint
     }
@@ -296,59 +297,89 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     /// NOTE: This function does not currently support updating the protocol
     /// version or the system packages
     pub fn advance_epoch(&self) {
-        let inner = self.inner.write().unwrap();
-        let current_epoch = inner.epoch_state.epoch();
-        let next_epoch = current_epoch + 1;
-        let next_epoch_protocol_version = inner.epoch_state.protocol_version();
-        let gas_cost_summary = inner.checkpoint_builder.epoch_rolling_gas_cost_summary();
-        let epoch_start_timestamp_ms = inner.store.get_clock().timestamp_ms();
-        let next_epoch_system_package_bytes = vec![];
+        let (
+            current_epoch,
+            next_epoch,
+            next_epoch_protocol_version,
+            storage_cost,
+            computation_cost,
+            computation_cost_burned,
+            storage_rebate,
+            non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+        ) = {
+            let inner = self.inner.read().unwrap();
+            let current_epoch = inner.epoch_state.epoch();
+            let next_epoch = current_epoch + 1;
+            let next_epoch_protocol_version = inner.epoch_state.protocol_version();
+            let gas_cost_summary = inner.checkpoint_builder.epoch_rolling_gas_cost_summary();
+            let epoch_start_timestamp_ms = inner.store.get_clock().timestamp_ms();
+            (
+                current_epoch,
+                next_epoch,
+                next_epoch_protocol_version,
+                gas_cost_summary.storage_cost,
+                gas_cost_summary.computation_cost,
+                gas_cost_summary.computation_cost_burned,
+                gas_cost_summary.storage_rebate,
+                gas_cost_summary.non_refundable_storage_fee,
+                epoch_start_timestamp_ms,
+            )
+        };
 
+        let next_epoch_system_package_bytes = vec![];
         let kinds = vec![EndOfEpochTransactionKind::new_change_epoch_v3(
             next_epoch,
             next_epoch_protocol_version,
-            gas_cost_summary.storage_cost,
-            gas_cost_summary.computation_cost,
-            gas_cost_summary.computation_cost_burned,
-            gas_cost_summary.storage_rebate,
-            gas_cost_summary.non_refundable_storage_fee,
+            storage_cost,
+            computation_cost,
+            computation_cost_burned,
+            storage_rebate,
+            non_refundable_storage_fee,
             epoch_start_timestamp_ms,
             next_epoch_system_package_bytes,
             vec![],
         )];
 
         let tx = VerifiedTransaction::new_end_of_epoch_transaction(kinds);
-        drop(inner);
         self.execute_transaction(tx.into())
             .expect("advancing the epoch cannot fail");
 
-        let mut inner = self.inner.write().unwrap();
-        let new_epoch_state = EpochState::new(inner.store.get_system_state());
-        let end_of_epoch_data = EndOfEpochData {
-            next_epoch_committee: new_epoch_state.committee().voting_rights.clone(),
-            next_epoch_protocol_version,
-            epoch_commitments: vec![],
-            // Do not simulate supply changes for now.
-            epoch_supply_change: 0,
-        };
-        let (checkpoint, contents, _) = {
-            let committee = CommitteeWithKeys::new(&inner.keystore, inner.epoch_state.committee());
-            let timestamp_ms = inner.store.get_clock().timestamp_ms();
-            inner.checkpoint_builder.build_end_of_epoch(
-                &committee,
-                timestamp_ms,
-                next_epoch,
-                end_of_epoch_data,
-            )
+        let (checkpoint, contents, new_epoch_state) = {
+            let mut inner = self.inner.write().unwrap();
+            let new_epoch_state = EpochState::new(inner.store.get_system_state());
+            let end_of_epoch_data = EndOfEpochData {
+                next_epoch_committee: new_epoch_state.committee().voting_rights.clone(),
+                next_epoch_protocol_version,
+                epoch_commitments: vec![],
+                // Do not simulate supply changes for now.
+                epoch_supply_change: 0,
+            };
+            let (checkpoint, contents, _) = {
+                let committee =
+                    CommitteeWithKeys::new(&inner.keystore, inner.epoch_state.committee());
+                let timestamp_ms = inner.store.get_clock().timestamp_ms();
+                inner.checkpoint_builder.build_end_of_epoch(
+                    &committee,
+                    timestamp_ms,
+                    next_epoch,
+                    end_of_epoch_data,
+                )
+            };
+
+            inner.store.insert_checkpoint(checkpoint.clone());
+            inner.store.insert_checkpoint_contents(contents.clone());
+            inner
+                .store
+                .update_last_checkpoint_of_epoch(current_epoch, *checkpoint.sequence_number());
+            (checkpoint, contents, new_epoch_state)
         };
 
-        inner.store.insert_checkpoint(checkpoint.clone());
-        inner.store.insert_checkpoint_contents(contents.clone());
-        inner
-            .store
-            .update_last_checkpoint_of_epoch(current_epoch, *checkpoint.sequence_number());
-        self.process_data_ingestion_locked(&inner, checkpoint, contents)
-            .unwrap();
+        // Process data ingestion without holding the lock
+        self.process_data_ingestion(checkpoint, contents).unwrap();
+
+        // Finally, update the epoch state
+        let mut inner = self.inner.write().unwrap();
         inner.epoch_state = new_epoch_state;
     }
 
@@ -460,14 +491,19 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     }
 
     pub fn set_data_ingestion_path(&self, data_ingestion_path: PathBuf) {
-        let mut inner = self.inner.write().unwrap();
-        inner.data_ingestion_path = Some(data_ingestion_path);
-        let checkpoint = inner.store.get_checkpoint_by_sequence_number(0).unwrap();
-        let contents = inner
-            .store
-            .get_checkpoint_contents_by_digest(&checkpoint.content_digest);
-        self.process_data_ingestion_locked(&inner, checkpoint, contents.unwrap())
-            .unwrap();
+        let checkpoint = {
+            let mut inner = self.inner.write().unwrap();
+            inner.data_ingestion_path = Some(data_ingestion_path);
+            let checkpoint = inner.store.get_checkpoint_by_sequence_number(0).unwrap();
+            let contents = inner
+                .store
+                .get_checkpoint_contents_by_digest(&checkpoint.content_digest);
+            (checkpoint, contents)
+        };
+        // Release lock before expensive data ingestion operation
+        if let (checkpoint, Some(contents)) = checkpoint {
+            self.process_data_ingestion(checkpoint, contents).unwrap();
+        }
     }
 
     /// Overrides the next checkpoint number indirectly by setting the previous
@@ -483,20 +519,20 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
             .override_next_checkpoint_number(number, &committee);
     }
 
-    /// Creates a CheckpointData structure from the provided checkpoint and
-    /// contents and writes it to disk if "data_ingestion_path" is set.
-    fn process_data_ingestion_locked(
+    /// Process data ingestion without holding the inner lock.
+    /// This version should be used when you don't already hold the lock.
+    fn process_data_ingestion(
         &self,
-        inner: &SimulacrumInner<R, S>,
         checkpoint: VerifiedCheckpoint,
         checkpoint_contents: CheckpointContents,
     ) -> anyhow::Result<()> {
-        if let Some(path) = &inner.data_ingestion_path {
+        let path = self.inner.read().unwrap().data_ingestion_path.clone();
+        if let Some(data_path) = path {
             let file_name = format!("{}.chk", checkpoint.sequence_number);
             let checkpoint_data = self.try_get_checkpoint_data(checkpoint, checkpoint_contents)?;
-            std::fs::create_dir_all(path)?;
+            std::fs::create_dir_all(&data_path)?;
             let blob = Blob::encode(&checkpoint_data, BlobEncoding::Bcs)?;
-            std::fs::write(path.join(file_name), blob.to_bytes())?;
+            std::fs::write(data_path.join(file_name), blob.to_bytes())?;
         }
         Ok(())
     }

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -15,6 +15,7 @@
 mod epoch_state;
 pub mod state_reader;
 pub mod store;
+pub mod transaction_executor;
 
 use std::{
     num::NonZeroUsize,
@@ -759,33 +760,33 @@ mod tests {
         let rng = StdRng::from_seed([0; 32]);
         let chain3 = Simulacrum::new_with_rng(rng);
 
-        let committee1 = chain1.with_store(|store| store.get_committee_by_epoch(0));
-        let committee3 = chain3.with_store(|store| store.get_committee_by_epoch(0));
+        let committee1 = chain1.with_store(|store| store.get_committee_by_epoch(0).cloned());
+        let committee3 = chain3.with_store(|store| store.get_committee_by_epoch(0).cloned());
         assert_ne!(committee1, committee3);
     }
 
     #[test]
     fn simple() {
         let steps = 10;
-        let mut chain = Simulacrum::new();
+        let sim = Simulacrum::new();
 
-        let start_time_ms = chain.with_store(|store| {
+        let start_time_ms = sim.with_store(|store| {
             let clock = store.get_clock();
             println!("clock: {clock:#?}");
             clock.timestamp_ms()
         });
 
         for _ in 0..steps {
-            chain.advance_clock(Duration::from_millis(1));
-            chain.create_checkpoint();
-            chain.with_store(|store| {
+            sim.advance_clock(Duration::from_millis(1));
+            sim.create_checkpoint();
+            sim.with_store(|store| {
                 let clock = store.get_clock();
                 println!("clock: {clock:#?}");
             });
         }
-        let end_time_ms = chain.with_store(|store| store.get_clock().timestamp_ms());
+        let end_time_ms = sim.with_store(|store| store.get_clock().timestamp_ms());
         assert_eq!(end_time_ms - start_time_ms, steps);
-        chain.with_store(|store| {
+        sim.with_store(|store| {
             dbg!(store.get_highest_checkpoint());
         });
     }
@@ -793,25 +794,25 @@ mod tests {
     #[test]
     fn simple_epoch() {
         let steps = 10;
-        let mut chain = Simulacrum::new();
+        let sim = Simulacrum::new();
 
-        let start_epoch = chain.with_store(|store| store.get_highest_checkpoint().unwrap().epoch);
+        let start_epoch = sim.with_store(|store| store.get_highest_checkpoint().unwrap().epoch);
         for i in 0..steps {
-            chain.advance_epoch();
-            chain.advance_clock(Duration::from_millis(1));
-            chain.create_checkpoint();
+            sim.advance_epoch();
+            sim.advance_clock(Duration::from_millis(1));
+            sim.create_checkpoint();
             println!("{i}");
         }
-        let end_epoch = chain.with_store(|store| store.get_highest_checkpoint().unwrap().epoch);
+        let end_epoch = sim.with_store(|store| store.get_highest_checkpoint().unwrap().epoch);
         assert_eq!(end_epoch - start_epoch, steps);
-        chain.with_store(|store| {
+        sim.with_store(|store| {
             dbg!(store.get_highest_checkpoint());
         });
     }
 
     #[test]
     fn transfer() {
-        let mut sim = Simulacrum::new();
+        let sim = Simulacrum::new();
         let recipient = IotaAddress::random_for_testing_only();
         let (tx, transfer_amount) = sim.transfer_txn(recipient);
 
@@ -834,7 +835,7 @@ mod tests {
                 store
                     .owned_objects(recipient)
                     .next()
-                    .and_then(|object| GasCoin::try_from(&object).ok())
+                    .and_then(|object| GasCoin::try_from(object).ok())
                     .unwrap()
                     .value()
             );

--- a/crates/simulacrum/src/state_reader.rs
+++ b/crates/simulacrum/src/state_reader.rs
@@ -172,7 +172,6 @@ impl GrpcStateReader for SimulacrumGrpcReader {
     }
 
     fn get_transaction_checkpoint(&self, digest: &TransactionDigest) -> Option<u64> {
-        // TODO: Do we want to implement an index for this?
         self.simulacrum.with_store(|store| {
             let highest_seq = store
                 .get_highest_checkpoint()

--- a/crates/simulacrum/src/state_reader.rs
+++ b/crates/simulacrum/src/state_reader.rs
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! gRPC State Reader for Simulacrum
+//!
+//! This module provides a GrpcStateReader implementation that can read from
+//! simulacrum state without requiring mutable access in most cases.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use iota_grpc_server::GrpcStateReader;
+use iota_types::{
+    TypeTag,
+    base_types::{ObjectID, VersionNumber},
+    committee::Committee,
+    digests::{ChainIdentifier, TransactionDigest, TransactionEventsDigest},
+    effects::{TransactionEffects, TransactionEvents},
+    full_checkpoint_content::CheckpointData,
+    iota_system_state::{
+        IotaSystemState, epoch_start_iota_system_state::EpochStartSystemStateTrait,
+    },
+    messages_checkpoint::CertifiedCheckpointSummary,
+    object::Object,
+    storage::EpochInfo,
+    transaction::VerifiedTransaction,
+};
+use move_core_types::annotated_value::MoveTypeLayout;
+
+use crate::Simulacrum;
+
+/// GrpcStateReader implementation that works with simulacrum
+pub struct SimulacrumGrpcReader {
+    simulacrum: Arc<Simulacrum>,
+    chain_id: ChainIdentifier,
+}
+
+impl SimulacrumGrpcReader {
+    pub fn new(simulacrum: Arc<Simulacrum>, chain_id: ChainIdentifier) -> Self {
+        Self {
+            simulacrum,
+            chain_id,
+        }
+    }
+}
+
+impl GrpcStateReader for SimulacrumGrpcReader {
+    fn get_chain_identifier(&self) -> Result<ChainIdentifier> {
+        Ok(self.chain_id)
+    }
+
+    fn get_latest_checkpoint_sequence_number(&self) -> Option<u64> {
+        self.simulacrum.with_store(|store| {
+            store
+                .get_highest_checkpoint()
+                .map(|checkpoint| *checkpoint.sequence_number())
+        })
+    }
+
+    fn get_checkpoint_summary(&self, seq: u64) -> Option<CertifiedCheckpointSummary> {
+        self.simulacrum.with_store(|store| {
+            store
+                .get_checkpoint_by_sequence_number(seq)
+                .cloned()
+                .map(CertifiedCheckpointSummary::from)
+        })
+    }
+
+    fn get_checkpoint_data(&self, seq: u64) -> Option<CheckpointData> {
+        let checkpoint = self
+            .simulacrum
+            .with_store(|store| store.get_checkpoint_by_sequence_number(seq).cloned())?;
+
+        let contents = self.simulacrum.with_store(|store| {
+            store
+                .get_checkpoint_contents(&checkpoint.content_digest)
+                .cloned()
+        })?;
+
+        Some(CheckpointData {
+            checkpoint_summary: CertifiedCheckpointSummary::from(checkpoint),
+            checkpoint_contents: contents,
+            // TODO: we should return the transactions as well
+            transactions: vec![],
+        })
+    }
+
+    fn get_epoch_last_checkpoint(&self, epoch: u64) -> Result<Option<CertifiedCheckpointSummary>> {
+        // Simple implementation for simulacrum - find the last checkpoint of the given
+        // epoch
+        // TODO: optimize that by storing epoch -> last checkpoint mapping
+        let latest_seq = self
+            .simulacrum
+            .with_store(|store| {
+                store
+                    .get_highest_checkpoint()
+                    .map(|checkpoint| *checkpoint.sequence_number())
+            })
+            .unwrap_or(0);
+
+        for seq in (0..=latest_seq).rev() {
+            if let Some(checkpoint) = self
+                .simulacrum
+                .with_store(|store| store.get_checkpoint_by_sequence_number(seq).cloned())
+            {
+                if checkpoint.epoch() == epoch {
+                    return Ok(Some(CertifiedCheckpointSummary::from(checkpoint)));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    fn get_lowest_available_checkpoint(&self) -> Result<u64> {
+        // Simulacrum starts from checkpoint 0
+        Ok(0)
+    }
+
+    fn get_lowest_available_checkpoint_objects(&self) -> Result<u64> {
+        // Simulacrum has all objects from the beginning
+        Ok(0)
+    }
+
+    fn get_object(&self, object_id: &ObjectID) -> Option<Object> {
+        self.simulacrum
+            .with_store(|store| store.get_object(object_id).cloned())
+    }
+
+    fn get_object_by_key(&self, object_id: &ObjectID, version: VersionNumber) -> Option<Object> {
+        self.simulacrum
+            .with_store(|store| store.get_object_at_version(object_id, version).cloned())
+    }
+
+    fn get_committee(&self, epoch: u64) -> Result<Option<Arc<Committee>>> {
+        let current_epoch = self.simulacrum.with_store(|store| {
+            store
+                .get_highest_checkpoint()
+                .map(|cp| cp.epoch())
+                .unwrap_or(0)
+        });
+
+        if epoch == current_epoch {
+            let epoch_start_state = self.simulacrum.epoch_start_state();
+            Ok(Some(Arc::new(epoch_start_state.get_iota_committee())))
+        } else {
+            // TODO: implement
+            Ok(None)
+        }
+    }
+
+    fn get_system_state(&self) -> Result<IotaSystemState> {
+        Ok(self.simulacrum.with_store(|store| store.get_system_state()))
+    }
+
+    fn get_epoch_info(&self, _epoch: u64) -> Option<EpochInfo> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        None
+    }
+
+    fn get_type_layout(&self, _type_tag: &TypeTag) -> Result<Option<MoveTypeLayout>> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        Ok(None)
+    }
+
+    fn get_transaction(&self, _digest: &TransactionDigest) -> Option<Arc<VerifiedTransaction>> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        None
+    }
+
+    fn get_transaction_effects(&self, _digest: &TransactionDigest) -> Option<TransactionEffects> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        None
+    }
+
+    fn get_transaction_events(
+        &self,
+        _digest: &TransactionEventsDigest,
+    ) -> Option<TransactionEvents> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        None
+    }
+
+    fn get_transaction_checkpoint(&self, _digest: &TransactionDigest) -> Option<u64> {
+        // Not implemented for simulacrum gRPC reader
+        // TODO: implement
+        None
+    }
+}

--- a/crates/simulacrum/src/state_reader.rs
+++ b/crates/simulacrum/src/state_reader.rs
@@ -67,18 +67,14 @@ impl GrpcStateReader for SimulacrumGrpcReader {
     fn get_checkpoint_data(&self, seq: u64) -> Option<CheckpointData> {
         self.simulacrum
             .with_store(|store| match store.get_checkpoint_by_sequence_number(seq) {
-                None => return None,
+                None => None,
                 Some(checkpoint) => {
-                    let Some(contents) = store
+                    let contents = store
                         .get_checkpoint_contents(&checkpoint.content_digest)
-                        .cloned()
-                    else {
-                        return None;
-                    };
-                    match store.try_get_checkpoint_data(checkpoint.clone(), contents) {
-                        Ok(data) => Some(data),
-                        Err(_) => None,
-                    }
+                        .cloned()?;
+                    store
+                        .try_get_checkpoint_data(checkpoint.clone(), contents)
+                        .ok()
                 }
             })
     }

--- a/crates/simulacrum/src/state_reader.rs
+++ b/crates/simulacrum/src/state_reader.rs
@@ -17,12 +17,10 @@ use iota_types::{
     digests::{ChainIdentifier, TransactionDigest, TransactionEventsDigest},
     effects::{TransactionEffects, TransactionEvents},
     full_checkpoint_content::CheckpointData,
-    iota_system_state::{
-        IotaSystemState, epoch_start_iota_system_state::EpochStartSystemStateTrait,
-    },
+    iota_system_state::{IotaSystemState, IotaSystemStateTrait},
     messages_checkpoint::CertifiedCheckpointSummary,
     object::Object,
-    storage::EpochInfo,
+    storage::{EpochInfo, ReadStore, RestStateReader},
     transaction::VerifiedTransaction,
 };
 use move_core_types::annotated_value::MoveTypeLayout;
@@ -67,48 +65,32 @@ impl GrpcStateReader for SimulacrumGrpcReader {
     }
 
     fn get_checkpoint_data(&self, seq: u64) -> Option<CheckpointData> {
-        let checkpoint = self
-            .simulacrum
-            .with_store(|store| store.get_checkpoint_by_sequence_number(seq).cloned())?;
-
-        let contents = self.simulacrum.with_store(|store| {
-            store
-                .get_checkpoint_contents(&checkpoint.content_digest)
-                .cloned()
-        })?;
-
-        Some(CheckpointData {
-            checkpoint_summary: CertifiedCheckpointSummary::from(checkpoint),
-            checkpoint_contents: contents,
-            // TODO: we should return the transactions as well
-            transactions: vec![],
-        })
+        self.simulacrum
+            .with_store(|store| match store.get_checkpoint_by_sequence_number(seq) {
+                None => return None,
+                Some(checkpoint) => {
+                    let Some(contents) = store
+                        .get_checkpoint_contents(&checkpoint.content_digest)
+                        .cloned()
+                    else {
+                        return None;
+                    };
+                    match store.try_get_checkpoint_data(checkpoint.clone(), contents) {
+                        Ok(data) => Some(data),
+                        Err(_) => None,
+                    }
+                }
+            })
     }
 
     fn get_epoch_last_checkpoint(&self, epoch: u64) -> Result<Option<CertifiedCheckpointSummary>> {
-        // Simple implementation for simulacrum - find the last checkpoint of the given
-        // epoch
-        // TODO: optimize that by storing epoch -> last checkpoint mapping
-        let latest_seq = self
-            .simulacrum
-            .with_store(|store| {
-                store
-                    .get_highest_checkpoint()
-                    .map(|checkpoint| *checkpoint.sequence_number())
-            })
-            .unwrap_or(0);
-
-        for seq in (0..=latest_seq).rev() {
-            if let Some(checkpoint) = self
-                .simulacrum
-                .with_store(|store| store.get_checkpoint_by_sequence_number(seq).cloned())
-            {
-                if checkpoint.epoch() == epoch {
-                    return Ok(Some(CertifiedCheckpointSummary::from(checkpoint)));
-                }
-            }
-        }
-        Ok(None)
+        let summary = self.simulacrum.with_store(|store| {
+            store
+                .get_last_checkpoint_of_epoch(epoch)
+                .and_then(|seq| store.get_checkpoint_by_sequence_number(seq).cloned())
+                .map(CertifiedCheckpointSummary::from)
+        });
+        Ok(summary)
     }
 
     fn get_lowest_available_checkpoint(&self) -> Result<u64> {
@@ -132,62 +114,91 @@ impl GrpcStateReader for SimulacrumGrpcReader {
     }
 
     fn get_committee(&self, epoch: u64) -> Result<Option<Arc<Committee>>> {
-        let current_epoch = self.simulacrum.with_store(|store| {
-            store
-                .get_highest_checkpoint()
-                .map(|cp| cp.epoch())
-                .unwrap_or(0)
-        });
-
-        if epoch == current_epoch {
-            let epoch_start_state = self.simulacrum.epoch_start_state();
-            Ok(Some(Arc::new(epoch_start_state.get_iota_committee())))
-        } else {
-            // TODO: implement
-            Ok(None)
-        }
+        Ok(self
+            .simulacrum
+            .with_store(|store| store.get_committee_by_epoch(epoch).cloned())
+            .map(Arc::new))
     }
 
     fn get_system_state(&self) -> Result<IotaSystemState> {
         Ok(self.simulacrum.with_store(|store| store.get_system_state()))
     }
 
-    fn get_epoch_info(&self, _epoch: u64) -> Option<EpochInfo> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        None
+    fn get_epoch_info(&self, epoch: u64) -> Option<EpochInfo> {
+        self.simulacrum.with_store(|store| {
+            // Get the start checkpoint of the epoch
+            let start_checkpoint_seq = store
+                .get_last_checkpoint_of_epoch(epoch - 1)
+                .map(|seq| seq + 1)
+                .unwrap_or(0);
+
+            let start_checkpoint = store
+                .get_checkpoint_by_sequence_number(start_checkpoint_seq)
+                .cloned()?;
+
+            let system_state = store.get_system_state();
+
+            Some(EpochInfo {
+                epoch,
+                protocol_version: system_state.protocol_version(),
+                start_timestamp_ms: start_checkpoint.data().timestamp_ms,
+                end_timestamp_ms: None,
+                start_checkpoint: start_checkpoint_seq,
+                end_checkpoint: None,
+                reference_gas_price: system_state.reference_gas_price(),
+                system_state,
+            })
+        })
     }
 
-    fn get_type_layout(&self, _type_tag: &TypeTag) -> Result<Option<MoveTypeLayout>> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        Ok(None)
+    fn get_type_layout(&self, type_tag: &TypeTag) -> Result<Option<MoveTypeLayout>> {
+        self.simulacrum
+            .get_type_layout(type_tag)
+            .map_err(Into::into)
     }
 
-    fn get_transaction(&self, _digest: &TransactionDigest) -> Option<Arc<VerifiedTransaction>> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        None
+    fn get_transaction(&self, digest: &TransactionDigest) -> Option<Arc<VerifiedTransaction>> {
+        self.simulacrum
+            .with_store(|store| store.get_transaction(digest).cloned().map(Arc::new))
     }
 
-    fn get_transaction_effects(&self, _digest: &TransactionDigest) -> Option<TransactionEffects> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        None
+    fn get_transaction_effects(&self, digest: &TransactionDigest) -> Option<TransactionEffects> {
+        self.simulacrum
+            .with_store(|store| store.get_transaction_effects(digest).cloned())
     }
 
     fn get_transaction_events(
         &self,
-        _digest: &TransactionEventsDigest,
+        digest: &TransactionEventsDigest,
     ) -> Option<TransactionEvents> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        None
+        self.simulacrum
+            .with_store(|store| store.get_transaction_events(digest).cloned())
     }
 
-    fn get_transaction_checkpoint(&self, _digest: &TransactionDigest) -> Option<u64> {
-        // Not implemented for simulacrum gRPC reader
-        // TODO: implement
-        None
+    fn get_transaction_checkpoint(&self, digest: &TransactionDigest) -> Option<u64> {
+        // TODO: Do we want to implement an index for this?
+        self.simulacrum.with_store(|store| {
+            let highest_seq = store
+                .get_highest_checkpoint()
+                .map(|cp| *cp.sequence_number())?;
+
+            // Search backwards from the highest checkpoint to find the transaction
+            for seq in (0..=highest_seq).rev() {
+                if let Some(checkpoint) = store.get_checkpoint_by_sequence_number(seq) {
+                    if let Some(contents) =
+                        store.get_checkpoint_contents(&checkpoint.content_digest)
+                    {
+                        // Check if this checkpoint contains the transaction
+                        if contents
+                            .iter()
+                            .any(|exec_digests| exec_digests.transaction == *digest)
+                        {
+                            return Some(*checkpoint.sequence_number());
+                        }
+                    }
+                }
+            }
+            None
+        })
     }
 }

--- a/crates/simulacrum/src/store/in_mem_store.rs
+++ b/crates/simulacrum/src/store/in_mem_store.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 
 use iota_config::genesis;
 use iota_types::{
@@ -18,8 +21,8 @@ use iota_types::{
     },
     object::{Object, Owner},
     storage::{
-        BackingPackageStore, ChildObjectResolver, ObjectStore, PackageObject, get_module,
-        load_package_object_from_object_store,
+        BackingPackageStore, ChildObjectResolver, ObjectStore, PackageObject, ReadStore,
+        get_module, load_package_object_from_object_store,
     },
     transaction::VerifiedTransaction,
 };
@@ -45,6 +48,9 @@ pub struct InMemoryStore {
 
     // Committee data
     epoch_to_committee: Vec<Committee>,
+
+    // Epoch data
+    last_checkpoints_per_epoch: HashMap<EpochId, CheckpointSequenceNumber>,
 
     // Object data
     live_objects: HashMap<ObjectID, SequenceNumber>,
@@ -90,6 +96,7 @@ impl InMemoryStore {
     pub fn get_committee_by_epoch(&self, epoch: EpochId) -> Option<&Committee> {
         self.epoch_to_committee.get(epoch as usize)
     }
+
     pub fn get_transaction(&self, digest: &TransactionDigest) -> Option<&VerifiedTransaction> {
         self.transactions.get(digest)
     }
@@ -130,6 +137,10 @@ impl InMemoryStore {
             .expect("clock object should deserialize")
     }
 
+    pub fn get_last_checkpoint_of_epoch(&self, epoch: EpochId) -> Option<CheckpointSequenceNumber> {
+        self.last_checkpoints_per_epoch.get(&epoch).cloned()
+    }
+
     pub fn owned_objects(&self, owner: IotaAddress) -> impl Iterator<Item = &Object> {
         self.live_objects
             .iter()
@@ -137,6 +148,19 @@ impl InMemoryStore {
             .filter(
                 move |object| matches!(object.owner, Owner::AddressOwner(addr) if addr == owner),
             )
+    }
+
+    pub fn update_last_checkpoint_by_epoch(
+        &mut self,
+        epoch: EpochId,
+        last_checkpoint: CheckpointSequenceNumber,
+    ) {
+        self.last_checkpoints_per_epoch
+            .entry(epoch)
+            .and_modify(|last| {
+                *last = last_checkpoint;
+            })
+            .or_insert(last_checkpoint);
     }
 }
 
@@ -326,6 +350,145 @@ impl ObjectStore for InMemoryStore {
     }
 }
 
+impl ReadStore for InMemoryStore {
+    fn try_get_committee(
+        &self,
+        epoch: iota_types::committee::EpochId,
+    ) -> iota_types::storage::error::Result<Option<std::sync::Arc<Committee>>> {
+        Ok(self
+            .get_committee_by_epoch(epoch)
+            .cloned()
+            .map(std::sync::Arc::new))
+    }
+
+    fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
+        Ok(self.get_highest_checkpoint().cloned().ok_or(
+            iota_types::storage::error::Error::missing("no checkpoints in store"),
+        )?)
+    }
+
+    fn try_get_highest_verified_checkpoint(
+        &self,
+    ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
+        Ok(self.get_highest_checkpoint().cloned().ok_or(
+            iota_types::storage::error::Error::missing("no checkpoints in store"),
+        )?)
+    }
+
+    fn try_get_highest_synced_checkpoint(
+        &self,
+    ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
+        Ok(self.get_highest_checkpoint().cloned().ok_or(
+            iota_types::storage::error::Error::missing("no checkpoints in store"),
+        )?)
+    }
+
+    fn try_get_lowest_available_checkpoint(
+        &self,
+    ) -> iota_types::storage::error::Result<iota_types::messages_checkpoint::CheckpointSequenceNumber>
+    {
+        // we never prune the sim store
+        Ok(0)
+    }
+
+    fn try_get_checkpoint_by_digest(
+        &self,
+        digest: &iota_types::messages_checkpoint::CheckpointDigest,
+    ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
+        Ok(self.get_checkpoint_by_digest(digest).cloned())
+    }
+
+    fn try_get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
+    ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
+        Ok(self
+            .get_checkpoint_by_sequence_number(sequence_number)
+            .cloned())
+    }
+
+    fn try_get_checkpoint_contents_by_digest(
+        &self,
+        digest: &iota_types::messages_checkpoint::CheckpointContentsDigest,
+    ) -> iota_types::storage::error::Result<
+        Option<iota_types::messages_checkpoint::CheckpointContents>,
+    > {
+        Ok(self.get_checkpoint_contents(digest).cloned())
+    }
+
+    fn try_get_checkpoint_contents_by_sequence_number(
+        &self,
+        sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
+    ) -> iota_types::storage::error::Result<
+        Option<iota_types::messages_checkpoint::CheckpointContents>,
+    > {
+        let checkpoint = self.get_checkpoint_by_sequence_number(sequence_number);
+
+        match checkpoint {
+            None => Ok(None),
+            Some(checkpoint) => {
+                let contents_digest = checkpoint.content_digest;
+                let contents = self.get_checkpoint_contents(&contents_digest);
+                Ok(contents.cloned())
+            }
+        }
+    }
+
+    fn try_get_transaction(
+        &self,
+        tx_digest: &iota_types::digests::TransactionDigest,
+    ) -> iota_types::storage::error::Result<Option<Arc<VerifiedTransaction>>> {
+        Ok(self.get_transaction(tx_digest).cloned().map(Arc::new))
+    }
+
+    fn try_get_transaction_effects(
+        &self,
+        tx_digest: &iota_types::digests::TransactionDigest,
+    ) -> iota_types::storage::error::Result<Option<TransactionEffects>> {
+        Ok(self.get_transaction_effects(tx_digest).cloned())
+    }
+
+    fn try_get_events(
+        &self,
+        event_digest: &iota_types::digests::TransactionEventsDigest,
+    ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEvents>> {
+        Ok(self.get_transaction_events(event_digest).cloned())
+    }
+
+    fn try_get_full_checkpoint_contents_by_sequence_number(
+        &self,
+        sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
+    ) -> iota_types::storage::error::Result<
+        Option<iota_types::messages_checkpoint::FullCheckpointContents>,
+    > {
+        let checkpoint = self.get_checkpoint_contents_by_sequence_number(sequence_number);
+        match checkpoint {
+            None => Ok(None),
+            Some(contents) => iota_types::messages_checkpoint::FullCheckpointContents::try_from_checkpoint_contents(
+                self,
+                contents,
+            ),
+        }
+    }
+
+    fn try_get_full_checkpoint_contents(
+        &self,
+        digest: &iota_types::messages_checkpoint::CheckpointContentsDigest,
+    ) -> iota_types::storage::error::Result<
+        Option<iota_types::messages_checkpoint::FullCheckpointContents>,
+    > {
+        let contents = match self.get_checkpoint_contents(digest) {
+            Some(c) => c,
+            None => return Ok(None),
+        };
+
+        iota_types::messages_checkpoint::FullCheckpointContents::try_from_checkpoint_contents(
+            self,
+            contents.clone(),
+        )
+    }
+}
+
 #[derive(Debug)]
 pub struct KeyStore {
     validator_keys: BTreeMap<AuthorityName, AuthorityKeyPair>,
@@ -388,46 +551,8 @@ impl KeyStore {
 }
 
 impl SimulatorStore for InMemoryStore {
-    fn get_checkpoint_by_sequence_number(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Option<VerifiedCheckpoint> {
-        self.get_checkpoint_by_sequence_number(sequence_number)
-            .cloned()
-    }
-
-    fn get_checkpoint_by_digest(&self, digest: &CheckpointDigest) -> Option<VerifiedCheckpoint> {
-        self.get_checkpoint_by_digest(digest).cloned()
-    }
-
     fn get_highest_checkpoint(&self) -> Option<VerifiedCheckpoint> {
         self.get_highest_checkpoint().cloned()
-    }
-
-    fn get_checkpoint_contents(
-        &self,
-        digest: &CheckpointContentsDigest,
-    ) -> Option<CheckpointContents> {
-        self.get_checkpoint_contents(digest).cloned()
-    }
-
-    fn get_committee_by_epoch(&self, epoch: EpochId) -> Option<Committee> {
-        self.get_committee_by_epoch(epoch).cloned()
-    }
-
-    fn get_transaction(&self, digest: &TransactionDigest) -> Option<VerifiedTransaction> {
-        self.get_transaction(digest).cloned()
-    }
-
-    fn get_transaction_effects(&self, digest: &TransactionDigest) -> Option<TransactionEffects> {
-        self.get_transaction_effects(digest).cloned()
-    }
-
-    fn get_transaction_events(
-        &self,
-        digest: &TransactionEventsDigest,
-    ) -> Option<TransactionEvents> {
-        self.get_transaction_events(digest).cloned()
     }
 
     fn get_transaction_events_by_tx_digest(
@@ -454,6 +579,10 @@ impl SimulatorStore for InMemoryStore {
 
     fn get_clock(&self) -> iota_types::clock::Clock {
         self.get_clock()
+    }
+
+    fn get_last_checkpoint_of_epoch(&self, epoch: EpochId) -> Option<CheckpointSequenceNumber> {
+        self.get_last_checkpoint_of_epoch(epoch)
     }
 
     fn owned_objects(&self, owner: IotaAddress) -> Box<dyn Iterator<Item = Object> + '_> {
@@ -504,5 +633,13 @@ impl SimulatorStore for InMemoryStore {
 
     fn backing_store(&self) -> &dyn iota_types::storage::BackingStore {
         self
+    }
+
+    fn update_last_checkpoint_of_epoch(
+        &mut self,
+        epoch: EpochId,
+        last_checkpoint: CheckpointSequenceNumber,
+    ) {
+        self.update_last_checkpoint_by_epoch(epoch, last_checkpoint);
     }
 }

--- a/crates/simulacrum/src/store/in_mem_store.rs
+++ b/crates/simulacrum/src/store/in_mem_store.rs
@@ -362,25 +362,31 @@ impl ReadStore for InMemoryStore {
     }
 
     fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        Ok(self.get_highest_checkpoint().cloned().ok_or(
-            iota_types::storage::error::Error::missing("no checkpoints in store"),
-        )?)
+        self.get_highest_checkpoint()
+            .cloned()
+            .ok_or(iota_types::storage::error::Error::missing(
+                "no checkpoints in store",
+            ))
     }
 
     fn try_get_highest_verified_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        Ok(self.get_highest_checkpoint().cloned().ok_or(
-            iota_types::storage::error::Error::missing("no checkpoints in store"),
-        )?)
+        self.get_highest_checkpoint()
+            .cloned()
+            .ok_or(iota_types::storage::error::Error::missing(
+                "no checkpoints in store",
+            ))
     }
 
     fn try_get_highest_synced_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        Ok(self.get_highest_checkpoint().cloned().ok_or(
-            iota_types::storage::error::Error::missing("no checkpoints in store"),
-        )?)
+        self.get_highest_checkpoint()
+            .cloned()
+            .ok_or(iota_types::storage::error::Error::missing(
+                "no checkpoints in store",
+            ))
     }
 
     fn try_get_lowest_available_checkpoint(

--- a/crates/simulacrum/src/store/in_mem_store.rs
+++ b/crates/simulacrum/src/store/in_mem_store.rs
@@ -332,6 +332,24 @@ pub struct KeyStore {
     account_keys: BTreeMap<IotaAddress, AccountKeyPair>,
 }
 
+impl Clone for KeyStore {
+    fn clone(&self) -> Self {
+        use fastcrypto::traits::KeyPair;
+        Self {
+            validator_keys: self
+                .validator_keys
+                .iter()
+                .map(|(k, v)| (*k, v.copy()))
+                .collect(),
+            account_keys: self
+                .account_keys
+                .iter()
+                .map(|(k, v)| (*k, v.copy()))
+                .collect(),
+        }
+    }
+}
+
 impl KeyStore {
     pub fn from_network_config(
         network_config: &iota_swarm_config::network_config::NetworkConfig,

--- a/crates/simulacrum/src/store/in_mem_store.rs
+++ b/crates/simulacrum/src/store/in_mem_store.rs
@@ -428,16 +428,9 @@ impl ReadStore for InMemoryStore {
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::CheckpointContents>,
     > {
-        let checkpoint = self.get_checkpoint_by_sequence_number(sequence_number);
-
-        match checkpoint {
-            None => Ok(None),
-            Some(checkpoint) => {
-                let contents_digest = checkpoint.content_digest;
-                let contents = self.get_checkpoint_contents(&contents_digest);
-                Ok(contents.cloned())
-            }
-        }
+        Ok(self
+            .get_checkpoint_by_sequence_number(sequence_number)
+            .and_then(|c| self.get_checkpoint_contents(&c.content_digest).cloned()))
     }
 
     fn try_get_transaction(
@@ -467,14 +460,13 @@ impl ReadStore for InMemoryStore {
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::FullCheckpointContents>,
     > {
-        let checkpoint = self.get_checkpoint_contents_by_sequence_number(sequence_number);
-        match checkpoint {
-            None => Ok(None),
-            Some(contents) => iota_types::messages_checkpoint::FullCheckpointContents::try_from_checkpoint_contents(
-                self,
-                contents,
-            ),
-        }
+        self.try_get_checkpoint_contents_by_sequence_number(sequence_number)?
+            .map_or(Ok(None), |contents| {
+                iota_types::messages_checkpoint::FullCheckpointContents::try_from_checkpoint_contents(
+                    self,
+                    contents,
+                )
+            })
     }
 
     fn try_get_full_checkpoint_contents(
@@ -483,15 +475,13 @@ impl ReadStore for InMemoryStore {
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::FullCheckpointContents>,
     > {
-        let contents = match self.get_checkpoint_contents(digest) {
-            Some(c) => c,
-            None => return Ok(None),
-        };
-
-        iota_types::messages_checkpoint::FullCheckpointContents::try_from_checkpoint_contents(
-            self,
-            contents.clone(),
-        )
+        self.get_checkpoint_contents(digest)
+            .map_or(Ok(None), |contents| {
+                iota_types::messages_checkpoint::FullCheckpointContents::try_from_checkpoint_contents(
+                    self,
+                    contents.clone(),
+                )
+            })
     }
 }
 

--- a/crates/simulacrum/src/store/mod.rs
+++ b/crates/simulacrum/src/store/mod.rs
@@ -8,13 +8,10 @@ use iota_config::genesis;
 use iota_types::{
     base_types::{IotaAddress, ObjectID, ObjectRef, SequenceNumber},
     committee::{Committee, EpochId},
-    digests::{ObjectDigest, TransactionDigest, TransactionEventsDigest},
+    digests::{ObjectDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::{IotaResult, UserInputError},
-    messages_checkpoint::{
-        CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
-        VerifiedCheckpoint,
-    },
+    messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber, VerifiedCheckpoint},
     object::Object,
     storage::{BackingStore, ChildObjectResolver},
     transaction::{
@@ -25,7 +22,10 @@ use iota_types::{
 pub mod in_mem_store;
 
 pub trait SimulatorStore:
-    iota_types::storage::BackingPackageStore + iota_types::storage::ObjectStore + ChildObjectResolver
+    iota_types::storage::BackingPackageStore
+    + iota_types::storage::ObjectStore
+    + ChildObjectResolver
+    + iota_types::storage::ReadStore
 {
     fn init_with_genesis(&mut self, genesis: &genesis::Genesis) {
         self.insert_checkpoint(genesis.checkpoint());
@@ -50,28 +50,7 @@ pub trait SimulatorStore:
         );
     }
 
-    fn get_checkpoint_by_sequence_number(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Option<VerifiedCheckpoint>;
-
-    fn get_checkpoint_by_digest(&self, digest: &CheckpointDigest) -> Option<VerifiedCheckpoint>;
-
     fn get_highest_checkpoint(&self) -> Option<VerifiedCheckpoint>;
-
-    fn get_checkpoint_contents(
-        &self,
-        digest: &CheckpointContentsDigest,
-    ) -> Option<CheckpointContents>;
-
-    fn get_committee_by_epoch(&self, epoch: EpochId) -> Option<Committee>;
-
-    fn get_transaction(&self, digest: &TransactionDigest) -> Option<VerifiedTransaction>;
-
-    fn get_transaction_effects(&self, digest: &TransactionDigest) -> Option<TransactionEffects>;
-
-    fn get_transaction_events(&self, digest: &TransactionEventsDigest)
-    -> Option<TransactionEvents>;
 
     fn get_transaction_events_by_tx_digest(
         &self,
@@ -85,6 +64,8 @@ pub trait SimulatorStore:
     fn get_system_state(&self) -> iota_types::iota_system_state::IotaSystemState;
 
     fn get_clock(&self) -> iota_types::clock::Clock;
+
+    fn get_last_checkpoint_of_epoch(&self, epoch: EpochId) -> Option<CheckpointSequenceNumber>;
 
     fn owned_objects(&self, owner: IotaAddress) -> Box<dyn Iterator<Item = Object> + '_>;
 
@@ -115,6 +96,12 @@ pub trait SimulatorStore:
     );
 
     fn backing_store(&self) -> &dyn BackingStore;
+
+    fn update_last_checkpoint_of_epoch(
+        &mut self,
+        epoch: EpochId,
+        last_checkpoint: CheckpointSequenceNumber,
+    );
 
     // TODO: This function is now out-of-sync with read_objects_for_execution from
     // transaction_input_loader.rs. For instance, it does not support the use of

--- a/crates/simulacrum/src/transaction_executor.rs
+++ b/crates/simulacrum/src/transaction_executor.rs
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transaction executor implementation for Simulacrum
+//!
+//! This module provides a TransactionExecutor implementation that allows
+//! transaction execution and simulation via gRPC without requiring quorum
+//! consensus.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use iota_types::{
+    effects::TransactionEffectsAPI,
+    quorum_driver_types::{
+        ExecuteTransactionRequestV1, ExecuteTransactionResponseV1, FinalizedEffects,
+        QuorumDriverError,
+    },
+    transaction::TransactionData,
+    transaction_executor::{
+        SimulateTransactionResult, TransactionExecutor as TransactionExecutorTrait, VmChecks,
+    },
+};
+
+use crate::Simulacrum;
+
+/// Transaction executor implementation for simulacrum
+/// This allows transaction execution and simulation via gRPC without requiring
+/// quorum consensus
+pub struct TransactionExecutor {
+    simulacrum: Arc<Simulacrum>,
+}
+
+impl TransactionExecutor {
+    pub fn new(simulacrum: Arc<Simulacrum>) -> Self {
+        Self { simulacrum }
+    }
+}
+
+#[async_trait]
+impl TransactionExecutorTrait for TransactionExecutor {
+    async fn execute_transaction(
+        &self,
+        request: ExecuteTransactionRequestV1,
+        _client_addr: Option<std::net::SocketAddr>,
+    ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
+        let simulacrum = &*self.simulacrum;
+
+        // Execute the transaction directly (it's already a Transaction type)
+        let (effects, _execution_error) = simulacrum
+            .execute_transaction(request.transaction.clone())
+            .map_err(|e| {
+                QuorumDriverError::QuorumDriverInternal(iota_types::error::IotaError::Unknown(
+                    e.to_string(),
+                ))
+            })?;
+
+        // Create a checkpoint to finalize the transaction
+        let checkpoint = simulacrum.create_checkpoint();
+
+        tracing::debug!(
+            tx_digest = ?effects.transaction_digest(),
+            checkpoint = checkpoint.sequence_number(),
+            "Transaction executed and finalized in simulacrum"
+        );
+
+        // For simulacrum, we create a dummy certified effects since there's no real
+        // validator consensus. We use
+        // CertifiedTransactionEffects::new_from_data_and_sig with empty
+        // signatures.
+        let (test_committee, _) = iota_types::committee::Committee::new_simple_test_committee();
+        let effects_cert = iota_types::effects::CertifiedTransactionEffects::new_from_data_and_sig(
+            effects.clone(),
+            iota_types::crypto::AuthorityQuorumSignInfo::new_from_auth_sign_infos(
+                vec![],
+                &test_committee,
+            )
+            .unwrap(),
+        );
+        let verified_effects =
+            iota_types::effects::VerifiedCertifiedTransactionEffects::new_unchecked(effects_cert);
+
+        // Build response
+        let response = ExecuteTransactionResponseV1 {
+            effects: FinalizedEffects::new_from_effects_cert(verified_effects.into()),
+            events: if request.include_events {
+                // TODO: get events from simulacrum store
+                None
+            } else {
+                None
+            },
+            input_objects: if request.include_input_objects {
+                // TODO: get input objects from simulacrum store
+                None
+            } else {
+                None
+            },
+            output_objects: if request.include_output_objects {
+                // TODO: get output objects from simulacrum store
+                None
+            } else {
+                None
+            },
+            auxiliary_data: if request.include_auxiliary_data {
+                // TODO: get auxiliary data
+                None
+            } else {
+                None
+            },
+        };
+
+        Ok(response)
+    }
+
+    fn simulate_transaction(
+        &self,
+        transaction: TransactionData,
+        checks: VmChecks,
+    ) -> Result<SimulateTransactionResult, iota_types::error::IotaError> {
+        // Simulacrum is already thread-safe, no locking needed
+        self.simulacrum.simulate_transaction(transaction, checks)
+    }
+}

--- a/crates/simulacrum/src/transaction_executor.rs
+++ b/crates/simulacrum/src/transaction_executor.rs
@@ -17,6 +17,7 @@ use iota_types::{
         ExecuteTransactionRequestV1, ExecuteTransactionResponseV1, FinalizedEffects,
         QuorumDriverError,
     },
+    storage,
     transaction::TransactionData,
     transaction_executor::{
         SimulateTransactionResult, TransactionExecutor as TransactionExecutorTrait, VmChecks,
@@ -95,32 +96,20 @@ impl TransactionExecutorTrait for TransactionExecutor {
             },
             input_objects: if request.include_input_objects {
                 self.simulacrum.with_store(|store| {
-                    let mut objs = vec![];
-                    for (obj_id, version) in effects.modified_at_versions() {
-                        if let Some(obj) = store.get_object_at_version(&obj_id, version) {
-                            objs.push(obj.clone());
-                        }
-                    }
-                    Some(objs)
+                    storage::get_transaction_input_objects(store, &effects).ok()
                 })
             } else {
                 None
             },
             output_objects: if request.include_output_objects {
                 self.simulacrum.with_store(|store| {
-                    let mut objs = vec![];
-                    for (obj_ref, _, _) in effects.all_changed_objects() {
-                        if let Some(obj) = store.get_object_at_version(&obj_ref.0, obj_ref.1) {
-                            objs.push(obj.clone());
-                        }
-                    }
-                    Some(objs)
+                    storage::get_transaction_output_objects(store, &effects).ok()
                 })
             } else {
                 None
             },
             auxiliary_data: if request.include_auxiliary_data {
-                // TODO: Auxiliary data is not supported
+                // We don't have any aux data generated presently, also in the real network
                 None
             } else {
                 None

--- a/crates/simulacrum/src/transaction_executor.rs
+++ b/crates/simulacrum/src/transaction_executor.rs
@@ -47,7 +47,7 @@ impl TransactionExecutorTrait for TransactionExecutor {
     ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
         let simulacrum = &*self.simulacrum;
 
-        // Execute the transaction directly (it's already a Transaction type)
+        // Execute the transaction directly
         let (effects, _execution_error) = simulacrum
             .execute_transaction(request.transaction.clone())
             .map_err(|e| {
@@ -118,7 +118,6 @@ impl TransactionExecutorTrait for TransactionExecutor {
         transaction: TransactionData,
         checks: VmChecks,
     ) -> Result<SimulateTransactionResult, iota_types::error::IotaError> {
-        // Simulacrum is already thread-safe, no locking needed
         self.simulacrum.simulate_transaction(transaction, checks)
     }
 }

--- a/crates/simulacrum/src/transaction_executor.rs
+++ b/crates/simulacrum/src/transaction_executor.rs
@@ -85,25 +85,42 @@ impl TransactionExecutorTrait for TransactionExecutor {
         let response = ExecuteTransactionResponseV1 {
             effects: FinalizedEffects::new_from_effects_cert(verified_effects.into()),
             events: if request.include_events {
-                // TODO: get events from simulacrum store
-                None
+                self.simulacrum.with_store(|store| {
+                    store
+                        .get_transaction_events(effects.events_digest().unwrap())
+                        .cloned()
+                })
             } else {
                 None
             },
             input_objects: if request.include_input_objects {
-                // TODO: get input objects from simulacrum store
-                None
+                self.simulacrum.with_store(|store| {
+                    let mut objs = vec![];
+                    for (obj_id, version) in effects.modified_at_versions() {
+                        if let Some(obj) = store.get_object_at_version(&obj_id, version) {
+                            objs.push(obj.clone());
+                        }
+                    }
+                    Some(objs)
+                })
             } else {
                 None
             },
             output_objects: if request.include_output_objects {
-                // TODO: get output objects from simulacrum store
-                None
+                self.simulacrum.with_store(|store| {
+                    let mut objs = vec![];
+                    for (obj_ref, _, _) in effects.all_changed_objects() {
+                        if let Some(obj) = store.get_object_at_version(&obj_ref.0, obj_ref.1) {
+                            objs.push(obj.clone());
+                        }
+                    }
+                    Some(objs)
+                })
             } else {
                 None
             },
             auxiliary_data: if request.include_auxiliary_data {
-                // TODO: get auxiliary data
+                // TODO: Auxiliary data is not supported
                 None
             } else {
                 None


### PR DESCRIPTION
# Description of change

This PR add a simulacrum binary, that hosts a gRPC interface to interact with the fullnode API, and a REST API to control the simulacrum. This is useful to run simulacrum in the CI in non-rust projects.


## Links to any relevant issues

fixes #7844

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
