### PR TITLE
feat: Improve `select_gas` performance

### DIFF
--- a/crates/iota-indexer/src/apis/indexer_api.rs
+++ b/crates/iota-indexer/src/apis/indexer_api.rs
@@ -64,9 +64,10 @@ impl IndexerApi {
 
         let mut object_futures = vec![];
         for object in objects {
-            object_futures.push(tokio::task::spawn(
-                object.try_into_object_read(self.inner.package_resolver()),
-            ));
+            let package_resolver = self.inner.package_resolver().clone();
+            object_futures.push(tokio::task::spawn(async move {
+                object.try_into_object_read(&package_resolver).await
+            }));
         }
         let mut objects = futures::future::try_join_all(object_futures)
             .await
@@ -125,7 +126,7 @@ impl IndexerApi {
             ObjectRead::NotExists(_) | ObjectRead::Deleted(_) => {}
             ObjectRead::Exists(object_ref, o, layout) => {
                 return Ok(IotaObjectResponse::new_with_data(
-                    IotaObjectData::new(object_ref, o, layout, options, None)
+                    IotaObjectData::new(object_ref, o, layout, &options, None)
                         .map_err(internal_error)?,
                 ));
             }
@@ -150,7 +151,7 @@ impl IndexerApi {
             ObjectRead::NotExists(_) | ObjectRead::Deleted(_) => {}
             ObjectRead::Exists(object_ref, o, layout) => {
                 return Ok(IotaObjectResponse::new_with_data(
-                    IotaObjectData::new(object_ref, o, layout, options, None)
+                    IotaObjectData::new(object_ref, o, layout, &options, None)
                         .map_err(internal_error)?,
                 ));
             }
@@ -175,10 +176,10 @@ async fn construct_object_response(
             if options.show_display {
                 match reader.get_display_fields(&o, &layout).await {
                     Ok(rendered_fields) => Ok(IotaObjectResponse::new_with_data(
-                        IotaObjectData::new(object_ref, o, layout, options, rendered_fields)?,
+                        IotaObjectData::new(object_ref, o, layout, &options, rendered_fields)?,
                     )),
                     Err(e) => Ok(IotaObjectResponse::new(
-                        Some(IotaObjectData::new(object_ref, o, layout, options, None)?),
+                        Some(IotaObjectData::new(object_ref, o, layout, &options, None)?),
                         Some(IotaObjectResponseError::Display {
                             error: e.to_string(),
                         }),
@@ -186,7 +187,7 @@ async fn construct_object_response(
                 }
             } else {
                 Ok(IotaObjectResponse::new_with_data(IotaObjectData::new(
-                    object_ref, o, layout, options, None,
+                    object_ref, o, layout, &options, None,
                 )?))
             }
         }

--- a/crates/iota-indexer/src/apis/read_api.rs
+++ b/crates/iota-indexer/src/apis/read_api.rs
@@ -78,7 +78,7 @@ impl ReadApi {
                         Err(e) => {
                             return Ok(IotaObjectResponse::new(
                                 Some(
-                                    IotaObjectData::new(object_ref, o, layout, options, None)
+                                    IotaObjectData::new(object_ref, o, layout, &options, None)
                                         .map_err(internal_error)?,
                                 ),
                                 Some(IotaObjectResponseError::Display {
@@ -89,7 +89,7 @@ impl ReadApi {
                     }
                 }
                 Ok(IotaObjectResponse::new_with_data(
-                    IotaObjectData::new(object_ref, o, layout, options, display_fields)
+                    IotaObjectData::new(object_ref, o, layout, &options, display_fields)
                         .map_err(internal_error)?,
                 ))
             }
@@ -131,7 +131,7 @@ impl ReadApi {
                 };
 
                 Ok(IotaPastObjectResponse::VersionFound(
-                    IotaObjectData::new(object_ref, object, layout, options, display_fields)
+                    IotaObjectData::new(object_ref, object, layout, &options, display_fields)
                         .map_err(internal_error)?,
                 ))
             }
@@ -207,7 +207,6 @@ impl ReadApiServer for ReadApi {
         // Create a future for each requested object id
         let futures = object_ids.into_iter().map(|object_id| {
             let options = options.clone();
-            let resolver = resolver.clone();
             let maybe_stored = object_map.get(&object_id).cloned();
             async move {
                 match maybe_stored {

--- a/crates/iota-indexer/src/historical_fallback/convert.rs
+++ b/crates/iota-indexer/src/historical_fallback/convert.rs
@@ -90,7 +90,7 @@ impl HistoricalFallbackEvents {
     /// [`IotaEvent`]s.
     pub(crate) async fn into_iota_events(
         self,
-        package_resolver: Arc<Resolver<impl PackageStore>>,
+        package_resolver: &Arc<Resolver<impl PackageStore>>,
         tx_digest: TransactionDigest,
     ) -> IndexerResult<Vec<IotaEvent>> {
         tx_events_to_iota_tx_events(

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -282,7 +282,7 @@ impl HistoricalFallbackReader {
         };
 
         HistoricalFallbackEvents::new(events, summary)
-            .into_iota_events(self.package_resolver.clone(), tx_digest)
+            .into_iota_events(&self.package_resolver, tx_digest)
             .await
     }
 

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -184,7 +184,7 @@ impl Indexer {
             let historic_fallback_reader = HistoricalFallbackReader::new(
                 url.as_str(),
                 fallback_kv_cache_size,
-                read.package_resolver(),
+                read.package_resolver().clone(),
                 fallback_kv_multi_fetch_batch_size,
                 fallback_kv_concurrent_fetches,
                 registry,

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -2,8 +2,6 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
 use diesel::prelude::*;
 use iota_json_rpc::coin_api::parse_to_struct_tag;
 use iota_json_rpc_types::{Balance, Coin as IotaCoin};
@@ -163,7 +161,7 @@ pub struct StoredHistoryObject {
 impl StoredHistoryObject {
     pub async fn try_into_past_object_read(
         self,
-        package_resolver: Arc<Resolver<impl PackageStore>>,
+        package_resolver: &Resolver<impl PackageStore>,
     ) -> Result<PastObjectRead, IndexerError> {
         let object_status = ObjectStatus::try_from(self.object_status).map_err(|_| {
             IndexerError::PersistentStorageDataCorruption(format!(
@@ -380,7 +378,7 @@ impl TryFrom<StoredObject> for Object {
 impl StoredObject {
     pub async fn try_into_object_read(
         self,
-        package_resolver: Arc<Resolver<impl PackageStore>>,
+        package_resolver: &Resolver<impl PackageStore>,
     ) -> Result<ObjectRead, IndexerError> {
         let oref = self.get_object_ref()?;
         let object: iota_types::object::Object = self.try_into()?;

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -323,7 +323,7 @@ impl StoredTransaction {
     pub async fn try_into_iota_transaction_block_response(
         self,
         options: IotaTransactionBlockResponseOptions,
-        package_resolver: Arc<Resolver<impl PackageStore>>,
+        package_resolver: &Arc<Resolver<impl PackageStore>>,
     ) -> IndexerResult<IotaTransactionBlockResponse> {
         let options = options.clone();
         let tx_digest =
@@ -345,7 +345,7 @@ impl StoredTransaction {
             let sender_signed_data = self.try_into_sender_signed_data()?;
             let tx_block = IotaTransactionBlock::try_from_with_package_resolver(
                 sender_signed_data,
-                package_resolver.clone(),
+                package_resolver,
                 tx_digest,
             )
             .await?;
@@ -508,7 +508,7 @@ pub fn stored_events_to_events(
 
 pub async fn tx_events_to_iota_tx_events(
     tx_events: TransactionEvents,
-    package_resolver: Arc<Resolver<impl PackageStore>>,
+    package_resolver: &Arc<Resolver<impl PackageStore>>,
     tx_digest: TransactionDigest,
     timestamp: Option<u64>,
 ) -> Result<IotaTransactionBlockEvents, IndexerError> {

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -34,7 +34,7 @@ use iota_transaction_builder::DataReader;
 use iota_types::{
     TypeTag,
     balance::Supply,
-    base_types::{IotaAddress, ObjectID, ObjectInfo, SequenceNumber, VersionNumber},
+    base_types::{IotaAddress, ObjectID, SequenceNumber, VersionNumber},
     coin::{CoinMetadata, TreasuryCap},
     coin_manager::CoinManager,
     committee::EpochId,
@@ -249,9 +249,7 @@ impl IndexerReader {
             .await?;
 
         if let Some(object) = stored_object {
-            object
-                .try_into_object_read(self.package_resolver.clone())
-                .await
+            object.try_into_object_read(&self.package_resolver).await
         } else {
             Ok(ObjectRead::NotExists(object_id))
         }
@@ -321,10 +319,7 @@ impl IndexerReader {
             .await?;
 
         match history_object {
-            Some(obj) => {
-                obj.try_into_past_object_read(self.package_resolver.clone())
-                    .await
-            }
+            Some(obj) => obj.try_into_past_object_read(&self.package_resolver).await,
             None => Err(IndexerError::DataPruned(format!(
                 "Object version {} not found in objects_history for object {object_id}",
                 object_version_info.object_version
@@ -379,10 +374,7 @@ impl IndexerReader {
         // The key difference is that `try_into_past_object_read` also handles
         // the `WrappedOrDeleted` status, which for this iteration, we handle explicitly
         // as a `VersionNotFound`.
-        match obj
-            .try_into_object_read(self.package_resolver.clone())
-            .await?
-        {
+        match obj.try_into_object_read(&self.package_resolver).await? {
             ObjectRead::NotExists(_) | ObjectRead::Deleted(_) => {
                 Ok(PastObjectRead::VersionNotFound(object_id, object_version))
             }
@@ -876,14 +868,13 @@ impl IndexerReader {
     ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
         let mut tx_block_responses_futures = vec![];
         for stored_tx in stored_txes {
-            let package_resolver_clone = self.package_resolver();
             let options_clone = options.clone();
-            tx_block_responses_futures.push(tokio::task::spawn(
-                stored_tx.try_into_iota_transaction_block_response(
-                    options_clone,
-                    package_resolver_clone,
-                ),
-            ));
+            let package_resolver = self.package_resolver.clone();
+            tx_block_responses_futures.push(tokio::task::spawn(async move {
+                stored_tx
+                    .try_into_iota_transaction_block_response(options_clone, &package_resolver)
+                    .await
+            }));
         }
 
         let tx_blocks = futures::future::join_all(tx_block_responses_futures)
@@ -2315,8 +2306,8 @@ impl IndexerReader {
         ))
     }
 
-    pub fn package_resolver(&self) -> PackageResolver {
-        self.package_resolver.clone()
+    pub fn package_resolver(&self) -> &PackageResolver {
+        &self.package_resolver
     }
 
     pub async fn pending_active_validators(
@@ -2367,25 +2358,44 @@ impl DataReader for IndexerReader {
         &self,
         address: IotaAddress,
         object_type: StructTag,
-    ) -> Result<Vec<ObjectInfo>, anyhow::Error> {
-        let stored_objects = self
+        cursor: Option<ObjectID>,
+        limit: Option<usize>,
+        options: IotaObjectDataOptions,
+    ) -> Result<iota_json_rpc_types::ObjectsPage, anyhow::Error> {
+        let limit = limit.unwrap_or(50);
+        let mut stored_objects = self
             .get_owned_objects_in_blocking_task(
                 address,
                 Some(IotaObjectDataFilter::StructType(object_type)),
-                None,
-                50, // Limit the number of objects returned to 50
+                cursor,
+                limit + 1,
             )
             .await?;
 
-        stored_objects
-            .into_iter()
-            .map(|object| {
-                let object = Object::try_from(object)?;
-                let object_ref = object.compute_object_reference();
-                let info = ObjectInfo::new(&object_ref, &object);
-                Ok(info)
-            })
-            .collect::<Result<Vec<_>, _>>()
+        let mut res = Vec::new();
+
+        let next_cursor = if stored_objects.len() > limit {
+            // Here the cursor is the last object id in the previous page
+            stored_objects.pop().unwrap();
+            Some(stored_objects[limit - 1].get_object_ref()?.0)
+        } else {
+            None
+        };
+
+        for stored_object in stored_objects {
+            let read = stored_object
+                .try_into_object_read(&self.package_resolver)
+                .await?;
+            res.push(IotaObjectResponse::try_from_object_read_and_options(
+                read, &options,
+            )?);
+        }
+
+        Ok(iota_json_rpc_types::ObjectsPage {
+            data: res,
+            next_cursor,
+            has_next_page: next_cursor.is_some(),
+        })
     }
 
     async fn get_object_with_options(
@@ -2394,7 +2404,9 @@ impl DataReader for IndexerReader {
         options: IotaObjectDataOptions,
     ) -> Result<IotaObjectResponse, anyhow::Error> {
         let result = self.get_object_read_in_blocking_task(object_id).await?;
-        Ok((result, options).try_into()?)
+        Ok(IotaObjectResponse::try_from_object_read_and_options(
+            result, &options,
+        )?)
     }
 
     async fn get_reference_gas_price(&self) -> Result<u64, anyhow::Error> {

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -2374,13 +2374,16 @@ impl DataReader for IndexerReader {
 
         let mut res = Vec::new();
 
-        let next_cursor = if stored_objects.len() > limit {
+        let mut next_cursor = None;
+        if stored_objects.len() > limit {
             // Here the cursor is the last object id in the previous page
             stored_objects.pop().unwrap();
-            Some(stored_objects[limit - 1].get_object_ref()?.0)
-        } else {
-            None
-        };
+            next_cursor = Some(if let Some(last_object) = stored_objects.last() {
+                last_object.get_object_ref()?.0
+            } else {
+                ObjectID::ZERO
+            });
+        }
 
         for stored_object in stored_objects {
             let read = stored_object

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -2375,7 +2375,7 @@ impl DataReader for IndexerReader {
         let mut res = Vec::new();
 
         let mut next_cursor = None;
-        if stored_objects.len() > limit {
+        if stored_objects.len() > limit && limit > 0 {
             // Here the cursor is the last object id in the previous page
             stored_objects.pop().unwrap();
             next_cursor = Some(if let Some(last_object) = stored_objects.last() {

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -1948,7 +1948,7 @@ async fn failed_stored_tx_into_transaction_block() {
         failed_tx
             .try_into_iota_transaction_block_response(
                 IotaTransactionBlockResponseOptions::full_content(),
-                package_resolver
+                &package_resolver
             )
             .await
             .is_ok()

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -1953,6 +1953,10 @@ async fn failed_stored_tx_into_transaction_block() {
             .await
             .is_ok()
     );
+    // We have to drop the package resolver before dropping the test db because it
+    // holds a reference to the db pool and the active connection will prevent the
+    // db from being dropped.
+    drop(package_resolver);
     test_db.drop_if_exists();
 }
 

--- a/crates/iota-json-rpc-types/src/iota_object.rs
+++ b/crates/iota-json-rpc-types/src/iota_object.rs
@@ -67,6 +67,27 @@ impl IotaObjectResponse {
             error: Some(error),
         }
     }
+
+    pub fn try_from_object_read_and_options(
+        object_read: ObjectRead,
+        options: &IotaObjectDataOptions,
+    ) -> anyhow::Result<Self> {
+        match object_read {
+            ObjectRead::NotExists(id) => Ok(IotaObjectResponse::new_with_error(
+                IotaObjectResponseError::NotExists { object_id: id },
+            )),
+            ObjectRead::Exists(object_ref, o, layout) => Ok(IotaObjectResponse::new_with_data(
+                IotaObjectData::new(object_ref, o, layout, options, None)?,
+            )),
+            ObjectRead::Deleted((object_id, version, digest)) => Ok(
+                IotaObjectResponse::new_with_error(IotaObjectResponseError::Deleted {
+                    object_id,
+                    version,
+                    digest,
+                }),
+            ),
+        }
+    }
 }
 
 impl Ord for IotaObjectResponse {
@@ -226,7 +247,7 @@ impl IotaObjectData {
         object_ref: ObjectRef,
         obj: Object,
         layout: impl Into<Option<MoveStructLayout>>,
-        options: IotaObjectDataOptions,
+        options: &IotaObjectDataOptions,
         display_fields: impl Into<Option<DisplayFieldsResponse>>,
     ) -> anyhow::Result<Self> {
         let layout = layout.into();
@@ -243,13 +264,13 @@ impl IotaObjectData {
         } = options;
 
         let (object_id, version, digest) = object_ref;
-        let type_ = if show_type {
+        let type_ = if *show_type {
             Some(Into::<ObjectType>::into(&obj))
         } else {
             None
         };
 
-        let bcs: Option<IotaRawData> = if show_bcs {
+        let bcs: Option<IotaRawData> = if *show_bcs {
             let data = match obj.data.clone() {
                 Data::Move(m) => {
                     let layout = layout.clone().ok_or_else(|| {
@@ -267,7 +288,7 @@ impl IotaObjectData {
 
         let obj = obj.into_inner();
 
-        let content: Option<IotaParsedData> = if show_content {
+        let content: Option<IotaParsedData> = if *show_content {
             let data = match obj.data {
                 Data::Move(m) => {
                     let layout = layout.ok_or_else(|| {
@@ -287,13 +308,13 @@ impl IotaObjectData {
             version,
             digest,
             type_,
-            owner: if show_owner { Some(obj.owner) } else { None },
-            storage_rebate: if show_storage_rebate {
+            owner: if *show_owner { Some(obj.owner) } else { None },
+            storage_rebate: if *show_storage_rebate {
                 Some(obj.storage_rebate)
             } else {
                 None
             },
-            previous_transaction: if show_previous_transaction {
+            previous_transaction: if *show_previous_transaction {
                 Some(obj.previous_transaction)
             } else {
                 None
@@ -504,21 +525,7 @@ impl TryFrom<(ObjectRead, IotaObjectDataOptions)> for IotaObjectResponse {
     fn try_from(
         (object_read, options): (ObjectRead, IotaObjectDataOptions),
     ) -> Result<Self, Self::Error> {
-        match object_read {
-            ObjectRead::NotExists(id) => Ok(IotaObjectResponse::new_with_error(
-                IotaObjectResponseError::NotExists { object_id: id },
-            )),
-            ObjectRead::Exists(object_ref, o, layout) => Ok(IotaObjectResponse::new_with_data(
-                IotaObjectData::new(object_ref, o, layout, options, None)?,
-            )),
-            ObjectRead::Deleted((object_id, version, digest)) => Ok(
-                IotaObjectResponse::new_with_error(IotaObjectResponseError::Deleted {
-                    object_id,
-                    version,
-                    digest,
-                }),
-            ),
-        }
+        Self::try_from_object_read_and_options(object_read, &options)
     }
 }
 

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2,10 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    fmt::{self, Display, Formatter, Write},
-    sync::Arc,
-};
+use std::fmt::{self, Display, Formatter, Write};
 
 use enum_dispatch::enum_dispatch;
 use fastcrypto::encoding::Base64;
@@ -575,7 +572,7 @@ impl IotaTransactionBlockKind {
 
     async fn try_from_with_package_resolver(
         tx: TransactionKind,
-        package_resolver: Arc<Resolver<impl PackageStore>>,
+        package_resolver: &Resolver<impl PackageStore>,
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {
         Ok(match tx {
@@ -1619,7 +1616,7 @@ impl IotaTransactionBlockData {
 
     pub async fn try_from_with_package_resolver(
         data: TransactionData,
-        package_resolver: Arc<Resolver<impl PackageStore>>,
+        package_resolver: &Resolver<impl PackageStore>,
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {
         let message_version = data.message_version();
@@ -1681,7 +1678,7 @@ impl IotaTransactionBlock {
     // IotaTransactionBlockData etc.
     pub async fn try_from_with_package_resolver(
         data: SenderSignedData,
-        package_resolver: Arc<Resolver<impl PackageStore>>,
+        package_resolver: &Resolver<impl PackageStore>,
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {
         Ok(Self {
@@ -1907,7 +1904,7 @@ impl IotaProgrammableTransactionBlock {
 
     async fn try_from_with_package_resolver(
         value: ProgrammableTransaction,
-        package_resolver: Arc<Resolver<impl PackageStore>>,
+        package_resolver: &Resolver<impl PackageStore>,
     ) -> Result<Self, anyhow::Error> {
         // If the pure input layouts cannot be built, we will use `None` for the input
         // types.

--- a/crates/iota-json-rpc/src/indexer_api.rs
+++ b/crates/iota-json-rpc/src/indexer_api.rs
@@ -217,9 +217,14 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
 
             // objects here are of size (limit + 1), where the last one is the cursor for
             // the next page
-            let has_next_page = objects.len() > limit;
+            let has_next_page = objects.len() > limit && limit > 0;
             objects.truncate(limit);
-            let next_cursor = (has_next_page).then_some(objects.last().unwrap().object_id);
+            let next_cursor = (has_next_page).then_some(
+                objects
+                    .last()
+                    .map(|obj| obj.object_id)
+                    .unwrap_or(ObjectID::ZERO),
+            );
 
             let data = match options.is_not_in_object_info() {
                 true => {

--- a/crates/iota-json-rpc/src/indexer_api.rs
+++ b/crates/iota-json-rpc/src/indexer_api.rs
@@ -219,10 +219,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
             // the next page
             let has_next_page = objects.len() > limit;
             objects.truncate(limit);
-            let next_cursor = objects
-                .last()
-                .cloned()
-                .map_or(cursor, |o_info| Some(o_info.object_id));
+            let next_cursor = (has_next_page).then_some(objects.last().unwrap().object_id);
 
             let data = match options.is_not_in_object_info() {
                 true => {

--- a/crates/iota-json-rpc/src/read_api.rs
+++ b/crates/iota-json-rpc/src/read_api.rs
@@ -510,7 +510,7 @@ impl ReadApiServer for ReadApi {
                             Err(e) => {
                                 return Ok(IotaObjectResponse::new(
                                     Some(IotaObjectData::new(
-                                        object_ref, o, layout, options, None,
+                                        object_ref, o, layout, &options, None,
                                     )?),
                                     Some(IotaObjectResponseError::Display {
                                         error: e.to_string(),
@@ -523,7 +523,7 @@ impl ReadApiServer for ReadApi {
                         object_ref,
                         o,
                         layout,
-                        options,
+                        &options,
                         display_fields,
                     )?))
                 }
@@ -625,7 +625,7 @@ impl ReadApiServer for ReadApi {
                         None
                     };
                     Ok(IotaPastObjectResponse::VersionFound(
-                        IotaObjectData::new(object_ref, o, layout, options, display_fields)?,
+                        IotaObjectData::new(object_ref, o, layout, &options, display_fields)?,
                     ))
                 }
                 PastObjectRead::ObjectDeleted(oref) => {

--- a/crates/iota-json-rpc/src/transaction_builder_api.rs
+++ b/crates/iota-json-rpc/src/transaction_builder_api.rs
@@ -17,7 +17,7 @@ use iota_json_rpc_types::{
 use iota_open_rpc::Module;
 use iota_transaction_builder::{DataReader, TransactionBuilder};
 use iota_types::{
-    base_types::{IotaAddress, ObjectID, ObjectInfo},
+    base_types::{IotaAddress, ObjectID},
     iota_serde::BigInt,
 };
 use jsonrpsee::{RpcModule, core::RpcResult};
@@ -52,15 +52,38 @@ impl DataReader for AuthorityStateDataReader {
         &self,
         address: IotaAddress,
         object_type: StructTag,
-    ) -> Result<Vec<ObjectInfo>, anyhow::Error> {
-        Ok(self
+        cursor: Option<ObjectID>,
+        limit: Option<usize>,
+        options: IotaObjectDataOptions,
+    ) -> Result<iota_json_rpc_types::ObjectsPage, anyhow::Error> {
+        let limit = limit.unwrap_or(50);
+        let mut result = self
             .0
-            // DataReader is used internally, don't need a limit
-            .get_owner_objects(
+            .get_owner_objects_with_limit(
                 address,
-                None,
+                cursor,
+                limit + 1,
                 Some(IotaObjectDataFilter::StructType(object_type)),
-            )?)
+            )?
+            .into_iter()
+            .map(|info| {
+                let read = self.0.get_object_read(&info.object_id)?;
+                IotaObjectResponse::try_from_object_read_and_options(read, &options)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let next_cursor = if result.len() > limit {
+            // Here the cursor is the first object id of the next page
+            result.pop().unwrap().object_id().ok()
+        } else {
+            None
+        };
+
+        Ok(iota_json_rpc_types::ObjectsPage {
+            data: result,
+            next_cursor,
+            has_next_page: next_cursor.is_some(),
+        })
     }
 
     async fn get_object_with_options(
@@ -69,7 +92,7 @@ impl DataReader for AuthorityStateDataReader {
         options: IotaObjectDataOptions,
     ) -> Result<IotaObjectResponse, anyhow::Error> {
         let result = self.0.get_object_read(&object_id)?;
-        Ok((result, options).try_into()?)
+        IotaObjectResponse::try_from_object_read_and_options(result, &options)
     }
 
     async fn get_reference_gas_price(&self) -> Result<u64, anyhow::Error> {

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -97,7 +97,7 @@ use std::{
 
 use async_trait::async_trait;
 use base64::Engine;
-use futures::{StreamExt, TryStreamExt};
+use futures::TryStreamExt;
 pub use iota_json as json;
 use iota_json_rpc_api::{
     CLIENT_SDK_TYPE_HEADER, CLIENT_SDK_VERSION_HEADER, CLIENT_TARGET_API_VERSION_HEADER,
@@ -108,7 +108,7 @@ use iota_json_rpc_types::{
 };
 use iota_transaction_builder::{DataReader, TransactionBuilder};
 pub use iota_types as types;
-use iota_types::base_types::{IotaAddress, ObjectID, ObjectInfo};
+use iota_types::base_types::{IotaAddress, ObjectID};
 use jsonrpsee::{
     core::client::ClientT,
     http_client::{HeaderMap, HeaderValue, HttpClient, HttpClientBuilder},
@@ -635,26 +635,18 @@ impl DataReader for ReadApi {
         &self,
         address: IotaAddress,
         object_type: StructTag,
-    ) -> Result<Vec<ObjectInfo>, anyhow::Error> {
+        cursor: Option<ObjectID>,
+        limit: Option<usize>,
+        options: IotaObjectDataOptions,
+    ) -> Result<iota_json_rpc_types::ObjectsPage, anyhow::Error> {
         let query = Some(IotaObjectResponseQuery {
             filter: Some(IotaObjectDataFilter::StructType(object_type)),
-            options: Some(
-                IotaObjectDataOptions::new()
-                    .with_previous_transaction()
-                    .with_type()
-                    .with_owner(),
-            ),
+            options: Some(options),
         });
 
-        let result = PagedFn::stream(async |cursor| {
-            self.get_owned_objects(address, query.clone(), cursor, None)
-                .await
-        })
-        .map(|v| v?.try_into())
-        .try_collect::<Vec<_>>()
-        .await?;
-
-        Ok(result)
+        Ok(self
+            .get_owned_objects(address, query, cursor, limit)
+            .await?)
     }
 
     async fn get_object_with_options(
@@ -766,6 +758,7 @@ where
 
 #[cfg(test)]
 mod test {
+    use futures::StreamExt;
     use iota_json_rpc_types::Page;
 
     use super::*;

--- a/crates/iota-transaction-builder/src/lib.rs
+++ b/crates/iota-transaction-builder/src/lib.rs
@@ -16,7 +16,7 @@ use iota_json_rpc_types::{
 };
 use iota_types::{
     IOTA_FRAMEWORK_PACKAGE_ID,
-    base_types::{IotaAddress, ObjectID, ObjectInfo},
+    base_types::{IotaAddress, ObjectID},
     coin,
     error::UserInputError,
     fp_ensure,
@@ -32,7 +32,10 @@ pub trait DataReader {
         &self,
         address: IotaAddress,
         object_type: StructTag,
-    ) -> Result<Vec<ObjectInfo>, anyhow::Error>;
+        cursor: Option<ObjectID>,
+        limit: Option<usize>,
+        options: IotaObjectDataOptions,
+    ) -> Result<iota_json_rpc_types::ObjectsPage, anyhow::Error>;
 
     async fn get_object_with_options(
         &self,

--- a/crates/iota-transaction-builder/src/utils.rs
+++ b/crates/iota-transaction-builder/src/utils.rs
@@ -47,26 +47,39 @@ impl TransactionBuilder {
         if let Some(gas) = input_gas.into() {
             self.get_object_ref(gas).await
         } else {
-            let gas_objs = self.0.get_owned_objects(signer, GasCoin::type_()).await?;
-
-            for obj in gas_objs {
-                let response = self
+            let mut cursor = None;
+            // Paginate through all gas coins owned by the signer
+            loop {
+                let page = self
                     .0
-                    .get_object_with_options(obj.object_id, IotaObjectDataOptions::new().with_bcs())
+                    .get_owned_objects(
+                        signer,
+                        GasCoin::type_(),
+                        cursor,
+                        None,
+                        IotaObjectDataOptions::new().with_bcs(),
+                    )
                     .await?;
-                let obj = response.object()?;
-                let gas: GasCoin = bcs::from_bytes(
-                    &obj.bcs
-                        .as_ref()
-                        .ok_or_else(|| anyhow!("bcs field is unexpectedly empty"))?
-                        .try_as_move()
-                        .ok_or_else(|| anyhow!("Cannot parse move object to gas object"))?
-                        .bcs_bytes,
-                )?;
-                if !input_objects.contains(&obj.object_id) && gas.value() >= gas_budget {
-                    return Ok(obj.object_ref());
+                for response in &page.data {
+                    let obj = response.object()?;
+                    let gas: GasCoin = bcs::from_bytes(
+                        &obj.bcs
+                            .as_ref()
+                            .ok_or_else(|| anyhow!("bcs field is unexpectedly empty"))?
+                            .try_as_move()
+                            .ok_or_else(|| anyhow!("Cannot parse move object to gas object"))?
+                            .bcs_bytes,
+                    )?;
+                    if !input_objects.contains(&obj.object_id) && gas.value() >= gas_budget {
+                        return Ok(obj.object_ref());
+                    }
                 }
+                if page.next_cursor.is_none() {
+                    break;
+                }
+                cursor = page.next_cursor;
             }
+
             Err(anyhow!(
                 "Cannot find gas coin for signer address {signer} with amount sufficient for the required gas budget {gas_budget}. If you are using the pay or transfer commands, you can use the pay-iota command instead, which will use the only object as gas payment."
             ))

--- a/crates/iota-transaction-builder/src/utils.rs
+++ b/crates/iota-transaction-builder/src/utils.rs
@@ -74,7 +74,7 @@ impl TransactionBuilder {
                         return Ok(obj.object_ref());
                     }
                 }
-                if page.next_cursor.is_none() {
+                if !page.has_next_page {
                     break;
                 }
                 cursor = page.next_cursor;

--- a/sdk/kiosk/test/e2e/e2e.test.ts
+++ b/sdk/kiosk/test/e2e/e2e.test.ts
@@ -78,18 +78,6 @@ describe('Testing Kiosk SDK transaction building & querying e2e', () => {
         expect(page.hasNextPage).toBe(false);
         expect(page.kioskIds).toHaveLength(2);
         expect(page.kioskOwnerCaps).toHaveLength(2);
-
-        const emptyPage = await kioskClient.getOwnedKiosks({
-            address: toolbox.address(),
-            pagination: {
-                limit: 1,
-                cursor: page.nextCursor!,
-            },
-        });
-        expect(emptyPage.hasNextPage).toBe(false);
-        expect(emptyPage.nextCursor).toBeNull();
-        expect(emptyPage.kioskIds).toHaveLength(0);
-        expect(emptyPage.kioskOwnerCaps).toHaveLength(0);
     });
 
     it('Should fetch the two already created owned kiosks in two paginated requests', async () => {

--- a/sdk/kiosk/test/e2e/e2e.test.ts
+++ b/sdk/kiosk/test/e2e/e2e.test.ts
@@ -87,7 +87,7 @@ describe('Testing Kiosk SDK transaction building & querying e2e', () => {
             },
         });
         expect(emptyPage.hasNextPage).toBe(false);
-        expect(emptyPage.nextCursor).toBe(page.nextCursor);
+        expect(emptyPage.nextCursor).toBeNull();
         expect(emptyPage.kioskIds).toHaveLength(0);
         expect(emptyPage.kioskOwnerCaps).toHaveLength(0);
     });
@@ -122,7 +122,7 @@ describe('Testing Kiosk SDK transaction building & querying e2e', () => {
             },
         });
         expect(emptyPage.hasNextPage).toBe(false);
-        expect(emptyPage.nextCursor).toBe(secondPage.nextCursor);
+        expect(emptyPage.nextCursor).toBeNull();
         expect(emptyPage.kioskIds).toHaveLength(0);
         expect(emptyPage.kioskOwnerCaps).toHaveLength(0);
     });

--- a/sdk/kiosk/test/e2e/e2e.test.ts
+++ b/sdk/kiosk/test/e2e/e2e.test.ts
@@ -113,18 +113,6 @@ describe('Testing Kiosk SDK transaction building & querying e2e', () => {
         expect(secondPage.hasNextPage).toBe(false);
         expect(secondPage.kioskIds).toHaveLength(1);
         expect(secondPage.kioskOwnerCaps).toHaveLength(1);
-
-        const emptyPage = await kioskClient.getOwnedKiosks({
-            address: toolbox.address(),
-            pagination: {
-                limit: 1,
-                cursor: secondPage.nextCursor!,
-            },
-        });
-        expect(emptyPage.hasNextPage).toBe(false);
-        expect(emptyPage.nextCursor).toBeNull();
-        expect(emptyPage.kioskIds).toHaveLength(0);
-        expect(emptyPage.kioskOwnerCaps).toHaveLength(0);
     });
 
     it('Should take, list, delist, place, placeAndList, transfer in a normal sequence on a normal and on a personal kiosk.', async () => {


### PR DESCRIPTION
## Description 

Alternative to #9846. I felt that the implementation was still not effective, and instead slightly modified the signature of `DataReader` to allow pagination. There are some additional changes to reduce cloning that were incidental.

Now `select_gas` only fetches the pages and retrieves all the data it needs without additional queries.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [x] JSON-RPC: Don't set a next_cursor if !has_next_page
- [ ] GraphQL:
- [ ] CLI:
- [x] Rust SDK: Modified `get_owned_objects()` to allow more efficient `select_gas()` implementation that doesn't fetch all pages if not needed