### PR TITLE
feat(indexer): Store Unwrapped object change for IndexedTransactions

### DIFF
--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -520,6 +520,16 @@ pub enum IndexedObjectChange {
         object_id: ObjectID,
         version: SequenceNumber,
     },
+    /// Unwrapped object
+    Unwrapped {
+        sender: IotaAddress,
+        owner: Owner,
+        #[serde_as(as = "IotaStructTag")]
+        object_type: StructTag,
+        object_id: ObjectID,
+        version: SequenceNumber,
+        digest: ObjectDigest,
+    },
     /// New object creation
     Created {
         sender: IotaAddress,
@@ -599,6 +609,21 @@ impl From<ObjectChange> for IndexedObjectChange {
                 object_type,
                 object_id,
                 version,
+            },
+            ObjectChange::Unwrapped {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                digest,
+            } => Self::Unwrapped {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                digest,
             },
             ObjectChange::Created {
                 sender,
@@ -686,6 +711,21 @@ impl From<IndexedObjectChange> for ObjectChange {
                 object_type,
                 object_id,
                 version,
+            },
+            IndexedObjectChange::Unwrapped {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                digest,
+            } => ObjectChange::Unwrapped {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                digest,
             },
             IndexedObjectChange::Created {
                 sender,

--- a/crates/iota-indexer/tests/data/wrap_unwrap/Move.toml
+++ b/crates/iota-indexer/tests/data/wrap_unwrap/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "wrap_unwrap"
+edition = "2024.beta"
+
+[dependencies]
+Iota = { local = "../../../../iota-framework/packages/iota-framework" }
+
+[addresses]
+wrap_unwrap = "0x0"

--- a/crates/iota-indexer/tests/data/wrap_unwrap/sources/wrap_unwrap.move
+++ b/crates/iota-indexer/tests/data/wrap_unwrap/sources/wrap_unwrap.move
@@ -1,0 +1,29 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+/// Test module for wrapping and unwrapping objects
+module wrap_unwrap::wrap_unwrap {
+
+    public struct Inner has key, store {
+        id: UID,
+    }
+
+    public struct Wrapper has key, store {
+        id: UID,
+        inner: Inner,
+    }
+
+    public entry fun create_and_wrap(ctx: &mut TxContext) {
+        let inner = Inner { id: object::new(ctx) };
+        iota::transfer::public_transfer(
+            Wrapper { id: object::new(ctx), inner },
+            tx_context::sender(ctx),
+        );
+    }
+
+    public entry fun unwrap(wrapper: Wrapper, ctx: &mut TxContext) {
+        let Wrapper { id, inner } = wrapper;
+        object::delete(id);
+        iota::transfer::public_transfer(inner, tx_context::sender(ctx));
+    }
+}

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -10,13 +10,14 @@ use iota_indexer::{
     store::{PgIndexerStore, package_resolver::IndexerStorePackageResolver},
     test_utils::{TestDatabase, db_url},
 };
-use iota_json::{call_args, type_args};
+use iota_json::{IotaJsonValue, call_args, type_args};
 use iota_json_rpc_api::{IndexerApiClient, ReadApiClient, TransactionBuilderClient};
 use iota_json_rpc_types::{
     CheckpointId, IotaGetPastObjectRequest, IotaObjectDataOptions, IotaObjectRef,
     IotaObjectResponse, IotaObjectResponseQuery, IotaPastObjectResponse,
     IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
-    IotaTransactionBlockResponseOptions, IotaTransactionBlockResponseQueryV2, TransactionFilterV2,
+    IotaTransactionBlockResponseOptions, IotaTransactionBlockResponseQueryV2, ObjectChange,
+    TransactionFilterV2,
 };
 use iota_package_resolver::Resolver;
 use iota_protocol_config::ProtocolVersion;
@@ -26,7 +27,7 @@ use iota_test_transaction_builder::{
 };
 use iota_types::{
     base_types::{ObjectID, SequenceNumber},
-    crypto::{AccountKeyPair, get_key_pair},
+    crypto::{AccountKeyPair, IotaKeyPair, get_key_pair},
     digests::{ChainIdentifier, ObjectDigest, TransactionDigest},
     error::IotaObjectResponseError,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -39,10 +40,11 @@ use move_core_types::identifier::Identifier;
 use serde_json::Value;
 
 use crate::{
+    coin_api::execute_move_call,
     common::{
         ApiTestSetup, FIXTURES_DIR, execute_tx_and_wait_for_indexer_checkpoint,
         indexer_wait_for_checkpoint, indexer_wait_for_checkpoint_pruned, indexer_wait_for_object,
-        indexer_wait_for_transaction, rpc_call_error_msg_matches,
+        indexer_wait_for_transaction, publish_test_move_package, rpc_call_error_msg_matches,
         start_test_cluster_with_read_write_indexer,
     },
     write_api::{create_basic_object, deploy_basics_pkg},
@@ -2510,6 +2512,108 @@ fn find_transaction_for_create_and_wrap_same_ptb() -> Result<(), anyhow::Error> 
             query_res.data.first().unwrap().digest,
             create_and_wrap_tx_res.digest,
             "expected create and wrap transaction to be found"
+        );
+
+        Ok(())
+    })
+}
+
+#[test]
+fn get_transaction_block_with_unwrapped_object_changes() -> Result<(), anyhow::Error> {
+    let ApiTestSetup {
+        runtime,
+        store,
+        cluster,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+        let keypair = IotaKeyPair::Ed25519(keypair);
+        let gas = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(500_000_000_000),
+                address,
+            )
+            .await;
+        let gas_object_id = gas.0;
+        indexer_wait_for_object(client, gas.0, gas.1).await;
+
+        let ((package_id, _, _), publish_tx_response) =
+            publish_test_move_package(client, address, &keypair, "wrap_unwrap").await?;
+        indexer_wait_for_transaction(publish_tx_response.digest, store, client).await;
+
+        let create_wrapped_res = execute_move_call(
+            client,
+            address,
+            &keypair,
+            package_id,
+            "wrap_unwrap".to_string(),
+            "create_and_wrap".to_string(),
+            vec![],
+            vec![],
+            Some(gas_object_id),
+        )
+        .await?;
+
+        let wrapper_object_id = create_wrapped_res
+            .effects
+            .as_ref()
+            .unwrap()
+            .created()
+            .first()
+            .expect("expected created object")
+            .reference
+            .object_id;
+
+        let unwrap_res = execute_move_call(
+            client,
+            address,
+            &keypair,
+            package_id,
+            "wrap_unwrap".to_string(),
+            "unwrap".to_string(),
+            vec![],
+            vec![IotaJsonValue::from_object_id(wrapper_object_id)],
+            Some(gas_object_id),
+        )
+        .await?;
+        indexer_wait_for_transaction(unwrap_res.digest, store, client).await;
+
+        let options = IotaTransactionBlockResponseOptions::default().with_object_changes();
+        let fullnode_tx = cluster
+            .rpc_client()
+            .get_transaction_block(unwrap_res.digest, Some(options.clone()))
+            .await
+            .unwrap();
+        let indexer_tx = client
+            .get_transaction_block(unwrap_res.digest, Some(options.clone()))
+            .await
+            .unwrap();
+
+        assert!(
+            fullnode_tx
+                .object_changes
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|change| matches!(change, ObjectChange::Unwrapped { .. })),
+            "fullnode response should contain Unwrapped object change"
+        );
+        assert!(
+            indexer_tx
+                .object_changes
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|change| matches!(change, ObjectChange::Unwrapped { .. })),
+            "indexer response should contain Unwrapped object change"
+        );
+
+        assert_eq!(
+            fullnode_tx, indexer_tx,
+            "fullnode and indexer responses should match"
         );
 
         Ok(())

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -334,7 +334,8 @@ impl Display for IotaTransactionBlockResponse {
                 mut published,
                 mut transferred,
                 mut wrapped,
-            ) = (vec![], vec![], vec![], vec![], vec![], vec![]);
+                mut unwrapped,
+            ) = (vec![], vec![], vec![], vec![], vec![], vec![], vec![]);
 
             for obj in object_changes {
                 match obj {
@@ -344,6 +345,7 @@ impl Display for IotaTransactionBlockResponse {
                     ObjectChange::Published { .. } => published.push(obj),
                     ObjectChange::Transferred { .. } => transferred.push(obj),
                     ObjectChange::Wrapped { .. } => wrapped.push(obj),
+                    ObjectChange::Unwrapped { .. } => unwrapped.push(obj),
                 };
             }
 
@@ -353,6 +355,7 @@ impl Display for IotaTransactionBlockResponse {
             write_obj_changes(published, "Published", &mut builder)?;
             write_obj_changes(transferred, "Transferred", &mut builder)?;
             write_obj_changes(wrapped, "Wrapped", &mut builder)?;
+            write_obj_changes(unwrapped, "Unwrapped", &mut builder)?;
 
             let mut table = builder.build();
             table.with(TablePanel::header("Object Changes"));

--- a/crates/iota-json-rpc-types/src/object_changes.rs
+++ b/crates/iota-json-rpc-types/src/object_changes.rs
@@ -85,6 +85,20 @@ pub enum ObjectChange {
         #[serde_as(as = "AsSequenceNumber")]
         version: SequenceNumber,
     },
+    /// Unwrapped object
+    #[serde(rename_all = "camelCase")]
+    Unwrapped {
+        sender: IotaAddress,
+        owner: Owner,
+        #[schemars(with = "String")]
+        #[serde_as(as = "IotaStructTag")]
+        object_type: StructTag,
+        object_id: ObjectID,
+        #[schemars(with = "AsSequenceNumber")]
+        #[serde_as(as = "AsSequenceNumber")]
+        version: SequenceNumber,
+        digest: ObjectDigest,
+    },
     /// New object creation
     #[serde(rename_all = "camelCase")]
     Created {
@@ -109,6 +123,7 @@ impl ObjectChange {
             | ObjectChange::Mutated { object_id, .. }
             | ObjectChange::Deleted { object_id, .. }
             | ObjectChange::Wrapped { object_id, .. }
+            | ObjectChange::Unwrapped { object_id, .. }
             | ObjectChange::Created { object_id, .. } => *object_id,
         }
     }
@@ -128,6 +143,12 @@ impl ObjectChange {
                 ..
             }
             | ObjectChange::Mutated {
+                object_id,
+                version,
+                digest,
+                ..
+            }
+            | ObjectChange::Unwrapped {
                 object_id,
                 version,
                 digest,
@@ -157,6 +178,9 @@ impl ObjectChange {
                 version, digest, ..
             }
             | ObjectChange::Mutated {
+                version, digest, ..
+            }
+            | ObjectChange::Unwrapped {
                 version, digest, ..
             }
             | ObjectChange::Created {
@@ -257,6 +281,25 @@ impl Display for ObjectChange {
                     sender,
                     object_type,
                     u64::from(*version)
+                )
+            }
+            ObjectChange::Unwrapped {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                digest,
+            } => {
+                write!(
+                    f,
+                    " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ Owner: {}\n │ ObjectType: {} \n │ Version: {}\n │ Digest: {}\n └──",
+                    object_id,
+                    sender,
+                    owner,
+                    object_type,
+                    u64::from(*version),
+                    digest
                 )
             }
             ObjectChange::Created {

--- a/crates/iota-json-rpc/src/object_changes.rs
+++ b/crates/iota-json-rpc/src/object_changes.rs
@@ -52,7 +52,14 @@ pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
                     version,
                     digest,
                 }),
-                _ => {}
+                WriteKind::Unwrap => object_changes.push(ObjectChange::Unwrapped {
+                    sender,
+                    owner,
+                    object_type,
+                    object_id,
+                    version,
+                    digest,
+                }),
             }
         } else if let Some(p) = o.data.try_as_package() {
             if kind == WriteKind::Create {

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -10618,6 +10618,45 @@
             }
           },
           {
+            "description": "Unwrapped object",
+            "type": "object",
+            "required": [
+              "digest",
+              "objectId",
+              "objectType",
+              "owner",
+              "sender",
+              "type",
+              "version"
+            ],
+            "properties": {
+              "digest": {
+                "$ref": "#/components/schemas/ObjectDigest"
+              },
+              "objectId": {
+                "$ref": "#/components/schemas/ObjectID"
+              },
+              "objectType": {
+                "type": "string"
+              },
+              "owner": {
+                "$ref": "#/components/schemas/Owner"
+              },
+              "sender": {
+                "$ref": "#/components/schemas/IotaAddress"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "unwrapped"
+                ]
+              },
+              "version": {
+                "$ref": "#/components/schemas/SequenceNumber2"
+              }
+            }
+          },
+          {
             "description": "New object creation",
             "type": "object",
             "required": [

--- a/crates/iota/src/displays/dry_run_tx_block.rs
+++ b/crates/iota/src/displays/dry_run_tx_block.rs
@@ -49,7 +49,8 @@ impl Display for Pretty<'_, DryRunTransactionBlockResponse> {
                 mut published,
                 mut transferred,
                 mut wrapped,
-            ) = (vec![], vec![], vec![], vec![], vec![], vec![]);
+                mut unwrapped,
+            ) = (vec![], vec![], vec![], vec![], vec![], vec![], vec![]);
             for obj in &response.object_changes {
                 match obj {
                     ObjectChange::Created { .. } => created.push(obj),
@@ -58,6 +59,7 @@ impl Display for Pretty<'_, DryRunTransactionBlockResponse> {
                     ObjectChange::Published { .. } => published.push(obj),
                     ObjectChange::Transferred { .. } => transferred.push(obj),
                     ObjectChange::Wrapped { .. } => wrapped.push(obj),
+                    ObjectChange::Unwrapped { .. } => unwrapped.push(obj),
                 };
             }
 
@@ -67,6 +69,7 @@ impl Display for Pretty<'_, DryRunTransactionBlockResponse> {
             write_obj_changes(published, "Published", &mut builder)?;
             write_obj_changes(transferred, "Transferred", &mut builder)?;
             write_obj_changes(wrapped, "Wrapped", &mut builder)?;
+            write_obj_changes(unwrapped, "Unwrapped", &mut builder)?;
 
             let mut table = builder.build();
             table.with(TablePanel::header("Object Changes"));


### PR DESCRIPTION
# Description of change

Unwrapped objects will now be stored in object_changes field for newly indexed transactions and returned from the indexer json rpc.

This should be followed up by a PR that adds a backfill operation for older data.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9748

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
