### PR TITLE
feat(iota): print execution error source

### DIFF
--- a/crates/iota/src/displays/dry_run_tx_block.rs
+++ b/crates/iota/src/displays/dry_run_tx_block.rs
@@ -14,6 +14,7 @@ use tabled::{
 };
 
 use crate::{client_commands::estimate_gas_budget_from_gas_cost, displays::Pretty};
+
 impl Display for Pretty<'_, DryRunTransactionBlockResponse> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Pretty(response) = self;

--- a/crates/iota/src/displays/dry_run_tx_block.rs
+++ b/crates/iota/src/displays/dry_run_tx_block.rs
@@ -105,7 +105,13 @@ impl Display for Pretty<'_, DryRunTransactionBlockResponse> {
                 response.effects.gas_cost_summary(),
                 response.input.gas_data().price
             )
-        )
+        )?;
+
+        if let Some(err) = &response.execution_error_source {
+            writeln!(f, "Execution error: {}", err)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/iota/src/displays/dry_run_tx_block.rs
+++ b/crates/iota/src/displays/dry_run_tx_block.rs
@@ -109,7 +109,7 @@ impl Display for Pretty<'_, DryRunTransactionBlockResponse> {
         )?;
 
         if let Some(err) = &response.execution_error_source {
-            writeln!(f, "Execution error: {}", err)?;
+            writeln!(f, "Execution error: {err}")?;
         }
 
         Ok(())


### PR DESCRIPTION
# Description of change

Add execution error source to dry_run output.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/6448
Based on upstream PR https://github.com/MystenLabs/sui/pull/21472

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [X] CLI: Add execution error source to dry_run output
- [ ] Rust SDK:
- [ ] REST API:
