### PR TITLE
feat(starfish): adjust commit range during request

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -1802,6 +1802,24 @@ mod tests {
             total_hits
         );
 
+        let commit_sync_fetch_commits_handler_uncertified_skipped: u64 = authorities
+            .iter()
+            .map(|a| {
+                a.context()
+                    .metrics
+                    .node_metrics
+                    .commit_sync_fetch_commits_handler_uncertified_skipped
+                    .with_label_values(&["fast_commit_sync"])
+                    .get()
+            })
+            .sum();
+
+        assert!(
+            commit_sync_fetch_commits_handler_uncertified_skipped > 0,
+            "Expected uncertified commits skipped > 0 for fast sync, got {}",
+            commit_sync_fetch_commits_handler_uncertified_skipped
+        );
+
         // Stop all authorities
         for authority in authorities {
             authority.stop().await;

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1017,6 +1017,27 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         else {
             return Ok((vec![], vec![]));
         };
+        let commit_range_length = new_commit_end - commit_range.start() + 1;
+        match commit_sync_type {
+            CommitSyncType::Regular => {
+                if commit_range_length > batch_size as CommitIndex {
+                    return Err(ConsensusError::TooManyCommitsReceived {
+                        count: commit_range_length,
+                        limit: batch_size as CommitIndex,
+                        sync_type: "regular",
+                    });
+                }
+            }
+            CommitSyncType::Fast => {
+                if commit_range_length > 2 * batch_size as CommitIndex {
+                    return Err(ConsensusError::TooManyCommitsReceived {
+                        count: commit_range_length,
+                        limit: 2 * batch_size as CommitIndex,
+                        sync_type: "fast",
+                    });
+                }
+            }
+        }
 
         // Then scan commits up to the certifiable index
         let commits = self

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -984,25 +984,28 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // Bound the range based on sync type.
         let batch_size = commit_sync_type.commit_sync_batch_size(&self.context);
-        let inclusive_end = commit_range
+        let inclusive_bound = commit_range
             .end()
             .min(commit_range.start() + batch_size as CommitIndex - 1);
-        // First, find the highest certifiable commit index
-        let Some((highest_index, certifier_block_refs)) = self
-            .find_highest_certifiable_commit_in_range(
-                &commit_range,
-                inclusive_end,
-                &commit_sync_type,
-            )?
+
+        // Find certifiable commit based on sync type
+        let find_certifiable_commit = |commit_sync_type: &CommitSyncType| -> ConsensusResult<Option<(CommitIndex, Vec<BlockRef>)>> {
+            match commit_sync_type {
+                CommitSyncType::Regular => self.find_highest_certifiable_commit_in_range(&commit_range, inclusive_bound, commit_sync_type),
+                CommitSyncType::Fast => self.find_lowest_certifiable_commit_from(inclusive_bound, commit_sync_type),
+            }
+        };
+
+        let Some((new_commit_end, certifier_block_refs)) =
+            find_certifiable_commit(&commit_sync_type)?
         else {
-            // No certifiable commits found
             return Ok((vec![], vec![]));
         };
 
-        // Then scan commits up to the highest certifiable index
+        // Then scan commits up to the certifiable index
         let commits = self
             .store
-            .scan_commits((commit_range.start()..=highest_index).into())?;
+            .scan_commits((commit_range.start()..=new_commit_end).into())?;
         // Try reading from voting block headers storage first, then fallback to regular
         // block headers for any that weren't found.
         let voting_headers = self

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -452,6 +452,61 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             .with_label_values(&[peer_hostname, "handle_subscribed_block_bundle"])
             .inc_by(digests_to_exclude.len() as u64);
     }
