### PR TITLE
fix(transactional-test-runner): Always wait for snapshot catchup

### DIFF
--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -622,8 +622,9 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                     .wait_for_checkpoint_catchup(highest_checkpoint, Duration::from_secs(60))
                     .await;
 
-                // wait_for_objects_snapshot_catchup(graphql_client,
-                // Duration::from_secs(180)).await;
+                offchain_reader
+                    .wait_for_objects_snapshot_catchup(Duration::from_secs(180))
+                    .await;
 
                 if let Some(checkpoint_to_prune) = wait_for_checkpoint_pruned {
                     offchain_reader


### PR DESCRIPTION
# Description of change

Wait for snapshot catchup in graphql e2e tests

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9753

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
