### PR TITLE
refactor(iota-graphql-rpc, iota-indexer-streaming): relay errors to subscribers and add broker self-healing and retry mechanism for transient errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6694,6 +6694,7 @@ name = "iota-indexer-streaming"
 version = "1.15.0-alpha"
 dependencies = [
  "async-trait",
+ "backoff",
  "futures",
  "iota-indexer",
  "iota-types",

--- a/crates/iota-graphql-rpc/src/error.rs
+++ b/crates/iota-graphql-rpc/src/error.rs
@@ -5,6 +5,7 @@
 use async_graphql::{ErrorExtensionValues, ErrorExtensions, Pos, Response, ServerError};
 use async_graphql_axum::GraphQLResponse;
 use iota_indexer::errors::IndexerError;
+use iota_indexer_streaming::error::IndexerStreamingError;
 use iota_names::error::IotaNamesError;
 
 /// Error codes for the `extensions.code` field of a GraphQL error that
@@ -113,6 +114,12 @@ impl ErrorExtensions for Error {
 
 impl From<IndexerError> for Error {
     fn from(e: IndexerError) -> Self {
+        Error::Internal(e.to_string())
+    }
+}
+
+impl From<IndexerStreamingError> for Error {
+    fn from(e: IndexerStreamingError) -> Self {
         Error::Internal(e.to_string())
     }
 }

--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -7,6 +7,7 @@ use async_graphql::{Context, OutputType, ResultExt, SimpleObject, Subscription, 
 use futures::{Stream, StreamExt, TryStreamExt, future};
 use iota_indexer::read::IndexerReader;
 use iota_indexer_streaming::{
+    error::IndexerStreamingError,
     memory::{Config, InMemory},
     metrics::InMemoryStreamMetrics,
 };
@@ -188,10 +189,11 @@ impl GraphQLStream {
                             })
                         })
                     }
-                    Err(BroadcastStreamRecvError::Lagged(count)) => {
+                    Err(IndexerStreamingError::Lagged(BroadcastStreamRecvError::Lagged(count))) => {
                         warn!("subscriber lagging by {count} messages");
                         Ok(SubscriptionItem::Lagged(Lagged { count }))
                     }
+                    Err(err) => Err(err.into()),
                 };
                 future::ready(subscription_item)
             })
@@ -219,10 +221,11 @@ impl GraphQLStream {
                     Ok(stored) => {
                         Event::try_from_stored_event(stored, 0).map(SubscriptionItem::Payload)
                     }
-                    Err(BroadcastStreamRecvError::Lagged(count)) => {
+                    Err(IndexerStreamingError::Lagged(BroadcastStreamRecvError::Lagged(count))) => {
                         warn!("subscriber lagging by {count} messages");
                         Ok(SubscriptionItem::Lagged(Lagged { count }))
                     }
+                    Err(err) => Err(err.into()),
                 };
                 future::ready(subscription_item)
             })

--- a/crates/iota-indexer-streaming/Cargo.toml
+++ b/crates/iota-indexer-streaming/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 # external dependencies
 async-trait.workspace = true
+backoff.workspace = true
 futures.workspace = true
 prometheus.workspace = true
 serde.workspace = true

