### PR TITLE
refactor(types): rename MoveAuthenticator constructor

### DIFF
--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/randomness_attack.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/randomness_attack.snap
@@ -21,6 +21,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 27:
 //# init-abstract-account --sender A --package-metadata object(3,0) --inputs "randomness_attack" "authenticate_random" --create-function simple_abstract_account::abstract_account::create --account-type simple_abstract_account::abstract_account::AbstractAccount
+events: Event { package_id: simple_abstract_account, transaction_module: Identifier("abstract_account"), sender: A, type_: StructTag { address: iota, module: Identifier("account"), name: Identifier("MutableAccountCreated"), type_params: [Struct(StructTag { address: simple_abstract_account, module: Identifier("abstract_account"), name: Identifier("AbstractAccount"), type_params: [] })] }, contents: [225, 24, 72, 218, 173, 229, 21, 128, 137, 239, 139, 216, 88, 144, 136, 148, 162, 26, 254, 91, 7, 187, 186, 36, 45, 249, 106, 109, 74, 133, 185, 134, 156, 37, 67, 160, 27, 23, 244, 200, 83, 2, 207, 60, 121, 247, 186, 6, 46, 144, 90, 182, 79, 173, 234, 236, 19, 14, 81, 157, 13, 43, 133, 91, 17, 114, 97, 110, 100, 111, 109, 110, 101, 115, 115, 95, 97, 116, 116, 97, 99, 107, 19, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 101, 95, 114, 97, 110, 100, 111, 109] }
 created: object(4,0), object(4,1), object(4,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6938800,  storage_rebate: 980400, non_refundable_storage_fee: 0

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -515,9 +515,11 @@ impl TestEnvironment {
         .take(Ed25519Signature::LENGTH * 2)
         .collect();
         let signature_call_arg = CallArg::Pure(bcs::to_bytes(&hex_encoded_signature)?);
-        Ok(GenericSignature::MoveAuthenticator(
-            MoveAuthenticator::new_for_testing(vec![signature_call_arg], vec![], self_call_arg),
-        ))
+        Ok(GenericSignature::MoveAuthenticator(MoveAuthenticator::new(
+            vec![signature_call_arg],
+            vec![],
+            self_call_arg,
+        )))
     }
 
     // Create the MoveAuthenticator for the free access authenticator:
@@ -535,9 +537,11 @@ impl TestEnvironment {
             initial_shared_version: aa_ref.1,
             mutable: false,
         });
-        Ok(GenericSignature::MoveAuthenticator(
-            MoveAuthenticator::new_for_testing(vec![], vec![], self_call_arg),
-        ))
+        Ok(GenericSignature::MoveAuthenticator(MoveAuthenticator::new(
+            vec![],
+            vec![],
+            self_call_arg,
+        )))
     }
 
     fn craft_aa_simple_ptb(&self) -> anyhow::Result<ProgrammableTransaction> {

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -1423,7 +1423,7 @@ impl IotaTestAdapter {
 
         Ok((
             aa_id,
-            GenericSignature::MoveAuthenticator(MoveAuthenticator::new_for_testing(
+            GenericSignature::MoveAuthenticator(MoveAuthenticator::new(
                 auth_inputs,
                 vec![],
                 CallArg::Object(aa_arg),

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -55,7 +55,7 @@ impl Hash for MoveAuthenticator {
 }
 
 impl MoveAuthenticator {
-    pub fn new_for_testing(
+    pub fn new(
         call_args: Vec<CallArg>,
         type_arguments: Vec<TypeInput>,
         object_to_authenticate: CallArg,

--- a/crates/iota-types/src/unit_tests/utils.rs
+++ b/crates/iota-types/src/unit_tests/utils.rs
@@ -328,9 +328,11 @@ mod move_authenticator {
             initial_shared_version: OBJECT_START_VERSION,
             mutable: false,
         });
-        let authenticator = GenericSignature::MoveAuthenticator(
-            MoveAuthenticator::new_for_testing(vec![], vec![], self_call_arg),
-        );
+        let authenticator = GenericSignature::MoveAuthenticator(MoveAuthenticator::new(
+            vec![],
+            vec![],
+            self_call_arg,
+        ));
 
         Transaction::new(SenderSignedData::new(data, vec![authenticator]))
     }


### PR DESCRIPTION
# Description of change

Rename `new_for_testing` to `new`.

## Links to any relevant issues

Closes #9797 

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
