### PR TITLE
feat(consensus): save voting blocks

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -218,6 +218,7 @@ impl ConsensusAuthority {
             network_client.clone(),
             block_verifier.clone(),
             dag_state.clone(),
+            store.clone(),
         )
         .start();
 
@@ -229,6 +230,7 @@ impl ConsensusAuthority {
             network_client.clone(),
             block_verifier.clone(),
             dag_state.clone(),
+            store.clone(),
         )
         .start();
 
@@ -1450,5 +1452,361 @@ mod tests {
             mismatches.len(),
             mismatches.join("\n")
         );
+    }
+
+    /// Test that voting blocks stored during fast sync can be served to peers.
+    /// This test verifies:
+    /// 1. Validator A fast syncs and stores voting block headers
+    /// 2. Validator B fast syncs and can receive commits/voting blocks from A
+    /// 3. Both validators agree on commit history
+    ///
+    /// Test flow to ensure B requests commits A has in voting storage:
+    /// - Phase 1: All run → commits 1-N1 (all validators have these)
+    /// - Phase 2: Stop B first (B stops at N1)
+    /// - Phase 3: A + the other 5 validators continue → commits N1-N2 (B
+    ///   doesn't have these)
+    /// - Phase 4: Stop A (A stops at N2)
+    /// - Phase 5: The remaining 5 validators continue → commits N2-N3 (neither
+    ///   A nor B have these)
+    /// - Phase 6: Restart A, fast syncs N2-N3 → stores voting headers
+    /// - Phase 7: Restart B, needs N1-N3 → should get N2-N3 from A's voting
+    ///   storage
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_fast_sync_voting_blocks_served_to_peer() {
+        telemetry_subscribers::init_for_testing();
+        let db_registry = Registry::new();
+        DBMetrics::init(&db_registry);
+
+        // Use 7 validators so that quorum (5) can still be reached with 2 validators
+        // stopped.
+        const NUM_AUTHORITIES: usize = 7;
+        const COMMIT_GAP_THRESHOLD: u32 = 30;
+
+        // Work phases need to be long enough to create a gap larger than
+        // COMMIT_GAP_THRESHOLD (30) for fast sync to trigger.
+        let stable_work_duration = Duration::from_secs(10);
+
+        let (committee, keypairs) = local_committee_and_keys(0, vec![1; NUM_AUTHORITIES]);
+        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+        protocol_config.set_consensus_transaction_ref_for_testing(true);
+
+        let temp_dirs: Vec<TempDir> = (0..NUM_AUTHORITIES)
+            .map(|_| TempDir::new().unwrap())
+            .collect();
+
+        let mut authorities = Vec::with_capacity(NUM_AUTHORITIES);
+        let mut boot_counters = [0u64; NUM_AUTHORITIES];
+        let mut consumer_monitors = Vec::with_capacity(NUM_AUTHORITIES);
+        let mut output_receivers = Vec::with_capacity(NUM_AUTHORITIES);
+
+        let validator_a_index: usize = 0;
+        let validator_b_index: usize = 1;
+
+        // Start all authorities
+        for (index, _) in committee.authorities() {
+            let parameters = Parameters {
+                db_path: temp_dirs[index.value()].path().to_path_buf(),
+                dag_state_cached_rounds: 5,
+                commit_sync_parallel_fetches: 2,
+                commit_sync_batch_size: 10,
+                commit_sync_gap_threshold: COMMIT_GAP_THRESHOLD,
+                fast_commit_sync_batch_size: 20,
+                sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+                ..Default::default()
+            };
+            let (authority, receiver, monitor) = make_authority_with_params(
+                index,
+                &temp_dirs[index.value()],
+                committee.clone(),
+                keypairs.clone(),
+                boot_counters[index],
+                protocol_config.clone(),
+                parameters,
+                0,
+            )
+            .await;
+            boot_counters[index] += 1;
+            authorities.push(authority);
+            output_receivers.push(receiver);
+            consumer_monitors.push(monitor);
+        }
+
+        // Phase 1: Let all authorities run and commit transactions
+        let start_time = Instant::now();
+        let mut committed_index = [0u32; NUM_AUTHORITIES];
+        while start_time.elapsed() < stable_work_duration {
+            for (index, receiver) in output_receivers.iter_mut().enumerate() {
+                while let Ok(committed_subdag) = receiver.try_recv() {
+                    let commit_index = committed_subdag.commit_ref.index;
+                    assert!(
+                        commit_index > committed_index[index],
+                        "Commit index {} should be greater than previous {}",
+                        commit_index,
+                        committed_index[index]
+                    );
+                    committed_index[index] = commit_index;
+                    consumer_monitors[index].set_highest_handled_commit(commit_index);
+                }
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+
+        // Phase 2: Stop validator B first (so B misses commits created while it's down)
+        let last_processed_b = consumer_monitors[validator_b_index].highest_handled_commit();
+        authorities.remove(validator_b_index).stop().await;
+
+        // Phase 3: Let A and others continue committing (B misses these)
+        let start_time = Instant::now();
+        while start_time.elapsed() < stable_work_duration {
+            for (index, receiver) in output_receivers.iter_mut().enumerate() {
+                if index == validator_b_index {
+                    continue;
+                }
+                while let Ok(committed_subdag) = receiver.try_recv() {
+                    let commit_index = committed_subdag.commit_ref.index;
+                    assert!(
+                        commit_index > committed_index[index],
+                        "Commit index {} should be greater than previous {}",
+                        commit_index,
+                        committed_index[index]
+                    );
+                    committed_index[index] = commit_index;
+                    consumer_monitors[index].set_highest_handled_commit(commit_index);
+                }
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+
+        // Phase 4: Stop validator A
+        let last_processed_a = consumer_monitors[validator_a_index].highest_handled_commit();
+        authorities.remove(validator_a_index).stop().await;
+
+        // Phase 5: Let the remaining validators (all except A and B) continue
+        // committing (both A and B miss these commits)
+        let start_time = Instant::now();
+        while start_time.elapsed() < stable_work_duration {
+            for (index, receiver) in output_receivers.iter_mut().enumerate() {
+                if index == validator_a_index || index == validator_b_index {
+                    continue;
+                }
+                while let Ok(committed_subdag) = receiver.try_recv() {
+                    let commit_index = committed_subdag.commit_ref.index;
+                    assert!(
+                        commit_index > committed_index[index],
+                        "Commit index {} should be greater than previous {}",
+                        commit_index,
+                        committed_index[index]
+                    );
+                    committed_index[index] = commit_index;
+                    consumer_monitors[index].set_highest_handled_commit(commit_index);
+                }
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+
+        // Phase 6: Restart validator A - it will fast sync and store voting blocks
+        let parameters = Parameters {
+            db_path: temp_dirs[validator_a_index].path().to_path_buf(),
+            dag_state_cached_rounds: 5,
+            commit_sync_parallel_fetches: 2,
+            commit_sync_batch_size: 10,
+            commit_sync_gap_threshold: COMMIT_GAP_THRESHOLD,
+            fast_commit_sync_batch_size: 20,
+            sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            ..Default::default()
+        };
+        let (authority, receiver, monitor) = make_authority_with_params(
+            committee.to_authority_index(validator_a_index).unwrap(),
+            &temp_dirs[validator_a_index],
+            committee.clone(),
+            keypairs.clone(),
+            boot_counters[validator_a_index],
+            protocol_config.clone(),
+            parameters,
+            last_processed_a,
+        )
+        .await;
+        boot_counters[validator_a_index] += 1;
+        output_receivers[validator_a_index] = receiver;
+        consumer_monitors[validator_a_index] = monitor;
+        authorities.insert(validator_a_index, authority);
+
+        // Wait for validator A to catch up via fast sync
+        let start_time = Instant::now();
+        let mut a_caught_up = false;
+        while start_time.elapsed() < Duration::from_secs(60) {
+            for (index, receiver) in output_receivers.iter_mut().enumerate() {
+                if index == validator_b_index {
+                    continue;
+                }
+                while let Ok(committed_subdag) = receiver.try_recv() {
+                    let commit_index = committed_subdag.commit_ref.index;
+                    assert!(
+                        commit_index > committed_index[index],
+                        "Commit index {} should be greater than previous {}",
+                        commit_index,
+                        committed_index[index]
+                    );
+                    committed_index[index] = commit_index;
+                    consumer_monitors[index].set_highest_handled_commit(commit_index);
+                }
+            }
+
+            let a_index = consumer_monitors[validator_a_index].highest_handled_commit();
+            let max_other = consumer_monitors
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| *i != validator_a_index && *i != validator_b_index)
+                .map(|(_, m)| m.highest_handled_commit())
+                .max()
+                .unwrap_or(0);
+
+            if a_index > 0 && a_index + 20 >= max_other {
+                a_caught_up = true;
+                break;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+
+        assert!(
+            a_caught_up,
+            "Validator A should have caught up via fast sync"
+        );
+
+        // Phase 7: Restart validator B - it needs commits that A fast-synced
+        // B should be able to get voting block headers from A's voting storage
+        let parameters = Parameters {
+            db_path: temp_dirs[validator_b_index].path().to_path_buf(),
+            dag_state_cached_rounds: 5,
+            commit_sync_parallel_fetches: 2,
+            commit_sync_batch_size: 10,
+            commit_sync_gap_threshold: COMMIT_GAP_THRESHOLD,
+            fast_commit_sync_batch_size: 20,
+            sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            ..Default::default()
+        };
+        let (authority, receiver, monitor) = make_authority_with_params(
+            committee.to_authority_index(validator_b_index).unwrap(),
+            &temp_dirs[validator_b_index],
+            committee.clone(),
+            keypairs.clone(),
+            boot_counters[validator_b_index],
+            protocol_config.clone(),
+            parameters,
+            last_processed_b,
+        )
+        .await;
+        output_receivers[validator_b_index] = receiver;
+        consumer_monitors[validator_b_index] = monitor;
+
+        authorities.insert(validator_b_index, authority);
+
+        // Wait for validator B to catch up
+        let start_time = Instant::now();
+        let mut b_caught_up = false;
+        while start_time.elapsed() < Duration::from_secs(60) {
+            for (index, receiver) in output_receivers.iter_mut().enumerate() {
+                while let Ok(committed_subdag) = receiver.try_recv() {
+                    let commit_index = committed_subdag.commit_ref.index;
+                    assert!(
+                        commit_index > committed_index[index],
+                        "Commit index {} should be greater than previous {}",
+                        commit_index,
+                        committed_index[index]
+                    );
+                    committed_index[index] = commit_index;
+                    consumer_monitors[index].set_highest_handled_commit(commit_index);
+                }
+            }
+
+            let b_index = consumer_monitors[validator_b_index].highest_handled_commit();
+            let max_other = consumer_monitors
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| *i != validator_b_index)
+                .map(|(_, m)| m.highest_handled_commit())
+                .max()
+                .unwrap_or(0);
+
+            if b_index > 0 && b_index + 20 >= max_other {
+                b_caught_up = true;
+                break;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+
+        assert!(
+            b_caught_up,
+            "Validator B should have caught up via fast sync"
+        );
+
+        // Verify both validators A and B have similar commit indices
+        let a_final = consumer_monitors[validator_a_index].highest_handled_commit();
+        let b_final = consumer_monitors[validator_b_index].highest_handled_commit();
+
+        assert!(
+            a_final > last_processed_a,
+            "Validator A should have progressed: before_restart={}, final={}",
+            last_processed_a,
+            a_final
+        );
+        assert!(
+            b_final > last_processed_b,
+            "Validator B should have progressed: before_restart={}, final={}",
+            last_processed_b,
+            b_final
+        );
+
+        // Both should be within reasonable range of each other
+        let diff = (a_final as i64 - b_final as i64).unsigned_abs() as u32;
+        assert!(
+            diff < 30,
+            "Validators A and B should have similar commit indices: A={}, B={}, diff={}",
+            a_final,
+            b_final,
+            diff
+        );
+
+        // Collect voting block headers metrics to verify voting storage was used.
+        let total_hits: u64 = authorities
+            .iter()
+            .map(|a| {
+                a.context()
+                    .metrics
+                    .node_metrics
+                    .commit_sync_voting_block_headers_hits
+                    .get()
+            })
+            .sum();
+
+        let total_fallbacks: u64 = authorities
+            .iter()
+            .map(|a| {
+                a.context()
+                    .metrics
+                    .node_metrics
+                    .commit_sync_voting_block_headers_fallbacks
+                    .get()
+            })
+            .sum();
+
+        info!(
+            "Voting block headers metrics: hits={}, fallbacks={}",
+            total_hits, total_fallbacks
+        );
+
+        // In tests, peer selection is deterministic (not shuffled), so B will
+        // request from A first. A has voting storage for commits it fast-synced,
+        // so we should get voting hits.
+        assert!(
+            total_hits > 0,
+            "Expected voting block headers hits > 0, got {}",
+            total_hits
+        );
+
+        // Stop all authorities
+        for authority in authorities {
+            authority.stop().await;
+        }
     }
 }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -892,8 +892,43 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .store
             .scan_commits((commit_range.start()..=inclusive_end).into())?;
         let mut certifier_block_refs = vec![];
-        'commit: while let Some(c) = commits.last() {
+        // Find the highest commit index with votes, skipping any gaps in indexes
+        // without votes.
+        let mut search_up_to = inclusive_end;
+        'commit: loop {
+            // Find the highest index with at least some votes, up to our search bound.
+            let Some(index_with_votes) = self
+                .store
+                .read_highest_commit_index_with_votes(search_up_to)?
+            else {
+                // No votes found for any index in the range, return empty commits.
+                commits.clear();
+                break 'commit;
+            };
+
+            // If the index with votes is below our commit range start, there are no
+            // certifiable commits.
+            if index_with_votes < commit_range.start() {
+                commits.clear();
+                break 'commit;
+            }
+
+            // Truncate commits to only include those up to index_with_votes.
+            while commits.last().is_some_and(|c| c.index() > index_with_votes) {
+                commits.pop();
+            }
+
+            let Some(c) = commits.last() else {
+                break 'commit;
+            };
+
             let index = c.index();
+            if index != index_with_votes {
+                warn!(
+                    "Commit index {} does not match index with votes {}, expected them to be equal",
+                    index, index_with_votes
+                );
+            }
             let votes = self.store.read_commit_votes(index)?;
             let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
             for v in &votes {
@@ -916,14 +951,61 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                     .with_label_values(&[commit_sync_type.as_str()])
                     .inc();
                 commits.pop();
+                // Continue searching from index - 1
+                search_up_to = index.saturating_sub(1);
+                if search_up_to < commit_range.start() {
+                    commits.clear();
+                    break 'commit;
+                }
             }
         }
-        let certifier_block_headers = self
+        // Try reading from voting block headers storage first, then fallback to regular
+        // block headers for any that weren't found.
+        let voting_headers = self
             .store
-            .read_verified_block_headers(&certifier_block_refs)?
-            .into_iter()
-            .flatten()
+            .read_voting_block_headers(&certifier_block_refs)?;
+
+        // Collect refs that weren't found in voting storage
+        let missing_refs: Vec<BlockRef> = certifier_block_refs
+            .iter()
+            .zip(voting_headers.iter())
+            .filter_map(|(r, h)| if h.is_none() { Some(*r) } else { None })
             .collect();
+
+        // Track metrics for voting storage hits vs fallbacks
+        let voting_hits = voting_headers.iter().filter(|h| h.is_some()).count();
+        self.context
+            .metrics
+            .node_metrics
+            .commit_sync_voting_block_headers_hits
+            .inc_by(voting_hits as u64);
+
+        // Read missing headers from regular block storage
+        let fallback_headers = if !missing_refs.is_empty() {
+            self.context
+                .metrics
+                .node_metrics
+                .commit_sync_voting_block_headers_fallbacks
+                .inc_by(missing_refs.len() as u64);
+            self.store.read_verified_block_headers(&missing_refs)?
+        } else {
+            vec![]
+        };
+
+        // Merge results: use voting headers where available, fallback headers otherwise
+        let mut fallback_iter = fallback_headers.into_iter();
+        let certifier_block_headers: Vec<VerifiedBlockHeader> = voting_headers
+            .into_iter()
+            .zip(certifier_block_refs.iter())
+            .map(|(h, block_ref)| {
+                h.or_else(|| fallback_iter.next().flatten()).ok_or(
+                    ConsensusError::MissingVoringBlockHeaderInStorage {
+                        block_ref: *block_ref,
+                    },
+                )
+            })
+            .collect::<ConsensusResult<Vec<_>>>()?;
+
         Ok((commits, certifier_block_headers))
     }
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -10,6 +10,7 @@ use std::{
 
 use iota_metrics::spawn_logged_monitored_task;
 use parking_lot::RwLock;
+#[cfg(not(test))]
 use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
 use starfish_config::AuthorityIndex;
 use tokio::{runtime::Handle, sync::oneshot, task::JoinSet, time::MissedTickBehavior};
@@ -32,6 +33,7 @@ use crate::{
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     network::{NetworkClient, SerializedTransactionsV2},
+    storage::Store,
     transaction_ref::{GenericTransactionRef, TransactionRef},
 };
 
@@ -79,6 +81,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         network_client: Arc<C>,
         block_verifier: Arc<dyn BlockVerifier>,
         dag_state: Arc<RwLock<DagState>>,
+        store: Arc<dyn Store>,
     ) -> Self {
         let inner = Arc::new(Inner {
             context,
@@ -88,6 +91,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             network_client,
             block_verifier,
             dag_state,
+            store,
             sync_type: CommitSyncType::Fast,
         });
         let synced_commit_index = inner.dag_state.read().last_commit_index();
@@ -490,7 +494,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // 2. Verify the response contains block headers that can certify the last
         //    returned commit, and the returned commits are chained by digest,
         // so earlier commits are certified as well.
-        let commits = Handle::current()
+        let (commits, voting_block_headers) = Handle::current()
             .spawn_blocking({
                 let inner = inner.clone();
                 move || {
@@ -504,6 +508,15 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             })
             .await
             .expect("Spawn blocking should not fail")?;
+
+        // Store the voting block headers for later use when serving fetch_commits
+        // requests. The overhead is small since we store votes only for the last commit
+        // in a batch.
+        if !voting_block_headers.is_empty() {
+            inner
+                .store
+                .write_voting_block_headers(voting_block_headers)?;
+        }
 
         // 3. Collect all committed transaction block refs from commits
         let mut committed_tx_refs: BTreeSet<TransactionRef> = commits
@@ -653,6 +666,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         );
 
         // Shuffle target authorities for load balancing
+        #[allow(unused_mut)]
         let mut target_authorities: Vec<_> = inner
             .context
             .committee
@@ -665,6 +679,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 }
             })
             .collect();
+        #[cfg(not(test))]
         target_authorities.shuffle(&mut ThreadRng::default());
 
         // Fetch headers in chunks to avoid overwhelming the network

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -512,11 +512,9 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // Store the voting block headers for later use when serving fetch_commits
         // requests. The overhead is small since we store votes only for the last commit
         // in a batch.
-        if !voting_block_headers.is_empty() {
-            inner
-                .store
-                .write_voting_block_headers(voting_block_headers)?;
-        }
+        inner
+            .store
+            .write_voting_block_headers(voting_block_headers)?;
 
         // 3. Collect all committed transaction block refs from commits
         let mut committed_tx_refs: BTreeSet<TransactionRef> = commits
@@ -666,7 +664,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         );
 
         // Shuffle target authorities for load balancing
-        #[allow(unused_mut)]
+        #[cfg_attr(test, expect(unused_mut))]
         let mut target_authorities: Vec<_> = inner
             .context
             .committee

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -450,7 +450,6 @@ where
     loop {
         // Attempt to fetch commits and blocks through min(committee size,
         // MAX_NUM_TARGETS) peers.
-        #[allow(unused_mut)]
         let mut target_authorities = inner
             .context
             .committee

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -41,6 +41,7 @@ use std::{
 use bytes::Bytes;
 use itertools::Itertools;
 use parking_lot::RwLock;
+#[cfg(not(test))]
 use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
 use starfish_config::AuthorityIndex;
 use tokio::{sync::oneshot, task::JoinHandle, time::sleep};
@@ -161,6 +162,7 @@ pub(crate) struct Inner<C: NetworkClient> {
     pub(crate) network_client: Arc<C>,
     pub(crate) block_verifier: Arc<dyn BlockVerifier>,
     pub(crate) dag_state: Arc<RwLock<DagState>>,
+    pub(crate) store: Arc<dyn crate::storage::Store>,
     pub(crate) sync_type: CommitSyncType,
 }
 
@@ -176,14 +178,14 @@ impl<C: NetworkClient> Inner<C> {
 
     /// Verifies the commits and also certifies them using the provided vote
     /// blocks for the last commit. The method returns the trusted commits
-    /// and the votes as verified blocks.
+    /// and the verified voting block headers.
     pub(crate) fn verify_commits(
         &self,
         peer: AuthorityIndex,
         commit_range: CommitRange,
         serialized_commits: Vec<Bytes>,
         serialized_vote_blocks_headers: Vec<Bytes>,
-    ) -> ConsensusResult<Vec<TrustedCommit>> {
+    ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<VerifiedBlockHeader>)> {
         // Parse and verify commits.
         let mut commits = Vec::new();
         for serialized in &serialized_commits {
@@ -226,7 +228,8 @@ impl<C: NetworkClient> Inner<C> {
         // Parse and verify blocks. Then accumulate votes on the end commit.
         let end_commit_ref = CommitRef::new(end_commit.index(), *end_commit_digest);
         let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
-        for serialized_block_header in serialized_vote_blocks_headers.into_iter() {
+        let mut verified_voting_headers = Vec::new();
+        for serialized_block_header in serialized_vote_blocks_headers {
             let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_block_header)
                 .map_err(ConsensusError::MalformedHeader)?;
             // The block signature needs to be verified.
@@ -236,6 +239,11 @@ impl<C: NetworkClient> Inner<C> {
                     stake_aggregator.add(signed_block_header.author(), &self.context.committee);
                 }
             }
+            // Store the verified voting block header
+            verified_voting_headers.push(VerifiedBlockHeader::new_verified(
+                signed_block_header,
+                serialized_block_header,
+            ));
         }
 
         // Check if the end commit has enough votes.
@@ -252,7 +260,7 @@ impl<C: NetworkClient> Inner<C> {
             .zip(serialized_commits)
             .map(|((_d, c), s)| TrustedCommit::new_trusted(c, s))
             .collect();
-        Ok(trusted_commits)
+        Ok((trusted_commits, verified_voting_headers))
     }
 }
 
@@ -416,7 +424,10 @@ where
     Fut: std::future::Future<Output = ConsensusResult<T>> + Send,
 {
     // Individual request base timeout.
+    #[cfg(not(test))]
     const TIMEOUT: Duration = Duration::from_secs(10);
+    #[cfg(test)]
+    const TIMEOUT: Duration = Duration::from_millis(500);
     // Max per-request timeout will be base timeout times a multiplier.
     // At the extreme, this means there will be 120s timeout to fetch
     // max_blocks_per_fetch blocks.
@@ -439,6 +450,7 @@ where
     loop {
         // Attempt to fetch commits and blocks through min(committee size,
         // MAX_NUM_TARGETS) peers.
+        #[allow(unused_mut)]
         let mut target_authorities = inner
             .context
             .committee
@@ -451,6 +463,7 @@ where
                 }
             })
             .collect_vec();
+        #[cfg(not(test))]
         target_authorities.shuffle(&mut ThreadRng::default());
         target_authorities.truncate(MAX_NUM_TARGETS);
         // Increase timeout multiplier for each loop until MAX_TIMEOUT_MULTIPLIER.

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -39,6 +39,7 @@ use crate::{
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     network::{NetworkClient, SerializedTransactionsV1, SerializedTransactionsV2},
+    storage::Store,
     transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _},
 };
 
@@ -76,6 +77,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
         network_client: Arc<C>,
         block_verifier: Arc<dyn BlockVerifier>,
         dag_state: Arc<RwLock<DagState>>,
+        store: Arc<dyn Store>,
     ) -> Self {
         let inner = Arc::new(Inner {
             context,
@@ -85,6 +87,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
             network_client,
             block_verifier,
             dag_state,
+            store,
             sync_type: CommitSyncType::Regular,
         });
         let synced_commit_index = inner.dag_state.read().last_commit_index();
@@ -504,7 +507,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
         //    returned commit,
         // and the returned commits are chained by digest, so earlier commits are
         // certified as well.
-        let commits = Handle::current()
+        let (commits, _) = Handle::current()
             .spawn_blocking({
                 let inner = inner.clone();
                 move || {
@@ -848,7 +851,7 @@ mod tests {
         dag_state::DagState,
         error::ConsensusResult,
         network::{BlockBundleStream, NetworkClient},
-        storage::mem_store::MemStore,
+        storage::{Store, mem_store::MemStore},
         transaction_ref::GenericTransactionRef,
     };
 
@@ -934,8 +937,8 @@ mod tests {
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_thread_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(FakeNetworkClient::default());
-        let store = Arc::new(MemStore::new(context.clone()));
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let store: Arc<dyn Store> = Arc::new(MemStore::new(context.clone()));
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let commit_consumer_monitor = Arc::new(CommitConsumerMonitor::new(0));
 
@@ -947,6 +950,7 @@ mod tests {
             network_client,
             block_verifier,
             dag_state,
+            store,
         );
 
         // Check initial state.

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -277,6 +277,9 @@ pub(crate) enum ConsensusError {
 
     #[error("Failed to fetch {num_requested} block headers from any peer")]
     FailedToFetchBlockHeaders { num_requested: usize },
+
+    #[error("Voting block header {block_ref:?} for commit certification was not found in storage")]
+    MissingVoringBlockHeaderInStorage { block_ref: BlockRef },
 }
 
 impl ConsensusError {

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -228,6 +228,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_fetch_once_errors: IntCounterVec,
     pub(crate) commit_sync_fetch_missing_block_headers: IntCounterVec,
     pub(crate) commit_sync_fetch_missing_transactions: IntCounterVec,
+    pub(crate) commit_sync_voting_block_headers_hits: IntCounter,
+    pub(crate) commit_sync_voting_block_headers_fallbacks: IntCounter,
     pub(crate) uptime: Histogram,
 }
 
@@ -962,6 +964,16 @@ impl NodeMetrics {
                 "commit_sync_fetch_missing_transactions",
                 "Number of committed transactions that are missing when processing transactions via commit sync.",
                 &["authority", "source"],
+                registry
+            ).unwrap(),
+            commit_sync_voting_block_headers_hits: register_int_counter_with_registry!(
+                "commit_sync_voting_block_headers_hits",
+                "Number of voting block headers served from voting storage during commit sync.",
+                registry
+            ).unwrap(),
+            commit_sync_voting_block_headers_fallbacks: register_int_counter_with_registry!(
+                "commit_sync_voting_block_headers_fallbacks",
+                "Number of voting block headers served from regular storage (fallback) during commit sync.",
                 registry
             ).unwrap(),
             uptime: register_histogram_with_registry!(

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -49,6 +49,8 @@ struct Inner {
     commits: BTreeMap<(CommitIndex, CommitDigest), TrustedCommit>,
     commit_votes: BTreeSet<(CommitIndex, CommitDigest, BlockRef)>,
     commit_info: BTreeMap<(CommitIndex, CommitDigest), CommitInfo>,
+    /// Stores voting block headers separately from regular block headers.
+    voting_block_headers: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedBlockHeader>,
 }
 
 impl MemStore {
@@ -63,6 +65,7 @@ impl MemStore {
                 commits: BTreeMap::new(),
                 commit_votes: BTreeSet::new(),
                 commit_info: BTreeMap::new(),
+                voting_block_headers: BTreeMap::new(),
             }),
             context,
         }
@@ -435,6 +438,23 @@ impl Store for MemStore {
         Ok(votes)
     }
 
+    fn read_highest_commit_index_with_votes(
+        &self,
+        up_to_index: CommitIndex,
+    ) -> ConsensusResult<Option<CommitIndex>> {
+        let inner = self.inner.read();
+        // Do a reverse iteration to find the highest index with votes <= up_to_index
+        let result = inner
+            .commit_votes
+            .range((
+                Included((CommitIndex::MIN, CommitDigest::MIN, BlockRef::MIN)),
+                Included((up_to_index, CommitDigest::MAX, BlockRef::MAX)),
+            ))
+            .next_back()
+            .map(|(index, _, _)| *index);
+        Ok(result)
+    }
+
     fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>> {
         let inner = self.inner.read();
         Ok(inner
@@ -455,5 +475,38 @@ impl Store for MemStore {
             })
             .collect();
         Ok(exist)
+    }
+
+    fn write_voting_block_headers(&self, headers: Vec<VerifiedBlockHeader>) -> ConsensusResult<()> {
+        let mut inner = self.inner.write();
+        for header in headers {
+            let key = (header.round(), header.author(), header.digest());
+            let block_ref = header.reference();
+            // Store commit votes from this block header
+            for vote in header.commit_votes() {
+                inner
+                    .commit_votes
+                    .insert((vote.index, vote.digest, block_ref));
+            }
+            inner.voting_block_headers.insert(key, header);
+        }
+        Ok(())
+    }
+
+    fn read_voting_block_headers(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>> {
+        let inner = self.inner.read();
+        let headers = refs
+            .iter()
+            .map(|r| {
+                inner
+                    .voting_block_headers
+                    .get(&(r.round, r.author, r.digest))
+                    .cloned()
+            })
+            .collect();
+        Ok(headers)
     }
 }

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -147,8 +147,28 @@ pub(crate) trait Store: Send + Sync {
     /// Reads all blocks voting on a particular commit.
     fn read_commit_votes(&self, commit_index: CommitIndex) -> ConsensusResult<Vec<BlockRef>>;
 
+    /// Finds the highest commit index that has at least one vote, up to (and
+    /// including) the given index. Returns None if no votes exist for any
+    /// index <= up_to_index.
+    fn read_highest_commit_index_with_votes(
+        &self,
+        up_to_index: CommitIndex,
+    ) -> ConsensusResult<Option<CommitIndex>>;
+
     /// Reads the last commit info, written atomically with the last commit.
     fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>>;
+
+    /// Writes voting block headers to a separate storage. These are block
+    /// headers that contain commit votes used to certify commits during
+    /// synchronization.
+    fn write_voting_block_headers(&self, headers: Vec<VerifiedBlockHeader>) -> ConsensusResult<()>;
+
+    /// Reads voting block headers from the separate voting storage.
+    /// Returns None for headers that are not found.
+    fn read_voting_block_headers(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>>;
 }
 
 /// Represents data to be written to the store together atomically.

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -55,6 +55,10 @@ pub(crate) struct RocksDBStore {
     commit_votes: DBMap<(CommitIndex, CommitDigest, BlockRef), ()>,
     /// Stores info related to Commit that helps recovery.
     commit_info: DBMap<(CommitIndex, CommitDigest), CommitInfo>,
+    /// Stores voting block headers separately from regular block headers.
+    /// These are block headers that contain commit votes used to certify
+    /// commits.
+    voting_block_headers: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
     /// Context to access protocol configuration
     #[cfg_attr(not(test), allow(dead_code))]
     context: Arc<Context>,
@@ -70,6 +74,7 @@ impl RocksDBStore {
     const COMMITS_CF: &'static str = "commits";
     const COMMIT_VOTES_CF: &'static str = "commit_votes";
     const COMMIT_INFO_CF: &'static str = "commit_info";
+    const VOTING_BLOCK_HEADERS_CF: &'static str = "voting_block_headers";
 
     /// Creates a new instance of RocksDB storage.
     pub(crate) fn new(path: &str, context: Arc<Context>) -> Self {
@@ -112,6 +117,9 @@ impl RocksDBStore {
             (Self::COMMITS_CF, cf_options.clone()),
             (Self::COMMIT_VOTES_CF, cf_options.clone()),
             (Self::COMMIT_INFO_CF, cf_options.clone()),
+            // Voting block headers are much fewer than regular block headers,
+            // so using standard options is sufficient.
+            (Self::VOTING_BLOCK_HEADERS_CF, cf_options.clone()),
         ];
         let rocksdb = open_cf_opts(
             path,
@@ -130,6 +138,7 @@ impl RocksDBStore {
             commits,
             commit_votes,
             commit_info,
+            voting_block_headers,
         ) = reopen!(&rocksdb,
             Self::BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
             Self::TRANSACTIONS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
@@ -138,7 +147,8 @@ impl RocksDBStore {
             Self::TRANSACTION_COMMITMENTS_BY_AUTHORITIES_CF;<(AuthorityIndex, Round, TransactionsCommitment, BlockHeaderDigest), ()>,
             Self::COMMITS_CF;<(CommitIndex, CommitDigest), Bytes>,
             Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
-            Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>
+            Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>,
+            Self::VOTING_BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>
         );
 
         Self {
@@ -150,6 +160,7 @@ impl RocksDBStore {
             commits,
             commit_votes,
             commit_info,
+            voting_block_headers,
             context,
         }
     }
@@ -676,6 +687,27 @@ impl Store for RocksDBStore {
         Ok(votes)
     }
 
+    fn read_highest_commit_index_with_votes(
+        &self,
+        up_to_index: CommitIndex,
+    ) -> ConsensusResult<Option<CommitIndex>> {
+        // Do a reverse iteration from up_to_index to find the first entry with votes.
+        // The commit_votes table is keyed by (CommitIndex, CommitDigest, BlockRef).
+        let result = self
+            .commit_votes
+            .reversed_safe_iter_with_bounds(
+                Some((CommitIndex::MIN, CommitDigest::MIN, BlockRef::MIN)),
+                Some((up_to_index, CommitDigest::MAX, BlockRef::MAX)),
+            )?
+            .next();
+
+        match result {
+            Some(Ok(((index, _, _), _))) => Ok(Some(index)),
+            Some(Err(e)) => Err(ConsensusError::RocksDBFailure(e)),
+            None => Ok(None),
+        }
+    }
+
     fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>> {
         let Some(result) = self
             .commit_info
@@ -686,6 +718,48 @@ impl Store for RocksDBStore {
         };
         let (key, commit_info) = result.map_err(ConsensusError::RocksDBFailure)?;
         Ok(Some((CommitRef::new(key.0, key.1), commit_info)))
+    }
+
+    fn write_voting_block_headers(&self, headers: Vec<VerifiedBlockHeader>) -> ConsensusResult<()> {
+        if headers.is_empty() {
+            return Ok(());
+        }
+        let mut batch = self.voting_block_headers.batch();
+        for header in &headers {
+            let key = (header.round(), header.author(), header.digest());
+            batch
+                .insert_batch(
+                    &self.voting_block_headers,
+                    [(key, header.serialized().clone())],
+                )
+                .map_err(ConsensusError::RocksDBFailure)?;
+            // Store commit votes from this block header
+            let block_ref = header.reference();
+            for vote in header.commit_votes() {
+                batch
+                    .insert_batch(
+                        &self.commit_votes,
+                        [((vote.index, vote.digest, block_ref), ())],
+                    )
+                    .map_err(ConsensusError::RocksDBFailure)?;
+            }
+        }
+        batch.write().map_err(ConsensusError::RocksDBFailure)
+    }
+
+    fn read_voting_block_headers(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>> {
+        let keys: Vec<_> = refs.iter().map(|r| (r.round, r.author, r.digest)).collect();
+        let results = self
+            .voting_block_headers
+            .multi_get(keys)
+            .map_err(ConsensusError::RocksDBFailure)?;
+        results
+            .into_iter()
+            .map(|r| r.map(VerifiedBlockHeader::new_from_bytes).transpose())
+            .collect()
     }
 }
 

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -13,7 +13,7 @@ use crate::{
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, Slot, TestBlockHeader, VerifiedBlock,
     },
-    commit::{CommitDigest, TrustedCommit},
+    commit::{CommitDigest, CommitRef, TrustedCommit},
     context::Context,
     transaction_ref::GenericTransactionRef,
 };
@@ -38,6 +38,15 @@ impl TestStore {
             TestStore::RocksDB((_, _, enabled)) => *enabled,
             TestStore::Mem(_, enabled) => *enabled,
         }
+    }
+
+    /// Creates a context with the same configuration as the store.
+    fn context(&self) -> Arc<Context> {
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_transaction_ref_for_testing(self.transaction_ref_enabled());
+        Arc::new(context)
     }
 }
 
@@ -556,4 +565,183 @@ async fn read_and_scan_commits(
         assert_eq!(scanned_commits.len(), 4, "{scanned_commits:?}");
         assert_eq!(scanned_commits, written_commits,);
     }
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_voting_block_headers_storage(
+    #[values(new_rocksdb_teststore(true), new_mem_teststore(true))] test_store: TestStore,
+) {
+    let store = test_store.store();
+
+    // Create blocks with commit votes
+    let voting_blocks: Vec<VerifiedBlock> = vec![
+        VerifiedBlock::new_for_test(
+            TestBlockHeader::new(10, 0)
+                .set_commit_votes(vec![CommitRef::new(5, CommitDigest::MIN)])
+                .build(),
+        ),
+        VerifiedBlock::new_for_test(
+            TestBlockHeader::new(10, 1)
+                .set_commit_votes(vec![CommitRef::new(5, CommitDigest::MIN)])
+                .build(),
+        ),
+        VerifiedBlock::new_for_test(
+            TestBlockHeader::new(11, 0)
+                .set_commit_votes(vec![CommitRef::new(6, CommitDigest::MIN)])
+                .build(),
+        ),
+    ];
+
+    let voting_headers: Vec<_> = voting_blocks
+        .iter()
+        .map(|b| b.verified_block_header.clone())
+        .collect();
+
+    // Write to voting storage
+    store
+        .write_voting_block_headers(voting_headers.clone())
+        .expect("Write voting block headers should not fail");
+
+    // Read back
+    let refs: Vec<_> = voting_blocks.iter().map(|b| b.reference()).collect();
+    let read_headers = store
+        .read_voting_block_headers(&refs)
+        .expect("Read voting block headers should not fail");
+
+    assert_eq!(read_headers.len(), 3);
+    assert_eq!(read_headers[0].as_ref().unwrap(), &voting_headers[0]);
+    assert_eq!(read_headers[1].as_ref().unwrap(), &voting_headers[1]);
+    assert_eq!(read_headers[2].as_ref().unwrap(), &voting_headers[2]);
+
+    // Verify NOT in regular storage (isolation)
+    let regular_headers = store
+        .read_verified_block_headers(&refs)
+        .expect("Read verified block headers should not fail");
+    assert!(regular_headers[0].is_none());
+    assert!(regular_headers[1].is_none());
+    assert!(regular_headers[2].is_none());
+
+    // Test missing ref returns None
+    let missing_ref = BlockRef::new(
+        99,
+        AuthorityIndex::new_for_test(0),
+        BlockHeaderDigest::default(),
+    );
+    let missing = store
+        .read_voting_block_headers(&[missing_ref])
+        .expect("Read missing should not fail");
+    assert!(missing[0].is_none());
+
+    // Test reading subset with some missing
+    let mixed_refs = vec![refs[0], missing_ref, refs[2]];
+    let mixed_results = store
+        .read_voting_block_headers(&mixed_refs)
+        .expect("Read mixed should not fail");
+    assert_eq!(mixed_results.len(), 3);
+    assert!(mixed_results[0].is_some());
+    assert!(mixed_results[1].is_none());
+    assert!(mixed_results[2].is_some());
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_read_highest_commit_index_with_votes(
+    #[values(new_rocksdb_teststore(true), new_mem_teststore(true))] test_store: TestStore,
+) {
+    let store = test_store.store();
+    let context = test_store.context();
+
+    // Create blocks voting on commits at indexes 1, 2, 5, 10 (with gaps at 3, 4,
+    // 6-9)
+    let blocks_with_votes = [
+        VerifiedBlock::new_for_test(
+            TestBlockHeader::new(5, 0)
+                .set_commit_votes(vec![CommitRef::new(1, CommitDigest::MIN)])
+                .build(),
+        ),
+        VerifiedBlock::new_for_test(
+            TestBlockHeader::new(6, 0)
+                .set_commit_votes(vec![CommitRef::new(2, CommitDigest::MIN)])
+                .build(),
+        ),
+        VerifiedBlock::new_for_test(
+            TestBlockHeader::new(10, 0)
+                .set_commit_votes(vec![CommitRef::new(5, CommitDigest::MIN)])
+                .build(),
+        ),
+        VerifiedBlock::new_for_test(
+            TestBlockHeader::new(15, 0)
+                .set_commit_votes(vec![CommitRef::new(10, CommitDigest::MIN)])
+                .build(),
+        ),
+    ];
+
+    // Write blocks (this records commit votes in the commit_votes table)
+    store
+        .write(
+            WriteBatch::default().block_headers(
+                blocks_with_votes
+                    .iter()
+                    .map(|b| b.verified_block_header.clone())
+                    .collect(),
+            ),
+            context,
+        )
+        .expect("Write should not fail");
+
+    // Test read_highest_commit_index_with_votes - should find highest index with
+    // votes
+    assert_eq!(
+        store.read_highest_commit_index_with_votes(10).unwrap(),
+        Some(10),
+        "Should find votes at index 10"
+    );
+    assert_eq!(
+        store.read_highest_commit_index_with_votes(9).unwrap(),
+        Some(5),
+        "Should skip gap 6-9 and find votes at index 5"
+    );
+    assert_eq!(
+        store.read_highest_commit_index_with_votes(7).unwrap(),
+        Some(5),
+        "Should skip gap and find votes at index 5"
+    );
+    assert_eq!(
+        store.read_highest_commit_index_with_votes(5).unwrap(),
+        Some(5),
+        "Should find votes at index 5"
+    );
+    assert_eq!(
+        store.read_highest_commit_index_with_votes(4).unwrap(),
+        Some(2),
+        "Should skip gap 3-4 and find votes at index 2"
+    );
+    assert_eq!(
+        store.read_highest_commit_index_with_votes(3).unwrap(),
+        Some(2),
+        "Should skip gap and find votes at index 2"
+    );
+    assert_eq!(
+        store.read_highest_commit_index_with_votes(2).unwrap(),
+        Some(2),
+        "Should find votes at index 2"
+    );
+    assert_eq!(
+        store.read_highest_commit_index_with_votes(1).unwrap(),
+        Some(1),
+        "Should find votes at index 1"
+    );
+    assert_eq!(
+        store.read_highest_commit_index_with_votes(0).unwrap(),
+        None,
+        "Should return None when no votes exist at or below index 0"
+    );
+
+    // Test with very high index
+    assert_eq!(
+        store.read_highest_commit_index_with_votes(1000).unwrap(),
+        Some(10),
+        "Should find highest votes at index 10 even when searching up to 1000"
+    );
 }


### PR DESCRIPTION
# Description of change

This PR optimizes the search for voting blocks for the last commit in range by looking at the latest index in the range that has at least some votes instead of iterating over all indexes sequentially, which can take a long time in fast sync when we don't have votes for many indexes.

We also start to save voting headers that the validator fetches during fast sync and store them in a separate structure. Validator uses these headers when other validators request voting blocks from them. Validator doesn't use these blocks for header synchronization.

PR includes new tests and metrics.

## Links to any relevant issues

Fixes #9766 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
