### PR TITLE
fix(docs): move legacy migration tool outside of wallet section

### DIFF
--- a/docs/content/sidebars/users.js
+++ b/docs/content/sidebars/users.js
@@ -26,7 +26,6 @@ const users = [
                 type: 'category',
                 label: 'Import Method',
                 items: [
-                  'users/iota-wallet/how-to/import/legacy',
                   'users/iota-wallet/how-to/import/ledger',
                   'users/iota-wallet/how-to/import/keystone',
                   'users/iota-wallet/how-to/import/mnemonic',
@@ -74,6 +73,7 @@ const users = [
       },
     ],
   },
+  'users/legacy-migration-tool',
 ];
 
 module.exports = users;

--- a/docs/content/users/legacy-migration-tool.mdx
+++ b/docs/content/users/legacy-migration-tool.mdx
@@ -1,17 +1,17 @@
 ---
-description: A guide on how to migrate legacy funds into the IOTA Wallet.
+description: A guide on how to migrate legacy funds from the trinary protocol.
 teams:
    - iotaledger/tooling
-tags: [iota-wallet]
+title: Legacy Migration Tool
 ---
 
-# Migrate Legacy Funds to IOTA Wallet
+# Migrate Legacy Funds
 
-To migrate your legacy IOTA funds to the IOTA Wallet you first have to install the latest version of the [IOTA Legacy Migration Tool](https://github.com/iotaledger/legacy-migration-tool/releases).
+To migrate your legacy IOTA funds to your new IOTA Wallet you first have to install the latest version of the [IOTA Legacy Migration Tool](https://github.com/iotaledger/legacy-migration-tool/releases).
 
 :::warning Legacy Funds
 
-Legacy funds are funds that were held in the Trinity Wallet. If you already used the Firefly Wallet this guide does not apply to you and you should use [this guide](../import.mdx) instead.
+Legacy funds are funds that were held in the Trinity Wallet. If you already used the Firefly Wallet this guide does not apply to you and you should use [this guide](iota-wallet/how-to/import.mdx) instead.
 
 :::
 


### PR DESCRIPTION
# Description of change

A suggestion from my side to move the legacy tool to its own place as it is wallet agnostic. Not sure if it should get such a prominent position but it makes the most sense to me. We could also think about not showing it in the sidebar at all and just have a link or being able to find it through search.

## Links to any relevant issues

Related to #9617.