### PR TITLE
fix(iota): make `ExecuteSignedTx` signatures required

### DIFF
--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -198,7 +198,7 @@ pub enum IotaClientCommands {
         tx_bytes: String,
         /// A list of Base64 encoded signatures `flag || signature || pubkey`,
         /// separated by space.
-        #[arg(long, num_args(1..))]
+        #[arg(long, num_args(1..), required = true)]
         signatures: Vec<String>,
     },
     /// Execute a combined serialized SenderSignedData string.


### PR DESCRIPTION
# Description of change

The `signatures` argument of `iota client execute-signed-tx` was not required even though it was `num_args(1..)`. Not providing one at all would later fail with `ErrorObject { code: ServerError(-32002), message: "Invalid user signature: Expect 1 signer signatures but got 0", data: None }`. This PR actually makes it required so the argument appears in the usage and presence is checked earlier. It will now fail with `error: the following required arguments were not provided: --signatures <SIGNATURES>...`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
