### PR TITLE
upstream(core): Split batch building and batch writing into two separate phases

### DIFF
--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -783,11 +783,11 @@ impl AuthorityStore {
     /// version, and then writes objects, certificates, parents and clean up
     /// locks atomically.
     #[instrument(level = "debug", skip_all)]
-    pub fn write_transaction_outputs(
+    pub fn build_db_batch(
         &self,
         epoch_id: EpochId,
         tx_outputs: &[Arc<TransactionOutputs>],
-    ) -> IotaResult {
+    ) -> IotaResult<DBBatch> {
         let mut written = Vec::with_capacity(tx_outputs.len());
         for outputs in tx_outputs {
             written.extend(outputs.written.values().cloned());
@@ -800,9 +800,8 @@ impl AuthorityStore {
         // test crashing before writing the batch
         fail_point!("crash");
 
-        write_batch.write()?;
         trace!(
-            "committed transactions: {:?}",
+            "built batch for committed transactions: {:?}",
             tx_outputs
                 .iter()
                 .map(|tx| tx.transaction.digest())
@@ -812,7 +811,7 @@ impl AuthorityStore {
         // test crashing before notifying
         fail_point!("crash");
 
-        Ok(())
+        Ok(write_batch)
     }
 
     fn write_one_transaction_outputs(

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -428,9 +428,15 @@ impl<'a> TestAuthorityBuilder<'a> {
                 )
                 .unwrap();
 
-            state
+            let batch = state
                 .get_cache_commit()
-                .commit_transaction_outputs(epoch_store.epoch(), &[*genesis.transaction().digest()])
+                .build_db_batch(epoch_store.epoch(), &[*genesis.transaction().digest()]);
+
+            state.get_cache_commit().commit_transaction_outputs(
+                epoch_store.epoch(),
+                batch,
+                &[*genesis.transaction().digest()],
+            );
         }
 
         // We want to insert these objects directly instead of relying on genesis

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -296,8 +296,14 @@ impl CheckpointExecutor {
                 // Commit all transaction effects to disk
                 let cache_commit = self.state.get_cache_commit();
                 debug!(?seq, "committing checkpoint transactions to disk");
+                let batch = cache_commit.build_db_batch(
+                    self.epoch_store.epoch(),
+                    &ckpt_state.data.tx_digests,
+                );
+
                 cache_commit.commit_transaction_outputs(
                     self.epoch_store.epoch(),
+                    batch,
                     &ckpt_state.data.tx_digests,
                 );
 

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -25,6 +25,7 @@ use iota_types::{
 };
 use prometheus::Registry;
 use tracing::instrument;
+use typed_store::rocks::DBBatch;
 
 use crate::{
     authority::{
@@ -154,19 +155,30 @@ pub fn build_execution_cache_from_env(
     }
 }
 
+pub type Batch = (Vec<Arc<TransactionOutputs>>, DBBatch);
+
 pub trait ExecutionCacheCommit: Send + Sync {
+    /// Build a DBBatch containing the given transaction outputs.
+    fn build_db_batch(&self, epoch: EpochId, digests: &[TransactionDigest]) -> Batch;
+
     /// Durably commit the outputs of the given transactions to the database.
     /// Will be called by CheckpointExecutor to ensure that transaction outputs
     /// are written durably before marking a checkpoint as finalized.
     fn try_commit_transaction_outputs(
         &self,
         epoch: EpochId,
+        batch: Batch,
         digests: &[TransactionDigest],
     ) -> IotaResult;
 
     /// Non-fallible version of `try_commit_transaction_outputs`.
-    fn commit_transaction_outputs(&self, epoch: EpochId, digests: &[TransactionDigest]) {
-        self.try_commit_transaction_outputs(epoch, digests)
+    fn commit_transaction_outputs(
+        &self,
+        epoch: EpochId,
+        batch: Batch,
+        digests: &[TransactionDigest],
+    ) {
+        self.try_commit_transaction_outputs(epoch, batch, digests)
             .expect("storage access failed");
     }
 

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -27,7 +27,7 @@ use tracing::instrument;
 use typed_store::Map;
 
 use super::{
-    CheckpointCache, ExecutionCacheCommit, ExecutionCacheMetrics, ExecutionCacheReconfigAPI,
+    Batch, CheckpointCache, ExecutionCacheCommit, ExecutionCacheMetrics, ExecutionCacheReconfigAPI,
     ExecutionCacheWrite, ObjectCacheRead, StateSyncAPI, TestingAPI, TransactionCacheRead,
     implement_passthrough_traits,
 };
@@ -281,8 +281,8 @@ impl ExecutionCacheWrite for PassthroughCache {
         self.store
             .check_owned_objects_are_live(&tx_outputs.live_object_markers_to_delete)?;
 
-        self.store
-            .write_transaction_outputs(epoch_id, &[tx_outputs])?;
+        let batch = self.store.build_db_batch(epoch_id, &[tx_outputs])?;
+        batch.write()?;
 
         self.executed_effects_digests_notify_read
             .notify(&tx_digest, &effects_digest);
@@ -337,9 +337,16 @@ impl AccumulatorStore for PassthroughCache {
 }
 
 impl ExecutionCacheCommit for PassthroughCache {
+    fn build_db_batch(&self, _epoch: EpochId, _digests: &[TransactionDigest]) -> Batch {
+        // Nothing needs to be done since they were already committed in
+        // write_transaction_outputs
+        (vec![], self.store.perpetual_tables.transactions.batch())
+    }
+
     fn try_commit_transaction_outputs(
         &self,
         _epoch: EpochId,
+        _batch: Batch,
         _digests: &[TransactionDigest],
     ) -> IotaResult {
         // Nothing needs to be done since they were already committed in

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -22,7 +22,7 @@ use iota_types::{
 use tracing::instrument;
 
 use super::{
-    CheckpointCache, ExecutionCacheCommit, ExecutionCacheConfig, ExecutionCacheMetrics,
+    Batch, CheckpointCache, ExecutionCacheCommit, ExecutionCacheConfig, ExecutionCacheMetrics,
     ExecutionCacheReconfigAPI, ExecutionCacheType, ExecutionCacheWrite, ObjectCacheRead,
     PassthroughCache, StateSyncAPI, TestingAPI, TransactionCacheRead, WritebackCache,
 };
@@ -318,12 +318,17 @@ impl AccumulatorStore for ProxyCache {
 }
 
 impl ExecutionCacheCommit for ProxyCache {
+    fn build_db_batch(&self, epoch: EpochId, digests: &[TransactionDigest]) -> super::Batch {
+        delegate_method!(self.build_db_batch(epoch, digests))
+    }
+
     fn try_commit_transaction_outputs(
         &self,
         epoch: EpochId,
+        batch: Batch,
         digests: &[TransactionDigest],
     ) -> IotaResult {
-        delegate_method!(self.try_commit_transaction_outputs(epoch, digests))
+        delegate_method!(self.try_commit_transaction_outputs(epoch, batch, digests))
     }
 
     fn try_persist_transaction(&self, tx: &VerifiedExecutableTransaction) -> IotaResult {

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -359,7 +359,8 @@ impl Scenario {
 
     // commit a transaction to the database
     pub async fn commit(&mut self, tx: TransactionDigest) {
-        self.cache().commit_transaction_outputs(1, &[tx]);
+        let batch = self.cache().build_db_batch(1, &[tx]);
+        self.cache().commit_transaction_outputs(1, batch, &[tx]);
         self.count_action();
     }
 
@@ -555,7 +556,8 @@ async fn test_committed() {
 
         s.assert_live(&[1, 2]);
         s.assert_dirty(&[1, 2]);
-        s.cache().commit_transaction_outputs(1, &[tx]);
+        let batch = s.cache().build_db_batch(1, &[tx]);
+        s.cache().commit_transaction_outputs(1, batch, &[tx]);
         s.assert_not_dirty(&[1, 2]);
         s.assert_cached(&[1, 2]);
 

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -941,8 +941,6 @@ impl WritebackCache {
         Ok(())
     }
 
-    // Commits dirty data for the given TransactionDigest to the db.
-    #[instrument(level = "debug", skip_all)]
     fn build_db_batch(&self, epoch: EpochId, digests: &[TransactionDigest]) -> Batch {
         let _metrics_guard = iota_metrics::monitored_scope("WritebackCache::build_db_batch");
         let mut all_outputs = Vec::with_capacity(digests.len());

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -79,7 +79,7 @@ use tap::TapOptional;
 use tracing::{debug, info, instrument, trace, warn};
 
 use super::{
-    CheckpointCache, ExecutionCacheAPI, ExecutionCacheCommit, ExecutionCacheMetrics,
+    Batch, CheckpointCache, ExecutionCacheAPI, ExecutionCacheCommit, ExecutionCacheMetrics,
     ExecutionCacheReconfigAPI, ExecutionCacheWrite, ObjectCacheRead, StateSyncAPI, TestingAPI,
     TransactionCacheRead,
     cache_types::{CacheResult, CachedVersionMap, IsNewer, MonotonicCache, Ticket},
@@ -943,14 +943,8 @@ impl WritebackCache {
 
     // Commits dirty data for the given TransactionDigest to the db.
     #[instrument(level = "debug", skip_all)]
-    fn commit_transaction_outputs(
-        &self,
-        epoch: EpochId,
-        digests: &[TransactionDigest],
-    ) -> IotaResult {
-        fail_point!("writeback-cache-commit");
-        trace!(?digests);
-
+    fn build_db_batch(&self, epoch: EpochId, digests: &[TransactionDigest]) -> Batch {
+        let _metrics_guard = iota_metrics::monitored_scope("WritebackCache::build_db_batch");
         let mut all_outputs = Vec::with_capacity(digests.len());
         for tx in digests {
             let Some(outputs) = self
@@ -972,11 +966,33 @@ impl WritebackCache {
             all_outputs.push(outputs);
         }
 
+        let batch = self
+            .store
+            .build_db_batch(epoch, &all_outputs)
+            .expect("db error");
+        (all_outputs, batch)
+    }
+
+    // Commits dirty data for the given TransactionDigest to the db.
+    #[instrument(level = "debug", skip_all)]
+    fn commit_transaction_outputs(
+        &self,
+        epoch: EpochId,
+        (all_outputs, db_batch): Batch,
+        digests: &[TransactionDigest],
+    ) -> IotaResult {
+        let _metrics_guard =
+            iota_metrics::monitored_scope("WritebackCache::commit_transaction_outputs");
+        fail_point!("writeback-cache-commit");
+        trace!(?digests);
+
         // Flush writes to disk before removing anything from dirty set. otherwise,
         // a cache eviction could cause a value to disappear briefly, even if we insert
         // to the cache before removing from the dirty set.
-        self.store.write_transaction_outputs(epoch, &all_outputs)?;
+        db_batch.write().expect("db error");
 
+        let _metrics_guard =
+            iota_metrics::monitored_scope("WritebackCache::commit_transaction_outputs::flush");
         for outputs in all_outputs.iter() {
             let tx_digest = outputs.transaction.digest();
             assert!(
@@ -1290,12 +1306,17 @@ impl WritebackCache {
 impl ExecutionCacheAPI for WritebackCache {}
 
 impl ExecutionCacheCommit for WritebackCache {
+    fn build_db_batch(&self, epoch: EpochId, digests: &[TransactionDigest]) -> Batch {
+        self.build_db_batch(epoch, digests)
+    }
+
     fn try_commit_transaction_outputs(
         &self,
         epoch: EpochId,
+        batch: Batch,
         digests: &[TransactionDigest],
     ) -> IotaResult {
-        WritebackCache::commit_transaction_outputs(self, epoch, digests)
+        WritebackCache::commit_transaction_outputs(self, epoch, batch, digests)
     }
 
     fn try_persist_transaction(&self, tx: &VerifiedExecutableTransaction) -> IotaResult {

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -3450,6 +3450,15 @@ async fn test_store_revert_transfer_iota() {
     assert!(!tx_cache.is_tx_already_executed(&tx_digest));
 }
 
+fn build_and_commit(
+    cache_commit: &Arc<dyn ExecutionCacheCommit>,
+    epoch: EpochId,
+    txs: &[TransactionDigest],
+) {
+    let batch = cache_commit.build_db_batch(epoch, txs);
+    cache_commit.commit_transaction_outputs(epoch, batch, txs);
+}
+
 #[tokio::test]
 async fn test_store_revert_wrap_move_call() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
@@ -3468,12 +3477,11 @@ async fn test_store_revert_wrap_move_call() {
     .await
     .unwrap();
 
-    authority_state
-        .get_cache_commit()
-        .commit_transaction_outputs(
-            authority_state.epoch_store_for_testing().epoch(),
-            &[*create_effects.transaction_digest()],
-        );
+    build_and_commit(
+        authority_state.get_cache_commit(),
+        authority_state.epoch_store_for_testing().epoch(),
+        &[*create_effects.transaction_digest()],
+    );
 
     assert!(create_effects.status().is_ok());
     assert_eq!(create_effects.created().len(), 1);
@@ -3563,15 +3571,14 @@ async fn test_store_revert_unwrap_move_call() {
     .await
     .unwrap();
 
-    authority_state
-        .get_cache_commit()
-        .commit_transaction_outputs(
-            authority_state.epoch_store_for_testing().epoch(),
-            &[
-                *create_effects.transaction_digest(),
-                *wrap_effects.transaction_digest(),
-            ],
-        );
+    build_and_commit(
+        authority_state.get_cache_commit(),
+        authority_state.epoch_store_for_testing().epoch(),
+        &[
+            *create_effects.transaction_digest(),
+            *wrap_effects.transaction_digest(),
+        ],
+    );
 
     assert!(wrap_effects.status().is_ok());
     assert_eq!(wrap_effects.created().len(), 1);
@@ -3835,15 +3842,14 @@ async fn test_store_revert_add_ofield() {
     let outer_v0 = create_outer_effects.created()[0].0;
     let inner_v0 = create_inner_effects.created()[0].0;
 
-    authority_state
-        .get_cache_commit()
-        .commit_transaction_outputs(
-            authority_state.epoch_store_for_testing().epoch(),
-            &[
-                *create_outer_effects.transaction_digest(),
-                *create_inner_effects.transaction_digest(),
-            ],
-        );
+    build_and_commit(
+        authority_state.get_cache_commit(),
+        authority_state.epoch_store_for_testing().epoch(),
+        &[
+            *create_outer_effects.transaction_digest(),
+            *create_inner_effects.transaction_digest(),
+        ],
+    );
 
     let add_txn = to_sender_signed_transaction(
         TransactionData::new_move_call(
@@ -3960,16 +3966,15 @@ async fn test_store_revert_remove_ofield() {
     assert!(add_effects.status().is_ok());
     assert_eq!(add_effects.created().len(), 1);
 
-    authority_state
-        .get_cache_commit()
-        .commit_transaction_outputs(
-            authority_state.epoch_store_for_testing().epoch(),
-            &[
-                *create_outer_effects.transaction_digest(),
-                *create_inner_effects.transaction_digest(),
-                *add_effects.transaction_digest(),
-            ],
-        );
+    build_and_commit(
+        authority_state.get_cache_commit(),
+        authority_state.epoch_store_for_testing().epoch(),
+        &[
+            *create_outer_effects.transaction_digest(),
+            *create_inner_effects.transaction_digest(),
+            *add_effects.transaction_digest(),
+        ],
+    );
 
     let field_v0 = add_effects.created()[0].0;
     let outer_v1 = find_by_id(&add_effects.mutated(), outer_v0.0).unwrap();

--- a/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
@@ -365,8 +365,14 @@ async fn test_package_denied() {
     .await
     .unwrap();
 
+    let batch = state.get_cache_commit().build_db_batch(
+        state.epoch_store_for_testing().epoch(),
+        &[tx_c, tx_b, tx_a, tx_c_prime, tx_b_prime],
+    );
+
     state.get_cache_commit().commit_transaction_outputs(
         state.epoch_store_for_testing().epoch(),
+        batch,
         &[tx_c, tx_b, tx_a, tx_c_prime, tx_b_prime],
     );
 

--- a/crates/iota-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/iota-single-node-benchmark/src/benchmark_context.rs
@@ -116,14 +116,17 @@ impl BenchmarkContext {
             .execute_raw_transactions(root_object_create_transactions)
             .await;
         let mut new_gas_objects = HashMap::new();
+        let cache_commit = self.validator().get_validator().get_cache_commit().clone();
         for effects in results {
-            self.validator()
-                .get_validator()
-                .get_cache_commit()
-                .commit_transaction_outputs(
-                    effects.executed_epoch(),
-                    &[*effects.transaction_digest()],
-                );
+            let batch = cache_commit
+                .build_db_batch(effects.executed_epoch(), &[*effects.transaction_digest()]);
+
+            cache_commit.commit_transaction_outputs(
+                effects.executed_epoch(),
+                batch,
+                &[*effects.transaction_digest()],
+            );
+
             let (owner, root_object) = effects
                 .created()
                 .into_iter()
@@ -168,7 +171,6 @@ impl BenchmarkContext {
             .execute_raw_transactions(shared_object_create_transactions)
             .await;
         let mut new_gas_objects = HashMap::new();
-        let epoch_id = self.validator.get_epoch_store().epoch();
         let cache_commit = self.validator.get_validator().get_cache_commit();
         for effects in results {
             let shared_object = effects
@@ -192,7 +194,13 @@ impl BenchmarkContext {
             // object store, hence requiring these objects committed to DB.
             // For checkpoint executor, in order to commit a checkpoint it is required
             // previous versions of objects are already committed.
-            cache_commit.commit_transaction_outputs(epoch_id, &[*effects.transaction_digest()]);
+            let batch = cache_commit
+                .build_db_batch(effects.executed_epoch(), &[*effects.transaction_digest()]);
+            cache_commit.commit_transaction_outputs(
+                effects.executed_epoch(),
+                batch,
+                &[*effects.transaction_digest()],
+            );
         }
         self.refresh_gas_objects(new_gas_objects);
         info!("Finished preparing shared objects");


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.45.3, v1.46.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/84e622208e3e91ef7112d798547a388c43304ba8
- Description:

This facility will be used in a forth-coming PR to optimize checkpoint
execution performance.

## Links to any relevant issues

Part of #9768

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

