### PR TITLE
upstream(core): Delay delete of deferred transactions until end of commit handler

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1869,23 +1869,24 @@ impl AuthorityPerEpochStore {
         Vec<DeferralKey>,
         Vec<(DeferralKey, Vec<DeferredTransaction>)>,
     ) {
-        let mut keys = Vec::new();
-        let mut txns = Vec::new();
-        let mut deferred_transactions = self.consensus_output_cache.deferred_transactions_v2.lock();
+        let (keys, txns) = {
+            let mut keys = Vec::new();
+            let mut txns = Vec::new();
 
-        for (key, transactions) in deferred_transactions.range(min..max) {
-            debug!(
-                "Loaded {:?} deferred txn with deferral key {:?}",
-                transactions.len(),
-                key
-            );
-            keys.push(*key);
-            txns.push((*key, transactions.clone()));
-        }
+            let deferred_transactions = self.consensus_output_cache.deferred_transactions_v2.lock();
 
-        for key in &keys {
-            deferred_transactions.remove(key);
-        }
+            for (key, transactions) in deferred_transactions.range(min..max) {
+                debug!(
+                    "Loaded {:?} deferred txn with deferral key {:?}",
+                    transactions.len(),
+                    key
+                );
+                keys.push(*key);
+                txns.push((*key, transactions.clone()));
+            }
+
+            (keys, txns)
+        };
 
         (keys, txns)
     }
@@ -1898,29 +1899,30 @@ impl AuthorityPerEpochStore {
         Vec<DeferralKey>,
         Vec<(DeferralKey, Vec<DeferredTransaction>)>,
     ) {
-        let mut keys = Vec::new();
-        let mut txns = Vec::new();
-        let mut deferred_transactions = self.consensus_output_cache.deferred_transactions.lock();
+        let (keys, txns) = {
+            let mut keys = Vec::new();
+            let mut txns = Vec::new();
 
-        for (key, transactions) in deferred_transactions.range(min..max) {
-            debug!(
-                "Loaded {:?} deferred txn with deferral key {:?}",
-                transactions.len(),
-                key
-            );
-            keys.push(*key);
-            txns.push((
-                *key,
-                transactions
-                    .iter()
-                    .map(|tx| DeferredTransaction::new(tx.clone(), None))
-                    .collect(),
-            ));
-        }
+            let deferred_transactions = self.consensus_output_cache.deferred_transactions.lock();
 
-        for key in &keys {
-            deferred_transactions.remove(key);
-        }
+            for (key, transactions) in deferred_transactions.range(min..max) {
+                debug!(
+                    "Loaded {:?} deferred txn with deferral key {:?}",
+                    transactions.len(),
+                    key
+                );
+                keys.push(*key);
+                txns.push((
+                    *key,
+                    transactions
+                        .iter()
+                        .map(|tx| DeferredTransaction::new(tx.clone(), None))
+                        .collect(),
+                ));
+            }
+
+            (keys, txns)
+        };
 
         (keys, txns)
     }
@@ -3100,6 +3102,25 @@ impl AuthorityPerEpochStore {
                     },
                 });
                 self.write_pending_checkpoint(&mut output, &pending_checkpoint)?;
+            }
+        }
+
+        {
+            if self
+                .protocol_config
+                .congestion_control_gas_price_feedback_mechanism()
+            {
+                let mut deferred_transactions =
+                    self.consensus_output_cache.deferred_transactions_v2.lock();
+                for deleted_deferred_key in output.get_deleted_deferred_txn_keys() {
+                    deferred_transactions.remove(&deleted_deferred_key);
+                }
+            } else {
+                let mut deferred_transactions =
+                    self.consensus_output_cache.deferred_transactions.lock();
+                for deleted_deferred_key in output.get_deleted_deferred_txn_keys() {
+                    deferred_transactions.remove(&deleted_deferred_key);
+                }
             }
         }
 

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -87,6 +87,10 @@ impl ConsensusCommitOutput {
         }
     }
 
+    pub fn get_deleted_deferred_txn_keys(&self) -> impl Iterator<Item = DeferralKey> + use<'_> {
+        self.deleted_deferred_txns.iter().cloned()
+    }
+
     fn get_randomness_last_round_timestamp(&self) -> Option<TimestampMs> {
         self.next_randomness_round.as_ref().map(|(_, ts)| *ts)
     }


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.44.3, v1.45.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/5828f401068efe0843562c8a3574e65ad3eacd35
- Description:

This fixes a bug in how we handle the end of epoch pre- and post- data quarantining.

In the old code, we check if there were any deferred txns loaded in the current commit with this code:
https://github.com/iotaledger/iota/blob/88ddf7c92329762690548a22929b2ef7c9e674cd/crates/iota-core/src/authority/authority_per_epoch_store.rs#L2008

Because this looks at the table, it does not reflect that the fact that we may have already scheduled deletes from the table.

In the new code, we look at the in-memory map https://github.com/iotaledger/iota/blob/32017bc15373bfa4d1a7b872da21b3abb8563875/crates/iota-core/src/authority/authority_per_epoch_store.rs#L2126
- keys are removed from this map immediately upon loading them at
https://github.com/iotaledger/iota/blob/32017bc15373bfa4d1a7b872da21b3abb8563875/crates/iota-core/src/authority/authority_per_epoch_store.rs#L3115

This in turn can cause us to improperly skip drop randomness transactions at the end of the epoch here:
https://github.com/iotaledger/iota/blob/32017bc15373bfa4d1a7b872da21b3abb8563875/crates/iota-core/src/authority/authority_per_epoch_store.rs#L3702

## Links to any relevant issues

None

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

