### PR TITLE
feat: bump `iota` to v1.16.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,7 +1813,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "const-str",
  "git-version",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "iota"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5549,7 +5549,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-sdk-types",
  "iota-simulator",
  "iota-source-validation",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5630,7 +5630,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "arrow-array 53.1.0",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5681,7 +5681,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5756,7 +5756,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5777,7 +5777,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "iota-build-cache-server"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5863,7 +5863,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-move-build",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-sdk-types",
  "iota-swarm",
  "iota-swarm-config",
@@ -5885,7 +5885,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5904,7 +5904,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6089,7 +6089,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6156,7 +6156,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6184,7 +6184,7 @@ dependencies = [
  "iota-node",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-sdk-types",
  "iota-simulator",
  "iota-storage",
@@ -6215,7 +6215,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "serde_yaml",
 ]
@@ -6254,7 +6254,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6270,7 +6270,7 @@ dependencies = [
  "iota-keys",
  "iota-metrics",
  "iota-network-stack",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-sdk-types",
  "iota-types",
  "parking_lot 0.12.3",
@@ -6299,7 +6299,7 @@ source = "git+https://github.com/iotaledger/flamegraph-svg?rev=ba681350dc9a72c9b
 
 [[package]]
 name = "iota-framework"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6337,7 +6337,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6358,7 +6358,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6408,7 +6408,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6418,7 +6418,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6426,7 +6426,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6439,7 +6439,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6514,7 +6514,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6527,14 +6527,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "axum 0.8.4",
 ]
 
 [[package]]
 name = "iota-grpc-client"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "futures",
@@ -6548,7 +6548,7 @@ dependencies = [
 
 [[package]]
 name = "iota-grpc-server"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6571,7 +6571,7 @@ dependencies = [
 
 [[package]]
 name = "iota-grpc-types"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "bcs",
  "iota-json-rpc-types",
@@ -6585,7 +6585,7 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "axum 0.8.4",
  "bytes",
@@ -6606,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6675,7 +6675,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6691,7 +6691,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-streaming"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "async-trait",
  "futures",
@@ -6709,7 +6709,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6728,7 +6728,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6784,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6803,7 +6803,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6822,7 +6822,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6841,7 +6841,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6875,7 +6875,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "bip32",
@@ -6896,7 +6896,7 @@ dependencies = [
 
 [[package]]
 name = "iota-kvstore"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6914,7 +6914,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6935,7 +6935,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger-signer"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6943,7 +6943,7 @@ dependencies = [
  "bip32",
  "clap",
  "iota-ledger",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-sdk-types",
  "thiserror 1.0.64",
  "tokio",
@@ -6952,7 +6952,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6966,7 +6966,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-types",
  "move-core-types",
  "object_store 0.10.2",
@@ -6985,7 +6985,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -6995,7 +6995,7 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7007,7 +7007,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "backoff",
@@ -7028,7 +7028,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7053,7 +7053,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -7092,7 +7092,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "bin-version",
  "clap",
@@ -7146,7 +7146,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7158,7 +7158,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -7197,7 +7197,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anemo",
  "bcs",
@@ -7226,7 +7226,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7280,7 +7280,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7304,7 +7304,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7316,7 +7316,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-alt"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "move-package-alt",
  "serde",
@@ -7324,7 +7324,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7340,13 +7340,13 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -7356,7 +7356,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7377,7 +7377,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -7387,7 +7387,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "clap",
  "insta",
@@ -7402,7 +7402,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7411,7 +7411,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7426,7 +7426,7 @@ dependencies = [
  "hex",
  "hyper 1.4.1",
  "iota-metrics",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-tls",
  "iota-types",
  "itertools 0.13.0",
@@ -7454,7 +7454,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7470,7 +7470,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-transaction-checks",
  "iota-types",
  "jsonrpsee",
@@ -7499,7 +7499,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7528,7 +7528,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-kv"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7555,7 +7555,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7572,7 +7572,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-sdk-types",
  "iota-swarm-config",
  "iota-types",
@@ -7596,7 +7596,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7606,7 +7606,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-sdk-types",
  "iota-types",
  "itertools 0.13.0",
@@ -7661,7 +7661,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7726,7 +7726,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7748,7 +7748,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7782,7 +7782,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7809,7 +7809,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "colored",
@@ -7819,7 +7819,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -7841,7 +7841,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7856,7 +7856,7 @@ dependencies = [
  "iota-move",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-source-validation",
  "move-core-types",
  "move-package",
@@ -7877,7 +7877,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7928,7 +7928,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "bcs",
  "clap",
@@ -7956,7 +7956,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "futures",
@@ -7983,7 +7983,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8011,7 +8011,7 @@ dependencies = [
 
 [[package]]
 name = "iota-synthetic-ingestion"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8028,12 +8028,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-sdk-types",
  "iota-types",
  "move-core-types",
@@ -8041,7 +8041,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8063,7 +8063,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -8085,7 +8085,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -8108,7 +8108,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8124,7 +8124,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -8137,7 +8137,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8182,7 +8182,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8258,7 +8258,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8286,7 +8286,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11646,7 +11646,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13644,7 +13644,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14440,7 +14440,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -14532,7 +14532,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -14550,7 +14550,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.15.0-alpha",
+ "iota-sdk 1.16.0-alpha",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -15470,7 +15470,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -15536,7 +15536,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "bcs",
  "bincode",
@@ -15565,7 +15565,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -15575,7 +15575,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "serde",
  "thiserror 1.0.64",
@@ -15583,7 +15583,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "1.15.0-alpha"
+version = "1.16.0-alpha"
 
 [workspace.metadata.cargo-udeps.ignore]
 normal = ["move-package-alt"]

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -114,12 +114,12 @@ task 15, lines 64-69:
 //# run-graphql --show-usage --show-headers --show-service-version
 Headers: {
     "content-type": "application/graphql-response+json",
-    "x-iota-rpc-version": "1.15.0-testing-no-sha",
+    "x-iota-rpc-version": "1.16.0-testing-no-sha",
     "vary": "origin, access-control-request-method, access-control-request-headers",
     "access-control-allow-origin": "*",
     "content-length": "157",
 }
-Service version: 1.15.0-testing-no-sha
+Service version: 1.16.0-testing-no-sha
 Response: {
   "data": {
     "checkpoint": {
@@ -376,7 +376,7 @@ Response: {
   "data": {
     "serviceConfig": {
       "availableVersions": [
-        "1.15"
+        "1.16"
       ]
     }
   }

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "1.15.0-alpha"
+    "version": "1.16.0-alpha"
   },
   "methods": [
     {


### PR DESCRIPTION
# Description of change

 bump `iota` to v1.16.0-alpha