+
+    /// Finds the highest commit index in the commit range up to search_up_to
+    /// that can be certified with available votes. Returns the highest
+    /// certifiable commit index and the block refs (votes) that certify it,
+    /// or None if no certifiable commit is found.
+    fn find_highest_certifiable_commit_in_range(
+        &self,
+        commit_range: &CommitRange,
+        mut search_up_to: CommitIndex,
+        commit_sync_type: &CommitSyncType,
+    ) -> ConsensusResult<Option<(CommitIndex, Vec<BlockRef>)>> {
+        loop {
+            // Find the highest index with at least some votes, up to our search bound.
+            let Some(index_with_votes) = self
+                .store
+                .read_highest_commit_index_with_votes(search_up_to)?
+            else {
+                // No votes found for any index in the range.
+                return Ok(None);
+            };
+
+            // If the index with votes is below our commit range start, there are no
+            // certifiable commits.
+            if index_with_votes < commit_range.start() {
+                return Ok(None);
+            }
+
+            let votes = self.store.read_commit_votes(index_with_votes)?;
+            let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
+            for v in &votes {
+                stake_aggregator.add(v.author, &self.context.committee);
+            }
+            if stake_aggregator.reached_threshold(&self.context.committee) {
+                return Ok(Some((index_with_votes, votes)));
+            } else {
+                debug!(
+                    "Commit {} votes did not reach quorum to certify, {} < {}, skipping",
+                    index_with_votes,
+                    stake_aggregator.stake(),
+                    stake_aggregator.threshold(&self.context.committee)
+                );
+                self.context
+                    .metrics
+                    .node_metrics
+                    .commit_sync_fetch_commits_handler_uncertified_skipped
+                    .with_label_values(&[commit_sync_type.as_str()])
+                    .inc();
+                // Continue searching from index_with_votes - 1
+                search_up_to = index_with_votes.saturating_sub(1);
+                if search_up_to < commit_range.start() {
+                    return Ok(None);
+                }
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -888,77 +943,22 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let inclusive_end = commit_range
             .end()
             .min(commit_range.start() + batch_size as CommitIndex - 1);
-        let mut commits = self
+        // First, find the highest certifiable commit index
+        let Some((highest_index, certifier_block_refs)) = self
+            .find_highest_certifiable_commit_in_range(
+                &commit_range,
+                inclusive_end,
+                &commit_sync_type,
+            )?
+        else {
+            // No certifiable commits found
+            return Ok((vec![], vec![]));
+        };
+
+        // Then scan commits up to the highest certifiable index
+        let commits = self
             .store
-            .scan_commits((commit_range.start()..=inclusive_end).into())?;
-        let mut certifier_block_refs = vec![];
-        // Find the highest commit index with votes, skipping any gaps in indexes
-        // without votes.
-        let mut search_up_to = inclusive_end;
-        'commit: loop {
-            // Find the highest index with at least some votes, up to our search bound.
-            let Some(index_with_votes) = self
-                .store
-                .read_highest_commit_index_with_votes(search_up_to)?
-            else {
-                // No votes found for any index in the range, return empty commits.
-                commits.clear();
-                break 'commit;
-            };
-
-            // If the index with votes is below our commit range start, there are no
-            // certifiable commits.
-            if index_with_votes < commit_range.start() {
-                commits.clear();
-                break 'commit;
-            }
-
-            // Truncate commits to only include those up to index_with_votes.
-            while commits.last().is_some_and(|c| c.index() > index_with_votes) {
-                commits.pop();
-            }
-
-            let Some(c) = commits.last() else {
-                break 'commit;
-            };
-
-            let index = c.index();
-            if index != index_with_votes {
-                warn!(
-                    "Commit index {} does not match index with votes {}, expected them to be equal",
-                    index, index_with_votes
-                );
-            }
-            let votes = self.store.read_commit_votes(index)?;
-            let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
-            for v in &votes {
-                stake_aggregator.add(v.author, &self.context.committee);
-            }
-            if stake_aggregator.reached_threshold(&self.context.committee) {
-                certifier_block_refs = votes;
-                break 'commit;
-            } else {
-                debug!(
-                    "Commit {} votes did not reach quorum to certify, {} < {}, skipping",
-                    index,
-                    stake_aggregator.stake(),
-                    stake_aggregator.threshold(&self.context.committee)
-                );
-                self.context
-                    .metrics
-                    .node_metrics
-                    .commit_sync_fetch_commits_handler_uncertified_skipped
-                    .with_label_values(&[commit_sync_type.as_str()])
-                    .inc();
-                commits.pop();
-                // Continue searching from index - 1
-                search_up_to = index.saturating_sub(1);
-                if search_up_to < commit_range.start() {
-                    commits.clear();
-                    break 'commit;
-                }
-            }
-        }
+            .scan_commits((commit_range.start()..=highest_index).into())?;
         // Try reading from voting block headers storage first, then fallback to regular
         // block headers for any that weren't found.
         let voting_headers = self

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -507,6 +507,50 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             }
         }
     }
