### PR TITLE
feat(starfish): write voting blocks with core thread

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -218,7 +218,6 @@ impl ConsensusAuthority {
             network_client.clone(),
             block_verifier.clone(),
             dag_state.clone(),
-            store.clone(),
         )
         .start();
 
@@ -230,7 +229,6 @@ impl ConsensusAuthority {
             network_client.clone(),
             block_verifier.clone(),
             dag_state.clone(),
-            store.clone(),
         )
         .start();
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -2097,6 +2097,7 @@ mod tests {
             &self,
             _commits: Vec<crate::commit::TrustedCommit>,
             _subdags: Vec<crate::commit::CommittedSubDag>,
+            _voting_block_headers: Vec<crate::VerifiedBlockHeader>,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -2095,9 +2095,7 @@ mod tests {
 
         async fn add_subdags_from_fast_sync(
             &self,
-            _commits: Vec<crate::commit::TrustedCommit>,
-            _subdags: Vec<crate::commit::CommittedSubDag>,
-            _voting_block_headers: Vec<crate::VerifiedBlockHeader>,
+            _output: crate::commit_syncer::fast::FastSyncOutput,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -48,11 +48,23 @@ pub(crate) struct FastCommitSyncer<C: NetworkClient> {
     // States only used by the scheduler.
 
     // Inflight requests to fetch commits from different authorities.
-    inflight_fetches: JoinSet<(u32, Vec<TrustedCommit>, Vec<CommittedSubDag>, Vec<VerifiedBlockHeader>)>,
+    inflight_fetches: JoinSet<(
+        u32,
+        Vec<TrustedCommit>,
+        Vec<CommittedSubDag>,
+        Vec<VerifiedBlockHeader>,
+    )>,
     // Additional ranges of commits to fetch.
     pending_fetches: BTreeSet<CommitRange>,
     // Fetched commits and blocks by commit range.
-    fetched_ranges: BTreeMap<CommitRange, (Vec<TrustedCommit>, Vec<CommittedSubDag>, Vec<VerifiedBlockHeader>)>,
+    fetched_ranges: BTreeMap<
+        CommitRange,
+        (
+            Vec<TrustedCommit>,
+            Vec<CommittedSubDag>,
+            Vec<VerifiedBlockHeader>,
+        ),
+    >,
     // Highest commit index among inflight and pending fetches.
     // Used to determine the start of new ranges to be fetched.
     highest_scheduled_index: Option<CommitIndex>,
@@ -459,7 +471,12 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
     async fn fetch_loop(
         inner: Arc<Inner<C>>,
         commit_range: CommitRange,
-    ) -> (CommitIndex, Vec<TrustedCommit>, Vec<CommittedSubDag>, Vec<VerifiedBlockHeader>) {
+    ) -> (
+        CommitIndex,
+        Vec<TrustedCommit>,
+        Vec<CommittedSubDag>,
+        Vec<VerifiedBlockHeader>,
+    ) {
         let (end_index, (commits, committed_subdags, voting_block_headers)) =
             shared_fetch_loop(inner, commit_range, 2, Self::fetch_once).await;
         (end_index, commits, committed_subdags, voting_block_headers)
@@ -471,7 +488,11 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         target_authority: AuthorityIndex,
         commit_range: CommitRange,
         timeout: Duration,
-    ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<CommittedSubDag>, Vec<VerifiedBlockHeader>)> {
+    ) -> ConsensusResult<(
+        Vec<TrustedCommit>,
+        Vec<CommittedSubDag>,
+        Vec<VerifiedBlockHeader>,
+    )> {
         let _timer = inner
             .context
             .metrics

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -33,7 +33,6 @@ use crate::{
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     network::{NetworkClient, SerializedTransactionsV2},
-    storage::Store,
     transaction_ref::{GenericTransactionRef, TransactionRef},
 };
 
@@ -81,7 +80,6 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         network_client: Arc<C>,
         block_verifier: Arc<dyn BlockVerifier>,
         dag_state: Arc<RwLock<DagState>>,
-        store: Arc<dyn Store>,
     ) -> Self {
         let inner = Arc::new(Inner {
             context,
@@ -91,7 +89,6 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             network_client,
             block_verifier,
             dag_state,
-            store,
             sync_type: CommitSyncType::Fast,
         });
         let synced_commit_index = inner.dag_state.read().last_commit_index();

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -481,16 +481,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         inner: Arc<Inner<C>>,
         commit_range: CommitRange,
     ) -> (CommitIndex, FastSyncOutput) {
-        let (end_index, (commits, committed_subdags, voting_block_headers)) =
-            shared_fetch_loop(inner, commit_range, 2, Self::fetch_once).await;
-        (
-            end_index,
-            FastSyncOutput {
-                commits,
-                committed_subdags,
-                voting_block_headers,
-            },
-        )
+        shared_fetch_loop(inner, commit_range, 2, Self::fetch_once).await
     }
 
     // Fetches commits and transactions from a single authority.
@@ -499,11 +490,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         target_authority: AuthorityIndex,
         commit_range: CommitRange,
         timeout: Duration,
-    ) -> ConsensusResult<(
-        Vec<TrustedCommit>,
-        Vec<CommittedSubDag>,
-        Vec<VerifiedBlockHeader>,
-    )> {
+    ) -> ConsensusResult<FastSyncOutput> {
         let _timer = inner
             .context
             .metrics
@@ -635,7 +622,11 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             ));
         }
 
-        Ok((commits, committed_subdags, voting_block_headers))
+        Ok(FastSyncOutput {
+            commits,
+            committed_subdags,
+            voting_block_headers,
+        })
     }
 
     /// Fetches block headers needed for component reinitialization from the

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -333,17 +333,13 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
     }
 
     async fn handle_fetch_result(&mut self, target_end: CommitIndex, output: FastSyncOutput) {
-        let FastSyncOutput {
-            commits,
-            committed_subdags,
-            voting_block_headers,
-        } = output;
-        assert!(!committed_subdags.is_empty());
+        assert!(!output.committed_subdags.is_empty());
 
         // Track that we have actually fetched data during this fast sync session.
         self.has_fetched_data = true;
 
-        let total_transactions_size_bytes = committed_subdags
+        let total_transactions_size_bytes = output
+            .committed_subdags
             .iter()
             .flat_map(|subdag| &subdag.transactions)
             .map(|txns| txns.serialized().len() as u64)
@@ -354,15 +350,15 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         metrics
             .commit_sync_fetched_commits
             .with_label_values(&[sync_label])
-            .inc_by(committed_subdags.len() as u64);
+            .inc_by(output.committed_subdags.len() as u64);
         metrics
             .commit_sync_total_fetched_transactions_size
             .with_label_values(&[sync_label])
             .inc_by(total_transactions_size_bytes);
 
         let (commit_start, commit_end) = (
-            committed_subdags.first().unwrap().commit_ref.index,
-            committed_subdags.last().unwrap().commit_ref.index,
+            output.committed_subdags.first().unwrap().commit_ref.index,
+            output.committed_subdags.last().unwrap().commit_ref.index,
         );
         self.highest_fetched_commit_index = self.highest_fetched_commit_index.max(commit_end);
         metrics
@@ -370,22 +366,16 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             .with_label_values(&[sync_label])
             .set(self.highest_fetched_commit_index as i64);
 
-        // Allow returning partial results, and try fetching the rest separately.
+        // Allow returning partial results and try fetching the rest separately.
         requeue_partial_range(&mut self.pending_fetches, commit_end, target_end);
-        // Make sure synced_commit_index is up to date.
+        // Make sure the synced_commit_index is up to date.
         self.synced_commit_index = self
             .synced_commit_index
             .max(self.inner.dag_state.read().last_commit_index());
         // Only add new blocks if at least some of them are not already synced.
         if self.synced_commit_index < commit_end {
-            self.fetched_ranges.insert(
-                (commit_start..=commit_end).into(),
-                FastSyncOutput {
-                    commits,
-                    committed_subdags,
-                    voting_block_headers,
-                },
-            );
+            self.fetched_ranges
+                .insert((commit_start..=commit_end).into(), output);
         }
         // Try to process as many fetched blocks as possible.
         while let Some((fetched_commit_range, _)) = self.fetched_ranges.first_key_value() {
@@ -395,7 +385,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 if fetched_commit_range.start() <= self.synced_commit_index + 1 {
                     self.fetched_ranges.pop_first().unwrap()
                 } else {
-                    // Found gap between earliest fetched block and latest synced block,
+                    // Found a gap between the earliest fetched block and the latest synced block,
                     // so not sending additional blocks to Core.
                     metrics
                         .commit_sync_gap_on_processing
@@ -403,11 +393,6 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                         .inc();
                     break;
                 };
-            let FastSyncOutput {
-                commits,
-                committed_subdags: subdags,
-                voting_block_headers: voting_headers,
-            } = output;
             // Avoid sending to Core a whole batch of already synced blocks.
             if fetched_commit_range.end() <= self.synced_commit_index {
                 continue;
@@ -416,20 +401,15 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             debug!(
                 "[{}] Fetched {} subdags with transactions for commit range {:?}",
                 sync_label,
-                subdags.len(),
+                output.committed_subdags.len(),
                 fetched_commit_range,
             );
 
-            // If core thread cannot handle the incoming blocks, it is ok to block here.
-
+            // If the core thread cannot handle the incoming blocks, it is ok to block here.
             if let Err(e) = self
                 .inner
                 .core_thread_dispatcher
-                .add_subdags_from_fast_sync(FastSyncOutput {
-                    commits,
-                    committed_subdags: subdags,
-                    voting_block_headers: voting_headers,
-                })
+                .add_subdags_from_fast_sync(output.clone())
                 .await
             {
                 info!(

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -39,6 +39,15 @@ use crate::{
 /// Timeout for fetching block headers during close-to-quorum finalization.
 const FETCH_HEADERS_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Output from fast sync fetch operations containing commits, subdags, and
+/// voting headers.
+#[derive(Clone, Debug, Default)]
+pub struct FastSyncOutput {
+    pub commits: Vec<TrustedCommit>,
+    pub committed_subdags: Vec<CommittedSubDag>,
+    pub voting_block_headers: Vec<VerifiedBlockHeader>,
+}
+
 pub(crate) struct FastCommitSyncer<C: NetworkClient> {
     // States shared by scheduler and fetch tasks.
 
@@ -48,23 +57,11 @@ pub(crate) struct FastCommitSyncer<C: NetworkClient> {
     // States only used by the scheduler.
 
     // Inflight requests to fetch commits from different authorities.
-    inflight_fetches: JoinSet<(
-        u32,
-        Vec<TrustedCommit>,
-        Vec<CommittedSubDag>,
-        Vec<VerifiedBlockHeader>,
-    )>,
+    inflight_fetches: JoinSet<(u32, FastSyncOutput)>,
     // Additional ranges of commits to fetch.
     pending_fetches: BTreeSet<CommitRange>,
     // Fetched commits and blocks by commit range.
-    fetched_ranges: BTreeMap<
-        CommitRange,
-        (
-            Vec<TrustedCommit>,
-            Vec<CommittedSubDag>,
-            Vec<VerifiedBlockHeader>,
-        ),
-    >,
+    fetched_ranges: BTreeMap<CommitRange, FastSyncOutput>,
     // Highest commit index among inflight and pending fetches.
     // Used to determine the start of new ranges to be fetched.
     highest_scheduled_index: Option<CommitIndex>,
@@ -148,8 +145,8 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                             return;
                         }
                     }
-                    let (target_end, commits, committed_subdags, voting_block_headers) = result.unwrap();
-                    self.handle_fetch_result(target_end, commits, committed_subdags, voting_block_headers).await;
+                    let (target_end, output) = result.unwrap();
+                    self.handle_fetch_result(target_end, output).await;
                 }
                 _ = &mut rx_shutdown => {
                     // Shutdown requested.
@@ -335,13 +332,12 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         }
     }
 
-    async fn handle_fetch_result(
-        &mut self,
-        target_end: CommitIndex,
-        commits: Vec<TrustedCommit>,
-        committed_subdags: Vec<CommittedSubDag>,
-        voting_block_headers: Vec<VerifiedBlockHeader>,
-    ) {
+    async fn handle_fetch_result(&mut self, target_end: CommitIndex, output: FastSyncOutput) {
+        let FastSyncOutput {
+            commits,
+            committed_subdags,
+            voting_block_headers,
+        } = output;
         assert!(!committed_subdags.is_empty());
 
         // Track that we have actually fetched data during this fast sync session.
@@ -384,14 +380,18 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         if self.synced_commit_index < commit_end {
             self.fetched_ranges.insert(
                 (commit_start..=commit_end).into(),
-                (commits, committed_subdags, voting_block_headers),
+                FastSyncOutput {
+                    commits,
+                    committed_subdags,
+                    voting_block_headers,
+                },
             );
         }
         // Try to process as many fetched blocks as possible.
         while let Some((fetched_commit_range, _)) = self.fetched_ranges.first_key_value() {
             // Only pop fetched_ranges if there is no gap with blocks already synced.
             // Note: start, end and synced_commit_index are all inclusive.
-            let (fetched_commit_range, (commits, subdags, voting_headers)) =
+            let (fetched_commit_range, output) =
                 if fetched_commit_range.start() <= self.synced_commit_index + 1 {
                     self.fetched_ranges.pop_first().unwrap()
                 } else {
@@ -403,6 +403,11 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                         .inc();
                     break;
                 };
+            let FastSyncOutput {
+                commits,
+                committed_subdags: subdags,
+                voting_block_headers: voting_headers,
+            } = output;
             // Avoid sending to Core a whole batch of already synced blocks.
             if fetched_commit_range.end() <= self.synced_commit_index {
                 continue;
@@ -420,7 +425,11 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             if let Err(e) = self
                 .inner
                 .core_thread_dispatcher
-                .add_subdags_from_fast_sync(commits, subdags, voting_headers)
+                .add_subdags_from_fast_sync(FastSyncOutput {
+                    commits,
+                    committed_subdags: subdags,
+                    voting_block_headers: voting_headers,
+                })
                 .await
             {
                 info!(
@@ -471,15 +480,17 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
     async fn fetch_loop(
         inner: Arc<Inner<C>>,
         commit_range: CommitRange,
-    ) -> (
-        CommitIndex,
-        Vec<TrustedCommit>,
-        Vec<CommittedSubDag>,
-        Vec<VerifiedBlockHeader>,
-    ) {
+    ) -> (CommitIndex, FastSyncOutput) {
         let (end_index, (commits, committed_subdags, voting_block_headers)) =
             shared_fetch_loop(inner, commit_range, 2, Self::fetch_once).await;
-        (end_index, commits, committed_subdags, voting_block_headers)
+        (
+            end_index,
+            FastSyncOutput {
+                commits,
+                committed_subdags,
+                voting_block_headers,
+            },
+        )
     }
 
     // Fetches commits and transactions from a single authority.
@@ -777,16 +788,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
 
     #[cfg(test)]
     #[allow(dead_code)]
-    fn fetched_ranges(
-        &self,
-    ) -> BTreeMap<
-        CommitRange,
-        (
-            Vec<TrustedCommit>,
-            Vec<CommittedSubDag>,
-            Vec<VerifiedBlockHeader>,
-        ),
-    > {
+    fn fetched_ranges(&self) -> BTreeMap<CommitRange, FastSyncOutput> {
         self.fetched_ranges.clone()
     }
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -777,7 +777,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
 
     #[cfg(test)]
     #[allow(dead_code)]
-    fn fetched_ranges(&self) -> BTreeMap<CommitRange, (Vec<TrustedCommit>, Vec<CommittedSubDag>)> {
+    fn fetched_ranges(&self) -> BTreeMap<CommitRange, (Vec<TrustedCommit>, Vec<CommittedSubDag>, Vec<VerifiedBlockHeader>)> {
         self.fetched_ranges.clone()
     }
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -777,7 +777,16 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
 
     #[cfg(test)]
     #[allow(dead_code)]
-    fn fetched_ranges(&self) -> BTreeMap<CommitRange, (Vec<TrustedCommit>, Vec<CommittedSubDag>, Vec<VerifiedBlockHeader>)> {
+    fn fetched_ranges(
+        &self,
+    ) -> BTreeMap<
+        CommitRange,
+        (
+            Vec<TrustedCommit>,
+            Vec<CommittedSubDag>,
+            Vec<VerifiedBlockHeader>,
+        ),
+    > {
         self.fetched_ranges.clone()
     }
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -49,11 +49,11 @@ pub(crate) struct FastCommitSyncer<C: NetworkClient> {
     // States only used by the scheduler.
 
     // Inflight requests to fetch commits from different authorities.
-    inflight_fetches: JoinSet<(u32, Vec<TrustedCommit>, Vec<CommittedSubDag>)>,
+    inflight_fetches: JoinSet<(u32, Vec<TrustedCommit>, Vec<CommittedSubDag>, Vec<VerifiedBlockHeader>)>,
     // Additional ranges of commits to fetch.
     pending_fetches: BTreeSet<CommitRange>,
     // Fetched commits and blocks by commit range.
-    fetched_ranges: BTreeMap<CommitRange, (Vec<TrustedCommit>, Vec<CommittedSubDag>)>,
+    fetched_ranges: BTreeMap<CommitRange, (Vec<TrustedCommit>, Vec<CommittedSubDag>, Vec<VerifiedBlockHeader>)>,
     // Highest commit index among inflight and pending fetches.
     // Used to determine the start of new ranges to be fetched.
     highest_scheduled_index: Option<CommitIndex>,
@@ -139,8 +139,8 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                             return;
                         }
                     }
-                    let (target_end, commits, committed_subdags) = result.unwrap();
-                    self.handle_fetch_result(target_end, commits, committed_subdags).await;
+                    let (target_end, commits, committed_subdags, voting_block_headers) = result.unwrap();
+                    self.handle_fetch_result(target_end, commits, committed_subdags, voting_block_headers).await;
                 }
                 _ = &mut rx_shutdown => {
                     // Shutdown requested.
@@ -331,6 +331,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         target_end: CommitIndex,
         commits: Vec<TrustedCommit>,
         committed_subdags: Vec<CommittedSubDag>,
+        voting_block_headers: Vec<VerifiedBlockHeader>,
     ) {
         assert!(!committed_subdags.is_empty());
 
@@ -374,14 +375,14 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         if self.synced_commit_index < commit_end {
             self.fetched_ranges.insert(
                 (commit_start..=commit_end).into(),
-                (commits, committed_subdags),
+                (commits, committed_subdags, voting_block_headers),
             );
         }
         // Try to process as many fetched blocks as possible.
         while let Some((fetched_commit_range, _)) = self.fetched_ranges.first_key_value() {
             // Only pop fetched_ranges if there is no gap with blocks already synced.
             // Note: start, end and synced_commit_index are all inclusive.
-            let (fetched_commit_range, (commits, subdags)) =
+            let (fetched_commit_range, (commits, subdags, voting_headers)) =
                 if fetched_commit_range.start() <= self.synced_commit_index + 1 {
                     self.fetched_ranges.pop_first().unwrap()
                 } else {
@@ -410,7 +411,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             if let Err(e) = self
                 .inner
                 .core_thread_dispatcher
-                .add_subdags_from_fast_sync(commits, subdags)
+                .add_subdags_from_fast_sync(commits, subdags, voting_headers)
                 .await
             {
                 info!(
@@ -461,10 +462,10 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
     async fn fetch_loop(
         inner: Arc<Inner<C>>,
         commit_range: CommitRange,
-    ) -> (CommitIndex, Vec<TrustedCommit>, Vec<CommittedSubDag>) {
-        let (end_index, (commits, committed_subdags)) =
+    ) -> (CommitIndex, Vec<TrustedCommit>, Vec<CommittedSubDag>, Vec<VerifiedBlockHeader>) {
+        let (end_index, (commits, committed_subdags, voting_block_headers)) =
             shared_fetch_loop(inner, commit_range, 2, Self::fetch_once).await;
-        (end_index, commits, committed_subdags)
+        (end_index, commits, committed_subdags, voting_block_headers)
     }
 
     // Fetches commits and transactions from a single authority.
@@ -473,7 +474,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         target_authority: AuthorityIndex,
         commit_range: CommitRange,
         timeout: Duration,
-    ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<CommittedSubDag>)> {
+    ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<CommittedSubDag>, Vec<VerifiedBlockHeader>)> {
         let _timer = inner
             .context
             .metrics
@@ -508,13 +509,6 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             })
             .await
             .expect("Spawn blocking should not fail")?;
-
-        // Store the voting block headers for later use when serving fetch_commits
-        // requests. The overhead is small since we store votes only for the last commit
-        // in a batch.
-        inner
-            .store
-            .write_voting_block_headers(voting_block_headers)?;
 
         // 3. Collect all committed transaction block refs from commits
         let mut committed_tx_refs: BTreeSet<TransactionRef> = commits
@@ -612,7 +606,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             ));
         }
 
-        Ok((commits, committed_subdags))
+        Ok((commits, committed_subdags, voting_block_headers))
     }
 
     /// Fetches block headers needed for component reinitialization from the

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -162,7 +162,6 @@ pub(crate) struct Inner<C: NetworkClient> {
     pub(crate) network_client: Arc<C>,
     pub(crate) block_verifier: Arc<dyn BlockVerifier>,
     pub(crate) dag_state: Arc<RwLock<DagState>>,
-    pub(crate) store: Arc<dyn crate::storage::Store>,
     pub(crate) sync_type: CommitSyncType,
 }
 

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -39,7 +39,6 @@ use crate::{
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     network::{NetworkClient, SerializedTransactionsV1, SerializedTransactionsV2},
-    storage::Store,
     transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _},
 };
 
@@ -77,7 +76,6 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
         network_client: Arc<C>,
         block_verifier: Arc<dyn BlockVerifier>,
         dag_state: Arc<RwLock<DagState>>,
-        store: Arc<dyn Store>,
     ) -> Self {
         let inner = Arc::new(Inner {
             context,
@@ -87,7 +85,6 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
             network_client,
             block_verifier,
             dag_state,
-            store,
             sync_type: CommitSyncType::Regular,
         });
         let synced_commit_index = inner.dag_state.read().last_commit_index();
@@ -950,7 +947,6 @@ mod tests {
             network_client,
             block_verifier,
             dag_state,
-            store,
         );
 
         // Check initial state.

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -534,6 +534,7 @@ impl Core {
         &mut self,
         commits: Vec<TrustedCommit>,
         committed_subdags: Vec<CommittedSubDag>,
+        voting_block_headers: Vec<VerifiedBlockHeader>,
     ) -> ConsensusResult<()> {
         let _scope = monitored_scope("Core::handle_committed_sub_dags_from_fast_sync");
         let _s = self
@@ -577,6 +578,9 @@ impl Core {
                     );
                 }
             }
+
+            // Store voting block headers for later use when serving fetch_commits requests
+            dag_state.add_voting_block_headers(voting_block_headers);
         }
 
         // Flush commits to storage so they're available for

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -30,17 +30,18 @@ use crate::storage::Store;
 #[cfg(test)]
 use crate::storage::rocksdb_store::RocksDBStore;
 #[cfg(test)]
-use crate::{CommitConsumer, TransactionClient, storage::mem_store::MemStore};
+use crate::{CommitConsumer, CommittedSubDag, TransactionClient, storage::mem_store::MemStore};
 use crate::{
-    CommittedSubDag, Transaction,
+    Transaction,
     block_header::{
         BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockRef, BlockTimestampMs, GENESIS_ROUND,
         Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
         VerifiedOwnShard, VerifiedTransactions,
     },
     block_manager::BlockManager,
-    commit::{CertifiedCommits, CommitAPI, PendingSubDag, TrustedCommit},
+    commit::{CertifiedCommits, CommitAPI, PendingSubDag},
     commit_observer::{CommitObserver, CommittedSubDagSource},
+    commit_syncer::fast::FastSyncOutput,
     context::Context,
     dag_state::{DagState, TransactionSource},
     encoder::{ShardEncoder, create_encoder},
@@ -532,10 +533,13 @@ impl Core {
     /// cache.
     pub(crate) fn handle_committed_sub_dags_from_fast_sync(
         &mut self,
-        commits: Vec<TrustedCommit>,
-        committed_subdags: Vec<CommittedSubDag>,
-        voting_block_headers: Vec<VerifiedBlockHeader>,
+        output: FastSyncOutput,
     ) -> ConsensusResult<()> {
+        let FastSyncOutput {
+            commits,
+            committed_subdags,
+            voting_block_headers,
+        } = output;
         let _scope = monitored_scope("Core::handle_committed_sub_dags_from_fast_sync");
         let _s = self
             .context

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -493,7 +493,10 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
     ) -> Result<(), CoreError> {
         let (sender, receiver) = oneshot::channel();
         self.send(CoreThreadCommand::AddSubdagFromFastSync(
-            commits, subdags, voting_block_headers, sender,
+            commits,
+            subdags,
+            voting_block_headers,
+            sender,
         ))
         .await;
         Ok(receiver.await.map_err(|e| Shutdown(e.to_string()))?)

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -85,6 +85,7 @@ enum CoreThreadCommand {
     AddSubdagFromFastSync(
         Vec<TrustedCommit>,
         Vec<CommittedSubDag>,
+        Vec<VerifiedBlockHeader>, // voting block headers
         oneshot::Sender<()>,
     ),
     /// Reinitialize consensus components after fast sync completes.
@@ -160,6 +161,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
         &self,
         commits: Vec<TrustedCommit>,
         subdags: Vec<CommittedSubDag>,
+        voting_block_headers: Vec<VerifiedBlockHeader>,
     ) -> Result<(), CoreError>;
 
     /// Reinitialize consensus components after fast sync completes.
@@ -252,11 +254,11 @@ impl CoreThread {
                     }
 
                     match command {
-                        CoreThreadCommand::AddSubdagFromFastSync(commits, subdags, sender) => {
+                        CoreThreadCommand::AddSubdagFromFastSync(commits, subdags, voting_block_headers, sender) => {
                             info!("Adding subdags from fast sync, entering fast sync mode; {} index_start and {} index_end", subdags.first().map(|sd| sd.base.leader.round).unwrap_or(0), subdags.last().map(|sd| sd.base.leader.round).unwrap_or(0));
                             fast_sync_ongoing = true;
                             let _scope = monitored_scope("CoreThread::loop::add_subdags_from_fast_sync");
-                            self.core.handle_committed_sub_dags_from_fast_sync(commits, subdags)?;
+                            self.core.handle_committed_sub_dags_from_fast_sync(commits, subdags, voting_block_headers)?;
                             sender.send(()).ok();
                         }
                         CoreThreadCommand::AddBlocks(blocks, sender) => {
@@ -487,10 +489,11 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         &self,
         commits: Vec<TrustedCommit>,
         subdags: Vec<CommittedSubDag>,
+        voting_block_headers: Vec<VerifiedBlockHeader>,
     ) -> Result<(), CoreError> {
         let (sender, receiver) = oneshot::channel();
         self.send(CoreThreadCommand::AddSubdagFromFastSync(
-            commits, subdags, sender,
+            commits, subdags, voting_block_headers, sender,
         ))
         .await;
         Ok(receiver.await.map_err(|e| Shutdown(e.to_string()))?)
@@ -685,6 +688,7 @@ pub(crate) mod tests {
             &self,
             _commits: Vec<TrustedCommit>,
             _subdags: Vec<CommittedSubDag>,
+            _voting_block_headers: Vec<VerifiedBlockHeader>,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -19,9 +19,10 @@ use tokio::sync::{oneshot, watch};
 use tracing::{info, warn};
 
 use crate::{
-    CommittedSubDag, VerifiedBlockHeader,
+    VerifiedBlockHeader,
     block_header::{BlockRef, Round, VerifiedBlock, VerifiedOwnShard, VerifiedTransactions},
-    commit::{CertifiedCommits, TrustedCommit},
+    commit::CertifiedCommits,
+    commit_syncer::fast::FastSyncOutput,
     context::Context,
     core::{Core, ReasonToCreateBlock},
     core_thread::CoreError::Shutdown,
@@ -82,12 +83,7 @@ enum CoreThreadCommand {
     GetMissingTransactionData(
         oneshot::Sender<BTreeMap<GenericTransactionRef, BTreeSet<AuthorityIndex>>>,
     ),
-    AddSubdagFromFastSync(
-        Vec<TrustedCommit>,
-        Vec<CommittedSubDag>,
-        Vec<VerifiedBlockHeader>, // voting block headers
-        oneshot::Sender<()>,
-    ),
+    AddSubdagFromFastSync(FastSyncOutput, oneshot::Sender<()>),
     /// Reinitialize consensus components after fast sync completes.
     /// Stores the block headers on disk (for the cached_rounds window)
     /// and reinitializes DagState, BlockManager, CommitObserver, etc.
@@ -157,12 +153,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
         CoreError,
     >;
 
-    async fn add_subdags_from_fast_sync(
-        &self,
-        commits: Vec<TrustedCommit>,
-        subdags: Vec<CommittedSubDag>,
-        voting_block_headers: Vec<VerifiedBlockHeader>,
-    ) -> Result<(), CoreError>;
+    async fn add_subdags_from_fast_sync(&self, output: FastSyncOutput) -> Result<(), CoreError>;
 
     /// Reinitialize consensus components after fast sync completes.
     /// Stores block headers and reinitializes DagState, BlockManager,
@@ -254,11 +245,11 @@ impl CoreThread {
                     }
 
                     match command {
-                        CoreThreadCommand::AddSubdagFromFastSync(commits, subdags, voting_block_headers, sender) => {
-                            info!("Adding subdags from fast sync, entering fast sync mode; {} index_start and {} index_end", subdags.first().map(|sd| sd.base.leader.round).unwrap_or(0), subdags.last().map(|sd| sd.base.leader.round).unwrap_or(0));
+                        CoreThreadCommand::AddSubdagFromFastSync(output, sender) => {
+                            info!("Adding subdags from fast sync, entering fast sync mode; {} index_start and {} index_end", output.committed_subdags.first().map(|sd| sd.base.leader.round).unwrap_or(0), output.committed_subdags.last().map(|sd| sd.base.leader.round).unwrap_or(0));
                             fast_sync_ongoing = true;
                             let _scope = monitored_scope("CoreThread::loop::add_subdags_from_fast_sync");
-                            self.core.handle_committed_sub_dags_from_fast_sync(commits, subdags, voting_block_headers)?;
+                            self.core.handle_committed_sub_dags_from_fast_sync(output)?;
                             sender.send(()).ok();
                         }
                         CoreThreadCommand::AddBlocks(blocks, sender) => {
@@ -485,20 +476,10 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         Ok(receiver.await.map_err(|e| Shutdown(e.to_string()))?)
     }
 
-    async fn add_subdags_from_fast_sync(
-        &self,
-        commits: Vec<TrustedCommit>,
-        subdags: Vec<CommittedSubDag>,
-        voting_block_headers: Vec<VerifiedBlockHeader>,
-    ) -> Result<(), CoreError> {
+    async fn add_subdags_from_fast_sync(&self, output: FastSyncOutput) -> Result<(), CoreError> {
         let (sender, receiver) = oneshot::channel();
-        self.send(CoreThreadCommand::AddSubdagFromFastSync(
-            commits,
-            subdags,
-            voting_block_headers,
-            sender,
-        ))
-        .await;
+        self.send(CoreThreadCommand::AddSubdagFromFastSync(output, sender))
+            .await;
         Ok(receiver.await.map_err(|e| Shutdown(e.to_string()))?)
     }
 
@@ -689,9 +670,7 @@ pub(crate) mod tests {
 
         async fn add_subdags_from_fast_sync(
             &self,
-            _commits: Vec<TrustedCommit>,
-            _subdags: Vec<CommittedSubDag>,
-            _voting_block_headers: Vec<VerifiedBlockHeader>,
+            _output: FastSyncOutput,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1882,7 +1882,13 @@ impl DagState {
         // Write all buffered data to storage
         self.store
             .write(
-                WriteBatch::new(transactions, block_headers, commits, commit_info, voting_block_headers),
+                WriteBatch::new(
+                    transactions,
+                    block_headers,
+                    commits,
+                    commit_info,
+                    voting_block_headers,
+                ),
                 self.context.clone(),
             )
             .unwrap_or_else(|e| panic!("Failed to write to storage: {e:?}"));

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -172,6 +172,11 @@ pub(crate) struct DagState {
     block_headers_to_write: Vec<VerifiedBlockHeader>,
     commits_to_write: Vec<TrustedCommit>,
 
+    /// Voting block headers to be flushed to storage. These are block headers
+    /// received during fast sync that contain commit votes used to certify
+    /// commits.
+    voting_block_headers_to_write: Vec<VerifiedBlockHeader>,
+
     /// Buffer the reputation scores & last_committed_rounds to be flushed with
     /// the next dag state flush. This is okay because we can recover
     /// reputation scores & last_committed_rounds from the commits as
@@ -272,6 +277,7 @@ impl DagState {
             transactions_to_write: vec![],
             block_headers_to_write: vec![],
             commits_to_write: vec![],
+            voting_block_headers_to_write: vec![],
             commit_info_to_write: vec![],
             pending_acknowledgments: BTreeSet::new(),
             scoring_subdag,
@@ -528,6 +534,13 @@ impl DagState {
                 }
             }
         }
+    }
+
+    /// Adds voting block headers to be flushed to storage. These are block
+    /// headers received during fast sync that contain commit votes used to
+    /// certify commits.
+    pub(crate) fn add_voting_block_headers(&mut self, headers: Vec<VerifiedBlockHeader>) {
+        self.voting_block_headers_to_write.extend(headers);
     }
 
     #[cfg_attr(not(test), expect(dead_code))]
@@ -1833,12 +1846,14 @@ impl DagState {
         let block_headers = std::mem::take(&mut self.block_headers_to_write);
         let commits = std::mem::take(&mut self.commits_to_write);
         let commit_info = std::mem::take(&mut self.commit_info_to_write);
+        let voting_block_headers = std::mem::take(&mut self.voting_block_headers_to_write);
 
         // Early return if there's nothing to flush
         if transactions.is_empty()
             && block_headers.is_empty()
             && commits.is_empty()
             && commit_info.is_empty()
+            && voting_block_headers.is_empty()
         {
             return;
         }
@@ -1867,7 +1882,7 @@ impl DagState {
         // Write all buffered data to storage
         self.store
             .write(
-                WriteBatch::new(transactions, block_headers, commits, commit_info),
+                WriteBatch::new(transactions, block_headers, commits, commit_info, voting_block_headers),
                 self.context.clone(),
             )
             .unwrap_or_else(|e| panic!("Failed to write to storage: {e:?}"));

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -2428,9 +2428,7 @@ mod tests {
 
         async fn add_subdags_from_fast_sync(
             &self,
-            _commits: Vec<crate::commit::TrustedCommit>,
-            _subdags: Vec<crate::commit::CommittedSubDag>,
-            _voting_block_headers: Vec<crate::block_header::VerifiedBlockHeader>,
+            _output: crate::commit_syncer::fast::FastSyncOutput,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -2430,6 +2430,7 @@ mod tests {
             &self,
             _commits: Vec<crate::commit::TrustedCommit>,
             _subdags: Vec<crate::commit::CommittedSubDag>,
+            _voting_block_headers: Vec<crate::block_header::VerifiedBlockHeader>,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -744,9 +744,7 @@ mod tests {
 
         async fn add_subdags_from_fast_sync(
             &self,
-            _commits: Vec<crate::commit::TrustedCommit>,
-            _subdags: Vec<crate::commit::CommittedSubDag>,
-            _voting_block_headers: Vec<VerifiedBlockHeader>,
+            _output: crate::commit_syncer::fast::FastSyncOutput,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -746,6 +746,7 @@ mod tests {
             &self,
             _commits: Vec<crate::commit::TrustedCommit>,
             _subdags: Vec<crate::commit::CommittedSubDag>,
+            _voting_block_headers: Vec<VerifiedBlockHeader>,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -135,6 +135,19 @@ impl Store for MemStore {
                 .insert((commit_ref.index, commit_ref.digest), commit_info);
         }
 
+        // Handle voting block headers
+        for header in write_batch.voting_block_headers {
+            let key = (header.round(), header.author(), header.digest());
+            let block_ref = header.reference();
+            // Store commit votes from this block header
+            for vote in header.commit_votes() {
+                inner
+                    .commit_votes
+                    .insert((vote.index, vote.digest, block_ref));
+            }
+            inner.voting_block_headers.insert(key, header);
+        }
+
         Ok(())
     }
 
@@ -475,22 +488,6 @@ impl Store for MemStore {
             })
             .collect();
         Ok(exist)
-    }
-
-    fn write_voting_block_headers(&self, headers: Vec<VerifiedBlockHeader>) -> ConsensusResult<()> {
-        let mut inner = self.inner.write();
-        for header in headers {
-            let key = (header.round(), header.author(), header.digest());
-            let block_ref = header.reference();
-            // Store commit votes from this block header
-            for vote in header.commit_votes() {
-                inner
-                    .commit_votes
-                    .insert((vote.index, vote.digest, block_ref));
-            }
-            inner.voting_block_headers.insert(key, header);
-        }
-        Ok(())
     }
 
     fn read_voting_block_headers(

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -220,7 +220,10 @@ impl WriteBatch {
     }
 
     #[cfg(test)]
-    pub(crate) fn voting_block_headers(mut self, voting_block_headers: Vec<VerifiedBlockHeader>) -> Self {
+    pub(crate) fn voting_block_headers(
+        mut self,
+        voting_block_headers: Vec<VerifiedBlockHeader>,
+    ) -> Self {
         self.voting_block_headers = voting_block_headers;
         self
     }

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -158,11 +158,6 @@ pub(crate) trait Store: Send + Sync {
     /// Reads the last commit info, written atomically with the last commit.
     fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>>;
 
-    /// Writes voting block headers to a separate storage. These are block
-    /// headers that contain commit votes used to certify commits during
-    /// synchronization.
-    fn write_voting_block_headers(&self, headers: Vec<VerifiedBlockHeader>) -> ConsensusResult<()>;
-
     /// Reads voting block headers from the separate voting storage.
     /// Returns None for headers that are not found.
     fn read_voting_block_headers(
@@ -178,6 +173,7 @@ pub(crate) struct WriteBatch {
     pub(crate) block_headers: Vec<VerifiedBlockHeader>,
     pub(crate) commits: Vec<TrustedCommit>,
     pub(crate) commit_info: Vec<(CommitRef, CommitInfo)>,
+    pub(crate) voting_block_headers: Vec<VerifiedBlockHeader>,
 }
 
 impl WriteBatch {
@@ -186,12 +182,14 @@ impl WriteBatch {
         block_headers: Vec<VerifiedBlockHeader>,
         commits: Vec<TrustedCommit>,
         commit_info: Vec<(CommitRef, CommitInfo)>,
+        voting_block_headers: Vec<VerifiedBlockHeader>,
     ) -> Self {
         WriteBatch {
             transactions,
             block_headers,
             commits,
             commit_info,
+            voting_block_headers,
         }
     }
 
@@ -218,6 +216,12 @@ impl WriteBatch {
     #[cfg(test)]
     pub(crate) fn commit_info(mut self, commit_info: Vec<(CommitRef, CommitInfo)>) -> Self {
         self.commit_info = commit_info;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn voting_block_headers(mut self, voting_block_headers: Vec<VerifiedBlockHeader>) -> Self {
+        self.voting_block_headers = voting_block_headers;
         self
     }
 }

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -273,6 +273,26 @@ impl Store for RocksDBStore {
                 .map_err(ConsensusError::RocksDBFailure)?;
         }
 
+        // Handle voting block headers
+        for header in write_batch.voting_block_headers {
+            let block_ref = header.reference();
+            batch
+                .insert_batch(
+                    &self.voting_block_headers,
+                    [((block_ref.round, block_ref.author, block_ref.digest), header.serialized().clone())],
+                )
+                .map_err(ConsensusError::RocksDBFailure)?;
+            // Store commit votes from this block header
+            for vote in header.commit_votes() {
+                batch
+                    .insert_batch(
+                        &self.commit_votes,
+                        [((vote.index, vote.digest, block_ref), ())],
+                    )
+                    .map_err(ConsensusError::RocksDBFailure)?;
+            }
+        }
+
         batch.write()?;
         fail_point!("consensus-store-after-write");
         Ok(())
@@ -718,33 +738,6 @@ impl Store for RocksDBStore {
         };
         let (key, commit_info) = result.map_err(ConsensusError::RocksDBFailure)?;
         Ok(Some((CommitRef::new(key.0, key.1), commit_info)))
-    }
-
-    fn write_voting_block_headers(&self, headers: Vec<VerifiedBlockHeader>) -> ConsensusResult<()> {
-        if headers.is_empty() {
-            return Ok(());
-        }
-        let mut batch = self.voting_block_headers.batch();
-        for header in &headers {
-            let key = (header.round(), header.author(), header.digest());
-            batch
-                .insert_batch(
-                    &self.voting_block_headers,
-                    [(key, header.serialized().clone())],
-                )
-                .map_err(ConsensusError::RocksDBFailure)?;
-            // Store commit votes from this block header
-            let block_ref = header.reference();
-            for vote in header.commit_votes() {
-                batch
-                    .insert_batch(
-                        &self.commit_votes,
-                        [((vote.index, vote.digest, block_ref), ())],
-                    )
-                    .map_err(ConsensusError::RocksDBFailure)?;
-            }
-        }
-        batch.write().map_err(ConsensusError::RocksDBFailure)
     }
 
     fn read_voting_block_headers(

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -279,7 +279,10 @@ impl Store for RocksDBStore {
             batch
                 .insert_batch(
                     &self.voting_block_headers,
-                    [((block_ref.round, block_ref.author, block_ref.digest), header.serialized().clone())],
+                    [(
+                        (block_ref.round, block_ref.author, block_ref.digest),
+                        header.serialized().clone(),
+                    )],
                 )
                 .map_err(ConsensusError::RocksDBFailure)?;
             // Store commit votes from this block header

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -573,6 +573,7 @@ async fn test_voting_block_headers_storage(
     #[values(new_rocksdb_teststore(true), new_mem_teststore(true))] test_store: TestStore,
 ) {
     let store = test_store.store();
+    let context = test_store.context();
 
     // Create blocks with commit votes
     let voting_blocks: Vec<VerifiedBlock> = vec![
@@ -598,9 +599,10 @@ async fn test_voting_block_headers_storage(
         .map(|b| b.verified_block_header.clone())
         .collect();
 
-    // Write to voting storage
+    // Write to voting storage using WriteBatch
+    let write_batch = WriteBatch::default().voting_block_headers(voting_headers.clone());
     store
-        .write_voting_block_headers(voting_headers.clone())
+        .write(write_batch, context.clone())
         .expect("Write voting block headers should not fail");
 
     // Read back

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -2372,9 +2372,7 @@ mod tests {
 
         async fn add_subdags_from_fast_sync(
             &self,
-            _commits: Vec<crate::commit::TrustedCommit>,
-            _subdags: Vec<crate::commit::CommittedSubDag>,
-            _voting_block_headers: Vec<crate::block_header::VerifiedBlockHeader>,
+            _output: crate::commit_syncer::fast::FastSyncOutput,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -2374,6 +2374,7 @@ mod tests {
             &self,
             _commits: Vec<crate::commit::TrustedCommit>,
             _subdags: Vec<crate::commit::CommittedSubDag>,
+            _voting_block_headers: Vec<crate::block_header::VerifiedBlockHeader>,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }


### PR DESCRIPTION
# Description of change

PR modifies the mechanism of saving voting blocks so it is done through dag_state with the core thread.


## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
