### PR TITLE
feat(indexer): Add "object-changes-unwrapped" backfill job

### DIFF
--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -125,6 +125,11 @@ It supports following backfill options:
 This job backfills the `tx_wrapped_or_deleted_objects` table, which indexes transactions that either wrapped or deleted given objects.
 Replace `<START>` and `<END>` with the desired checkpoint range to backfill (e.g., `0` `10000`, both inclusive), and `<REMOTE_STORE_URL>` with the fullnode REST API URL used to fetch checkpoint data.
 
+#### Backfill job: `object-changes-unwrapped`
+
+This job backfills the information about unwrapped objects to the `transactions` table.
+Replace `<START>` and `<END>` with the desired checkpoint range to backfill (e.g., `0` `10000`, both inclusive), and `<REMOTE_STORE_URL>` with the fullnode REST API URL used to fetch checkpoint data.
+
 ```sh
 cargo run --bin iota-indexer -- --database-url <DATABASE_URL> run-backfill <START> <END> ingestion tx-wrapped-or-deleted-objects --remote-store-url <REMOTE_STORE_URL>
 ```

--- a/crates/iota-indexer/src/backfill/ingestion/adapter.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/adapter.rs
@@ -33,7 +33,7 @@ impl<T: IngestionBackfill> Worker for Adapter<T> {
         &self,
         checkpoint: Arc<CheckpointData>,
     ) -> Result<(), IndexerError> {
-        let processed = T::process_checkpoint(checkpoint.clone())?;
+        let processed = T::process_checkpoint(checkpoint.clone()).await?;
         self.ready_checkpoints
             .insert(checkpoint.checkpoint_summary.sequence_number, processed);
         self.notify.notify_waiters();

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/mod.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod object_changes_unwrapped;
 pub(crate) mod tx_wrapped_or_deleted_objects;

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/object_changes_unwrapped.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/object_changes_unwrapped.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 use std::sync::Arc;
 

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/object_changes_unwrapped.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/object_changes_unwrapped.rs
@@ -4,13 +4,13 @@ use std::sync::Arc;
 
 use diesel::{ExpressionMethods, RunQueryDsl};
 use downcast::Any;
-use iota_types::full_checkpoint_content::CheckpointData;
+use iota_types::{effects::TransactionEffectsAPI, full_checkpoint_content::CheckpointData};
 
 use crate::{
     Duration, IndexerMetrics, Registry, backfill::ingestion::IngestionBackfill, db::ConnectionPool,
     errors::IndexerError, ingestion::primary::prepare::PrimaryWorker,
     models::transactions::StoredTransaction, schema::transactions,
-    transactional_blocking_with_retry, types::IndexedObjectChange,
+    transactional_blocking_with_retry,
 };
 
 const PG_DB_COMMIT_SLEEP_DURATION: Duration = Duration::from_secs(3600);
@@ -43,7 +43,12 @@ impl IngestionBackfill for ObjectChangesUnwrappedBackfill {
 
         let mut results = Vec::new();
 
-        for (tx, (expected_digest, tx_sequence_number)) in transactions.iter().zip(tx_seq_numbers) {
+        // Only transactions with unwrapped objects need to be backfilled
+        for (tx, (expected_digest, tx_sequence_number)) in transactions
+            .iter()
+            .zip(tx_seq_numbers)
+            .filter(|(tx, _)| !tx.effects.unwrapped().is_empty())
+        {
             let actual_digest = tx.transaction.digest();
 
             if expected_digest != *actual_digest {
@@ -61,14 +66,7 @@ impl IngestionBackfill for ObjectChangesUnwrappedBackfill {
             )
             .await?;
 
-            // Only transactions with Unwrapped need to be backfilled
-            let has_unwrapped = indexed_tx
-                .object_changes
-                .iter()
-                .any(|change| matches!(change, IndexedObjectChange::Unwrapped { .. }));
-            if has_unwrapped {
-                results.push(StoredTransaction::from(&indexed_tx));
-            }
+            results.push(StoredTransaction::from(&indexed_tx));
         }
 
         Ok(results)

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/object_changes_unwrapped.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/object_changes_unwrapped.rs
@@ -42,6 +42,7 @@ impl IngestionBackfill for ObjectChangesUnwrappedBackfill {
             .map(|(seq, digest)| (digest.transaction, seq));
 
         let mut results = Vec::new();
+        let dummy_metrics = IndexerMetrics::new(&Registry::new());
 
         // Only transactions with unwrapped objects need to be backfilled
         for (tx, (expected_digest, tx_sequence_number)) in transactions
@@ -62,7 +63,7 @@ impl IngestionBackfill for ObjectChangesUnwrappedBackfill {
                 tx_sequence_number,
                 checkpoint_seq,
                 checkpoint_summary.timestamp_ms,
-                &IndexerMetrics::new(&Registry::new()),
+                &dummy_metrics,
             )
             .await?;
 

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/object_changes_unwrapped.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/object_changes_unwrapped.rs
@@ -1,0 +1,108 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+use std::sync::Arc;
+
+use diesel::{ExpressionMethods, RunQueryDsl};
+use downcast::Any;
+use iota_types::full_checkpoint_content::CheckpointData;
+
+use crate::{
+    Duration, IndexerMetrics, Registry, backfill::ingestion::IngestionBackfill, db::ConnectionPool,
+    errors::IndexerError, ingestion::primary::prepare::PrimaryWorker,
+    models::transactions::StoredTransaction, schema::transactions,
+    transactional_blocking_with_retry, types::IndexedObjectChange,
+};
+
+const PG_DB_COMMIT_SLEEP_DURATION: Duration = Duration::from_secs(3600);
+
+pub(crate) struct ObjectChangesUnwrappedBackfill;
+
+#[async_trait::async_trait]
+impl IngestionBackfill for ObjectChangesUnwrappedBackfill {
+    type ProcessedType = StoredTransaction;
+
+    async fn process_checkpoint(
+        checkpoint: Arc<CheckpointData>,
+    ) -> Result<Vec<Self::ProcessedType>, IndexerError> {
+        let checkpoint_summary = &checkpoint.checkpoint_summary;
+        let checkpoint_contents = &checkpoint.checkpoint_contents;
+        let transactions = &checkpoint.transactions;
+        let checkpoint_seq = checkpoint_summary.sequence_number;
+
+        if checkpoint_contents.size() != transactions.len() {
+            return Err(IndexerError::FullNodeReading(format!(
+                "checkpoint content size mismatch at checkpoint {checkpoint_seq}: expected {}, found {}",
+                checkpoint_contents.size(),
+                transactions.len()
+            )));
+        }
+
+        let tx_seq_numbers = checkpoint_contents
+            .enumerate_transactions(checkpoint_summary)
+            .map(|(seq, digest)| (digest.transaction, seq));
+
+        let mut results = Vec::new();
+
+        for (tx, (expected_digest, tx_sequence_number)) in transactions.iter().zip(tx_seq_numbers) {
+            let actual_digest = tx.transaction.digest();
+
+            if expected_digest != *actual_digest {
+                return Err(IndexerError::FullNodeReading(format!(
+                    "digest mismatch at checkpoint {checkpoint_seq}: expected {expected_digest}, found {actual_digest}",
+                )));
+            }
+
+            let indexed_tx = PrimaryWorker::index_transaction(
+                tx,
+                tx_sequence_number,
+                checkpoint_seq,
+                checkpoint_summary.timestamp_ms,
+                &IndexerMetrics::new(&Registry::new()),
+            )
+            .await?;
+
+            // Only transactions with Unwrapped need to be backfilled
+            let has_unwrapped = indexed_tx
+                .object_changes
+                .iter()
+                .any(|change| matches!(change, IndexedObjectChange::Unwrapped { .. }));
+            if has_unwrapped {
+                results.push(StoredTransaction::from(&indexed_tx));
+            }
+        }
+
+        Ok(results)
+    }
+
+    async fn persist_chunk(
+        pool: ConnectionPool,
+        processed_data: Vec<Self::ProcessedType>,
+    ) -> Result<(), IndexerError> {
+        if processed_data.is_empty() {
+            return Ok(());
+        }
+
+        let (tx_sequence_numbers, object_changes): (Vec<i64>, Vec<Vec<Option<Vec<u8>>>>) =
+            processed_data
+                .into_iter()
+                .map(|tx| (tx.tx_sequence_number, tx.object_changes))
+                .unzip();
+
+        // The UPDATE only affects rows that exist in the database. Update for
+        // non-existing rows is silently skipped.
+        transactional_blocking_with_retry!(
+            &pool,
+            |conn| {
+                for (tx_seq, obj_changes) in tx_sequence_numbers.iter().zip(object_changes.iter()) {
+                    diesel::update(transactions::table)
+                        .filter(transactions::tx_sequence_number.eq(tx_seq))
+                        .set(transactions::object_changes.eq(obj_changes))
+                        .execute(conn)?;
+                }
+
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+    }
+}

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/tx_wrapped_or_deleted_objects.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/tx_wrapped_or_deleted_objects.rs
@@ -20,7 +20,7 @@ pub(crate) struct TxWrappedOrDeletedObjectsBackfill;
 impl IngestionBackfill for TxWrappedOrDeletedObjectsBackfill {
     type ProcessedType = StoredTxWrappedOrDeletedObject;
 
-    fn process_checkpoint(
+    async fn process_checkpoint(
         checkpoint: Arc<CheckpointData>,
     ) -> Result<Vec<Self::ProcessedType>, IndexerError> {
         let checkpoint_summary = &checkpoint.checkpoint_summary;

--- a/crates/iota-indexer/src/backfill/ingestion/mod.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/mod.rs
@@ -18,7 +18,7 @@ pub(crate) trait IngestionBackfill: Send + Sync {
     type ProcessedType: Send + Sync;
 
     /// Converts a `CheckpointData` into zero-or-more items (`ProcessedType`).
-    fn process_checkpoint(
+    async fn process_checkpoint(
         checkpoint: Arc<CheckpointData>,
     ) -> Result<Vec<Self::ProcessedType>, IndexerError>;
 

--- a/crates/iota-indexer/src/backfill/ingestion/task.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/task.rs
@@ -184,7 +184,7 @@ mod tests {
     impl IngestionBackfill for BackfillDummyTable {
         type ProcessedType = usize;
 
-        fn process_checkpoint(
+        async fn process_checkpoint(
             checkpoint: Arc<CheckpointData>,
         ) -> Result<Vec<Self::ProcessedType>, IndexerError> {
             Ok(vec![checkpoint.checkpoint_summary.sequence_number as usize])

--- a/crates/iota-indexer/src/backfill/mod.rs
+++ b/crates/iota-indexer/src/backfill/mod.rs
@@ -11,7 +11,10 @@ use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use crate::{
     backfill::{
         ingestion::{
-            jobs::tx_wrapped_or_deleted_objects::TxWrappedOrDeletedObjectsBackfill,
+            jobs::{
+                object_changes_unwrapped::ObjectChangesUnwrappedBackfill,
+                tx_wrapped_or_deleted_objects::TxWrappedOrDeletedObjectsBackfill,
+            },
             task::IngestionBackfillTask,
         },
         sql::sql_backfill::SqlBackfill,
@@ -78,6 +81,7 @@ pub enum BackfillKind {
 pub enum IngestionBackfillKind {
     /// Backfills the `tx_wrapped_or_deleted_objects` table.
     TxWrappedOrDeletedObjects,
+    ObjectChangesUnwrapped,
 }
 
 pub(crate) async fn get_backfill(
@@ -89,6 +93,13 @@ pub(crate) async fn get_backfill(
         BackfillKind::Ingestion { kind, config } => match kind {
             IngestionBackfillKind::TxWrappedOrDeletedObjects => Ok(Arc::new(
                 IngestionBackfillTask::<TxWrappedOrDeletedObjectsBackfill>::new(
+                    config,
+                    range_start as CheckpointSequenceNumber,
+                )
+                .await?,
+            )),
+            IngestionBackfillKind::ObjectChangesUnwrapped => Ok(Arc::new(
+                IngestionBackfillTask::<ObjectChangesUnwrappedBackfill>::new(
                     config,
                     range_start as CheckpointSequenceNumber,
                 )


### PR DESCRIPTION
# Description of change

Add "object-changes-unwrapped" backfill job.
It updates object_changes field of all transactions that contain an (newly introduced) `Unwrapped` object change.
Other transactions are not affected.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9788

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

The backfill was tested by running it manually on a local network.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [x] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