+
+    /// Finds the lowest commit index from search_from that can be certified
+    /// with available votes. Returns the lowest certifiable commit index and
+    /// the block refs (votes) that certify it, or None if no certifiable
+    /// commit is found.
+    fn find_lowest_certifiable_commit_from(
+        &self,
+        search_from: CommitIndex,
+        commit_sync_type: &CommitSyncType,
+    ) -> ConsensusResult<Option<(CommitIndex, Vec<BlockRef>)>> {
+        let mut current_search_from = search_from;
+        loop {
+            let Some(index_with_votes) = self
+                .store
+                .read_lowest_commit_index_with_votes(current_search_from)?
+            else {
+                return Ok(None);
+            };
+
+            let votes = self.store.read_commit_votes(index_with_votes)?;
+            let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
+            for v in &votes {
+                stake_aggregator.add(v.author, &self.context.committee);
+            }
+            if stake_aggregator.reached_threshold(&self.context.committee) {
+                return Ok(Some((index_with_votes, votes)));
+            } else {
+                debug!(
+                    "Commit {} votes did not reach quorum to certify, {} < {}, skipping",
+                    index_with_votes,
+                    stake_aggregator.stake(),
+                    stake_aggregator.threshold(&self.context.committee)
+                );
+                self.context
+                    .metrics
+                    .node_metrics
+                    .commit_sync_fetch_commits_handler_uncertified_skipped
+                    .with_label_values(&[commit_sync_type.as_str()])
+                    .inc();
+                // Continue searching from index_with_votes + 1
+                current_search_from = index_with_votes.saturating_add(1);
+            }
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -974,6 +974,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         Ok(serialized_headers)
     }
 
+    // The range for returned trusted commits starts at the same index, but the end
+    // can be different, bigger for fast sync and smaller for regular.
     async fn handle_fetch_commits(
         &self,
         _peer: AuthorityIndex,

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -485,6 +485,12 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 stake_aggregator.add(v.author, &self.context.committee);
             }
             if stake_aggregator.reached_threshold(&self.context.committee) {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .commit_sync_fetch_commits_handler_uncertified_skipped
+                    .with_label_values(&[commit_sync_type.as_str()])
+                    .inc_by((search_up_to - index_with_votes) as u64);
                 return Ok(Some((index_with_votes, votes)));
             } else {
                 debug!(
@@ -498,7 +504,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     .node_metrics
                     .commit_sync_fetch_commits_handler_uncertified_skipped
                     .with_label_values(&[commit_sync_type.as_str()])
-                    .inc();
+                    .inc_by((search_up_to - index_with_votes + 1) as u64);
                 // Continue searching from index_with_votes - 1
                 search_up_to = index_with_votes.saturating_sub(1);
                 if search_up_to < commit_range.start() {
@@ -532,6 +538,12 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 stake_aggregator.add(v.author, &self.context.committee);
             }
             if stake_aggregator.reached_threshold(&self.context.committee) {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .commit_sync_fetch_commits_handler_uncertified_skipped
+                    .with_label_values(&[commit_sync_type.as_str()])
+                    .inc_by((index_with_votes - current_search_from) as u64);
                 return Ok(Some((index_with_votes, votes)));
             } else {
                 debug!(
@@ -545,7 +557,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     .node_metrics
                     .commit_sync_fetch_commits_handler_uncertified_skipped
                     .with_label_values(&[commit_sync_type.as_str()])
-                    .inc();
+                    .inc_by((index_with_votes - current_search_from + 1) as u64);
                 // Continue searching from index_with_votes + 1
                 current_search_from = index_with_votes.saturating_add(1);
             }
@@ -974,6 +986,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         Ok(serialized_headers)
     }
 
+    /// Handles fetch requests for commit data and their certifying block
+    /// headers.
     // The range for returned trusted commits starts at the same index, but the end
     // can be different, bigger for fast sync and smaller for regular.
     async fn handle_fetch_commits(

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -19,7 +19,7 @@ use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
 use tokio::sync::{Mutex, broadcast, mpsc::Sender};
 use tokio_util::sync::ReusableBoxFuture;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     CommitIndex, Round, Transaction, VerifiedBlockHeader,
@@ -521,6 +521,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
     fn find_lowest_certifiable_commit_from(
         &self,
         search_from: CommitIndex,
+        search_up_to: CommitIndex,
         commit_sync_type: &CommitSyncType,
     ) -> ConsensusResult<Option<(CommitIndex, Vec<BlockRef>)>> {
         let mut current_search_from = search_from;
@@ -531,6 +532,10 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             else {
                 return Ok(None);
             };
+
+            if index_with_votes > search_up_to {
+                return Ok(None);
+            }
 
             let votes = self.store.read_commit_votes(index_with_votes)?;
             let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
@@ -1008,20 +1013,27 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let find_certifiable_commit = |commit_sync_type: &CommitSyncType| -> ConsensusResult<Option<(CommitIndex, Vec<BlockRef>)>> {
             match commit_sync_type {
                 CommitSyncType::Regular => self.find_highest_certifiable_commit_in_range(&commit_range, inclusive_bound, commit_sync_type),
-                CommitSyncType::Fast => self.find_lowest_certifiable_commit_from(inclusive_bound, commit_sync_type),
+                CommitSyncType::Fast => {
+                    let search_up_to = inclusive_bound + batch_size as CommitIndex;
+                    self.find_lowest_certifiable_commit_from(inclusive_bound, search_up_to, commit_sync_type)
+                }
             }
         };
 
-        let Some((new_commit_end, certifier_block_refs)) =
+        let Some((new_commit_inclusive_end, certifier_block_refs)) =
             find_certifiable_commit(&commit_sync_type)?
         else {
             return Ok((vec![], vec![]));
         };
-        let commit_range_length = new_commit_end - commit_range.start() + 1;
+        let commit_range_length = new_commit_inclusive_end - commit_range.start() + 1;
         match commit_sync_type {
             CommitSyncType::Regular => {
                 if commit_range_length > batch_size as CommitIndex {
-                    return Err(ConsensusError::TooManyCommitsReceived {
+                    error!(
+                        "Commit range exceeded limit after scanning during regular sync: {} > {}",
+                        commit_range_length, batch_size
+                    );
+                    return Err(ConsensusError::CommitRangeExceededAfterScanning {
                         count: commit_range_length,
                         limit: batch_size as CommitIndex,
                         sync_type: "regular",
@@ -1030,7 +1042,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             }
             CommitSyncType::Fast => {
                 if commit_range_length > 2 * batch_size as CommitIndex {
-                    return Err(ConsensusError::TooManyCommitsReceived {
+                    error!(
+                        "Commit range exceeded limit after scanning during fast sync: {} > {}",
+                        commit_range_length,
+                        2 * batch_size
+                    );
+                    return Err(ConsensusError::CommitRangeExceededAfterScanning {
                         count: commit_range_length,
                         limit: 2 * batch_size as CommitIndex,
                         sync_type: "fast",
@@ -1042,7 +1059,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // Then scan commits up to the certifiable index
         let commits = self
             .store
-            .scan_commits((commit_range.start()..=new_commit_end).into())?;
+            .scan_commits((commit_range.start()..=new_commit_inclusive_end).into())?;
         // Try reading from voting block headers storage first, then fallback to regular
         // block headers for any that weren't found.
         let voting_headers = self

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -491,6 +491,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // 2. Verify the response contains block headers that can certify the last
         //    returned commit, and the returned commits are chained by digest,
         // so earlier commits are certified as well.
+        let batch_size = inner.sync_type.commit_sync_batch_size(&inner.context) as usize;
         let (commits, voting_block_headers) = Handle::current()
             .spawn_blocking({
                 let inner = inner.clone();
@@ -500,6 +501,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                         commit_range,
                         serialized_commits,
                         serialized_proof_for_last_commit,
+                        2 * batch_size,
                     )
                 }
             })

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -214,10 +214,6 @@ impl<C: NetworkClient> Inner<C> {
                     });
                 }
             }
-            // Do not process more commits past the end index.
-            if commit.index() > commit_range.end() {
-                break;
-            }
             commits.push((digest, commit));
         }
         let Some((end_commit_digest, end_commit)) = commits.last() else {

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -184,7 +184,17 @@ impl<C: NetworkClient> Inner<C> {
         commit_range: CommitRange,
         serialized_commits: Vec<Bytes>,
         serialized_vote_blocks_headers: Vec<Bytes>,
+        max_commits: usize,
     ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<VerifiedBlockHeader>)> {
+        // Validate response size - peer should not return more than max_commits
+        if serialized_commits.len() > max_commits {
+            return Err(ConsensusError::TooManyCommitsFromPeer {
+                peer,
+                count: serialized_commits.len() as CommitIndex,
+                limit: max_commits as CommitIndex,
+            });
+        }
+
         // Parse and verify commits.
         let mut commits = Vec::new();
         for serialized in &serialized_commits {

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -504,6 +504,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
         //    returned commit,
         // and the returned commits are chained by digest, so earlier commits are
         // certified as well.
+        let batch_size = inner.sync_type.commit_sync_batch_size(&inner.context) as usize;
         let (commits, _) = Handle::current()
             .spawn_blocking({
                 let inner = inner.clone();
@@ -513,6 +514,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                         commit_range,
                         serialized_commits,
                         serialized_voting_block_headers,
+                        batch_size,
                     )
                 }
             })

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -142,6 +142,13 @@ pub(crate) enum ConsensusError {
     #[error("Too many ancestors in the block: {0} > {1}")]
     TooManyAncestors(usize, usize),
 
+    #[error("Too many commits received during {sync_type} sync: {count} > {limit}")]
+    TooManyCommitsReceived {
+        count: CommitIndex,
+        limit: CommitIndex,
+        sync_type: &'static str,
+    },
+
     #[error("Ancestors from the same authority {0}")]
     DuplicatedAncestorsAuthority(AuthorityIndex),
 

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -142,11 +142,20 @@ pub(crate) enum ConsensusError {
     #[error("Too many ancestors in the block: {0} > {1}")]
     TooManyAncestors(usize, usize),
 
-    #[error("Too many commits received during {sync_type} sync: {count} > {limit}")]
-    TooManyCommitsReceived {
+    #[error(
+        "Commit range exceeded limit after scanning during {sync_type} sync: {count} > {limit}"
+    )]
+    CommitRangeExceededAfterScanning {
         count: CommitIndex,
         limit: CommitIndex,
         sync_type: &'static str,
+    },
+
+    #[error("Peer {peer} sent too many commits: {count} > {limit}")]
+    TooManyCommitsFromPeer {
+        peer: AuthorityIndex,
+        count: CommitIndex,
+        limit: CommitIndex,
     },
 
     #[error("Ancestors from the same authority {0}")]

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -468,6 +468,22 @@ impl Store for MemStore {
         Ok(result)
     }
 
+    fn read_lowest_commit_index_with_votes(
+        &self,
+        from_index: CommitIndex,
+    ) -> ConsensusResult<Option<CommitIndex>> {
+        let inner = self.inner.read();
+        let result = inner
+            .commit_votes
+            .range((
+                Included((from_index, CommitDigest::MIN, BlockRef::MIN)),
+                std::ops::Bound::Unbounded,
+            ))
+            .next()
+            .map(|(index, _, _)| *index);
+        Ok(result)
+    }
+
     fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>> {
         let inner = self.inner.read();
         Ok(inner

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -155,6 +155,14 @@ pub(crate) trait Store: Send + Sync {
         up_to_index: CommitIndex,
     ) -> ConsensusResult<Option<CommitIndex>>;
 
+    /// Finds the lowest commit index that has at least one vote, from (and
+    /// including) the given index. Returns None if no votes exist for any
+    /// index >= from_index.
+    fn read_lowest_commit_index_with_votes(
+        &self,
+        from_index: CommitIndex,
+    ) -> ConsensusResult<Option<CommitIndex>>;
+
     /// Reads the last commit info, written atomically with the last commit.
     fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>>;
 

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -731,6 +731,25 @@ impl Store for RocksDBStore {
         }
     }
 
+    fn read_lowest_commit_index_with_votes(
+        &self,
+        from_index: CommitIndex,
+    ) -> ConsensusResult<Option<CommitIndex>> {
+        let result = self
+            .commit_votes
+            .safe_range_iter((
+                Included((from_index, CommitDigest::MIN, BlockRef::MIN)),
+                std::ops::Bound::Unbounded,
+            ))
+            .next();
+
+        match result {
+            Some(Ok(((index, _, _), _))) => Ok(Some(index)),
+            Some(Err(e)) => Err(ConsensusError::RocksDBFailure(e)),
+            None => Ok(None),
+        }
+    }
+
     fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>> {
         let Some(result) = self
             .commit_info


### PR DESCRIPTION
# Description of change

This PR modifies the commit fetching mechanism during the fast sync by allowing the extension of the commit range. It may be useful when for the last commit in the initial range we don't have enough voting headers, but a quorum exists for one of the later commits. The commit range shouldn't be extended to more than twice the initial length.

Fix #9822 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
