### PR TITLE
fix(starfish): separate recovery of commit observer into the linearizer initialization and sending commits to the consensus handler

### DIFF
--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -737,7 +737,7 @@ pub(crate) fn sort_sub_dag_blocks(block_headers: &mut [VerifiedBlockHeader]) {
     })
 }
 
-// Recovers the full CommittedSubDag from block store, based on Commit.
+// Recovers PendingSubDAG from block store, based on Commit.
 pub fn load_pending_subdag_from_store(
     store: &dyn Store,
     commit: TrustedCommit,

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -275,72 +275,130 @@ impl CommitObserver {
             return;
         }
 
-        self.commit_solidifier
-            .set_last_committed_index(last_commit_index);
+        // Phase 1: Resend all possible committed sub-dags that haven't been processed
+        let sent_commits =
+            self.resend_unprocessed_commits(last_processed_commit_index, last_commit_index);
 
-        // Phase 1: Recover linearizer state (only gc_depth*2 commits needed)
-        self.recover_linearizer_state(last_commit_index);
-
-        // Phase 2: Resend unprocessed commits
-        self.resend_unprocessed_commits(last_processed_commit_index, last_commit_index);
+        // Phase 2: Recover linearizer and solidifier state
+        self.recover_linearizer_and_solidifier_state(last_commit_index);
 
         info!(
-            "Commit observer recovery completed, took {:?}",
+            "Commit observer recovery completed, resent {} commits, took {:?}",
+            sent_commits.len(),
             now.elapsed()
         );
     }
 
-    /// Recovers linearizer trackers from recent commits.
-    /// Only processes commits in the gc_depth*2 window.
-    fn recover_linearizer_state(&mut self, last_commit_index: CommitIndex) {
+    /// Recovers linearizer trackers from recent commits and seeds the
+    /// commit solidifier with any unprocessed commits.
+    fn recover_linearizer_and_solidifier_state(&mut self, last_commit_index: CommitIndex) {
         let linearizer_recovery_start = last_commit_index
             .saturating_sub(self.context.protocol_config.gc_depth() * 2)
             .max(1);
+        let solidifier_recovery_start = self.last_sent_commit_index.saturating_add(1).max(1);
+        let recovery_start = linearizer_recovery_start.min(solidifier_recovery_start);
 
         let recovery_commits = self
             .store
-            .scan_commits((linearizer_recovery_start..=last_commit_index).into())
+            .scan_commits((recovery_start..=last_commit_index).into())
             .expect("Scanning commits should not fail");
 
         info!(
-            "Recovering linearizer state from {} commits (indices {}..={})",
+            "Recovering linearizer/solidifier state from {} commits (indices {}..={})",
             recovery_commits.len(),
-            linearizer_recovery_start,
+            recovery_start,
             last_commit_index
         );
 
+        self.commit_solidifier
+            .set_last_committed_index(self.last_sent_commit_index);
+
+        let mut pending_for_solidifier = Vec::new();
         for commit in recovery_commits {
             // Recovery only needs headers/acks, so reputation scores are irrelevant here.
+            let commit_index = commit.index();
             let pending_sub_dag =
                 load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]);
 
-            // Rebuild traversed headers tracker
-            self.linearizer
-                .record_traversed_headers(pending_sub_dag.headers.iter());
+            if commit_index >= linearizer_recovery_start {
+                // Rebuild traversed headers tracker
+                self.linearizer
+                    .record_traversed_headers(pending_sub_dag.headers.iter());
 
-            // Recover transaction acknowledgments tracker state
-            for ((round, authority_idx), transaction_acknowledgments) in
-                pending_sub_dag.transaction_acknowledgments().into_iter()
-            {
-                self.linearizer.add_committed_transaction_acks(
-                    round,
-                    authority_idx,
-                    transaction_acknowledgments,
-                );
+                // Recover transaction acknowledgments tracker state
+                for ((round, authority_idx), transaction_acknowledgments) in
+                    pending_sub_dag.transaction_acknowledgments().into_iter()
+                {
+                    self.linearizer.add_committed_transaction_acks(
+                        round,
+                        authority_idx,
+                        transaction_acknowledgments,
+                    );
+                }
+            }
+
+            if commit_index >= solidifier_recovery_start {
+                pending_for_solidifier.push(pending_sub_dag);
             }
         }
+
+        if !pending_for_solidifier.is_empty() {
+            let (solid_sub_dags, _missing) = self
+                .commit_solidifier
+                .try_get_solid_sub_dags(&pending_for_solidifier);
+            let _sent_commits = self.send_recovered_sub_dags(
+                solid_sub_dags,
+                CommittedSubDagSource::Recover,
+                "Sending solid commit during recovery after resend",
+            );
+        }
+    }
+
+    fn send_recovered_sub_dags(
+        &mut self,
+        committed_subdags: Vec<CommittedSubDag>,
+        source: CommittedSubDagSource,
+        log_prefix: &'static str,
+    ) -> Vec<CommitIndex> {
+        if committed_subdags.is_empty() {
+            return Vec::new();
+        }
+
+        let mut sent_commit_indices = Vec::with_capacity(committed_subdags.len());
+        for committed_subdag in committed_subdags.iter() {
+            assert_eq!(
+                committed_subdag.commit_ref.index,
+                self.last_sent_commit_index + 1
+            );
+            info!(
+                "{log_prefix} (index: {})",
+                committed_subdag.commit_ref.index
+            );
+            self.sender
+                .send(committed_subdag.clone())
+                .unwrap_or_else(|e| {
+                    panic!("Failed to send commit during recovery, probably due to shutdown: {e:?}")
+                });
+            self.last_sent_commit_index = committed_subdag.commit_ref.index;
+            sent_commit_indices.push(committed_subdag.commit_ref.index);
+        }
+
+        self.report_metrics(&[], &committed_subdags, source);
+
+        sent_commit_indices
     }
 
     /// Resends commits that haven't been processed by the consumer.
     /// Creates CommittedSubDag with empty headers (like fast sync).
+    /// Returns the commit indices that were resent.
     fn resend_unprocessed_commits(
         &mut self,
         last_processed_commit_index: CommitIndex,
         last_commit_index: CommitIndex,
-    ) {
+    ) -> Vec<CommitIndex> {
         if last_processed_commit_index >= last_commit_index {
             info!("No unprocessed commits to resend");
-            return;
+            return Vec::new();
         }
 
         let unprocessed_commits = self
@@ -356,9 +414,12 @@ impl CommitObserver {
         );
 
         let num_commits = unprocessed_commits.len();
+        let mut committed_subdags = Vec::new();
+        let mut expected_commit_index = self.last_sent_commit_index + 1;
         for (index, commit) in unprocessed_commits.into_iter().enumerate() {
             let commit_index = commit.index();
-            assert_eq!(commit_index, self.last_sent_commit_index + 1);
+            assert_eq!(commit_index, expected_commit_index);
+            expected_commit_index += 1;
 
             // Only the last commit carries scores for leader schedule consumers.
             let reputation_scores = if index == num_commits - 1 {
@@ -383,10 +444,11 @@ impl CommitObserver {
                 .enumerate()
                 .find_map(|(idx, tx)| tx.is_none().then_some((idx, committed_tx_refs[idx])))
             {
-                panic!(
-                    "Missing committed transaction during recovery for commit {commit_index}: {:?} (index {missing_index})",
-                    missing_ref
+                info!(
+                    "Stopping resend at commit {} due to missing transaction {:?} (index {})",
+                    commit_index, missing_ref, missing_index
                 );
+                break;
             }
             let transactions = transaction_results
                 .into_iter()
@@ -395,7 +457,7 @@ impl CommitObserver {
 
             let committed_subdag = CommittedSubDag::new(
                 commit.leader(),
-                vec![], // Empty headers like fast sync
+                vec![], // Empty headers is fine for resending during recovery
                 commit.block_headers().to_vec(),
                 transactions,
                 commit.timestamp_ms(),
@@ -403,13 +465,14 @@ impl CommitObserver {
                 reputation_scores,
             );
 
-            info!("Resending commit {} during recovery", commit_index);
-            self.sender.send(committed_subdag).unwrap_or_else(|e| {
-                panic!("Failed to send commit during recovery, probably due to shutdown: {e:?}")
-            });
-
-            self.last_sent_commit_index = commit_index;
+            committed_subdags.push(committed_subdag);
         }
+
+        self.send_recovered_sub_dags(
+            committed_subdags,
+            CommittedSubDagSource::Recover,
+            "Resending commit during recovery",
+        )
     }
 
     /// Get all missing transactions from pending subdags along with authorities
@@ -543,8 +606,11 @@ mod tests {
 
     use super::*;
     use crate::{
-        block_header::BlockRef, context::Context, dag_state::DagState,
-        storage::mem_store::MemStore, test_dag_builder::DagBuilder,
+        block_header::BlockRef,
+        context::Context,
+        dag_state::{DagState, TransactionSource},
+        storage::mem_store::MemStore,
+        test_dag_builder::DagBuilder,
     };
 
     #[tokio::test]
@@ -894,6 +960,109 @@ mod tests {
         // No commits should be resubmitted as consensus store's last commit index
         // is equal to last processed index by consumer
         verify_channel_empty(&mut receiver);
+    }
+
+    #[tokio::test]
+    async fn test_recovery_resends_available_commits_and_tracks_missing_transactions() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities = 4;
+        let context = Arc::new(Context::new_for_test(num_authorities).0);
+        let mem_store = Arc::new(MemStore::new(context.clone()));
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            mem_store.clone(),
+        )));
+        let (sender, mut receiver) = unbounded_channel("consensus_output");
+
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
+            context.clone(),
+            dag_state.clone(),
+        ));
+
+        let num_rounds = 6;
+        let mut builder = DagBuilder::new(context.clone());
+        builder.layers(1..=num_rounds).build();
+
+        {
+            let mut dag_state_guard = dag_state.write();
+            dag_state_guard.accept_block_headers(builder.block_headers.values().cloned().collect());
+            for (block_ref, transactions) in builder.transactions.iter() {
+                if block_ref.round <= 3 {
+                    dag_state_guard.add_transactions(transactions.clone(), TransactionSource::Test);
+                }
+            }
+        }
+
+        let mut observer = CommitObserver::new(
+            context.clone(),
+            CommitConsumer::new(sender.clone(), 0),
+            dag_state.clone(),
+            mem_store.clone(),
+            leader_schedule.clone(),
+        );
+
+        let leaders = builder
+            .leader_blocks(1..=num_rounds)
+            .into_iter()
+            .map(Option::unwrap)
+            .collect::<Vec<_>>();
+
+        let _ = observer
+            .handle_committed_leaders(leaders, CommittedSubDagSource::Consensus)
+            .unwrap();
+
+        while let Ok(_subdag) = receiver.try_recv() {}
+
+        let last_commit = mem_store.read_last_commit().unwrap().unwrap();
+        let last_commit_index = last_commit.index();
+        let commits = mem_store
+            .scan_commits((1..=last_commit_index).into())
+            .unwrap();
+
+        let mut first_missing_index = None;
+        let mut expected_missing_refs = Vec::new();
+        {
+            let dag_state_guard = dag_state.read();
+            for commit in &commits {
+                let committed_refs = commit.committed_transactions();
+                let tx_results = dag_state_guard.get_verified_transactions(&committed_refs);
+                let missing_refs = committed_refs
+                    .into_iter()
+                    .zip(tx_results.iter())
+                    .filter_map(|(tx_ref, tx)| tx.is_none().then_some(tx_ref))
+                    .collect::<Vec<_>>();
+                if !missing_refs.is_empty() {
+                    first_missing_index = Some(commit.index());
+                    expected_missing_refs = missing_refs;
+                    break;
+                }
+            }
+        }
+
+        let first_missing_index =
+            first_missing_index.expect("Expected at least one commit with missing transactions");
+        assert!(first_missing_index > 1);
+
+        let observer = CommitObserver::new(
+            context.clone(),
+            CommitConsumer::new(sender, 0),
+            dag_state.clone(),
+            mem_store.clone(),
+            leader_schedule,
+        );
+
+        let mut expected_index = 1u32;
+        while let Ok(subdag) = receiver.try_recv() {
+            assert!(subdag.headers.is_empty());
+            assert_eq!(subdag.commit_ref.index, expected_index);
+            expected_index += 1;
+        }
+        assert_eq!(expected_index - 1, first_missing_index - 1);
+
+        let missing = observer.get_missing_transaction_data();
+        for missing_ref in expected_missing_refs {
+            assert!(missing.contains_key(&missing_ref));
+        }
     }
 
     /// After receiving all expected subdags, ensure channel is empty

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -327,7 +327,7 @@ impl CommitObserver {
                 .commit_solidifier
                 .try_get_solid_sub_dags(&pending_for_solidifier);
             self.send_sub_dags(&solid_sub_dags, source)
-                .expect("Failed to send solid commits during recovery");
+                .expect("We should successfully send solid commits during recovery");
             self.report_metrics(&[], &solid_sub_dags, source);
         }
     }
@@ -447,7 +447,11 @@ impl CommitObserver {
             }
             let transactions = transaction_results
                 .into_iter()
-                .map(|tx| tx.expect("Missing committed transaction during recovery"))
+                .map(|tx| {
+                    tx.expect(
+                        "We should expect all committed transactions be present after the check",
+                    )
+                })
                 .collect();
 
             let committed_subdag = CommittedSubDag::new(
@@ -465,7 +469,7 @@ impl CommitObserver {
 
         let sent_indices = self
             .send_sub_dags(&committed_subdags, source)
-            .expect("Failed to send commits during recovery");
+            .expect("We should expect successful sending committed subDags during recovery");
         self.report_metrics(&[], &committed_subdags, source);
         sent_indices
     }

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -258,87 +258,67 @@ impl CommitObserver {
 
     fn recover_and_send_commits(&mut self, last_processed_commit_index: CommitIndex) {
         let now = Instant::now();
-        // TODO: remove this check, to allow consensus to regenerate commits?
         let last_commit = self
             .store
             .read_last_commit()
             .expect("Reading the last commit should not fail");
+        let last_commit_index = last_commit
+            .as_ref()
+            .map(|commit| commit.index())
+            .unwrap_or(0);
+        assert!(
+            last_commit_index >= last_processed_commit_index,
+            "The consensus DB is behind the node DB!"
+        );
+        if last_commit_index == 0 {
+            info!("No commits to recover in commit observer");
+            return;
+        }
 
-        // Value used to recover transactions_ack_tracker in the linearizer.
-        let mut recovery_lower_bound: CommitIndex = last_processed_commit_index + 1;
-        if let Some(last_commit) = &last_commit {
-            let last_commit_index = last_commit.index();
+        self.commit_solidifier
+            .set_last_committed_index(last_commit_index);
 
-            // The earliest commit that still might acknowledge not-yet-committed
-            // transactions that still have a chance of being committed is no higher than
-            // `last_pending_commit_index - protocol_config.gc_depth() * 2, once for
-            // max linearizer depth and once for max transaction ack depth.
+        // Phase 1: Recover linearizer state (only gc_depth*2 commits needed)
+        self.recover_linearizer_state(last_commit_index);
 
-            let commit_index_to_recover_acks =
-                last_commit_index.saturating_sub(self.context.protocol_config.gc_depth() * 2);
+        // Phase 2: Resend unprocessed commits
+        self.resend_unprocessed_commits(last_processed_commit_index, last_commit_index);
 
-            recovery_lower_bound = recovery_lower_bound
-                .min(commit_index_to_recover_acks)
-                .max(1);
-            assert!(last_commit_index >= last_processed_commit_index);
-        };
+        info!(
+            "Commit observer recovery completed, took {:?}",
+            now.elapsed()
+        );
+    }
 
-        // Retrieve all the commits from the recover lower bound until the end.
+    /// Recovers linearizer trackers from recent commits.
+    /// Only processes commits in the gc_depth*2 window.
+    fn recover_linearizer_state(&mut self, last_commit_index: CommitIndex) {
+        let linearizer_recovery_start = last_commit_index
+            .saturating_sub(self.context.protocol_config.gc_depth() * 2)
+            .max(1);
+
         let recovery_commits = self
             .store
-            .scan_commits((recovery_lower_bound..=CommitIndex::MAX).into())
+            .scan_commits((linearizer_recovery_start..=last_commit_index).into())
             .expect("Scanning commits should not fail");
 
         info!(
-            "Recovering commit observer state after last processed index {last_processed_commit_index} and \
-            recovery lower bound {recovery_lower_bound} with last commit {} and {} recovery commits",
-            last_commit.map(|c| c.index()).unwrap_or_default(),
-            recovery_commits.len()
+            "Recovering linearizer state from {} commits (indices {}..={})",
+            recovery_commits.len(),
+            linearizer_recovery_start,
+            last_commit_index
         );
 
-        // Recover transaction acknowledgment tracker in the linearizer using all the
-        // commits and resend all the committed sub-dags to the consensus output channel
-        // for all the commits above the last processed index.
-        let mut next_commit_index_to_recover = recovery_lower_bound;
-        let num_recovery_commits = recovery_commits.len();
-
-        for (index, commit) in recovery_commits.into_iter().enumerate() {
-            let commit_index = commit.index();
-            // Commit index must be continuous during recovery.
-            assert_eq!(commit_index, next_commit_index_to_recover);
-            // For the first recovery commit, set the solidifier's baseline to just
-            // before this commit. This ensures the solidifier correctly tracks commits
-            // from the recovery start point forward.
-            if index == 0 {
-                self.commit_solidifier
-                    .set_last_committed_index(commit_index.saturating_sub(1));
-            }
-            // On recovery leader schedule will be updated with the current scores
-            // and the scores will be passed along with the last commit sent to
-            // iota so that the current scores are available for submission.
-            let reputation_scores = if index == num_recovery_commits - 1 {
-                self.leader_schedule
-                    .leader_swap_table
-                    .read()
-                    .reputation_scores_desc
-                    .clone()
-            } else {
-                vec![]
-            };
-
-            info!("Processing commit {} during recovery", commit_index);
-
+        for commit in recovery_commits {
+            // Recovery only needs headers/acks, so reputation scores are irrelevant here.
             let pending_sub_dag =
-                load_pending_subdag_from_store(self.store.as_ref(), commit, reputation_scores);
+                load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]);
 
-            // Rebuild traversed headers tracker so recovery can honor the
-            // traversed-headers gate when committing transactions.
+            // Rebuild traversed headers tracker
             self.linearizer
                 .record_traversed_headers(pending_sub_dag.headers.iter());
 
-            // Recover transaction acknowledgments tracker state by adding transaction
-            // acknowledgments from all pending sub-dags that still might
-            // correctly acknowledge transactions.
+            // Recover transaction acknowledgments tracker state
             for ((round, authority_idx), transaction_acknowledgments) in
                 pending_sub_dag.transaction_acknowledgments().into_iter()
             {
@@ -348,48 +328,88 @@ impl CommitObserver {
                     transaction_acknowledgments,
                 );
             }
-            // Put all the pending sub-dags into the commit solidifier to make sure that
-            // they are tracked there. The commit will be sent to IOTA here if all the
-            // transactions are available or will be kept in the buffer and sent later when
-            // the transactions become available.
-            let (solid_sub_dags, _missing) = self
-                .commit_solidifier
-                .try_get_solid_sub_dags(&[pending_sub_dag]);
-            // Only submit unprocessed commits to IOTA
-            for solid_sub_dag in solid_sub_dags {
-                if solid_sub_dag.commit_ref.index > last_processed_commit_index {
-                    // Commit index must be continuous during recovery.
-                    assert_eq!(
-                        solid_sub_dag.commit_ref.index,
-                        self.last_sent_commit_index + 1
-                    );
-                    info!(
-                        "Sending solid commit {} during recovery",
-                        solid_sub_dag.commit_ref.index
-                    );
-                    self.sender.send(solid_sub_dag).unwrap_or_else(|e| {
-                        panic!(
-                            "Failed to send commit during recovery, probably due to shutdown: {e:?}"
-                        )
-                    });
+        }
+    }
 
-                    self.last_sent_commit_index += 1;
-                } else {
-                    debug!(
-                        "Not sending solid commit as commit index {} <= \
-                    {last_processed_commit_index} last processed index",
-                        solid_sub_dag.commit_ref.index
-                    );
-                }
-            }
-
-            next_commit_index_to_recover += 1;
+    /// Resends commits that haven't been processed by the consumer.
+    /// Creates CommittedSubDag with empty headers (like fast sync).
+    fn resend_unprocessed_commits(
+        &mut self,
+        last_processed_commit_index: CommitIndex,
+        last_commit_index: CommitIndex,
+    ) {
+        if last_processed_commit_index >= last_commit_index {
+            info!("No unprocessed commits to resend");
+            return;
         }
 
+        let unprocessed_commits = self
+            .store
+            .scan_commits((last_processed_commit_index + 1..=last_commit_index).into())
+            .expect("Scanning commits should not fail");
+
         info!(
-            "Commit observer recovery completed, took {:?}",
-            now.elapsed()
+            "Resending {} unprocessed commits (indices {}..={})",
+            unprocessed_commits.len(),
+            last_processed_commit_index + 1,
+            last_commit_index
         );
+
+        let num_commits = unprocessed_commits.len();
+        for (index, commit) in unprocessed_commits.into_iter().enumerate() {
+            let commit_index = commit.index();
+            assert_eq!(commit_index, self.last_sent_commit_index + 1);
+
+            // Only the last commit carries scores for leader schedule consumers.
+            let reputation_scores = if index == num_commits - 1 {
+                self.leader_schedule
+                    .leader_swap_table
+                    .read()
+                    .reputation_scores_desc
+                    .clone()
+            } else {
+                vec![]
+            };
+
+            // Create CommittedSubDag with empty headers (like fast sync)
+            let committed_tx_refs = commit.committed_transactions();
+            let transaction_results = {
+                self.dag_state
+                    .read()
+                    .get_verified_transactions(&committed_tx_refs)
+            };
+            if let Some((missing_index, missing_ref)) = transaction_results
+                .iter()
+                .enumerate()
+                .find_map(|(idx, tx)| tx.is_none().then_some((idx, committed_tx_refs[idx])))
+            {
+                panic!(
+                    "Missing committed transaction during recovery for commit {commit_index}: {:?} (index {missing_index})",
+                    missing_ref
+                );
+            }
+            let transactions = transaction_results
+                .into_iter()
+                .map(|tx| tx.expect("Missing committed transaction during recovery"))
+                .collect();
+
+            let committed_subdag = CommittedSubDag::new(
+                commit.leader(),
+                vec![], // Empty headers like fast sync
+                commit.block_headers().to_vec(),
+                transactions,
+                commit.timestamp_ms(),
+                commit.reference(),
+                reputation_scores,
+            );
+
+            info!("Resending commit {} during recovery", commit_index);
+            self.sender.send(committed_subdag).unwrap_or_else(|e| {
+                panic!("Failed to send commit during recovery, probably due to shutdown: {e:?}")
+            });
+
+            self.last_sent_commit_index = commit_index;
+        }
     }
 
     /// Get all missing transactions from pending subdags along with authorities
@@ -772,7 +792,15 @@ mod tests {
         processed_subdag_index = expected_last_processed_index;
         while let Ok(subdag) = receiver.try_recv() {
             info!("Processed {subdag} on resubmission");
-            assert_eq!(subdag.base, created_commits[processed_subdag_index].base);
+            let expected_base = &created_commits[processed_subdag_index].base;
+            assert!(subdag.headers.is_empty());
+            assert_eq!(subdag.leader, expected_base.leader);
+            assert_eq!(subdag.commit_ref, expected_base.commit_ref);
+            assert_eq!(
+                subdag.committed_header_refs,
+                expected_base.committed_header_refs
+            );
+            assert_eq!(subdag.timestamp_ms, expected_base.timestamp_ms);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
             processed_subdag_index = subdag.commit_ref.index as usize;
             if processed_subdag_index == expected_last_sent_index {

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -252,15 +252,20 @@ impl CommitObserver {
         }
 
         // Phase 1: Resend all solid committed sub-dags that haven't been processed
-        let sent_commits =
-            self.resend_unprocessed_commits(last_processed_commit_index, last_commit_index, source);
+        let sent_commits = self.resend_unprocessed_solid_commits(
+            last_processed_commit_index,
+            last_commit_index,
+            source,
+        );
 
         // Phase 2: Recover linearizer and solidifier state
         self.recover_linearizer_and_solidifier_state(last_commit_index, source);
 
         info!(
-            "Commit observer recovery completed, resent {} commits, took {:?}",
+            "Commit observer recovery completed, resent {} commits with indices [{}..{}], took {:?}",
             sent_commits.len(),
+            sent_commits.first().unwrap_or(&0),
+            sent_commits.last().unwrap_or(&0),
             now.elapsed()
         );
     }
@@ -291,7 +296,7 @@ impl CommitObserver {
         );
 
         self.commit_solidifier
-            .set_last_committed_index(self.last_sent_commit_index);
+            .set_last_solid_committed_index(self.last_sent_commit_index);
 
         let mut pending_for_solidifier = Vec::new();
         for commit in recovery_commits {
@@ -383,10 +388,13 @@ impl CommitObserver {
         Ok(sent_commit_indices)
     }
 
-    /// Resends commits that haven't been processed by the consumer.
+    /// Resends solid commits that haven't been processed by the consumer.
     /// Creates CommittedSubDag with empty headers (like fast sync).
     /// Returns the commit indices that were resent.
-    fn resend_unprocessed_commits(
+    /// Note: it is possible that some commits in interval
+    /// last_processed_commit_index+1.. last_commit_index might be not yet
+    /// solid
+    fn resend_unprocessed_solid_commits(
         &mut self,
         last_processed_commit_index: CommitIndex,
         last_commit_index: CommitIndex,

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -104,7 +104,8 @@ impl CommitObserver {
             last_sent_commit_index: last_processed_commit_index,
         };
 
-        observer.recover_and_send_commits(last_processed_commit_index);
+        observer
+            .recover_and_send_commits(last_processed_commit_index, CommittedSubDagSource::Recover);
         observer
     }
 
@@ -117,12 +118,12 @@ impl CommitObserver {
         let now = Instant::now();
 
         // Clear linearizer state
-        self.linearizer.reinitialize();
+        self.linearizer.clear_state();
         self.last_sent_commit_index = last_commit_index;
 
         // Reuse existing recovery logic - it won't resend commits since
         // they're all <= last_commit_index
-        self.recover_and_send_commits(last_commit_index);
+        self.recover_and_send_commits(last_commit_index, CommittedSubDagSource::FastCommitSyncer);
 
         info!(
             "CommitObserver reinitialized at commit index {}, took {:?}",
@@ -218,45 +219,20 @@ impl CommitObserver {
             dag_state_guard.flush();
         }
 
-        let mut sent_sub_dags = Vec::with_capacity(committed_subdags.len());
-        for solid_sub_dag in committed_subdags.iter() {
-            // Skip commits that have already been sent
-            if solid_sub_dag.commit_ref.index <= self.last_sent_commit_index {
-                debug!(
-                    "Skipping already sent commit (index: {} <= last sent: {})",
-                    solid_sub_dag.commit_ref.index, self.last_sent_commit_index
-                );
-                continue;
-            }
+        // Send committed sub-dags through the channel
+        let _sent_indices = self.send_sub_dags(&committed_subdags, source)?;
 
-            // Ensure commits are sent in order - if we're skipping indices, something is
-            // wrong
-            assert_eq!(
-                solid_sub_dag.commit_ref.index,
-                self.last_sent_commit_index + 1,
-            );
-
-            // Failures in sender.send() are assumed to be permanent
-            if let Err(err) = self.sender.send(solid_sub_dag.clone()) {
-                warn!("Failed to send committed sub-dag, probably due to shutdown: {err:?}");
-                return Err(ConsensusError::Shutdown);
-            }
-            info!(
-                "Sending commit to execution (index: {}, leader {})",
-                solid_sub_dag.commit_ref, solid_sub_dag.leader
-            );
-
-            self.last_sent_commit_index = solid_sub_dag.commit_ref.index;
-            sent_sub_dags.push(solid_sub_dag);
-        }
+        // Report metrics for both pending and committed sub-dags
         self.report_metrics(pending_sub_dags, &committed_subdags, source);
-
-        tracing::trace!("Committed & sent {sent_sub_dags:#?}");
 
         Ok(())
     }
 
-    fn recover_and_send_commits(&mut self, last_processed_commit_index: CommitIndex) {
+    fn recover_and_send_commits(
+        &mut self,
+        last_processed_commit_index: CommitIndex,
+        source: CommittedSubDagSource,
+    ) {
         let now = Instant::now();
         let last_commit = self
             .store
@@ -275,12 +251,12 @@ impl CommitObserver {
             return;
         }
 
-        // Phase 1: Resend all possible committed sub-dags that haven't been processed
+        // Phase 1: Resend all solid committed sub-dags that haven't been processed
         let sent_commits =
-            self.resend_unprocessed_commits(last_processed_commit_index, last_commit_index);
+            self.resend_unprocessed_commits(last_processed_commit_index, last_commit_index, source);
 
         // Phase 2: Recover linearizer and solidifier state
-        self.recover_linearizer_and_solidifier_state(last_commit_index);
+        self.recover_linearizer_and_solidifier_state(last_commit_index, source);
 
         info!(
             "Commit observer recovery completed, resent {} commits, took {:?}",
@@ -291,11 +267,15 @@ impl CommitObserver {
 
     /// Recovers linearizer trackers from recent commits and seeds the
     /// commit solidifier with any unprocessed commits.
-    fn recover_linearizer_and_solidifier_state(&mut self, last_commit_index: CommitIndex) {
+    fn recover_linearizer_and_solidifier_state(
+        &mut self,
+        last_commit_index: CommitIndex,
+        source: CommittedSubDagSource,
+    ) {
         let linearizer_recovery_start = last_commit_index
             .saturating_sub(self.context.protocol_config.gc_depth() * 2)
             .max(1);
-        let solidifier_recovery_start = self.last_sent_commit_index.saturating_add(1).max(1);
+        let solidifier_recovery_start = self.last_sent_commit_index.saturating_add(1);
         let recovery_start = linearizer_recovery_start.min(solidifier_recovery_start);
 
         let recovery_commits = self
@@ -346,46 +326,61 @@ impl CommitObserver {
             let (solid_sub_dags, _missing) = self
                 .commit_solidifier
                 .try_get_solid_sub_dags(&pending_for_solidifier);
-            let _sent_commits = self.send_recovered_sub_dags(
-                solid_sub_dags,
-                CommittedSubDagSource::Recover,
-                "Sending solid commit during recovery after resend",
-            );
+            self.send_sub_dags(&solid_sub_dags, source)
+                .expect("Failed to send solid commits during recovery");
+            self.report_metrics(&[], &solid_sub_dags, source);
         }
     }
 
-    fn send_recovered_sub_dags(
+    /// Sends committed sub-dags through the channel.
+    /// Skips commits that have already been sent (index <=
+    /// last_sent_commit_index). Returns the list of commit indices that
+    /// were actually sent. Note: Caller is responsible for reporting
+    /// metrics via `report_metrics`.
+    fn send_sub_dags(
         &mut self,
-        committed_subdags: Vec<CommittedSubDag>,
+        committed_subdags: &[CommittedSubDag],
         source: CommittedSubDagSource,
-        log_prefix: &'static str,
-    ) -> Vec<CommitIndex> {
+    ) -> ConsensusResult<Vec<CommitIndex>> {
         if committed_subdags.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
 
         let mut sent_commit_indices = Vec::with_capacity(committed_subdags.len());
+
         for committed_subdag in committed_subdags.iter() {
+            // Skip commits that have already been sent
+            if committed_subdag.commit_ref.index <= self.last_sent_commit_index {
+                debug!(
+                    "Skipping already sent commit (index: {} <= last sent: {})",
+                    committed_subdag.commit_ref.index, self.last_sent_commit_index
+                );
+                continue;
+            }
+
+            // Ensure commits are sent in order
             assert_eq!(
                 committed_subdag.commit_ref.index,
-                self.last_sent_commit_index + 1
+                self.last_sent_commit_index + 1,
             );
+
+            if let Err(err) = self.sender.send(committed_subdag.clone()) {
+                warn!("Failed to send committed sub-dag, probably due to shutdown: {err:?}");
+                return Err(ConsensusError::Shutdown);
+            }
+
             info!(
-                "{log_prefix} (index: {})",
-                committed_subdag.commit_ref.index
+                "Sending commit to execution (index: {}, leader {}, source: {})",
+                committed_subdag.commit_ref,
+                committed_subdag.leader,
+                source.as_str()
             );
-            self.sender
-                .send(committed_subdag.clone())
-                .unwrap_or_else(|e| {
-                    panic!("Failed to send commit during recovery, probably due to shutdown: {e:?}")
-                });
+
             self.last_sent_commit_index = committed_subdag.commit_ref.index;
             sent_commit_indices.push(committed_subdag.commit_ref.index);
         }
 
-        self.report_metrics(&[], &committed_subdags, source);
-
-        sent_commit_indices
+        Ok(sent_commit_indices)
     }
 
     /// Resends commits that haven't been processed by the consumer.
@@ -395,6 +390,7 @@ impl CommitObserver {
         &mut self,
         last_processed_commit_index: CommitIndex,
         last_commit_index: CommitIndex,
+        source: CommittedSubDagSource,
     ) -> Vec<CommitIndex> {
         if last_processed_commit_index >= last_commit_index {
             info!("No unprocessed commits to resend");
@@ -432,7 +428,6 @@ impl CommitObserver {
                 vec![]
             };
 
-            // Create CommittedSubDag with empty headers (like fast sync)
             let committed_tx_refs = commit.committed_transactions();
             let transaction_results = {
                 self.dag_state
@@ -457,7 +452,7 @@ impl CommitObserver {
 
             let committed_subdag = CommittedSubDag::new(
                 commit.leader(),
-                vec![], // Empty headers is fine for resending during recovery
+                vec![], // Empty headers is fine for resending during recovery or reinitialization
                 commit.block_headers().to_vec(),
                 transactions,
                 commit.timestamp_ms(),
@@ -468,11 +463,11 @@ impl CommitObserver {
             committed_subdags.push(committed_subdag);
         }
 
-        self.send_recovered_sub_dags(
-            committed_subdags,
-            CommittedSubDagSource::Recover,
-            "Resending commit during recovery",
-        )
+        let sent_indices = self
+            .send_sub_dags(&committed_subdags, source)
+            .expect("Failed to send commits during recovery");
+        self.report_metrics(&[], &committed_subdags, source);
+        sent_indices
     }
 
     /// Get all missing transactions from pending subdags along with authorities
@@ -979,6 +974,9 @@ mod tests {
             dag_state.clone(),
         ));
 
+        // Populate fully connected test blocks for round 1 ~ 6, authorities 0 ~ 3.
+        // Only add transactions for rounds 1-3 to simulate partial transaction
+        // availability. Transactions for rounds 4-6 will be "missing" during recovery.
         let num_rounds = 6;
         let mut builder = DagBuilder::new(context.clone());
         builder.layers(1..=num_rounds).build();
@@ -1007,10 +1005,15 @@ mod tests {
             .map(Option::unwrap)
             .collect::<Vec<_>>();
 
+        // All 6 rounds should produce commits (one per leader round)
+        assert_eq!(leaders.len(), num_rounds as usize);
+
         let _ = observer
             .handle_committed_leaders(leaders, CommittedSubDagSource::Consensus)
             .unwrap();
 
+        // Drain the receiver to simulate consumer processing commits before crash.
+        // We need to determine which commits have available transactions for resending.
         while let Ok(_subdag) = receiver.try_recv() {}
 
         let last_commit = mem_store.read_last_commit().unwrap().unwrap();
@@ -1019,6 +1022,13 @@ mod tests {
             .scan_commits((1..=last_commit_index).into())
             .unwrap();
 
+        // Verify we stored all commits
+        assert_eq!(commits.len(), num_rounds as usize);
+
+        // Determine which commit first has missing transactions.
+        // Each commit references transactions from blocks up to the leader's round.
+        // Since we only added transactions for rounds <= 3, commits including
+        // blocks from round > 3 will have missing transactions.
         let mut first_missing_index = None;
         let mut expected_missing_refs = Vec::new();
         {
@@ -1041,8 +1051,23 @@ mod tests {
 
         let first_missing_index =
             first_missing_index.expect("Expected at least one commit with missing transactions");
-        assert!(first_missing_index > 1);
+        // First commit with missing transactions should occur when commits start
+        // including blocks from rounds > 3. With the fully connected DAG structure,
+        // this happens at commit 4 or later depending on how blocks are ordered.
+        assert!(
+            first_missing_index > 1,
+            "Expected first missing at index > 1, got {}",
+            first_missing_index
+        );
+        assert!(
+            first_missing_index <= num_rounds as CommitIndex,
+            "Expected first missing within num_rounds, got {}",
+            first_missing_index
+        );
 
+        // Re-create commit observer starting from index 0 to simulate full recovery.
+        // Recovery should resend commits up to (but not including) the first commit
+        // with missing transactions.
         let observer = CommitObserver::new(
             context.clone(),
             CommitConsumer::new(sender, 0),
@@ -1051,18 +1076,65 @@ mod tests {
             leader_schedule,
         );
 
+        // Check commits sent over consensus output channel during recovery.
+        // Recovery resends subdags with empty headers (like fast sync).
         let mut expected_index = 1u32;
         while let Ok(subdag) = receiver.try_recv() {
+            // Recovery resends subdags with empty headers (like fast sync)
             assert!(subdag.headers.is_empty());
             assert_eq!(subdag.commit_ref.index, expected_index);
+
+            // Verify subdag matches the original commit structure
+            let original_commit = &commits[(expected_index - 1) as usize];
+            assert_eq!(subdag.leader, original_commit.leader());
+            assert_eq!(
+                subdag.committed_header_refs,
+                original_commit.block_headers()
+            );
+
             expected_index += 1;
         }
-        assert_eq!(expected_index - 1, first_missing_index - 1);
 
+        // Verify exactly (first_missing_index - 1) commits were resent
+        let resent_count = expected_index - 1;
+        assert_eq!(resent_count, first_missing_index - 1);
+        assert!(
+            resent_count > 0,
+            "Expected at least one commit to be resent"
+        );
+
+        // Verify missing transactions are properly tracked with acknowledgers.
+        // The linearizer recovers ack state from commits within gc_depth*2 window,
+        // so all commits in this small test should have acknowledgers available.
         let missing = observer.get_missing_transaction_data();
-        for missing_ref in expected_missing_refs {
-            assert!(missing.contains_key(&missing_ref));
+        assert!(
+            !missing.is_empty(),
+            "Expected missing transactions to be tracked"
+        );
+        assert_eq!(
+            missing.len(),
+            expected_missing_refs.len(),
+            "Mismatch in number of missing transactions"
+        );
+
+        for missing_ref in &expected_missing_refs {
+            assert!(
+                missing.contains_key(missing_ref),
+                "Missing ref {:?} not tracked",
+                missing_ref
+            );
+            // Each missing transaction should have acknowledgers recorded since
+            // all commits are within the recovery window (gc_depth * 2).
+            let acknowledgers = missing.get(missing_ref).unwrap();
+            assert!(
+                !acknowledgers.is_empty(),
+                "No acknowledgers tracked for {:?}",
+                missing_ref
+            );
         }
+
+        // Verify no additional subdags were sent
+        verify_channel_empty(&mut receiver);
     }
 
     /// After receiving all expected subdags, ensure channel is empty

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -51,7 +51,7 @@ impl CommitSolidifier {
         }
     }
 
-    pub(crate) fn set_last_committed_index(&mut self, index: CommitIndex) {
+    pub(crate) fn set_last_solid_committed_index(&mut self, index: CommitIndex) {
         self.last_solid_committed_index = index;
     }
 
@@ -99,12 +99,12 @@ impl CommitSolidifier {
                 .or_insert_with(|| subdag.clone());
         }
         let mut committed_subdags = Vec::new();
-        let mut last_committed = self.last_solid_committed_index;
+        let mut last_solid_committed = self.last_solid_committed_index;
         let mut missing = BTreeSet::new();
 
         // Try to commit in order
         loop {
-            let next_index = last_committed + 1;
+            let next_index = last_solid_committed + 1;
             // If the next expected subdag is not in the buffer, we cannot commit anything
             // further
             let Some(pending_subdag) = self.pending_subdags.get(&next_index) else {
@@ -114,7 +114,7 @@ impl CommitSolidifier {
                 Ok(committed_subdag) => {
                     committed_subdags.push(committed_subdag);
                     self.pending_subdags.remove(&next_index);
-                    last_committed = next_index;
+                    last_solid_committed = next_index;
                 }
                 Err(missing_refs) => {
                     // If we have missing refs, we cannot commit this subdag
@@ -140,7 +140,7 @@ impl CommitSolidifier {
         }
 
         // Update last_committed_index
-        self.last_solid_committed_index = last_committed;
+        self.last_solid_committed_index = last_solid_committed;
 
         // Only check for missing refs in the newly passed subdags that weren't
         // processed yet
@@ -1032,15 +1032,15 @@ mod tests {
         assert_eq!(commit_solidifier.last_solid_committed_index, 0);
 
         // Set to a new value
-        commit_solidifier.set_last_committed_index(5);
+        commit_solidifier.set_last_solid_committed_index(5);
         assert_eq!(commit_solidifier.last_solid_committed_index, 5);
 
         // Can set to a lower value
-        commit_solidifier.set_last_committed_index(3);
+        commit_solidifier.set_last_solid_committed_index(3);
         assert_eq!(commit_solidifier.last_solid_committed_index, 3);
 
         // Can set to 0
-        commit_solidifier.set_last_committed_index(0);
+        commit_solidifier.set_last_solid_committed_index(0);
         assert_eq!(commit_solidifier.last_solid_committed_index, 0);
     }
 

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -66,7 +66,7 @@ impl Linearizer {
 
     /// Reinitialize Linearizer after fast sync completes.
     /// Clears tracked state for a fresh start.
-    pub(crate) fn reinitialize(&mut self) {
+    pub(crate) fn clear_state(&mut self) {
         self.transactions_ack_tracker.clear();
         self.traversed_headers_tracker.clear();
     }

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -28,6 +28,18 @@ use tempfile::TempDir;
 use tokio::sync::RwLock;
 use tracing::{info, trace};
 
+/// Restart mode for authority nodes during testing
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum RestartMode {
+    /// Erase both consensus DB and node tracking state (fresh start)
+    CleanAll,
+    /// Keep both consensus DB and node tracking state (crash recovery)
+    PersistAll,
+    /// Keep consensus DB but reset last_processed_commit to 0.
+    /// Tests recovery when consensus state is intact but node tracking is lost.
+    ResetLastProcessed,
+}
+
 #[derive(Clone)]
 pub(crate) struct Config {
     pub authority_index: AuthorityIndex,
@@ -90,18 +102,31 @@ impl AuthorityNode {
         Ok(())
     }
 
-    /// Restart the node, optionally with a fresh database
-    pub async fn restart(&self, clean_db: bool) -> Result<()> {
+    /// Restart the node with the specified mode
+    pub async fn restart(&self, mode: RestartMode) -> Result<()> {
         self.stop();
-        if clean_db {
-            *self.db_dir.lock() = Arc::new(TempDir::new()?);
-            self.last_processed_commit.store(0, Ordering::SeqCst);
-            // Treat clean DB as a fresh node: reset boot counter to enable
-            // sync_last_known_own_block, and clear tracking state (commit
-            // digests and committed transactions).
-            self.boot_counter.store(0, Ordering::SeqCst);
-            self.commit_digests.write().await.clear();
-            self.committed_transactions.write().await.clear();
+        match mode {
+            RestartMode::CleanAll => {
+                // Erase consensus DB and all node tracking
+                *self.db_dir.lock() = Arc::new(TempDir::new()?);
+                self.last_processed_commit.store(0, Ordering::SeqCst);
+                // Treat clean DB as a fresh node: reset boot counter to enable
+                // sync_last_known_own_block, and clear tracking state (commit
+                // digests and committed transactions).
+                self.boot_counter.store(0, Ordering::SeqCst);
+                self.commit_digests.write().await.clear();
+                self.committed_transactions.write().await.clear();
+            }
+            RestartMode::ResetLastProcessed => {
+                // Keep consensus DB, reset node tracking state
+                self.last_processed_commit.store(0, Ordering::SeqCst);
+                self.commit_digests.write().await.clear();
+                self.committed_transactions.write().await.clear();
+                // Keep boot_counter incrementing (not a fresh node)
+            }
+            RestartMode::PersistAll => {
+                // Keep both consensus DB and node tracking (no changes)
+            }
         }
         self.start().await
     }

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -336,14 +336,6 @@ mod test {
                     .spawn_committed_subdag_consumer()
                     .unwrap();
 
-                // Determine sync baseline based on restart mode:
-                // - CleanAll/ResetLastProcessed: node's internal state is reset to 0
-                // - PersistAll: node retains its state from commit_at_stop
-                let sync_baseline = match mode {
-                    RestartMode::CleanAll | RestartMode::ResetLastProcessed => 0,
-                    RestartMode::PersistAll => commit_at_stop,
-                };
-
                 // Wait for catch-up
                 sleep(restart_config.post_restart_wait).await;
 
@@ -351,7 +343,6 @@ mod test {
                     .iter()
                     .map(|a| a.commit_consumer_monitor().highest_handled_commit())
                     .collect();
-                let restarted = commits_after[authority_idx];
                 let network_max = commits_after
                     .iter()
                     .enumerate()

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -26,7 +26,7 @@ mod test {
     use tokio::{sync::RwLock, time::sleep};
     use typed_store::DBMetrics;
 
-    use crate::node::{AuthorityNode, Config};
+    use crate::node::{AuthorityNode, Config, RestartMode};
 
     fn test_config() -> SimConfig {
         env_config(
@@ -145,11 +145,14 @@ mod test {
     ///    (some may be lost during restarts when in RAM)
     ///
     /// Parameters:
-    /// - `clean_db`: If true, authorities restart with fresh empty DBs
-    ///   (simulates node replacement)
+    /// - `mode`: Restart mode controlling DB and state persistence
+    ///   - `CleanAll`: Fresh empty DB (simulates node replacement)
+    ///   - `PersistAll`: Keep DB and state (crash recovery)
+    ///   - `ResetLastProcessed`: Keep DB but reset tracking (tests two-phase
+    ///     recovery)
     /// - `long_run`: If true, use longer pre-stop and catch-up times
     /// - `long_restart`: If true, use longer stopped duration
-    async fn run_sequential_restarts_test(clean_db: bool, long_run: bool, long_restart: bool) {
+    async fn run_sequential_restarts_test(mode: RestartMode, long_run: bool, long_restart: bool) {
         // ═══════════════════════════════════════════════════════════════
         // Constants
         // ═══════════════════════════════════════════════════════════════
@@ -327,17 +330,19 @@ mod test {
                 )
                 .await;
 
-                // Restart the authority (with or without clean DB)
-                authorities[authority_idx].restart(clean_db).await.unwrap();
+                // Restart the authority with the specified mode
+                authorities[authority_idx].restart(mode).await.unwrap();
                 authorities[authority_idx]
                     .spawn_committed_subdag_consumer()
                     .unwrap();
 
-                // For clean DB restarts, the node's internal state is reset to 0, so use that
-                // as the baseline for sync metrics. For persistent DB restarts,
-                // the node retains its state, so use the captured
-                // commit_at_stop value.
-                let sync_baseline = if clean_db { 0 } else { commit_at_stop };
+                // Determine sync baseline based on restart mode:
+                // - CleanAll/ResetLastProcessed: node's internal state is reset to 0
+                // - PersistAll: node retains its state from commit_at_stop
+                let sync_baseline = match mode {
+                    RestartMode::CleanAll | RestartMode::ResetLastProcessed => 0,
+                    RestartMode::PersistAll => commit_at_stop,
+                };
 
                 // Wait for catch-up
                 sleep(restart_config.post_restart_wait).await;
@@ -440,46 +445,64 @@ mod test {
         );
     }
 
+    /// Fresh DB after each restart, long run before stop, long stop duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_clean_db_long_run_long_stop() {
-        run_sequential_restarts_test(true, true, true).await;
+        run_sequential_restarts_test(RestartMode::CleanAll, true, true).await;
     }
 
+    /// Fresh DB after each restart, short run before stop, short stop duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_clean_db_short_run_short_stop() {
-        run_sequential_restarts_test(true, false, false).await;
+        run_sequential_restarts_test(RestartMode::CleanAll, false, false).await;
     }
 
+    /// Fresh DB after each restart, long run before stop, short stop duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_clean_db_long_run_short_stop() {
-        run_sequential_restarts_test(true, true, false).await;
+        run_sequential_restarts_test(RestartMode::CleanAll, true, false).await;
     }
 
+    /// Fresh DB after each restart, short run before stop, long stop duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_clean_db_short_run_long_stop() {
-        run_sequential_restarts_test(true, false, true).await;
+        run_sequential_restarts_test(RestartMode::CleanAll, false, true).await;
     }
 
+    /// Persistent DB after each restart, long run before stop, long stop
+    /// duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_persistent_db_long_run_long_stop() {
-        run_sequential_restarts_test(false, true, true).await;
+        run_sequential_restarts_test(RestartMode::PersistAll, true, true).await;
     }
 
+    /// Persistent DB after each restart, short run before stop, short stop
+    /// duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_persistent_db_short_run_short_stop() {
-        run_sequential_restarts_test(false, false, false).await;
+        run_sequential_restarts_test(RestartMode::PersistAll, false, false).await;
     }
 
+    /// Persistent DB after each restart, long run before stop, short stop
+    /// duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_persistent_db_long_run_short_stop() {
-        run_sequential_restarts_test(false, true, false).await;
+        run_sequential_restarts_test(RestartMode::PersistAll, true, false).await;
     }
 
     // TODO: This test is expected to panic due to fast sync failure when it is
     // aborted before full sync catch-up. It should be added once the fix for
     // fast syncing is applied.
+    // /// Persistent DB, short run before stop, long stop duration.
     // #[sim_test(config = "test_config()")]
     // async fn test_sequential_restarts_persistent_db_short_run_long_stop() {
-    //     run_sequential_restarts_test(false, false, true).await;
+    //     run_sequential_restarts_test(RestartMode::PersistAll, false, true).await;
     // }
+
+    /// DB intact but last_processed_commit reset; long run before stop, long
+    /// stop duration.
+    #[sim_test(config = "test_config()")]
+    async fn test_sequential_restarts_reset_last_processed_long_run_long_stop() {
+        run_sequential_restarts_test(RestartMode::ResetLastProcessed, true, true).await;
+    }
 }

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -493,8 +493,8 @@ mod test {
     // TODO: This test is expected to panic due to fast sync failure when it is
     // aborted before full sync catch-up. It should be added once the fix for
     // fast syncing is applied.
-    // /// Persistent DB, short run before stop, long stop duration.
-    // #[sim_test(config = "test_config()")]
+    // /// Persistent DB after each restart, short run before stop, long stop
+    // duration. #[sim_test(config = "test_config()")]
     // async fn test_sequential_restarts_persistent_db_short_run_long_stop() {
     //     run_sequential_restarts_test(RestartMode::PersistAll, false, true).await;
     // }


### PR DESCRIPTION
# Description of change

Fix panic during consensus restart when block headers could be missing for some commits in the prefix, e.g. after fast sync finished the job, but the node db for the epoch is cleaned or last processed commit in the handler is lower that the last commit produced by the consensus.                                   
                                                             
  Changes:                                                   
  - Split commit observer recovery into two phases:         
       1. linearizer and solidifier state rebuild (from recent commits only)
       2. unprocessed commit resending (with empty headers)          
  - Add RestartMode enum to simtests with new ResetLastProcessed mode that validates the fix   

## Links to any relevant issues

Fixes #9873 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage): Added one more simtest
- [x] I have added tests that prove my fix is effective or that my feature works: Added one more test that was failing before the fix
- [x] I have checked that new and existing unit tests pass locally with my changes
