### PR TITLE
upstream(core): Increase dashmap shards and use segmented Moka cache to reduce lock contention

### DIFF
--- a/crates/iota-core/src/execution_cache/cache_types.rs
+++ b/crates/iota-core/src/execution_cache/cache_types.rs
@@ -11,7 +11,7 @@ use std::{
 
 use iota_common::debug_fatal;
 use iota_types::base_types::SequenceNumber;
-use moka::sync::Cache as MokaCache;
+use moka::sync::SegmentedCache as MokaCache;
 use parking_lot::Mutex;
 
 pub enum CacheResult<T> {
@@ -156,7 +156,7 @@ where
 {
     pub fn new(cache_size: u64) -> Self {
         Self {
-            cache: MokaCache::builder().max_capacity(cache_size).build(),
+            cache: MokaCache::builder(8).max_capacity(cache_size).build(),
             key_generation: (0..KEY_GENERATION_SIZE)
                 .map(|_| AtomicU64::new(0))
                 .collect(),

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -72,7 +72,7 @@ use iota_types::{
     storage::{MarkerValue, ObjectKey, ObjectOrTombstone, ObjectStore, PackageObject},
     transaction::{VerifiedSignedTransaction, VerifiedTransaction},
 };
-use moka::sync::Cache as MokaCache;
+use moka::sync::SegmentedCache as MokaCache;
 use parking_lot::Mutex;
 use prometheus::Registry;
 use tap::TapOptional;
@@ -242,12 +242,12 @@ struct UncommittedData {
 impl UncommittedData {
     fn new() -> Self {
         Self {
-            objects: DashMap::new(),
-            markers: DashMap::new(),
-            transaction_effects: DashMap::new(),
-            executed_effects_digests: DashMap::new(),
-            pending_transaction_writes: DashMap::new(),
-            transaction_events: DashMap::new(),
+            objects: DashMap::with_shard_amount(2048),
+            markers: DashMap::with_shard_amount(2048),
+            transaction_effects: DashMap::with_shard_amount(2048),
+            executed_effects_digests: DashMap::with_shard_amount(2048),
+            pending_transaction_writes: DashMap::with_shard_amount(2048),
+            transaction_events: DashMap::with_shard_amount(2048),
             total_transaction_inserts: AtomicU64::new(0),
             total_transaction_commits: AtomicU64::new(0),
         }
@@ -343,10 +343,10 @@ struct CachedCommittedData {
 
 impl CachedCommittedData {
     fn new(config: &WritebackCacheConfig) -> Self {
-        let object_cache = MokaCache::builder()
+        let object_cache = MokaCache::builder(8)
             .max_capacity(config.object_cache_size())
             .build();
-        let marker_cache = MokaCache::builder()
+        let marker_cache = MokaCache::builder(8)
             .max_capacity(config.marker_cache_size())
             .build();
 
@@ -355,7 +355,7 @@ impl CachedCommittedData {
         let transaction_events = MonotonicCache::new(config.events_cache_size());
         let executed_effects_digests = MonotonicCache::new(config.executed_effect_cache_size());
 
-        let transaction_objects = MokaCache::builder()
+        let transaction_objects = MokaCache::builder(8)
             .max_capacity(config.transaction_objects_cache_size())
             .build();
 
@@ -471,7 +471,7 @@ impl WritebackCache {
         metrics: Arc<ExecutionCacheMetrics>,
         backpressure_manager: Arc<BackpressureManager>,
     ) -> Self {
-        let packages = MokaCache::builder()
+        let packages = MokaCache::builder(8)
             .max_capacity(config.package_cache_size())
             .build();
         Self {


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.45.3, v1.46.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/c7695a8ebb087aaa3b491e1f1267e0fbbcb8b956
- Description:

Since these structures are created once at startup, this should have
very little downside.

## Links to any relevant issues

Part of #9768

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