--- a/crates/iota-indexer-streaming/src/error.rs
+++ b/crates/iota-indexer-streaming/src/error.rs
@@ -5,21 +5,30 @@
 //! crate.
 
 use iota_indexer::errors::IndexerError;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
 pub type IndexerStreamingResult<T> = std::result::Result<T, IndexerStreamingError>;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum IndexerStreamingError {
     #[error("postgres error: {0}")]
     Postgres(String),
     #[error("streaming data processor error: {0}")]
     StreamingDataProcessor(String),
     #[error("indexer error: {0}")]
-    Indexer(#[from] IndexerError),
+    Indexer(String),
+    #[error(transparent)]
+    Lagged(#[from] BroadcastStreamRecvError),
 }
 
 impl From<tokio_postgres::Error> for IndexerStreamingError {
     fn from(error: tokio_postgres::Error) -> Self {
         IndexerStreamingError::Postgres(error.to_string())
+    }
+}
+
+impl From<IndexerError> for IndexerStreamingError {
+    fn from(error: IndexerError) -> Self {
+        IndexerStreamingError::Indexer(error.to_string())
     }
 }

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -29,10 +29,10 @@ use iota_indexer::{
 };
 use iota_types::event::Event;
 use prometheus::IntGauge;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 use tokio_postgres::{
-    AsyncMessage, Client, Config as PostgresConfig, Connection, NoTls, Socket, tls::NoTlsStream,
+    AsyncMessage, Config as PostgresConfig, Connection, NoTls, Socket, tls::NoTlsStream,
 };
 use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 use tracing::{debug, error};
@@ -44,6 +44,10 @@ use crate::{
 
 /// Postgres NOTIFY channel name.
 const CHANNEL_NAME: &str = "checkpoint_committed";
+
+/// Delay in seconds before retrying to connect to the Postgres database in case
+/// of failure.
+const RETRY_POSTGRES_CONNECTION_DELAY: Duration = Duration::from_secs(5);
 
 /// Notification received from PostgreSQL NOTIFY channel when a checkpoint is
 /// committed.
@@ -64,6 +68,7 @@ struct CheckpointCommitNotification {
 
 /// Represents the possible configuration of the [`InMemory`] streaming of
 /// transactions and events data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct Config {
     /// The buffer size of the [`tokio::sync::broadcast`] channel used for
     /// broadcasting transactions and events data to subscribers.
@@ -144,11 +149,9 @@ impl Default for Config {
 /// });
 /// ```
 pub struct InMemory {
-    event_tx: broadcast::Sender<StoredEvent>,
-    transaction_tx: broadcast::Sender<StoredTransaction>,
+    event_tx: broadcast::Sender<IndexerStreamingResult<StoredEvent>>,
+    transaction_tx: broadcast::Sender<IndexerStreamingResult<StoredTransaction>>,
     metrics: Arc<InMemoryStreamMetrics>,
-    // to receive notifications from the database we must keep the client alive.
-    _client: Client,
 }
 
 impl InMemory {
@@ -158,6 +161,8 @@ impl InMemory {
     /// - establishes a connection to PostgreSQL.
     /// - sets up the notification listener.
     /// - spawns the background task that processes checkpoint notifications.
+    /// - handles automatically reconnecting to PostgreSQL if the connection is
+    ///   lost.
     pub async fn new(
         db_url: &str,
         config: Config,
@@ -166,40 +171,67 @@ impl InMemory {
     ) -> IndexerStreamingResult<Self> {
         let metrics = metrics.into();
 
-        let (client, connection) = PostgresConfig::from_str(db_url)
-            .map_err(|e| {
-                IndexerStreamingError::Postgres(format!("failed to parse Postgresdb url: {e}"))
-            })?
-            .connect(NoTls)
-            .await?;
+        let pg_config = PostgresConfig::from_str(db_url).map_err(|e| {
+            IndexerStreamingError::Postgres(format!("failed to parse Postgresdb url: {e}"))
+        })?;
 
         let (event_tx, _) = broadcast::channel(config.channel_buffer_size.get());
         let (transaction_tx, _) = broadcast::channel(config.channel_buffer_size.get());
 
-        // the database connection must be spawned into a separate task in order to
-        // communicate with the database.
+        // task responsible for establishing a permanent postgres connection for
+        // listening to notifications and broadcasting events and transactions to
+        // subscribers.
         tokio::spawn({
-            Self::process_checkpoint_notifications(
-                metrics.clone(),
-                config,
-                connection,
-                indexer_reader,
-                event_tx.clone(),
-                transaction_tx.clone(),
-            )
-            .inspect_err(|e| error!("failed to process checkpoint notification: {e}"))
-        });
+            let event_tx = event_tx.clone();
+            let transaction_tx = transaction_tx.clone();
+            let metrics = metrics.clone();
+            let pg_config = pg_config.clone();
 
-        // listen for notifications on a specific channel.
-        client
-            .execute(&format!("LISTEN {CHANNEL_NAME};"), &[])
-            .await?;
+            async move {
+                loop {
+                    let (client, connection) = match pg_config.connect(NoTls).await {
+                        Ok(value) => value,
+                        Err(e) => {
+                            Self::publish_error(e.into(), &event_tx, &transaction_tx);
+                            tokio::time::sleep(RETRY_POSTGRES_CONNECTION_DELAY).await;
+                            continue;
+                        }
+                    };
+
+                    // the client's queries require the connection to be actively polled to execute.
+                    // process_checkpoint_notifications is a long-running future that polls the
+                    // connection for notifications and should never resolve (unless a fatal error
+                    // occurs).
+                    let query_fut = async {
+                        client
+                            .query(&format!("LISTEN {CHANNEL_NAME};"), &[])
+                            .await
+                            .map_err(Into::into)
+                    };
+
+                    let process_notification_fut = Self::process_checkpoint_notifications(
+                        &metrics,
+                        &config,
+                        connection,
+                        &indexer_reader,
+                        &event_tx,
+                        &transaction_tx,
+                    );
+
+                    // by using try_join!, we poll both futures concurrently, which allows the
+                    // client query to execute while the connection is being actively polled
+                    // for incoming notifications.
+                    if let Err(e) = futures::try_join!(query_fut, process_notification_fut) {
+                        Self::publish_error(e, &event_tx, &transaction_tx);
+                    }
+                }
+            }
+        });
 
         Ok(Self {
             event_tx,
             transaction_tx,
             metrics,
-            _client: client,
         })
     }
 
@@ -227,11 +259,10 @@ impl InMemory {
     ///    }
     /// });
     /// ```
-    pub fn subscribe_events(
-        &self,
-    ) -> impl Stream<Item = Result<StoredEvent, BroadcastStreamRecvError>> {
+    pub fn subscribe_events(&self) -> impl Stream<Item = IndexerStreamingResult<StoredEvent>> {
         let stream = BroadcastStream::new(self.event_tx.subscribe());
         SubscriberStream::new(stream, METRICS_EVENT_LABEL, self.metrics.clone())
+            .map(Self::flatten_error)
     }
 
     /// Subscribe to a stream of [`StoredTransaction`].
@@ -259,9 +290,21 @@ impl InMemory {
     /// ```
     pub fn subscribe_transactions(
         &self,
-    ) -> impl Stream<Item = Result<StoredTransaction, BroadcastStreamRecvError>> {
+    ) -> impl Stream<Item = IndexerStreamingResult<StoredTransaction>> {
         let stream = BroadcastStream::new(self.transaction_tx.subscribe());
         SubscriberStream::new(stream, METRICS_TRANSACTION_LABEL, self.metrics.clone())
+            .map(Self::flatten_error)
+    }
+
+    /// Flattens nested `Result` types from the broadcast stream.
+    fn flatten_error<T>(
+        result: Result<IndexerStreamingResult<T>, BroadcastStreamRecvError>,
+    ) -> IndexerStreamingResult<T> {
+        match result {
+            Ok(Ok(ev)) => Ok(ev),
+            Ok(Err(e)) => Err(e),
+            Err(err) => Err(err.into()),
+        }
     }
 
     /// Listens for database notifications and processes them.
@@ -272,14 +315,22 @@ impl InMemory {
     ///   exceeded.
     /// - fetches the transactions within the batch bounds and sends them to
     ///   subscribers alongside extracted events.
+    /// - leverages exponential backoff retries for transient errors when
+    ///   processing notifications.
     async fn process_checkpoint_notifications(
-        metrics: Arc<InMemoryStreamMetrics>,
-        config: Config,
+        metrics: &InMemoryStreamMetrics,
+        config: &Config,
         mut connection: Connection<Socket, NoTlsStream>,
-        indexer_reader: IndexerReader,
-        event_tx: broadcast::Sender<StoredEvent>,
-        transaction_tx: broadcast::Sender<StoredTransaction>,
+        indexer_reader: &IndexerReader,
+        event_tx: &broadcast::Sender<IndexerStreamingResult<StoredEvent>>,
+        transaction_tx: &broadcast::Sender<IndexerStreamingResult<StoredTransaction>>,
     ) -> IndexerStreamingResult<()> {
+        let mut backoff = backoff::ExponentialBackoff::default();
+        backoff.max_elapsed_time = Some(Duration::from_secs(60));
+        backoff.initial_interval = Duration::from_millis(100);
+        backoff.current_interval = backoff.initial_interval;
+        backoff.multiplier = 1.0;
+
         // create a stream from the connection that forwards messages to the channel.
         let mut stream = stream::poll_fn(move |cx| connection.poll_message(cx))
             .ready_chunks(config.notification_chunk_size.get());
@@ -290,7 +341,7 @@ impl InMemory {
                 metrics.process_notification_batch_latency.start_timer();
 
             if let Some((min_tx_sequence_number, max_tx_sequence_number)) =
-                Self::resolve_tx_bounds(&metrics, messages)?
+                Self::resolve_tx_bounds(metrics, &messages)?
             {
                 metrics
                     .notified_tx_seq_num_start_range
@@ -305,28 +356,48 @@ impl InMemory {
                     let end = (start + config.transaction_batch_size.get().saturating_sub(1))
                         .min(max_tx_sequence_number);
 
-                    Self::process_transaction_batch(
-                        &metrics,
-                        start,
-                        end,
-                        &indexer_reader,
-                        &event_tx,
-                        &transaction_tx,
-                    )
-                    .await?;
+                    if let Err(e) = backoff::future::retry(backoff.clone(), || {
+                        Self::process_transaction_batch(
+                            metrics,
+                            start,
+                            end,
+                            indexer_reader,
+                            event_tx,
+                            transaction_tx,
+                        )
+                        .map_err(backoff::Error::transient)
+                        .inspect_err(|e| {
+                            error!("transient error processing transaction batch: {e}")
+                        })
+                    })
+                    .await
+                    {
+                        // once we exaust all backoff retries, we publish the error and move on to
+                        // the next batch. The client can decide how to handle the error
+                        // accordingly.
+                        error!(
+                            batch_start = start,
+                            batch_end = end,
+                            error = ?e,
+                            "batch processing failed after retries, publishing error to clients"
+                        );
+                        Self::publish_error(e, event_tx, transaction_tx);
+                    }
 
                     start = end + 1;
                 }
             }
         }
-        Ok(())
+        Err(IndexerStreamingError::Postgres(
+            "postgres notification stream closed, retrying establishing connection...".into(),
+        ))
     }
 
     /// Resolves the transaction sequence number bounds from the given messages
     /// batch.
     fn resolve_tx_bounds(
         metrics: &InMemoryStreamMetrics,
-        messages: Vec<Result<AsyncMessage, tokio_postgres::Error>>,
+        messages: &[Result<AsyncMessage, tokio_postgres::Error>],
     ) -> IndexerStreamingResult<Option<(i64, i64)>> {
         let mut filtered_messages = Self::filter_checkpoint_notifications(metrics, messages);
 
@@ -349,8 +420,8 @@ impl InMemory {
         start: i64,
         end: i64,
         indexer_reader: &IndexerReader,
-        event_tx: &broadcast::Sender<StoredEvent>,
-        transaction_tx: &broadcast::Sender<StoredTransaction>,
+        event_tx: &broadcast::Sender<IndexerStreamingResult<StoredEvent>>,
+        transaction_tx: &broadcast::Sender<IndexerStreamingResult<StoredTransaction>>,
     ) -> IndexerStreamingResult<()> {
         // auto-records duration on drop (function return).
         let _record_function_execution_latency =
@@ -395,16 +466,16 @@ impl InMemory {
     async fn publish_tx_and_events(
         metrics: &InMemoryStreamMetrics,
         transactions: Vec<StoredTransaction>,
-        event_tx: &broadcast::Sender<StoredEvent>,
-        transaction_tx: &broadcast::Sender<StoredTransaction>,
+        event_tx: &broadcast::Sender<IndexerStreamingResult<StoredEvent>>,
+        transaction_tx: &broadcast::Sender<IndexerStreamingResult<StoredTransaction>>,
     ) -> IndexerStreamingResult<()> {
         // we ignore errors here because we may receive an error if no subscribers are
         // registered which may happen.
         for tx in transactions {
             for event in Self::stored_events_from_transaction(&tx)? {
-                _ = event_tx.send(event);
+                _ = event_tx.send(Ok(event));
             }
-            _ = transaction_tx.send(tx);
+            _ = transaction_tx.send(Ok(tx));
         }
 
         // we sacrifice per-event/transaction granularity to avoid degrading
@@ -421,13 +492,26 @@ impl InMemory {
         Ok(())
     }
 
+    /// Relay an irrecoverable error to all subscribers.
+    ///
+    /// Providing transparency on what happen on the broker side, the client can
+    /// decide how to handle the error accordingly.
+    fn publish_error(
+        error: IndexerStreamingError,
+        event_tx: &broadcast::Sender<IndexerStreamingResult<StoredEvent>>,
+        transaction_tx: &broadcast::Sender<IndexerStreamingResult<StoredTransaction>>,
+    ) {
+        _ = event_tx.send(Err(error.clone()));
+        _ = transaction_tx.send(Err(error));
+    }
+
     /// Filters and parses database notifications into
     /// [`CheckpointCommitNotification`] from PostgreSQL messages.
     fn filter_checkpoint_notifications<'a>(
         metrics: &'a InMemoryStreamMetrics,
-        messages: Vec<Result<AsyncMessage, tokio_postgres::Error>>,
-    ) -> impl Iterator<Item = IndexerStreamingResult<CheckpointCommitNotification>> + use<'a> {
-        messages.into_iter().filter_map(|msg_result| {
+        messages: &'a [Result<AsyncMessage, tokio_postgres::Error>],
+    ) -> impl Iterator<Item = IndexerStreamingResult<CheckpointCommitNotification>> + 'a {
+        messages.iter().filter_map(|msg_result| {
             match msg_result {
                 Ok(AsyncMessage::Notification(n)) => {
                     match serde_json::from_str::<CheckpointCommitNotification>(n.payload()) {

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -328,7 +328,7 @@ impl InMemory {
         transaction_tx: &broadcast::Sender<IndexerStreamingResult<StoredTransaction>>,
     ) -> IndexerStreamingResult<()> {
         let mut backoff = backoff::ExponentialBackoff::default();
-        backoff.max_elapsed_time = Some(Duration::from_secs(60));
+        backoff.max_elapsed_time = Some(Duration::from_secs(5));
         backoff.initial_interval = Duration::from_millis(100);
         backoff.current_interval = backoff.initial_interval;
         backoff.multiplier = 1.0;

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -192,6 +192,7 @@ impl InMemory {
                     let (client, connection) = match pg_config.connect(NoTls).await {
                         Ok(value) => value,
                         Err(e) => {
+                            error!("unable to connect to postgres: {e}");
                             Self::publish_error(e.into(), &event_tx, &transaction_tx);
                             tokio::time::sleep(RETRY_POSTGRES_CONNECTION_DELAY).await;
                             continue;
@@ -222,6 +223,7 @@ impl InMemory {
                     // client query to execute while the connection is being actively polled
                     // for incoming notifications.
                     if let Err(e) = futures::try_join!(query_fut, process_notification_fut) {
+                        error!("processing checkpoint notifications failed: {e}");
                         Self::publish_error(e, &event_tx, &transaction_tx);
                     }
                 }


### PR DESCRIPTION
# Description of change

This patch enhances the resilience of the `InMemory` broker when handling database failures. By adding these additional changes:

- Implements linear backoff retry (100ms intervals, 5s max duration) for transient database errors like statement timeouts. Previously, these errors would kill the broadcasting task. The broker now retries operations before giving up, improving uptime during temporary database load.

- After exhausting retries, errors are propagated to subscribers through broadcast channels, allowing them to handle failures appropriately (reconnect, alert, graceful degradation).

- When the PostgreSQL connection is lost, the task automatically re-establishes it (5s retry delay) and resumes notification processing without manual intervention.

### Motivation

This addresses issues on alphanet where database collation caused statement timeouts, halting GraphQL subscriptions and requiring manual restart. The broker can now survive transient database issues and automatically recover from connection failures.

## Links to any relevant issues

fixes #9787

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

---

- started a private network with indexer and graphql servers
```shell
RUST_LOG=iota_graphql_rpc=error,iota_indexer_streaming=info cargo r --features indexer -- start --force-regenesis --with-graphql

```

- Used GraphQL IDE to issue a subscription query

```graphql
subscription Transactions {
    transactions {
        __typename
        ... on TransactionBlock {
            digest
        }
        ... on Lagged {
            count
        }
    }
}
```

- Once data is being received, we started to simulate transient error on the database side, we restarted it, stopped for variable amount of time ect.
- the backoff and the reconnection to the database was behaving as expected.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch does not directly affect the normal operation of the indexer, thus no further tests were made.
