### PR TITLE
feat(iota): add iota keytool tx-digest command

### DIFF
--- a/crates/iota/src/keytool.rs
+++ b/crates/iota/src/keytool.rs
@@ -37,7 +37,10 @@ use iota_keys::{
     keystore::{AccountKeystore, Keystore, StoredKey},
 };
 use iota_ledger::Ledger;
-use iota_sdk_types::crypto::{Intent, IntentMessage};
+use iota_sdk_types::{
+    SenderSignedTransaction, Transaction,
+    crypto::{Intent, IntentMessage},
+};
 use iota_types::{
     base_types::IotaAddress,
     crypto::{
@@ -97,6 +100,8 @@ pub enum KeyToolCommand {
         #[arg(long, default_value = "0")]
         cur_epoch: u64,
     },
+    /// Compute the digest of a transaction from its Base64 encoded bytes.
+    TxDigest { tx_bytes: String },
     /// Output the private key of the given key identity in IOTA CLI Keystore as
     /// Bech32 encoded string starting with `iotaprivkey`.
     Export {
@@ -424,6 +429,15 @@ pub struct SignData {
     iota_signature: String,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TxDigestOutput {
+    // Base58
+    digest: String,
+    digest_hex: String,
+    signing_digest_hex: String,
+}
+
 // Commented for now: https://github.com/iotaledger/iota/issues/1777
 // #[derive(Serialize)]
 // #[serde(rename_all = "camelCase")]
@@ -464,6 +478,7 @@ pub enum CommandOutput {
     Show(Key),
     Sign(SignData),
     SignKMS(SerializedSig),
+    TxDigest(TxDigestOutput),
     UpdateAlias(AliasUpdate),
     // Commented for now: https://github.com/iotaledger/iota/issues/1777
     // ZkLoginSignAndExecuteTx(ZkLoginSignAndExecuteTx),
@@ -538,6 +553,22 @@ impl KeyToolCommand {
                 };
 
                 CommandOutput::DecodeMultiSig(output)
+            }
+            KeyToolCommand::TxDigest { tx_bytes } => {
+                let tx_bytes = Base64::decode(&tx_bytes)
+                    .map_err(|e| anyhow!("Invalid base64 tx bytes: {e:?}"))?;
+                let tx = match bcs::from_bytes::<Transaction>(&tx_bytes) {
+                    Ok(tx) => tx,
+                    Err(_) => {
+                        let deserialized_tx = bcs::from_bytes::<SenderSignedTransaction>(&tx_bytes)?;
+                       deserialized_tx.0.transaction
+                    }
+                };
+                CommandOutput::TxDigest(TxDigestOutput {
+                    digest: tx.digest().to_string(),
+                    digest_hex: format!("0x{}", Hex::encode(tx.digest())),
+                    signing_digest_hex: format!("0x{}", Hex::encode(tx.signing_digest())),
+                })
             }
             KeyToolCommand::DecodeOrVerifyTx {
                 tx_bytes,

--- a/crates/iota/src/unit_tests/keytool_tests.rs
+++ b/crates/iota/src/unit_tests/keytool_tests.rs
@@ -734,3 +734,60 @@ async fn test_multi_sig_combine_partial_sig() -> Result<(), anyhow::Error> {
 
     Ok(())
 }
+
+#[test]
+async fn test_tx_digest() -> Result<(), anyhow::Error> {
+    let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
+
+    // Test unsigned transaction data
+    let result = KeyToolCommand::TxDigest {
+        tx_bytes: "AAACAAgAypo7AAAAAAAgERERERUE6TUOY11lzTjM0sApQ0xqOkgNiUepumoVshUCAgABAQAAAQEDAAAAAAEBABEREREVBOk1DmNdZc04zNLAKUNMajpIDYlHqbpqFbIVAU4PMbTXGjSXQkjCr1LNtHK9EpH/1O8JRuHyWt6uUtBZP247KQAAAAAgFOO+ZFsHJj7S4YIF5O9JdCdReidVJ0ky484jB8YJn/gRERERFQTpNQ5jXWXNOMzSwClDTGo6SA2JR6m6ahWyFegDAAAAAAAA4G88AAAAAAAA".to_string(),
+    }
+    .execute(&mut keystore)
+    .await?;
+
+    match result {
+        CommandOutput::TxDigest(output) => {
+            assert_eq!(
+                &output.digest,
+                "Fv6odr6tuuVmpDw5tyheRBQ2oivAnmudLtKBDv4T4MPE"
+            );
+            assert_eq!(
+                &output.digest_hex,
+                "0xdd9df6678f2fcdac1b1e13751afb74b0f81c9993699954ee2f0f459dd0a0da11"
+            );
+            assert_eq!(
+                &output.signing_digest_hex,
+                "0x7cfef332628f699c2aac858c5566a5bab8c7c43407038a5a76561df5c33f1eba"
+            );
+        }
+        _ => panic!("Wrong output type"),
+    }
+
+    // Test signed transaction data
+    let result = KeyToolCommand::TxDigest {
+        tx_bytes: "AQAAAAAAAgAIAMqaOwAAAAAAIBEREREVBOk1DmNdZc04zNLAKUNMajpIDYlHqbpqFbIVAgIAAQEAAAEBAwAAAAABAQARERERFQTpNQ5jXWXNOMzSwClDTGo6SA2JR6m6ahWyFQFODzG01xo0l0JIwq9SzbRyvRKR/9TvCUbh8lrerlLQWT9uOykAAAAAIBTjvmRbByY+0uGCBeTvSXQnUXonVSdJMuPOIwfGCZ/4ERERERUE6TUOY11lzTjM0sApQ0xqOkgNiUepumoVshXoAwAAAAAAAOBvPAAAAAAAAAFhAKFqV1NustAADKOOOfAZIA/9HrnmA9PqwAmOrqTs7OKjaEXylfywifj2XZyBmEJYodGE89xlkDOthe+bpBIrkwEoe8lptdiMUw3h3rcxQJf3bWp9zFLP4Eq3rpQOam52cw==".to_string(),
+    }
+    .execute(&mut keystore)
+    .await?;
+
+    match result {
+        CommandOutput::TxDigest(output) => {
+            assert_eq!(
+                &output.digest,
+                "Fv6odr6tuuVmpDw5tyheRBQ2oivAnmudLtKBDv4T4MPE"
+            );
+            assert_eq!(
+                &output.digest_hex,
+                "0xdd9df6678f2fcdac1b1e13751afb74b0f81c9993699954ee2f0f459dd0a0da11"
+            );
+            assert_eq!(
+                &output.signing_digest_hex,
+                "0x7cfef332628f699c2aac858c5566a5bab8c7c43407038a5a76561df5c33f1eba"
+            );
+        }
+        _ => panic!("Wrong output type"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
# Description of change

Add iota keytool tx-digest command so one can get the digest for given transaction bytes.
```
iota keytool tx-digest AQAAAAAAAgAIAMqaOwAAAAAAIBEREREVBOk1DmNdZc04zNLAKUNMajpIDYlHqbpqFbIVAgIAAQEAAAEBAwAAAAABAQARERERFQTpNQ5jXWXNOMzSwClDTGo6SA2JR6m6ahWyFQFODzG01xo0l0JIwq9SzbRyvRKR/9TvCUbh8lrerlLQWT9uOykAAAAAIBTjvmRbByY+0uGCBeTvSXQnUXonVSdJMuPOIwfGCZ/4ERERERUE6TUOY11lzTjM0sApQ0xqOkgNiUepumoVshXoAwAAAAAAAOBvPAAAAAAAAAFhAKFqV1NustAADKOOOfAZIA/9HrnmA9PqwAmOrqTs7OKjaEXylfywifj2XZyBmEJYodGE89xlkDOthe+bpBIrkwEoe8lptdiMUw3h3rcxQJf3bWp9zFLP4Eq3rpQOam52cw==
╭──────────────────┬──────────────────────────────────────────────────────────────────────╮
│ digest           │  Fv6odr6tuuVmpDw5tyheRBQ2oivAnmudLtKBDv4T4MPE                        │
│ digestHex        │  0xdd9df6678f2fcdac1b1e13751afb74b0f81c9993699954ee2f0f459dd0a0da11  │
│ signingDigestHex │  0x7cfef332628f699c2aac858c5566a5bab8c7c43407038a5a76561df5c33f1eba  │
╰──────────────────┴──────────────────────────────────────────────────────────────────────╯
 ~/Desktop/iota   dev-tools/keytool-tx-digest ±  iota keytool tx-digest AQAAAAAAAgAIAMqaOwAAAAAAIBEREREVBOk1DmNdZc04zNLAKUNMajpIDYlHqbpqFbIVAgIAAQEAAAEBAwAAAAABAQARERERFQTpNQ5jXWXNOMzSwClDTGo6SA2JR6m6ahWyFQFODzG01xo0l0JIwq9SzbRyvRKR/9TvCUbh8lrerlLQWT9uOykAAAAAIBTjvmRbByY+0uGCBeTvSXQnUXonVSdJMuPOIwfGCZ/4ERERERUE6TUOY11lzTjM0sApQ0xqOkgNiUepumoVshXoAwAAAAAAAOBvPAAAAAAAAAFhAKFqV1NustAADKOOOfAZIA/9HrnmA9PqwAmOrqTs7OKjaEXylfywifj2XZyBmEJYodGE89xlkDOthe+bpBIrkwEoe8lptdiMUw3h3rcxQJf3bWp9zFLP4Eq3rpQOam52cw== --json
{
  "digest": "Fv6odr6tuuVmpDw5tyheRBQ2oivAnmudLtKBDv4T4MPE",
  "digestHex": "0xdd9df6678f2fcdac1b1e13751afb74b0f81c9993699954ee2f0f459dd0a0da11",
  "signingDigestHex": "0x7cfef332628f699c2aac858c5566a5bab8c7c43407038a5a76561df5c33f1eba"
}
 ~/Desktop/iota   dev-tools/keytool-tx-digest ±  iota keytool tx-digest AAACAAgAypo7AAAAAAAgERERERUE6TUOY11lzTjM0sApQ0xqOkgNiUepumoVshUCAgABAQAAAQEDAAAAAAEBABEREREVBOk1DmNdZc04zNLAKUNMajpIDYlHqbpqFbIVAU4PMbTXGjSXQkjCr1LNtHK9EpH/1O8JRuHyWt6uUtBZP247KQAAAAAgFOO+ZFsHJj7S4YIF5O9JdCdReidVJ0ky484jB8YJn/gRERERFQTpNQ5jXWXNOMzSwClDTGo6SA2JR6m6ahWyFegDAAAAAAAA4G88AAAAAAAA
╭──────────────────┬──────────────────────────────────────────────────────────────────────╮
│ digest           │  Fv6odr6tuuVmpDw5tyheRBQ2oivAnmudLtKBDv4T4MPE                        │
│ digestHex        │  0xdd9df6678f2fcdac1b1e13751afb74b0f81c9993699954ee2f0f459dd0a0da11  │
│ signingDigestHex │  0x7cfef332628f699c2aac858c5566a5bab8c7c43407038a5a76561df5c33f1eba  │
╰──────────────────┴──────────────────────────────────────────────────────────────────────╯
 ~/Desktop/iota   dev-tools/keytool-tx-digest ±  iota keytool tx-digest AAACAAgAypo7AAAAAAAgERERERUE6TUOY11lzTjM0sApQ0xqOkgNiUepumoVshUCAgABAQAAAQEDAAAAAAEBABEREREVBOk1DmNdZc04zNLAKUNMajpIDYlHqbpqFbIVAU4PMbTXGjSXQkjCr1LNtHK9EpH/1O8JRuHyWt6uUtBZP247KQAAAAAgFOO+ZFsHJj7S4YIF5O9JdCdReidVJ0ky484jB8YJn/gRERERFQTpNQ5jXWXNOMzSwClDTGo6SA2JR6m6ahWyFegDAAAAAAAA4G88AAAAAAAA --json
{
  "digest": "Fv6odr6tuuVmpDw5tyheRBQ2oivAnmudLtKBDv4T4MPE",
  "digestHex": "0xdd9df6678f2fcdac1b1e13751afb74b0f81c9993699954ee2f0f459dd0a0da11",
  "signingDigestHex": "0x7cfef332628f699c2aac858c5566a5bab8c7c43407038a5a76561df5c33f1eba"
```

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/9820

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Add `iota keytool tx-digest` command to compute a digest for base64 encoded transaction bytes
- [ ] Rust SDK:
- [ ] REST API:
