### PR TITLE
feat(gRPC): add e2e test cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6172,6 +6172,7 @@ dependencies = [
  "iota-core",
  "iota-framework",
  "iota-genesis-builder",
+ "iota-grpc-client",
  "iota-grpc-types",
  "iota-json-rpc",
  "iota-json-rpc-api",

--- a/crates/iota-e2e-tests/Cargo.toml
+++ b/crates/iota-e2e-tests/Cargo.toml
@@ -45,6 +45,7 @@ iota-config.workspace = true
 iota-core.workspace = true
 iota-framework.workspace = true
 iota-genesis-builder.workspace = true
+iota-grpc-client.workspace = true
 iota-grpc-types.workspace = true
 iota-json-rpc.workspace = true
 iota-json-rpc-api.workspace = true

--- a/crates/iota-e2e-tests/tests/grpc/client/checkpoints.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/checkpoints.rs
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_macros::sim_test;
+
+use super::common::{assert_not_found_error, setup_grpc_test};
+
+#[sim_test]
+async fn get_latest_checkpoint() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let checkpoint = client
+        .get_latest_checkpoint()
+        .await
+        .expect("Failed to get latest checkpoint");
+
+    assert!(
+        checkpoint.checkpoint.sequence_number >= 1,
+        "Latest checkpoint sequence number should be at least 1"
+    );
+}
+
+#[sim_test]
+async fn get_checkpoint_by_sequence() {
+    let (_test_cluster, client) = setup_grpc_test(2).await;
+
+    let checkpoint = client
+        .get_checkpoint(1)
+        .await
+        .expect("Failed to get checkpoint by sequence number");
+
+    assert_eq!(
+        checkpoint.checkpoint.sequence_number, 1,
+        "Checkpoint sequence number should match requested"
+    );
+}
+
+#[sim_test]
+async fn get_checkpoint_sequence_zero() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let checkpoint = client
+        .get_checkpoint(0)
+        .await
+        .expect("Failed to get genesis checkpoint");
+
+    assert_eq!(
+        checkpoint.checkpoint.sequence_number, 0,
+        "Genesis checkpoint should have sequence number 0"
+    );
+}
+
+#[sim_test]
+async fn get_checkpoint_nonexistent_sequence() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let result = client.get_checkpoint(999_999_999).await;
+    assert_not_found_error(result);
+}
+
+#[sim_test]
+async fn get_checkpoint_future_sequence() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let latest = client
+        .get_latest_checkpoint()
+        .await
+        .expect("Failed to get latest checkpoint");
+
+    let future_sequence = latest.checkpoint.sequence_number + 100;
+    let result = client.get_checkpoint(future_sequence).await;
+
+    assert!(
+        result.is_err(),
+        "Fetching future checkpoint should return an error"
+    );
+}

--- a/crates/iota-e2e-tests/tests/grpc/client/checkpoints.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/checkpoints.rs
@@ -6,67 +6,44 @@ use iota_macros::sim_test;
 use super::common::{assert_not_found_error, setup_grpc_test};
 
 #[sim_test]
-async fn get_latest_checkpoint() {
-    let (_test_cluster, client) = setup_grpc_test(1).await;
-
-    let checkpoint = client
-        .get_latest_checkpoint()
-        .await
-        .expect("Failed to get latest checkpoint");
-
-    assert!(
-        checkpoint.checkpoint.sequence_number >= 1,
-        "Latest checkpoint sequence number should be at least 1"
-    );
-}
-
-#[sim_test]
-async fn get_checkpoint_by_sequence() {
+async fn get_checkpoint_scenarios() {
     let (_test_cluster, client) = setup_grpc_test(2).await;
 
-    let checkpoint = client
-        .get_checkpoint(1)
-        .await
-        .expect("Failed to get checkpoint by sequence number");
-
-    assert_eq!(
-        checkpoint.checkpoint.sequence_number, 1,
-        "Checkpoint sequence number should match requested"
-    );
-}
-
-#[sim_test]
-async fn get_checkpoint_sequence_zero() {
-    let (_test_cluster, client) = setup_grpc_test(1).await;
-
-    let checkpoint = client
-        .get_checkpoint(0)
-        .await
-        .expect("Failed to get genesis checkpoint");
-
-    assert_eq!(
-        checkpoint.checkpoint.sequence_number, 0,
-        "Genesis checkpoint should have sequence number 0"
-    );
-}
-
-#[sim_test]
-async fn get_checkpoint_nonexistent_sequence() {
-    let (_test_cluster, client) = setup_grpc_test(1).await;
-
-    let result = client.get_checkpoint(999_999_999).await;
-    assert_not_found_error(result);
-}
-
-#[sim_test]
-async fn get_checkpoint_future_sequence() {
-    let (_test_cluster, client) = setup_grpc_test(1).await;
-
+    // Test: get latest checkpoint
     let latest = client
         .get_latest_checkpoint()
         .await
         .expect("Failed to get latest checkpoint");
+    assert!(
+        latest.checkpoint.sequence_number >= 1,
+        "Latest checkpoint sequence number should be at least 1"
+    );
 
+    // Test: get genesis checkpoint (sequence 0)
+    let genesis = client
+        .get_checkpoint(0)
+        .await
+        .expect("Failed to get genesis checkpoint");
+    assert_eq!(
+        genesis.checkpoint.sequence_number, 0,
+        "Genesis checkpoint should have sequence number 0"
+    );
+
+    // Test: get checkpoint by sequence number
+    let checkpoint_1 = client
+        .get_checkpoint(1)
+        .await
+        .expect("Failed to get checkpoint by sequence number");
+    assert_eq!(
+        checkpoint_1.checkpoint.sequence_number, 1,
+        "Checkpoint sequence number should match requested"
+    );
+
+    // Test: nonexistent checkpoint returns not-found error
+    let result = client.get_checkpoint(999_999_999).await;
+    assert_not_found_error(result);
+
+    // Test: future checkpoint returns not-found error
     let future_sequence = latest.checkpoint.sequence_number + 100;
     let result = client.get_checkpoint(future_sequence).await;
     assert_not_found_error(result);

--- a/crates/iota-e2e-tests/tests/grpc/client/checkpoints.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/checkpoints.rs
@@ -69,9 +69,5 @@ async fn get_checkpoint_future_sequence() {
 
     let future_sequence = latest.checkpoint.sequence_number + 100;
     let result = client.get_checkpoint(future_sequence).await;
-
-    assert!(
-        result.is_err(),
-        "Fetching future checkpoint should return an error"
-    );
+    assert_not_found_error(result);
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/checkpoints.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/checkpoints.rs
@@ -3,7 +3,7 @@
 
 use iota_macros::sim_test;
 
-use super::common::{assert_not_found_error, setup_grpc_test};
+use super::common::{assert_grpc_not_found, setup_grpc_test};
 
 #[sim_test]
 async fn get_checkpoint_scenarios() {
@@ -41,10 +41,10 @@ async fn get_checkpoint_scenarios() {
 
     // Test: nonexistent checkpoint returns not-found error
     let result = client.get_checkpoint(999_999_999).await;
-    assert_not_found_error(result);
+    assert_grpc_not_found(result);
 
     // Test: future checkpoint returns not-found error
     let future_sequence = latest.checkpoint.sequence_number + 100;
     let result = client.get_checkpoint(future_sequence).await;
-    assert_not_found_error(result);
+    assert_grpc_not_found(result);
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/common.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/common.rs
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_grpc_client::{Client, Error};
+use iota_sdk_types::{Digest, ExecutionStatus, SignedTransaction, Transaction, UserSignature};
+use iota_test_transaction_builder::{TestTransactionBuilder, make_transfer_iota_transaction};
+use iota_types::base_types::IotaAddress;
+use test_cluster::{TestCluster, TestClusterBuilder};
+
+/// Set up a test cluster with gRPC enabled and connect a client.
+///
+/// This is the standard setup for all high-level gRPC client tests.
+/// Waits for the specified checkpoint before returning.
+pub async fn setup_grpc_test(wait_for_checkpoint: u64) -> (TestCluster, Client) {
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .build()
+        .await;
+
+    test_cluster
+        .wait_for_checkpoint(wait_for_checkpoint, None)
+        .await;
+
+    let client = Client::connect(test_cluster.grpc_url())
+        .await
+        .expect("Failed to connect to gRPC server");
+
+    (test_cluster, client)
+}
+
+/// Check if execution status is success.
+pub fn is_success(status: &ExecutionStatus) -> bool {
+    matches!(status, ExecutionStatus::Success)
+}
+
+/// Convert `iota_types::transaction::TransactionData` to
+/// `iota_sdk_types::Transaction`.
+///
+/// BCS round-trip is required because iota_types and iota_sdk_types are
+/// separate type systems that happen to have compatible BCS representations.
+pub fn to_sdk_transaction(tx_data: &iota_types::transaction::TransactionData) -> Transaction {
+    let bcs_bytes = bcs::to_bytes(tx_data).expect("BCS serialization failed");
+    bcs::from_bytes(&bcs_bytes).expect("BCS deserialization failed")
+}
+
+/// Convert `iota_types::transaction::Transaction` to
+/// `iota_sdk_types::SignedTransaction`.
+pub fn to_sdk_signed_transaction(tx: iota_types::transaction::Transaction) -> SignedTransaction {
+    let transaction = to_sdk_transaction(tx.transaction_data());
+
+    let signatures: Vec<UserSignature> = tx
+        .tx_signatures()
+        .iter()
+        .map(|sig| {
+            // BCS round-trip for type system compatibility
+            let sig_bytes = bcs::to_bytes(sig).expect("BCS serialization failed");
+            bcs::from_bytes(&sig_bytes).expect("Signature deserialization failed")
+        })
+        .collect();
+
+    SignedTransaction {
+        transaction,
+        signatures,
+    }
+}
+
+/// Create a signed transaction for testing (IOTA transfer to random recipient).
+pub async fn create_signed_transaction(test_cluster: &TestCluster) -> SignedTransaction {
+    let recipient = IotaAddress::random_for_testing_only();
+    let tx = make_transfer_iota_transaction(&test_cluster.wallet, Some(recipient), Some(100)).await;
+    to_sdk_signed_transaction(tx)
+}
+
+/// Create an unsigned transaction for simulation testing.
+pub async fn create_transaction_for_simulation(test_cluster: &TestCluster) -> Transaction {
+    let (sender, gas) = test_cluster
+        .wallet
+        .get_one_gas_object()
+        .await
+        .unwrap()
+        .unwrap();
+
+    let rgp = test_cluster.get_reference_gas_price().await;
+
+    let tx_data = TestTransactionBuilder::new(sender, gas, rgp)
+        .transfer_iota(None, sender)
+        .build();
+
+    to_sdk_transaction(&tx_data)
+}
+
+/// Execute a transaction and return its digest.
+///
+/// This is useful for tests that need a finalized transaction to query.
+pub async fn execute_transaction_and_get_digest(test_cluster: &TestCluster) -> Digest {
+    let (sender, gas) = test_cluster
+        .wallet
+        .get_one_gas_object()
+        .await
+        .unwrap()
+        .unwrap();
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let transaction_data = TestTransactionBuilder::new(sender, gas, rgp)
+        .transfer_iota(None, sender)
+        .build();
+    let signed_transaction = test_cluster.wallet.sign_transaction(&transaction_data);
+    let transaction_digest = *signed_transaction.digest();
+
+    test_cluster
+        .wallet
+        .execute_transaction_may_fail(signed_transaction)
+        .await
+        .unwrap();
+
+    Digest::new(transaction_digest.into_inner())
+}
+
+/// Assert that a result is a "not found" style error.
+///
+/// The server may return different error types for not-found conditions:
+/// - `NotFound` or `InvalidArgument` gRPC status
+/// - `ProtoConversion` error when server returns empty data
+/// - `Server` error with a message
+pub fn assert_not_found_error<T: std::fmt::Debug>(result: Result<T, Error>) {
+    assert!(result.is_err(), "Expected not-found error, got success");
+
+    match result {
+        Err(Error::ProtoConversion(_)) => {
+            // Server returned empty/null data that failed to deserialize
+        }
+        Err(Error::Grpc(status)) => {
+            assert!(
+                status.code() == tonic::Code::NotFound
+                    || status.code() == tonic::Code::InvalidArgument,
+                "Expected NotFound or InvalidArgument, got: {:?}",
+                status.code()
+            );
+        }
+        Err(Error::Server(msg)) => {
+            assert!(!msg.is_empty(), "Error message should not be empty");
+        }
+        Err(e) => panic!("Unexpected error type: {e:?}"),
+        Ok(_) => unreachable!(),
+    }
+}

--- a/crates/iota-e2e-tests/tests/grpc/client/common.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/common.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_grpc_client::{Client, Error};
-use iota_sdk_types::{Digest, ExecutionStatus, SignedTransaction, Transaction, UserSignature};
+use iota_sdk_types::{Digest, ExecutionStatus, SignedTransaction, Transaction};
 use iota_test_transaction_builder::{TestTransactionBuilder, make_transfer_iota_transaction};
 use iota_types::base_types::IotaAddress;
 use test_cluster::{TestCluster, TestClusterBuilder};
@@ -33,42 +33,11 @@ pub fn is_success(status: &ExecutionStatus) -> bool {
     matches!(status, ExecutionStatus::Success)
 }
 
-/// Convert `iota_types::transaction::TransactionData` to
-/// `iota_sdk_types::Transaction`.
-///
-/// BCS round-trip is required because iota_types and iota_sdk_types are
-/// separate type systems that happen to have compatible BCS representations.
-pub fn to_sdk_transaction(tx_data: &iota_types::transaction::TransactionData) -> Transaction {
-    let bcs_bytes = bcs::to_bytes(tx_data).expect("BCS serialization failed");
-    bcs::from_bytes(&bcs_bytes).expect("BCS deserialization failed")
-}
-
-/// Convert `iota_types::transaction::Transaction` to
-/// `iota_sdk_types::SignedTransaction`.
-pub fn to_sdk_signed_transaction(tx: iota_types::transaction::Transaction) -> SignedTransaction {
-    let transaction = to_sdk_transaction(tx.transaction_data());
-
-    let signatures: Vec<UserSignature> = tx
-        .tx_signatures()
-        .iter()
-        .map(|sig| {
-            // BCS round-trip for type system compatibility
-            let sig_bytes = bcs::to_bytes(sig).expect("BCS serialization failed");
-            bcs::from_bytes(&sig_bytes).expect("Signature deserialization failed")
-        })
-        .collect();
-
-    SignedTransaction {
-        transaction,
-        signatures,
-    }
-}
-
 /// Create a signed transaction for testing (IOTA transfer to random recipient).
 pub async fn create_signed_transaction(test_cluster: &TestCluster) -> SignedTransaction {
     let recipient = IotaAddress::random_for_testing_only();
     let tx = make_transfer_iota_transaction(&test_cluster.wallet, Some(recipient), Some(100)).await;
-    to_sdk_signed_transaction(tx)
+    tx.try_into().expect("SDK type conversion failed")
 }
 
 /// Create an unsigned transaction for simulation testing.
@@ -86,7 +55,7 @@ pub async fn create_transaction_for_simulation(test_cluster: &TestCluster) -> Tr
         .transfer_iota(None, sender)
         .build();
 
-    to_sdk_transaction(&tx_data)
+    tx_data.try_into().expect("SDK type conversion failed")
 }
 
 /// Execute a transaction and return its digest.

--- a/crates/iota-e2e-tests/tests/grpc/client/common.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/common.rs
@@ -84,31 +84,21 @@ pub async fn execute_transaction_and_get_digest(test_cluster: &TestCluster) -> D
     Digest::new(transaction_digest.into_inner())
 }
 
-/// Assert that a result is a "not found" style error.
-///
-/// The server may return different error types for not-found conditions:
-/// - `NotFound` or `InvalidArgument` gRPC status
-/// - `ProtoConversion` error when server returns empty data
-/// - `Server` error with a message
-pub fn assert_not_found_error<T: std::fmt::Debug>(result: Result<T, Error>) {
-    assert!(result.is_err(), "Expected not-found error, got success");
+/// Check if error is a gRPC error with the specified status code.
+pub fn is_grpc_error(err: &Error, code: tonic::Code) -> bool {
+    matches!(err, Error::Grpc(status) if status.code() == code)
+}
 
+/// Check if error is a gRPC NotFound error.
+pub fn is_grpc_not_found(err: &Error) -> bool {
+    is_grpc_error(err, tonic::Code::NotFound)
+}
+
+/// Assert that a result is a gRPC NotFound error.
+pub fn assert_grpc_not_found<T: std::fmt::Debug>(result: Result<T, Error>) {
     match result {
-        Err(Error::ProtoConversion(_)) => {
-            // Server returned empty/null data that failed to deserialize
-        }
-        Err(Error::Grpc(status)) => {
-            assert!(
-                status.code() == tonic::Code::NotFound
-                    || status.code() == tonic::Code::InvalidArgument,
-                "Expected NotFound or InvalidArgument, got: {:?}",
-                status.code()
-            );
-        }
-        Err(Error::Server(msg)) => {
-            assert!(!msg.is_empty(), "Error message should not be empty");
-        }
-        Err(e) => panic!("Unexpected error type: {e:?}"),
-        Ok(_) => unreachable!(),
+        Err(ref err) if is_grpc_not_found(err) => {}
+        Err(err) => panic!("Expected gRPC NotFound error, got: {err:?}"),
+        Ok(val) => panic!("Expected gRPC NotFound error, got success: {val:?}"),
     }
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/common.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/common.rs
@@ -94,11 +94,48 @@ pub fn is_grpc_not_found(err: &Error) -> bool {
     is_grpc_error(err, tonic::Code::NotFound)
 }
 
+/// Assert that a result is a gRPC error with the specified status code.
+pub fn assert_grpc_error<T: std::fmt::Debug>(result: Result<T, Error>, code: tonic::Code) {
+    match result {
+        Err(ref err) if is_grpc_error(err, code) => {}
+        Err(err) => panic!("Expected gRPC {code:?} error, got: {err:?}"),
+        Ok(val) => panic!("Expected gRPC {code:?} error, got success: {val:?}"),
+    }
+}
+
 /// Assert that a result is a gRPC NotFound error.
 pub fn assert_grpc_not_found<T: std::fmt::Debug>(result: Result<T, Error>) {
     match result {
         Err(ref err) if is_grpc_not_found(err) => {}
         Err(err) => panic!("Expected gRPC NotFound error, got: {err:?}"),
         Ok(val) => panic!("Expected gRPC NotFound error, got success: {val:?}"),
+    }
+}
+
+/// Check if error is a Server error containing "not found".
+pub fn is_server_not_found(err: &Error) -> bool {
+    matches!(err, Error::Server(msg) if msg.to_lowercase().contains("not found"))
+}
+
+/// Assert that a result is a Server "not found" error.
+pub fn assert_server_not_found<T: std::fmt::Debug>(result: Result<T, Error>) {
+    match result {
+        Err(ref err) if is_server_not_found(err) => {}
+        Err(err) => panic!("Expected Server not-found error, got: {err:?}"),
+        Ok(val) => panic!("Expected Server not-found error, got success: {val:?}"),
+    }
+}
+
+/// Check if error is a proto conversion error.
+pub fn is_proto_conversion_error(err: &Error) -> bool {
+    matches!(err, Error::ProtoConversion(_))
+}
+
+/// Assert that a result is a proto conversion error.
+pub fn assert_proto_conversion_error<T: std::fmt::Debug>(result: Result<T, Error>) {
+    match result {
+        Err(ref err) if is_proto_conversion_error(err) => {}
+        Err(err) => panic!("Expected ProtoConversion error, got: {err:?}"),
+        Ok(val) => panic!("Expected ProtoConversion error, got success: {val:?}"),
     }
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/epochs.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/epochs.rs
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_macros::sim_test;
+
+use super::common::setup_grpc_test;
+
+#[sim_test]
+async fn get_reference_gas_price() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let gas_price = client
+        .get_reference_gas_price()
+        .await
+        .expect("Failed to get reference gas price");
+
+    assert!(gas_price > 0, "Reference gas price should be positive");
+    assert!(
+        gas_price <= 10_000_000,
+        "Reference gas price {gas_price} seems unreasonably high"
+    );
+}

--- a/crates/iota-e2e-tests/tests/grpc/client/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/execute.rs
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_grpc_client::Error;
+use iota_macros::sim_test;
+use iota_sdk_types::UserSignature;
+
+use super::common::{create_signed_transaction, is_success, setup_grpc_test};
+
+#[sim_test]
+async fn execute_transaction_transfer() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let signed_tx = create_signed_transaction(&test_cluster).await;
+
+    let result = client
+        .execute_transaction(signed_tx, None)
+        .await
+        .expect("Failed to execute transaction");
+
+    assert!(
+        is_success(result.effects.status()),
+        "Transaction should have succeeded"
+    );
+
+    // Verify gas was charged
+    let gas_summary = result.effects.gas_summary();
+    assert!(
+        gas_summary.computation_cost > 0 || gas_summary.storage_cost > 0,
+        "Some gas should have been charged"
+    );
+}
+
+#[sim_test]
+async fn execute_transaction_response_fields() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let signed_tx = create_signed_transaction(&test_cluster).await;
+
+    let result = client
+        .execute_transaction(signed_tx, None)
+        .await
+        .expect("Failed to execute transaction");
+
+    assert!(
+        is_success(result.effects.status()),
+        "Effects should show successful execution"
+    );
+    assert!(
+        result.input_objects.is_some(),
+        "Input objects should be present with default mask"
+    );
+    assert!(
+        result.output_objects.is_some(),
+        "Output objects should be present with default mask"
+    );
+}
+
+#[sim_test]
+async fn execute_transaction_minimal_mask() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let signed_tx = create_signed_transaction(&test_cluster).await;
+
+    let result = client
+        .execute_transaction(signed_tx, Some("transaction.effects"))
+        .await
+        .expect("Failed to execute transaction");
+
+    assert!(
+        is_success(result.effects.status()),
+        "Effects should show successful execution"
+    );
+    assert!(
+        result.input_objects.is_none(),
+        "Input objects should not be present with minimal mask"
+    );
+    assert!(
+        result.output_objects.is_none(),
+        "Output objects should not be present with minimal mask"
+    );
+}
+
+#[sim_test]
+async fn execute_transaction_invalid_signature() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let mut signed_tx = create_signed_transaction(&test_cluster).await;
+
+    // Corrupt the signature by modifying its bytes to create a definitively invalid
+    // signature. We serialize the original signature, corrupt it, then
+    // deserialize back.
+    assert!(
+        !signed_tx.signatures.is_empty(),
+        "Transaction should have at least one signature"
+    );
+    let mut sig_bytes = bcs::to_bytes(&signed_tx.signatures[0]).expect("BCS serialization failed");
+    // Flip bits in the signature data to corrupt it (skip the enum discriminant
+    // byte)
+    for byte in sig_bytes.iter_mut().skip(1) {
+        *byte = !*byte;
+    }
+    let corrupted_sig: UserSignature =
+        bcs::from_bytes(&sig_bytes).expect("Corrupted signature should still deserialize");
+    signed_tx.signatures = vec![corrupted_sig];
+
+    let result = client.execute_transaction(signed_tx, None).await;
+
+    // Transaction with invalid signature should be rejected
+    assert!(
+        result.is_err(),
+        "Transaction with invalid signature should fail"
+    );
+
+    match result {
+        Err(Error::Grpc(status)) => {
+            assert!(
+                status.code() != tonic::Code::Ok,
+                "Should fail with a non-OK status"
+            );
+        }
+        Err(Error::Signature(_)) => {
+            // Signature validation failed on client side
+        }
+        Err(e) => panic!("Unexpected error type: {e:?}"),
+        Ok(_) => unreachable!(),
+    }
+}
+
+#[sim_test]
+async fn execute_transaction_idempotency() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let signed_tx = create_signed_transaction(&test_cluster).await;
+
+    let result1 = client
+        .execute_transaction(signed_tx.clone(), None)
+        .await
+        .expect("First execution should succeed");
+
+    assert!(
+        is_success(result1.effects.status()),
+        "First execution should succeed"
+    );
+
+    let result2 = client.execute_transaction(signed_tx, None).await;
+
+    // Re-submitting the same transaction may either:
+    // - Return the cached successful result
+    // - Return an error indicating the transaction was already executed
+    // Both behaviors are acceptable for idempotency
+    match result2 {
+        Ok(response) => {
+            assert!(
+                is_success(response.effects.status()),
+                "Re-execution should show success (cached result)"
+            );
+        }
+        Err(Error::Grpc(status)) => {
+            // Server may reject duplicate transaction
+            assert!(
+                status.code() == tonic::Code::AlreadyExists
+                    || status.code() == tonic::Code::InvalidArgument,
+                "Expected AlreadyExists or InvalidArgument for duplicate, got: {:?}",
+                status.code()
+            );
+        }
+        Err(e) => panic!("Unexpected error for duplicate transaction: {e:?}"),
+    }
+}

