### PR TITLE
upstream(core): remove std::env::set_var in iota-proxy

### DIFF
--- a/crates/iota-proxy/src/admin.rs
+++ b/crates/iota-proxy/src/admin.rs
@@ -97,6 +97,7 @@ pub fn app(
     client: ReqwestClient,
     relay: HistogramRelay,
     allower: Option<IotaNodeProvider>,
+    timeout_secs: Option<u64>,
 ) -> Router {
     // build our application with a route and our sender mpsc
     let mut router = Router::new()
@@ -116,10 +117,9 @@ pub fn app(
         // Enforce on all routes.
         // If the request does not complete within the specified timeout it will be aborted
         // and a 408 Request Timeout response will be sent.
-        .layer(TimeoutLayer::new(Duration::from_secs(var!(
-            "NODE_CLIENT_TIMEOUT",
-            20
-        ))))
+        .layer(TimeoutLayer::new(Duration::from_secs(
+            timeout_secs.unwrap_or(20),
+        )))
         .layer(Extension(relay))
         .layer(Extension(labels))
         .layer(Extension(client))

--- a/crates/iota-proxy/src/lib.rs
+++ b/crates/iota-proxy/src/lib.rs
@@ -139,6 +139,7 @@ mod tests {
             client,
             HistogramRelay::new(),
             Some(allower.clone()),
+            None,
         );
 
         let listener = std::net::TcpListener::bind("localhost:0").unwrap();
@@ -243,11 +244,7 @@ mod tests {
             "dummy user agent",
         );
 
-        // this will affect other tests if they are run in parallel, but we only have
-        // two tests, so it shouldn't be an issue (yet) even still, the other
-        // tests complete very fast so those tests would also need to slow down by
-        // orders and orders to be bothered by this env var
-        std::env::set_var("NODE_CLIENT_TIMEOUT", "5");
+        let timeout_secs = Some(2u64);
 
         let app = admin::app(
             Labels {
@@ -256,6 +253,7 @@ mod tests {
             client,
             HistogramRelay::new(),
             Some(allower.clone()),
+            timeout_secs,
         );
 
         let listener = std::net::TcpListener::bind("localhost:0").unwrap();
@@ -314,7 +312,5 @@ mod tests {
             .expect("expected a successful post with a self-signed certificate");
         let status = res.status();
         assert_eq!(status, StatusCode::REQUEST_TIMEOUT);
-        // Clean up the environment variable
-        std::env::remove_var("NODE_CLIENT_TIMEOUT");
     }
 }

--- a/crates/iota-proxy/src/main.rs
+++ b/crates/iota-proxy/src/main.rs
@@ -100,6 +100,12 @@ async fn main() -> Result<()> {
             "unavailable",
         ))
         .unwrap();
+
+    let timeout_secs = match env::var("NODE_CLIENT_TIMEOUT") {
+        Ok(val) => val.parse::<u64>().ok(),
+        Err(_) => None,
+    };
+
     let app = app(
         Labels {
             network: config.network,
@@ -107,6 +113,7 @@ async fn main() -> Result<()> {
         client,
         histogram_relay,
         allower,
+        timeout_secs,
     );
 
     server(listener, app, Some(acceptor)).await.unwrap();


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.45.3, v1.46.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/00bd29318d5abbd6fbb2610e739e5e05d7f3a2ec
- Description:

remove `std::env::set_var` from tests and allow timeout to be set
without relying on an env var

## Links to any relevant issues

Part of #9768

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
