### PR TITLE
feat(gRPC): add high-level client API calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6479,17 +6479,12 @@ dependencies = [
 name = "iota-grpc-client"
 version = "1.15.0-alpha"
 dependencies = [
- "anyhow",
  "base64 0.21.7",
- "futures",
  "http 1.3.1",
  "iota-grpc-types",
- "iota-json-rpc-types",
  "iota-sdk-types",
- "iota-types",
- "move-core-types",
- "serde_json",
- "tap",
+ "serde",
+ "thiserror 1.0.64",
  "tonic 0.14.2",
 ]
 

--- a/crates/iota-grpc-client/Cargo.toml
+++ b/crates/iota-grpc-client/Cargo.toml
@@ -11,17 +11,12 @@ workspace = true
 
 [dependencies]
 # external dependencies
-anyhow.workspace = true
 base64.workspace = true
-futures.workspace = true
 http.workspace = true
-serde_json.workspace = true
-tap.workspace = true
+serde.workspace = true
+thiserror.workspace = true
 tonic = { workspace = true, features = ["tls-ring"] }
 
 # internal dependencies
 iota-grpc-types.workspace = true
-iota-json-rpc-types.workspace = true
 iota-sdk-types.workspace = true
-iota-types.workspace = true
-move-core-types.workspace = true

--- a/crates/iota-grpc-client/src/api/common.rs
+++ b/crates/iota-grpc-client/src/api/common.rs
@@ -67,7 +67,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 // If `None` is passed, these defaults are used. If a custom mask is provided,
 // it completely replaces the default (no merging).
 
-/// Default field mask for [`Client::get_transactions`].
+/// Default field mask for [`crate::Client::get_transactions`].
 ///
 /// **Required fields for `TransactionResponse` deserialization:**
 /// - `transaction.bcs` - Transaction data (required)
@@ -84,7 +84,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub const TRANSACTIONS_READ_MASK: &str =
     "transaction.bcs,signatures.bcs,effects.bcs,events,checkpoint,timestamp";
 
-/// Default field mask for [`Client::get_objects`].
+/// Default field mask for [`crate::Client::get_objects`].
 ///
 /// **Required fields for `Object` deserialization:**
 /// - `bcs` - Object BCS data (required)
@@ -93,8 +93,8 @@ pub const TRANSACTIONS_READ_MASK: &str =
 /// will fail.
 pub const OBJECTS_READ_MASK: &str = "bcs";
 
-/// Default field mask for [`Client::execute_transaction`] and
-/// [`Client::simulate_transaction`].
+/// Default field mask for [`crate::Client::execute_transaction`] and
+/// [`crate::Client::simulate_transaction`].
 ///
 /// **Required fields for response deserialization:**
 /// - `transaction.effects` - Transaction effects (required)

--- a/crates/iota-grpc-client/src/api/common.rs
+++ b/crates/iota-grpc-client/src/api/common.rs
@@ -1,0 +1,276 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Common utilities shared across API modules.
+
+pub use iota_grpc_types::field::{FieldMask, FieldMaskUtil};
+pub use iota_grpc_types::proto::TryFromProtoError;
+use iota_grpc_types::v0::{
+    bcs::BcsData,
+    ledger_service::{ObjectResult, TransactionResult, object_result, transaction_result},
+    transaction::{
+        ExecutedTransaction, Transaction as ProtoTransaction,
+        TransactionEvents as ProtoTransactionEvents,
+    },
+};
+use iota_sdk_types::{Digest, Event, Object, TransactionEffects, TransactionEvents};
+use serde::Serialize;
+
+/// Errors that can occur during gRPC client API operations.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Error converting proto types to SDK types.
+    #[error("proto conversion error: {0}")]
+    ProtoConversion(#[from] TryFromProtoError),
+
+    /// Error from the gRPC server.
+    #[error("server error: {0}")]
+    Server(String),
+
+    /// Error converting signatures.
+    #[error("signature conversion error: {0}")]
+    Signature(String),
+
+    /// Resource not found.
+    #[error("{resource} not found: {id}")]
+    NotFound {
+        /// The type of resource that was not found.
+        resource: &'static str,
+        /// The identifier of the resource.
+        id: String,
+    },
+
+    /// gRPC transport or protocol error.
+    #[error("grpc error: {0}")]
+    Grpc(#[from] tonic::Status),
+}
+
+impl From<Error> for tonic::Status {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::ProtoConversion(e) => {
+                tonic::Status::internal(format!("proto conversion error: {e}"))
+            }
+            Error::Server(msg) => tonic::Status::internal(format!("server error: {msg}")),
+            Error::Signature(msg) => {
+                tonic::Status::internal(format!("signature conversion error: {msg}"))
+            }
+            Error::NotFound { resource, id } => {
+                tonic::Status::not_found(format!("{resource} not found: {id}"))
+            }
+            Error::Grpc(status) => status,
+        }
+    }
+}
+
+/// Result type alias for API operations.
+pub type Result<T> = std::result::Result<T, Error>;
+
+// =============================================================================
+// Field Masks
+// =============================================================================
+//
+// These masks specify which fields to request from the server. Users can
+// provide custom masks to optimize bandwidth, but must include the required
+// fields for SDK type deserialization.
+//
+// If `None` is passed, these defaults are used. If a custom mask is provided,
+// it completely replaces the default (no merging).
+
+/// Default field mask for [`Client::get_transactions`].
+///
+/// **Required fields for `TransactionResponse` deserialization:**
+/// - `transaction.bcs` - Transaction data (required)
+/// - `effects.bcs` - Transaction effects (required)
+///
+/// **Optional fields:**
+/// - `events` - Transaction events
+/// - `checkpoint` - Checkpoint sequence number
+/// - `timestamp` - Execution timestamp
+///
+/// If you provide a custom mask, you must include at least `transaction.bcs`
+/// and `effects.bcs`, or deserialization will fail.
+pub const TRANSACTIONS_READ_MASK: &str = "transaction.bcs,effects.bcs,events,checkpoint,timestamp";
+
+/// Default field mask for [`Client::get_objects`].
+///
+/// **Required fields for `Object` deserialization:**
+/// - `bcs` - Object BCS data (required)
+///
+/// If you provide a custom mask, you must include `bcs`, or deserialization
+/// will fail.
+pub const OBJECTS_READ_MASK: &str = "bcs";
+
+/// Default field mask for [`Client::execute_transaction`] and
+/// [`Client::simulate_transaction`].
+///
+/// **Required fields for response deserialization:**
+/// - `transaction.effects` - Transaction effects (required)
+///
+/// **Optional fields:**
+/// - `transaction.events` - Transaction events
+/// - `transaction.input_objects` - Input objects used
+/// - `transaction.output_objects` - Output objects created/modified
+///
+/// If you provide a custom mask, you must include at least `transaction.effects`,
+/// or deserialization will fail.
+pub const EXECUTION_READ_MASK: &str =
+    "transaction.effects,transaction.events,transaction.input_objects,transaction.output_objects";
+
+/// A trait for proto result types that follow the pattern of having
+/// `Some(Result::Value)`, `Some(Result::Error)`, or `None`.
+///
+/// This allows generic handling of gRPC response results that can be either
+/// a success value, a server error, or missing.
+pub trait ProtoResult {
+    /// The success value type.
+    type Value;
+
+    /// Extract the result, converting to our error types.
+    fn into_result(self) -> Result<Self::Value>;
+}
+
+impl ProtoResult for ObjectResult {
+    type Value = iota_grpc_types::v0::object::Object;
+
+    fn into_result(self) -> Result<Self::Value> {
+        match self.result {
+            Some(object_result::Result::Object(obj)) => Ok(obj),
+            Some(object_result::Result::Error(e)) => Err(Error::Server(e.message)),
+            None => Err(TryFromProtoError::missing("result").into()),
+        }
+    }
+}
+
+impl ProtoResult for TransactionResult {
+    type Value = Box<ExecutedTransaction>;
+
+    fn into_result(self) -> Result<Self::Value> {
+        match self.result {
+            Some(transaction_result::Result::Transaction(tx)) => Ok(tx),
+            Some(transaction_result::Result::Error(e)) => Err(Error::Server(e.message)),
+            None => Err(TryFromProtoError::missing("result").into()),
+        }
+    }
+}
+
+/// Build a proto Transaction from serializable transaction data and digest.
+pub fn build_proto_transaction<T: Serialize>(data: &T, digest: Digest) -> Result<ProtoTransaction> {
+    let bcs = BcsData::serialize(data)
+        .map_err(|e| Error::from(TryFromProtoError::invalid("transaction", e)))?;
+
+    Ok(ProtoTransaction {
+        digest: Some(digest.into()),
+        bcs: Some(bcs),
+    })
+}
+
+/// Convert proto TransactionEffects BCS to SDK TransactionEffects.
+fn convert_effects(
+    proto: &iota_grpc_types::v0::transaction::TransactionEffects,
+) -> Result<TransactionEffects> {
+    let bcs = proto
+        .bcs
+        .as_ref()
+        .ok_or(TryFromProtoError::missing("effects.bcs"))?;
+
+    bcs.deserialize()
+        .map_err(|e| TryFromProtoError::invalid("effects.bcs", e).into())
+}
+
+/// Convert proto TransactionEvents to SDK TransactionEvents.
+fn convert_events(proto: &ProtoTransactionEvents) -> Result<Option<TransactionEvents>> {
+    let Some(events) = proto.events.as_ref() else {
+        return Ok(None);
+    };
+
+    let sdk_events: Vec<Event> = events
+        .events
+        .iter()
+        .map(|e| {
+            let bcs = e
+                .bcs
+                .as_ref()
+                .ok_or(TryFromProtoError::missing("event.bcs"))?;
+            bcs.deserialize()
+                .map_err(|e| TryFromProtoError::invalid("event.bcs", e).into())
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(Some(TransactionEvents(sdk_events)))
+}
+
+/// Convert a single proto Object to SDK Object.
+pub fn convert_object(
+    proto: &iota_grpc_types::v0::object::Object,
+    field_name: &str,
+) -> Result<Object> {
+    let bcs = proto
+        .bcs
+        .as_ref()
+        .ok_or(TryFromProtoError::missing(field_name))?;
+
+    bcs.deserialize()
+        .map_err(|e| TryFromProtoError::invalid(field_name, e).into())
+}
+
+/// Response for transaction execution.
+///
+/// Contains the effects, optional events, and optional objects.
+#[derive(Debug, Clone)]
+pub struct TransactionExecutionResponse {
+    /// The effects of executing this transaction.
+    pub effects: TransactionEffects,
+    /// Events emitted during execution (if requested).
+    pub events: Option<TransactionEvents>,
+    /// Input objects used by the transaction (if requested).
+    pub input_objects: Option<Vec<Object>>,
+    /// Output objects created/modified by the transaction (if requested).
+    pub output_objects: Option<Vec<Object>>,
+}
+
+/// Extract execution data from a proto ExecutedTransaction.
+pub fn extract_execution_data(proto: &ExecutedTransaction) -> Result<TransactionExecutionResponse> {
+    let effects = proto
+        .effects
+        .as_ref()
+        .map(convert_effects)
+        .transpose()?
+        .ok_or(TryFromProtoError::missing("effects"))?;
+
+    let events = proto
+        .events
+        .as_ref()
+        .map(convert_events)
+        .transpose()?
+        .flatten();
+
+    let input_objects = proto
+        .input_objects
+        .as_ref()
+        .map(|objs| {
+            objs.objects
+                .iter()
+                .map(|o| convert_object(o, "input_object"))
+                .collect::<Result<Vec<_>>>()
+        })
+        .transpose()?;
+
+    let output_objects = proto
+        .output_objects
+        .as_ref()
+        .map(|objs| {
+            objs.objects
+                .iter()
+                .map(|o| convert_object(o, "output_object"))
+                .collect::<Result<Vec<_>>>()
+        })
+        .transpose()?;
+
+    Ok(TransactionExecutionResponse {
+        effects,
+        events,
+        input_objects,
+        output_objects,
+    })
+}

--- a/crates/iota-grpc-client/src/api/common.rs
+++ b/crates/iota-grpc-client/src/api/common.rs
@@ -33,15 +33,6 @@ pub enum Error {
     #[error("signature conversion error: {0}")]
     Signature(String),
 
-    /// Resource not found.
-    #[error("{resource} not found: {id}")]
-    NotFound {
-        /// The type of resource that was not found.
-        resource: &'static str,
-        /// The identifier of the resource.
-        id: String,
-    },
-
     /// gRPC transport or protocol error.
     #[error("grpc error: {0}")]
     Grpc(#[from] tonic::Status),
@@ -56,9 +47,6 @@ impl From<Error> for tonic::Status {
             Error::Server(msg) => tonic::Status::internal(format!("server error: {msg}")),
             Error::Signature(msg) => {
                 tonic::Status::internal(format!("signature conversion error: {msg}"))
-            }
-            Error::NotFound { resource, id } => {
-                tonic::Status::not_found(format!("{resource} not found: {id}"))
             }
             Error::Grpc(status) => status,
         }
@@ -83,6 +71,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 ///
 /// **Required fields for `TransactionResponse` deserialization:**
 /// - `transaction.bcs` - Transaction data (required)
+/// - `signatures.bcs` - User signatures (required)
 /// - `effects.bcs` - Transaction effects (required)
 ///
 /// **Optional fields:**
@@ -90,9 +79,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// - `checkpoint` - Checkpoint sequence number
 /// - `timestamp` - Execution timestamp
 ///
-/// If you provide a custom mask, you must include at least `transaction.bcs`
-/// and `effects.bcs`, or deserialization will fail.
-pub const TRANSACTIONS_READ_MASK: &str = "transaction.bcs,effects.bcs,events,checkpoint,timestamp";
+/// If you provide a custom mask, you must include at least `transaction.bcs`,
+/// `signatures.bcs`, and `effects.bcs`, or deserialization will fail.
+pub const TRANSACTIONS_READ_MASK: &str =
+    "transaction.bcs,signatures.bcs,effects.bcs,events,checkpoint,timestamp";
 
 /// Default field mask for [`Client::get_objects`].
 ///
@@ -216,6 +206,30 @@ pub fn convert_object(
         .map_err(|e| TryFromProtoError::invalid(field_name, e).into())
 }
 
+/// Extract only effects and events from a proto ExecutedTransaction.
+///
+/// This is a lighter alternative to [`extract_execution_data`] for cases
+/// where input/output objects are not needed (e.g., transaction queries).
+pub fn extract_effects_and_events(
+    proto: &ExecutedTransaction,
+) -> Result<(TransactionEffects, Option<TransactionEvents>)> {
+    let effects = proto
+        .effects
+        .as_ref()
+        .map(convert_effects)
+        .transpose()?
+        .ok_or(TryFromProtoError::missing("effects"))?;
+
+    let events = proto
+        .events
+        .as_ref()
+        .map(convert_events)
+        .transpose()?
+        .flatten();
+
+    Ok((effects, events))
+}
+
 /// Response for transaction execution.
 ///
 /// Contains the effects, optional events, and optional objects.
@@ -252,19 +266,7 @@ pub fn extract_execution_response(
 
 /// Extract execution data from a proto ExecutedTransaction.
 pub fn extract_execution_data(proto: &ExecutedTransaction) -> Result<TransactionExecutionResponse> {
-    let effects = proto
-        .effects
-        .as_ref()
-        .map(convert_effects)
-        .transpose()?
-        .ok_or(TryFromProtoError::missing("effects"))?;
-
-    let events = proto
-        .events
-        .as_ref()
-        .map(convert_events)
-        .transpose()?
-        .flatten();
+    let (effects, events) = extract_effects_and_events(proto)?;
 
     let input_objects = proto
         .input_objects

--- a/crates/iota-grpc-client/src/api/common.rs
+++ b/crates/iota-grpc-client/src/api/common.rs
@@ -3,8 +3,6 @@
 
 //! Common utilities shared across API modules.
 
-pub use iota_grpc_types::field::{FieldMask, FieldMaskUtil};
-pub use iota_grpc_types::proto::TryFromProtoError;
 use iota_grpc_types::v0::{
     bcs::BcsData,
     ledger_service::{ObjectResult, TransactionResult, object_result, transaction_result},
@@ -12,6 +10,10 @@ use iota_grpc_types::v0::{
         ExecutedTransaction, Transaction as ProtoTransaction,
         TransactionEvents as ProtoTransactionEvents,
     },
+};
+pub use iota_grpc_types::{
+    field::{FieldMask, FieldMaskUtil},
+    proto::TryFromProtoError,
 };
 use iota_sdk_types::{Digest, Event, Object, TransactionEffects, TransactionEvents};
 use serde::Serialize;
@@ -112,8 +114,8 @@ pub const OBJECTS_READ_MASK: &str = "bcs";
 /// - `transaction.input_objects` - Input objects used
 /// - `transaction.output_objects` - Output objects created/modified
 ///
-/// If you provide a custom mask, you must include at least `transaction.effects`,
-/// or deserialization will fail.
+/// If you provide a custom mask, you must include at least
+/// `transaction.effects`, or deserialization will fail.
 pub const EXECUTION_READ_MASK: &str =
     "transaction.effects,transaction.events,transaction.input_objects,transaction.output_objects";
 

--- a/crates/iota-grpc-client/src/api/common.rs
+++ b/crates/iota-grpc-client/src/api/common.rs
@@ -231,6 +231,25 @@ pub struct TransactionExecutionResponse {
     pub output_objects: Option<Vec<Object>>,
 }
 
+/// Build a field mask with a custom value or default.
+///
+/// This is a convenience helper that handles the common pattern of using
+/// a user-provided field mask or falling back to a default.
+pub fn field_mask_with_default(custom: Option<&str>, default: &str) -> FieldMask {
+    FieldMask::from_str(custom.unwrap_or(default))
+}
+
+/// Extract execution data from an optional ExecutedTransaction response.
+///
+/// This is a convenience wrapper that handles the common pattern of extracting
+/// the transaction from a response and converting it to SDK types.
+pub fn extract_execution_response(
+    transaction: Option<ExecutedTransaction>,
+) -> Result<TransactionExecutionResponse> {
+    let executed = transaction.ok_or(TryFromProtoError::missing("transaction"))?;
+    extract_execution_data(&executed)
+}
+
 /// Extract execution data from a proto ExecutedTransaction.
 pub fn extract_execution_data(proto: &ExecutedTransaction) -> Result<TransactionExecutionResponse> {
     let effects = proto

--- a/crates/iota-grpc-client/src/api/execution/execute.rs
+++ b/crates/iota-grpc-client/src/api/execution/execute.rs
@@ -60,8 +60,6 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// [`EXECUTION_READ_MASK`]: crate::EXECUTION_READ_MASK
     pub async fn execute_transaction(
         &self,
         signed_transaction: SignedTransaction,

--- a/crates/iota-grpc-client/src/api/execution/execute.rs
+++ b/crates/iota-grpc-client/src/api/execution/execute.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! High-level API for transaction execution.
+
+use iota_grpc_types::v0::{
+    signatures::{UserSignature as ProtoUserSignature, UserSignatures},
+    transaction_execution_service::ExecuteTransactionRequest,
+};
+use iota_sdk_types::SignedTransaction;
+
+use crate::{
+    Client,
+    api::{
+        EXECUTION_READ_MASK, Error, FieldMask, FieldMaskUtil, Result, TransactionExecutionResponse,
+        TryFromProtoError, build_proto_transaction, extract_execution_data,
+    },
+};
+
+impl Client {
+    /// Execute a signed transaction.
+    ///
+    /// This submits the transaction to the network for execution and waits for
+    /// the result. The transaction must be signed with valid signatures.
+    ///
+    /// Returns `TransactionExecutionResponse` containing the transaction
+    /// effects, events, and optionally input/output objects.
+    ///
+    /// # Field Mask
+    ///
+    /// The optional `read_mask` parameter controls which fields the server
+    /// returns. If `None`, uses [`EXECUTION_READ_MASK`] which includes effects,
+    /// events, and input/output objects.
+    ///
+    /// **Required fields** (must be included in custom masks):
+    /// - `transaction.effects` - Transaction effects
+    ///
+    /// **Optional fields:**
+    /// - `transaction.events` - Transaction events
+    /// - `transaction.input_objects` - Input objects used
+    /// - `transaction.output_objects` - Output objects created/modified
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_grpc_client::Client;
+    /// # use iota_sdk_types::SignedTransaction;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::connect("http://localhost:9000").await?;
+    ///
+    /// let signed_tx: SignedTransaction = todo!();
+    ///
+    /// // Default: get effects, events, and objects
+    /// let result = client.execute_transaction(signed_tx.clone(), None).await?;
+    ///
+    /// // Minimal: only effects (smaller response)
+    /// let result = client
+    ///     .execute_transaction(signed_tx, Some("transaction.effects"))
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`EXECUTION_READ_MASK`]: crate::EXECUTION_READ_MASK
+    pub async fn execute_transaction(
+        &self,
+        signed_transaction: SignedTransaction,
+        read_mask: Option<&str>,
+    ) -> Result<TransactionExecutionResponse> {
+        // Build proto transaction directly from SDK types
+        let tx_digest = signed_transaction.transaction.digest();
+        let proto_transaction =
+            build_proto_transaction(&signed_transaction.transaction, tx_digest)?;
+
+        // Convert signatures to proto format using existing TryFrom
+        let proto_signatures = UserSignatures {
+            signatures: signed_transaction
+                .signatures
+                .into_iter()
+                .map(|sig| {
+                    ProtoUserSignature::try_from(sig).map_err(|e| Error::Signature(e.to_string()))
+                })
+                .collect::<Result<Vec<_>>>()?,
+        };
+
+        let mask = read_mask.unwrap_or(EXECUTION_READ_MASK);
+        let request = ExecuteTransactionRequest {
+            transaction: Some(proto_transaction),
+            signatures: Some(proto_signatures),
+            read_mask: Some(FieldMask::from_str(mask)),
+        };
+
+        let mut client = self.execution_service_client();
+
+        let response = client.execute_transaction(request).await?.into_inner();
+
+        let executed = response
+            .transaction
+            .ok_or(TryFromProtoError::missing("transaction"))?;
+
+        extract_execution_data(&executed)
+    }
+}

--- a/crates/iota-grpc-client/src/api/execution/execute.rs
+++ b/crates/iota-grpc-client/src/api/execution/execute.rs
@@ -12,8 +12,8 @@ use iota_sdk_types::SignedTransaction;
 use crate::{
     Client,
     api::{
-        EXECUTION_READ_MASK, Error, FieldMask, FieldMaskUtil, Result, TransactionExecutionResponse,
-        TryFromProtoError, build_proto_transaction, extract_execution_data,
+        EXECUTION_READ_MASK, Error, Result, TransactionExecutionResponse, build_proto_transaction,
+        extract_execution_response, field_mask_with_default,
     },
 };
 
@@ -81,21 +81,18 @@ impl Client {
                 .collect::<Result<Vec<_>>>()?,
         };
 
-        let mask = read_mask.unwrap_or(EXECUTION_READ_MASK);
         let request = ExecuteTransactionRequest {
             transaction: Some(proto_transaction),
             signatures: Some(proto_signatures),
-            read_mask: Some(FieldMask::from_str(mask)),
+            read_mask: Some(field_mask_with_default(read_mask, EXECUTION_READ_MASK)),
         };
 
-        let mut client = self.execution_service_client();
+        let response = self
+            .execution_service_client()
+            .execute_transaction(request)
+            .await?
+            .into_inner();
 
-        let response = client.execute_transaction(request).await?.into_inner();
-
-        let executed = response
-            .transaction
-            .ok_or(TryFromProtoError::missing("transaction"))?;
-
-        extract_execution_data(&executed)
+        extract_execution_response(response.transaction)
     }
 }

--- a/crates/iota-grpc-client/src/api/execution/mod.rs
+++ b/crates/iota-grpc-client/src/api/execution/mod.rs
@@ -1,0 +1,9 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! High-level API for TransactionExecutionService operations.
+//!
+//! Provides ergonomic methods for executing and simulating transactions.
+
+mod execute;
+mod simulate;

--- a/crates/iota-grpc-client/src/api/execution/simulate.rs
+++ b/crates/iota-grpc-client/src/api/execution/simulate.rs
@@ -11,8 +11,8 @@ use iota_sdk_types::Transaction;
 use crate::{
     Client,
     api::{
-        EXECUTION_READ_MASK, FieldMask, FieldMaskUtil, Result, TransactionSimulationResponse,
-        TryFromProtoError, build_proto_transaction, extract_execution_data,
+        EXECUTION_READ_MASK, Result, TransactionSimulationResponse, build_proto_transaction,
+        extract_execution_response, field_mask_with_default,
     },
 };
 
@@ -78,22 +78,19 @@ impl Client {
             vec![]
         };
 
-        let mask = read_mask.unwrap_or(EXECUTION_READ_MASK);
         let request = SimulateTransactionRequest {
             transaction: Some(proto_transaction),
             tx_checks,
             estimate_gas_budget: None,
-            read_mask: Some(FieldMask::from_str(mask)),
+            read_mask: Some(field_mask_with_default(read_mask, EXECUTION_READ_MASK)),
         };
 
-        let mut client = self.execution_service_client();
+        let response = self
+            .execution_service_client()
+            .simulate_transaction(request)
+            .await?
+            .into_inner();
 
-        let response = client.simulate_transaction(request).await?.into_inner();
-
-        let executed = response
-            .transaction
-            .ok_or(TryFromProtoError::missing("transaction"))?;
-
-        Ok(extract_execution_data(&executed)?.into())
+        Ok(extract_execution_response(response.transaction)?.into())
     }
 }

--- a/crates/iota-grpc-client/src/api/execution/simulate.rs
+++ b/crates/iota-grpc-client/src/api/execution/simulate.rs
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! High-level API for transaction simulation.
+
+use iota_grpc_types::v0::transaction_execution_service::{
+    SimulateTransactionRequest, simulate_transaction_request::TransactionCheckModes,
+};
+use iota_sdk_types::Transaction;
+
+use crate::{
+    Client,
+    api::{
+        EXECUTION_READ_MASK, FieldMask, FieldMaskUtil, Result, TransactionSimulationResponse,
+        TryFromProtoError, build_proto_transaction, extract_execution_data,
+    },
+};
+
+impl Client {
+    /// Simulate a transaction without executing it.
+    ///
+    /// This allows you to preview the effects of a transaction before
+    /// actually submitting it to the network.
+    ///
+    /// Set `dev_inspect` to true for relaxed Move VM checks (useful for
+    /// debugging and development).
+    ///
+    /// Returns `TransactionSimulationResponse` containing the simulated
+    /// effects, events, and input/output objects.
+    ///
+    /// # Field Mask
+    ///
+    /// The optional `read_mask` parameter controls which fields the server
+    /// returns. If `None`, uses [`EXECUTION_READ_MASK`] which includes effects,
+    /// events, and input/output objects.
+    ///
+    /// **Required fields** (must be included in custom masks):
+    /// - `transaction.effects` - Transaction effects
+    ///
+    /// **Optional fields:**
+    /// - `transaction.events` - Transaction events
+    /// - `transaction.input_objects` - Input objects used
+    /// - `transaction.output_objects` - Output objects created/modified
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_grpc_client::Client;
+    /// # use iota_sdk_types::Transaction;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::connect("http://localhost:9000").await?;
+    ///
+    /// let tx: Transaction = todo!();
+    ///
+    /// // Standard simulation with all fields
+    /// let result = client.simulate_transaction(tx.clone(), false, None).await?;
+    /// println!("Simulation status: {:?}", result.effects.status());
+    ///
+    /// // Dev-inspect mode with minimal fields
+    /// let result = client
+    ///     .simulate_transaction(tx, true, Some("transaction.effects"))
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`EXECUTION_READ_MASK`]: crate::EXECUTION_READ_MASK
+    pub async fn simulate_transaction(
+        &self,
+        transaction: Transaction,
+        dev_inspect: bool,
+        read_mask: Option<&str>,
+    ) -> Result<TransactionSimulationResponse> {
+        // Build proto transaction directly from SDK types
+        let proto_transaction = build_proto_transaction(&transaction, transaction.digest())?;
+
+        let tx_checks = if dev_inspect {
+            vec![TransactionCheckModes::DisableVmChecks as i32]
+        } else {
+            vec![]
+        };
+
+        let mask = read_mask.unwrap_or(EXECUTION_READ_MASK);
+        let request = SimulateTransactionRequest {
+            transaction: Some(proto_transaction),
+            tx_checks,
+            estimate_gas_budget: None,
+            read_mask: Some(FieldMask::from_str(mask)),
+        };
+
+        let mut client = self.execution_service_client();
+
+        let response = client.simulate_transaction(request).await?.into_inner();
+
+        let executed = response
+            .transaction
+            .ok_or(TryFromProtoError::missing("transaction"))?;
+
+        Ok(extract_execution_data(&executed)?.into())
+    }
+}

--- a/crates/iota-grpc-client/src/api/execution/simulate.rs
+++ b/crates/iota-grpc-client/src/api/execution/simulate.rs
@@ -63,8 +63,6 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// [`EXECUTION_READ_MASK`]: crate::EXECUTION_READ_MASK
     pub async fn simulate_transaction(
         &self,
         transaction: Transaction,

--- a/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
+++ b/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
@@ -18,8 +18,8 @@ impl Client {
     /// Get the latest checkpoint.
     ///
     /// Note: If you only need the latest checkpoint sequence number (not the
-    /// full checkpoint data), use [`ResponseExt::checkpoint_height()`] on any
-    /// gRPC response instead.
+    /// full checkpoint data), use [`crate::ResponseExt::checkpoint_height()`]
+    /// on any gRPC response instead.
     ///
     /// # Example
     ///

--- a/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
+++ b/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! High-level API for checkpoint queries.
+
+use iota_grpc_types::{
+    field::FieldMask,
+    v0::ledger_service::{GetCheckpointDataRequest, get_checkpoint_data_request},
+};
+use iota_sdk_types::{CheckpointSequenceNumber, Digest, SignedCheckpointSummary};
+
+use crate::{
+    Client,
+    api::{Result, TryFromProtoError},
+};
+
+impl Client {
+    /// Get the latest checkpoint.
+    ///
+    /// Note: If you only need the latest checkpoint sequence number (not the
+    /// full checkpoint data), use [`ResponseExt::checkpoint_height()`] on any
+    /// gRPC response instead.
+    ///
+    /// [`ResponseExt::checkpoint_height()`]: crate::ResponseExt::checkpoint_height
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_grpc_client::Client;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::connect("http://localhost:9000").await?;
+    /// let latest = client.get_latest_checkpoint().await?;
+    /// println!("Latest checkpoint: {}", latest.checkpoint.sequence_number);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_latest_checkpoint(&self) -> Result<SignedCheckpointSummary> {
+        self.get_checkpoint_internal(get_checkpoint_data_request::CheckpointId::Latest(true))
+            .await
+    }
+
+    /// Get a checkpoint by sequence number.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_grpc_client::Client;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::connect("http://localhost:9000").await?;
+    /// let checkpoint = client.get_checkpoint(100).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Result<SignedCheckpointSummary> {
+        self.get_checkpoint_internal(get_checkpoint_data_request::CheckpointId::SequenceNumber(
+            sequence_number,
+        ))
+        .await
+    }
+
+    /// Get a checkpoint by digest.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_grpc_client::Client;
+    /// # use iota_sdk_types::Digest;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::connect("http://localhost:9000").await?;
+    /// let digest: Digest = todo!();
+    /// let checkpoint = client.get_checkpoint_by_digest(&digest).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_checkpoint_by_digest(
+        &self,
+        digest: &Digest,
+    ) -> Result<SignedCheckpointSummary> {
+        self.get_checkpoint_internal(get_checkpoint_data_request::CheckpointId::Digest(
+            (*digest).into(),
+        ))
+        .await
+    }
+
+    /// Internal helper to fetch a checkpoint by any ID type.
+    async fn get_checkpoint_internal(
+        &self,
+        checkpoint_id: get_checkpoint_data_request::CheckpointId,
+    ) -> Result<SignedCheckpointSummary> {
+        let request = GetCheckpointDataRequest {
+            checkpoint_id: Some(checkpoint_id),
+            checkpoint_read_mask: Some(FieldMask {
+                paths: vec!["summary.bcs".to_string()],
+            }),
+            transactions_filter: None,
+            transaction_read_mask: None,
+            events_filter: None,
+            event_read_mask: None,
+            max_message_size_bytes: None,
+        };
+
+        let mut client = self.ledger_service_client();
+
+        let mut stream = client.get_checkpoint_data(request).await?.into_inner();
+
+        // The stream may contain multiple message types (checkpoint, transactions,
+        // events). Iterate to find the checkpoint payload and return early once
+        // found.
+        while let Some(data) = stream.message().await? {
+            let Some(iota_grpc_types::v0::ledger_service::checkpoint_data::Payload::Checkpoint(
+                checkpoint,
+            )) = data.payload
+            else {
+                continue;
+            };
+
+            let summary_bcs = checkpoint
+                .summary
+                .as_ref()
+                .and_then(|s| s.bcs.as_ref())
+                .ok_or(TryFromProtoError::missing("summary.bcs"))?;
+
+            return summary_bcs
+                .deserialize()
+                .map_err(|e| TryFromProtoError::invalid("summary.bcs", e).into());
+        }
+
+        Err(TryFromProtoError::missing("checkpoint").into())
+    }
+}

--- a/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
+++ b/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
@@ -21,8 +21,6 @@ impl Client {
     /// full checkpoint data), use [`ResponseExt::checkpoint_height()`] on any
     /// gRPC response instead.
     ///
-    /// [`ResponseExt::checkpoint_height()`]: crate::ResponseExt::checkpoint_height
-    ///
     /// # Example
     ///
     /// ```no_run

--- a/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
+++ b/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
@@ -97,7 +97,7 @@ impl Client {
             transaction_read_mask: None,
             events_filter: None,
             event_read_mask: None,
-            max_message_size_bytes: None,
+            max_message_size_bytes: self.max_decoding_message_size().map(|s| s as u32),
         };
 
         let mut client = self.ledger_service_client();

--- a/crates/iota-grpc-client/src/api/ledger/epochs.rs
+++ b/crates/iota-grpc-client/src/api/ledger/epochs.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! High-level API for epoch queries.
+
+use iota_grpc_types::{
+    field::FieldMask,
+    v0::{epoch::Epoch, ledger_service::GetEpochRequest},
+};
+
+use crate::{
+    Client,
+    api::{Result, TryFromProtoError},
+};
+
+impl Client {
+    /// Get the reference gas price for the current epoch.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_grpc_client::Client;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::connect("http://localhost:9000").await?;
+    /// let gas_price = client.get_reference_gas_price().await?;
+    /// println!("Reference gas price: {gas_price} NANOS");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_reference_gas_price(&self) -> Result<u64> {
+        self.get_epoch_field("reference_gas_price", |e| e.reference_gas_price)
+            .await
+    }
+
+    /// Internal helper to fetch a single field from the current epoch.
+    async fn get_epoch_field<T>(
+        &self,
+        field: &str,
+        extractor: impl FnOnce(Epoch) -> Option<T>,
+    ) -> Result<T> {
+        let request = GetEpochRequest {
+            epoch: None, // Current epoch
+            read_mask: Some(FieldMask {
+                paths: vec![field.to_string()],
+            }),
+        };
+
+        let mut client = self.ledger_service_client();
+        let response = client.get_epoch(request).await?.into_inner();
+
+        response
+            .epoch
+            .and_then(extractor)
+            .ok_or(TryFromProtoError::missing(field).into())
+    }
+}

--- a/crates/iota-grpc-client/src/api/ledger/mod.rs
+++ b/crates/iota-grpc-client/src/api/ledger/mod.rs
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! High-level API for LedgerService operations.
+//!
+//! Provides ergonomic methods for querying transactions, objects, checkpoints,
+//! and epochs.
+
+mod checkpoints;
+mod epochs;
+mod objects;
+mod transactions;

--- a/crates/iota-grpc-client/src/api/ledger/objects.rs
+++ b/crates/iota-grpc-client/src/api/ledger/objects.rs
@@ -48,8 +48,6 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// [`OBJECTS_READ_MASK`]: crate::OBJECTS_READ_MASK
     pub async fn get_objects(
         &self,
         refs: &[(ObjectId, Option<Version>)],

--- a/crates/iota-grpc-client/src/api/ledger/objects.rs
+++ b/crates/iota-grpc-client/src/api/ledger/objects.rs
@@ -20,6 +20,9 @@ impl Client {
     /// Each tuple contains (ObjectId, Option<Version>). If version is None,
     /// the latest version is returned.
     ///
+    /// Results are returned in the same order as the input refs.
+    /// If an object is not found, an error is returned.
+    ///
     /// # Field Mask
     ///
     /// The optional `read_mask` parameter controls which fields the server
@@ -79,13 +82,14 @@ impl Client {
         let mut client = self.ledger_service_client();
 
         let mut stream = client.get_objects(request).await?.into_inner();
+
+        // Server guarantees results are returned in request order
         let mut results = Vec::with_capacity(refs.len());
 
         while let Some(response) = stream.message().await? {
             for result in response.objects {
                 let proto_obj = result.into_result()?;
-                let obj = convert_object(&proto_obj, "object.bcs")?;
-                results.push(obj);
+                results.push(convert_object(&proto_obj, "object.bcs")?);
             }
         }
 

--- a/crates/iota-grpc-client/src/api/ledger/objects.rs
+++ b/crates/iota-grpc-client/src/api/ledger/objects.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! High-level API for object queries.
+
+use iota_grpc_types::v0::{
+    ledger_service::{GetObjectsRequest, ObjectRequest, ObjectRequests},
+    types::ObjectReference,
+};
+use iota_sdk_types::{Object, ObjectId, Version};
+
+use crate::{
+    Client,
+    api::{FieldMask, FieldMaskUtil, OBJECTS_READ_MASK, ProtoResult, Result, convert_object},
+};
+
+impl Client {
+    /// Get objects by their IDs and optional versions.
+    ///
+    /// Each tuple contains (ObjectId, Option<Version>). If version is None,
+    /// the latest version is returned.
+    ///
+    /// # Field Mask
+    ///
+    /// The optional `read_mask` parameter controls which fields the server
+    /// returns. If `None`, uses [`OBJECTS_READ_MASK`] which includes all
+    /// fields needed for `Object` deserialization.
+    ///
+    /// **Required fields** (must be included in custom masks):
+    /// - `bcs` - Object BCS data
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_grpc_client::Client;
+    /// # use iota_sdk_types::ObjectId;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::connect("http://localhost:9000").await?;
+    /// let object_id: ObjectId = "0x2".parse()?;
+    ///
+    /// // Default: get BCS data
+    /// let objs = client.get_objects(&[(object_id, None)], None).await?;
+    ///
+    /// // With reference info (if you also want object metadata)
+    /// let objs = client
+    ///     .get_objects(&[(object_id, None)], Some("bcs,reference"))
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`OBJECTS_READ_MASK`]: crate::OBJECTS_READ_MASK
+    pub async fn get_objects(
+        &self,
+        refs: &[(ObjectId, Option<Version>)],
+        read_mask: Option<&str>,
+    ) -> Result<Vec<Object>> {
+        if refs.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let requests = ObjectRequests {
+            requests: refs
+                .iter()
+                .map(|(id, version)| ObjectRequest {
+                    object_ref: Some(ObjectReference {
+                        object_id: Some(id.to_string()),
+                        version: *version,
+                        digest: None,
+                    }),
+                })
+                .collect(),
+        };
+
+        let mask = read_mask.unwrap_or(OBJECTS_READ_MASK);
+        let request = GetObjectsRequest {
+            requests: Some(requests),
+            read_mask: Some(FieldMask::from_str(mask)),
+            max_message_size_bytes: None,
+        };
+
+        let mut client = self.ledger_service_client();
+
+        let mut stream = client.get_objects(request).await?.into_inner();
+        let mut results = Vec::with_capacity(refs.len());
+
+        while let Some(response) = stream.message().await? {
+            for result in response.objects {
+                let proto_obj = result.into_result()?;
+                let obj = convert_object(&proto_obj, "object.bcs")?;
+                results.push(obj);
+            }
+        }
+
+        Ok(results)
+    }
+}

--- a/crates/iota-grpc-client/src/api/ledger/objects.rs
+++ b/crates/iota-grpc-client/src/api/ledger/objects.rs
@@ -17,7 +17,7 @@ use crate::{
 impl Client {
     /// Get objects by their IDs and optional versions.
     ///
-    /// Each tuple contains (ObjectId, Option<Version>). If version is None,
+    /// Each tuple contains `(ObjectId, Option<Version>)`. If version is None,
     /// the latest version is returned.
     ///
     /// Results are returned in the same order as the input refs.

--- a/crates/iota-grpc-client/src/api/ledger/objects.rs
+++ b/crates/iota-grpc-client/src/api/ledger/objects.rs
@@ -11,7 +11,7 @@ use iota_sdk_types::{Object, ObjectId, Version};
 
 use crate::{
     Client,
-    api::{FieldMask, FieldMaskUtil, OBJECTS_READ_MASK, ProtoResult, Result, convert_object},
+    api::{OBJECTS_READ_MASK, ProtoResult, Result, convert_object, field_mask_with_default},
 };
 
 impl Client {
@@ -70,10 +70,9 @@ impl Client {
                 .collect(),
         };
 
-        let mask = read_mask.unwrap_or(OBJECTS_READ_MASK);
         let request = GetObjectsRequest {
             requests: Some(requests),
-            read_mask: Some(FieldMask::from_str(mask)),
+            read_mask: Some(field_mask_with_default(read_mask, OBJECTS_READ_MASK)),
             max_message_size_bytes: None,
         };
 

--- a/crates/iota-grpc-client/src/api/ledger/objects.rs
+++ b/crates/iota-grpc-client/src/api/ledger/objects.rs
@@ -76,7 +76,7 @@ impl Client {
         let request = GetObjectsRequest {
             requests: Some(requests),
             read_mask: Some(field_mask_with_default(read_mask, OBJECTS_READ_MASK)),
-            max_message_size_bytes: None,
+            max_message_size_bytes: self.max_decoding_message_size().map(|s| s as u32),
         };
 
         let mut client = self.ledger_service_client();

--- a/crates/iota-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-grpc-client/src/api/ledger/transactions.rs
@@ -62,8 +62,6 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// [`TRANSACTIONS_READ_MASK`]: crate::TRANSACTIONS_READ_MASK
     pub async fn get_transactions(
         &self,
         digests: &[Digest],

--- a/crates/iota-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-grpc-client/src/api/ledger/transactions.rs
@@ -14,8 +14,8 @@ use iota_sdk_types::Digest;
 use crate::{
     Client,
     api::{
-        Error, FieldMask, FieldMaskUtil, ProtoResult, Result, TRANSACTIONS_READ_MASK,
-        TransactionResponse, TryFromProtoError, extract_execution_data,
+        Error, ProtoResult, Result, TRANSACTIONS_READ_MASK, TransactionResponse, TryFromProtoError,
+        extract_execution_data, field_mask_with_default,
     },
 };
 
@@ -80,10 +80,9 @@ impl Client {
                 .collect(),
         };
 
-        let mask = read_mask.unwrap_or(TRANSACTIONS_READ_MASK);
         let request = GetTransactionsRequest {
             requests: Some(requests),
-            read_mask: Some(FieldMask::from_str(mask)),
+            read_mask: Some(field_mask_with_default(read_mask, TRANSACTIONS_READ_MASK)),
             max_message_size_bytes: None,
         };
 

--- a/crates/iota-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-grpc-client/src/api/ledger/transactions.rs
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! High-level API for transaction queries.
+
+use std::collections::HashMap;
+
+use iota_grpc_types::{
+    proto::proto_to_timestamp_ms,
+    v0::ledger_service::{GetTransactionsRequest, TransactionRequest, TransactionRequests},
+};
+use iota_sdk_types::Digest;
+
+use crate::{
+    Client,
+    api::{
+        Error, FieldMask, FieldMaskUtil, ProtoResult, Result, TRANSACTIONS_READ_MASK,
+        TransactionResponse, TryFromProtoError, extract_execution_data,
+    },
+};
+
+impl Client {
+    /// Get transactions by their digests.
+    ///
+    /// Returns `TransactionResponse` for each transaction, containing the
+    /// transaction data, signatures, effects, and optional events.
+    ///
+    /// Results are returned in the same order as the input digests.
+    /// If a transaction is not found, an error is returned.
+    ///
+    /// # Field Mask
+    ///
+    /// The optional `read_mask` parameter controls which fields the server
+    /// returns. If `None`, uses [`TRANSACTIONS_READ_MASK`] which includes all
+    /// fields needed for `TransactionResponse`.
+    ///
+    /// **Required fields** (must be included in custom masks):
+    /// - `transaction.bcs` - Transaction data
+    /// - `effects.bcs` - Transaction effects
+    ///
+    /// **Optional fields:**
+    /// - `events` - Transaction events
+    /// - `checkpoint` - Checkpoint sequence number
+    /// - `timestamp` - Execution timestamp
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_grpc_client::Client;
+    /// # use iota_sdk_types::Digest;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::connect("http://localhost:9000").await?;
+    /// let digest: Digest = todo!();
+    ///
+    /// // Default: get all fields
+    /// let txs = client.get_transactions(&[digest], None).await?;
+    ///
+    /// // Custom: only required fields (smaller response)
+    /// let txs = client
+    ///     .get_transactions(&[digest], Some("transaction.bcs,effects.bcs"))
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`TRANSACTIONS_READ_MASK`]: crate::TRANSACTIONS_READ_MASK
+    pub async fn get_transactions(
+        &self,
+        digests: &[Digest],
+        read_mask: Option<&str>,
+    ) -> Result<Vec<TransactionResponse>> {
+        if digests.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let requests = TransactionRequests {
+            requests: digests
+                .iter()
+                .map(|d| TransactionRequest {
+                    digest: Some((*d).into()),
+                })
+                .collect(),
+        };
+
+        let mask = read_mask.unwrap_or(TRANSACTIONS_READ_MASK);
+        let request = GetTransactionsRequest {
+            requests: Some(requests),
+            read_mask: Some(FieldMask::from_str(mask)),
+            max_message_size_bytes: None,
+        };
+
+        let mut client = self.ledger_service_client();
+
+        let mut stream = client.get_transactions(request).await?.into_inner();
+
+        // Build a map from digest to index for O(1) lookups
+        let digest_to_index: HashMap<Digest, usize> =
+            digests.iter().enumerate().map(|(i, d)| (*d, i)).collect();
+
+        // Pre-allocate results vector with None values
+        let mut results: Vec<Option<TransactionResponse>> = vec![None; digests.len()];
+
+        while let Some(response) = stream.message().await? {
+            for result in response.transactions {
+                let proto_tx = result.into_result()?;
+                let tx_response = convert_to_response(*proto_tx)?;
+                if let Some(&index) = digest_to_index.get(&tx_response.digest) {
+                    results[index] = Some(tx_response);
+                }
+            }
+        }
+
+        // Convert to Vec<TransactionResponse>, erroring if any are missing
+        results
+            .into_iter()
+            .enumerate()
+            .map(|(i, opt)| {
+                opt.ok_or_else(|| Error::NotFound {
+                    resource: "transaction",
+                    id: digests[i].to_string(),
+                })
+            })
+            .collect()
+    }
+}
+
+/// Convert a proto ExecutedTransaction to TransactionResponse.
+fn convert_to_response(
+    proto: iota_grpc_types::v0::transaction::ExecutedTransaction,
+) -> Result<TransactionResponse> {
+    // Extract and deserialize transaction BCS (required)
+    let tx_bcs = proto
+        .transaction
+        .as_ref()
+        .and_then(|t| t.bcs.as_ref())
+        .ok_or(TryFromProtoError::missing("transaction.bcs"))?;
+
+    let signed_tx: iota_sdk_types::SignedTransaction = tx_bcs
+        .deserialize()
+        .map_err(|e| TryFromProtoError::invalid("transaction.bcs", e))?;
+
+    // Extract checkpoint and timestamp from proto (these are per-transaction
+    // historical data, not available in response headers)
+    let checkpoint = proto.checkpoint;
+    let timestamp_ms = proto.timestamp.map(proto_to_timestamp_ms).transpose()?;
+
+    let data = extract_execution_data(&proto)?;
+
+    Ok(TransactionResponse {
+        digest: signed_tx.transaction.digest(),
+        transaction: signed_tx.transaction,
+        signatures: signed_tx.signatures,
+        effects: data.effects,
+        events: data.events,
+        checkpoint,
+        timestamp_ms,
+    })
+}

--- a/crates/iota-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-grpc-client/src/api/ledger/transactions.rs
@@ -3,19 +3,17 @@
 
 //! High-level API for transaction queries.
 
-use std::collections::HashMap;
-
 use iota_grpc_types::{
     proto::proto_to_timestamp_ms,
     v0::ledger_service::{GetTransactionsRequest, TransactionRequest, TransactionRequests},
 };
-use iota_sdk_types::Digest;
+use iota_sdk_types::{Digest, Transaction, UserSignature};
 
 use crate::{
     Client,
     api::{
         Error, ProtoResult, Result, TRANSACTIONS_READ_MASK, TransactionResponse, TryFromProtoError,
-        extract_execution_data, field_mask_with_default,
+        extract_effects_and_events, field_mask_with_default,
     },
 };
 
@@ -36,6 +34,7 @@ impl Client {
     ///
     /// **Required fields** (must be included in custom masks):
     /// - `transaction.bcs` - Transaction data
+    /// - `signatures.bcs` - User signatures
     /// - `effects.bcs` - Transaction effects
     ///
     /// **Optional fields:**
@@ -57,7 +56,10 @@ impl Client {
     ///
     /// // Custom: only required fields (smaller response)
     /// let txs = client
-    ///     .get_transactions(&[digest], Some("transaction.bcs,effects.bcs"))
+    ///     .get_transactions(
+    ///         &[digest],
+    ///         Some("transaction.bcs,signatures.bcs,effects.bcs"),
+    ///     )
     ///     .await?;
     /// # Ok(())
     /// # }
@@ -90,34 +92,17 @@ impl Client {
 
         let mut stream = client.get_transactions(request).await?.into_inner();
 
-        // Build a map from digest to index for O(1) lookups
-        let digest_to_index: HashMap<Digest, usize> =
-            digests.iter().enumerate().map(|(i, d)| (*d, i)).collect();
-
-        // Pre-allocate results vector with None values
-        let mut results: Vec<Option<TransactionResponse>> = vec![None; digests.len()];
+        // Server guarantees results are returned in request order
+        let mut results = Vec::with_capacity(digests.len());
 
         while let Some(response) = stream.message().await? {
             for result in response.transactions {
                 let proto_tx = result.into_result()?;
-                let tx_response = convert_to_response(*proto_tx)?;
-                if let Some(&index) = digest_to_index.get(&tx_response.digest) {
-                    results[index] = Some(tx_response);
-                }
+                results.push(convert_to_response(*proto_tx)?);
             }
         }
 
-        // Convert to Vec<TransactionResponse>, erroring if any are missing
-        results
-            .into_iter()
-            .enumerate()
-            .map(|(i, opt)| {
-                opt.ok_or_else(|| Error::NotFound {
-                    resource: "transaction",
-                    id: digests[i].to_string(),
-                })
-            })
-            .collect()
+        Ok(results)
     }
 }
 
@@ -126,30 +111,53 @@ fn convert_to_response(
     proto: iota_grpc_types::v0::transaction::ExecutedTransaction,
 ) -> Result<TransactionResponse> {
     // Extract and deserialize transaction BCS (required)
+    // Note: The BCS contains Transaction (not SignedTransaction).
+    // Signatures are stored separately in proto.signatures.
     let tx_bcs = proto
         .transaction
         .as_ref()
         .and_then(|t| t.bcs.as_ref())
         .ok_or(TryFromProtoError::missing("transaction.bcs"))?;
 
-    let signed_tx: iota_sdk_types::SignedTransaction = tx_bcs
+    let transaction: Transaction = tx_bcs
         .deserialize()
         .map_err(|e| TryFromProtoError::invalid("transaction.bcs", e))?;
+
+    // Extract signatures from proto.signatures
+    let signatures = extract_signatures(&proto)?;
 
     // Extract checkpoint and timestamp from proto (these are per-transaction
     // historical data, not available in response headers)
     let checkpoint = proto.checkpoint;
     let timestamp_ms = proto.timestamp.map(proto_to_timestamp_ms).transpose()?;
 
-    let data = extract_execution_data(&proto)?;
+    let (effects, events) = extract_effects_and_events(&proto)?;
 
     Ok(TransactionResponse {
-        digest: signed_tx.transaction.digest(),
-        transaction: signed_tx.transaction,
-        signatures: signed_tx.signatures,
-        effects: data.effects,
-        events: data.events,
+        digest: transaction.digest(),
+        transaction,
+        signatures,
+        effects,
+        events,
         checkpoint,
         timestamp_ms,
     })
+}
+
+/// Extract user signatures from proto ExecutedTransaction.
+fn extract_signatures(
+    proto: &iota_grpc_types::v0::transaction::ExecutedTransaction,
+) -> Result<Vec<UserSignature>> {
+    proto
+        .signatures
+        .as_ref()
+        .map(|sigs| {
+            sigs.signatures
+                .iter()
+                .map(|sig| {
+                    UserSignature::try_from(sig).map_err(|e| Error::Signature(e.to_string()))
+                })
+                .collect::<Result<Vec<_>>>()
+        })
+        .unwrap_or_else(|| Ok(vec![]))
 }

--- a/crates/iota-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-grpc-client/src/api/ledger/transactions.rs
@@ -85,7 +85,7 @@ impl Client {
         let request = GetTransactionsRequest {
             requests: Some(requests),
             read_mask: Some(field_mask_with_default(read_mask, TRANSACTIONS_READ_MASK)),
-            max_message_size_bytes: None,
+            max_message_size_bytes: self.max_decoding_message_size().map(|s| s as u32),
         };
 
         let mut client = self.ledger_service_client();

--- a/crates/iota-grpc-client/src/api/mod.rs
+++ b/crates/iota-grpc-client/src/api/mod.rs
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! High-level API for gRPC client operations.
+//!
+//! This module provides ergonomic wrappers around the raw gRPC service clients,
+//! allowing users to work with SDK types directly without dealing with proto
+//! types.
+
+use iota_sdk_types::{
+    CheckpointSequenceNumber, Digest, Object, Transaction, TransactionEffects, TransactionEvents,
+    UserSignature,
+};
+
+mod common;
+pub mod execution;
+pub mod ledger;
+
+pub use common::{
+    EXECUTION_READ_MASK, Error, OBJECTS_READ_MASK, Result, TRANSACTIONS_READ_MASK,
+    TransactionExecutionResponse,
+};
+pub(crate) use common::{
+    FieldMask, FieldMaskUtil, ProtoResult, TryFromProtoError, build_proto_transaction,
+    convert_object, extract_execution_data,
+};
+
+/// Response for a transaction query.
+///
+/// Contains the transaction data, signatures, effects, and optional events.
+#[derive(Debug, Clone)]
+pub struct TransactionResponse {
+    /// Transaction digest.
+    pub digest: Digest,
+    /// The transaction data.
+    pub transaction: Transaction,
+    /// User signatures on the transaction.
+    pub signatures: Vec<UserSignature>,
+    /// The effects of executing this transaction.
+    pub effects: TransactionEffects,
+    /// Events emitted during execution (if available).
+    pub events: Option<TransactionEvents>,
+    /// Checkpoint that includes this transaction (if finalized).
+    pub checkpoint: Option<CheckpointSequenceNumber>,
+    /// Timestamp in milliseconds when the transaction was executed (if
+    /// available).
+    pub timestamp_ms: Option<u64>,
+}
+
+/// Response for transaction simulation.
+///
+/// Contains the simulated effects, events, and objects.
+///
+/// Unlike [`TransactionExecutionResponse`], simulation always returns input and
+/// output objects (as `Vec<Object>` rather than `Option<Vec<Object>>`) because
+/// previewing object changes is the primary purpose of simulation.
+#[derive(Debug, Clone)]
+pub struct TransactionSimulationResponse {
+    /// The simulated effects.
+    pub effects: TransactionEffects,
+    /// Events that would be emitted.
+    pub events: Option<TransactionEvents>,
+    /// Input objects used by the transaction (always populated for simulation).
+    pub input_objects: Vec<Object>,
+    /// Output objects that would be created/modified (always populated for
+    /// simulation).
+    pub output_objects: Vec<Object>,
+}
+
+impl From<TransactionExecutionResponse> for TransactionSimulationResponse {
+    fn from(data: TransactionExecutionResponse) -> Self {
+        Self {
+            effects: data.effects,
+            events: data.events,
+            input_objects: data.input_objects.unwrap_or_default(),
+            output_objects: data.output_objects.unwrap_or_default(),
+        }
+    }
+}

--- a/crates/iota-grpc-client/src/api/mod.rs
+++ b/crates/iota-grpc-client/src/api/mod.rs
@@ -21,8 +21,8 @@ pub use common::{
     TransactionExecutionResponse,
 };
 pub(crate) use common::{
-    FieldMask, FieldMaskUtil, ProtoResult, TryFromProtoError, build_proto_transaction,
-    convert_object, extract_execution_data,
+    ProtoResult, TryFromProtoError, build_proto_transaction, convert_object,
+    extract_execution_data, extract_execution_response, field_mask_with_default,
 };
 
 /// Response for a transaction query.

--- a/crates/iota-grpc-client/src/api/mod.rs
+++ b/crates/iota-grpc-client/src/api/mod.rs
@@ -22,7 +22,7 @@ pub use common::{
 };
 pub(crate) use common::{
     ProtoResult, TryFromProtoError, build_proto_transaction, convert_object,
-    extract_execution_data, extract_execution_response, field_mask_with_default,
+    extract_effects_and_events, extract_execution_response, field_mask_with_default,
 };
 
 /// Response for a transaction query.

--- a/crates/iota-grpc-client/src/client.rs
+++ b/crates/iota-grpc-client/src/client.rs
@@ -2,18 +2,16 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    sync::{Arc, OnceLock},
-    time::Duration,
-};
+use std::time::Duration;
 
-use iota_grpc_types::v0::ledger_service::ledger_service_client::LedgerServiceClient;
-use tap::Pipe;
+use iota_grpc_types::v0::{
+    ledger_service::ledger_service_client::LedgerServiceClient,
+    transaction_execution_service::transaction_execution_service_client::TransactionExecutionServiceClient,
+};
 use tonic::{codec::CompressionEncoding, transport::channel::ClientTlsConfig};
 
-use crate::interceptors::HeadersInterceptor;
+use crate::{api::Result, interceptors::HeadersInterceptor};
 
-type Result<T, E = tonic::Status> = std::result::Result<T, E>;
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 type InterceptedChannel =
@@ -30,9 +28,6 @@ pub struct Client {
     headers: HeadersInterceptor,
     /// Maximum decoding message size for responses
     max_decoding_message_size: Option<usize>,
-
-    /// Cached ledger client (singleton)
-    ledger_client: Arc<OnceLock<LedgerServiceClient<InterceptedChannel>>>,
 }
 
 impl Client {
@@ -66,7 +61,6 @@ impl Client {
             channel,
             headers: Default::default(),
             max_decoding_message_size: None,
-            ledger_client: Arc::new(OnceLock::new()),
         })
     }
 
@@ -100,35 +94,62 @@ impl Client {
         self
     }
 
-    // ========================================
-    // Service Client Factories
-    // ========================================
-
     /// Get a ledger service client.
-    ///
-    /// Returns `Some(LedgerClient)` if the server supports ledger-related
-    /// operations, `None` otherwise. The client is created only once and
-    /// cached for subsequent calls.
-    pub fn ledger_service_client(&self) -> Option<LedgerServiceClient<InterceptedChannel>> {
-        // For now, always return Some since ledger service is always available
-        // In the future, this could check server capabilities first
-        Some(
-            self.ledger_client
-                .get_or_init(|| {
-                    LedgerServiceClient::with_interceptor(
-                        self.channel.clone(),
-                        self.headers.clone(),
-                    )
-                    .accept_compressed(CompressionEncoding::Zstd)
-                    .pipe(|client| {
-                        if let Some(limit) = self.max_decoding_message_size {
-                            client.max_decoding_message_size(limit)
-                        } else {
-                            client
-                        }
-                    })
-                })
-                .clone(),
-        )
+    pub fn ledger_service_client(&self) -> LedgerServiceClient<InterceptedChannel> {
+        self.configure_client(LedgerServiceClient::with_interceptor(
+            self.channel.clone(),
+            self.headers.clone(),
+        ))
+    }
+
+    /// Get a transaction execution service client.
+    pub fn execution_service_client(
+        &self,
+    ) -> TransactionExecutionServiceClient<InterceptedChannel> {
+        self.configure_client(TransactionExecutionServiceClient::with_interceptor(
+            self.channel.clone(),
+            self.headers.clone(),
+        ))
+    }
+
+    /// Apply common client configuration (compression, message size limits).
+    fn configure_client<C: GrpcClientConfig>(&self, client: C) -> C {
+        let client = client.accept_compressed(CompressionEncoding::Zstd);
+        if let Some(limit) = self.max_decoding_message_size {
+            client.max_decoding_message_size(limit)
+        } else {
+            client
+        }
     }
 }
+
+/// Trait for common gRPC client configuration methods.
+///
+/// This trait abstracts over the common configuration methods shared by
+/// tonic-generated service clients, allowing `configure_client` to work
+/// generically.
+trait GrpcClientConfig: Sized {
+    fn accept_compressed(self, encoding: CompressionEncoding) -> Self;
+    fn max_decoding_message_size(self, limit: usize) -> Self;
+}
+
+/// Implement `GrpcClientConfig` for tonic-generated service clients.
+macro_rules! impl_grpc_client_config {
+    ($($client:ty),* $(,)?) => {
+        $(
+            impl GrpcClientConfig for $client {
+                fn accept_compressed(self, encoding: CompressionEncoding) -> Self {
+                    self.accept_compressed(encoding)
+                }
+                fn max_decoding_message_size(self, limit: usize) -> Self {
+                    self.max_decoding_message_size(limit)
+                }
+            }
+        )*
+    };
+}
+
+impl_grpc_client_config!(
+    LedgerServiceClient<InterceptedChannel>,
+    TransactionExecutionServiceClient<InterceptedChannel>,
+);

--- a/crates/iota-grpc-client/src/lib.rs
+++ b/crates/iota-grpc-client/src/lib.rs
@@ -2,6 +2,44 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! gRPC client for IOTA node operations.
+//!
+//! This crate provides a high-level client for interacting with IOTA nodes
+//! via gRPC. It wraps the low-level proto types and provides ergonomic APIs
+//! using SDK types from `iota_sdk_types`.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use iota_grpc_client::Client;
+//! use iota_sdk_types::{Digest, ObjectId};
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = Client::connect("http://localhost:9000").await?;
+//!
+//! // Get a transaction with full details (None = use default field mask)
+//! let digest: Digest = todo!();
+//! let txs = client.get_transactions(&[digest], None).await?;
+//! if let Some(tx) = txs.first() {
+//!     println!("Transaction digest: {:?}", tx.digest);
+//! }
+//!
+//! // Get an object (None = use default field mask)
+//! let object_id: ObjectId = "0x2".parse()?;
+//! let objects = client.get_objects(&[(object_id, None)], None).await?;
+//! if let Some(object) = objects.first() {
+//!     println!("Object version: {:?}", object.version());
+//! }
+//! # Ok(())
+//! # }
+//! ```
+
+pub mod api;
+
+// Re-export types for convenience
+pub use api::{
+    EXECUTION_READ_MASK, Error, OBJECTS_READ_MASK, Result, TRANSACTIONS_READ_MASK,
+    TransactionExecutionResponse, TransactionResponse, TransactionSimulationResponse,
+};
 
 mod client;
 pub use client::Client;


### PR DESCRIPTION
# Description of change

Add high-level gRPC API calls, which makes the types of input parameters and responses be all from `iota-sdk-types` for ease of usage.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/9620

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes