### PR TITLE
upstream(core): Congestion control loadtest changes

### DIFF
--- a/crates/iota-benchmark/src/options.rs
+++ b/crates/iota-benchmark/src/options.rs
@@ -193,6 +193,9 @@ pub enum RunSpec {
         // relative weight of randomized transaction in the benchmark workload
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0])]
         randomized_transaction: Vec<u32>,
+        // relative weight of slow transactions in the benchmark workload
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0])]
+        slow: Vec<u32>,
 
         // --- workload-specific options --- (TODO: use subcommands or similar)
         // 100 for max hotness i.e all requests target

--- a/crates/iota-benchmark/src/workloads/adversarial.rs
+++ b/crates/iota-benchmark/src/workloads/adversarial.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{path::PathBuf, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
@@ -36,7 +36,10 @@ use crate::{
     drivers::Interval,
     in_memory_wallet::{InMemoryWallet, move_call_pt_impl},
     system_state_observer::{SystemState, SystemStateObserver},
-    workloads::{Gas, GasCoinConfig, payload::Payload, workload::ExpectedFailureType},
+    workloads::{
+        Gas, GasCoinConfig, benchmark_move_base_dir, payload::Payload,
+        workload::ExpectedFailureType,
+    },
 };
 
 /// Number of vectors to create in LargeTransientRuntimeVectors workload
@@ -250,7 +253,7 @@ impl AdversarialTestPayload {
                 to_sender_signed_transaction(data, account.key())
             }
             AdversarialPayloadType::MaxPackagePublish => {
-                let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+                let mut path = benchmark_move_base_dir();
                 path.push("src/workloads/data/max_package");
                 TestTransactionBuilder::new(self.sender, account.gas, gas_price)
                     .publish(path)
@@ -468,7 +471,7 @@ impl Workload<dyn Payload> for AdversarialWorkload {
         system_state_observer: Arc<SystemStateObserver>,
     ) {
         let gas = &self.init_gas;
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut path = benchmark_move_base_dir();
         path.push("src/workloads/data/adversarial");
         let SystemState {
             reference_gas_price,

--- a/crates/iota-benchmark/src/workloads/data/slow/Move.toml
+++ b/crates/iota-benchmark/src/workloads/data/slow/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "slow"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-benchmark/src/workloads/data/slow/Move.toml
+++ b/crates/iota-benchmark/src/workloads/data/slow/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "slow"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+Iota = { local = "../../../../../iota-framework/packages/iota-framework" }
+
+[addresses]
+slow = "0x0"
+iota = "0000000000000000000000000000000000000000000000000000000000000002"

--- a/crates/iota-benchmark/src/workloads/data/slow/sources/slow.move
+++ b/crates/iota-benchmark/src/workloads/data/slow/sources/slow.move
@@ -1,0 +1,46 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module slow::slow {
+    use std::vector;
+    use iota::clock;
+
+    public struct Obj has key, store {
+        id: object::UID,
+    }
+
+    /// Entry points that can be slow to execute.
+
+    /// create `n` vectors of size `size` bytes.
+    public fun slow(mut n: u64, size: u64) {
+        let mut top_level = vector[];
+        while (n > 0) {
+            let mut contents = vector[];
+            let mut i = size;
+            while (i > 0) {
+                vector::push_back(&mut contents, 0u8);
+                i = i - 1;
+            };
+            vector::push_back(&mut top_level, contents);
+            n = n - 1;
+        };
+    }
+
+    /// bimodal alternates between slow and fast execution every 10 seconds
+    public fun bimodal(clock: &clock::Clock) {
+        let t = clock.timestamp_ms();
+        if ((t / 10000) % 2 == 0) {
+            slow(100, 100);
+        } else {
+            slow(10, 10);
+        }
+    }
+
+    /// Initialize object to be used as mutable shared input
+    fun init(ctx: &mut TxContext) {
+        let id = object::new(ctx);
+        let mut x = Obj { id };
+        transfer::share_object(x);
+    }
+}

--- a/crates/iota-benchmark/src/workloads/mod.rs
+++ b/crates/iota-benchmark/src/workloads/mod.rs
@@ -11,11 +11,12 @@ pub mod randomized_transaction;
 pub mod randomness;
 pub mod shared_counter;
 pub mod shared_object_deletion;
+pub mod slow;
 pub mod transfer_object;
 pub mod workload;
 pub mod workload_configuration;
 
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
@@ -58,4 +59,12 @@ pub struct GasCoinConfig {
     pub address: IotaAddress,
     // recipient account key pair (useful for signing txns)
     pub keypair: Arc<AccountKeyPair>,
+}
+
+pub fn benchmark_move_base_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("BENCHMARK_MOVE_BASE_DIR") {
+        PathBuf::from(dir)
+    } else {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    }
 }

--- a/crates/iota-benchmark/src/workloads/slow.rs
+++ b/crates/iota-benchmark/src/workloads/slow.rs
@@ -1,0 +1,270 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use iota_test_transaction_builder::TestTransactionBuilder;
+use iota_types::{
+    IOTA_CLOCK_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION,
+    base_types::{IotaAddress, ObjectID, ObjectRef, random_object_ref},
+    crypto::get_key_pair,
+    object::Owner,
+    transaction::{ObjectArg, Transaction},
+};
+use move_core_types::identifier::Identifier;
+
+use super::{
+    WorkloadBuilderInfo, WorkloadParams,
+    workload::{MAX_GAS_FOR_TESTING, Workload, WorkloadBuilder},
+};
+use crate::{
+    ExecutionEffects, ProgrammableTransactionBuilder, ValidatorProxy,
+    drivers::Interval,
+    in_memory_wallet::InMemoryWallet,
+    system_state_observer::{SystemState, SystemStateObserver},
+    workloads::{
+        Gas, GasCoinConfig, benchmark_move_base_dir, payload::Payload,
+        workload::ExpectedFailureType,
+    },
+};
+
+#[derive(Debug)]
+pub struct SlowTestPayload {
+    /// ID of the Move package with slow utility functions
+    package_id: ObjectID,
+    shared_object_ref: ObjectRef,
+    /// address to send slow transactions from
+    sender: IotaAddress,
+    state: InMemoryWallet,
+    system_state_observer: Arc<SystemStateObserver>,
+}
+
+impl std::fmt::Display for SlowTestPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "slow")
+    }
+}
+
+impl Payload for SlowTestPayload {
+    fn make_new_payload(&mut self, effects: &ExecutionEffects) {
+        debug_assert!(
+            effects.is_ok(),
+            "Slow transactions should never abort: {effects:?}",
+        );
+
+        self.state.update(effects);
+    }
+
+    fn make_transaction(&mut self) -> Transaction {
+        self.create_transaction()
+    }
+
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
+    }
+}
+
+impl SlowTestPayload {
+    fn create_transaction(&self) -> Transaction {
+        let account = self.state.account(&self.sender).unwrap();
+        let gas_price = self
+            .system_state_observer
+            .state
+            .borrow()
+            .reference_gas_price;
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let args = vec![
+            builder
+                .obj(ObjectArg::SharedObject {
+                    id: IOTA_CLOCK_OBJECT_ID,
+                    initial_shared_version: IOTA_CLOCK_OBJECT_SHARED_VERSION,
+                    mutable: false,
+                })
+                .unwrap(),
+        ];
+        builder.programmable_move_call(
+            self.package_id,
+            Identifier::new("slow").unwrap(),
+            Identifier::new("bimodal").unwrap(),
+            vec![],
+            args,
+        );
+
+        // Add unused mutable shared object input to activate congestion control.
+        builder
+            .obj(ObjectArg::SharedObject {
+                id: self.shared_object_ref.0,
+                initial_shared_version: self.shared_object_ref.1,
+                mutable: true,
+            })
+            .unwrap();
+
+        TestTransactionBuilder::new(self.sender, account.gas, gas_price)
+            .programmable(builder.finish())
+            .build_and_sign(account.key())
+    }
+}
+
+#[derive(Debug)]
+pub struct SlowWorkloadBuilder {
+    num_payloads: u64,
+}
+
+#[async_trait]
+impl WorkloadBuilder<dyn Payload> for SlowWorkloadBuilder {
+    async fn generate_coin_config_for_init(&self) -> Vec<GasCoinConfig> {
+        // Gas coin for publishing package
+        let (address, keypair) = get_key_pair();
+        vec![GasCoinConfig {
+            amount: MAX_GAS_FOR_TESTING,
+            address,
+            keypair: Arc::new(keypair),
+        }]
+    }
+
+    async fn generate_coin_config_for_payloads(&self) -> Vec<GasCoinConfig> {
+        let mut configs = vec![];
+        // Gas coins for running workload
+        for _i in 0..self.num_payloads {
+            let (address, keypair) = get_key_pair();
+            configs.push(GasCoinConfig {
+                amount: MAX_GAS_FOR_TESTING,
+                address,
+                keypair: Arc::new(keypair),
+            });
+        }
+        configs
+    }
+
+    async fn build(
+        &self,
+        mut init_gas: Vec<Gas>,
+        payload_gas: Vec<Gas>,
+    ) -> Box<dyn Workload<dyn Payload>> {
+        Box::<dyn Workload<dyn Payload>>::from(Box::new(SlowWorkload {
+            package_id: ObjectID::ZERO,
+            shared_obj_ref: {
+                let mut f = random_object_ref();
+                f.0 = ObjectID::ZERO;
+                f
+            },
+            init_gas: init_gas.pop().unwrap(),
+            payload_gas,
+        }))
+    }
+}
+
+impl SlowWorkloadBuilder {
+    pub fn from(
+        workload_weight: f32,
+        target_qps: u64,
+        num_workers: u64,
+        in_flight_ratio: u64,
+        duration: Interval,
+        group: u32,
+    ) -> Option<WorkloadBuilderInfo> {
+        let target_qps = (workload_weight * target_qps as f32).ceil() as u64;
+        let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
+        let max_ops = target_qps * in_flight_ratio;
+        if max_ops == 0 || num_workers == 0 {
+            None
+        } else {
+            let workload_params = WorkloadParams {
+                target_qps,
+                num_workers,
+                max_ops,
+                duration,
+                group,
+            };
+            let workload_builder =
+                Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(SlowWorkloadBuilder {
+                    num_payloads: max_ops,
+                }));
+            let builder_info = WorkloadBuilderInfo {
+                workload_params,
+                workload_builder,
+            };
+            Some(builder_info)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SlowWorkload {
+    /// ID of the Move package with slow functions
+    package_id: ObjectID,
+    /// ID of the object used for mutable shared input
+    shared_obj_ref: ObjectRef,
+    /// Shared object refs for checking max reads with contention
+    // shared_objs: Vec<BenchMoveCallArg>,
+    pub init_gas: Gas,
+    pub payload_gas: Vec<Gas>,
+}
+
+#[async_trait]
+impl Workload<dyn Payload> for SlowWorkload {
+    async fn init(
+        &mut self,
+        proxy: Arc<dyn ValidatorProxy + Sync + Send>,
+        system_state_observer: Arc<SystemStateObserver>,
+    ) {
+        let gas = &self.init_gas;
+        let mut path = benchmark_move_base_dir();
+        path.push("src/workloads/data/slow");
+        let SystemState {
+            reference_gas_price,
+            protocol_config: _,
+        } = system_state_observer.state.borrow().clone();
+        let transaction = TestTransactionBuilder::new(gas.1, gas.0, reference_gas_price)
+            .publish(path)
+            .build_and_sign(gas.2.as_ref());
+        let effects = proxy.execute_transaction_block(transaction).await.unwrap();
+        let created = effects.created();
+        // should only create the package object, upgrade cap, shared obj.
+        assert_eq!(created.len() as u64, 3);
+        let package_obj = created
+            .iter()
+            .find(|o| matches!(o.1, Owner::Immutable))
+            .unwrap();
+
+        for o in &created {
+            let obj = proxy.get_object(o.0.0).await.unwrap();
+            if let Some(tag) = obj.data.struct_tag() {
+                if tag.to_string().contains("::slow::Obj") {
+                    self.shared_obj_ref = o.0;
+                    break;
+                }
+            }
+        }
+        assert!(
+            self.shared_obj_ref.0 != ObjectID::ZERO,
+            "Dynamic field parent must be created"
+        );
+        self.package_id = package_obj.0.0;
+    }
+
+    async fn make_test_payloads(
+        &self,
+        _proxy: Arc<dyn ValidatorProxy + Sync + Send>,
+        system_state_observer: Arc<SystemStateObserver>,
+    ) -> Vec<Box<dyn Payload>> {
+        let mut payloads = Vec::new();
+
+        for gas in &self.payload_gas {
+            payloads.push(SlowTestPayload {
+                package_id: self.package_id,
+                shared_object_ref: self.shared_obj_ref,
+                sender: gas.1,
+                state: InMemoryWallet::new(gas),
+                system_state_observer: system_state_observer.clone(),
+            })
+        }
+        payloads
+            .into_iter()
+            .map(|b| Box::<dyn Payload>::from(Box::new(b)))
+            .collect()
+    }
+}

--- a/crates/iota-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/iota-benchmark/src/workloads/workload_configuration.rs
@@ -22,7 +22,7 @@ use crate::{
     workloads::{
         ExpectedFailureType, GroupID, WorkloadBuilderInfo, WorkloadInfo,
         batch_payment::BatchPaymentWorkloadBuilder, delegation::DelegationWorkloadBuilder,
-        shared_counter::SharedCounterWorkloadBuilder,
+        shared_counter::SharedCounterWorkloadBuilder, slow::SlowWorkloadBuilder,
         transfer_object::TransferObjectWorkloadBuilder,
     },
 };
@@ -38,6 +38,7 @@ pub struct WorkloadWeights {
     pub expected_failure: u32,
     pub randomness: u32,
     pub randomized_transaction: u32,
+    pub slow: u32,
 }
 
 pub struct WorkloadConfig {
@@ -78,6 +79,7 @@ impl WorkloadConfiguration {
                 expected_failure,
                 randomness,
                 randomized_transaction,
+                slow,
                 shared_counter_hotness_factor,
                 num_shared_counters,
                 shared_counter_max_tip,
@@ -113,6 +115,7 @@ impl WorkloadConfiguration {
                             expected_failure: expected_failure[i],
                             randomness: randomness[i],
                             randomized_transaction: randomized_transaction[i],
+                            slow: slow[i],
                         },
                         adversarial_cfg: AdversarialPayloadCfg::from_str(&adversarial_cfg[i])
                             .unwrap(),
@@ -219,7 +222,8 @@ impl WorkloadConfiguration {
             + weights.adversarial
             + weights.randomness
             + weights.expected_failure
-            + weights.randomized_transaction;
+            + weights.randomized_transaction
+            + weights.slow;
         let reference_gas_price = system_state_observer.state.borrow().reference_gas_price;
         let mut workload_builders = vec![];
         let shared_workload = SharedCounterWorkloadBuilder::from(
@@ -317,7 +321,15 @@ impl WorkloadConfiguration {
             group,
         );
         workload_builders.push(randomized_transaction_workload);
-
+        let slow_workload = SlowWorkloadBuilder::from(
+            weights.slow as f32 / total_weight as f32,
+            target_qps,
+            num_workers,
+            in_flight_ratio,
+            duration,
+            group,
+        );
+        workload_builders.push(slow_workload);
         workload_builders
     }
 }

--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -24,6 +24,7 @@ mod test {
         util::get_ed25519_keypair_from_keystore,
         workloads::{
             adversarial::AdversarialPayloadCfg,
+            benchmark_move_base_dir,
             expected_failure::ExpectedFailurePayloadCfg,
             workload::ExpectedFailureType,
             workload_configuration::{WorkloadConfig, WorkloadConfiguration, WorkloadWeights},
@@ -983,6 +984,7 @@ mod test {
     struct SimulatedLoadConfig {
         num_transfer_accounts: u64,
         shared_counter_weight: u32,
+        slow_weight: u32,
         transfer_object_weight: u32,
         delegation_weight: u32,
         batch_payment_weight: u32,
@@ -1001,6 +1003,7 @@ mod test {
         fn default() -> Self {
             Self {
                 shared_counter_weight: 1,
+                slow_weight: 1,
                 transfer_object_weight: 1,
                 num_transfer_accounts: 2,
                 delegation_weight: 1,
@@ -1100,6 +1103,7 @@ mod test {
             adversarial: adversarial_weight,
             expected_failure: config.expected_failure_weight,
             randomized_transaction: config.randomized_transaction_weight,
+            slow: config.slow_weight,
         };
 
         let workload_config = WorkloadConfig {
@@ -1167,7 +1171,7 @@ mod test {
 
         let surfer_task = tokio::spawn(async move {
             // now do a iota-surfer test
-            let mut test_packages_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let mut test_packages_dir = benchmark_move_base_dir();
             test_packages_dir.extend(["..", "..", "crates", "iota-surfer", "tests"]);
             let test_package_paths: Vec<PathBuf> = std::fs::read_dir(test_packages_dir)
                 .unwrap()


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.45.3, v1.46.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/1e44011c7276dbdd5ce2a4311b83bb4e2859486b
- Description:
  - Add slow tx workload for congestion control to benchmark test suite
  - Add slow workload to simtests
  - Allow runtime specification of workload move dir

## Links to any relevant issues

Part of #9768

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