--- a/crates/iota-e2e-tests/tests/grpc/client/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/execute.rs
@@ -29,23 +29,8 @@ async fn execute_transaction_transfer() {
         gas_summary.computation_cost > 0 || gas_summary.storage_cost > 0,
         "Some gas should have been charged"
     );
-}
 
-#[sim_test]
-async fn execute_transaction_response_fields() {
-    let (test_cluster, client) = setup_grpc_test(1).await;
-
-    let signed_tx = create_signed_transaction(&test_cluster).await;
-
-    let result = client
-        .execute_transaction(signed_tx, None)
-        .await
-        .expect("Failed to execute transaction");
-
-    assert!(
-        is_success(result.effects.status()),
-        "Effects should show successful execution"
-    );
+    // Verify response fields are present with default mask
     assert!(
         result.input_objects.is_some(),
         "Input objects should be present with default mask"

--- a/crates/iota-e2e-tests/tests/grpc/client/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/execute.rs
@@ -131,28 +131,16 @@ async fn execute_transaction_idempotency() {
         "First execution should succeed"
     );
 
-    let result2 = client.execute_transaction(signed_tx, None).await;
+    // Re-submitting the same transaction must return the cached successful result.
+    // The server uses TransactionOrchestrator with a NotifyRead pub-sub mechanism
+    // that naturally returns cached effects for duplicates.
+    let result2 = client
+        .execute_transaction(signed_tx, None)
+        .await
+        .expect("Re-execution should return cached result");
 
-    // Re-submitting the same transaction may either:
-    // - Return the cached successful result
-    // - Return an error indicating the transaction was already executed
-    // Both behaviors are acceptable for idempotency
-    match result2 {
-        Ok(response) => {
-            assert!(
-                is_success(response.effects.status()),
-                "Re-execution should show success (cached result)"
-            );
-        }
-        Err(Error::Grpc(status)) => {
-            // Server may reject duplicate transaction
-            assert!(
-                status.code() == tonic::Code::AlreadyExists
-                    || status.code() == tonic::Code::InvalidArgument,
-                "Expected AlreadyExists or InvalidArgument for duplicate, got: {:?}",
-                status.code()
-            );
-        }
-        Err(e) => panic!("Unexpected error for duplicate transaction: {e:?}"),
-    }
+    assert!(
+        is_success(result2.effects.status()),
+        "Re-execution should show success (cached result)"
+    );
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/execute.rs
@@ -95,9 +95,11 @@ async fn execute_transaction_invalid_signature() {
         "Transaction should have at least one signature"
     );
     let mut sig_bytes = bcs::to_bytes(&signed_tx.signatures[0]).expect("BCS serialization failed");
-    // Flip bits in the signature data to corrupt it (skip the enum discriminant
-    // byte)
-    for byte in sig_bytes.iter_mut().skip(1) {
+    // Only flip bytes near the end of the signature data where the actual
+    // cryptographic signature bytes are. We must preserve the BCS length
+    // prefixes at the beginning to allow deserialization.
+    let corrupt_count = sig_bytes.len().min(32);
+    for byte in sig_bytes.iter_mut().rev().take(corrupt_count) {
         *byte = !*byte;
     }
     let corrupted_sig: UserSignature =

--- a/crates/iota-e2e-tests/tests/grpc/client/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/execute.rs
@@ -110,23 +110,9 @@ async fn execute_transaction_invalid_signature() {
 
     // Transaction with invalid signature should be rejected
     assert!(
-        result.is_err(),
-        "Transaction with invalid signature should fail"
+        matches!(result, Err(Error::Grpc(_)) | Err(Error::Signature(_))),
+        "Expected Grpc or Signature error, got: {result:?}"
     );
-
-    match result {
-        Err(Error::Grpc(status)) => {
-            assert!(
-                status.code() != tonic::Code::Ok,
-                "Should fail with a non-OK status"
-            );
-        }
-        Err(Error::Signature(_)) => {
-            // Signature validation failed on client side
-        }
-        Err(e) => panic!("Unexpected error type: {e:?}"),
-        Ok(_) => unreachable!(),
-    }
 }
 
 #[sim_test]

--- a/crates/iota-e2e-tests/tests/grpc/client/mod.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+mod checkpoints;
+mod common;
+mod epochs;
+mod execute;
+mod objects;
+mod simulate;
+mod transactions;

--- a/crates/iota-e2e-tests/tests/grpc/client/objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/objects.rs
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_macros::sim_test;
+use iota_sdk_types::ObjectId;
+
+use super::common::{assert_not_found_error, setup_grpc_test};
+
+/// System package IDs that are always available.
+const SYSTEM_PACKAGE_IDS: [&str; 3] = ["0x1", "0x2", "0x3"];
+
+#[sim_test]
+async fn get_objects_single() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let object_id: ObjectId = "0x2".parse().expect("Invalid object ID");
+
+    let objects = client
+        .get_objects(&[(object_id, None)], None)
+        .await
+        .expect("Failed to get object");
+
+    assert_eq!(objects.len(), 1, "Expected exactly one object");
+
+    let object = &objects[0];
+    assert!(object.version() > 0, "Object should have a valid version");
+}
+
+#[sim_test]
+async fn get_objects_batch_system_packages() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let object_ids: Vec<ObjectId> = SYSTEM_PACKAGE_IDS
+        .iter()
+        .map(|s| s.parse().expect("Invalid object ID"))
+        .collect();
+
+    let refs: Vec<_> = object_ids.iter().map(|id| (*id, None)).collect();
+
+    let objects = client
+        .get_objects(&refs, None)
+        .await
+        .expect("Failed to get objects");
+
+    assert_eq!(
+        objects.len(),
+        object_ids.len(),
+        "Should return same number of objects as requested"
+    );
+
+    for object in &objects {
+        assert!(
+            object.version() > 0,
+            "Each object should have a valid version"
+        );
+        assert!(
+            object.data.is_package(),
+            "System object should be a package"
+        );
+    }
+}
+
+#[sim_test]
+async fn get_objects_empty_input() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let objects = client
+        .get_objects(&[], None)
+        .await
+        .expect("Empty input should succeed");
+
+    assert!(objects.is_empty(), "Empty input should return empty result");
+}
+
+#[sim_test]
+async fn get_objects_nonexistent() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let fake_id: ObjectId = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        .parse()
+        .expect("Invalid object ID");
+
+    let result = client.get_objects(&[(fake_id, None)], None).await;
+    assert_not_found_error(result);
+}
+
+#[sim_test]
+async fn get_objects_with_version() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let object_id: ObjectId = "0x2".parse().expect("Invalid object ID");
+
+    let objects = client
+        .get_objects(&[(object_id, None)], None)
+        .await
+        .expect("Failed to get object");
+
+    let current_version = objects[0].version();
+
+    let objects_with_version = client
+        .get_objects(&[(object_id, Some(current_version))], None)
+        .await
+        .expect("Failed to get object with specific version");
+
+    assert_eq!(
+        objects_with_version[0].version(),
+        current_version,
+        "Object version should match requested version"
+    );
+}
+
+#[sim_test]
+async fn get_objects_invalid_version() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let object_id: ObjectId = "0x2".parse().expect("Invalid object ID");
+
+    let result = client
+        .get_objects(&[(object_id, Some(999_999_999))], None)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "Fetching object with invalid version should return an error"
+    );
+}
+
+#[sim_test]
+async fn get_objects_mixed_valid_invalid() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let valid_id: ObjectId = "0x2".parse().expect("Invalid object ID");
+    let invalid_id: ObjectId = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        .parse()
+        .expect("Invalid object ID");
+
+    let result = client
+        .get_objects(&[(valid_id, None), (invalid_id, None)], None)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "Mixed valid/invalid should return an error when encountering invalid object"
+    );
+}

