### PR TITLE
feat(ci): compare release with previous minor of same TLR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,7 +251,7 @@ jobs:
           trl=$(echo "$iota_tag" | sed -n 's/^[^-]*\(-.*\)/\1/p')
           echo "trl = $trl"
 
-          current_minor=$(echo "$iota_tag" | sed -E 's/^v([0-9]+)\.([0-9]+)\..*/\2/')
+          current_minor=$(echo "$iota_tag" | sed -E 's/^v[0-9]+\.([0-9]+)\..*/\1/')
           current_major=$(echo "$iota_tag" | sed -E 's/^v([0-9]+)\..*/\1/')
           previous_minor=$((current_minor - 1))
           echo "Current major: $current_major, current minor: $current_minor, previous minor: $previous_minor"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,13 @@ jobs:
           echo "iota_tag = $iota_tag"
           trl=$(echo "$iota_tag" | sed -n 's/^[^-]*\(-.*\)/\1/p')
           echo "trl = $trl"
-          previous_tag=$(git tag --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$trl$" | grep -Fv $iota_tag | head -n 1)
+
+          current_minor=$(echo "$iota_tag" | sed -E 's/^v([0-9]+)\.([0-9]+)\..*/\2/')
+          current_major=$(echo "$iota_tag" | sed -E 's/^v([0-9]+)\..*/\1/')
+          previous_minor=$((current_minor - 1))
+          echo "Current major: $current_major, current minor: $current_minor, previous minor: $previous_minor"
+
+          previous_tag=$(git tag --sort=-version:refname | grep -E "^v${current_major}\.${previous_minor}\.[0-9]+${trl}$" | head -n 1)
           echo "Previous tag: $previous_tag"
           previous_commit_hash=$(git rev-list -n 1 "${previous_tag}")
           echo "Previous commit hash: $previous_commit_hash"


### PR DESCRIPTION
# Description of change

Always compare releases with the previous minor release of the same TLR instead of potentially previous patch release.

Before
```sh
$ iota_tag=v1.14.1-rc
$ echo "iota_tag = $iota_tag"
iota_tag = v1.14.1-rc
$ trl=$(echo "$iota_tag" | sed -n 's/^[^-]*\(-.*\)/\1/p')
$ echo "trl = $trl"
trl = -rc
$ previous_tag=$(git tag --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$trl$" | grep -Fv $iota_tag | head -n 1)
$ echo "Previous tag: $previous_tag"
Previous tag: v1.14.0-rc
```

After
```sh
$ iota_tag=v1.14.1-rc
$ echo "iota_tag = $iota_tag"
iota_tag = v1.14.1-rc
$ trl=$(echo "$iota_tag" | sed -n 's/^[^-]*\(-.*\)/\1/p')
$ echo "trl = $trl"
trl = -rc
$ current_minor=$(echo "$iota_tag" | sed -E 's/^v[0-9]+\.([0-9]+)\..*/\1/')
$ current_major=$(echo "$iota_tag" | sed -E 's/^v([0-9]+)\..*/\1/')
$ previous_minor=$((current_minor - 1))
$ echo "Current major: $current_major, current minor: $current_minor, previous minor: $previous_minor"
Current major: 1, current minor: 14, previous minor: 13
$ previous_tag=$(git tag --sort=-version:refname | grep -E "^v${current_major}\.${previous_minor}\.[0-9]+${trl}$" | head -n 1)
$ echo "Previous tag: $previous_tag"
Previous tag: v1.13.1-rc
```

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/9761

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
