### PR TITLE
feat(indexer): Update indexer commands in docker composes with new CLI

### DIFF
--- a/dev-tools/iota-private-network/docker-compose.yaml
+++ b/dev-tools/iota-private-network/docker-compose.yaml
@@ -333,10 +333,10 @@ services:
       - RPC_WORKER_THREAD=12
     command:
       - /usr/local/bin/iota-indexer
-      - --db-url=postgres://iota_indexer:iota_indexer@postgres_primary:5432/iota_indexer
-      - --rpc-client-url=http://fullnode-3:9000
-      - --fullnode-sync-worker
-      - --client-metric-port=9181
+      - --database-url=postgres://iota_indexer:iota_indexer@postgres_primary:5432/iota_indexer
+      - --metrics-address=0.0.0.0:9181
+      - indexer
+      - --remote-store-url=http://fullnode-3:9000/api/v1
       - --reset-db
     ports:
       - "127.0.0.1:9004:9000/tcp"
@@ -361,10 +361,11 @@ services:
       - RPC_WORKER_THREAD=12
     command:
       - /usr/local/bin/iota-indexer
-      - --db-url=postgres://iota_indexer:iota_indexer@postgres_replica:5432/iota_indexer
+      - --database-url=postgres://iota_indexer:iota_indexer@postgres_replica:5432/iota_indexer
+      - --metrics-address=0.0.0.0:9181
+      - json-rpc-service
       - --rpc-client-url=http://fullnode-4:9000
-      - --rpc-server-worker
-      - --client-metric-port=9181
+      - --rpc-address=0.0.0.0:9000
     ports:
       - "127.0.0.1:9005:9000/tcp"
       - "127.0.0.1:9182:9181/tcp"

--- a/dev-tools/pg-services-local/docker-compose.yaml
+++ b/dev-tools/pg-services-local/docker-compose.yaml
@@ -62,10 +62,10 @@ services:
       - RUST_LOG=info
     command:
       - /usr/local/bin/iota-indexer
-      - --db-url=postgres://postgres:postgrespw@postgres:5432/iota_indexer
-      - --rpc-client-url=http://local-network:9000
-      - --fullnode-sync-worker
-      - --client-metric-port=9181
+      - --database-url=postgres://postgres:postgrespw@postgres:5432/iota_indexer
+      - --metrics-address=0.0.0.0:9181
+      - indexer
+      - --remote-store-url=http://local-network:9000/api/v1
       - --reset-db
     ports:
       - "127.0.0.1:9181:9181/tcp"
@@ -86,11 +86,11 @@ services:
       - RPC_WORKER_THREAD=12
     command:
       - /usr/local/bin/iota-indexer
-      - --db-url=postgres://postgres:postgrespw@postgres:5432/iota_indexer
+      - --database-url=postgres://postgres:postgrespw@postgres:5432/iota_indexer
+      - --metrics-address=0.0.0.0:9181
+      - json-rpc-service
       - --rpc-client-url=http://local-network:9000
-      - --rpc-server-worker
-      - --client-metric-port=9181
-      - --rpc-server-port=9000
+      - --rpc-address=0.0.0.0:9000
     ports:
       - "127.0.0.1:9005:9000/tcp"
       - "127.0.0.1:9182:9181/tcp"
@@ -113,10 +113,9 @@ services:
       - ADDRESS_PROCESSOR_BATCH_SIZE=500
     command:
       - /usr/local/bin/iota-indexer
-      - --db-url=postgres://postgres:postgrespw@postgres:5432/iota_indexer
-      - --rpc-client-url=http://local-network:9000
-      - --client-metric-port=9181
-      - --analytical-worker
+      - --database-url=postgres://postgres:postgrespw@postgres:5432/iota_indexer
+      - --metrics-address=0.0.0.0:9181
+      - analytical-worker
     ports:
       - "127.0.0.1:9184:9181/tcp"
     depends_on:


### PR DESCRIPTION
# Description of change

It's been some time since we introduced the new indexer CLI.
It's time to migrate to use it in the remaining places.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9810

## How the change has been tested

Ran pg_services_local and checked that there are no errors, sync is progressing and txs can be executed via the indexer rpc.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [x] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

