### PR TITLE
feat(iota-types,iota-core): Introduce `CancelledTransactionsV2` type

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -146,7 +146,10 @@ pub(crate) mod consensus_quarantine;
 use consensus_quarantine::{
     ConsensusCommitOutput, ConsensusOutputCache, ConsensusOutputQuarantine,
 };
-use iota_types::crypto::AuthorityPublicKey;
+use iota_types::{
+    crypto::AuthorityPublicKey,
+    messages_consensus::{CancelledTransactionV2, VersionAssignment},
+};
 
 // CertLockGuard and CertTxGuard are functionally identical right now, but we
 // retain a distinction anyway. If we need to support distributed object
@@ -3332,8 +3335,7 @@ impl AuthorityPerEpochStore {
             }
         }
 
-        let mut version_assignment: Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)> =
-            Vec::new();
+        let mut version_assignment: Vec<CancelledTransactionV2> = Vec::new();
 
         let mut shared_input_next_version = HashMap::new();
         for txn in transactions.iter() {
@@ -3347,7 +3349,13 @@ impl AuthorityPerEpochStore {
                         self.protocol_config
                             .congestion_control_gas_price_feedback_mechanism(),
                     );
-                    version_assignment.push((*txn.digest(), assigned_versions));
+                    version_assignment.push(CancelledTransactionV2::new(
+                        *txn.digest(),
+                        assigned_versions
+                            .into_iter()
+                            .map(|(object_id, version)| VersionAssignment::new(object_id, version))
+                            .collect(),
+                    ));
                 }
                 None => {}
             }

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -19,7 +19,7 @@ use iota_metrics::{monitored_mpsc::UnboundedReceiver, monitored_scope, spawn_mon
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
     authenticator_state::ActiveJwk,
-    base_types::{AuthorityName, EpochId, ObjectID, SequenceNumber, TransactionDigest},
+    base_types::{AuthorityName, EpochId, TransactionDigest},
     digests::{AdditionalConsensusStateDigest, ConsensusCommitDigest},
     executable_transaction::{TrustedExecutableTransaction, VerifiedExecutableTransaction},
     iota_system_state::epoch_start_iota_system_state::EpochStartSystemStateTrait,
@@ -151,6 +151,7 @@ mod additional_consensus_state {
     }
 }
 pub(crate) use additional_consensus_state::AdditionalConsensusState;