--- a/crates/iota-e2e-tests/tests/grpc/client/objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/objects.rs
@@ -4,7 +4,7 @@
 use iota_macros::sim_test;
 use iota_sdk_types::ObjectId;
 
-use super::common::{assert_not_found_error, setup_grpc_test};
+use super::common::{assert_grpc_not_found, setup_grpc_test};
 
 /// System package IDs that are always available.
 const SYSTEM_PACKAGE_IDS: [&str; 3] = ["0x1", "0x2", "0x3"];
@@ -80,7 +80,7 @@ async fn get_objects_scenarios() {
         .parse()
         .expect("Invalid object ID");
     let result = client.get_objects(&[(fake_id, None)], None).await;
-    assert_not_found_error(result);
+    assert_grpc_not_found(result);
 
     // Test: invalid version returns error
     let object_id: ObjectId = "0x2".parse().expect("Invalid object ID");

--- a/crates/iota-e2e-tests/tests/grpc/client/objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/objects.rs
@@ -4,7 +4,7 @@
 use iota_macros::sim_test;
 use iota_sdk_types::ObjectId;
 
-use super::common::{assert_grpc_not_found, setup_grpc_test};
+use super::common::{assert_server_not_found, setup_grpc_test};
 
 /// System package IDs that are always available.
 const SYSTEM_PACKAGE_IDS: [&str; 3] = ["0x1", "0x2", "0x3"];
@@ -80,7 +80,7 @@ async fn get_objects_scenarios() {
         .parse()
         .expect("Invalid object ID");
     let result = client.get_objects(&[(fake_id, None)], None).await;
-    assert_grpc_not_found(result);
+    assert_server_not_found(result);
 
     // Test: invalid version returns error
     let object_id: ObjectId = "0x2".parse().expect("Invalid object ID");

--- a/crates/iota-e2e-tests/tests/grpc/client/objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/objects.rs
@@ -10,44 +10,36 @@ use super::common::{assert_not_found_error, setup_grpc_test};
 const SYSTEM_PACKAGE_IDS: [&str; 3] = ["0x1", "0x2", "0x3"];
 
 #[sim_test]
-async fn get_objects_single() {
+async fn get_objects_scenarios() {
     let (_test_cluster, client) = setup_grpc_test(1).await;
 
+    // Test: get single object
     let object_id: ObjectId = "0x2".parse().expect("Invalid object ID");
-
     let objects = client
         .get_objects(&[(object_id, None)], None)
         .await
         .expect("Failed to get object");
-
     assert_eq!(objects.len(), 1, "Expected exactly one object");
+    assert!(
+        objects[0].version() > 0,
+        "Object should have a valid version"
+    );
 
-    let object = &objects[0];
-    assert!(object.version() > 0, "Object should have a valid version");
-}
-
-#[sim_test]
-async fn get_objects_batch_system_packages() {
-    let (_test_cluster, client) = setup_grpc_test(1).await;
-
+    // Test: get batch of system packages
     let object_ids: Vec<ObjectId> = SYSTEM_PACKAGE_IDS
         .iter()
         .map(|s| s.parse().expect("Invalid object ID"))
         .collect();
-
     let refs: Vec<_> = object_ids.iter().map(|id| (*id, None)).collect();
-
     let objects = client
         .get_objects(&refs, None)
         .await
         .expect("Failed to get objects");
-
     assert_eq!(
         objects.len(),
         object_ids.len(),
         "Should return same number of objects as requested"
     );
-
     for object in &objects {
         assert!(
             object.version() > 0,
@@ -58,86 +50,56 @@ async fn get_objects_batch_system_packages() {
             "System object should be a package"
         );
     }
-}
 
-#[sim_test]
-async fn get_objects_empty_input() {
-    let (_test_cluster, client) = setup_grpc_test(1).await;
-
+    // Test: empty input returns empty result
     let objects = client
         .get_objects(&[], None)
         .await
         .expect("Empty input should succeed");
-
     assert!(objects.is_empty(), "Empty input should return empty result");
-}
 
-#[sim_test]
-async fn get_objects_nonexistent() {
-    let (_test_cluster, client) = setup_grpc_test(1).await;
-
-    let fake_id: ObjectId = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-        .parse()
-        .expect("Invalid object ID");
-
-    let result = client.get_objects(&[(fake_id, None)], None).await;
-    assert_not_found_error(result);
-}
-
-#[sim_test]
-async fn get_objects_with_version() {
-    let (_test_cluster, client) = setup_grpc_test(1).await;
-
+    // Test: get object with specific version
     let object_id: ObjectId = "0x2".parse().expect("Invalid object ID");
-
     let objects = client
         .get_objects(&[(object_id, None)], None)
         .await
         .expect("Failed to get object");
-
     let current_version = objects[0].version();
-
     let objects_with_version = client
         .get_objects(&[(object_id, Some(current_version))], None)
         .await
         .expect("Failed to get object with specific version");
-
     assert_eq!(
         objects_with_version[0].version(),
         current_version,
         "Object version should match requested version"
     );
-}
 
-#[sim_test]
-async fn get_objects_invalid_version() {
-    let (_test_cluster, client) = setup_grpc_test(1).await;
+    // Test: nonexistent object returns not-found error
+    let fake_id: ObjectId = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        .parse()
+        .expect("Invalid object ID");
+    let result = client.get_objects(&[(fake_id, None)], None).await;
+    assert_not_found_error(result);
 
+    // Test: invalid version returns error
     let object_id: ObjectId = "0x2".parse().expect("Invalid object ID");
-
     let result = client
         .get_objects(&[(object_id, Some(999_999_999))], None)
         .await;
-
     assert!(
         result.is_err(),
         "Fetching object with invalid version should return an error"
     );
-}
 
-#[sim_test]
-async fn get_objects_mixed_valid_invalid() {
-    let (_test_cluster, client) = setup_grpc_test(1).await;
-
+    // Test: mixed valid/invalid returns error
     let valid_id: ObjectId = "0x2".parse().expect("Invalid object ID");
     let invalid_id: ObjectId = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
         .parse()
         .expect("Invalid object ID");
-
     let result = client
         .get_objects(&[(valid_id, None), (invalid_id, None)], None)
         .await;
-
     assert!(
         result.is_err(),
         "Mixed valid/invalid should return an error when encountering invalid object"

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_macros::sim_test;
+use iota_test_transaction_builder::TestTransactionBuilder;
+use iota_types::base_types::IotaAddress;
+
+use super::common::{
+    create_transaction_for_simulation, is_success, setup_grpc_test, to_sdk_transaction,
+};
+
+#[sim_test]
+async fn simulate_transaction_modes() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    // Test both regular simulation and dev-inspect mode
+    for (dev_inspect, mode_name) in [(false, "regular"), (true, "dev-inspect")] {
+        let transaction = create_transaction_for_simulation(&test_cluster).await;
+
+        let result = client
+            .simulate_transaction(transaction, dev_inspect, None)
+            .await
+            .unwrap_or_else(|e| panic!("Failed to simulate transaction in {mode_name} mode: {e}"));
+
+        assert!(
+            is_success(result.effects.status()),
+            "{mode_name} simulation should succeed"
+        );
+
+        // Verify gas costs are reported
+        let gas_summary = result.effects.gas_summary();
+        assert!(
+            gas_summary.computation_cost > 0 || gas_summary.storage_cost > 0,
+            "{mode_name} simulation should report gas costs"
+        );
+    }
+}
+
+#[sim_test]
+async fn simulate_transaction_minimal_mask() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let transaction = create_transaction_for_simulation(&test_cluster).await;
+
+    let result = client
+        .simulate_transaction(transaction, false, Some("transaction.effects"))
+        .await
+        .expect("Failed to simulate transaction with minimal mask");
+
+    assert!(
+        is_success(result.effects.status()),
+        "Effects should be present with minimal mask"
+    );
+}
+
+#[sim_test]
+async fn simulate_transaction_idempotency() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let transaction = create_transaction_for_simulation(&test_cluster).await;
+
+    let result1 = client
+        .simulate_transaction(transaction.clone(), false, None)
+        .await
+        .expect("First simulation should succeed");
+
+    let result2 = client
+        .simulate_transaction(transaction, false, None)
+        .await
+        .expect("Second simulation should also succeed");
+
+    assert!(
+        is_success(result1.effects.status()),
+        "First simulation should succeed"
+    );
+    assert!(
+        is_success(result2.effects.status()),
+        "Second simulation should succeed"
+    );
+}
+
+#[sim_test]
+async fn simulate_transaction_insufficient_gas() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let (sender, gas) = test_cluster
+        .wallet
+        .get_one_gas_object()
+        .await
+        .unwrap()
+        .unwrap();
+
+    let rgp = test_cluster.get_reference_gas_price().await;
+
+    let tx_data = TestTransactionBuilder::new(sender, gas, rgp)
+        .transfer_iota(None, sender)
+        .with_gas_budget(1)
+        .build();
+
+    let transaction = to_sdk_transaction(&tx_data);
+    let result = client.simulate_transaction(transaction, false, None).await;
+
+    // With insufficient gas budget, simulation may either:
+    // - Return an error from the server
+    // - Succeed but show failure in effects (InsufficientGas)
+    match result {
+        Ok(response) => {
+            assert!(
+                !is_success(response.effects.status()),
+                "Simulation with insufficient gas should fail in effects"
+            );
+        }
+        Err(_) => {
+            // Server rejected the transaction due to invalid gas budget
+        }
+    }
+}
+
+#[sim_test]
+async fn simulate_transaction_invalid() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let (sender, gas) = test_cluster
+        .wallet
+        .get_one_gas_object()
+        .await
+        .unwrap()
+        .unwrap();
+
+    let rgp = test_cluster.get_reference_gas_price().await;
+
+    let fake_recipient = IotaAddress::random_for_testing_only();
+    let tx_data = TestTransactionBuilder::new(sender, gas, rgp)
+        .transfer_iota(Some(1_000_000_000_000), fake_recipient)
+        .build();
+
+    let transaction = to_sdk_transaction(&tx_data);
+    let result = client.simulate_transaction(transaction, false, None).await;
+
+    // Transferring more than available balance should either:
+    // - Return an error from the server
+    // - Succeed but show failure in effects (InsufficientCoinBalance)
+    match result {
+        Ok(response) => {
+            assert!(
+                !is_success(response.effects.status()),
+                "Simulation with insufficient balance should fail in effects"
+            );
+        }
+        Err(_) => {
+            // Server rejected the transaction due to insufficient balance
+        }
+    }
+}

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -8,7 +8,7 @@ use iota_types::base_types::IotaAddress;
 use tonic::Code;
 
 use super::common::{
-    create_transaction_for_simulation, is_grpc_error, is_success, setup_grpc_test,
+    assert_grpc_error, create_transaction_for_simulation, is_success, setup_grpc_test,
 };
 
 #[sim_test]
@@ -64,10 +64,7 @@ async fn simulate_transaction_scenarios() {
         .build();
     let transaction: Transaction = tx_data.try_into().expect("SDK type conversion failed");
     let result = client.simulate_transaction(transaction, false, None).await;
-    assert!(
-        matches!(&result, Err(err) if is_grpc_error(err, Code::Internal)),
-        "Insufficient gas budget should return gRPC Internal error, got: {result:?}"
-    );
+    assert_grpc_error(result, Code::Internal);
 
     // Test: transfer exceeding balance returns Ok with failed effects
     // Transfer amount validation happens during Move VM execution, not upfront,

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -10,10 +10,10 @@ use super::common::{
 };
 
 #[sim_test]
-async fn simulate_transaction_modes() {
+async fn simulate_transaction_scenarios() {
     let (test_cluster, client) = setup_grpc_test(1).await;
 
-    // Test both regular simulation and dev-inspect mode
+    // Test: regular and dev-inspect simulation modes
     for (dev_inspect, mode_name) in [(false, "regular"), (true, "dev-inspect")] {
         let transaction = create_transaction_for_simulation(&test_cluster).await;
 
@@ -27,53 +27,38 @@ async fn simulate_transaction_modes() {
             "{mode_name} simulation should succeed"
         );
 
-        // Verify gas costs are reported
         let gas_summary = result.effects.gas_summary();
         assert!(
             gas_summary.computation_cost > 0 || gas_summary.storage_cost > 0,
             "{mode_name} simulation should report gas costs"
         );
     }
-}
 
-#[sim_test]
-async fn simulate_transaction_minimal_mask() {
-    let (test_cluster, client) = setup_grpc_test(1).await;
-
+    // Test: minimal read mask
     let transaction = create_transaction_for_simulation(&test_cluster).await;
-
     let result = client
         .simulate_transaction(transaction, false, Some("transaction.effects"))
         .await
         .expect("Failed to simulate transaction with minimal mask");
-
     assert!(
         is_success(result.effects.status()),
         "Effects should be present with minimal mask"
     );
-}
 
-#[sim_test]
-async fn simulate_transaction_insufficient_gas() {
-    let (test_cluster, client) = setup_grpc_test(1).await;
-
+    // Test: insufficient gas budget
     let (sender, gas) = test_cluster
         .wallet
         .get_one_gas_object()
         .await
         .unwrap()
         .unwrap();
-
     let rgp = test_cluster.get_reference_gas_price().await;
-
     let tx_data = TestTransactionBuilder::new(sender, gas, rgp)
         .transfer_iota(None, sender)
         .with_gas_budget(1)
         .build();
-
     let transaction = to_sdk_transaction(&tx_data);
     let result = client.simulate_transaction(transaction, false, None).await;
-
     // With insufficient gas budget, simulation may either:
     // - Return an error from the server
     // - Succeed but show failure in effects (InsufficientGas)
@@ -88,31 +73,21 @@ async fn simulate_transaction_insufficient_gas() {
             // Server rejected the transaction due to invalid gas budget
         }
     }
-}
 
-#[sim_test]
-async fn simulate_transaction_invalid() {
-    let (test_cluster, client) = setup_grpc_test(1).await;
-
+    // Test: transfer exceeding balance
     let (sender, gas) = test_cluster
         .wallet
         .get_one_gas_object()
         .await
         .unwrap()
         .unwrap();
-
     let rgp = test_cluster.get_reference_gas_price().await;
-
     let fake_recipient = IotaAddress::random_for_testing_only();
-    // Use an extremely large amount (10^18) to ensure it exceeds any test wallet
-    // balance
     let tx_data = TestTransactionBuilder::new(sender, gas, rgp)
         .transfer_iota(Some(1_000_000_000_000_000_000), fake_recipient)
         .build();
-
     let transaction = to_sdk_transaction(&tx_data);
     let result = client.simulate_transaction(transaction, false, None).await;
-
     // Transferring more than available balance should either:
     // - Return an error from the server
     // - Succeed but show failure in effects (InsufficientCoinBalance)

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -54,32 +54,6 @@ async fn simulate_transaction_minimal_mask() {
 }
 
 #[sim_test]
-async fn simulate_transaction_idempotency() {
-    let (test_cluster, client) = setup_grpc_test(1).await;
-
-    let transaction = create_transaction_for_simulation(&test_cluster).await;
-
-    let result1 = client
-        .simulate_transaction(transaction.clone(), false, None)
-        .await
-        .expect("First simulation should succeed");
-
-    let result2 = client
-        .simulate_transaction(transaction, false, None)
-        .await
-        .expect("Second simulation should also succeed");
-
-    assert!(
-        is_success(result1.effects.status()),
-        "First simulation should succeed"
-    );
-    assert!(
-        is_success(result2.effects.status()),
-        "Second simulation should succeed"
-    );
-}
-
-#[sim_test]
 async fn simulate_transaction_insufficient_gas() {
     let (test_cluster, client) = setup_grpc_test(1).await;
 
@@ -130,8 +104,9 @@ async fn simulate_transaction_invalid() {
     let rgp = test_cluster.get_reference_gas_price().await;
 
     let fake_recipient = IotaAddress::random_for_testing_only();
+    // Use an extremely large amount (10^18) to ensure it exceeds any test wallet balance
     let tx_data = TestTransactionBuilder::new(sender, gas, rgp)
-        .transfer_iota(Some(1_000_000_000_000), fake_recipient)
+        .transfer_iota(Some(1_000_000_000_000_000_000), fake_recipient)
         .build();
 
     let transaction = to_sdk_transaction(&tx_data);

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -104,7 +104,8 @@ async fn simulate_transaction_invalid() {
     let rgp = test_cluster.get_reference_gas_price().await;
 
     let fake_recipient = IotaAddress::random_for_testing_only();
-    // Use an extremely large amount (10^18) to ensure it exceeds any test wallet balance
+    // Use an extremely large amount (10^18) to ensure it exceeds any test wallet
+    // balance
     let tx_data = TestTransactionBuilder::new(sender, gas, rgp)
         .transfer_iota(Some(1_000_000_000_000_000_000), fake_recipient)
         .build();

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_macros::sim_test;
+use iota_sdk_types::Transaction;
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::base_types::IotaAddress;
 
-use super::common::{
-    create_transaction_for_simulation, is_success, setup_grpc_test, to_sdk_transaction,
-};
+use super::common::{create_transaction_for_simulation, is_success, setup_grpc_test};
 
 #[sim_test]
 async fn simulate_transaction_scenarios() {
@@ -57,7 +56,7 @@ async fn simulate_transaction_scenarios() {
         .transfer_iota(None, sender)
         .with_gas_budget(1)
         .build();
-    let transaction = to_sdk_transaction(&tx_data);
+    let transaction: Transaction = tx_data.try_into().expect("SDK type conversion failed");
     let result = client.simulate_transaction(transaction, false, None).await;
     // With insufficient gas budget, simulation may either:
     // - Return an error from the server
@@ -86,7 +85,7 @@ async fn simulate_transaction_scenarios() {
     let tx_data = TestTransactionBuilder::new(sender, gas, rgp)
         .transfer_iota(Some(1_000_000_000_000_000_000), fake_recipient)
         .build();
-    let transaction = to_sdk_transaction(&tx_data);
+    let transaction: Transaction = tx_data.try_into().expect("SDK type conversion failed");
     let result = client.simulate_transaction(transaction, false, None).await;
     // Transferring more than available balance should either:
     // - Return an error from the server

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -5,8 +5,11 @@ use iota_macros::sim_test;
 use iota_sdk_types::Transaction;
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::base_types::IotaAddress;
+use tonic::Code;
 
-use super::common::{create_transaction_for_simulation, is_success, setup_grpc_test};
+use super::common::{
+    create_transaction_for_simulation, is_grpc_error, is_success, setup_grpc_test,
+};
 
 #[sim_test]
 async fn simulate_transaction_scenarios() {
@@ -44,7 +47,10 @@ async fn simulate_transaction_scenarios() {
         "Effects should be present with minimal mask"
     );
 
-    // Test: insufficient gas budget
+    // Test: insufficient gas budget returns gRPC error
+    // Gas budget validation (min/max bounds) happens upfront in
+    // check_gas_balance(), so a budget of 1 (below minimum) is rejected before
+    // execution begins.
     let (sender, gas) = test_cluster
         .wallet
         .get_one_gas_object()
@@ -58,22 +64,14 @@ async fn simulate_transaction_scenarios() {
         .build();
     let transaction: Transaction = tx_data.try_into().expect("SDK type conversion failed");
     let result = client.simulate_transaction(transaction, false, None).await;
-    // With insufficient gas budget, simulation may either:
-    // - Return an error from the server
-    // - Succeed but show failure in effects (InsufficientGas)
-    match result {
-        Ok(response) => {
-            assert!(
-                !is_success(response.effects.status()),
-                "Simulation with insufficient gas should fail in effects"
-            );
-        }
-        Err(_) => {
-            // Server rejected the transaction due to invalid gas budget
-        }
-    }
+    assert!(
+        matches!(&result, Err(err) if is_grpc_error(err, Code::Internal)),
+        "Insufficient gas budget should return gRPC Internal error, got: {result:?}"
+    );
 
-    // Test: transfer exceeding balance
+    // Test: transfer exceeding balance returns Ok with failed effects
+    // Transfer amount validation happens during Move VM execution, not upfront,
+    // so the RPC succeeds but effects show failure (e.g., InsufficientCoinBalance).
     let (sender, gas) = test_cluster
         .wallet
         .get_one_gas_object()
@@ -86,19 +84,12 @@ async fn simulate_transaction_scenarios() {
         .transfer_iota(Some(1_000_000_000_000_000_000), fake_recipient)
         .build();
     let transaction: Transaction = tx_data.try_into().expect("SDK type conversion failed");
-    let result = client.simulate_transaction(transaction, false, None).await;
-    // Transferring more than available balance should either:
-    // - Return an error from the server
-    // - Succeed but show failure in effects (InsufficientCoinBalance)
-    match result {
-        Ok(response) => {
-            assert!(
-                !is_success(response.effects.status()),
-                "Simulation with insufficient balance should fail in effects"
-            );
-        }
-        Err(_) => {
-            // Server rejected the transaction due to insufficient balance
-        }
-    }
+    let response = client
+        .simulate_transaction(transaction, false, None)
+        .await
+        .expect("Simulation should succeed at RPC level");
+    assert!(
+        !is_success(response.effects.status()),
+        "Effects should show failure due to insufficient balance"
+    );
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_grpc_client::Error;
+use iota_macros::sim_test;
+use iota_sdk_types::Digest;
+
+use super::common::{
+    assert_not_found_error, execute_transaction_and_get_digest, is_success, setup_grpc_test,
+};
+
+#[sim_test]
+async fn get_transactions_single() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let digest = execute_transaction_and_get_digest(&test_cluster).await;
+    test_cluster.wait_for_checkpoint(2, None).await;
+
+    let transactions = client
+        .get_transactions(&[digest], None)
+        .await
+        .expect("Failed to get transaction");
+
+    assert_eq!(transactions.len(), 1, "Expected exactly one transaction");
+
+    let tx = &transactions[0];
+    assert_eq!(
+        tx.digest, digest,
+        "Transaction digest should match requested digest"
+    );
+    assert!(!tx.signatures.is_empty(), "Signatures should be present");
+}
+
+#[sim_test]
+async fn get_transactions_batch() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let digest1 = execute_transaction_and_get_digest(&test_cluster).await;
+    let digest2 = execute_transaction_and_get_digest(&test_cluster).await;
+    test_cluster.wait_for_checkpoint(3, None).await;
+
+    let transactions = client
+        .get_transactions(&[digest1, digest2], None)
+        .await
+        .expect("Failed to get transactions");
+
+    assert_eq!(transactions.len(), 2, "Expected exactly two transactions");
+    assert_eq!(
+        transactions[0].digest, digest1,
+        "First transaction should match first digest"
+    );
+    assert_eq!(
+        transactions[1].digest, digest2,
+        "Second transaction should match second digest"
+    );
+}
+
+#[sim_test]
+async fn get_transactions_empty_input() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let transactions = client
+        .get_transactions(&[], None)
+        .await
+        .expect("Empty input should succeed");
+
+    assert!(
+        transactions.is_empty(),
+        "Empty input should return empty result"
+    );
+}
+
+#[sim_test]
+async fn get_transactions_nonexistent() {
+    let (_test_cluster, client) = setup_grpc_test(1).await;
+
+    let fake_digest = Digest::new([0u8; 32]);
+    let result = client.get_transactions(&[fake_digest], None).await;
+    assert_not_found_error(result);
+}
+
+#[sim_test]
+async fn get_transactions_mixed_valid_invalid() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let valid_digest = execute_transaction_and_get_digest(&test_cluster).await;
+    test_cluster.wait_for_checkpoint(2, None).await;
+
+    let fake_digest = Digest::new([0u8; 32]);
+
+    let result = client
+        .get_transactions(&[valid_digest, fake_digest], None)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "Mixed valid/invalid should return an error when encountering invalid digest"
+    );
+}
+
+#[sim_test]
+async fn get_transactions_response_fields() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let digest = execute_transaction_and_get_digest(&test_cluster).await;
+    test_cluster.wait_for_checkpoint(3, None).await;
+
+    let transactions = client
+        .get_transactions(&[digest], None)
+        .await
+        .expect("Failed to get transaction");
+
+    let tx = &transactions[0];
+
+    assert_eq!(tx.digest, digest, "Digest should match");
+    assert!(!tx.signatures.is_empty(), "Signatures should be present");
+    assert!(
+        is_success(tx.effects.status()),
+        "Transaction should have succeeded"
+    );
+    assert!(
+        tx.checkpoint.is_some(),
+        "Checkpoint should be present after finalization"
+    );
+    assert!(
+        tx.timestamp_ms.is_some(),
+        "Timestamp should be present after finalization"
+    );
+}
+
+#[sim_test]
+async fn get_transactions_invalid_read_mask() {
+    let (test_cluster, client) = setup_grpc_test(1).await;
+
+    let digest = execute_transaction_and_get_digest(&test_cluster).await;
+    test_cluster.wait_for_checkpoint(2, None).await;
+
+    // Try to fetch with an incomplete read mask (missing required fields)
+    let result = client
+        .get_transactions(&[digest], Some("transaction.digest"))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "Incomplete read mask should cause deserialization error"
+    );
+
+    match result {
+        Err(Error::ProtoConversion(_)) => {}
+        Err(e) => panic!("Expected ProtoConversion error, got: {e:?}"),
+        Ok(_) => panic!("Expected error for incomplete read mask"),
+    }
+}

--- a/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
@@ -1,12 +1,12 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_grpc_client::Error;
 use iota_macros::sim_test;
 use iota_sdk_types::Digest;
 
 use super::common::{
-    assert_grpc_not_found, execute_transaction_and_get_digest, is_success, setup_grpc_test,
+    assert_proto_conversion_error, assert_server_not_found, execute_transaction_and_get_digest,
+    is_success, setup_grpc_test,
 };
 
 #[sim_test]
@@ -61,7 +61,7 @@ async fn get_transactions_scenarios() {
     // Test: nonexistent transaction returns not-found error
     let fake_digest = Digest::new([0u8; 32]);
     let result = client.get_transactions(&[fake_digest], None).await;
-    assert_grpc_not_found(result);
+    assert_server_not_found(result);
 
     // Test: mixed valid/invalid returns error
     let fake_digest = Digest::new([0u8; 32]);
@@ -96,13 +96,5 @@ async fn get_transactions_scenarios() {
     let result = client
         .get_transactions(&[digest1], Some("transaction.digest"))
         .await;
-    assert!(
-        result.is_err(),
-        "Incomplete read mask should cause deserialization error"
-    );
-    match result {
-        Err(Error::ProtoConversion(_)) => {}
-        Err(e) => panic!("Expected ProtoConversion error, got: {e:?}"),
-        Ok(_) => panic!("Expected error for incomplete read mask"),
-    }
+    assert_proto_conversion_error(result);
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
@@ -10,40 +10,34 @@ use super::common::{
 };
 
 #[sim_test]
-async fn get_transactions_single() {
+async fn get_transactions_scenarios() {
     let (test_cluster, client) = setup_grpc_test(1).await;
 
-    let digest = execute_transaction_and_get_digest(&test_cluster).await;
-    test_cluster.wait_for_checkpoint(2, None).await;
-
-    let transactions = client
-        .get_transactions(&[digest], None)
-        .await
-        .expect("Failed to get transaction");
-
-    assert_eq!(transactions.len(), 1, "Expected exactly one transaction");
-
-    let tx = &transactions[0];
-    assert_eq!(
-        tx.digest, digest,
-        "Transaction digest should match requested digest"
-    );
-    assert!(!tx.signatures.is_empty(), "Signatures should be present");
-}
-
-#[sim_test]
-async fn get_transactions_batch() {
-    let (test_cluster, client) = setup_grpc_test(1).await;
-
+    // Execute transactions upfront for later tests
     let digest1 = execute_transaction_and_get_digest(&test_cluster).await;
     let digest2 = execute_transaction_and_get_digest(&test_cluster).await;
     test_cluster.wait_for_checkpoint(3, None).await;
 
+    // Test: get single transaction
+    let transactions = client
+        .get_transactions(&[digest1], None)
+        .await
+        .expect("Failed to get transaction");
+    assert_eq!(transactions.len(), 1, "Expected exactly one transaction");
+    assert_eq!(
+        transactions[0].digest, digest1,
+        "Transaction digest should match requested digest"
+    );
+    assert!(
+        !transactions[0].signatures.is_empty(),
+        "Signatures should be present"
+    );
+
+    // Test: get batch of transactions
     let transactions = client
         .get_transactions(&[digest1, digest2], None)
         .await
         .expect("Failed to get transactions");
-
     assert_eq!(transactions.len(), 2, "Expected exactly two transactions");
     assert_eq!(
         transactions[0].digest, digest1,
@@ -53,66 +47,37 @@ async fn get_transactions_batch() {
         transactions[1].digest, digest2,
         "Second transaction should match second digest"
     );
-}
 
-#[sim_test]
-async fn get_transactions_empty_input() {
-    let (_test_cluster, client) = setup_grpc_test(1).await;
-
+    // Test: empty input returns empty result
     let transactions = client
         .get_transactions(&[], None)
         .await
         .expect("Empty input should succeed");
-
     assert!(
         transactions.is_empty(),
         "Empty input should return empty result"
     );
-}
 
-#[sim_test]
-async fn get_transactions_nonexistent() {
-    let (_test_cluster, client) = setup_grpc_test(1).await;
-
+    // Test: nonexistent transaction returns not-found error
     let fake_digest = Digest::new([0u8; 32]);
     let result = client.get_transactions(&[fake_digest], None).await;
     assert_not_found_error(result);
-}
 
-#[sim_test]
-async fn get_transactions_mixed_valid_invalid() {
-    let (test_cluster, client) = setup_grpc_test(1).await;
-
-    let valid_digest = execute_transaction_and_get_digest(&test_cluster).await;
-    test_cluster.wait_for_checkpoint(2, None).await;
-
+    // Test: mixed valid/invalid returns error
     let fake_digest = Digest::new([0u8; 32]);
-
-    let result = client
-        .get_transactions(&[valid_digest, fake_digest], None)
-        .await;
-
+    let result = client.get_transactions(&[digest1, fake_digest], None).await;
     assert!(
         result.is_err(),
         "Mixed valid/invalid should return an error when encountering invalid digest"
     );
-}
 
-#[sim_test]
-async fn get_transactions_response_fields() {
-    let (test_cluster, client) = setup_grpc_test(1).await;
-
-    let digest = execute_transaction_and_get_digest(&test_cluster).await;
-    test_cluster.wait_for_checkpoint(3, None).await;
-
+    // Test: response fields are complete
     let transactions = client
-        .get_transactions(&[digest], None)
+        .get_transactions(&[digest1], None)
         .await
         .expect("Failed to get transaction");
-
     let tx = &transactions[0];
-
-    assert_eq!(tx.digest, digest, "Digest should match");
+    assert_eq!(tx.digest, digest1, "Digest should match");
     assert!(!tx.signatures.is_empty(), "Signatures should be present");
     assert!(
         is_success(tx.effects.status()),
@@ -126,25 +91,15 @@ async fn get_transactions_response_fields() {
         tx.timestamp_ms.is_some(),
         "Timestamp should be present after finalization"
     );
-}
 
-#[sim_test]
-async fn get_transactions_invalid_read_mask() {
-    let (test_cluster, client) = setup_grpc_test(1).await;
-
-    let digest = execute_transaction_and_get_digest(&test_cluster).await;
-    test_cluster.wait_for_checkpoint(2, None).await;
-
-    // Try to fetch with an incomplete read mask (missing required fields)
+    // Test: invalid read mask causes deserialization error
     let result = client
-        .get_transactions(&[digest], Some("transaction.digest"))
+        .get_transactions(&[digest1], Some("transaction.digest"))
         .await;
-
     assert!(
         result.is_err(),
         "Incomplete read mask should cause deserialization error"
     );
-
     match result {
         Err(Error::ProtoConversion(_)) => {}
         Err(e) => panic!("Expected ProtoConversion error, got: {e:?}"),

--- a/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
@@ -6,7 +6,7 @@ use iota_macros::sim_test;
 use iota_sdk_types::Digest;
 
 use super::common::{
-    assert_not_found_error, execute_transaction_and_get_digest, is_success, setup_grpc_test,
+    assert_grpc_not_found, execute_transaction_and_get_digest, is_success, setup_grpc_test,
 };
 
 #[sim_test]
@@ -61,7 +61,7 @@ async fn get_transactions_scenarios() {
     // Test: nonexistent transaction returns not-found error
     let fake_digest = Digest::new([0u8; 32]);
     let result = client.get_transactions(&[fake_digest], None).await;
-    assert_not_found_error(result);
+    assert_grpc_not_found(result);
 
     // Test: mixed valid/invalid returns error
     let fake_digest = Digest::new([0u8; 32]);

--- a/crates/iota-e2e-tests/tests/grpc/main.rs
+++ b/crates/iota-e2e-tests/tests/grpc/main.rs
@@ -2,5 +2,6 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+mod client;
 mod utils;
 mod v0;

--- a/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/execute.rs
@@ -123,7 +123,7 @@ async fn execute_transaction_readmask_scenarios() {
                 .iter()
                 .map(|s| UserSignature {
                     bcs: Some(BcsData {
-                        data: s.as_ref().to_vec().into(),
+                        data: bcs::to_bytes(s).unwrap().into(),
                     }),
                 })
                 .collect(),
@@ -174,7 +174,7 @@ async fn execute_transaction_invalid_bcs() {
             .iter()
             .map(|s| UserSignature {
                 bcs: Some(BcsData {
-                    data: s.as_ref().to_vec().into(),
+                    data: bcs::to_bytes(s).unwrap().into(),
                 }),
             })
             .collect(),
@@ -268,7 +268,7 @@ async fn execute_transaction_empty_request() {
             .iter()
             .map(|s| UserSignature {
                 bcs: Some(BcsData {
-                    data: s.as_ref().to_vec().into(),
+                    data: bcs::to_bytes(s).unwrap().into(),
                 }),
             })
             .collect(),

--- a/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/header.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/header.rs
@@ -56,7 +56,7 @@ async fn test_response_headers() {
                 .iter()
                 .map(|s| UserSignature {
                     bcs: Some(BcsData {
-                        data: s.as_ref().to_vec().into(),
+                        data: bcs::to_bytes(s).unwrap().into(),
                     }),
                 })
                 .collect(),

--- a/crates/iota-grpc-client/src/api/common.rs
+++ b/crates/iota-grpc-client/src/api/common.rs
@@ -71,7 +71,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 ///
 /// **Required fields for `TransactionResponse` deserialization:**
 /// - `transaction.bcs` - Transaction data (required)
-/// - `signatures.bcs` - User signatures (required)
+/// - `signatures` - User signatures (required)
 /// - `effects.bcs` - Transaction effects (required)
 ///
 /// **Optional fields:**
@@ -80,9 +80,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// - `timestamp` - Execution timestamp
 ///
 /// If you provide a custom mask, you must include at least `transaction.bcs`,
-/// `signatures.bcs`, and `effects.bcs`, or deserialization will fail.
+/// `signatures`, and `effects.bcs`, or deserialization will fail.
 pub const TRANSACTIONS_READ_MASK: &str =
-    "transaction.bcs,signatures.bcs,effects.bcs,events,checkpoint,timestamp";
+    "transaction.bcs,signatures,effects.bcs,events,checkpoint,timestamp";
 
 /// Default field mask for [`crate::Client::get_objects`].
 ///

--- a/crates/iota-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-grpc-client/src/api/ledger/transactions.rs
@@ -34,7 +34,7 @@ impl Client {
     ///
     /// **Required fields** (must be included in custom masks):
     /// - `transaction.bcs` - Transaction data
-    /// - `signatures.bcs` - User signatures
+    /// - `signatures` - User signatures
     /// - `effects.bcs` - Transaction effects
     ///
     /// **Optional fields:**
@@ -56,10 +56,7 @@ impl Client {
     ///
     /// // Custom: only required fields (smaller response)
     /// let txs = client
-    ///     .get_transactions(
-    ///         &[digest],
-    ///         Some("transaction.bcs,signatures.bcs,effects.bcs"),
-    ///     )
+    ///     .get_transactions(&[digest], Some("transaction.bcs,signatures,effects.bcs"))
     ///     .await?;
     /// # Ok(())
     /// # }

--- a/crates/iota-grpc-server/src/ledger_service/get_checkpoint_data.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_checkpoint_data.rs
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_grpc_types::{
+    field::{FieldMaskTree, FieldMaskUtil},
+    v0::{
+        bcs::BcsData,
+        checkpoint::{Checkpoint, CheckpointSummary},
+        ledger_service::{
+            CheckpointData, GetCheckpointDataRequest, checkpoint_data,
+            get_checkpoint_data_request::CheckpointId,
+        },
+    },
+};
+use iota_types::messages_checkpoint::CertifiedCheckpointSummary;
+use prost_types::FieldMask;
+use tonic::Status;
+
+use crate::types::GrpcReader;
+
+pub const READ_MASK_DEFAULT: &str = crate::field_mask!("summary.bcs");
+
+/// Get checkpoint data based on the request.
+///
+/// Returns a single checkpoint payload wrapped in a CheckpointData message.
+#[tracing::instrument(skip(reader))]
+pub fn get_checkpoint_data(
+    reader: &GrpcReader,
+    request: GetCheckpointDataRequest,
+) -> Result<CheckpointData, Status> {
+    // Parse and validate the read mask
+    let read_mask = request
+        .checkpoint_read_mask
+        .unwrap_or_else(|| FieldMask::from_str(READ_MASK_DEFAULT));
+    read_mask
+        .validate::<Checkpoint>()
+        .map_err(|path| Status::invalid_argument(format!("invalid read_mask path: {path}")))?;
+    let read_mask = FieldMaskTree::from(read_mask);
+
+    // Get the checkpoint based on the checkpoint_id
+    let checkpoint_id = request
+        .checkpoint_id
+        .ok_or_else(|| Status::invalid_argument("checkpoint_id is required"))?;
+
+    let checkpoint_summary = match checkpoint_id {
+        CheckpointId::Latest(true) => reader
+            .get_latest_checkpoint()
+            .map_err(|e| Status::internal(format!("Failed to get latest checkpoint: {e}")))?,
+        CheckpointId::Latest(false) => {
+            return Err(Status::invalid_argument("latest must be true if specified"));
+        }
+        CheckpointId::SequenceNumber(seq) => reader
+            .get_checkpoint_summary(seq)
+            .map_err(|e| Status::internal(format!("Failed to get checkpoint: {e}")))?
+            .ok_or_else(|| {
+                Status::not_found(format!("Checkpoint with sequence number {seq} not found"))
+            })?,
+        CheckpointId::Digest(_) => {
+            return Err(Status::unimplemented(
+                "Checkpoint lookup by digest is not supported",
+            ));
+        }
+    };
+
+    // Build the Checkpoint proto message
+    let checkpoint = build_checkpoint_proto(&checkpoint_summary, &read_mask)?;
+
+    Ok(CheckpointData {
+        payload: Some(checkpoint_data::Payload::Checkpoint(checkpoint)),
+    })
+}
+
+/// Build a Checkpoint proto message from a CertifiedCheckpointSummary.
+fn build_checkpoint_proto(
+    summary: &CertifiedCheckpointSummary,
+    read_mask: &FieldMaskTree,
+) -> Result<Checkpoint, Status> {
+    let mut checkpoint = Checkpoint::default();
+
+    // Populate sequence_number if requested
+    if read_mask.contains(Checkpoint::SEQUENCE_NUMBER_FIELD.name) {
+        checkpoint.sequence_number = Some(*summary.sequence_number());
+    }
+
+    // Populate summary if requested (handles nested fields like summary.bcs)
+    if let Some(submask) = read_mask.subtree(Checkpoint::SUMMARY_FIELD.name) {
+        let mut proto_summary = CheckpointSummary::default();
+
+        // Serialize the full CertifiedCheckpointSummary as BCS
+        // This is what the client expects to deserialize as SignedCheckpointSummary
+        if submask.contains(CheckpointSummary::BCS_FIELD.name) {
+            proto_summary.bcs = BcsData::serialize(summary).ok();
+        }
+
+        // Add digest if requested
+        if submask.contains(CheckpointSummary::DIGEST_FIELD.name) {
+            let digest: iota_sdk_types::Digest = (*summary.digest()).into();
+            proto_summary.digest = Some(digest.into());
+        }
+
+        checkpoint.summary = Some(proto_summary);
+    }
+
+    // Populate signature if requested
+    if read_mask.contains(Checkpoint::SIGNATURE_FIELD.name) {
+        let sig: iota_sdk_types::ValidatorAggregatedSignature = summary.auth_sig().clone().into();
+        checkpoint.signature = Some(sig.into());
+    }
+
+    Ok(checkpoint)
+}

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+mod get_checkpoint_data;
 mod get_epoch;
 mod get_objects;
 mod get_service_info;
@@ -114,16 +115,16 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
     /// Checkpoint operations
     async fn get_checkpoint_data(
         &self,
-        _request: tonic::Request<grpc_ledger_service::GetCheckpointDataRequest>,
+        request: tonic::Request<grpc_ledger_service::GetCheckpointDataRequest>,
     ) -> std::result::Result<tonic::Response<Self::StreamCheckpointDataStream>, tonic::Status> {
+        let reader = self.reader.clone();
+        let req = request.into_inner();
+
         let stream = async_stream::try_stream! {
-            // not implemented
-            yield grpc_ledger_service::CheckpointData {
-                payload: None,
-            };
+            let checkpoint_data = get_checkpoint_data::get_checkpoint_data(&reader, req)?;
+            yield checkpoint_data;
         };
 
-        // not implemented
         let response = Response::new(Box::pin(stream) as Self::StreamCheckpointDataStream);
         Ok(append_info_headers!(response, self.reader.clone()))
     }

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -162,7 +162,7 @@ pub async fn execute_transaction(
                     .with_reason(ErrorReason::FieldMissing)
             })?;
 
-            iota_sdk_types::UserSignature::from_bytes(&bcs_data.data).map_err(|e| {
+            bcs::from_bytes::<iota_sdk_types::UserSignature>(&bcs_data.data).map_err(|e| {
                 FieldViolation::new_at("signatures", i)
                     .with_description(format!("invalid signature: {e}"))
                     .with_reason(ErrorReason::FieldInvalid)


### PR DESCRIPTION
# Description of change

- Add e2e tests for gRPC clients.
  - We cover edge cases but try to make the test set minimal, like if they are covered by Rust's type system, or similar error conditions (e.g., gas_budget=1 and gas_budget=0), we don't include them because they are redundant.
  - Run `cargo simtest -p iota-e2e-tests -- client::` for all the e2e tests.
- Fixes the signatures field mask (changing signatures.bcs to signatures) in the gRPC client
- Implements the previously unimplemented `get_checkpoint_data` endpoint in the server for ease our e2e tests
  - Note that we might need change after checkpoint streaming is completed
- Corrects signature deserialization to use BCS (found by our e2e tests)

## Links to any relevant issues

Fixes #9621

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
