### PR TITLE
refactor(iota-kvstore, iota-rest-kv): optimize bigtable query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4517,25 +4517,24 @@ dependencies = [
 
 [[package]]
 name = "gcp_auth"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf67f30198e045a039264c01fb44659ce82402d7771c50938beb41a5ac87733"
+checksum = "c2b3d0b409a042a380111af38136310839af8ac1a0917fb6e84515ed1e4bf3ee"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
- "home",
  "http 1.3.1",
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "ring",
- "rustls-pemfile 2.1.3",
+ "rustls-pki-types",
  "serde",
  "serde_json",
- "thiserror 1.0.64",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -5870,7 +5869,7 @@ dependencies = [
 [[package]]
 name = "iota-bigtable"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-bigtable.git?rev=c1a4c951473eafcd8bf841b9e7b82ee8c5b29b3e#c1a4c951473eafcd8bf841b9e7b82ee8c5b29b3e"
+source = "git+https://github.com/iotaledger/iota-bigtable.git?rev=4141c1245a415cab71a3d47821bfd8fed3437673#4141c1245a415cab71a3d47821bfd8fed3437673"
 dependencies = [
  "gcp_auth",
  "http 1.3.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5869,7 +5869,7 @@ dependencies = [
 [[package]]
 name = "iota-bigtable"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-bigtable.git?rev=4141c1245a415cab71a3d47821bfd8fed3437673#4141c1245a415cab71a3d47821bfd8fed3437673"
+source = "git+https://github.com/iotaledger/iota-bigtable.git?rev=265bc250c7772a3703ed965c9542f61d35f54821#265bc250c7772a3703ed965c9542f61d35f54821"
 dependencies = [
  "gcp_auth",
  "http 1.3.1",

--- a/crates/iota-kvstore/Cargo.toml
+++ b/crates/iota-kvstore/Cargo.toml
@@ -12,7 +12,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
 clap.workspace = true
-iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", rev = "4141c1245a415cab71a3d47821bfd8fed3437673" }
+iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", rev = "265bc250c7772a3703ed965c9542f61d35f54821" }
 serde.workspace = true
 strum.workspace = true
 tokio.workspace = true

--- a/crates/iota-kvstore/Cargo.toml
+++ b/crates/iota-kvstore/Cargo.toml
@@ -12,7 +12,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
 clap.workspace = true
-iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", rev = "c1a4c951473eafcd8bf841b9e7b82ee8c5b29b3e" }
+iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", rev = "4141c1245a415cab71a3d47821bfd8fed3437673" }
 serde.workspace = true
 strum.workspace = true
 tokio.workspace = true

--- a/crates/iota-kvstore/src/bigtable/client.rs
+++ b/crates/iota-kvstore/src/bigtable/client.rs
@@ -20,18 +20,18 @@ use tracing::error;
 
 use crate::{Checkpoint, KeyValueStoreReader, KeyValueStoreWriter, TransactionData};
 
-const OBJECTS_TABLE: &str = "objects";
-const TRANSACTIONS_TABLE: &str = "transactions";
-const CHECKPOINTS_TABLE: &str = "checkpoints";
-const CHECKPOINTS_BY_DIGEST_TABLE: &str = "checkpoints_by_digest";
+pub const OBJECTS_TABLE: &str = "objects";
+pub const TRANSACTIONS_TABLE: &str = "transactions";
+pub const CHECKPOINTS_TABLE: &str = "checkpoints";
+pub const CHECKPOINTS_BY_DIGEST_TABLE: &str = "checkpoints_by_digest";
 
-const DEFAULT_COLUMN_QUALIFIER: &str = "";
-const CHECKPOINT_SUMMARY_COLUMN_QUALIFIER: &str = "cs";
-const CHECKPOINT_CONTENTS_COLUMN_QUALIFIER: &str = "cc";
-const TRANSACTION_COLUMN_QUALIFIER: &str = "tx";
-const EFFECTS_COLUMN_QUALIFIER: &str = "fx";
-const EVENTS_COLUMN_QUALIFIER: &str = "evtx";
-const TRANSACTION_TO_CHECKPOINT: &str = "tx2c";
+pub const DEFAULT_COLUMN_QUALIFIER: &str = "";
+pub const CHECKPOINT_SUMMARY_COLUMN_QUALIFIER: &str = "cs";
+pub const CHECKPOINT_CONTENTS_COLUMN_QUALIFIER: &str = "cc";
+pub const TRANSACTION_COLUMN_QUALIFIER: &str = "tx";
+pub const EFFECTS_COLUMN_QUALIFIER: &str = "fx";
+pub const EVENTS_COLUMN_QUALIFIER: &str = "evtx";
+pub const TRANSACTION_TO_CHECKPOINT: &str = "tx2c";
 
 #[async_trait]
 impl KeyValueStoreWriter for BigTableClient {
@@ -124,8 +124,8 @@ impl KeyValueStoreReader for BigTableClient {
     async fn get_objects(&mut self, object_keys: &[ObjectKey]) -> Result<Vec<Object>, Self::Error> {
         let keys = object_keys.iter().map(raw_object_key).collect();
         let mut objects = vec![];
-        for row_cells in self.multi_get(OBJECTS_TABLE, keys, None).await? {
-            for cell in row_cells {
+        for row in self.multi_get(OBJECTS_TABLE, keys, None).await? {
+            for cell in row.cells {
                 let obj = bcs::from_bytes::<Object>(&cell.value)?;
                 objects.push(obj);
             }
@@ -139,13 +139,13 @@ impl KeyValueStoreReader for BigTableClient {
     ) -> Result<Vec<TransactionData>, Self::Error> {
         let keys = transactions.iter().map(|tx| tx.inner().to_vec()).collect();
         let mut result = vec![];
-        for row_cells in self.multi_get(TRANSACTIONS_TABLE, keys, None).await? {
+        for row in self.multi_get(TRANSACTIONS_TABLE, keys, None).await? {
             let mut transaction = None;
             let mut effects = None;
             let mut events = None;
             let mut checkpoint_number = 0;
 
-            for Cell { name, value } in row_cells {
+            for Cell { name, value } in row.cells {
                 match std::str::from_utf8(&name)? {
                     TRANSACTION_COLUMN_QUALIFIER => {
                         transaction = Some(bcs::from_bytes::<Transaction>(&value)?)
@@ -184,10 +184,10 @@ impl KeyValueStoreReader for BigTableClient {
             .map(|sq| sq.to_be_bytes().to_vec())
             .collect();
         let mut checkpoints = vec![];
-        for row_cells in self.multi_get(CHECKPOINTS_TABLE, keys, None).await? {
+        for row in self.multi_get(CHECKPOINTS_TABLE, keys, None).await? {
             let mut summary = None;
             let mut contents = None;
-            for Cell { name, value } in row_cells {
+            for Cell { name, value } in row.cells {
                 match std::str::from_utf8(&name)? {
                     CHECKPOINT_SUMMARY_COLUMN_QUALIFIER => {
                         summary = Some(bcs::from_bytes::<CertifiedCheckpointSummary>(&value)?)
@@ -204,6 +204,7 @@ impl KeyValueStoreReader for BigTableClient {
                 summary: summary.ok_or_else(|| anyhow::anyhow!("summary field is missing"))?,
                 contents: contents.ok_or_else(|| anyhow::anyhow!("contents field is missing"))?,
             };
+
             checkpoints.push(checkpoint);
         }
         Ok(checkpoints)
@@ -221,8 +222,8 @@ impl KeyValueStoreReader for BigTableClient {
             .multi_get(CHECKPOINTS_BY_DIGEST_TABLE, keys, None)
             .await?
             .into_iter()
-            .filter_map(|row_cells| {
-                row_cells
+            .filter_map(|row| {
+                row.cells
                     .into_iter()
                     .next()
                     .map(|cell| cell.value.as_slice().try_into().map(u64::from_be_bytes))
@@ -232,7 +233,7 @@ impl KeyValueStoreReader for BigTableClient {
     }
 }
 
-fn raw_object_key(object_key: &ObjectKey) -> Vec<u8> {
+pub fn raw_object_key(object_key: &ObjectKey) -> Vec<u8> {
     let mut raw_key = object_key.0.to_vec();
     raw_key.extend(object_key.1.value().to_be_bytes());
     raw_key

--- a/crates/iota-kvstore/src/bigtable/mod.rs
+++ b/crates/iota-kvstore/src/bigtable/mod.rs
@@ -4,8 +4,6 @@
 
 /// Implementation of key-value store reader and writer traits for the BigTable
 /// client.
-pub(crate) mod client;
+pub mod client;
 /// Data ingestion core `Worker` implementation.
 pub(crate) mod worker;
-
-pub use iota_bigtable::BigTableClient;

--- a/crates/iota-kvstore/src/lib.rs
+++ b/crates/iota-kvstore/src/lib.rs
@@ -20,7 +20,8 @@ use serde::{Deserialize, Serialize};
 /// BigTable Key Value store implementation.
 mod bigtable;
 
-pub use bigtable::{BigTableClient, worker::KvWorker};
+pub use bigtable::{client, worker::KvWorker};
+pub use iota_bigtable::{BigTableClient, Cell, Row, proto};
 
 /// Read key-value data from a persistent store, such as objects, transactions,
 /// and checkpoints.

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -112,7 +112,7 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                let keys = digests.iter().map(|tx| tx.inner().to_vec()).collect();
+                let keys = digests.iter().map(|tx| Some(tx.inner().to_vec())).collect();
 
                 multi_get_cell(
                     &mut client,
@@ -128,7 +128,7 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                let keys = digests.iter().map(|tx| tx.inner().to_vec()).collect();
+                let keys = digests.iter().map(|tx| Some(tx.inner().to_vec())).collect();
 
                 multi_get_cell(
                     &mut client,
@@ -146,7 +146,7 @@ impl KvStoreClient {
 
                 let keys = seq_nums
                     .iter()
-                    .map(|sq| sq.to_be_bytes().to_vec())
+                    .map(|sq| Some(sq.to_be_bytes().to_vec()))
                     .collect();
 
                 multi_get_cell(
@@ -165,7 +165,7 @@ impl KvStoreClient {
 
                 let keys = seq_nums
                     .iter()
-                    .map(|sq| sq.to_be_bytes().to_vec())
+                    .map(|sq| Some(sq.to_be_bytes().to_vec()))
                     .collect();
 
                 multi_get_cell(
@@ -184,8 +184,8 @@ impl KvStoreClient {
 
                 let digest_keys = checkpoint_digests
                     .iter()
-                    .map(|digest| digest.inner().to_vec())
-                    .collect::<Vec<Vec<u8>>>();
+                    .map(|digest| Some(digest.inner().to_vec()))
+                    .collect::<Vec<Option<Vec<u8>>>>();
 
                 fetch_checkpoint_summary_by_digests(&mut client, digest_keys).await
             }
@@ -195,7 +195,7 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                let keys = digests.iter().map(|tx| tx.inner().to_vec()).collect();
+                let keys = digests.iter().map(|tx| Some(tx.inner().to_vec())).collect();
 
                 multi_get_cell(
                     &mut client,
@@ -213,7 +213,10 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                let keys = object_keys.iter().map(raw_object_key).collect();
+                let keys = object_keys
+                    .iter()
+                    .map(|key| Some(raw_object_key(key)))
+                    .collect();
 
                 multi_get_cell(&mut client, OBJECTS_TABLE, keys, DEFAULT_COLUMN_QUALIFIER).await
             }
@@ -223,7 +226,7 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                let keys = digests.iter().map(|tx| tx.inner().to_vec()).collect();
+                let keys = digests.iter().map(|tx| Some(tx.inner().to_vec())).collect();
 
                 multi_get_cell(
                     &mut client,
@@ -263,6 +266,11 @@ impl KvStoreClient {
 /// Fetch multiple values from a BigTable table with a specific key and column
 /// qualifier.
 ///
+/// Keys wrapped in `Option<Vec<u8>>` allow chaining multiple queries: the
+/// result from one `multi_get_cell` (which contains `None` for missing keys)
+/// can be directly passed as input to the next call. `None` keys are skipped in
+/// the query but preserve their position in the result.
+///
 /// The result's length is guaranteed to match the input `keys` length. Each
 /// position in the result corresponds to the key at the same position in the
 /// input. This allows the caller to easily determine which requested keys have
@@ -272,18 +280,18 @@ impl KvStoreClient {
 async fn multi_get_cell(
     client: &mut BigTableClient,
     table_name: &str,
-    keys: Vec<Vec<u8>>,
+    keys: Vec<Option<Vec<u8>>>,
     column_qualifier: &str,
 ) -> Result<Vec<Option<Bytes>>, anyhow::Error> {
     // pre-allocate results with None. Matching cells will replace None with
     // Some(value), and unmatched keys will remain None.
     let mut results = vec![None; keys.len()];
 
-    let key_to_index: HashMap<Vec<u8>, usize> = keys
+    let key_to_index = keys
         .iter()
         .enumerate()
-        .map(|(index, key)| (key.clone(), index))
-        .collect();
+        .filter_map(|(index, key)| key.as_ref().map(|k| (k.clone(), index)))
+        .collect::<HashMap<Vec<u8>, usize>>();
 
     // create the exact match filter
     // We use ^ and $ to ensure it's an exact byte match, not a substring match.
@@ -294,7 +302,11 @@ async fn multi_get_cell(
     };
 
     for row in client
-        .multi_get(table_name, keys, Some(exact_column_filter))
+        .multi_get(
+            table_name,
+            key_to_index.keys().cloned().collect(),
+            Some(exact_column_filter),
+        )
         .await?
     {
         for Cell { name, value } in row.cells {
@@ -315,10 +327,8 @@ async fn multi_get_cell(
 /// Fetch multiple checkpoint summaries by its checkpoint digest.
 async fn fetch_checkpoint_summary_by_digests(
     client: &mut BigTableClient,
-    keys: Vec<Vec<u8>>,
+    keys: Vec<Option<Vec<u8>>>,
 ) -> Result<Vec<Option<Bytes>>, anyhow::Error> {
-    let keys_len = keys.len();
-
     let sequence_numbers = multi_get_cell(
         client,
         CHECKPOINTS_BY_DIGEST_TABLE,
@@ -328,47 +338,15 @@ async fn fetch_checkpoint_summary_by_digests(
     .await?;
 
     let seq_numbers_keys = sequence_numbers
-        .iter()
-        .flatten()
-        .map(|bytes| bytes.to_vec())
-        .collect::<Vec<Vec<u8>>>();
+        .into_iter()
+        .map(|bytes| bytes.map(|b| b.to_vec()))
+        .collect::<Vec<Option<Vec<u8>>>>();
 
-    let checkpoint_summaries = multi_get_cell(
+    multi_get_cell(
         client,
         CHECKPOINTS_TABLE,
-        seq_numbers_keys.clone(),
+        seq_numbers_keys,
         CHECKPOINT_SUMMARY_COLUMN_QUALIFIER,
     )
-    .await?;
-
-    // the response len matches the original requested keys, meaning all data was
-    // found.
-    if keys_len == checkpoint_summaries.len() {
-        return Ok(checkpoint_summaries);
-    }
-
-    let mut results = vec![None; keys_len];
-
-    let seq_nums_to_index = sequence_numbers
-        .iter()
-        .enumerate()
-        .filter_map(|(index, opt_seq_num)| {
-            opt_seq_num.as_ref().map(|seq_num| {
-                let seq_num_vec = seq_num.to_vec();
-                (seq_num_vec.clone(), index)
-            })
-        })
-        .collect::<HashMap<Vec<u8>, usize>>();
-
-    // fill the checkpoint summary in the same order as the original requested keys
-    for (index, opt_summary) in checkpoint_summaries.into_iter().enumerate() {
-        if let Some(summary) = opt_summary {
-            let seq_num = &seq_numbers_keys[index];
-            if let Some(&original_index) = seq_nums_to_index.get(seq_num) {
-                results[original_index] = Some(summary);
-            }
-        }
-    }
-
-    Ok(results)
+    .await
 }

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -182,79 +182,12 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                // pre-allocate results with None. Matching cells will replace None with
-                // Some(value), and unmatched keys will remain None.
-                let mut results = vec![None; keys.len()];
-
                 let digest_keys = checkpoint_digests
                     .iter()
                     .map(|digest| digest.inner().to_vec())
                     .collect::<Vec<Vec<u8>>>();
 
-                // map digest key bytes to original index for later lookup.
-                let digest_key_to_index = digest_keys
-                    .iter()
-                    .enumerate()
-                    .map(|(index, key)| (key.clone(), index))
-                    .collect::<HashMap<Vec<u8>, usize>>();
-
-                // get checkpoint sequence numbers from provided digest keys.
-                let digest_to_seq_num = client
-                    .multi_get(CHECKPOINTS_BY_DIGEST_TABLE, digest_keys.clone(), None)
-                    .await
-                    .map_err(anyhow::Error::from)?
-                    .into_iter()
-                    .filter_map(|row| {
-                        row.cells
-                            .into_iter()
-                            .next()
-                            .map(|cell| (row.key, cell.value))
-                    })
-                    .collect::<HashMap<Vec<u8>, Vec<u8>>>();
-
-                // map checkpoint sequence numbers to their digest indices to maintain order
-                // through second query.
-                let seq_num_to_digest_index = digest_to_seq_num
-                    .iter()
-                    .filter_map(|(digest_key, seq_num)| {
-                        digest_key_to_index
-                            .get(digest_key)
-                            .map(|&index| (seq_num.clone(), index))
-                    })
-                    .collect::<HashMap<Vec<u8>, usize>>();
-
-                // get checkpoint summaries using sequence numbers as keys.
-                let seq_nums = digest_to_seq_num
-                    .values()
-                    .cloned()
-                    .collect::<Vec<Vec<u8>>>();
-
-                // narrow the search to only the checkpoint summaries.
-                let exact_column_filter = RowFilter {
-                    filter: Some(Filter::ColumnQualifierRegexFilter(
-                        format!("^{CHECKPOINT_SUMMARY_COLUMN_QUALIFIER}$").into_bytes(),
-                    )),
-                };
-
-                for row in client
-                    .multi_get(CHECKPOINTS_TABLE, seq_nums, Some(exact_column_filter))
-                    .await
-                    .map_err(anyhow::Error::from)?
-                {
-                    for Cell { name, value } in row.cells {
-                        let cell_name = std::str::from_utf8(&name).map_err(anyhow::Error::from)?;
-                        if cell_name == CHECKPOINT_SUMMARY_COLUMN_QUALIFIER {
-                            // map from sequence number back to original digest index
-                            if let Some(&digest_index) = seq_num_to_digest_index.get(&row.key) {
-                                results[digest_index] = Some(Bytes::from(value));
-                            }
-                        } else {
-                            error!("unexpected column {cell_name:?} in checkpoints table")
-                        }
-                    }
-                }
-
-                Ok(results)
+                fetch_checkpoint_summary_by_digests(&mut client, digest_keys).await
             }
             Key::TransactionToCheckpoint(_) => {
                 let digests = Self::extract_keys(&keys, |k| match k {
@@ -372,6 +305,67 @@ async fn multi_get_cell(
                 }
             } else {
                 error!("unexpected column {cell_name:?} in checkpoints table")
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+/// Fetch multiple checkpoint summaries by its checkpoint digest.
+async fn fetch_checkpoint_summary_by_digests(
+    client: &mut BigTableClient,
+    keys: Vec<Vec<u8>>,
+) -> Result<Vec<Option<Bytes>>, anyhow::Error> {
+    let keys_len = keys.len();
+
+    let sequence_numbers = multi_get_cell(
+        client,
+        CHECKPOINTS_BY_DIGEST_TABLE,
+        keys,
+        DEFAULT_COLUMN_QUALIFIER,
+    )
+    .await?;
+
+    let seq_numbers_keys = sequence_numbers
+        .iter()
+        .flatten()
+        .map(|bytes| bytes.to_vec())
+        .collect::<Vec<Vec<u8>>>();
+
+    let checkpoint_summaries = multi_get_cell(
+        client,
+        CHECKPOINTS_TABLE,
+        seq_numbers_keys.clone(),
+        CHECKPOINT_SUMMARY_COLUMN_QUALIFIER,
+    )
+    .await?;
+
+    // the response len matches the original requested keys, meaning all data was
+    // found.
+    if keys_len == checkpoint_summaries.len() {
+        return Ok(checkpoint_summaries);
+    }
+
+    let mut results = vec![None; keys_len];
+
+    let seq_nums_to_index = sequence_numbers
+        .iter()
+        .enumerate()
+        .filter_map(|(index, opt_seq_num)| {
+            opt_seq_num.as_ref().map(|seq_num| {
+                let seq_num_vec = seq_num.to_vec();
+                (seq_num_vec.clone(), index)
+            })
+        })
+        .collect::<HashMap<Vec<u8>, usize>>();
+
+    // fill the checkpoint summary in the same order as the original requested keys
+    for (index, opt_summary) in checkpoint_summaries.into_iter().enumerate() {
+        if let Some(summary) = opt_summary {
+            let seq_num = &seq_numbers_keys[index];
+            if let Some(&original_index) = seq_nums_to_index.get(seq_num) {
+                results[original_index] = Some(summary);
             }
         }
     }

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -10,10 +10,21 @@ use std::{
 
 use anyhow::Result;
 use bytes::Bytes;
-use iota_kvstore::{BigTableClient, KeyValueStoreReader};
+use iota_kvstore::{
+    BigTableClient, Cell,
+    client::{
+        CHECKPOINT_CONTENTS_COLUMN_QUALIFIER, CHECKPOINT_SUMMARY_COLUMN_QUALIFIER,
+        CHECKPOINTS_BY_DIGEST_TABLE, CHECKPOINTS_TABLE, DEFAULT_COLUMN_QUALIFIER,
+        EFFECTS_COLUMN_QUALIFIER, EVENTS_COLUMN_QUALIFIER, OBJECTS_TABLE,
+        TRANSACTION_COLUMN_QUALIFIER, TRANSACTION_TO_CHECKPOINT, TRANSACTIONS_TABLE,
+        raw_object_key,
+    },
+    proto::bigtable::v2::{RowFilter, row_filter::Filter},
+};
 use iota_storage::http_key_value_store::Key;
 use iota_types::storage::ObjectKey;
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
 use crate::errors::ApiError;
 
@@ -101,12 +112,15 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                let transactions = client.get_transactions(&digests).await?;
+                let keys = digests.iter().map(|tx| tx.inner().to_vec()).collect();
 
-                let ordered = Self::restore_order(digests, transactions, |tx_data| {
-                    *tx_data.transaction.digest()
-                });
-                Self::extract_values_and_serialize(ordered, |tx_data| Some(&tx_data.transaction))
+                multi_get_cell(
+                    &mut client,
+                    TRANSACTIONS_TABLE,
+                    keys,
+                    TRANSACTION_COLUMN_QUALIFIER,
+                )
+                .await
             }
             Key::TransactionEffects(_) => {
                 let digests = Self::extract_keys(&keys, |k| match k {
@@ -114,12 +128,15 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                let transactions = client.get_transactions(&digests).await?;
+                let keys = digests.iter().map(|tx| tx.inner().to_vec()).collect();
 
-                let ordered = Self::restore_order(digests, transactions, |tx_data| {
-                    *tx_data.transaction.digest()
-                });
-                Self::extract_values_and_serialize(ordered, |tx_data| Some(&tx_data.effects))
+                multi_get_cell(
+                    &mut client,
+                    TRANSACTIONS_TABLE,
+                    keys,
+                    EFFECTS_COLUMN_QUALIFIER,
+                )
+                .await
             }
             Key::CheckpointContents(_) => {
                 let seq_nums = Self::extract_keys(&keys, |k| match k {
@@ -127,12 +144,18 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                let checkpoints = client.get_checkpoints(&seq_nums).await?;
+                let keys = seq_nums
+                    .iter()
+                    .map(|sq| sq.to_be_bytes().to_vec())
+                    .collect();
 
-                let ordered = Self::restore_order(seq_nums, checkpoints, |chk| {
-                    *chk.summary.data().sequence_number()
-                });
-                Self::extract_values_and_serialize(ordered, |chk| Some(&chk.contents))
+                multi_get_cell(
+                    &mut client,
+                    CHECKPOINTS_TABLE,
+                    keys,
+                    CHECKPOINT_CONTENTS_COLUMN_QUALIFIER,
+                )
+                .await
             }
             Key::CheckpointSummary(_) => {
                 let seq_nums = Self::extract_keys(&keys, |k| match k {
@@ -140,12 +163,18 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                let checkpoints = client.get_checkpoints(&seq_nums).await?;
+                let keys = seq_nums
+                    .iter()
+                    .map(|sq| sq.to_be_bytes().to_vec())
+                    .collect();
 
-                let ordered = Self::restore_order(seq_nums, checkpoints, |chk| {
-                    *chk.summary.data().sequence_number()
-                });
-                Self::extract_values_and_serialize(ordered, |chk| Some(&chk.summary))
+                multi_get_cell(
+                    &mut client,
+                    CHECKPOINTS_TABLE,
+                    keys,
+                    CHECKPOINT_SUMMARY_COLUMN_QUALIFIER,
+                )
+                .await
             }
             Key::CheckpointSummaryByDigest(_) => {
                 let checkpoint_digests = Self::extract_keys(&keys, |k| match k {
@@ -153,14 +182,79 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                let checkpoints = client
-                    .get_checkpoints_by_digest(&checkpoint_digests)
-                    .await?;
+                // pre-allocate results with None. Matching cells will replace None with
+                // Some(value), and unmatched keys will remain None.
+                let mut results = vec![None; keys.len()];
 
-                let ordered = Self::restore_order(checkpoint_digests, checkpoints, |chk| {
-                    *chk.summary.digest()
-                });
-                Self::extract_values_and_serialize(ordered, |chk| Some(&chk.summary))
+                let digest_keys = checkpoint_digests
+                    .iter()
+                    .map(|digest| digest.inner().to_vec())
+                    .collect::<Vec<Vec<u8>>>();
+
+                // map digest key bytes to original index for later lookup.
+                let digest_key_to_index = digest_keys
+                    .iter()
+                    .enumerate()
+                    .map(|(index, key)| (key.clone(), index))
+                    .collect::<HashMap<Vec<u8>, usize>>();
+
+                // get checkpoint sequence numbers from provided digest keys.
+                let digest_to_seq_num = client
+                    .multi_get(CHECKPOINTS_BY_DIGEST_TABLE, digest_keys.clone(), None)
+                    .await
+                    .map_err(anyhow::Error::from)?
+                    .into_iter()
+                    .filter_map(|row| {
+                        row.cells
+                            .into_iter()
+                            .next()
+                            .map(|cell| (row.key, cell.value))
+                    })
+                    .collect::<HashMap<Vec<u8>, Vec<u8>>>();
+
+                // map checkpoint sequence numbers to their digest indices to maintain order
+                // through second query.
+                let seq_num_to_digest_index = digest_to_seq_num
+                    .iter()
+                    .filter_map(|(digest_key, seq_num)| {
+                        digest_key_to_index
+                            .get(digest_key)
+                            .map(|&index| (seq_num.clone(), index))
+                    })
+                    .collect::<HashMap<Vec<u8>, usize>>();
+
+                // get checkpoint summaries using sequence numbers as keys.
+                let seq_nums = digest_to_seq_num
+                    .values()
+                    .cloned()
+                    .collect::<Vec<Vec<u8>>>();
+
+                // narrow the search to only the checkpoint summaries.
+                let exact_column_filter = RowFilter {
+                    filter: Some(Filter::ColumnQualifierRegexFilter(
+                        format!("^{CHECKPOINT_SUMMARY_COLUMN_QUALIFIER}$").into_bytes(),
+                    )),
+                };
+
+                for row in client
+                    .multi_get(CHECKPOINTS_TABLE, seq_nums, Some(exact_column_filter))
+                    .await
+                    .map_err(anyhow::Error::from)?
+                {
+                    for Cell { name, value } in row.cells {
+                        let cell_name = std::str::from_utf8(&name).map_err(anyhow::Error::from)?;
+                        if cell_name == CHECKPOINT_SUMMARY_COLUMN_QUALIFIER {
+                            // map from sequence number back to original digest index
+                            if let Some(&digest_index) = seq_num_to_digest_index.get(&row.key) {
+                                results[digest_index] = Some(Bytes::from(value));
+                            }
+                        } else {
+                            error!("unexpected column {cell_name:?} in checkpoints table")
+                        }
+                    }
+                }
+
+                Ok(results)
             }
             Key::TransactionToCheckpoint(_) => {
                 let digests = Self::extract_keys(&keys, |k| match k {
@@ -168,14 +262,15 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                let transactions = client.get_transactions(&digests).await?;
+                let keys = digests.iter().map(|tx| tx.inner().to_vec()).collect();
 
-                let ordered = Self::restore_order(digests, transactions, |tx_data| {
-                    *tx_data.transaction.digest()
-                });
-                Self::extract_values_and_serialize(ordered, |tx_data| {
-                    Some(&tx_data.checkpoint_number)
-                })
+                multi_get_cell(
+                    &mut client,
+                    TRANSACTIONS_TABLE,
+                    keys,
+                    TRANSACTION_TO_CHECKPOINT,
+                )
+                .await
             }
             Key::ObjectKey(_, _) => {
                 let object_keys = Self::extract_keys(&keys, |k| match k {
@@ -185,12 +280,9 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                let objects = client.get_objects(&object_keys).await?;
+                let keys = object_keys.iter().map(raw_object_key).collect();
 
-                let ordered = Self::restore_order(object_keys, objects, |object| {
-                    ObjectKey(object.id(), object.version())
-                });
-                Self::extract_values_and_serialize(ordered, |object| Some(object))
+                multi_get_cell(&mut client, OBJECTS_TABLE, keys, DEFAULT_COLUMN_QUALIFIER).await
             }
             Key::EventsByTransactionDigest(_) => {
                 let digests = Self::extract_keys(&keys, |k| match k {
@@ -198,12 +290,15 @@ impl KvStoreClient {
                     _ => None,
                 })?;
 
-                let transactions = client.get_transactions(&digests).await?;
+                let keys = digests.iter().map(|tx| tx.inner().to_vec()).collect();
 
-                let ordered = Self::restore_order(digests, transactions, |tx_data| {
-                    *tx_data.transaction.digest()
-                });
-                Self::extract_values_and_serialize(ordered, |tx_data| tx_data.events.as_ref())
+                multi_get_cell(
+                    &mut client,
+                    TRANSACTIONS_TABLE,
+                    keys,
+                    EVENTS_COLUMN_QUALIFIER,
+                )
+                .await
             }
         }
         .map_err(Into::into)
@@ -230,62 +325,56 @@ impl KvStoreClient {
             })
             .collect()
     }
+}
 
-    /// Maps `results` from KV back to original order specified by `keys`.
-    ///
-    /// Takes:
-    /// - `keys`: The original list of keys in the order they were requested
-    /// - `results`: The results returned from the KV client (may be in
-    ///   different order or missing items)
-    /// - `key_extractor`: Function to extract the key from a result item
-    ///
-    /// Returns a vector in the same order as `keys`, with `Some(T)` for found
-    /// items and `None` for missing items.
-    fn restore_order<K, T, F>(keys: Vec<K>, results: Vec<T>, key_extractor: F) -> Vec<Option<T>>
-    where
-        K: std::hash::Hash + Eq,
-        T: Clone,
-        F: Fn(&T) -> K,
+/// Fetch multiple values from a BigTable table with a specific key and column
+/// qualifier.
+///
+/// The result's length is guaranteed to match the input `keys` length. Each
+/// position in the result corresponds to the key at the same position in the
+/// input. This allows the caller to easily determine which requested keys have
+/// data:
+/// - `Some(value)` at index `i` means `key[i]` exists and has data
+/// - `None` at index `i` means `key[i]` was not found or has no matching data
+async fn multi_get_cell(
+    client: &mut BigTableClient,
+    table_name: &str,
+    keys: Vec<Vec<u8>>,
+    column_qualifier: &str,
+) -> Result<Vec<Option<Bytes>>, anyhow::Error> {
+    // pre-allocate results with None. Matching cells will replace None with
+    // Some(value), and unmatched keys will remain None.
+    let mut results = vec![None; keys.len()];
+
+    let key_to_index: HashMap<Vec<u8>, usize> = keys
+        .iter()
+        .enumerate()
+        .map(|(index, key)| (key.clone(), index))
+        .collect();
+
+    // create the exact match filter
+    // We use ^ and $ to ensure it's an exact byte match, not a substring match.
+    let exact_column_filter = RowFilter {
+        filter: Some(Filter::ColumnQualifierRegexFilter(
+            format!("^{column_qualifier}$").into_bytes(),
+        )),
+    };
+
+    for row in client
+        .multi_get(table_name, keys, Some(exact_column_filter))
+        .await?
     {
-        // Create a map from key to result data
-        let results_map: HashMap<K, T> = results
-            .into_iter()
-            .map(|item| (key_extractor(&item), item))
-            .collect();
-
-        // Map back to original order
-        keys.into_iter()
-            .map(|key| results_map.get(&key).cloned())
-            .collect()
+        for Cell { name, value } in row.cells {
+            let cell_name = std::str::from_utf8(&name)?;
+            if cell_name == column_qualifier {
+                if let Some(&index) = key_to_index.get(&row.key) {
+                    results[index] = Some(Bytes::from(value));
+                }
+            } else {
+                error!("unexpected column {cell_name:?} in checkpoints table")
+            }
+        }
     }
 
-    /// Extracts final values from KV response and serializes them.
-    ///
-    /// Takes:
-    /// - `ordered_results`: Results in the desired order (with None for missing
-    ///   items)
-    /// - `value_extractor`: Function to extract the value from a result item
-    ///
-    /// Returns a vector of serialized bytes, with `None` for missing or empty
-    /// values.
-    fn extract_values_and_serialize<T, V, G>(
-        ordered_results: Vec<Option<T>>,
-        value_extractor: G,
-    ) -> Result<Vec<Option<Bytes>>>
-    where
-        V: Serialize,
-        G: Fn(&T) -> Option<&V>,
-    {
-        ordered_results
-            .iter()
-            .map(|opt_item| {
-                opt_item
-                    .as_ref()
-                    .and_then(&value_extractor)
-                    .map(|value| bcs::to_bytes(value).map(Bytes::from))
-                    .transpose()
-                    .map_err(Into::into)
-            })
-            .collect::<Result<Vec<_>>>()
-    }
+    Ok(results)
 }


### PR DESCRIPTION
# Description of change

Optimize BigTable queries in `iota-rest-kv` to avoid over-fetching. Previously, when requesting specific data (e.g., a transaction), the query would fetch all columns for that row key (including effects, events, etc.), even though only one column qualifier was needed. This patch filters queries to fetch only the requested column, reducing bandwidth and improving latency.

## Links to any relevant issues

fixes #9542, #9510 

## How the change has been tested

The tests were done manually by starting the `iota-rest-kv` on devnet, and used the `HttpRestKVClient` to fetch data making sure all worked correctly.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch does not affect the normal operation of the indexer, thus no further tests were conducted.