+use iota_types::messages_consensus::CancelledTransactionV2;
 
 pub struct ConsensusHandler<C> {
     /// A store created for each epoch. ConsensusHandler is recreated each
@@ -913,7 +914,7 @@ impl ConsensusCommitInfo {
     fn consensus_commit_prologue_v1_transaction(
         &self,
         epoch: u64,
-        cancelled_txn_version_assignment: Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>,
+        cancelled_txn_version_assignment: Vec<CancelledTransactionV2>,
     ) -> VerifiedExecutableTransaction {
         let transaction = VerifiedTransaction::new_consensus_commit_prologue_v1(
             epoch,
@@ -928,7 +929,7 @@ impl ConsensusCommitInfo {
     fn consensus_commit_prologue_v2_transaction(
         &self,
         epoch: u64,
-        cancelled_txn_version_assignment: Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>,
+        cancelled_txn_version_assignment: Vec<CancelledTransactionV2>,
         additional_state_digest: AdditionalConsensusStateDigest,
     ) -> VerifiedExecutableTransaction {
         let transaction = VerifiedTransaction::new_consensus_commit_prologue_v2(
@@ -946,7 +947,7 @@ impl ConsensusCommitInfo {
         &self,
         epoch: u64,
         protocol_config: &ProtocolConfig,
-        cancelled_txn_version_assignment: Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>,
+        cancelled_txn_version_assignment: Vec<CancelledTransactionV2>,
         additional_state: &AdditionalConsensusState,
     ) -> VerifiedExecutableTransaction {
         if protocol_config.record_additional_state_digest_in_prologue() {

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -33,7 +33,10 @@ use iota_types::{
     execution_status::{ExecutionFailureStatus, ExecutionStatus},
     gas_coin::GasCoin,
     iota_system_state::IotaSystemStateWrapper,
-    messages_consensus::{AuthorityCapabilitiesV1, ConsensusDeterminedVersionAssignments},
+    messages_consensus::{
+        AuthorityCapabilitiesV1, CancelledTransactionV2, ConsensusDeterminedVersionAssignments,
+        VersionAssignment,
+    },
     object::{Data, GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     randomness_state::get_randomness_state_obj_initial_shared_version,
@@ -6779,24 +6782,24 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     {
         assert!(matches!(
             &prologue_txn.consensus_determined_version_assignments,
-            ConsensusDeterminedVersionAssignments::CancelledTransactions(assignment)
-            if assignment == &vec![(
-                *cancelled_txn.digest(),
-                vec![
-                    (
-                        shared_objects[0].id(),
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+            ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(assignment)
+            if assignment == &vec![CancelledTransactionV2 {
+                digest: *cancelled_txn.digest(),
+                version_assignments: vec![
+                    VersionAssignment {
+                        object_id: shared_objects[0].id(),
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             suggested_gas_price
                         ),
-                    ),
-                    (
-                        shared_objects[1].id(),
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                    },
+                    VersionAssignment {
+                        object_id: shared_objects[1].id(),
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             suggested_gas_price
                         ),
-                    )
+                    }
                 ]
-            )]
+            }]
         ));
     } else {
         panic!("First scheduled transaction must be a ConsensusCommitPrologueV2 transaction.");

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -13,7 +13,9 @@ use iota_types::{
     effects::{TransactionEffects, TransactionEffectsAPI, UnchangedSharedKind},
     executable_transaction::VerifiedExecutableTransaction,
     execution_status::{CongestedObjects, ExecutionFailureStatus, ExecutionStatus},
-    messages_consensus::ConsensusDeterminedVersionAssignments,
+    messages_consensus::{
+        CancelledTransactionV2, ConsensusDeterminedVersionAssignments, VersionAssignment,
+    },
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{
@@ -653,44 +655,44 @@ async fn transaction_duration_exceeds_max_execution_duration_per_commit() {
     {
         // Check if `ConsensusDeterminedVersionAssignments` are correct.
         let cancelled_txs = vec![
-            (
-                *scheduled_transactions[1].digest(),
-                vec![
-                    (
-                        tester.shared_counter_1.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+            CancelledTransactionV2 {
+                digest: *scheduled_transactions[1].digest(),
+                version_assignments: vec![
+                    VersionAssignment {
+                        object_id: tester.shared_counter_1.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             REFERENCE_GAS_PRICE_FOR_TESTS,
                         ),
-                    ),
-                    (
-                        tester.shared_counter_2.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                    },
+                    VersionAssignment {
+                        object_id: tester.shared_counter_2.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             REFERENCE_GAS_PRICE_FOR_TESTS,
                         ),
-                    ),
+                    },
                 ],
-            ),
-            (
-                *scheduled_transactions[3].digest(),
-                vec![
-                    (
-                        tester.shared_counter_1.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+            },
+            CancelledTransactionV2 {
+                digest: *scheduled_transactions[3].digest(),
+                version_assignments: vec![
+                    VersionAssignment {
+                        object_id: tester.shared_counter_1.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             expected_suggested_gas_price_2,
                         ),
-                    ),
-                    (
-                        tester.shared_counter_2.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                    },
+                    VersionAssignment {
+                        object_id: tester.shared_counter_2.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             expected_suggested_gas_price_2,
                         ),
-                    ),
+                    },
                 ],
-            ),
+            },
         ];
         assert_eq!(
             prologue_tx.consensus_determined_version_assignments,
-            ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
+            ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(cancelled_txs)
         );
     } else {
         panic!("First scheduled transaction must be a ConsensusCommitPrologueV2 transaction.");
@@ -863,22 +865,22 @@ async fn gas_price_feedback_mechanism_is_turned_off() {
         scheduled_transactions[0].data().transaction_data().kind()
     {
         // Check if `ConsensusDeterminedVersionAssignments` are correct.
-        let cancelled_txs = vec![(
-            *scheduled_transactions[2].digest(),
-            vec![
-                (
-                    tester.shared_counter_1.0,
-                    SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK,
-                ),
-                (
-                    tester.shared_counter_2.0,
-                    SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK,
-                ),
+        let cancelled_txs = vec![CancelledTransactionV2 {
+            digest: *scheduled_transactions[2].digest(),
+            version_assignments: vec![
+                VersionAssignment {
+                    object_id: tester.shared_counter_1.0,
+                    version: SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK,
+                },
+                VersionAssignment {
+                    object_id: tester.shared_counter_2.0,
+                    version: SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK,
+                },
             ],
-        )];
+        }];
         assert_eq!(
             prologue_tx.consensus_determined_version_assignments,
-            ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
+            ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(cancelled_txs)
         );
     } else {
         panic!("First scheduled transaction must be a ConsensusCommitPrologueV2 transaction.");
@@ -1016,26 +1018,26 @@ async fn gas_price_feedback_mechanism_with_max_gas_price() {
         scheduled_transactions[0].data().transaction_data().kind()
     {
         // Check if `ConsensusDeterminedVersionAssignments` are correct.
-        let cancelled_txs = vec![(
-            *scheduled_transactions[2].digest(),
-            vec![
-                (
-                    tester.shared_counter_1.0,
-                    SequenceNumber::new_congested_with_suggested_gas_price(
+        let cancelled_txs = vec![CancelledTransactionV2 {
+            digest: *scheduled_transactions[2].digest(),
+            version_assignments: vec![
+                VersionAssignment {
+                    object_id: tester.shared_counter_1.0,
+                    version: SequenceNumber::new_congested_with_suggested_gas_price(
                         expected_suggested_gas_price,
                     ),
-                ),
-                (
-                    tester.shared_counter_2.0,
-                    SequenceNumber::new_congested_with_suggested_gas_price(
+                },
+                VersionAssignment {
+                    object_id: tester.shared_counter_2.0,
+                    version: SequenceNumber::new_congested_with_suggested_gas_price(
                         expected_suggested_gas_price,
                     ),
-                ),
+                },
             ],
-        )];
+        }];
         assert_eq!(
             prologue_tx.consensus_determined_version_assignments,
-            ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
+            ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(cancelled_txs)
         );
     } else {
         panic!("First scheduled transaction must be a ConsensusCommitPrologueV2 transaction.");
@@ -1168,7 +1170,7 @@ async fn gas_price_feedback_mechanism_for_multiple_commits() {
         // Check if `ConsensusDeterminedVersionAssignments` are correct.
         assert_eq!(
             prologue_tx.consensus_determined_version_assignments,
-            ConsensusDeterminedVersionAssignments::CancelledTransactions(vec![])
+            ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(vec![])
         );
     } else {
         panic!("First scheduled transaction must be a ConsensusCommitPrologueV2 transaction.");
@@ -1247,26 +1249,26 @@ async fn gas_price_feedback_mechanism_for_multiple_commits() {
         scheduled_transactions[0].data().transaction_data().kind()
     {
         // Check if `ConsensusDeterminedVersionAssignments` are correct.
-        let cancelled_txs = vec![(
-            *scheduled_transactions[2].digest(),
-            vec![
-                (
-                    tester.shared_counter_1.0,
-                    SequenceNumber::new_congested_with_suggested_gas_price(
+        let cancelled_txs = vec![CancelledTransactionV2 {
+            digest: *scheduled_transactions[2].digest(),
+            version_assignments: vec![
+                VersionAssignment {
+                    object_id: tester.shared_counter_1.0,
+                    version: SequenceNumber::new_congested_with_suggested_gas_price(
                         expected_suggested_gas_price,
                     ),
-                ),
-                (
-                    tester.shared_counter_2.0,
-                    SequenceNumber::new_congested_with_suggested_gas_price(
+                },
+                VersionAssignment {
+                    object_id: tester.shared_counter_2.0,
+                    version: SequenceNumber::new_congested_with_suggested_gas_price(
                         expected_suggested_gas_price,
                     ),
-                ),
+                },
             ],
-        )];
+        }];
         assert_eq!(
             prologue_tx.consensus_determined_version_assignments,
-            ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
+            ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(cancelled_txs)
         );
     } else {
         panic!("First scheduled transaction must be a ConsensusCommitPrologueV2 transaction.");
@@ -1427,113 +1429,113 @@ async fn gas_price_feedback_mechanism_non_trivial_case_total_tx_count_mode() {
     {
         // Check if `ConsensusDeterminedVersionAssignments` are correct.
         let cancelled_txs = vec![
-            (
-                *certificates[4].digest(),
-                vec![(
-                    tester.shared_counter_2.0,
-                    SequenceNumber::new_congested_with_suggested_gas_price(
+            CancelledTransactionV2 {
+                digest: *certificates[4].digest(),
+                version_assignments: vec![VersionAssignment {
+                    object_id: tester.shared_counter_2.0,
+                    version: SequenceNumber::new_congested_with_suggested_gas_price(
                         expected_suggested_gas_price_for_object_2,
                     ),
-                )],
-            ),
-            (
-                *certificates[5].digest(),
-                vec![(
-                    tester.shared_counter_2.0,
-                    SequenceNumber::new_congested_with_suggested_gas_price(
+                }],
+            },
+            CancelledTransactionV2 {
+                digest: *certificates[5].digest(),
+                version_assignments: vec![VersionAssignment {
+                    object_id: tester.shared_counter_2.0,
+                    version: SequenceNumber::new_congested_with_suggested_gas_price(
                         expected_suggested_gas_price_for_object_2,
                     ),
-                )],
-            ),
-            (
-                *certificates[6].digest(),
-                vec![
-                    (
-                        tester.shared_counter_1.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                }],
+            },
+            CancelledTransactionV2 {
+                digest: *certificates[6].digest(),
+                version_assignments: vec![
+                    VersionAssignment {
+                        object_id: tester.shared_counter_1.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             expected_suggested_gas_price_for_both_objects,
                         ),
-                    ),
-                    (
-                        tester.shared_counter_2.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                    },
+                    VersionAssignment {
+                        object_id: tester.shared_counter_2.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             expected_suggested_gas_price_for_both_objects,
                         ),
-                    ),
+                    },
                 ],
-            ),
-            (
-                *certificates[7].digest(),
-                vec![
-                    (
-                        tester.shared_counter_1.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+            },
+            CancelledTransactionV2 {
+                digest: *certificates[7].digest(),
+                version_assignments: vec![
+                    VersionAssignment {
+                        object_id: tester.shared_counter_1.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             expected_suggested_gas_price_for_both_objects,
                         ),
-                    ),
-                    (
-                        tester.shared_counter_2.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                    },
+                    VersionAssignment {
+                        object_id: tester.shared_counter_2.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             expected_suggested_gas_price_for_both_objects,
                         ),
-                    ),
+                    },
                 ],
-            ),
-            (
-                *certificates[10].digest(),
-                vec![
-                    (
-                        tester.shared_counter_1.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+            },
+            CancelledTransactionV2 {
+                digest: *certificates[10].digest(),
+                version_assignments: vec![
+                    VersionAssignment {
+                        object_id: tester.shared_counter_1.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             expected_suggested_gas_price_for_both_objects,
                         ),
-                    ),
-                    (
-                        tester.shared_counter_2.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                    },
+                    VersionAssignment {
+                        object_id: tester.shared_counter_2.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             expected_suggested_gas_price_for_both_objects,
                         ),
-                    ),
+                    },
                 ],
-            ),
-            (
-                *certificates[11].digest(),
-                vec![
-                    (
-                        tester.shared_counter_1.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+            },
+            CancelledTransactionV2 {
+                digest: *certificates[11].digest(),
+                version_assignments: vec![
+                    VersionAssignment {
+                        object_id: tester.shared_counter_1.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             expected_suggested_gas_price_for_both_objects,
                         ),
-                    ),
-                    (
-                        tester.shared_counter_2.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                    },
+                    VersionAssignment {
+                        object_id: tester.shared_counter_2.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             expected_suggested_gas_price_for_both_objects,
                         ),
-                    ),
+                    },
                 ],
-            ),
-            (
-                *certificates[12].digest(),
-                vec![
-                    (
-                        tester.shared_counter_1.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+            },
+            CancelledTransactionV2 {
+                digest: *certificates[12].digest(),
+                version_assignments: vec![
+                    VersionAssignment {
+                        object_id: tester.shared_counter_1.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             expected_suggested_gas_price_for_both_objects,
                         ),
-                    ),
-                    (
-                        tester.shared_counter_2.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                    },
+                    VersionAssignment {
+                        object_id: tester.shared_counter_2.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             expected_suggested_gas_price_for_both_objects,
                         ),
-                    ),
+                    },
                 ],
-            ),
+            },
         ];
         assert_eq!(
             prologue_tx.consensus_determined_version_assignments,
-            ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
+            ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(cancelled_txs)
         );
     } else {
         panic!("First scheduled transaction must be a ConsensusCommitPrologueV2 transaction.");
@@ -1738,113 +1740,113 @@ async fn gas_price_feedback_mechanism_non_trivial_case_total_gas_budget_mode() {
     {
         // Check if `ConsensusDeterminedVersionAssignments` are correct.
         let cancelled_txs = vec![
-            (
-                *certificates[4].digest(),
-                vec![(
-                    tester.shared_counter_2.0,
-                    SequenceNumber::new_congested_with_suggested_gas_price(
+            CancelledTransactionV2 {
+                digest: *certificates[4].digest(),
+                version_assignments: vec![VersionAssignment {
+                    object_id: tester.shared_counter_2.0,
+                    version: SequenceNumber::new_congested_with_suggested_gas_price(
                         certificates[2].gas_price() + 1,
                     ),
-                )],
-            ),
-            (
-                *certificates[5].digest(),
-                vec![(
-                    tester.shared_counter_2.0,
-                    SequenceNumber::new_congested_with_suggested_gas_price(
+                }],
+            },
+            CancelledTransactionV2 {
+                digest: *certificates[5].digest(),
+                version_assignments: vec![VersionAssignment {
+                    object_id: tester.shared_counter_2.0,
+                    version: SequenceNumber::new_congested_with_suggested_gas_price(
                         certificates[2].gas_price() + 1,
                     ),
-                )],
-            ),
-            (
-                *certificates[6].digest(),
-                vec![
-                    (
-                        tester.shared_counter_1.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                }],
+            },
+            CancelledTransactionV2 {
+                digest: *certificates[6].digest(),
+                version_assignments: vec![
+                    VersionAssignment {
+                        object_id: tester.shared_counter_1.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             certificates[1].gas_price() + 1,
                         ),
-                    ),
-                    (
-                        tester.shared_counter_2.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                    },
+                    VersionAssignment {
+                        object_id: tester.shared_counter_2.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             certificates[1].gas_price() + 1,
                         ),
-                    ),
+                    },
                 ],
-            ),
-            (
-                *certificates[7].digest(),
-                vec![
-                    (
-                        tester.shared_counter_1.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+            },
+            CancelledTransactionV2 {
+                digest: *certificates[7].digest(),
+                version_assignments: vec![
+                    VersionAssignment {
+                        object_id: tester.shared_counter_1.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             certificates[0].gas_price(),
                         ),
-                    ),
-                    (
-                        tester.shared_counter_2.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                    },
+                    VersionAssignment {
+                        object_id: tester.shared_counter_2.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             certificates[0].gas_price(),
                         ),
-                    ),
+                    },
                 ],
-            ),
-            (
-                *certificates[10].digest(),
-                vec![
-                    (
-                        tester.shared_counter_1.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+            },
+            CancelledTransactionV2 {
+                digest: *certificates[10].digest(),
+                version_assignments: vec![
+                    VersionAssignment {
+                        object_id: tester.shared_counter_1.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             certificates[2].gas_price() + 1,
                         ),
-                    ),
-                    (
-                        tester.shared_counter_2.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                    },
+                    VersionAssignment {
+                        object_id: tester.shared_counter_2.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             certificates[2].gas_price() + 1,
                         ),
-                    ),
+                    },
                 ],
-            ),
-            (
-                *certificates[11].digest(),
-                vec![
-                    (
-                        tester.shared_counter_1.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+            },
+            CancelledTransactionV2 {
+                digest: *certificates[11].digest(),
+                version_assignments: vec![
+                    VersionAssignment {
+                        object_id: tester.shared_counter_1.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             certificates[1].gas_price() + 1,
                         ),
-                    ),
-                    (
-                        tester.shared_counter_2.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                    },
+                    VersionAssignment {
+                        object_id: tester.shared_counter_2.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             certificates[1].gas_price() + 1,
                         ),
-                    ),
+                    },
                 ],
-            ),
-            (
-                *certificates[12].digest(),
-                vec![
-                    (
-                        tester.shared_counter_1.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+            },
+            CancelledTransactionV2 {
+                digest: *certificates[12].digest(),
+                version_assignments: vec![
+                    VersionAssignment {
+                        object_id: tester.shared_counter_1.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             certificates[0].gas_price(),
                         ),
-                    ),
-                    (
-                        tester.shared_counter_2.0,
-                        SequenceNumber::new_congested_with_suggested_gas_price(
+                    },
+                    VersionAssignment {
+                        object_id: tester.shared_counter_2.0,
+                        version: SequenceNumber::new_congested_with_suggested_gas_price(
                             certificates[0].gas_price(),
                         ),
-                    ),
+                    },
                 ],
-            ),
+            },
         ];
         assert_eq!(
             prologue_tx.consensus_determined_version_assignments,
-            ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
+            ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(cancelled_txs)
         );
     } else {
         panic!("First scheduled transaction must be a ConsensusCommitPrologueV2 transaction.");

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -255,7 +255,7 @@ async fn test_user_sends_consensus_commit_prologue_v2() {
             commit_timestamp_ms: 42,
             consensus_commit_digest: ConsensusCommitDigest::default(),
             consensus_determined_version_assignments:
-                ConsensusDeterminedVersionAssignments::CancelledTransactions(Vec::new()),
+                ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(Vec::new()),
             additional_state_digest: AdditionalConsensusStateDigest::default(),
         },
     ))

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -418,7 +418,10 @@ fn consensus_determined_version_assignments_to_sdk(
         },
         crate::messages_consensus::ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(
             vec,
-        ) => ConsensusDeterminedVersionAssignments::CancelledTransactions {
+        ) =>
+            // CancelledTransactionsV2 contains the same content as CancelledTransactions, just structured
+            // differently. No need to introduce a new SDK type for it.
+            ConsensusDeterminedVersionAssignments::CancelledTransactions {
             cancelled_transactions: vec
                 .into_iter()
                 .map(|value| CancelledTransaction {

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -416,6 +416,24 @@ fn consensus_determined_version_assignments_to_sdk(
                 })
                 .collect(),
         },
+        crate::messages_consensus::ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(
+            vec,
+        ) => ConsensusDeterminedVersionAssignments::CancelledTransactions {
+            cancelled_transactions: vec
+                .into_iter()
+                .map(|value| CancelledTransaction {
+                    digest: value.digest.into(),
+                    version_assignments: value
+                        .version_assignments
+                        .into_iter()
+                        .map(|value| VersionAssignment {
+                            object_id: value.object_id.into(),
+                            version: value.version.value(),
+                        })
+                        .collect(),
+                })
+                .collect(),
+        },
     }
 }
 
@@ -428,18 +446,22 @@ fn consensus_determined_version_assignments_from_sdk(
         ConsensusDeterminedVersionAssignments::CancelledTransactions {
             cancelled_transactions,
         } => {
-            crate::messages_consensus::ConsensusDeterminedVersionAssignments::CancelledTransactions(
+            // Since the content of CancelledTransactions doesn't change but the way it's
+            // structured, it's OK to always convert to V2. It can always be repacked to V1
+            // if needed.
+            crate::messages_consensus::ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(
                 cancelled_transactions
                     .into_iter()
-                    .map(|value| {
-                        (
-                            value.digest.into(),
-                            value
-                                .version_assignments
-                                .into_iter()
-                                .map(|value| (value.object_id.into(), value.version.into()))
-                                .collect(),
-                        )
+                    .map(|value| crate::messages_consensus::CancelledTransactionV2 {
+                        digest: value.digest.into(),
+                        version_assignments: value
+                            .version_assignments
+                            .into_iter()
+                            .map(|value| crate::messages_consensus::VersionAssignment {
+                                object_id: value.object_id.into(),
+                                version: value.version.into(),
+                            })
+                            .collect(),
                     })
                     .collect(),
             )

--- a/crates/iota-types/src/iota_serde.rs
+++ b/crates/iota-types/src/iota_serde.rs
@@ -318,6 +318,29 @@ where
     }
 }
 
+impl SerializeAs<crate::base_types::SequenceNumber> for BigInt<u64> {
+    fn serialize_as<S>(
+        value: &crate::base_types::SequenceNumber,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = value.value().to_string();
+        s.serialize(serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, crate::base_types::SequenceNumber> for BigInt<u64> {
+    fn deserialize_as<D>(deserializer: D) -> Result<crate::base_types::SequenceNumber, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let b = BigInt::deserialize(deserializer)?;
+        Ok(crate::base_types::SequenceNumber::from_u64(*b))
+    }
+}
+
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Copy, JsonSchema)]
 pub struct SequenceNumber(#[schemars(with = "BigInt<u64>")] u64);

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -17,6 +17,7 @@ use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
 use iota_sdk_types::crypto::IntentScope;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 use crate::{
     base_types::{
@@ -24,6 +25,7 @@ use crate::{
     },
     crypto::{AuthoritySignature, DefaultHash},
     digests::{AdditionalConsensusStateDigest, ConsensusCommitDigest, Digest},
+    iota_serde::BigInt,
     message_envelope::{Envelope, Message, VerifiedEnvelope},
     messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage},
     supported_protocol_versions::{
@@ -35,12 +37,38 @@ use crate::{
 /// Non-decreasing timestamp produced by consensus in ms.
 pub type TimestampMs = u64;
 
+/// Holds object ID and assigned version for cancelled shared objects.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+pub struct VersionAssignment {
+    /// ID of shared object that appear in cancelled transactions.
+    pub object_id: ObjectID,
+
+    /// Version assigned to cancelled shared object. It embeds the
+    /// cancellation reason.
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub version: SequenceNumber,
+}
+
+/// Holds digest of cancelled transaction and shared object version
+/// assignments.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+pub struct CancelledTransactionV2 {
+    /// Digest of cancelled transaction.
+    pub digest: TransactionDigest,
+
+    /// Version assignments for input shared objects.
+    pub version_assignments: Vec<VersionAssignment>,
+}
+
 /// Uses an enum to allow for future expansion of the
 /// ConsensusDeterminedVersionAssignments.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, JsonSchema)]
 pub enum ConsensusDeterminedVersionAssignments {
     // Cancelled transaction version assignment.
     CancelledTransactions(Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>),
+    CancelledTransactionsV2(Vec<CancelledTransactionV2>),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -51,6 +51,12 @@ pub struct VersionAssignment {
     pub version: SequenceNumber,
 }
 
+impl VersionAssignment {
+    pub fn new(object_id: ObjectID, version: SequenceNumber) -> Self {
+        Self { object_id, version }
+    }
+}
+
 /// Holds digest of cancelled transaction and shared object version
 /// assignments.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
@@ -60,6 +66,15 @@ pub struct CancelledTransactionV2 {
 
     /// Version assignments for input shared objects.
     pub version_assignments: Vec<VersionAssignment>,
+}
+
+impl CancelledTransactionV2 {
+    pub fn new(digest: TransactionDigest, version_assignments: Vec<VersionAssignment>) -> Self {
+        Self {
+            digest,
+            version_assignments,
+        }
+    }
 }
 
 /// Uses an enum to allow for future expansion of the

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2590,8 +2590,26 @@ impl VerifiedTransaction {
         round: u64,
         commit_timestamp_ms: CheckpointTimestamp,
         consensus_commit_digest: ConsensusCommitDigest,
-        cancelled_txn_version_assignment: Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>,
+        cancelled_txn_version_assignment: Vec<CancelledTransactionV2>,
     ) -> Self {
+        // Transform CancelledTransactionV2 into the expected format for V1.
+        let cancelled_transactions = cancelled_txn_version_assignment
+            .into_iter()
+            .map(
+                |CancelledTransactionV2 {
+                     digest,
+                     version_assignments,
+                 }| {
+                    (
+                        digest,
+                        version_assignments
+                            .into_iter()
+                            .map(|VersionAssignment { object_id, version }| (object_id, version))
+                            .collect(),
+                    )
+                },
+            )
+            .collect();
         ConsensusCommitPrologueV1 {
             epoch,
             round,
@@ -2601,7 +2619,7 @@ impl VerifiedTransaction {
             consensus_commit_digest,
             consensus_determined_version_assignments:
                 ConsensusDeterminedVersionAssignments::CancelledTransactions(
-                    cancelled_txn_version_assignment,
+                    cancelled_transactions,
                 ),
         }
         .pipe(TransactionKind::ConsensusCommitPrologueV1)
@@ -2613,19 +2631,9 @@ impl VerifiedTransaction {
         round: u64,
         commit_timestamp_ms: CheckpointTimestamp,
         consensus_commit_digest: ConsensusCommitDigest,
-        cancelled_txn_version_assignment: Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>,
+        cancelled_txn_version_assignment: Vec<CancelledTransactionV2>,
         additional_state_digest: AdditionalConsensusStateDigest,
     ) -> Self {
-        let cancelled_transactions = cancelled_txn_version_assignment
-            .into_iter()
-            .map(|(digest, version_assignments)| CancelledTransactionV2 {
-                digest,
-                version_assignments: version_assignments
-                    .into_iter()
-                    .map(|(object_id, version)| VersionAssignment { object_id, version })
-                    .collect(),
-            })
-            .collect();
         ConsensusCommitPrologueV2 {
             epoch,
             round,
@@ -2635,7 +2643,7 @@ impl VerifiedTransaction {
             consensus_commit_digest,
             consensus_determined_version_assignments:
                 ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(
-                    cancelled_transactions,
+                    cancelled_txn_version_assignment,
                 ),
             additional_state_digest,
         }

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -51,7 +51,8 @@ use crate::{
     message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope},
     messages_checkpoint::CheckpointTimestamp,
     messages_consensus::{
-        ConsensusCommitPrologueV1, ConsensusCommitPrologueV2, ConsensusDeterminedVersionAssignments,
+        CancelledTransactionV2, ConsensusCommitPrologueV1, ConsensusCommitPrologueV2,
+        ConsensusDeterminedVersionAssignments, VersionAssignment,
     },
     object::{MoveObject, Object, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -2615,6 +2616,16 @@ impl VerifiedTransaction {
         cancelled_txn_version_assignment: Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>,
         additional_state_digest: AdditionalConsensusStateDigest,
     ) -> Self {
+        let cancelled_transactions = cancelled_txn_version_assignment
+            .into_iter()
+            .map(|(digest, version_assignments)| CancelledTransactionV2 {
+                digest,
+                version_assignments: version_assignments
+                    .into_iter()
+                    .map(|(object_id, version)| VersionAssignment { object_id, version })
+                    .collect(),
+            })
+            .collect();
         ConsensusCommitPrologueV2 {
             epoch,
             round,
@@ -2623,8 +2634,8 @@ impl VerifiedTransaction {
             commit_timestamp_ms,
             consensus_commit_digest,
             consensus_determined_version_assignments:
-                ConsensusDeterminedVersionAssignments::CancelledTransactions(
-                    cancelled_txn_version_assignment,
+                ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(
+                    cancelled_transactions,
                 ),
             additional_state_digest,
         }


### PR DESCRIPTION
# Description of change

Currently existing (tuple) variant `CancelledTransactions(Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>)` looks complex and is not very readable and self-documented. This PR adds a new (struct) variant to the `ConsensusDeterminedVersionAssignments` enum. Additionally, since versions of cancelled objects are pretty big numbers (larger than `u64::MAX / 2`), this PR also adds serialization of `SequenceNumber` as `BigInt<u64>`.

It's a followup to #7697 

## Links to any relevant issues

Resolves #7692

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Introduce CancelledTransactionV2 structure as part of `ConsensusCommitPrologueV2` for better type readability. 
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
