### PR TITLE
feat(indexer): Implement backgorund task for reading watermarks table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6608,6 +6608,7 @@ name = "iota-indexer"
 version = "1.16.0-alpha"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "axum 0.8.4",
  "backoff",

--- a/crates/iota-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/iota-graphql-rpc/src/context_data/db_data_provider.rs
@@ -5,8 +5,12 @@
 use std::time::Duration;
 
 use iota_indexer::{
-    apis::GovernanceReadApi, db::ConnectionPoolConfig, metrics::IndexerMetrics,
-    pruning::watermark_task::WatermarkTask, read::IndexerReader, store::PgIndexerStore,
+    apis::GovernanceReadApi,
+    db::ConnectionPoolConfig,
+    metrics::IndexerMetrics,
+    pruning::watermark_task::{WatermarkCache, WatermarkTask},
+    read::IndexerReader,
+    store::PgIndexerStore,
 };
 use iota_json_rpc_types::Stake as RpcStakedIota;
 use iota_types::{
@@ -43,12 +47,13 @@ impl PgManager {
         let connection_pool = iota_indexer::db::new_connection_pool(&db_url.into(), &config)
             .map_err(|e| Error::Internal(format!("Failed to create connection pool: {e}")))?;
 
-        // Create store and watermark task for pruning support
+        // Create store and watermark cache for pruning support
         let store = PgIndexerStore::new(connection_pool.clone(), indexer_metrics);
-        let watermark_task = WatermarkTask::new(store);
+        let watermark_cache = WatermarkCache::new();
 
         // Start watermark task with cancellation token
-        let watermark_cache = watermark_task.start(cancellation_token);
+        let watermark_task = WatermarkTask::new(store, watermark_cache.clone());
+        watermark_task.start(cancellation_token);
 
         // Create reader with watermark cache
         Ok(IndexerReader::new(connection_pool, watermark_cache))

--- a/crates/iota-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/iota-graphql-rpc/src/context_data/db_data_provider.rs
@@ -4,12 +4,16 @@
 
 use std::time::Duration;
 
-use iota_indexer::{apis::GovernanceReadApi, db::ConnectionPoolConfig, read::IndexerReader};
+use iota_indexer::{
+    apis::GovernanceReadApi, db::ConnectionPoolConfig, metrics::IndexerMetrics,
+    pruning::watermark_task::WatermarkTask, read::IndexerReader, store::PgIndexerStore,
+};
 use iota_json_rpc_types::Stake as RpcStakedIota;
 use iota_types::{
     governance::StakedIota as NativeStakedIota,
     iota_system_state::iota_system_state_summary::IotaSystemStateSummary as NativeIotaSystemStateSummary,
 };
+use tokio_util::sync::CancellationToken;
 
 use crate::error::Error;
 
@@ -28,12 +32,27 @@ impl PgManager {
         db_url: impl Into<String>,
         pool_size: u32,
         timeout_ms: u64,
+        indexer_metrics: IndexerMetrics,
+        cancellation_token: CancellationToken,
     ) -> Result<IndexerReader, Error> {
         let mut config = ConnectionPoolConfig::default();
         config.set_pool_size(pool_size);
         config.set_statement_timeout(Duration::from_millis(timeout_ms));
-        IndexerReader::new_with_config(db_url, config)
-            .map_err(|e| Error::Internal(format!("Failed to create reader: {e}")))
+
+        // Create connection pool
+        let connection_pool = iota_indexer::db::new_connection_pool(&db_url.into(), &config)
+            .map_err(|e| Error::Internal(format!("Failed to create connection pool: {e}")))?;
+
+        // Create store and watermark task for pruning support
+        let store = PgIndexerStore::new(connection_pool.clone(), indexer_metrics);
+        let watermark_task = WatermarkTask::new(store);
+        let watermark_cache = watermark_task.cache();
+
+        // Start watermark task with cancellation token
+        watermark_task.start(cancellation_token);
+
+        // Create reader with watermark cache
+        Ok(IndexerReader::new(connection_pool, watermark_cache))
     }
 }
 

--- a/crates/iota-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/iota-graphql-rpc/src/context_data/db_data_provider.rs
@@ -46,10 +46,9 @@ impl PgManager {
         // Create store and watermark task for pruning support
         let store = PgIndexerStore::new(connection_pool.clone(), indexer_metrics);
         let watermark_task = WatermarkTask::new(store);
-        let watermark_cache = watermark_task.cache();
 
         // Start watermark task with cancellation token
-        watermark_task.start(cancellation_token);
+        let watermark_cache = watermark_task.start(cancellation_token);
 
         // Create reader with watermark cache
         Ok(IndexerReader::new(connection_pool, watermark_cache))

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -436,7 +436,7 @@ impl ServerBuilder {
             config.connection.clone(),
             config.service.clone(),
             metrics.clone(),
-            cancellation_token,
+            cancellation_token.clone(),
             *version,
         );
         let mut builder = ServerBuilder::new(state);
@@ -450,6 +450,8 @@ impl ServerBuilder {
             // utilisation (in the worst case we will use 2x the request timeout time in DB wall
             // time).
             config.service.limits.request_timeout_ms.into(),
+            indexer_metrics.clone(),
+            cancellation_token,
         )
         .map_err(|e| Error::ServerInit(format!("Failed to create pg connection pool: {e}")))?;
 
@@ -825,11 +827,14 @@ pub mod tests {
             connection_config.db_url.clone(),
             connection_config.db_pool_size,
             service_config.limits.request_timeout_ms.into(),
+            IndexerMetrics::new(&prometheus::Registry::new()),
+            CancellationToken::new(),
         )
         .expect("failed to create pg connection pool");
 
         let version = Version::for_testing();
         let metrics = metrics();
+
         let db = Db::new(
             reader.clone(),
             service_config.limits.clone(),
@@ -928,7 +933,10 @@ pub mod tests {
         let store = &cluster.indexer_store;
         let fn_rpc_url = &cluster.validator_fullnode_handle.fullnode_handle.rpc_url;
         let indexer_metrics = store.get_metrics();
-        let indexer_reader = iota_indexer::read::IndexerReader::new(store.blocking_cp());
+
+        // Use reader without watermark cache, test doesn't check pruning behaviour
+        let indexer_reader =
+            iota_indexer::read::IndexerReader::new_without_watermark_cache(store.blocking_cp());
         let json_rpc_client = build_json_rpc_client(fn_rpc_url).unwrap();
 
         let optimistic_tx_executor =

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 # external dependencies
 anyhow.workspace = true
+arc-swap.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 backoff.workspace = true

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     metrics::IndexerMetrics,
     processors::processor_orchestrator::ProcessorOrchestrator,
-    pruning::{optimistic_pruner::OptimisticPruner, pruner::Pruner},
+    pruning::{optimistic_pruner::OptimisticPruner, pruner::Pruner, watermark_task::WatermarkTask},
     read::IndexerReader,
     store::{IndexerAnalyticalStore, IndexerStore, PgIndexerStore},
 };
@@ -172,7 +172,11 @@ impl Indexer {
             env!("CARGO_PKG_VERSION")
         );
 
-        let mut read = IndexerReader::new(connection_pool.clone());
+        // Create and start the watermark task that will track pruning state
+        let watermark_task = WatermarkTask::new(store.clone());
+        let watermark_cache = watermark_task.cache();
+
+        let mut read = IndexerReader::new(connection_pool.clone(), watermark_cache);
 
         if let HistoricFallbackOptions {
             fallback_kv_url: Some(ref url),
@@ -195,7 +199,7 @@ impl Indexer {
             info!("No config for HistoricalFallbackReader provided, skipping...");
         }
 
-        let handle = build_json_rpc_server(store, registry, read, config, metrics)
+        let handle = build_json_rpc_server(store, registry, read, config, metrics, watermark_task)
             .await
             .expect("json rpc server should not run into errors upon start.");
         tokio::spawn(async move { handle.stopped().await })
@@ -204,6 +208,7 @@ impl Indexer {
 
         Ok(())
     }
+
     pub async fn start_analytical_worker<
         S: IndexerAnalyticalStore + Clone + Send + Sync + 'static,
     >(

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -25,10 +25,13 @@ use crate::{
     metrics::IndexerMetrics,
     processors::processor_orchestrator::ProcessorOrchestrator,
     pruning::{
-        optimistic_pruner::OptimisticPruner, pruner::Pruner, watermark_task::WatermarkCache,
+        optimistic_pruner::OptimisticPruner,
+        pruner::Pruner,
+        watermark_task::{WatermarkCache, WatermarkTask},
     },
     read::IndexerReader,
     store::{IndexerAnalyticalStore, IndexerStore, PgIndexerStore},
+    system_package_task::SystemPackageTask,
 };
 
 pub struct Indexer;
@@ -199,9 +202,19 @@ impl Indexer {
             info!("No config for HistoricalFallbackReader provided, skipping...");
         }
 
-        let handle = build_json_rpc_server(store, registry, read, config, metrics, watermark_cache)
-            .await
-            .expect("json rpc server should not run into errors upon start.");
+        let (handle, cancel) =
+            build_json_rpc_server(store.clone(), registry, read.clone(), config, metrics)
+                .await
+                .expect("json rpc server should not run into errors upon start.");
+
+        tracing::info!("Starting watermark background task to track pruning state");
+        let watermark_task = WatermarkTask::new(store, watermark_cache);
+        watermark_task.start(cancel.clone());
+
+        tracing::info!("Starting system package task");
+        let system_package_task =
+            SystemPackageTask::new(read, cancel, std::time::Duration::from_secs(10));
+        spawn_monitored_task!(async move { system_package_task.run().await });
 
         tokio::spawn(async move { handle.stopped().await })
             .await

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -24,7 +24,9 @@ use crate::{
     },
     metrics::IndexerMetrics,
     processors::processor_orchestrator::ProcessorOrchestrator,
-    pruning::{optimistic_pruner::OptimisticPruner, pruner::Pruner, watermark_task::WatermarkTask},
+    pruning::{
+        optimistic_pruner::OptimisticPruner, pruner::Pruner, watermark_task::WatermarkCache,
+    },
     read::IndexerReader,
     store::{IndexerAnalyticalStore, IndexerStore, PgIndexerStore},
 };
@@ -172,11 +174,9 @@ impl Indexer {
             env!("CARGO_PKG_VERSION")
         );
 
-        // Create and start the watermark task that will track pruning state
-        let watermark_task = WatermarkTask::new(store.clone());
-        let watermark_cache = watermark_task.cache();
-
-        let mut read = IndexerReader::new(connection_pool.clone(), watermark_cache);
+        // Create the watermark cache that will track pruning state
+        let watermark_cache = WatermarkCache::new();
+        let mut read = IndexerReader::new(connection_pool.clone(), watermark_cache.clone());
 
         if let HistoricFallbackOptions {
             fallback_kv_url: Some(ref url),
@@ -199,9 +199,10 @@ impl Indexer {
             info!("No config for HistoricalFallbackReader provided, skipping...");
         }
 
-        let handle = build_json_rpc_server(store, registry, read, config, metrics, watermark_task)
+        let handle = build_json_rpc_server(store, registry, read, config, metrics, watermark_cache)
             .await
             .expect("json rpc server should not run into errors upon start.");
+
         tokio::spawn(async move { handle.stopped().await })
             .await
             .expect("rpc server task failed");

--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -60,12 +60,6 @@ pub async fn build_json_rpc_server(
     let mut builder =
         JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), prometheus_registry, None, None);
 
-    let cancel = CancellationToken::new();
-
-    // Start the watermark background task to track pruning state
-    watermark_task.start(cancel.clone());
-    tracing::info!("Watermark task started");
-
     let fullnode_client = get_http_client(&config.rpc_client_url)?;
     // Register common modules
     builder.register_module(IndexerApi::new(
@@ -83,10 +77,13 @@ pub async fn build_json_rpc_server(
         OptimisticTransactionExecutor::new(&config.rpc_client_url, reader.clone(), store, metrics),
     ))?;
 
-    let system_package_task =
-        SystemPackageTask::new(reader, cancel.clone(), Duration::from_secs(10));
+    let cancel = CancellationToken::new();
+    tracing::info!("Starting watermark background task to track pruning state");
+    watermark_task.start(cancel.clone());
 
     tracing::info!("Starting system package task");
+    let system_package_task =
+        SystemPackageTask::new(reader, cancel.clone(), Duration::from_secs(10));
     spawn_monitored_task!(async move { system_package_task.run().await });
 
     Ok(builder

--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -25,6 +25,7 @@ use crate::{
     },
     config::JsonRpcConfig,
     optimistic_indexing::OptimisticTransactionExecutor,
+    pruning::watermark_task::{WatermarkCache, WatermarkTask},
     read::IndexerReader,
     store::PgIndexerStore,
 };
@@ -55,7 +56,7 @@ pub async fn build_json_rpc_server(
     reader: IndexerReader,
     config: &JsonRpcConfig,
     metrics: IndexerMetrics,
-    watermark_task: crate::pruning::watermark_task::WatermarkTask,
+    watermark_cache: WatermarkCache,
 ) -> Result<ServerHandle, IndexerError> {
     let mut builder =
         JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), prometheus_registry, None, None);
@@ -74,11 +75,18 @@ pub async fn build_json_rpc_server(
     builder.register_module(ExtendedApi::new(reader.clone()))?;
     builder.register_module(OptimisticWriteApi::new(
         WriteApi::new(fullnode_client, reader.clone()),
-        OptimisticTransactionExecutor::new(&config.rpc_client_url, reader.clone(), store, metrics),
+        OptimisticTransactionExecutor::new(
+            &config.rpc_client_url,
+            reader.clone(),
+            store.clone(),
+            metrics,
+        ),
     ))?;
 
     let cancel = CancellationToken::new();
+
     tracing::info!("Starting watermark background task to track pruning state");
+    let watermark_task = WatermarkTask::new(store, watermark_cache);
     watermark_task.start(cancel.clone());
 
     tracing::info!("Starting system package task");

--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -55,9 +55,16 @@ pub async fn build_json_rpc_server(
     reader: IndexerReader,
     config: &JsonRpcConfig,
     metrics: IndexerMetrics,
+    watermark_task: crate::pruning::watermark_task::WatermarkTask,
 ) -> Result<ServerHandle, IndexerError> {
     let mut builder =
         JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), prometheus_registry, None, None);
+
+    let cancel = CancellationToken::new();
+
+    // Start the watermark background task to track pruning state
+    watermark_task.start(cancel.clone());
+    tracing::info!("Watermark task started");
 
     let fullnode_client = get_http_client(&config.rpc_client_url)?;
     // Register common modules
@@ -76,7 +83,6 @@ pub async fn build_json_rpc_server(
         OptimisticTransactionExecutor::new(&config.rpc_client_url, reader.clone(), store, metrics),
     ))?;
 
-    let cancel = CancellationToken::new();
     let system_package_task =
         SystemPackageTask::new(reader, cancel.clone(), Duration::from_secs(10));
 

--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -4,8 +4,6 @@
 
 #![recursion_limit = "256"]
 
-use std::time::Duration;
-
 use anyhow::Result;
 use errors::IndexerError;
 use iota_json_rpc::{JsonRpcServerBuilder, ServerHandle, ServerType};
@@ -14,7 +12,6 @@ use iota_metrics::spawn_monitored_task;
 use jsonrpsee::http_client::{HeaderMap, HeaderValue, HttpClient, HttpClientBuilder};
 use metrics::IndexerMetrics;
 use prometheus::Registry;
-use system_package_task::SystemPackageTask;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
@@ -25,7 +22,6 @@ use crate::{
     },
     config::JsonRpcConfig,
     optimistic_indexing::OptimisticTransactionExecutor,
-    pruning::watermark_task::{WatermarkCache, WatermarkTask},
     read::IndexerReader,
     store::PgIndexerStore,
 };
@@ -56,8 +52,7 @@ pub async fn build_json_rpc_server(
     reader: IndexerReader,
     config: &JsonRpcConfig,
     metrics: IndexerMetrics,
-    watermark_cache: WatermarkCache,
-) -> Result<ServerHandle, IndexerError> {
+) -> Result<(ServerHandle, CancellationToken), IndexerError> {
     let mut builder =
         JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), prometheus_registry, None, None);
 
@@ -85,18 +80,16 @@ pub async fn build_json_rpc_server(
 
     let cancel = CancellationToken::new();
 
-    tracing::info!("Starting watermark background task to track pruning state");
-    let watermark_task = WatermarkTask::new(store, watermark_cache);
-    watermark_task.start(cancel.clone());
+    let handle = builder
+        .start(
+            config.rpc_address,
+            None,
+            ServerType::Http,
+            Some(cancel.clone()),
+        )
+        .await?;
 
-    tracing::info!("Starting system package task");
-    let system_package_task =
-        SystemPackageTask::new(reader, cancel.clone(), Duration::from_secs(10));
-    spawn_monitored_task!(async move { system_package_task.run().await });
-
-    Ok(builder
-        .start(config.rpc_address, None, ServerType::Http, Some(cancel))
-        .await?)
+    Ok((handle, cancel))
 }
 
 fn get_http_client(rpc_client_url: &str) -> Result<HttpClient, IndexerError> {

--- a/crates/iota-indexer/src/pruning/mod.rs
+++ b/crates/iota-indexer/src/pruning/mod.rs
@@ -4,3 +4,4 @@
 
 pub mod optimistic_pruner;
 pub mod pruner;
+pub mod watermark_task;

--- a/crates/iota-indexer/src/pruning/watermark_task.rs
+++ b/crates/iota-indexer/src/pruning/watermark_task.rs
@@ -37,16 +37,13 @@ pub struct WatermarkCache {
     inner: Arc<ArcSwap<WatermarkCacheInner>>,
 }
 
-#[derive(Default)]
-struct WatermarkCacheInner {
-    /// Map from entity name to its watermark data
-    watermarks: HashMap<String, StoredWatermark>,
-}
+/// Map from entity name to its watermark data
+type WatermarkCacheInner = HashMap<String, StoredWatermark>;
 
 impl Default for WatermarkCache {
     fn default() -> Self {
         Self {
-            inner: Arc::new(ArcSwap::from_pointee(WatermarkCacheInner::default())),
+            inner: Arc::new(ArcSwap::from_pointee(HashMap::new())),
         }
     }
 }
@@ -61,7 +58,7 @@ impl WatermarkCache {
     /// Returns `None` if the entity has no watermark
     pub fn get(&self, entity: CommitterTables) -> Option<StoredWatermark> {
         let cache = self.inner.load();
-        cache.watermarks.get(entity.as_ref()).cloned()
+        cache.get(entity.as_ref()).cloned()
     }
 
     /// Updates the cache with fresh watermarks from the database
@@ -74,11 +71,7 @@ impl WatermarkCache {
             new_watermarks.insert(watermark.entity.clone(), watermark);
         }
 
-        let new_inner = WatermarkCacheInner {
-            watermarks: new_watermarks,
-        };
-
-        self.inner.store(Arc::new(new_inner));
+        self.inner.store(Arc::new(new_watermarks));
     }
 }
 
@@ -90,32 +83,20 @@ pub struct WatermarkTask {
 }
 
 impl WatermarkTask {
-    /// Creates a new watermark task
-    pub fn new(store: PgIndexerStore) -> Self {
+    /// Creates a new watermark task with the given cache
+    pub fn new(store: PgIndexerStore, cache: WatermarkCache) -> Self {
         Self {
             store,
-            cache: WatermarkCache::new(),
+            cache,
             update_interval: WATERMARK_UPDATE_INTERVAL,
         }
     }
 
-    /// Gets a handle to the watermark cache for reading
-    ///
-    /// The returned [`WatermarkCache`] shares the same underlying data as other
-    /// cloned instances and will automatically reflect updates from the
-    /// background task.
-    pub fn cache(&self) -> WatermarkCache {
-        self.cache.clone()
-    }
-
     /// Starts the background task that updates watermarks
-    /// Returns a handle to the watermark cache
-    pub fn start(self, cancel: CancellationToken) -> WatermarkCache {
-        let cache = self.cache();
+    pub fn start(self, cancel: CancellationToken) {
         spawn_monitored_task!(async move {
             self.run(cancel).await;
         });
-        cache
     }
 
     /// Runs the watermark update loop

--- a/crates/iota-indexer/src/pruning/watermark_task.rs
+++ b/crates/iota-indexer/src/pruning/watermark_task.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 //! Background task that periodically fetches pruning watermarks from the
@@ -24,8 +24,14 @@ use crate::{
 const WATERMARK_UPDATE_INTERVAL: Duration = Duration::from_secs(5);
 
 /// In-memory cache of pruning watermarks
-/// Uses ArcSwap for lock-free reads to avoid write starvation under high read
-/// load
+///
+/// Provides fast access to watermark data without querying the database on
+/// every read. A background task periodically refreshes the cache from the
+/// database.
+///
+/// Uses [`ArcSwap`] for lock-free reads to avoid write starvation under high
+/// read load. Cloned instances share the same underlying data and will reflect
+/// updates from the background task.
 #[derive(Clone)]
 pub struct WatermarkCache {
     inner: Arc<ArcSwap<WatermarkCacheInner>>,
@@ -52,14 +58,15 @@ impl WatermarkCache {
     }
 
     /// Gets the watermark for a specific entity
-    /// Returns None if the entity has no watermark
+    /// Returns `None` if the entity has no watermark
     pub fn get(&self, entity: CommitterTables) -> Option<StoredWatermark> {
         let cache = self.inner.load();
         cache.watermarks.get(entity.as_ref()).cloned()
     }
 
     /// Updates the cache with fresh watermarks from the database
-    /// Uses ArcSwap for lock-free reads - writes create new Arc instead of
+    ///
+    /// Uses [`ArcSwap`] for lock-free reads - writes create new Arc instead of
     /// blocking readers
     fn update(&self, watermarks: Vec<StoredWatermark>) {
         let mut new_watermarks = HashMap::new();
@@ -93,6 +100,10 @@ impl WatermarkTask {
     }
 
     /// Gets a handle to the watermark cache for reading
+    ///
+    /// The returned [`WatermarkCache`] shares the same underlying data as other
+    /// cloned instances and will automatically reflect updates from the
+    /// background task.
     pub fn cache(&self) -> WatermarkCache {
         self.cache.clone()
     }

--- a/crates/iota-indexer/src/pruning/watermark_task.rs
+++ b/crates/iota-indexer/src/pruning/watermark_task.rs
@@ -1,0 +1,170 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Background task that periodically fetches pruning watermarks from the
+//! database and maintains them in memory for RPC reads to check data
+//! availability.
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use arc_swap::ArcSwap;
+use iota_metrics::spawn_monitored_task;
+use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+
+use crate::{
+    errors::IndexerError,
+    ingestion::common::persist::CommitterTables,
+    models::watermarks::StoredWatermark,
+    store::{IndexerStore, PgIndexerStore},
+};
+
+/// How often to refresh watermarks from the database
+const WATERMARK_UPDATE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// In-memory cache of pruning watermarks
+/// Uses ArcSwap for lock-free reads to avoid write starvation under high read
+/// load
+#[derive(Clone)]
+pub struct WatermarkCache {
+    inner: Arc<ArcSwap<WatermarkCacheInner>>,
+}
+
+#[derive(Default)]
+struct WatermarkCacheInner {
+    /// Map from entity name to its watermark data
+    watermarks: HashMap<String, StoredWatermark>,
+}
+
+impl Default for WatermarkCache {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(ArcSwap::from_pointee(WatermarkCacheInner::default())),
+        }
+    }
+}
+
+impl WatermarkCache {
+    /// Creates a new empty watermark cache
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Gets the watermark for a specific entity
+    /// Returns None if the entity has no watermark
+    pub fn get(&self, entity: CommitterTables) -> Option<StoredWatermark> {
+        let cache = self.inner.load();
+        cache.watermarks.get(entity.as_ref()).cloned()
+    }
+
+    /// Updates the cache with fresh watermarks from the database
+    /// Uses ArcSwap for lock-free reads - writes create new Arc instead of
+    /// blocking readers
+    fn update(&self, watermarks: Vec<StoredWatermark>) {
+        let mut new_watermarks = HashMap::new();
+        for watermark in watermarks {
+            new_watermarks.insert(watermark.entity.clone(), watermark);
+        }
+
+        let new_inner = WatermarkCacheInner {
+            watermarks: new_watermarks,
+        };
+
+        self.inner.store(Arc::new(new_inner));
+    }
+}
+
+/// Background task that periodically updates the watermark cache
+pub struct WatermarkTask {
+    store: PgIndexerStore,
+    cache: WatermarkCache,
+    update_interval: Duration,
+}
+
+impl WatermarkTask {
+    /// Creates a new watermark task
+    pub fn new(store: PgIndexerStore) -> Self {
+        Self {
+            store,
+            cache: WatermarkCache::new(),
+            update_interval: WATERMARK_UPDATE_INTERVAL,
+        }
+    }
+
+    /// Gets a handle to the watermark cache for reading
+    pub fn cache(&self) -> WatermarkCache {
+        self.cache.clone()
+    }
+
+    /// Starts the background task that updates watermarks
+    /// Returns a handle to the watermark cache
+    pub fn start(self, cancel: CancellationToken) -> WatermarkCache {
+        let cache = self.cache();
+        spawn_monitored_task!(async move {
+            self.run(cancel).await;
+        });
+        cache
+    }
+
+    /// Runs the watermark update loop
+    async fn run(self, cancel: CancellationToken) {
+        info!("Starting watermark update task");
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    info!("Watermark update task cancelled");
+                    break;
+                }
+                _ = sleep(self.update_interval) => {
+                    if let Err(e) = self.update_watermarks().await {
+                        error!("Failed to update watermarks: {}", e);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Fetches watermarks from the database and updates the cache
+    async fn update_watermarks(&self) -> Result<(), IndexerError> {
+        let (watermarks, _timestamp_ms) = self.store.get_watermarks().await?;
+
+        if !watermarks.is_empty() {
+            info!("Updated {} watermarks from database", watermarks.len());
+        }
+
+        self.cache.update(watermarks);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_watermark_cache() {
+        let cache = WatermarkCache::new();
+
+        // Initially empty
+        assert!(cache.get(CommitterTables::Transactions).is_none());
+
+        let watermark = StoredWatermark {
+            entity: CommitterTables::Transactions.as_ref().to_string(),
+            epoch_hi_inclusive: 100,
+            checkpoint_hi_inclusive: 1000,
+            tx_hi: 10000,
+            epoch_lo: 50,
+            reader_lo: 500,
+            timestamp_ms: 123456789,
+            pruner_hi: 400,
+        };
+
+        cache.update(vec![watermark.clone()]);
+
+        let retrieved = cache.get(CommitterTables::Transactions).unwrap();
+        assert_eq!(retrieved.reader_lo, 500);
+        assert_eq!(retrieved.epoch_lo, 50);
+    }
+}

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -76,6 +76,7 @@ use crate::{
         },
         tx_indices::TxSequenceNumber,
     },
+    pruning::watermark_task::WatermarkCache,
     schema::{
         address_metrics, addresses, chain_identifier, checkpoints, display, epochs, events,
         objects, objects_history, objects_snapshot, objects_version, optimistic_transactions,
@@ -104,6 +105,7 @@ pub struct IndexerReader {
     package_resolver: PackageResolver,
     obj_type_cache: Arc<Mutex<SizedCache<String, Option<ObjectID>>>>,
     fallback: Option<HistoricalFallbackReader>,
+    watermark_cache: WatermarkCache,
 }
 
 /// Encapsulates the logic for reading data from the database.
@@ -118,7 +120,7 @@ pub type PackageResolver = Arc<Resolver<PackageStoreWithLruCache<IndexerStorePac
 
 // Impl for common initialization and utilities
 impl IndexerReader {
-    pub fn new(pool: ConnectionPool) -> Self {
+    pub fn new(pool: ConnectionPool, watermark_cache: WatermarkCache) -> Self {
         let indexer_store_pkg_resolver = IndexerStorePackageResolver::new(pool.clone());
         let package_cache = PackageStoreWithLruCache::new(indexer_store_pkg_resolver);
         let package_resolver = Arc::new(Resolver::new(package_cache));
@@ -128,7 +130,14 @@ impl IndexerReader {
             package_resolver,
             obj_type_cache,
             fallback: None,
+            watermark_cache,
         }
+    }
+
+    /// Creates a new IndexerReader without a watermark cache (for tests or
+    /// non-pruning scenarios)
+    pub fn new_without_watermark_cache(pool: ConnectionPool) -> Self {
+        Self::new(pool, WatermarkCache::default())
     }
 
     /// Returns a [`DBReader`] bound to this `IndexerReader` instance which
@@ -140,6 +149,7 @@ impl IndexerReader {
     pub fn new_with_config<T: Into<String>>(
         db_url: T,
         config: ConnectionPoolConfig,
+        watermark_cache: WatermarkCache,
     ) -> Result<Self> {
         let manager = ConnectionManager::<PgConnection>::new(db_url);
 
@@ -155,7 +165,7 @@ impl IndexerReader {
             .build(manager)
             .map_err(|e| anyhow!("failed to initialize connection pool. Error: {:?}. If Error is None, please check whether the configured pool size (currently {}) exceeds the maximum number of connections allowed by the database.", e, config.pool_size))?;
 
-        Ok(Self::new(pool))
+        Ok(Self::new(pool, watermark_cache))
     }
 
     /// Add a historical fallback reader to the indexer.
@@ -169,6 +179,11 @@ impl IndexerReader {
     /// Access the internal fallback reader.
     pub(crate) fn fallback_reader(&self) -> Option<&HistoricalFallbackReader> {
         self.fallback.as_ref()
+    }
+
+    /// Accesses the watermark cache.
+    pub fn watermark_cache(&self) -> &WatermarkCache {
+        &self.watermark_cache
     }
 
     pub async fn spawn_blocking<F, R, E>(&self, f: F) -> Result<R, E>


### PR DESCRIPTION
# Description of change

To not hurt performance reading of watermarks table during user queries could be achieved by running a background task that fetches from watermarks task periodically and stores the result in memory, so that all reads can access it right away

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9899

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
