### PR TITLE
upstream(core): Fix passing the protocol config override

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -919,6 +919,10 @@ impl AuthorityPerEpochStore {
                 "cannot override chain on production networks!"
             );
         }
+        info!(
+            "initializing epoch store from chain id {chain_from_id:?} to chain id {:?}",
+            chain.1
+        );
 
         let protocol_config = ProtocolConfig::get_for_version(protocol_version, chain.1);
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -582,10 +582,9 @@ impl IotaNode {
             )))
         };
 
-        let chain_id = ChainIdentifier::from(*genesis.checkpoint().digest());
         let chain = match config.chain_override_for_testing {
             Some(chain) => chain,
-            None => ChainIdentifier::from(*genesis.checkpoint().digest()).chain(),
+            None => chain_identifier.chain(),
         };
 
         let epoch_options = default_db_options().optimize_db_for_write_throughput(4);
@@ -601,7 +600,7 @@ impl IotaNode {
             cache_metrics,
             signature_verifier_metrics,
             &config.expensive_safety_check_config,
-            (chain_id, chain),
+            (chain_identifier, chain),
             checkpoint_store
                 .get_highest_executed_checkpoint_seq_number()
                 .expect("checkpoint store read cannot fail")


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.45.3, v1.46.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/fae1c41a1a58bcf8fe64bf07ce25b6f95fcabc80

Comment: we cleaned up the init of the `chain_identifier` because that hash was calculated several times in different places.

## Links to any relevant issues

Part of #9768

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

