### PR TITLE
feat(starfish): add sequential restart simtests with strict transacti…

### DIFF
--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -746,13 +746,15 @@ pub fn load_pending_subdag_from_store(
     let mut leader_block_idx = None;
     let commit_block_headers = store
         .read_verified_block_headers(commit.block_headers())
-        .expect("We should have the block referenced in the commit data");
+        .expect("Block headers referenced in commit data should exist");
     let block_headers = commit_block_headers
         .into_iter()
         .enumerate()
         .map(|(idx, commit_block_opt)| {
-            let commit_block =
-                commit_block_opt.expect("We should have the block referenced in the commit data");
+            let commit_block = commit_block_opt.expect(
+                "Block header referenced in commit data should exist. \
+                 This could be due to unfinished fast syncing.",
+            );
             if commit_block.reference() == commit.leader() {
                 leader_block_idx = Some(idx);
             }

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -1,9 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+
 use std::{
+    collections::{HashMap, HashSet},
     net::{IpAddr, SocketAddr},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU32, AtomicU64, Ordering},
+    },
     time::Duration,
 };
 
@@ -15,56 +20,130 @@ use parking_lot::Mutex;
 use prometheus::Registry;
 use starfish_config::{AuthorityIndex, Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
 use starfish_core::{
-    BlockTimestampMs, Clock, CommitConsumer, CommitConsumerMonitor, CommittedSubDag,
-    ConsensusAuthority, TransactionClient, network::tonic_network::to_socket_addr,
+    BlockTimestampMs, Clock, CommitConsumer, CommitConsumerMonitor, CommitDigest, CommitIndex,
+    CommittedSubDag, ConsensusAuthority, TransactionClient, network::tonic_network::to_socket_addr,
     transaction::NoopTransactionVerifier,
 };
 use tempfile::TempDir;
+use tokio::sync::RwLock;
 use tracing::{info, trace};
 
 #[derive(Clone)]
-#[allow(unused)]
 pub(crate) struct Config {
     pub authority_index: AuthorityIndex,
     pub db_dir: Arc<TempDir>,
     pub committee: Committee,
     pub keypairs: Vec<(NetworkKeyPair, ProtocolKeyPair)>,
+    #[expect(dead_code)]
     pub network_type: ConsensusNetwork,
     pub boot_counter: u64,
     pub clock_drift: BlockTimestampMs,
     pub protocol_config: ProtocolConfig,
+    /// Last processed commit index for persistent DB restarts
+    pub last_processed_commit: CommitIndex,
 }
 
 pub(crate) struct AuthorityNode {
     inner: Mutex<Option<AuthorityNodeInner>>,
     config: Config,
+    db_dir: Mutex<Arc<TempDir>>,
+    boot_counter: AtomicU64,
+    /// Tracks the last processed commit index for persistent DB restarts
+    last_processed_commit: Arc<AtomicU32>,
+    /// Stores commit digests for consistency verification across authorities
+    commit_digests: Arc<RwLock<HashMap<CommitIndex, CommitDigest>>>,
+    /// Stores committed transactions for verification of sequencing
+    /// completeness
+    committed_transactions: Arc<RwLock<HashSet<Vec<u8>>>>,
 }
 
 impl AuthorityNode {
     pub fn new(config: Config) -> Self {
+        let initial_boot_counter = config.boot_counter;
+        let db_dir = config.db_dir.clone();
         Self {
             inner: Default::default(),
             config,
+            db_dir: Mutex::new(db_dir),
+            boot_counter: AtomicU64::new(initial_boot_counter),
+            last_processed_commit: Arc::new(AtomicU32::new(0)),
+            commit_digests: Arc::new(RwLock::new(HashMap::new())),
+            committed_transactions: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 
     /// Start this Node
     pub async fn start(&self) -> Result<()> {
-        info!(index =% self.config.authority_index, "starting in-memory node");
-        let config = self.config.clone();
+        let current_boot_counter = self.boot_counter.fetch_add(1, Ordering::SeqCst);
+        let last_processed = self.last_processed_commit.load(Ordering::SeqCst);
+        info!(
+            index =% self.config.authority_index,
+            boot_counter =% current_boot_counter,
+            last_processed,
+            "starting in-memory node"
+        );
+        let mut config = self.config.clone();
+        config.boot_counter = current_boot_counter;
+        config.db_dir = self.db_dir.lock().clone();
+        config.last_processed_commit = last_processed;
         *self.inner.lock() = Some(AuthorityNodeInner::spawn(config).await);
         Ok(())
     }
 
+    /// Restart the node, optionally with a fresh database
+    pub async fn restart(&self, clean_db: bool) -> Result<()> {
+        self.stop();
+        if clean_db {
+            *self.db_dir.lock() = Arc::new(TempDir::new()?);
+            self.last_processed_commit.store(0, Ordering::SeqCst);
+            // Treat clean DB as a fresh node: reset boot counter to enable
+            // sync_last_known_own_block, and clear tracking state (commit
+            // digests and committed transactions).
+            self.boot_counter.store(0, Ordering::SeqCst);
+            self.commit_digests.write().await.clear();
+            self.committed_transactions.write().await.clear();
+        }
+        self.start().await
+    }
+
+    /// Spawns a background task to consume committed subdags from consensus.
+    ///
+    /// This task:
+    /// - Tracks commit digests for consistency verification across authorities
+    /// - Records all committed transactions for verification
+    /// - Updates the last processed commit index for persistent DB restarts
+    /// - Notifies the commit consumer monitor of progress
+    ///
+    /// The spawned task runs until the commit receiver is closed (when the node
+    /// stops), so the task handle is intentionally not stored.
+    ///
+    /// Must be called after `start()` to begin tracking commits.
     pub fn spawn_committed_subdag_consumer(&self) -> Result<()> {
-        let authority_index = self.config.authority_index;
         let inner = self.inner.lock();
         if let Some(inner) = inner.as_ref() {
             let mut commit_receiver = inner.take_commit_receiver();
             let commit_consumer_monitor = inner.commit_consumer_monitor();
+            let commit_digests = self.commit_digests.clone();
+            let last_processed = self.last_processed_commit.clone();
+            let committed_transactions = self.committed_transactions.clone();
             let _handle = tokio::spawn(async move {
                 while let Some(subdag) = commit_receiver.recv().await {
-                    info!(authority =% authority_index, commit_index =% subdag.commit_ref.index, "received committed subdag");
+                    // Store commit digest for consistency verification
+                    commit_digests
+                        .write()
+                        .await
+                        .insert(subdag.commit_ref.index, subdag.commit_ref.digest);
+                    // Track committed transactions
+                    for verified_txns in &subdag.transactions {
+                        for txn in verified_txns.transactions() {
+                            committed_transactions
+                                .write()
+                                .await
+                                .insert(txn.data().to_vec());
+                        }
+                    }
+                    // Track last processed for persistent DB restarts
+                    last_processed.store(subdag.commit_ref.index, Ordering::SeqCst);
                     commit_consumer_monitor.set_highest_handled_commit(subdag.commit_ref.index);
                 }
             });
@@ -91,7 +170,6 @@ impl AuthorityNode {
     }
 
     /// Stop this Node
-    #[expect(dead_code)]
     pub fn stop(&self) {
         info!(index =% self.config.authority_index, "stopping in-memory node");
         *self.inner.lock() = None;
@@ -99,9 +177,18 @@ impl AuthorityNode {
     }
 
     /// If this Node is currently running
-    #[expect(dead_code)]
     pub fn is_running(&self) -> bool {
         self.inner.lock().as_ref().map_or(false, |c| c.is_alive())
+    }
+
+    /// Get the commit digest for a specific commit index
+    pub async fn get_commit_digest(&self, index: CommitIndex) -> Option<CommitDigest> {
+        self.commit_digests.read().await.get(&index).copied()
+    }
+
+    /// Get all committed transactions
+    pub async fn get_committed_transactions(&self) -> HashSet<Vec<u8>> {
+        self.committed_transactions.read().await.clone()
     }
 }
 
@@ -247,10 +334,11 @@ pub(crate) async fn make_authority(
         db_dir,
         committee,
         keypairs,
-        network_type,
+        network_type: _,
         boot_counter,
         clock_drift,
         protocol_config,
+        last_processed_commit,
     } = config;
 
     let registry = Registry::new();
@@ -271,7 +359,7 @@ pub(crate) async fn make_authority(
 
     let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
 
-    let commit_consumer = CommitConsumer::new(commit_sender, 0);
+    let commit_consumer = CommitConsumer::new(commit_sender, last_processed_commit);
     let commit_consumer_monitor = commit_consumer.monitor();
 
     let authority = ConsensusAuthority::start(

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -1,9 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(not(test), expect(unused))]
+
 #[cfg(msim)]
 mod test {
-    use std::{sync::Arc, time::Duration};
+    use std::{collections::HashSet, sync::Arc, time::Duration};
 
     use iota_config::local_ip_utils;
     use iota_macros::sim_test;
@@ -14,13 +17,13 @@ mod test {
         configs::{bimodal_latency_ms, env_config, uniform_latency_ms},
     };
     use prometheus::Registry;
-    use rand::{SeedableRng as _, rngs::StdRng};
+    use rand::{Rng, SeedableRng as _, rngs::StdRng};
     use starfish_config::{
-        Authority, AuthorityIndex, AuthorityKeyPair, Committee, Epoch, NetworkKeyPair,
-        ProtocolKeyPair, Stake,
+        Authority, AuthorityKeyPair, Committee, Epoch, NetworkKeyPair, ProtocolKeyPair, Stake,
     };
+    use starfish_core::transaction::BlockStatus;
     use tempfile::TempDir;
-    use tokio::time::sleep;
+    use tokio::{sync::RwLock, time::sleep};
     use typed_store::DBMetrics;
 
     use crate::node::{AuthorityNode, Config};
@@ -39,81 +42,6 @@ mod test {
                 ),
             ],
         )
-    }
-
-    #[sim_test(config = "test_config()")]
-    async fn test_committee_start_simple() {
-        telemetry_subscribers::init_for_testing();
-        let db_registry = Registry::new();
-        DBMetrics::init(&db_registry);
-
-        const NUM_OF_AUTHORITIES: usize = 10;
-        let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
-        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-
-        let mut authorities = Vec::with_capacity(committee.size());
-        let mut transaction_clients = Vec::with_capacity(committee.size());
-        let mut boot_counters = [0; NUM_OF_AUTHORITIES];
-        let mut clock_drifts = [0; NUM_OF_AUTHORITIES];
-        clock_drifts[0] = 50;
-        clock_drifts[1] = 100;
-        clock_drifts[2] = 120;
-
-        for (authority_index, _authority_info) in committee.authorities() {
-            let config = Config {
-                authority_index,
-                db_dir: Arc::new(TempDir::new().unwrap()),
-                committee: committee.clone(),
-                keypairs: keypairs.clone(),
-                network_type: iota_protocol_config::ConsensusNetwork::Tonic,
-                boot_counter: boot_counters[authority_index.value() as usize],
-                protocol_config: protocol_config.clone(),
-                clock_drift: clock_drifts[authority_index.value() as usize],
-            };
-            let node = AuthorityNode::new(config);
-
-            if authority_index != AuthorityIndex::new_for_test(NUM_OF_AUTHORITIES as u8 - 1) {
-                node.start().await.unwrap();
-                node.spawn_committed_subdag_consumer().unwrap();
-
-                let client = node.transaction_client();
-                transaction_clients.push(client);
-            }
-
-            boot_counters[authority_index] += 1;
-            authorities.push(node);
-        }
-
-        let transaction_clients_clone = transaction_clients.clone();
-        let _handle = tokio::spawn(async move {
-            const NUM_TRANSACTIONS: u16 = 1000;
-
-            for i in 0..NUM_TRANSACTIONS {
-                let txn = vec![i as u8; 16];
-                transaction_clients_clone[i as usize % transaction_clients_clone.len()]
-                    .submit(vec![txn])
-                    .await
-                    .unwrap();
-            }
-        });
-
-        // wait for authorities
-        sleep(Duration::from_secs(60)).await;
-
-        // Now start the last authority and let it start
-        authorities[NUM_OF_AUTHORITIES - 1].start().await.unwrap();
-        authorities[NUM_OF_AUTHORITIES - 1]
-            .spawn_committed_subdag_consumer()
-            .unwrap();
-
-        // Wait for it to catch up
-        sleep(Duration::from_secs(230)).await;
-        let commit_consumer_monitor = authorities[NUM_OF_AUTHORITIES - 1].commit_consumer_monitor();
-        let highest_committed_index = commit_consumer_monitor.highest_handled_commit();
-        assert!(
-            highest_committed_index >= 80,
-            "Highest handled commit {highest_committed_index} < 80"
-        );
     }
 
     /// Creates a committee for local testing, and the corresponding key pairs
@@ -150,4 +78,408 @@ mod test {
 
         local_ip_utils::new_udp_address_for_testing(&ip)
     }
+
+    /// Verifies commit digest consistency across all running authorities.
+    /// Checks that all authorities have identical commit digests for shared
+    /// commit indices.
+    async fn verify_commit_consistency(authorities: &[AuthorityNode], step: &str) {
+        let commit_indices: Vec<u32> = authorities
+            .iter()
+            .filter(|a| a.is_running())
+            .map(|a| a.commit_consumer_monitor().highest_handled_commit())
+            .collect();
+
+        if commit_indices.is_empty() {
+            return;
+        }
+
+        let min_commit: u32 = *commit_indices.iter().min().unwrap();
+        let max_commit = *commit_indices.iter().max().unwrap();
+
+        for commit_idx in min_commit..=max_commit {
+            let mut digests = Vec::new();
+            for (i, authority) in authorities.iter().enumerate() {
+                if authority.is_running() {
+                    if let Some(digest) = authority.get_commit_digest(commit_idx).await {
+                        digests.push((i, digest));
+                    }
+                }
+            }
+            if digests.len() > 1 {
+                let (_, first_digest) = &digests[0];
+                for (auth_idx, digest) in digests.iter().skip(1) {
+                    assert_eq!(
+                        first_digest, digest,
+                        "{step}: Commit {commit_idx} digest mismatch at authority {auth_idx}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Configuration for restart cycle timing
+    struct RestartCycleConfig {
+        /// Duration to wait before stopping an authority
+        pre_stop_wait: Duration,
+        /// Duration to wait after stopping, before restarting
+        stop_duration: Duration,
+        /// Duration to wait after restart for catch-up
+        post_restart_wait: Duration,
+        /// Number of stop/restart cycles per authority
+        cycles_per_authority: usize,
+    }
+
+    /// Helper function for sequential authority restarts with commit sync
+    /// catch-up and transaction sequencing verification.
+    ///
+    /// This test exercises the fast sync mechanism and verifies consensus
+    /// correctness by:
+    /// 1. Starting all authorities
+    /// 2. Sequentially stopping and restarting each authority (except one for
+    ///    quorum)
+    /// 3. Verifying that restarted authorities catch up via fast sync
+    /// 4. Verifying commit digest consistency across all authorities
+    /// 5. Verifying that all sequenced transactions are committed by all
+    ///    authorities
+    /// 6. Verifying that most submitted transactions are eventually sequenced
+    ///    (some may be lost during restarts when in RAM)
+    ///
+    /// Parameters:
+    /// - `clean_db`: If true, authorities restart with fresh empty DBs
+    ///   (simulates node replacement)
+    /// - `long_run`: If true, use longer pre-stop and catch-up times
+    /// - `long_restart`: If true, use longer stopped duration
+    async fn run_sequential_restarts_test(clean_db: bool, long_run: bool, long_restart: bool) {
+        // ═══════════════════════════════════════════════════════════════
+        // Constants
+        // ═══════════════════════════════════════════════════════════════
+        const NUM_OF_AUTHORITIES: usize = 7;
+        const CYCLES_PER_AUTHORITY: usize = 2;
+
+        // Timing constants
+        const LONG_DURATION_SECS: u64 = 120;
+        const SHORT_DURATION_SECS: u64 = 2;
+        const TXN_SUBMIT_INTERVAL_MS: u64 = 10;
+        const PRE_FINAL_RUN_SECS: u64 = 2 * LONG_DURATION_SECS;
+        const FINAL_SETTLEMENT_WAIT_SECS: u64 = LONG_DURATION_SECS;
+
+        // Verification thresholds
+        const MIN_BASELINE_COMMIT: u32 = 100;
+        const CATCH_UP_SLACK: u32 = 10;
+        const MAX_COMMIT_GAP: u32 = 20;
+        const MIN_INCREMENTAL_COMMIT_PROGRESS: u32 = 3;
+        const MIN_SUBMITTED_TRANSACTIONS: usize = 400;
+
+        // Clock drift range (ms)
+        const MAX_CLOCK_DRIFT_MS: u64 = 150;
+
+        // ═══════════════════════════════════════════════════════════════
+        // Setup
+        // ═══════════════════════════════════════════════════════════════
+        telemetry_subscribers::init_for_testing();
+        let db_registry = Registry::new();
+        DBMetrics::init(&db_registry);
+
+        // Enable transaction_ref (always enabled in this test)
+        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+        protocol_config.set_consensus_transaction_ref_for_testing(true);
+
+        // Calculate timing based on flags
+        let run_time = if long_run {
+            Duration::from_secs(LONG_DURATION_SECS)
+        } else {
+            Duration::from_secs(SHORT_DURATION_SECS)
+        };
+        let stop_time = if long_restart {
+            Duration::from_secs(LONG_DURATION_SECS)
+        } else {
+            Duration::from_secs(SHORT_DURATION_SECS)
+        };
+
+        let restart_config = RestartCycleConfig {
+            pre_stop_wait: Duration::from_secs(LONG_DURATION_SECS),
+            stop_duration: stop_time,
+            post_restart_wait: run_time,
+            cycles_per_authority: CYCLES_PER_AUTHORITY,
+        };
+        let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
+
+        // Generate pseudorandom clock drifts using MSIM_TEST_SEED for determinism
+        let seed_value: u64 = std::env::var("MSIM_TEST_SEED")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1);
+        let mut seed = [0u8; 32];
+        seed[..8].copy_from_slice(&seed_value.to_le_bytes());
+        let mut rng = StdRng::from_seed(seed);
+        let clock_drifts: Vec<u64> = (0..NUM_OF_AUTHORITIES)
+            .map(|_| rng.gen_range(0..MAX_CLOCK_DRIFT_MS))
+            .collect();
+
+        // Create and start all authorities
+        let mut authorities = Vec::with_capacity(committee.size());
+        let mut transaction_clients = Vec::with_capacity(committee.size());
+
+        for (authority_index, _authority_info) in committee.authorities() {
+            let config = Config {
+                authority_index,
+                db_dir: Arc::new(TempDir::new().unwrap()),
+                committee: committee.clone(),
+                keypairs: keypairs.clone(),
+                network_type: iota_protocol_config::ConsensusNetwork::Tonic,
+                boot_counter: 0,
+                protocol_config: protocol_config.clone(),
+                clock_drift: clock_drifts[authority_index.value() as usize],
+                last_processed_commit: 0,
+            };
+            let node = AuthorityNode::new(config);
+            node.start().await.unwrap();
+            node.spawn_committed_subdag_consumer().unwrap();
+
+            transaction_clients.push(node.transaction_client());
+            authorities.push(node);
+        }
+
+        // Spawn continuous transaction submission and track sequenced transactions
+        let clients_for_txns = transaction_clients.clone();
+        let submitted_transactions = Arc::new(RwLock::new(HashSet::new()));
+        let submitted_for_txns = submitted_transactions.clone();
+
+        let _txn_handle = tokio::spawn(async move {
+            let mut counter: u32 = 0;
+            loop {
+                let txn = counter.to_be_bytes().to_vec();
+                let client_idx = counter as usize % clients_for_txns.len();
+
+                // Submit transaction and wait for sequencing confirmation
+                match clients_for_txns[client_idx].submit(vec![txn.clone()]).await {
+                    Ok((_block_ref, status_receiver)) => {
+                        // Spawn task to wait for sequencing
+                        let submitted_for_txns = submitted_for_txns.clone();
+                        tokio::spawn(async move {
+                            match status_receiver.await {
+                                Ok(BlockStatus::Sequenced(_)) => {
+                                    // Transaction successfully sequenced - add to tracking set
+                                    submitted_for_txns.write().await.insert(txn);
+                                }
+                                Ok(BlockStatus::GarbageCollected(_)) => {
+                                    // Transaction was garbage collected, don't
+                                    // track
+                                }
+                                Err(_) => {
+                                    // Consensus shutting down, don't track
+                                }
+                            }
+                        });
+                    }
+                    Err(_) => {
+                        // Submission failed, don't track
+                    }
+                }
+
+                counter = counter.wrapping_add(1);
+                sleep(Duration::from_millis(TXN_SUBMIT_INTERVAL_MS)).await;
+            }
+        });
+
+        // Wait for initial consensus progress
+        sleep(restart_config.pre_stop_wait).await;
+
+        // Get baseline commit index
+        let baseline_commit = authorities[0]
+            .commit_consumer_monitor()
+            .highest_handled_commit();
+
+        assert!(
+            baseline_commit > MIN_BASELINE_COMMIT,
+            "Should have made initial progress: baseline_commit={baseline_commit}, min={MIN_BASELINE_COMMIT}"
+        );
+
+        // Verify consistency after baseline progress
+        verify_commit_consistency(&authorities, "after initial progress").await;
+
+        // Sequential restart cycles for each authority
+        // Only restart authorities 0..NUM_OF_AUTHORITIES-1 to have one always alive
+        // authority with clean state to serve as sync source
+        // TODO: once fast sync logic can handle early abortion, we can include all
+        // authorities in the restart cycles
+        for authority_idx in 0..(NUM_OF_AUTHORITIES - 1) {
+            for cycle in 0..restart_config.cycles_per_authority {
+                // Stop the authority
+                let commit_at_stop = authorities[authority_idx]
+                    .commit_consumer_monitor()
+                    .highest_handled_commit();
+                let max_commit_at_stop = authorities
+                    .iter()
+                    .map(|a| a.commit_consumer_monitor().highest_handled_commit())
+                    .max()
+                    .unwrap_or(commit_at_stop);
+                authorities[authority_idx].stop();
+                assert!(!authorities[authority_idx].is_running());
+
+                // Wait while stopped (other authorities make progress)
+                sleep(restart_config.stop_duration).await;
+
+                // Verify consistency while authority is stopped
+                verify_commit_consistency(
+                    &authorities,
+                    &format!("authority {authority_idx} cycle {cycle}: during stop"),
+                )
+                .await;
+
+                // Restart the authority (with or without clean DB)
+                authorities[authority_idx].restart(clean_db).await.unwrap();
+                authorities[authority_idx]
+                    .spawn_committed_subdag_consumer()
+                    .unwrap();
+
+                // For clean DB restarts, the node's internal state is reset to 0, so use that
+                // as the baseline for sync metrics. For persistent DB restarts,
+                // the node retains its state, so use the captured
+                // commit_at_stop value.
+                let sync_baseline = if clean_db { 0 } else { commit_at_stop };
+
+                // Wait for catch-up
+                sleep(restart_config.post_restart_wait).await;
+
+                let commits_after: Vec<u32> = authorities
+                    .iter()
+                    .map(|a| a.commit_consumer_monitor().highest_handled_commit())
+                    .collect();
+                let restarted = commits_after[authority_idx];
+                let network_max = commits_after
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| *i != authority_idx)
+                    .map(|(_, c)| *c)
+                    .max()
+                    .unwrap();
+                let incremental_progress = network_max.saturating_sub(max_commit_at_stop);
+                assert!(
+                    incremental_progress >= MIN_INCREMENTAL_COMMIT_PROGRESS,
+                    "Authority {authority_idx} cycle {cycle}: incremental commit progress too low: {incremental_progress} < {MIN_INCREMENTAL_COMMIT_PROGRESS}"
+                );
+
+                // Verify consistency after restart and catch-up
+                verify_commit_consistency(
+                    &authorities,
+                    &format!("authority {authority_idx} cycle {cycle}: after restart"),
+                )
+                .await;
+            }
+        }
+        sleep(Duration::from_secs(PRE_FINAL_RUN_SECS)).await;
+        // Stop transaction submission and verify all sequenced transactions are
+        // committed
+        _txn_handle.abort();
+        sleep(Duration::from_secs(FINAL_SETTLEMENT_WAIT_SECS)).await;
+
+        // Final verification: all authorities should be relatively close in commit
+        // index
+        let commit_indices: Vec<u32> = authorities
+            .iter()
+            .map(|a| a.commit_consumer_monitor().highest_handled_commit())
+            .collect();
+
+        let min_commit = *commit_indices.iter().min().unwrap();
+        let max_commit = *commit_indices.iter().max().unwrap();
+
+        assert!(
+            max_commit - min_commit < MAX_COMMIT_GAP,
+            "Gap too large: {max_commit} - {min_commit} >= {MAX_COMMIT_GAP}"
+        );
+
+        // Final commit consistency verification
+        verify_commit_consistency(&authorities, "final").await;
+
+        // Verify catch-up via fast sync: all authorities should have caught up after
+        // settlement
+        let final_commits: Vec<u32> = authorities
+            .iter()
+            .map(|a| a.commit_consumer_monitor().highest_handled_commit())
+            .collect();
+        let max_final = *final_commits.iter().max().unwrap();
+        let min_final = *final_commits.iter().min().unwrap();
+
+        assert!(
+            max_final - min_final <= CATCH_UP_SLACK,
+            "After settlement, authorities not caught up: min={min_final}, max={max_final}, gap={} (slack: {CATCH_UP_SLACK})",
+            max_final - min_final
+        );
+
+        // Get submitted transactions
+        let submitted = submitted_transactions.read().await.clone();
+
+        // Collect committed transactions from all running authorities
+        let mut committed_sets = Vec::new();
+        for authority in authorities.iter() {
+            if authority.is_running() {
+                let txns = authority.get_committed_transactions().await;
+                committed_sets.push(txns);
+            }
+        }
+
+        assert!(
+            !committed_sets.is_empty(),
+            "No running authorities to verify"
+        );
+        // Verify all submitted transactions are in the committed set (submitted ⊆
+        // committed)
+        for txn in &submitted {
+            assert!(
+                committed_sets.iter().any(|set| set.contains(txn)),
+                "Submitted transaction not in committed set: {txn:?}"
+            );
+        }
+
+        // Assert minimum submitted transactions
+        assert!(
+            submitted.len() >= MIN_SUBMITTED_TRANSACTIONS,
+            "Too few submitted transactions: {} < {MIN_SUBMITTED_TRANSACTIONS}",
+            submitted.len()
+        );
+    }
+
+    #[sim_test(config = "test_config()")]
+    async fn test_sequential_restarts_clean_db_long_run_long_stop() {
+        run_sequential_restarts_test(true, true, true).await;
+    }
+
+    #[sim_test(config = "test_config()")]
+    async fn test_sequential_restarts_clean_db_short_run_short_stop() {
+        run_sequential_restarts_test(true, false, false).await;
+    }
+
+    #[sim_test(config = "test_config()")]
+    async fn test_sequential_restarts_clean_db_long_run_short_stop() {
+        run_sequential_restarts_test(true, true, false).await;
+    }
+
+    #[sim_test(config = "test_config()")]
+    async fn test_sequential_restarts_clean_db_short_run_long_stop() {
+        run_sequential_restarts_test(true, false, true).await;
+    }
+
+    #[sim_test(config = "test_config()")]
+    async fn test_sequential_restarts_persistent_db_long_run_long_stop() {
+        run_sequential_restarts_test(false, true, true).await;
+    }
+
+    #[sim_test(config = "test_config()")]
+    async fn test_sequential_restarts_persistent_db_short_run_short_stop() {
+        run_sequential_restarts_test(false, false, false).await;
+    }
+
+    #[sim_test(config = "test_config()")]
+    async fn test_sequential_restarts_persistent_db_long_run_short_stop() {
+        run_sequential_restarts_test(false, true, false).await;
+    }
+
+    // TODO: This test is expected to panic due to fast sync failure when it is
+    // aborted before full sync catch-up. It should be added once the fix for
+    // fast syncing is applied.
+    // #[sim_test(config = "test_config()")]
+    // async fn test_sequential_restarts_persistent_db_short_run_long_stop() {
+    //     run_sequential_restarts_test(false, false, true).await;
+    // }
 }


### PR DESCRIPTION
# Description of change

This PR removes the only simtest from the starfish crate, which mimicks the restart of one node. However, it adds several comprehensive sequential restart simulation tests to validate Starfish consensus resilience during node restarts, along with strict transaction and commit digest consistency verification across authorities. In these tests, nodes restarts in cycle with different time parameters for running and stopping and with/without cleaning consensus dbs.

In the following (after we fix the recovery logic in case of aborted fast syncing), we can enhance the simtests. Specifically, uncomment the last prepared simtest, in which we have persisted dbs, short stable run, long stop time.

## Links to any relevant issues

Fixes #9764

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have checked that new and existing unit tests pass locally with my changes