### PR TITLE
upstream(core): Checkpoints that have been locally built by validators do not need tx-by-tx re-execution in CheckpointExecutor

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1513,6 +1513,23 @@ impl AuthorityPerEpochStore {
             .map_err(Into::into)
     }
 
+    /// Returns future containing the state accumulator for the given epoch
+    /// once available.
+    pub async fn notify_read_checkpoint_state_accumulator(
+        &self,
+        checkpoints: &[CheckpointSequenceNumber],
+    ) -> IotaResult<Vec<Accumulator>> {
+        let tables = self.tables()?;
+        self.checkpoint_state_notify_read
+            .read(checkpoints, |checkpoints| {
+                tables
+                    .state_hash_by_checkpoint
+                    .multi_get(checkpoints)
+                    .map_err(Into::into)
+            })
+            .await
+    }
+
     pub async fn notify_read_running_root(
         &self,
         checkpoint: CheckpointSequenceNumber,

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
@@ -13,16 +13,17 @@ use iota_types::{
 };
 
 use crate::{
-    checkpoints::checkpoint_executor::CheckpointExecutionData,
+    checkpoints::checkpoint_executor::{CheckpointExecutionData, CheckpointTransactionData},
     execution_cache::{ObjectCacheRead, TransactionCacheRead},
 };
 
 pub(crate) fn load_checkpoint_data(
     checkpoint_exec_data: &CheckpointExecutionData,
+    checkpoint_tx_data: &CheckpointTransactionData,
     object_cache_reader: &dyn ObjectCacheRead,
     transaction_cache_reader: &dyn TransactionCacheRead,
 ) -> IotaResult<CheckpointData> {
-    let event_digests = checkpoint_exec_data
+    let event_digests = checkpoint_tx_data
         .effects
         .iter()
         .flat_map(|fx| fx.events_digest().copied())
@@ -38,11 +39,11 @@ pub(crate) fn load_checkpoint_data(
         .collect::<IotaResult<Vec<_>>>()?;
 
     let events: HashMap<_, _> = event_digests.into_iter().zip(events).collect();
-    let mut full_transactions = Vec::with_capacity(checkpoint_exec_data.transactions.len());
-    for (tx, fx) in checkpoint_exec_data
+    let mut full_transactions = Vec::with_capacity(checkpoint_tx_data.transactions.len());
+    for (tx, fx) in checkpoint_tx_data
         .transactions
         .iter()
-        .zip(checkpoint_exec_data.effects.iter())
+        .zip(checkpoint_tx_data.effects.iter())
     {
         let events = fx.events_digest().map(|event_digest| {
             events

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/metrics.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/metrics.rs
@@ -21,6 +21,7 @@ pub struct CheckpointExecutorMetrics {
     pub checkpoint_transaction_count: Histogram,
     pub checkpoint_contents_age: Histogram,
     pub last_executed_checkpoint_age: Histogram,
+    pub checkpoint_executor_validator_path: IntGauge,
 }
 
 impl CheckpointExecutorMetrics {
@@ -94,6 +95,12 @@ impl CheckpointExecutorMetrics {
                 "last_executed_checkpoint_age",
                 "Age of the last executed checkpoint",
                 iota_metrics::LATENCY_SEC_BUCKETS.to_vec(),
+                registry
+            )
+            .unwrap(),
+            checkpoint_executor_validator_path: register_int_gauge_with_registry!(
+                "checkpoint_executor_validator_path",
+                "Number of checkpoints executed using the validator path",
                 registry
             )
             .unwrap(),

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -84,25 +84,24 @@ pub(crate) struct CheckpointExecutionData {
     pub checkpoint_contents: CheckpointContents,
     pub tx_digests: Vec<TransactionDigest>,
     pub fx_digests: Vec<TransactionEffectsDigest>,
+}
+
+pub(crate) struct CheckpointTransactionData {
     pub transactions: Vec<VerifiedExecutableTransaction>,
     pub effects: Vec<TransactionEffects>,
+    pub executed_fx_digests: Vec<Option<TransactionEffectsDigest>>,
 }
 
 pub(crate) struct CheckpointExecutionState {
     pub data: CheckpointExecutionData,
-    executed_fx_digests: Vec<Option<TransactionEffectsDigest>>,
     accumulator: Option<Accumulator>,
     full_data: Option<CheckpointData>,
 }
 
 impl CheckpointExecutionState {
-    pub fn new(
-        data: CheckpointExecutionData,
-        executed_fx_digests: Vec<Option<TransactionEffectsDigest>>,
-    ) -> Self {
+    pub fn new(data: CheckpointExecutionData) -> Self {
         Self {
             data,
-            executed_fx_digests,
             accumulator: None,
             full_data: None,
         }
@@ -367,12 +366,12 @@ impl CheckpointExecutor {
         checkpoint: VerifiedCheckpoint,
     ) -> CheckpointExecutionState {
         info!("executing checkpoint");
+        let sequence_number = checkpoint.sequence_number;
 
         checkpoint.report_checkpoint_age(&self.metrics.checkpoint_contents_age);
         self.backpressure_manager
-            .update_highest_certified_checkpoint(*checkpoint.sequence_number());
+            .update_highest_certified_checkpoint(sequence_number);
 
-        let sequence_number = checkpoint.sequence_number;
         if checkpoint.is_last_checkpoint_of_epoch() && sequence_number > 0 {
             let _wait_for_previous_checkpoints_guard =
                 iota_metrics::monitored_scope("CheckpointExecutor::wait_for_previous_checkpoints");
@@ -388,14 +387,88 @@ impl CheckpointExecutor {
         let _parallel_step_guard =
             iota_metrics::monitored_scope("CheckpointExecutor::parallel_step");
 
-        let (mut ckpt_state, unexecuted_tx_digests) = tokio::task::spawn_blocking({
+        // Note: only the fullnode path has end-of-epoch logic.
+        if self.state.is_fullnode(&self.epoch_store) || checkpoint.is_last_checkpoint_of_epoch() {
+            self.execute_checkpoint_fullnode(checkpoint).await
+        } else {
+            self.execute_checkpoint_validator(checkpoint).await
+        }
+    }
+
+    // On validators, checkpoints have often already been constructed locally, in
+    // which case we can skip many steps of the checkpoint execution process.
+    async fn execute_checkpoint_validator(
+        self: Arc<Self>,
+        checkpoint: VerifiedCheckpoint,
+    ) -> CheckpointExecutionState {
+        assert!(
+            !checkpoint.is_last_checkpoint_of_epoch(),
+            "only fullnode path has end-of-epoch logic"
+        );
+
+        let sequence_number = checkpoint.sequence_number;
+        let locally_built_checkpoint = self
+            .checkpoint_store
+            .get_locally_computed_checkpoint(sequence_number)
+            .expect("db error");
+
+        let Some(locally_built_checkpoint) = locally_built_checkpoint else {
+            // fall back to full node path if we are catching up.
+            // TODO: we may want to wait a small amount of time here before falling back.
+            // But its hard to know how long to wait. We could do something like wait up
+            // to 1 second if we are less than N checkpoints behind for some small N.
+            return self.execute_checkpoint_fullnode(checkpoint).await;
+        };
+
+        self.metrics.checkpoint_executor_validator_path.inc();
+
+        // Check for fork
+        assert_checkpoint_not_forked(
+            &locally_built_checkpoint,
+            &checkpoint,
+            &self.checkpoint_store,
+        );
+
+        // Checkpoint builder triggers accumulation of the checkpoint, so this is
+        // guaranteed to finish.
+
+        let checkpoint_contents = self
+            .checkpoint_store
+            .get_checkpoint_contents(&checkpoint.content_digest)
+            .expect("db error")
+            .expect("checkpoint contents not found");
+
+        let (tx_digests, fx_digests): (Vec<_>, Vec<_>) = checkpoint_contents
+            .iter()
+            .map(|digests| (digests.transaction, digests.effects))
+            .unzip();
+
+        self.epoch_store
+            .insert_finalized_transactions(&tx_digests, sequence_number)
+            .expect("failed to insert finalized transactions");
+
+        CheckpointExecutionState::new(CheckpointExecutionData {
+            checkpoint,
+            checkpoint_contents,
+            tx_digests,
+            fx_digests,
+        })
+    }
+
+    async fn execute_checkpoint_fullnode(
+        self: Arc<Self>,
+        checkpoint: VerifiedCheckpoint,
+    ) -> CheckpointExecutionState {
+        let sequence_number = checkpoint.sequence_number;
+        let (mut ckpt_state, tx_data, unexecuted_tx_digests) = tokio::task::spawn_blocking({
             let this = self.clone();
             move || {
                 let _scope =
                     iota_metrics::monitored_scope("CheckpointExecutor::execute_transactions");
-                let ckpt_state = this.load_checkpoint_transactions(checkpoint);
-                let unexecuted_tx_digests = this.schedule_transaction_execution(&ckpt_state);
-                (ckpt_state, unexecuted_tx_digests)
+                let (ckpt_state, tx_data) = this.load_checkpoint_transactions(checkpoint);
+                let unexecuted_tx_digests =
+                    this.schedule_transaction_execution(&ckpt_state, &tx_data);
+                (ckpt_state, tx_data, unexecuted_tx_digests)
             }
         })
         .await
@@ -406,7 +479,7 @@ impl CheckpointExecutor {
             .await;
 
         if ckpt_state.data.checkpoint.is_last_checkpoint_of_epoch() {
-            self.execute_change_epoch_tx(&ckpt_state).await;
+            self.execute_change_epoch_tx(&tx_data).await;
         }
 
         tokio::task::spawn_blocking(move || {
@@ -419,7 +492,7 @@ impl CheckpointExecutor {
                 self.state.congestion_tracker.process_checkpoint_effects(
                     &*self.transaction_cache_reader,
                     &ckpt_state.data.checkpoint,
-                    &ckpt_state.data.effects,
+                    &tx_data.effects,
                 );
             }
 
@@ -437,15 +510,11 @@ impl CheckpointExecutor {
             // before accumulating the checkpoint.
             ckpt_state.accumulator = Some(
                 self.accumulator
-                    .accumulate_checkpoint(
-                        &ckpt_state.data.effects,
-                        sequence_number,
-                        &self.epoch_store,
-                    )
+                    .accumulate_checkpoint(&tx_data.effects, sequence_number, &self.epoch_store)
                     .expect("epoch cannot have ended"),
             );
 
-            ckpt_state.full_data = self.process_checkpoint_data(&ckpt_state);
+            ckpt_state.full_data = self.process_checkpoint_data(&ckpt_state.data, &tx_data);
             ckpt_state
         })
         .await
@@ -458,14 +527,16 @@ impl CheckpointExecutor {
 
     fn process_checkpoint_data(
         &self,
-        ckpt_state: &CheckpointExecutionState,
+        ckpt_data: &CheckpointExecutionData,
+        tx_data: &CheckpointTransactionData,
     ) -> Option<CheckpointData> {
         if !self.checkpoint_data_enabled() {
             return None;
         }
 
         let checkpoint_data = load_checkpoint_data(
-            &ckpt_state.data,
+            ckpt_data,
+            tx_data,
             &*self.object_cache_reader,
             &*self.transaction_cache_reader,
         )
@@ -499,7 +570,7 @@ impl CheckpointExecutor {
     fn load_checkpoint_transactions(
         &self,
         checkpoint: VerifiedCheckpoint,
-    ) -> CheckpointExecutionState {
+    ) -> (CheckpointExecutionState, CheckpointTransactionData) {
         let seq = checkpoint.sequence_number;
         let epoch = checkpoint.epoch;
 
@@ -545,16 +616,18 @@ impl CheckpointExecutor {
                 .transaction_cache_reader
                 .multi_get_executed_effects_digests(&tx_digests);
 
-            CheckpointExecutionState::new(
-                CheckpointExecutionData {
+            (
+                CheckpointExecutionState::new(CheckpointExecutionData {
                     checkpoint,
                     checkpoint_contents,
                     tx_digests,
                     fx_digests,
+                }),
+                CheckpointTransactionData {
                     transactions,
                     effects,
+                    executed_fx_digests,
                 },
-                executed_fx_digests,
             )
         } else {
             // load items one-by-one
@@ -591,16 +664,18 @@ impl CheckpointExecutor {
                 .transaction_cache_reader
                 .multi_get_executed_effects_digests(&tx_digests);
 
-            CheckpointExecutionState::new(
-                CheckpointExecutionData {
+            (
+                CheckpointExecutionState::new(CheckpointExecutionData {
                     checkpoint,
                     checkpoint_contents,
                     tx_digests,
                     fx_digests,
+                }),
+                CheckpointTransactionData {
                     transactions,
                     effects,
+                    executed_fx_digests,
                 },
-                executed_fx_digests,
             )
         }
     }
@@ -609,16 +684,17 @@ impl CheckpointExecutor {
     fn schedule_transaction_execution(
         &self,
         ckpt_state: &CheckpointExecutionState,
+        tx_data: &CheckpointTransactionData,
     ) -> Vec<TransactionDigest> {
         // Find unexecuted transactions and their expected effects digests
         let (unexecuted_tx_digests, unexecuted_txns, unexecuted_effects): (Vec<_>, Vec<_>, Vec<_>) =
             itertools::multiunzip(
                 itertools::izip!(
-                    ckpt_state.data.transactions.iter(),
+                    tx_data.transactions.iter(),
                     ckpt_state.data.tx_digests.iter(),
                     ckpt_state.data.fx_digests.iter(),
-                    ckpt_state.data.effects.iter(),
-                    ckpt_state.executed_fx_digests.iter()
+                    tx_data.effects.iter(),
+                    tx_data.executed_fx_digests.iter()
                 )
                 .filter_map(
                     |(txn, tx_digest, expected_fx_digest, effects, executed_fx_digest)| {
@@ -660,9 +736,9 @@ impl CheckpointExecutor {
     }
 
     // Execute the change epoch txn
-    async fn execute_change_epoch_tx(&self, ckpt_state: &CheckpointExecutionState) {
-        let change_epoch_tx = ckpt_state.data.transactions.last().unwrap();
-        let change_epoch_fx = ckpt_state.data.effects.last().unwrap();
+    async fn execute_change_epoch_tx(&self, tx_data: &CheckpointTransactionData) {
+        let change_epoch_tx = tx_data.transactions.last().unwrap();
+        let change_epoch_fx = tx_data.effects.last().unwrap();
         assert_eq!(
             change_epoch_tx.digest(),
             change_epoch_fx.transaction_digest()
@@ -785,12 +861,18 @@ impl CheckpointExecutor {
             let summary = CertifiedCheckpointSummary::from(checkpoint_exec_data.checkpoint.clone());
             summary_sender(&summary);
         }
+
         if let Some(data_sender) = &self.data_sender {
             let checkpoint_data = if let Some(data) = checkpoint_data {
                 data.clone()
             } else {
+                // Reconstruct checkpoint data if needed (rare case: data_sender configured but
+                // checkpoint_data_enabled is false)
+                let (_, tx_data) =
+                    self.load_checkpoint_transactions(checkpoint_exec_data.checkpoint.clone());
                 load_checkpoint_data(
                     checkpoint_exec_data,
+                    &tx_data,
                     self.object_cache_reader.as_ref(),
                     self.transaction_cache_reader.as_ref(),
                 )

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -522,7 +522,9 @@ impl CheckpointExecutor {
     }
 
     fn checkpoint_data_enabled(&self) -> bool {
-        self.state.rest_index.is_some() || self.config.data_ingestion_dir.is_some()
+        self.state.rest_index.is_some()
+            || self.config.data_ingestion_dir.is_some()
+            || self.data_sender.is_some()
     }
 
     fn process_checkpoint_data(

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -106,6 +106,14 @@ impl CheckpointExecutionState {
             full_data: None,
         }
     }
+
+    pub fn new_with_accumulator(data: CheckpointExecutionData, accumulator: Accumulator) -> Self {
+        Self {
+            data,
+            accumulator: Some(accumulator),
+            full_data: None,
+        }
+    }
 }
 
 pub struct CheckpointExecutor {
@@ -431,6 +439,16 @@ impl CheckpointExecutor {
 
         // Checkpoint builder triggers accumulation of the checkpoint, so this is
         // guaranteed to finish.
+        let accumulator = self
+            .epoch_store
+            .notify_read_checkpoint_state_accumulator(&[sequence_number])
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        // Checkpoint builder triggers accumulation of the checkpoint, so this is
+        // guaranteed to finish.
 
         let checkpoint_contents = self
             .checkpoint_store
@@ -447,12 +465,15 @@ impl CheckpointExecutor {
             .insert_finalized_transactions(&tx_digests, sequence_number)
             .expect("failed to insert finalized transactions");
 
-        CheckpointExecutionState::new(CheckpointExecutionData {
-            checkpoint,
-            checkpoint_contents,
-            tx_digests,
-            fx_digests,
-        })
+        CheckpointExecutionState::new_with_accumulator(
+            CheckpointExecutionData {
+                checkpoint,
+                checkpoint_contents,
+                tx_digests,
+                fx_digests,
+            },
+            accumulator,
+        )
     }
 
     async fn execute_checkpoint_fullnode(

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/utils.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/utils.rs
@@ -11,7 +11,8 @@ use futures::{Stream, future::Either};
 use iota_common::fatal;
 use iota_types::{
     base_types::{TransactionDigest, TransactionEffectsDigest},
-    messages_checkpoint::{CheckpointSequenceNumber, VerifiedCheckpoint},
+    message_envelope::Message,
+    messages_checkpoint::{CheckpointSequenceNumber, CheckpointSummary, VerifiedCheckpoint},
 };
 use tracing::{debug, error, info, instrument, warn};
 
@@ -174,6 +175,80 @@ pub(super) fn assert_not_forked(
             tx_digest,
             expected_digest,
             actual_effects_digest,
+        );
+    }
+}
+
+pub(super) fn assert_checkpoint_not_forked(
+    locally_built_checkpoint: &CheckpointSummary,
+    verified_checkpoint: &VerifiedCheckpoint,
+    checkpoint_store: &CheckpointStore,
+) {
+    assert_eq!(
+        locally_built_checkpoint.sequence_number(),
+        verified_checkpoint.sequence_number(),
+        "Checkpoint sequence numbers must match"
+    );
+
+    if locally_built_checkpoint.digest() == *verified_checkpoint.digest() {
+        return;
+    }
+
+    let verified_checkpoint_summary = verified_checkpoint.data();
+
+    if locally_built_checkpoint.content_digest == verified_checkpoint_summary.content_digest {
+        // fork is in the checkpoint header
+        fatal!(
+            "Checkpoint fork detected in header! Locally built checkpoint: {:?}, verified checkpoint: {:?}",
+            locally_built_checkpoint,
+            verified_checkpoint
+        );
+    } else {
+        let local_contents = checkpoint_store
+            .get_checkpoint_contents(&locally_built_checkpoint.content_digest)
+            .expect("db error")
+            .expect("contents must exist if checkpoint was built locally!");
+
+        let verified_contents = checkpoint_store
+            .get_checkpoint_contents(&verified_checkpoint_summary.content_digest)
+            .expect("db error")
+            .expect("contents must exist if checkpoint has been synced!");
+
+        // fork is in the checkpoint contents
+        let mut local_contents_iter = local_contents.iter();
+        let mut verified_contents_iter = verified_contents.iter();
+        let mut pos = 0;
+
+        loop {
+            let local_digests = local_contents_iter.next();
+            let verified_digests = verified_contents_iter.next();
+
+            match (local_digests, verified_digests) {
+                (Some(local_digests), Some(verified_digests)) => {
+                    if local_digests != verified_digests {
+                        fatal!(
+                            "Checkpoint contents diverge at position {pos}! {local_digests:?} != {verified_digests:?}"
+                        );
+                    }
+                }
+                (None, Some(_)) | (Some(_), None) => {
+                    fatal!(
+                        "Checkpoint contents have different lengths! Locally built checkpoint: {:?}, verified checkpoint: {:?}",
+                        locally_built_checkpoint,
+                        verified_checkpoint
+                    );
+                }
+                (None, None) => {
+                    break;
+                }
+            }
+            pos += 1;
+        }
+
+        fatal!(
+            "Checkpoint fork detected in contents! Locally built checkpoint: {:?}, verified checkpoint: {:?}",
+            locally_built_checkpoint,
+            verified_checkpoint
         );
     }
 }

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -53,7 +53,7 @@ use parking_lot::Mutex;
 use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
 use tokio::{
-    sync::{Notify, watch},
+    sync::{Notify, mpsc, watch},
     task::JoinSet,
     time::timeout,
 };
@@ -881,6 +881,43 @@ pub enum CheckpointWatermark {
     HighestPruned,
 }
 
+struct CheckpointAccumulator {
+    epoch_store: Arc<AuthorityPerEpochStore>,
+    accumulator: Weak<StateAccumulator>,
+    receive_from_builder: mpsc::Receiver<(CheckpointSequenceNumber, Vec<TransactionEffects>)>,
+}
+
+impl CheckpointAccumulator {
+    fn new(
+        epoch_store: Arc<AuthorityPerEpochStore>,
+        accumulator: Weak<StateAccumulator>,
+        receive_from_builder: mpsc::Receiver<(CheckpointSequenceNumber, Vec<TransactionEffects>)>,
+    ) -> Self {
+        Self {
+            epoch_store,
+            accumulator,
+            receive_from_builder,
+        }
+    }
+
+    async fn run(self) {
+        let Self {
+            epoch_store,
+            accumulator,
+            mut receive_from_builder,
+        } = self;
+        while let Some((seq, effects)) = receive_from_builder.recv().await {
+            let Some(accumulator) = accumulator.upgrade() else {
+                info!("Accumulator was dropped, stopping checkpoint accumulation");
+                break;
+            };
+            accumulator
+                .accumulate_checkpoint(&effects, seq, &epoch_store)
+                .expect("epoch ended while accumulating checkpoint");
+        }
+    }
+}
+
 pub struct CheckpointBuilder {
     state: Arc<AuthorityState>,
     store: Arc<CheckpointStore>,
@@ -890,6 +927,7 @@ pub struct CheckpointBuilder {
     last_built: watch::Sender<CheckpointSequenceNumber>,
     effects_store: Arc<dyn TransactionCacheRead>,
     accumulator: Weak<StateAccumulator>,
+    send_to_accumulator: mpsc::Sender<(CheckpointSequenceNumber, Vec<TransactionEffects>)>,
     output: Box<dyn CheckpointOutput>,
     metrics: Arc<CheckpointMetrics>,
     max_transactions_per_checkpoint: usize,
@@ -925,7 +963,10 @@ impl CheckpointBuilder {
         epoch_store: Arc<AuthorityPerEpochStore>,
         notify: Arc<Notify>,
         effects_store: Arc<dyn TransactionCacheRead>,
+        // for synchronous accumulation of end-of-epoch checkpoint
         accumulator: Weak<StateAccumulator>,
+        // for asynchronous/concurrent accumulation of regular checkpoints
+        send_to_accumulator: mpsc::Sender<(CheckpointSequenceNumber, Vec<TransactionEffects>)>,
         output: Box<dyn CheckpointOutput>,
         notify_aggregator: Arc<Notify>,
         last_built: watch::Sender<CheckpointSequenceNumber>,
@@ -940,6 +981,7 @@ impl CheckpointBuilder {
             notify,
             effects_store,
             accumulator,
+            send_to_accumulator,
             output,
             notify_aggregator,
             last_built,
@@ -1377,6 +1419,7 @@ impl CheckpointBuilder {
         details: &PendingCheckpointInfo,
     ) -> anyhow::Result<NonEmpty<(CheckpointSummary, CheckpointContents)>> {
         let _scope = monitored_scope("CheckpointBuilder::create_checkpoints");
+
         let total = all_effects.len();
         let mut last_checkpoint =
             Self::load_last_built_checkpoint_summary(&self.epoch_store, &self.store)?;
@@ -1566,6 +1609,9 @@ impl CheckpointBuilder {
                     epoch_supply_change,
                 })
             } else {
+                self.send_to_accumulator
+                    .send((sequence_number, effects.clone()))
+                    .await?;
                 None
             };
             let contents = CheckpointContents::new_with_digests_and_signatures(
@@ -2283,17 +2329,29 @@ pub trait CheckpointServiceNotify {
 }
 
 enum CheckpointServiceState {
-    Unstarted(Box<(CheckpointBuilder, CheckpointAggregator)>),
+    Unstarted(
+        Box<(
+            CheckpointBuilder,
+            CheckpointAggregator,
+            CheckpointAccumulator,
+        )>,
+    ),
     Started,
 }
 
 impl CheckpointServiceState {
-    fn take_unstarted(&mut self) -> (CheckpointBuilder, CheckpointAggregator) {
+    fn take_unstarted(
+        &mut self,
+    ) -> (
+        CheckpointBuilder,
+        CheckpointAggregator,
+        CheckpointAccumulator,
+    ) {
         let mut state = CheckpointServiceState::Started;
         std::mem::swap(self, &mut state);
 
         match state {
-            CheckpointServiceState::Unstarted(tup) => (tup.0, tup.1),
+            CheckpointServiceState::Unstarted(tup) => (tup.0, tup.1, tup.2),
             CheckpointServiceState::Started => panic!("CheckpointServiceState is already started"),
         }
     }
@@ -2359,6 +2417,14 @@ impl CheckpointService {
             metrics.clone(),
         );
 
+        let (send_to_accumulator, receive_from_builder) = mpsc::channel(16);
+
+        let ckpt_accumulator = CheckpointAccumulator::new(
+            epoch_store.clone(),
+            accumulator.clone(),
+            receive_from_builder,
+        );
+
         let builder = CheckpointBuilder::new(
             state.clone(),
             checkpoint_store.clone(),
@@ -2366,6 +2432,7 @@ impl CheckpointService {
             notify_builder.clone(),
             effects_store,
             accumulator,
+            send_to_accumulator,
             checkpoint_output,
             notify_aggregator.clone(),
             highest_currently_built_seq_tx.clone(),
@@ -2388,7 +2455,9 @@ impl CheckpointService {
             highest_previously_built_seq,
             metrics,
             state: Mutex::new(CheckpointServiceState::Unstarted(Box::new((
-                builder, aggregator,
+                builder,
+                aggregator,
+                ckpt_accumulator,
             )))),
         })
     }
@@ -2404,9 +2473,10 @@ impl CheckpointService {
     pub async fn spawn(&self) -> JoinSet<()> {
         let mut tasks = JoinSet::new();
 
-        let (builder, aggregator) = self.state.lock().take_unstarted();
+        let (builder, aggregator, accumulator) = self.state.lock().take_unstarted();
         tasks.spawn(monitored_future!(builder.run()));
         tasks.spawn(monitored_future!(aggregator.run()));
+        tasks.spawn(monitored_future!(accumulator.run()));
 
         // If this times out, the validator may still start up. The worst that can
         // happen is that we will crash later on instead of immediately. The eventual


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.45.3, v1.46.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/8e938bb4802483a3f6a4adedf7ccbb4abb916b7f
- Description:

When validators have built checkpoints locally, they have already done
the work of ensuring that transactions are executed. Comparing the local
vs certified checkpoint digest is sufficient to ensure that the
execution results agree.

## Links to any relevant issues

Part of #9768

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes


