### PR TITLE
feat(indexer): Use watermarks table in pruner

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/prune/prune.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/prune.move
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 12 --addresses Test=0x0 A=0x42 --simulator --epochs-to-keep 2
+//# init --protocol-version 12 --addresses Test=0x0 A=0x42 --simulator --epochs-to-keep 1
 
 //# publish
 module Test::M1 {

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -841,7 +841,7 @@ mod test {
         let toml_content = r#"
         epochs_to_keep = 5
         [overrides]
-        tx_affected_addresses = 10
+        tx_senders = 10
         transactions = 20
         "#;
         temp_file.write_all(toml_content.as_bytes()).unwrap();
@@ -858,7 +858,7 @@ mod test {
         assert_eq!(
             retention_config
                 .overrides
-                .get(&PrunableTable::TxAffectedAddresses)
+                .get(&PrunableTable::TxSenders)
                 .copied(),
             Some(10)
         );
@@ -882,7 +882,7 @@ mod test {
                 PrunableTable::ObjectsHistory => {
                     assert_eq!(retention, OBJECTS_HISTORY_EPOCHS_TO_KEEP)
                 }
-                PrunableTable::TxAffectedAddresses => assert_eq!(retention, 10),
+                PrunableTable::TxSenders => assert_eq!(retention, 10),
                 PrunableTable::Transactions => assert_eq!(retention, 20),
                 _ => assert_eq!(retention, 5),
             };

--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -240,6 +240,7 @@ pub enum CommitterTables {
     TxKinds,
     TxRecipients,
     TxSenders,
+    TxWrappedOrDeletedObjects,
     Checkpoints,
     PrunerCpWatermark,
 }

--- a/crates/iota-indexer/src/pruning/pruner.rs
+++ b/crates/iota-indexer/src/pruning/pruner.rs
@@ -5,6 +5,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use serde::{Deserialize, Serialize};
+use strum::IntoEnumIterator;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
@@ -19,12 +20,23 @@ use crate::{
 };
 
 const UPDATE_WATERMARKS_LOWER_BOUNDS_TASK_INTERVAL: Duration = Duration::from_secs(5);
+/// Delay in milliseconds before pruning data after watermark timestamp.
+/// This delay allows in-flight reads that may be accessing data scheduled for
+/// pruning to complete or timeout, ensuring safe pruning without affecting
+/// active queries.
+#[cfg(any(test, feature = "pg_integration", feature = "shared_test_runtime"))]
+const PRUNING_DELAY_MS: u64 = 1000; // 1 second for tests
+
+#[cfg(not(any(test, feature = "pg_integration", feature = "shared_test_runtime")))]
+const PRUNING_DELAY_MS: u64 = 60000; // 60 seconds for production
+
+/// Maximum number of transactions to prune in a single batch for ByTransaction
+/// strategy
+const MAX_TRANSACTIONS_PER_PRUNE_BATCH: u64 = 100;
 
 pub struct Pruner {
     pub store: PgIndexerStore,
     pub partition_manager: PgPartitionManager,
-    // TODO: we can remove this when pruner logic is updated to use `retention_policies`.
-    pub epochs_to_keep: u64,
     pub retention_policies: HashMap<PrunableTable, u64>,
     pub metrics: IndexerMetrics,
 }
@@ -46,6 +58,7 @@ pub struct Pruner {
     Serialize,
     Deserialize,
     Clone,
+    Copy,
 )]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
@@ -63,8 +76,6 @@ pub enum PrunableTable {
     EventStructName,
     EventStructPackage,
 
-    TxAffectedAddresses,
-    TxAffectedObjects,
     TxCallsPkg,
     TxCallsMod,
     TxCallsFun,
@@ -74,9 +85,44 @@ pub enum PrunableTable {
     TxKinds,
     TxRecipients,
     TxSenders,
+    TxWrappedOrDeletedObjects,
 
     Checkpoints,
     PrunerCpWatermark,
+}
+
+/// Represents how a table is pruned
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PruningStrategy {
+    /// Drop partition by epoch number (for epoch-partitioned tables)
+    ByEpochPartition,
+    /// Delete rows by checkpoint number
+    ByCheckpoint,
+    /// Delete rows by transaction sequence number
+    ByTransaction,
+}
+
+/// Represents a specific chunk of data to be pruned
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PruningChunk {
+    /// Prune an entire epoch partition
+    Epoch(u64),
+    /// Prune a specific checkpoint
+    Checkpoint(u64),
+    /// Prune a range of transactions [start..=end] inclusive
+    TransactionRange(u64, u64),
+}
+
+impl PruningChunk {
+    /// Returns the start of the next chunk to prune (used for updating
+    /// pruner_hi watermark)
+    fn next_chunk_start(&self) -> u64 {
+        match self {
+            PruningChunk::Epoch(epoch) => epoch + 1,
+            PruningChunk::Checkpoint(checkpoint) => checkpoint + 1,
+            PruningChunk::TransactionRange(_, end) => end + 1,
+        }
+    }
 }
 
 impl PrunableTable {
@@ -95,8 +141,6 @@ impl PrunableTable {
             | PrunableTable::EventStructModule
             | PrunableTable::EventStructName
             | PrunableTable::EventStructPackage
-            | PrunableTable::TxAffectedAddresses
-            | PrunableTable::TxAffectedObjects
             | PrunableTable::TxCallsPkg
             | PrunableTable::TxCallsMod
             | PrunableTable::TxCallsFun
@@ -105,8 +149,293 @@ impl PrunableTable {
             | PrunableTable::TxInputObjects
             | PrunableTable::TxKinds
             | PrunableTable::TxRecipients
-            | PrunableTable::TxSenders => tx,
+            | PrunableTable::TxSenders
+            | PrunableTable::TxWrappedOrDeletedObjects => tx,
         }
+    }
+
+    /// Returns the pruning strategy for this table
+    pub fn pruning_strategy(&self) -> PruningStrategy {
+        match self {
+            // Epoch-partitioned tables - pruned by dropping partitions
+            // objects_history: partitioned by CheckpointSequenceNumber
+            // transactions: partitioned by TxSequenceNumber
+            // events: partitioned by TxSequenceNumber
+            PrunableTable::ObjectsHistory | PrunableTable::Transactions | PrunableTable::Events => {
+                PruningStrategy::ByEpochPartition
+            }
+
+            // Checkpoint-based tables (not partitioned) - pruned by DELETE
+            PrunableTable::Checkpoints | PrunableTable::PrunerCpWatermark => {
+                PruningStrategy::ByCheckpoint
+            }
+
+            // Transaction-based index tables (not partitioned) - pruned by DELETE
+            PrunableTable::EventEmitPackage
+            | PrunableTable::EventEmitModule
+            | PrunableTable::EventSenders
+            | PrunableTable::EventStructInstantiation
+            | PrunableTable::EventStructModule
+            | PrunableTable::EventStructName
+            | PrunableTable::EventStructPackage
+            | PrunableTable::TxCallsPkg
+            | PrunableTable::TxCallsMod
+            | PrunableTable::TxCallsFun
+            | PrunableTable::TxChangedObjects
+            | PrunableTable::TxDigests
+            | PrunableTable::TxInputObjects
+            | PrunableTable::TxKinds
+            | PrunableTable::TxRecipients
+            | PrunableTable::TxSenders
+            | PrunableTable::TxWrappedOrDeletedObjects => PruningStrategy::ByTransaction,
+        }
+    }
+}
+
+/// Executes pruning operations for a specific table
+pub struct TablePruner<'a> {
+    table: PrunableTable,
+    store: &'a PgIndexerStore,
+    partition_manager: &'a PgPartitionManager,
+    #[allow(dead_code)]
+    metrics: &'a IndexerMetrics,
+    cancel: CancellationToken,
+}
+
+impl<'a> TablePruner<'a> {
+    pub fn new(
+        table: PrunableTable,
+        store: &'a PgIndexerStore,
+        partition_manager: &'a PgPartitionManager,
+        metrics: &'a IndexerMetrics,
+        cancel: CancellationToken,
+    ) -> Self {
+        Self {
+            table,
+            store,
+            partition_manager,
+            metrics,
+            cancel,
+        }
+    }
+
+    /// Run the persistent pruning task for this executor's table
+    pub async fn run_pruning_task(self) -> IndexerResult<()> {
+        info!(
+            "Starting persistent pruning task for table {}",
+            self.table.as_ref()
+        );
+
+        let mut interval = tokio::time::interval(Duration::from_secs(5));
+
+        loop {
+            tokio::select! {
+                _ = self.cancel.cancelled() => {
+                    info!("Pruning task for table {} cancelled.", self.table.as_ref());
+                    return Ok(());
+                }
+                _ = interval.tick() => {
+                    if let Err(e) = self.prune_once_maybe().await {
+                        error!("error pruning table {}: {e}", self.table.as_ref());
+                    }
+                }
+            }
+        }
+    }
+
+    /// Perform one pruning iteration for this executor's table
+    async fn prune_once_maybe(&self) -> IndexerResult<()> {
+        // Fetch watermark for this specific table
+        let watermark = match self
+            .store
+            .get_watermark_by_entity(self.table.as_ref().to_string())
+            .await
+        {
+            Ok(Some(w)) => w,
+            Ok(None) => {
+                // No watermark entry yet, skip
+                tracing::warn!("no watermark entry found for table {}", self.table.as_ref());
+                return Ok(());
+            }
+            Err(e) => {
+                error!(
+                    "failed to fetch watermark for table {}: {e}",
+                    self.table.as_ref()
+                );
+                return Err(e);
+            }
+        };
+        // Wait for in-flight reads to timeout before pruning
+        self.wait_for_pruning_delay(watermark.timestamp_ms).await?;
+
+        let pruning_chunks = self.create_pruning_chunks(&watermark);
+
+        for pruning_chunk in pruning_chunks {
+            info!(
+                "Pruning table {} for {:?}",
+                self.table.as_ref(),
+                pruning_chunk
+            );
+            if let Err(err) = self.prune_by_chunk(pruning_chunk).await {
+                error!(
+                    "failed to prune table {} for {:?}: {err}",
+                    self.table.as_ref(),
+                    pruning_chunk
+                );
+                break;
+            }
+
+            // Update pruner_hi to the next chunk to prune
+            let next_chunk_start = pruning_chunk.next_chunk_start();
+            if let Err(err) = self
+                .store
+                .update_watermark_pruner_hi(&self.table, next_chunk_start)
+                .await
+            {
+                error!(
+                    "failed to update pruner_hi for table {} to next chunk {}: {err}",
+                    self.table.as_ref(),
+                    next_chunk_start
+                );
+            }
+        }
+
+        self.metrics.last_pruned_epoch.set(watermark.epoch_lo - 1);
+
+        Ok(())
+    }
+
+    /// Create an iterator of pruning chunks based on the watermark and pruning
+    /// strategy
+    fn create_pruning_chunks(
+        &self,
+        watermark: &crate::models::watermarks::StoredWatermark,
+    ) -> Box<dyn Iterator<Item = PruningChunk> + Send> {
+        let epoch_lo = watermark.epoch_lo as u64;
+        let pruner_hi = watermark.pruner_hi as u64;
+        let reader_lo = watermark.reader_lo as u64;
+
+        match self.table.pruning_strategy() {
+            PruningStrategy::ByEpochPartition => {
+                let range_end = epoch_lo;
+                info!(
+                    "pruning table {} in epoch range: [{pruner_hi}..{range_end})",
+                    self.table.as_ref()
+                );
+                Box::new((pruner_hi..range_end).map(PruningChunk::Epoch))
+            }
+            PruningStrategy::ByCheckpoint => {
+                let range_end = reader_lo;
+                info!(
+                    "pruning table {} in checkpoint range: [{pruner_hi}..{range_end})",
+                    self.table.as_ref()
+                );
+                Box::new((pruner_hi..range_end).map(PruningChunk::Checkpoint))
+            }
+            PruningStrategy::ByTransaction => {
+                let range_end = reader_lo;
+                info!(
+                    "pruning table {} in transaction range: [{pruner_hi}..{range_end})",
+                    self.table.as_ref()
+                );
+                Box::new(
+                    (pruner_hi..range_end)
+                        .step_by(MAX_TRANSACTIONS_PER_PRUNE_BATCH as usize)
+                        .map(move |start| {
+                            let end = (start + MAX_TRANSACTIONS_PER_PRUNE_BATCH).min(range_end);
+                            PruningChunk::TransactionRange(start, end - 1)
+                        }),
+                )
+            }
+        }
+    }
+
+    /// Wait for the pruning delay to ensure in-flight reads complete or timeout
+    async fn wait_for_pruning_delay(&self, watermark_timestamp_ms: i64) -> IndexerResult<()> {
+        // The watermark timestamp indicates when data was marked for pruning.
+        // We delay pruning to allow any reads accessing this data to complete or
+        // timeout.
+        let pruning_allowed_timestamp_ms = watermark_timestamp_ms as u64 + PRUNING_DELAY_MS;
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
+        if now_ms < pruning_allowed_timestamp_ms {
+            let wait_duration = Duration::from_millis(pruning_allowed_timestamp_ms - now_ms);
+            info!(
+                "waiting {}ms for in-flight reads to timeout before pruning table {} (watermark timestamp: {}, delay: {}ms)",
+                wait_duration.as_millis(),
+                self.table.as_ref(),
+                watermark_timestamp_ms,
+                PRUNING_DELAY_MS
+            );
+
+            tokio::select! {
+                _ = tokio::time::sleep(wait_duration) => {
+                    // Delay complete, in-flight reads should have timed out, safe to prune
+                }
+                _ = self.cancel.cancelled() => {
+                    info!("pruning task for table {} cancelled during delay", self.table.as_ref());
+                    return Err(IndexerError::Generic("Pruning task cancelled".to_string()));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Prune data based on the specified chunk
+    async fn prune_by_chunk(&self, chunk: PruningChunk) -> Result<(), IndexerError> {
+        match chunk {
+            PruningChunk::Epoch(epoch) => {
+                // Drop the partition for this epoch
+                self.partition_manager
+                    .drop_table_partition(self.table.as_ref().to_string(), epoch)?;
+                info!(
+                    "dropped epoch {epoch} partition for table {}",
+                    self.table.as_ref()
+                );
+            }
+
+            PruningChunk::Checkpoint(checkpoint) => {
+                // Prune by checkpoint
+                if let Err(e) = self
+                    .store
+                    .prune_table_by_checkpoint(&self.table, checkpoint)
+                    .await
+                {
+                    error!(
+                        "failed to prune table {} for checkpoint {checkpoint}: {e}",
+                        self.table.as_ref(),
+                    );
+                }
+                info!(
+                    "pruned table {} for checkpoint {checkpoint}",
+                    self.table.as_ref(),
+                );
+            }
+
+            PruningChunk::TransactionRange(start, end) => {
+                // Prune by transaction range
+                if let Err(e) = self
+                    .store
+                    .prune_table_by_tx_range(&self.table, start, end)
+                    .await
+                {
+                    error!(
+                        "failed to prune table {} for transaction range [{start}..={end}]: {e}",
+                        self.table.as_ref(),
+                    );
+                }
+                info!(
+                    "pruned table {} for transaction range [{start}..={end}]",
+                    self.table.as_ref(),
+                );
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -121,26 +450,14 @@ impl Pruner {
     ) -> Result<Self, IndexerError> {
         let blocking_cp = PrimaryWorker::pg_blocking_cp(store.clone()).unwrap();
         let partition_manager = PgPartitionManager::new(blocking_cp.clone())?;
-        let epochs_to_keep = retention_config.epochs_to_keep;
         let retention_policies = retention_config.retention_policies();
 
         Ok(Self {
             store,
-            epochs_to_keep,
             partition_manager,
             retention_policies,
             metrics,
         })
-    }
-
-    /// Given a table name, return the number of epochs to keep for that table.
-    /// Return `None` if the table is not prunable.
-    fn table_retention(&self, table_name: &str) -> Option<u64> {
-        if let Ok(variant) = table_name.parse::<PrunableTable>() {
-            self.retention_policies.get(&variant).copied()
-        } else {
-            None
-        }
     }
 
     pub async fn start(&self, cancel: CancellationToken) -> IndexerResult<()> {
@@ -153,74 +470,26 @@ impl Pruner {
             cancel_clone
         ));
 
-        let mut last_seen_max_epoch = 0;
-        // The first epoch that has not yet been pruned.
-        let mut next_prune_epoch = None;
-        while !cancel.is_cancelled() {
-            let (min_epoch, max_epoch) = self.store.get_available_epoch_range().await?;
-            if max_epoch == last_seen_max_epoch {
-                tokio::time::sleep(Duration::from_secs(5)).await;
-                continue;
-            }
-            last_seen_max_epoch = max_epoch;
+        // Spawn one persistent task for each PrunableTable variant
+        for table in PrunableTable::iter() {
+            let store_clone = self.store.clone();
+            let partition_manager_clone = self.partition_manager.clone();
+            let metrics_clone = self.metrics.clone();
+            let cancel_clone = cancel.clone();
 
-            // Not all partitioned tables are epoch-partitioned, so we need to filter them
-            // out.
-            let table_partitions: HashMap<_, _> = self
-                .partition_manager
-                .get_table_partitions()?
-                .into_iter()
-                .filter(|(table_name, _)| {
-                    self.partition_manager
-                        .get_strategy(table_name)
-                        .is_epoch_partitioned()
-                })
-                .collect();
-
-            for (table_name, (min_partition, max_partition)) in &table_partitions {
-                if let Some(epochs_to_keep) = self.table_retention(table_name) {
-                    if last_seen_max_epoch != *max_partition {
-                        error!(
-                            "epochs are out of sync for table {table_name}: max_epoch={last_seen_max_epoch}, max_partition={max_partition}",
-                        );
-                    }
-                    for epoch in
-                        *min_partition..last_seen_max_epoch.saturating_sub(epochs_to_keep - 1)
-                    {
-                        if cancel.is_cancelled() {
-                            info!("Pruner task cancelled.");
-                            return Ok(());
-                        }
-                        self.partition_manager
-                            .drop_table_partition(table_name.clone(), epoch)?;
-                        info!("Batch dropped table partition {table_name} epoch {epoch}",);
-                    }
-                }
-            }
-
-            // TODO: Once we have the watermarks table, we can iterate through each
-            // row returned from `watermarks`, look it up against
-            // `retention_policies`, and process them independently. This also
-            // means that pruning overrides will only apply for
-            // epoch-partitioned tables right now.
-            let prune_to_epoch = last_seen_max_epoch.saturating_sub(self.epochs_to_keep - 1);
-
-            let prune_start_epoch = next_prune_epoch.unwrap_or(min_epoch);
-            for epoch in prune_start_epoch..prune_to_epoch {
-                if cancel.is_cancelled() {
-                    info!("Pruner task cancelled.");
-                    return Ok(());
-                }
-                info!("Pruning epoch {}", epoch);
-                if let Err(err) = self.store.prune_epoch(epoch).await {
-                    error!("failed to prune epoch {epoch}: {err}");
-                    break;
-                };
-                self.metrics.last_pruned_epoch.set(epoch as i64);
-                info!("Pruned epoch {}", epoch);
-                next_prune_epoch = Some(epoch + 1);
-            }
+            spawn_monitored_task!(async move {
+                let table_pruner = TablePruner::new(
+                    table,
+                    &store_clone,
+                    &partition_manager_clone,
+                    &metrics_clone,
+                    cancel_clone,
+                );
+                table_pruner.run_pruning_task().await
+            });
         }
+
+        cancel.cancelled().await;
         info!("Pruner task cancelled.");
         Ok(())
     }

--- a/crates/iota-indexer/src/pruning/pruner.rs
+++ b/crates/iota-indexer/src/pruning/pruner.rs
@@ -32,7 +32,13 @@ const PRUNING_DELAY_MS: u64 = 60000; // 60 seconds for production
 
 /// Maximum number of transactions to prune in a single batch for ByTransaction
 /// strategy
-const MAX_TRANSACTIONS_PER_PRUNE_BATCH: u64 = 100;
+const MAX_TRANSACTIONS_PER_PRUNE_BATCH: u64 = 1000;
+
+/// Interval for running the pruning task
+const PRUNING_TASK_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Delay between pruning chunks to relieve I/O pressure on the database
+const DELAY_BETWEEN_PRUNING_CHUNKS: Duration = Duration::from_millis(100);
 
 pub struct Pruner {
     pub store: PgIndexerStore,
@@ -219,14 +225,14 @@ impl<'a> TablePruner<'a> {
         }
     }
 
-    /// Run the persistent pruning task for this executor's table
+    /// Runs the persistent pruning task for this executor's table
     pub async fn run_pruning_task(self) -> IndexerResult<()> {
         info!(
             "Starting persistent pruning task for table {}",
             self.table.as_ref()
         );
 
-        let mut interval = tokio::time::interval(Duration::from_secs(5));
+        let mut interval = tokio::time::interval(PRUNING_TASK_INTERVAL);
 
         loop {
             tokio::select! {
@@ -235,7 +241,7 @@ impl<'a> TablePruner<'a> {
                     return Ok(());
                 }
                 _ = interval.tick() => {
-                    if let Err(e) = self.prune_once_maybe().await {
+                    if let Err(e) = self.check_and_prune().await {
                         error!("error pruning table {}: {e}", self.table.as_ref());
                     }
                 }
@@ -243,8 +249,9 @@ impl<'a> TablePruner<'a> {
         }
     }
 
-    /// Perform one pruning iteration for this executor's table
-    async fn prune_once_maybe(&self) -> IndexerResult<()> {
+    /// Checks if pruning is needed and prunes data for this executor's table if
+    /// conditions are met
+    async fn check_and_prune(&self) -> IndexerResult<()> {
         // Fetch watermark for this specific table
         let watermark = match self
             .store
@@ -298,6 +305,9 @@ impl<'a> TablePruner<'a> {
                     next_chunk_start
                 );
             }
+
+            // Brief pause to relieve the I/O pressure on the DB
+            tokio::time::sleep(DELAY_BETWEEN_PRUNING_CHUNKS).await;
         }
 
         self.metrics.last_pruned_epoch.set(watermark.epoch_lo - 1);
@@ -305,7 +315,7 @@ impl<'a> TablePruner<'a> {
         Ok(())
     }
 
-    /// Create an iterator of pruning chunks based on the watermark and pruning
+    /// Creates an iterator of pruning chunks based on the watermark and pruning
     /// strategy
     fn create_pruning_chunks(
         &self,
@@ -350,7 +360,8 @@ impl<'a> TablePruner<'a> {
         }
     }
 
-    /// Wait for the pruning delay to ensure in-flight reads complete or timeout
+    /// Waits for the pruning delay to ensure in-flight reads complete or
+    /// timeout
     async fn wait_for_pruning_delay(&self, watermark_timestamp_ms: i64) -> IndexerResult<()> {
         // The watermark timestamp indicates when data was marked for pruning.
         // We delay pruning to allow any reads accessing this data to complete or
@@ -371,15 +382,16 @@ impl<'a> TablePruner<'a> {
                 PRUNING_DELAY_MS
             );
 
-            tokio::select! {
-                _ = tokio::time::sleep(wait_duration) => {
-                    // Delay complete, in-flight reads should have timed out, safe to prune
-                }
-                _ = self.cancel.cancelled() => {
-                    info!("pruning task for table {} cancelled during delay", self.table.as_ref());
-                    return Err(IndexerError::Generic("Pruning task cancelled".to_string()));
-                }
-            }
+            self.cancel
+                .run_until_cancelled(tokio::time::sleep(wait_duration))
+                .await
+                .ok_or_else(|| {
+                    info!(
+                        "pruning task for table {} cancelled during delay",
+                        self.table.as_ref()
+                    );
+                    IndexerError::Generic("Pruning task cancelled".to_string())
+                })?;
         }
 
         Ok(())

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -98,8 +98,6 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
 
     async fn advance_epoch(&self, epoch: EpochToCommit) -> Result<(), IndexerError>;
 
-    async fn prune_epoch(&self, epoch: u64) -> Result<(), IndexerError>;
-
     async fn get_network_total_transactions_by_end_of_epoch(
         &self,
         epoch: u64,
@@ -156,4 +154,28 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     ) -> Result<(), IndexerError>;
 
     async fn persist_tx_indices(&self, indices: Vec<TxIndex>) -> Result<(), IndexerError>;
+
+    async fn prune_table_by_checkpoint(
+        &self,
+        table: &PrunableTable,
+        checkpoint: u64,
+    ) -> Result<(), IndexerError>;
+
+    async fn prune_table_by_tx_range(
+        &self,
+        table: &PrunableTable,
+        min_tx: u64,
+        max_tx: u64,
+    ) -> Result<(), IndexerError>;
+
+    async fn update_watermark_pruner_hi(
+        &self,
+        table: &PrunableTable,
+        pruner_hi: u64,
+    ) -> Result<(), IndexerError>;
+
+    async fn get_watermark_by_entity(
+        &self,
+        entity: String,
+    ) -> Result<Option<StoredWatermark>, IndexerError>;
 }

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1354,7 +1354,7 @@ impl PgIndexerStore {
         )
     }
 
-    /// Prune a single transaction or event index table by transaction range
+    /// Prunes a single transaction or event index table by transaction range
     fn prune_single_tx_or_event_table(
         &self,
         table: &crate::pruning::pruner::PrunableTable,

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -275,52 +275,6 @@ impl PgIndexerStore {
         .context("Failed reading min and max epoch numbers from PostgresDB")
     }
 
-    fn get_min_prunable_checkpoint(&self) -> Result<u64, IndexerError> {
-        read_only_blocking!(&self.blocking_cp, |conn| {
-            pruner_cp_watermark::dsl::pruner_cp_watermark
-                .select(min(pruner_cp_watermark::checkpoint_sequence_number))
-                .first::<Option<i64>>(conn)
-                .map(|v| v.unwrap_or_default() as u64)
-        })
-        .context("Failed reading min prunable checkpoint sequence number from PostgresDB")
-    }
-
-    fn get_checkpoint_range_for_epoch(
-        &self,
-        epoch: u64,
-    ) -> Result<(u64, Option<u64>), IndexerError> {
-        read_only_blocking!(&self.blocking_cp, |conn| {
-            epochs::dsl::epochs
-                .select((epochs::first_checkpoint_id, epochs::last_checkpoint_id))
-                .filter(epochs::epoch.eq(epoch as i64))
-                .first::<(i64, Option<i64>)>(conn)
-                .map(|(min, max)| (min as u64, max.map(|v| v as u64)))
-        })
-        .context(
-            format!("failed reading checkpoint range from PostgresDB for epoch {epoch}").as_str(),
-        )
-    }
-
-    fn get_transaction_range_for_checkpoint(
-        &self,
-        checkpoint: u64,
-    ) -> Result<(u64, u64), IndexerError> {
-        read_only_blocking!(&self.blocking_cp, |conn| {
-            pruner_cp_watermark::dsl::pruner_cp_watermark
-                .select((
-                    pruner_cp_watermark::min_tx_sequence_number,
-                    pruner_cp_watermark::max_tx_sequence_number,
-                ))
-                .filter(pruner_cp_watermark::checkpoint_sequence_number.eq(checkpoint as i64))
-                .first::<(i64, i64)>(conn)
-                .map(|(min, max)| (min as u64, max as u64))
-        })
-        .context(
-            format!("failed reading transaction range from PostgresDB for checkpoint {checkpoint}")
-                .as_str(),
-        )
-    }
-
     pub(crate) async fn get_global_order_for_tx_seq_in_blocking_worker(
         &self,
         tx_seq: i64,
@@ -1400,134 +1354,185 @@ impl PgIndexerStore {
         )
     }
 
-    fn prune_event_indices_table(&self, min_tx: u64, max_tx: u64) -> Result<(), IndexerError> {
-        let (min_tx, max_tx) = (min_tx as i64, max_tx as i64);
-        transactional_blocking_with_retry!(
-            &self.blocking_cp,
-            |conn| {
-                prune_tx_or_event_indice_table!(
-                    event_emit_module,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune event_emit_module table"
-                );
-                prune_tx_or_event_indice_table!(
-                    event_emit_package,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune event_emit_package table"
-                );
-                prune_tx_or_event_indice_table![
-                    event_senders,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune event_senders table"
-                ];
-                prune_tx_or_event_indice_table![
-                    event_struct_instantiation,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune event_struct_instantiation table"
-                ];
-                prune_tx_or_event_indice_table![
-                    event_struct_module,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune event_struct_module table"
-                ];
-                prune_tx_or_event_indice_table![
-                    event_struct_name,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune event_struct_name table"
-                ];
-                prune_tx_or_event_indice_table![
-                    event_struct_package,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune event_struct_package table"
-                ];
-                Ok::<(), IndexerError>(())
-            },
-            PG_DB_COMMIT_SLEEP_DURATION
-        )
-    }
+    /// Prune a single transaction or event index table by transaction range
+    fn prune_single_tx_or_event_table(
+        &self,
+        table: &crate::pruning::pruner::PrunableTable,
+        min_tx: u64,
+        max_tx: u64,
+    ) -> Result<(), IndexerError> {
+        use crate::pruning::pruner::PrunableTable;
 
-    fn prune_tx_indices_table(&self, min_tx: u64, max_tx: u64) -> Result<(), IndexerError> {
         let (min_tx, max_tx) = (min_tx as i64, max_tx as i64);
+
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
-                prune_tx_or_event_indice_table!(
-                    tx_senders,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune tx_senders table"
-                );
-                prune_tx_or_event_indice_table!(
-                    tx_recipients,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune tx_recipients table"
-                );
-                prune_tx_or_event_indice_table![
-                    tx_input_objects,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune tx_input_objects table"
-                ];
-                prune_tx_or_event_indice_table![
-                    tx_changed_objects,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune tx_changed_objects table"
-                ];
-                prune_tx_or_event_indice_table![
-                    tx_wrapped_or_deleted_objects,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune tx_wrapped_or_deleted_objects table"
-                ];
-                prune_tx_or_event_indice_table![
-                    tx_calls_pkg,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune tx_calls_pkg table"
-                ];
-                prune_tx_or_event_indice_table![
-                    tx_calls_mod,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune tx_calls_mod table"
-                ];
-                prune_tx_or_event_indice_table![
-                    tx_calls_fun,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune tx_calls_fun table"
-                ];
-                prune_tx_or_event_indice_table![
-                    tx_digests,
-                    conn,
-                    min_tx,
-                    max_tx,
-                    "Failed to prune tx_digests table"
-                ];
+                match table {
+                    // Event index tables
+                    PrunableTable::EventEmitModule => {
+                        prune_tx_or_event_indice_table!(
+                            event_emit_module,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune event_emit_module table"
+                        );
+                    }
+                    PrunableTable::EventEmitPackage => {
+                        prune_tx_or_event_indice_table!(
+                            event_emit_package,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune event_emit_package table"
+                        );
+                    }
+                    PrunableTable::EventSenders => {
+                        prune_tx_or_event_indice_table!(
+                            event_senders,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune event_senders table"
+                        );
+                    }
+                    PrunableTable::EventStructInstantiation => {
+                        prune_tx_or_event_indice_table!(
+                            event_struct_instantiation,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune event_struct_instantiation table"
+                        );
+                    }
+                    PrunableTable::EventStructModule => {
+                        prune_tx_or_event_indice_table!(
+                            event_struct_module,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune event_struct_module table"
+                        );
+                    }
+                    PrunableTable::EventStructName => {
+                        prune_tx_or_event_indice_table!(
+                            event_struct_name,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune event_struct_name table"
+                        );
+                    }
+                    PrunableTable::EventStructPackage => {
+                        prune_tx_or_event_indice_table!(
+                            event_struct_package,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune event_struct_package table"
+                        );
+                    }
+
+                    // Transaction index tables
+                    PrunableTable::TxSenders => {
+                        prune_tx_or_event_indice_table!(
+                            tx_senders,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune tx_senders table"
+                        );
+                    }
+                    PrunableTable::TxRecipients => {
+                        prune_tx_or_event_indice_table!(
+                            tx_recipients,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune tx_recipients table"
+                        );
+                    }
+                    PrunableTable::TxInputObjects => {
+                        prune_tx_or_event_indice_table!(
+                            tx_input_objects,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune tx_input_objects table"
+                        );
+                    }
+                    PrunableTable::TxChangedObjects => {
+                        prune_tx_or_event_indice_table!(
+                            tx_changed_objects,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune tx_changed_objects table"
+                        );
+                    }
+                    PrunableTable::TxWrappedOrDeletedObjects => {
+                        prune_tx_or_event_indice_table!(
+                            tx_wrapped_or_deleted_objects,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune tx_wrapped_or_deleted_objects table"
+                        );
+                    }
+                    PrunableTable::TxCallsPkg => {
+                        prune_tx_or_event_indice_table!(
+                            tx_calls_pkg,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune tx_calls_pkg table"
+                        );
+                    }
+                    PrunableTable::TxCallsMod => {
+                        prune_tx_or_event_indice_table!(
+                            tx_calls_mod,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune tx_calls_mod table"
+                        );
+                    }
+                    PrunableTable::TxCallsFun => {
+                        prune_tx_or_event_indice_table!(
+                            tx_calls_fun,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune tx_calls_fun table"
+                        );
+                    }
+                    PrunableTable::TxDigests => {
+                        prune_tx_or_event_indice_table!(
+                            tx_digests,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune tx_digests table"
+                        );
+                    }
+                    PrunableTable::TxKinds => {
+                        prune_tx_or_event_indice_table!(
+                            tx_kinds,
+                            conn,
+                            min_tx,
+                            max_tx,
+                            "Failed to prune tx_kinds table"
+                        );
+                    }
+
+                    _ => {
+                        return Err(IndexerError::InvalidArgument(format!(
+                            "table {} is not a transaction or event index table",
+                            table.as_ref()
+                        )));
+                    }
+                }
                 Ok::<(), IndexerError>(())
             },
             PG_DB_COMMIT_SLEEP_DURATION
@@ -1549,6 +1554,23 @@ impl PgIndexerStore {
             },
             PG_DB_COMMIT_SLEEP_DURATION
         )
+    }
+
+    fn prune_table_by_checkpoint(
+        &self,
+        table: &crate::pruning::pruner::PrunableTable,
+        checkpoint: u64,
+    ) -> Result<(), IndexerError> {
+        use crate::pruning::pruner::PrunableTable;
+
+        match table {
+            PrunableTable::Checkpoints => self.prune_checkpoints_table(checkpoint),
+            PrunableTable::PrunerCpWatermark => self.prune_cp_tx_table(checkpoint),
+            _ => Err(IndexerError::InvalidArgument(format!(
+                "table {} is not pruned by checkpoint",
+                table.as_ref()
+            ))),
+        }
     }
 
     fn get_network_total_transactions_by_end_of_epoch(
@@ -1732,6 +1754,43 @@ impl PgIndexerStore {
                 .map_err(Into::into)
                 .context("Failed reading current timestamp from PostgresDB")?;
                 Ok::<_, IndexerError>((stored, timestamp))
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+    }
+
+    fn update_watermark_pruner_hi(
+        &self,
+        table: &PrunableTable,
+        pruner_hi: u64,
+    ) -> Result<(), IndexerError> {
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                diesel::update(watermarks::table.filter(watermarks::entity.eq(table.as_ref())))
+                    .set(watermarks::pruner_hi.eq(pruner_hi as i64))
+                    .execute(conn)
+                    .map_err(IndexerError::from)
+                    .context("failed to update watermark pruner_hi")?;
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+    }
+
+    fn get_watermark_by_entity(
+        &self,
+        entity: &str,
+    ) -> Result<Option<StoredWatermark>, IndexerError> {
+        run_query_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                watermarks::table
+                    .filter(watermarks::entity.eq(entity))
+                    .first::<StoredWatermark>(conn)
+                    .optional()
+                    .map_err(Into::into)
+                    .context("failed reading watermark by entity from PostgresDB")
             },
             PG_DB_COMMIT_SLEEP_DURATION
         )
@@ -2146,78 +2205,6 @@ impl IndexerStore for PgIndexerStore {
             .await
     }
 
-    async fn prune_epoch(&self, epoch: u64) -> Result<(), IndexerError> {
-        let (mut min_cp, max_cp) = match self.get_checkpoint_range_for_epoch(epoch)? {
-            (min_cp, Some(max_cp)) => Ok((min_cp, max_cp)),
-            _ => Err(IndexerError::PostgresRead(format!(
-                "Failed to get checkpoint range for epoch {epoch}"
-            ))),
-        }?;
-
-        // NOTE: for disaster recovery, min_cp is the min cp of the current epoch, which
-        // is likely partially pruned already. min_prunable_cp is the min cp to
-        // be pruned. By std::cmp::max, we will resume the pruning process from
-        // the next checkpoint, instead of the first cp of the current epoch.
-        let min_prunable_cp = self.get_min_prunable_checkpoint()?;
-        min_cp = std::cmp::max(min_cp, min_prunable_cp);
-        for cp in min_cp..=max_cp {
-            // NOTE: the order of pruning tables is crucial:
-            // 1. prune checkpoints table, checkpoints table is the source table of
-            //    available range,
-            // we prune it first to make sure that we always have full data for checkpoints
-            // within the available range;
-            // 2. then prune tx_* tables;
-            // 3. then prune pruner_cp_watermark table, which is the checkpoint pruning
-            //    watermark table and also tx seq source
-            // of a checkpoint to prune tx_* tables;
-            // 4. lastly we prune epochs table when all checkpoints of the epoch have been
-            //    pruned.
-            info!(
-                "Pruning checkpoint {} of epoch {} (min_prunable_cp: {})",
-                cp, epoch, min_prunable_cp
-            );
-            self.execute_in_blocking_worker(move |this| this.prune_checkpoints_table(cp))
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::error!("failed to prune checkpoint {cp}: {e}");
-                });
-
-            let (min_tx, max_tx) = self.get_transaction_range_for_checkpoint(cp)?;
-            self.execute_in_blocking_worker(move |this| {
-                this.prune_tx_indices_table(min_tx, max_tx)
-            })
-            .await
-            .unwrap_or_else(|e| {
-                tracing::error!("failed to prune transactions for cp {cp}: {e}");
-            });
-            info!(
-                "Pruned transactions for checkpoint {} from tx {} to tx {}",
-                cp, min_tx, max_tx
-            );
-            self.execute_in_blocking_worker(move |this| {
-                this.prune_event_indices_table(min_tx, max_tx)
-            })
-            .await
-            .unwrap_or_else(|e| {
-                tracing::error!("failed to prune events of transactions for cp {cp}: {e}");
-            });
-            info!(
-                "Pruned events of transactions for checkpoint {cp} from tx {min_tx} to tx {max_tx}"
-            );
-            self.metrics.last_pruned_transaction.set(max_tx as i64);
-
-            self.execute_in_blocking_worker(move |this| this.prune_cp_tx_table(cp))
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::error!("failed to prune pruner_cp_watermark table for cp {cp}: {e}");
-                });
-            info!("Pruned checkpoint {} of epoch {}", cp, epoch);
-            self.metrics.last_pruned_checkpoint.set(cp as i64);
-        }
-
-        Ok(())
-    }
-
     async fn get_network_total_transactions_by_end_of_epoch(
         &self,
         epoch: u64,
@@ -2481,6 +2468,51 @@ impl IndexerStore for PgIndexerStore {
 
     async fn get_watermarks(&self) -> Result<(Vec<StoredWatermark>, i64), IndexerError> {
         self.execute_in_blocking_worker(move |this| this.get_watermarks())
+            .await
+    }
+
+    async fn prune_table_by_checkpoint(
+        &self,
+        table: &crate::pruning::pruner::PrunableTable,
+        checkpoint: u64,
+    ) -> Result<(), IndexerError> {
+        let table_clone = *table;
+        self.execute_in_blocking_worker(move |this| {
+            this.prune_table_by_checkpoint(&table_clone, checkpoint)
+        })
+        .await
+    }
+
+    async fn prune_table_by_tx_range(
+        &self,
+        table: &crate::pruning::pruner::PrunableTable,
+        min_tx: u64,
+        max_tx: u64,
+    ) -> Result<(), IndexerError> {
+        let table_clone = *table;
+        self.execute_in_blocking_worker(move |this| {
+            this.prune_single_tx_or_event_table(&table_clone, min_tx, max_tx)
+        })
+        .await
+    }
+
+    async fn update_watermark_pruner_hi(
+        &self,
+        table: &PrunableTable,
+        pruner_hi: u64,
+    ) -> Result<(), IndexerError> {
+        let table = *table;
+        self.execute_in_blocking_worker(move |this| {
+            this.update_watermark_pruner_hi(&table, pruner_hi)
+        })
+        .await
+    }
+
+    async fn get_watermark_by_entity(
+        &self,
+        entity: String,
+    ) -> Result<Option<StoredWatermark>, IndexerError> {
+        self.execute_in_blocking_worker(move |this| this.get_watermark_by_entity(&entity))
             .await
     }
 }


### PR DESCRIPTION
# Description of change

Use watermarks table in pruner.
So that every table is pruned independently, and we wait till in-flight reads timeout before we remove data.

Some changes are still necessary for reads to actually check watermarks table before reading actual data, to be done in separate PRs.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9829
fixes #7554 

## How the change has been tested

Standard clippy and existing integration tests

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

