### PR TITLE
fix(starfish): add source for block headers and don't update cordial knowledge when commit syncing

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -33,7 +33,7 @@ use crate::{
     context::Context,
     cordial_knowledge::CordialKnowledgeHandle,
     core_thread::CoreThreadDispatcher,
-    dag_state::DagState,
+    dag_state::{BlockHeaderSource, DagState},
     encoder::ShardEncoder,
     error::{ConsensusError, ConsensusResult},
     header_synchronizer::HeaderSynchronizerHandle,
@@ -560,7 +560,10 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // sent in order of increasing rounds.
         let (mut missing_ancestors, mut missing_committed_txns) = self
             .core_dispatcher
-            .add_block_headers(additional_block_headers.clone())
+            .add_block_headers(
+                additional_block_headers.clone(),
+                BlockHeaderSource::BlockHeaderBundleStream,
+            )
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
         self.context
@@ -1324,7 +1327,7 @@ mod tests {
         cordial_knowledge::{ConnectionKnowledgeMessage, CordialKnowledge},
         core::{Core, CoreSignals, ReasonToCreateBlock},
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
-        dag_state::{DagState, TransactionSource},
+        dag_state::{BlockHeaderSource, DagState, TransactionSource},
         encoder::create_encoder,
         error::{ConsensusError, ConsensusResult},
         header_synchronizer::HeaderSynchronizer,
@@ -1961,7 +1964,10 @@ mod tests {
 
         for round in 1..=rounds / 2 {
             core_dispatcher
-                .add_block_headers(all_block_headers[round as usize].clone())
+                .add_block_headers(
+                    all_block_headers[round as usize].clone(),
+                    BlockHeaderSource::Test,
+                )
                 .await
                 .expect("block headers are expected to be added successfully");
         }
@@ -1984,7 +1990,7 @@ mod tests {
         for round in rounds / 2 + 1..=rounds {
             let headers = &all_block_headers[round as usize];
             core_dispatcher
-                .add_block_headers(headers[..2].to_vec())
+                .add_block_headers(headers[..2].to_vec(), BlockHeaderSource::Test)
                 .await
                 .expect("block headers are expected to be added successfully");
         }
@@ -2004,7 +2010,7 @@ mod tests {
         for round in rounds / 2 + 1..=rounds {
             let headers = &all_block_headers[round as usize];
             core_dispatcher
-                .add_block_headers(headers[2..].to_vec())
+                .add_block_headers(headers[2..].to_vec(), BlockHeaderSource::Test)
                 .await
                 .expect("block headers are expected to be added successfully");
         }
@@ -2047,6 +2053,7 @@ mod tests {
         async fn add_block_headers(
             &self,
             block_headers: Vec<VerifiedBlockHeader>,
+            source: BlockHeaderSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,
@@ -2060,7 +2067,7 @@ mod tests {
                 let entry = &mut vec[block_header.author()];
                 *entry = max(*entry, block_header.round());
             }
-            let _ = guard.add_block_headers(block_headers);
+            let _ = guard.add_block_headers(block_headers, source);
             Ok((BTreeSet::new(), BTreeMap::new()))
         }
 
@@ -2225,7 +2232,10 @@ mod tests {
         }
         for round in 1..=rounds {
             core_dispatcher
-                .add_block_headers(vec![all_headers[round as usize][0].clone()])
+                .add_block_headers(
+                    vec![all_headers[round as usize][0].clone()],
+                    BlockHeaderSource::Test,
+                )
                 .await
                 .expect("blocks header is expected to be added successfully");
             for peer in 1..validators {
@@ -2380,7 +2390,10 @@ mod tests {
         }
         for round in 1..=rounds {
             core_dispatcher
-                .add_block_headers(vec![all_headers[round as usize][0].clone()])
+                .add_block_headers(
+                    vec![all_headers[round as usize][0].clone()],
+                    BlockHeaderSource::Test,
+                )
                 .await
                 .expect("blocks header is expected to be added successfully");
             for peer in 1..validators {
@@ -3171,7 +3184,10 @@ mod tests {
 
         for round in 1..=rounds {
             core_dispatcher
-                .add_block_headers(all_block_headers[round as usize].clone())
+                .add_block_headers(
+                    all_block_headers[round as usize].clone(),
+                    BlockHeaderSource::Test,
+                )
                 .await
                 .expect("block headers are expected to be added successfully");
         }
@@ -3202,7 +3218,7 @@ mod tests {
         }
         all_block_headers.push(new_block_headers.clone());
         core_dispatcher
-            .add_block_headers(new_block_headers.clone())
+            .add_block_headers(new_block_headers.clone(), BlockHeaderSource::Test)
             .await
             .expect("block headers are expected to be added successfully");
 
@@ -3224,7 +3240,7 @@ mod tests {
             }
             all_block_headers.push(new_block_headers.clone());
             core_dispatcher
-                .add_block_headers(new_block_headers.clone())
+                .add_block_headers(new_block_headers.clone(), BlockHeaderSource::Test)
                 .await
                 .expect("block headers are expected to be added successfully");
         }

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     },
     block_manager::block_suspender::BlockSuspender,
     context::Context,
-    dag_state::{DagState, TransactionSource},
+    dag_state::{BlockHeaderSource, DagState, TransactionSource},
 };
 
 /// Block manager suspends incoming blocks until they are connected to the
@@ -84,6 +84,7 @@ impl BlockManager {
         self.write_block_headers_and_transactions_to_dag_state(
             block_headers_to_accept.clone(),
             accepted_transactions,
+            BlockHeaderSource::BlockStreaming,
         );
 
         (block_headers_to_accept, missing_block_headers)
@@ -99,6 +100,7 @@ impl BlockManager {
     pub(crate) fn try_accept_block_headers(
         &mut self,
         block_headers: Vec<VerifiedBlockHeader>,
+        source: BlockHeaderSource,
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_block_headers");
         // Headers are added through synchronizer, commit syncer and cordial
@@ -110,6 +112,7 @@ impl BlockManager {
         self.write_block_headers_and_transactions_to_dag_state(
             block_headers_to_accept.clone(),
             accepted_transactions,
+            source,
         );
         (block_headers_to_accept, ancestors_to_fetch)
     }
@@ -139,9 +142,10 @@ impl BlockManager {
         &self,
         block_headers: Vec<VerifiedBlockHeader>,
         transactions: Vec<VerifiedTransactions>,
+        source: BlockHeaderSource,
     ) {
         let mut write_guard = self.dag_state.write();
-        write_guard.accept_block_headers(block_headers);
+        write_guard.accept_block_headers(block_headers, source);
         for verified_transaction in transactions {
             write_guard.add_transactions(verified_transaction, TransactionSource::BlockStreaming);
         }
@@ -370,7 +374,7 @@ mod tests {
         block_header::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader},
         block_manager::BlockManager,
         context::Context,
-        dag_state::DagState,
+        dag_state::{BlockHeaderSource, DagState},
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
     };
@@ -403,8 +407,8 @@ mod tests {
             .collect::<Vec<VerifiedBlockHeader>>();
 
         // WHEN
-        let (accepted_blocks, missing) =
-            block_manager.try_accept_block_headers(round_2_block_headers.clone());
+        let (accepted_blocks, missing) = block_manager
+            .try_accept_block_headers(round_2_block_headers.clone(), BlockHeaderSource::Test);
 
         // THEN
         assert!(accepted_blocks.is_empty());
@@ -476,8 +480,8 @@ mod tests {
             .take_while(|(_, block_header)| block_header.round() >= 2)
         {
             // WHEN
-            let (accepted_blocks, missing) =
-                block_manager.try_accept_block_headers(vec![block_header.clone()]);
+            let (accepted_blocks, missing) = block_manager
+                .try_accept_block_headers(vec![block_header.clone()], BlockHeaderSource::Test);
 
             // THEN
             assert!(accepted_blocks.is_empty());
@@ -512,8 +516,8 @@ mod tests {
             .collect::<Vec<_>>();
 
         // WHEN
-        let (accepted_block_headers, missing) =
-            block_manager.try_accept_block_headers(all_block_headers.clone());
+        let (accepted_block_headers, missing) = block_manager
+            .try_accept_block_headers(all_block_headers.clone(), BlockHeaderSource::Test);
 
         // THEN
         assert_eq!(accepted_block_headers.len(), 8);
@@ -530,7 +534,8 @@ mod tests {
 
         // WHEN trying to accept same block headers again, then none will be returned as
         // those have been already accepted
-        let (accepted_block_headers, _) = block_manager.try_accept_block_headers(all_block_headers);
+        let (accepted_block_headers, _) =
+            block_manager.try_accept_block_headers(all_block_headers, BlockHeaderSource::Test);
         assert!(accepted_block_headers.is_empty());
     }
 
@@ -567,8 +572,8 @@ mod tests {
             // WHEN
             let mut all_accepted_block_headers = vec![];
             for block_header in &all_block_headers {
-                let (accepted_block_headers, _) =
-                    block_manager.try_accept_block_headers(vec![block_header.clone()]);
+                let (accepted_block_headers, _) = block_manager
+                    .try_accept_block_headers(vec![block_header.clone()], BlockHeaderSource::Test);
 
                 all_accepted_block_headers.extend(accepted_block_headers);
             }
@@ -620,8 +625,8 @@ mod tests {
 
         let mut block_manager = BlockManager::new(context.clone(), dag_state);
 
-        let (_, missing_blocks) =
-            block_manager.try_accept_block_headers(vec![blocks_round_2[0].clone()]);
+        let (_, missing_blocks) = block_manager
+            .try_accept_block_headers(vec![blocks_round_2[0].clone()], BlockHeaderSource::Test);
         // Blocks from round 1 are all missing, since the DAG is fully connected
         assert_eq!(missing_blocks, blocks_round_1);
 
@@ -653,7 +658,8 @@ mod tests {
 
         // Add a new block from round 2 from authority 1, which updates the set of
         // authorities that are aware of the missing blocks
-        block_manager.try_accept_block_headers(vec![blocks_round_2[1].clone()]);
+        block_manager
+            .try_accept_block_headers(vec![blocks_round_2[1].clone()], BlockHeaderSource::Test);
         let missing_blocks_with_authorities = block_manager.blocks_to_fetch();
         assert_eq!(
             missing_blocks_with_authorities[&block_round_1_authority_0],
@@ -698,6 +704,7 @@ mod tests {
                 .filter(|block_header| block_header.round() > 1)
                 .cloned()
                 .collect(),
+            BlockHeaderSource::Test,
         );
         // Missing refs should all come from round 1.
         assert!(accepted_block_headers.is_empty());
@@ -713,6 +720,7 @@ mod tests {
                 .filter(|block_header| block_header.round() == 1)
                 .cloned()
                 .collect(),
+            BlockHeaderSource::Test,
         );
         // With median-based timestamp, all blocks should be accepted regardless of
         // timestamp violations.
@@ -767,8 +775,8 @@ mod tests {
 
         // Try to accept blocks which will cause blocks to be suspended and added to
         // missing in block manager.
-        let (accepted_blocks_headers, missing) =
-            block_manager.try_accept_block_headers(round_2_block_headers.clone());
+        let (accepted_blocks_headers, missing) = block_manager
+            .try_accept_block_headers(round_2_block_headers.clone(), BlockHeaderSource::Test);
         assert!(accepted_blocks_headers.is_empty());
 
         let missing_block_refs = round_2_block_headers.first().unwrap().ancestors();

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -227,7 +227,7 @@ mod tests {
         block_header::{BlockRef, genesis_block_headers, genesis_blocks},
         commit::{CommitRef, PendingSubDag},
         context::Context,
-        dag_state::{DagState, TransactionSource},
+        dag_state::{BlockHeaderSource, DagState, TransactionSource},
         test_dag_builder::DagBuilder,
     };
 
@@ -284,7 +284,10 @@ mod tests {
             if included_rounds.contains(&0) {
                 let genesis_blocks = genesis_blocks(&self.context);
                 for (i, block) in genesis_blocks.iter().enumerate() {
-                    state.accept_block_header(block.verified_block_header.clone());
+                    state.accept_block_header(
+                        block.verified_block_header.clone(),
+                        BlockHeaderSource::Test,
+                    );
                     if !excluded_transactions.contains(&(0, i)) {
                         state.add_transactions(
                             block.verified_transactions.clone(),
@@ -302,7 +305,10 @@ mod tests {
 
                 let blocks = self.dag_builder.blocks(round..=round);
                 for (i, block) in blocks.iter().enumerate() {
-                    state.accept_block_header(block.verified_block_header.clone());
+                    state.accept_block_header(
+                        block.verified_block_header.clone(),
+                        BlockHeaderSource::Test,
+                    );
                     if !excluded_transactions.contains(&(round, i)) {
                         state.add_transactions(
                             block.verified_transactions.clone(),

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -32,7 +32,7 @@ use crate::{
 /// delay
 const MAX_ROUND_GAP_FOR_USEFUL_PARTS: Round = 40;
 /// Capacity of the cordial knowledge channel. For normal operation with
-/// 100 authorities, this allows buffering up to 5 seconds of headers at 200ms
+/// 100 authorities, this allows buffering up to 5 seconds of headers at 20
 /// blocks/sec. When the channel is full, the sender will skip sending new
 /// messages.
 const CORDIAL_KNOWLEDGE_CHANNEL_CAPACITY: usize = 10_000;

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -31,7 +31,15 @@ use crate::{
 /// relevant. 40 rounds correspond to at least 2 second due to the minimum block
 /// delay
 const MAX_ROUND_GAP_FOR_USEFUL_PARTS: Round = 40;
+/// Capacity of the cordial knowledge channel. For normal operation with
+/// 100 authorities, this allows buffering up to 5 seconds of headers at 200ms
+/// blocks/sec. When the channel is full, the sender will skip sending new
+/// messages.
 const CORDIAL_KNOWLEDGE_CHANNEL_CAPACITY: usize = 10_000;
+/// Eviction is performed every EVICTION_CHECK_INTERVAL processed messages.
+/// This allows batching eviction checks instead of checking on every
+/// message. For this operation, we don't need high precision, but we don't
+/// skip evictions for too long either.
 const EVICTION_CHECK_INTERVAL: usize = 10_000;
 
 /// Represents a subset of authorities using a bitmask.

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -9,10 +9,13 @@ use std::{
 
 use ahash::{AHashMap, AHashSet};
 use bytes::Bytes;
-use iota_metrics::monitored_mpsc::{self, UnboundedReceiver, UnboundedSender};
+use iota_metrics::monitored_mpsc::{self, Receiver, Sender};
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
-use tokio::{sync::Mutex, task::JoinError};
+use tokio::{
+    sync::{Mutex, mpsc::error::TrySendError},
+    task::JoinError,
+};
 use tracing::debug;
 
 use crate::{
@@ -28,6 +31,8 @@ use crate::{
 /// relevant. 40 rounds correspond to at least 2 second due to the minimum block
 /// delay
 const MAX_ROUND_GAP_FOR_USEFUL_PARTS: Round = 40;
+const CORDIAL_KNOWLEDGE_CHANNEL_CAPACITY: usize = 10_000;
+const EVICTION_CHECK_INTERVAL: usize = 10_000;
 
 /// Represents a subset of authorities using a bitmask.
 /// Each bit in the `low` and `high` fields corresponds to an authority index.
@@ -72,9 +77,11 @@ impl SubsetAuthorities {
 /// notifies per-connection tasks.
 pub(crate) struct CordialKnowledge {
     context: Arc<Context>,
-    /// Receives high-level updates from DAG state (new headers, new own shards,
-    /// evictions) and AuthorityService
-    cordial_knowledge_receiver: UnboundedReceiver<CordialKnowledgeMessage>,
+    /// Receives high-level updates from DAG state (new headers, new own shards)
+    /// and AuthorityService
+    cordial_knowledge_receiver: Receiver<CordialKnowledgeMessage>,
+    /// Receives eviction rounds from DagState (latest-only).
+    eviction_rounds_receiver: tokio::sync::watch::Receiver<Vec<Round>>,
     /// Keeps track of the last round for which each peer's shards were
     /// considered useful to us. This is a global knowledge and is shared with
     /// all connection tasks. Initialized to None for all authorities and
@@ -98,7 +105,7 @@ pub(crate) struct CordialKnowledge {
 }
 
 /// High-level messages sent to the CordialKnowledge task.
-/// NewHeader, NewShard, EvictBelow are received from DAG state.
+/// NewHeader, NewShard are received from DAG state.
 /// UsefulShardsFromPeers is received from AuthorityService.
 #[derive(Debug)]
 pub enum CordialKnowledgeMessage {
@@ -106,8 +113,6 @@ pub enum CordialKnowledgeMessage {
     NewHeader(VerifiedBlockHeader),
     /// A new verified own shard to integrate into cordial knowledge.
     NewShard(BlockRef),
-    /// Evict old rounds globally.
-    EvictBelow(Vec<Round>),
     /// Update internal state about shards from which authorities are useful for
     /// the local node
     UsefulShardsFromPeers(BTreeMap<AuthorityIndex, Round>),
@@ -119,7 +124,6 @@ impl CordialKnowledgeMessage {
         match self {
             CordialKnowledgeMessage::NewHeader(_) => "New header",
             CordialKnowledgeMessage::NewShard(_) => "New shard",
-            CordialKnowledgeMessage::EvictBelow(_) => "Eviction",
             CordialKnowledgeMessage::UsefulShardsFromPeers(_) => "Useful authors for shards",
         }
     }
@@ -128,7 +132,7 @@ impl CordialKnowledgeMessage {
 /// Handle to the CordialKnowledge task, allowing interaction and graceful
 /// shutdown.
 pub struct CordialKnowledgeHandle {
-    cordial_knowledge_sender: UnboundedSender<CordialKnowledgeMessage>,
+    cordial_knowledge_sender: Sender<CordialKnowledgeMessage>,
     connection_knowledges: Vec<Arc<RwLock<ConnectionKnowledge>>>,
     cordial_knowledge_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
@@ -225,9 +229,11 @@ impl CordialKnowledgeHandle {
         if !useful_shard_authors.is_empty() {
             let cordial_knowledge_message =
                 CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shard_authors);
-            cordial_knowledge_sender
-                .send(cordial_knowledge_message)
-                .map_err(|_err| ConsensusError::Shutdown)?;
+            if let Err(TrySendError::Closed(_)) =
+                cordial_knowledge_sender.try_send(cordial_knowledge_message)
+            {
+                return Err(ConsensusError::Shutdown);
+            }
         }
 
         Ok(())
@@ -243,15 +249,18 @@ impl CordialKnowledge {
     ) -> (
         Self,
         Vec<Arc<RwLock<ConnectionKnowledge>>>,
-        UnboundedSender<CordialKnowledgeMessage>,
+        Sender<CordialKnowledgeMessage>,
+        tokio::sync::watch::Sender<Vec<Round>>,
     ) {
         let num_authorities = context.committee.size();
 
-        // Main unbounded channel for high-level DAG updates (monitored for metrics)
+        // Main bounded channel for high-level DAG updates (monitored for metrics)
         let (cordial_knowledge_sender, cordial_knowledge_receiver): (
-            UnboundedSender<CordialKnowledgeMessage>,
-            UnboundedReceiver<CordialKnowledgeMessage>,
-        ) = monitored_mpsc::unbounded_channel("cordial_knowledge");
+            Sender<CordialKnowledgeMessage>,
+            Receiver<CordialKnowledgeMessage>,
+        ) = monitored_mpsc::channel("cordial_knowledge", CORDIAL_KNOWLEDGE_CHANNEL_CAPACITY);
+        let (eviction_rounds_sender, eviction_rounds_receiver) =
+            tokio::sync::watch::channel(Vec::new());
 
         let mut connection_knowledges = Vec::with_capacity(num_authorities);
 
@@ -269,12 +278,14 @@ impl CordialKnowledge {
             Self {
                 context,
                 cordial_knowledge_receiver,
+                eviction_rounds_receiver,
                 cordial_knowledge: vec![BTreeMap::new(); num_authorities],
                 last_useful_shards_from_peer_round: vec![None; num_authorities],
                 connection_knowledges: connection_knowledges.clone(),
             },
             connection_knowledges,
             cordial_knowledge_sender,
+            eviction_rounds_sender,
         )
     }
 
@@ -286,16 +297,21 @@ impl CordialKnowledge {
         dag_state: Arc<RwLock<DagState>>,
     ) -> Arc<CordialKnowledgeHandle> {
         // Build main CordialKnowledge and associated channels
-        let (cordial_knowledge, connection_knowledges, cordial_knowledge_sender) =
-            CordialKnowledge::new(context.clone(), dag_state.clone());
+        let (
+            cordial_knowledge,
+            connection_knowledges,
+            cordial_knowledge_sender,
+            eviction_rounds_sender,
+        ) = CordialKnowledge::new(context.clone(), dag_state.clone());
         // Spawn the main CordialKnowledge loop
         let cordial_knowledge_handle = tokio::spawn(async move {
             cordial_knowledge.run().await;
         });
 
-        dag_state
-            .write()
-            .set_cordial_knowledge_sender(cordial_knowledge_sender.clone());
+        dag_state.write().set_cordial_knowledge_senders(
+            cordial_knowledge_sender.clone(),
+            eviction_rounds_sender.clone(),
+        );
 
         // Return handle with all pieces assembled
         Arc::new(CordialKnowledgeHandle {
@@ -305,11 +321,12 @@ impl CordialKnowledge {
         })
     }
 
-    /// Main async loop: receives high-level updates (headers, shards,
-    /// evictions) from DAG state and updates global knowledge + notifies
-    /// per-connection tasks.
+    /// Main async loop: receives high-level updates (headers, shards)
+    /// from DAG state and updates global knowledge + notifies per-connection
+    /// tasks. Evictions are checked periodically via a watch channel.
     async fn run(mut self) {
         debug!("Cordial Knowledge main loop started");
+        let mut processed_since_eviction = 0usize;
 
         loop {
             match self.cordial_knowledge_receiver.recv().await {
@@ -318,6 +335,7 @@ impl CordialKnowledge {
                     while let Ok(msg) = self.cordial_knowledge_receiver.try_recv() {
                         batch.push(msg);
                     }
+                    processed_since_eviction = processed_since_eviction.saturating_add(batch.len());
                     // Report the buffer size
                     self.context
                         .metrics
@@ -339,6 +357,13 @@ impl CordialKnowledge {
                         }
                     }
 
+                    if processed_since_eviction >= EVICTION_CHECK_INTERVAL {
+                        self.append_eviction_msgs_if_changed(
+                            &mut vec_connection_knowledge_msgs_batch,
+                        );
+                        processed_since_eviction = 0;
+                    }
+
                     for (index, msgs) in vec_connection_knowledge_msgs_batch.into_iter().enumerate()
                     {
                         if !msgs.is_empty() {
@@ -355,6 +380,24 @@ impl CordialKnowledge {
         }
 
         debug!("Cordial Knowledge main loop finished");
+    }
+
+    fn append_eviction_msgs_if_changed(
+        &mut self,
+        vec_connection_knowledge_msgs_batch: &mut [Vec<ConnectionKnowledgeMessage>],
+    ) {
+        if !self.eviction_rounds_receiver.has_changed().unwrap_or(false) {
+            return;
+        }
+        let evicted_rounds = self.eviction_rounds_receiver.borrow_and_update().clone();
+        if evicted_rounds.len() != self.context.committee.size() {
+            return;
+        }
+        if let Some(vec_connection_knowledge_msgs) = self.handle_evict_below(evicted_rounds) {
+            for (index, msgs) in vec_connection_knowledge_msgs.into_iter().enumerate() {
+                vec_connection_knowledge_msgs_batch[index].extend(msgs);
+            }
+        }
     }
 
     /// Processes a single high-level cordial knowledge message.
@@ -375,7 +418,6 @@ impl CordialKnowledge {
         match cordial_knowledge_message {
             CordialKnowledgeMessage::NewHeader(header) => self.update_cordial_knowledge(&header),
             CordialKnowledgeMessage::NewShard(block_ref) => self.prepare_new_shard_msgs(block_ref),
-            CordialKnowledgeMessage::EvictBelow(round) => self.handle_evict_below(round),
             CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shards_from_peer) => {
                 self.handle_useful_shards_from(useful_shards_from_peer)
             }
@@ -1064,7 +1106,7 @@ mod tests {
         TestBlockHeader,
         block_header::{GENESIS_ROUND, VerifiedBlock, VerifiedOwnShard},
         context::Context,
-        dag_state::DagState,
+        dag_state::{BlockHeaderSource, DagState},
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
         test_dag_parser::parse_dag,
@@ -1175,7 +1217,9 @@ mod tests {
                         verified_block_header,
                         verified_transactions,
                     } = block.clone();
-                    dag_state.write().accept_block_header(verified_block_header);
+                    dag_state
+                        .write()
+                        .accept_block_header(verified_block_header, BlockHeaderSource::Test);
                     let shard_for_core = VerifiedOwnShard {
                         serialized_shard: Bytes::from([0u8; 32].to_vec()), /* put some dummy
                                                                             * shard data */
@@ -1194,7 +1238,9 @@ mod tests {
                     verified_block_header,
                     verified_transactions,
                 } = block.clone();
-                dag_state.write().accept_block_header(verified_block_header);
+                dag_state
+                    .write()
+                    .accept_block_header(verified_block_header, BlockHeaderSource::Test);
                 let shard_for_core = VerifiedOwnShard {
                     serialized_shard: Bytes::from([0u8; 32].to_vec()), // put some dummy shard data
                     block_ref: verified_transactions.block_ref(),

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -42,7 +42,7 @@ use crate::{
     commit::{CertifiedCommits, PendingSubDag},
     commit_observer::CommitObserver,
     context::Context,
-    dag_state::{DagState, TransactionSource},
+    dag_state::{BlockHeaderSource, DagState, TransactionSource},
     encoder::{ShardEncoder, create_encoder},
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
@@ -354,6 +354,7 @@ impl Core {
     pub(crate) fn add_block_headers(
         &mut self,
         block_headers: Vec<VerifiedBlockHeader>,
+        source: BlockHeaderSource,
     ) -> ConsensusResult<(
         BTreeSet<BlockRef>,
         BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
@@ -371,8 +372,9 @@ impl Core {
             .node_metrics
             .core_add_block_headers_batch_size
             .observe(block_headers.len() as f64);
-        let (accepted_block_headers, missing_block_refs) =
-            self.block_manager.try_accept_block_headers(block_headers);
+        let (accepted_block_headers, missing_block_refs) = self
+            .block_manager
+            .try_accept_block_headers(block_headers, source);
 
         let missing_committed_txns = if !accepted_block_headers.is_empty() {
             debug!(
@@ -503,7 +505,7 @@ impl Core {
             .collect::<Vec<_>>();
 
         // Add block headers in certified commits to the block manager.
-        self.add_block_headers(block_headers)
+        self.add_block_headers(block_headers, BlockHeaderSource::CommitSyncer)
     }
 
     /// If needed, signals a new clock round and sets up leader timeout.
@@ -1991,7 +1993,7 @@ mod test {
 
                 core_fixture
                     .core
-                    .add_block_headers(last_round_blocks.clone())
+                    .add_block_headers(last_round_blocks.clone(), BlockHeaderSource::Test)
                     .unwrap();
 
                 // Only when round > 1 and using non-genesis parents.
@@ -2026,7 +2028,7 @@ mod test {
 
             core_fixture
                 .core
-                .add_block_headers(last_round_blocks.clone())
+                .add_block_headers(last_round_blocks.clone(), BlockHeaderSource::Test)
                 .unwrap();
             let (new_block_opt, missing_committed_txns) = core_fixture
                 .core
@@ -2157,7 +2159,7 @@ mod test {
                 // emitted
                 core_fixture
                     .core
-                    .add_block_headers(last_round_block_headers.clone())
+                    .add_block_headers(last_round_block_headers.clone(), BlockHeaderSource::Test)
                     .unwrap();
 
                 // A "new round" signal should be received given that all the blocks of previous
@@ -2482,7 +2484,9 @@ mod test {
         let block_headers = dag_builder.block_headers(1..=6);
 
         for block_header in block_headers {
-            core.dag_state.write().accept_block_header(block_header);
+            core.dag_state
+                .write()
+                .accept_block_header(block_header, BlockHeaderSource::Test);
         }
 
         // Get all the committed sub dags up to round 10
@@ -2526,7 +2530,9 @@ mod test {
         // accepted via the certified commits processing.
         let block_headers = dag_builder.block_headers(8..=12);
         for block_header in block_headers {
-            core.dag_state.write().accept_block_header(block_header);
+            core.dag_state
+                .write()
+                .accept_block_header(block_header, BlockHeaderSource::Test);
         }
 
         // The corresponding blocks of the certified commits should be accepted and
@@ -2568,7 +2574,7 @@ mod test {
                 // emitted
                 core_fixture
                     .core
-                    .add_block_headers(last_round_block_headers.clone())
+                    .add_block_headers(last_round_block_headers.clone(), BlockHeaderSource::Test)
                     .unwrap();
                 // A "new round" signal should be received given that all the blocks of previous
                 // round have been processed
@@ -2700,7 +2706,7 @@ mod test {
                 // emitted
                 core_fixture
                     .core
-                    .add_block_headers(last_round_block_headers.clone())
+                    .add_block_headers(last_round_block_headers.clone(), BlockHeaderSource::Test)
                     .unwrap();
 
                 // A "new round" signal should be received given that all the blocks of previous
@@ -2796,7 +2802,7 @@ mod test {
                 // leader authority 3
                 core_fixture
                     .core
-                    .add_block_headers(last_round_block_headers.clone())
+                    .add_block_headers(last_round_block_headers.clone(), BlockHeaderSource::Test)
                     .unwrap();
                 core_fixture
                     .core
@@ -2825,7 +2831,7 @@ mod test {
         // add blocks to trigger proposal.
         core_fixture
             .core
-            .add_block_headers(all_block_headers)
+            .add_block_headers(all_block_headers, BlockHeaderSource::Test)
             .unwrap();
 
         // Assert that a block has been created for round 11 and it references to blocks

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -29,7 +29,7 @@ use crate::{
     context::Context,
     core::{Core, ReasonToCreateBlock},
     core_thread::CoreError::Shutdown,
-    dag_state::{DagState, TransactionSource},
+    dag_state::{BlockHeaderSource, DagState, TransactionSource},
     error::{ConsensusError, ConsensusResult},
 };
 
@@ -47,6 +47,7 @@ enum CoreThreadCommand {
     /// Add block headers to be processed and accepted
     AddBlockHeaders(
         Vec<VerifiedBlockHeader>,
+        BlockHeaderSource,
         oneshot::Sender<(
             BTreeSet<BlockRef>,
             BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
@@ -109,6 +110,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
     async fn add_block_headers(
         &self,
         blocks: Vec<VerifiedBlockHeader>,
+        source: BlockHeaderSource,
     ) -> Result<
         (
             BTreeSet<BlockRef>,
@@ -201,9 +203,10 @@ impl CoreThread {
                             let (missing_block_refs, missing_committed_txns) = self.core.add_blocks(blocks)?;
                             sender.send((missing_block_refs, missing_committed_txns)).ok();
                         }
-                        CoreThreadCommand::AddBlockHeaders(block_headers, sender) => {
+                        CoreThreadCommand::AddBlockHeaders(block_headers, source, sender) => {
                             let _scope = monitored_scope("CoreThread::loop::add_block_headers");
-                            let (missing_block_refs, missing_committed_txns) = self.core.add_block_headers(block_headers)?;
+                            let (missing_block_refs, missing_committed_txns) =
+                                self.core.add_block_headers(block_headers, source)?;
                             sender.send((missing_block_refs, missing_committed_txns)).ok();
                         }
                         CoreThreadCommand::AddCertifiedCommits(commits, sender) => {
@@ -370,6 +373,7 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
     async fn add_block_headers(
         &self,
         block_headers: Vec<VerifiedBlockHeader>,
+        source: BlockHeaderSource,
     ) -> Result<
         (
             BTreeSet<BlockRef>,
@@ -378,8 +382,12 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         CoreError,
     > {
         let (sender, receiver) = oneshot::channel();
-        self.send(CoreThreadCommand::AddBlockHeaders(block_headers, sender))
-            .await;
+        self.send(CoreThreadCommand::AddBlockHeaders(
+            block_headers,
+            source,
+            sender,
+        ))
+        .await;
         Ok(receiver.await.map_err(|e| Shutdown(e.to_string()))?)
     }
 
@@ -564,6 +572,7 @@ pub(crate) mod tests {
         async fn add_block_headers(
             &self,
             block_headers: Vec<VerifiedBlockHeader>,
+            _source: BlockHeaderSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,
@@ -698,8 +707,18 @@ pub(crate) mod tests {
         assert!(dispatcher_1.add_blocks(vec![]).await.is_ok());
         assert!(dispatcher_2.add_blocks(vec![]).await.is_ok());
 
-        assert!(dispatcher_1.add_block_headers(vec![]).await.is_ok());
-        assert!(dispatcher_2.add_block_headers(vec![]).await.is_ok());
+        assert!(
+            dispatcher_1
+                .add_block_headers(vec![], BlockHeaderSource::Test)
+                .await
+                .is_ok()
+        );
+        assert!(
+            dispatcher_2
+                .add_block_headers(vec![], BlockHeaderSource::Test)
+                .await
+                .is_ok()
+        );
 
         // Now shutdown the dispatcher
         handle.stop().await;
@@ -707,7 +726,17 @@ pub(crate) mod tests {
         // Try to send some commands
         assert!(dispatcher_1.add_blocks(vec![]).await.is_err());
         assert!(dispatcher_2.add_blocks(vec![]).await.is_err());
-        assert!(dispatcher_1.add_block_headers(vec![]).await.is_err());
-        assert!(dispatcher_2.add_block_headers(vec![]).await.is_err());
+        assert!(
+            dispatcher_1
+                .add_block_headers(vec![], BlockHeaderSource::Test)
+                .await
+                .is_err()
+        );
+        assert!(
+            dispatcher_2
+                .add_block_headers(vec![], BlockHeaderSource::Test)
+                .await
+                .is_err()
+        );
     }
 }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -88,13 +88,33 @@ impl std::fmt::Display for TransactionSource {
     }
 }
 
+/// Represents the source from which block headers were received and added to
+/// the DAG state. This is used for metrics tracking and debugging.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum BlockHeaderSource {
+    /// Block headers from full blocks received via network streaming.
+    /// This is the primary method for receiving real-time blocks as they're
+    /// created by other validators in the network.
     BlockStreaming,
+
+    /// Block headers received in block header bundle stream protocol.
+    /// Used by cordial knowledge dissemination to efficiently propagate headers
+    /// without full block data.
     BlockHeaderBundleStream,
+
+    /// Block headers extracted from certified commits during synchronization.
+    /// These headers are part of already-finalized commits received from peers.
     CommitSyncer,
+
+    /// Block headers fetched by the periodic header synchronizer component.
+    /// This synchronizer actively requests missing headers to fill gaps in the
+    /// DAG.
     HeaderSynchronizer,
+
+    /// Block headers loaded from persistent storage during node recovery.
+    /// Used when restarting a node to restore the in-memory DAG state.
     Recover,
+
     /// Only used in test code.
     #[cfg(test)]
     Test,

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -13,10 +13,13 @@ use std::{
 };
 
 use bytes::Bytes;
-use iota_metrics::monitored_mpsc::UnboundedSender;
+use iota_metrics::monitored_mpsc::Sender;
 use itertools::Itertools as _;
 use starfish_config::AuthorityIndex;
-use tokio::time::Instant;
+use tokio::{
+    sync::{mpsc::error::TrySendError, watch},
+    time::Instant,
+};
 use tracing::{debug, error, info, trace, warn};
 
 use crate::{
@@ -82,6 +85,34 @@ impl TransactionSource {
 impl std::fmt::Display for TransactionSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum BlockHeaderSource {
+    BlockStreaming,
+    BlockHeaderBundleStream,
+    CommitSyncer,
+    HeaderSynchronizer,
+    Recover,
+    /// Only used in test code.
+    #[cfg(test)]
+    Test,
+}
+
+impl BlockHeaderSource {
+    /// Returns the string label used for metrics reporting.
+    /// This ensures consistency with existing metrics that may be monitored.
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            BlockHeaderSource::HeaderSynchronizer => "Header synchronizer",
+            BlockHeaderSource::BlockHeaderBundleStream => "Block headers in streaming",
+            BlockHeaderSource::BlockStreaming => "Full blocks in streaming",
+            BlockHeaderSource::CommitSyncer => "Commit syncer",
+            BlockHeaderSource::Recover => "Recover",
+            #[cfg(test)]
+            BlockHeaderSource::Test => "Test",
+        }
     }
 }
 
@@ -178,8 +209,8 @@ pub(crate) struct DagState {
     /// The number of cached rounds
     cached_rounds: Round,
 
-    /// Cordial Knowledge sender
-    cordial_knowledge_sender: Option<UnboundedSender<CordialKnowledgeMessage>>,
+    /// Cordial Knowledge senders (main updates, eviction rounds).
+    cordial_knowledge_senders: Option<(Sender<CordialKnowledgeMessage>, watch::Sender<Vec<Round>>)>,
 }
 
 impl DagState {
@@ -263,7 +294,7 @@ impl DagState {
             store: store.clone(),
             cached_rounds,
             evicted_rounds: vec![0; num_authorities],
-            cordial_knowledge_sender: None,
+            cordial_knowledge_senders: None,
         };
 
         for (i, round) in last_committed_rounds.into_iter().enumerate() {
@@ -285,7 +316,7 @@ impl DagState {
 
             // Update the block metadata for the authority.
             for block_header in &block_headers {
-                state.update_block_header_metadata(block_header);
+                state.update_block_header_metadata(block_header, BlockHeaderSource::Recover);
             }
             for transactions in &transactions_by_author {
                 state.update_transaction_metadata(transactions);
@@ -303,15 +334,20 @@ impl DagState {
         state
     }
 
-    pub fn set_cordial_knowledge_sender(
+    pub fn set_cordial_knowledge_senders(
         &mut self,
-        sender: UnboundedSender<CordialKnowledgeMessage>,
+        sender: Sender<CordialKnowledgeMessage>,
+        eviction_sender: watch::Sender<Vec<Round>>,
     ) {
-        self.cordial_knowledge_sender = Some(sender);
+        self.cordial_knowledge_senders = Some((sender, eviction_sender));
     }
 
     /// Accepts a block header into DagState and keeps it in memory.
-    pub(crate) fn accept_block_header(&mut self, block_header: VerifiedBlockHeader) {
+    pub(crate) fn accept_block_header(
+        &mut self,
+        block_header: VerifiedBlockHeader,
+        source: BlockHeaderSource,
+    ) {
         assert_ne!(
             block_header.round(),
             GENESIS_ROUND,
@@ -350,13 +386,13 @@ impl DagState {
                 block header(s) {existing_blocks:#?} already exists."
             );
         }
-        self.update_block_header_metadata(&block_header);
+        self.update_block_header_metadata(&block_header, source);
         debug!(
             "block header {} pushed to write to store batch by {}",
             block_header, self.context.own_index
         );
         self.block_headers_to_write.push(block_header);
-        let source = if self.context.own_index == block_ref.author {
+        let author_label = if self.context.own_index == block_ref.author {
             "own"
         } else {
             "others"
@@ -366,7 +402,7 @@ impl DagState {
             .metrics
             .node_metrics
             .accepted_block_headers
-            .with_label_values(&[source])
+            .with_label_values(&[author_label])
             .inc();
     }
 
@@ -423,10 +459,10 @@ impl DagState {
             .is_none()
         {
             debug!("Adding shard for block ref: {block_ref}");
-            if let Some(sender) = &self.cordial_knowledge_sender {
+            if let Some((sender, _)) = &self.cordial_knowledge_senders {
                 let cordial_message = CordialKnowledgeMessage::NewShard(block_ref);
-                if let Err(e) = sender.send(cordial_message) {
-                    warn!("Failed to send cordial knowledge update: {e}");
+                if let Err(TrySendError::Closed(_)) = sender.try_send(cordial_message) {
+                    warn!("Failed to send cordial knowledge update: channel closed");
                 }
             }
         }
@@ -462,7 +498,11 @@ impl DagState {
     }
 
     /// Updates internal metadata for accepted block header.
-    fn update_block_header_metadata(&mut self, block_header: &VerifiedBlockHeader) {
+    fn update_block_header_metadata(
+        &mut self,
+        block_header: &VerifiedBlockHeader,
+        source: BlockHeaderSource,
+    ) {
         let block_ref = block_header.reference();
         self.recent_block_headers
             .insert(block_ref, block_header.clone());
@@ -487,10 +527,18 @@ impl DagState {
             .highest_accepted_authority_round
             .with_label_values(&[hostname])
             .set(highest_accepted_round_for_author as i64);
-        if let Some(sender) = &self.cordial_knowledge_sender {
-            let cordial_message = CordialKnowledgeMessage::NewHeader(block_header.clone());
-            if let Err(e) = sender.send(cordial_message) {
-                warn!("Failed to send cordial knowledge update: {e}");
+        self.context
+            .metrics
+            .node_metrics
+            .accepted_block_headers_source
+            .with_label_values(&[source.as_str()])
+            .inc();
+        if source != BlockHeaderSource::CommitSyncer && source != BlockHeaderSource::Recover {
+            if let Some((sender, _)) = &self.cordial_knowledge_senders {
+                let cordial_message = CordialKnowledgeMessage::NewHeader(block_header.clone());
+                if let Err(TrySendError::Closed(_)) = sender.try_send(cordial_message) {
+                    warn!("Failed to send cordial knowledge update: channel closed");
+                }
             }
         }
     }
@@ -501,7 +549,11 @@ impl DagState {
     }
 
     /// Accepts block headers into DagState and keeps it in memory.
-    pub(crate) fn accept_block_headers(&mut self, block_headers: Vec<VerifiedBlockHeader>) {
+    pub(crate) fn accept_block_headers(
+        &mut self,
+        block_headers: Vec<VerifiedBlockHeader>,
+        source: BlockHeaderSource,
+    ) {
         debug!(
             "Accepting block headers: {}",
             block_headers
@@ -510,7 +562,7 @@ impl DagState {
                 .join(",")
         );
         for block_header in block_headers {
-            self.accept_block_header(block_header);
+            self.accept_block_header(block_header, source);
         }
     }
 
@@ -1468,15 +1520,14 @@ impl DagState {
     /// with the eviction method, thereby should be called every time the
     /// eviction happens.
     pub(crate) fn evict_cordial_knowledge(&mut self) {
-        if let Some(cordial_knowledge_sender) = &self.cordial_knowledge_sender {
+        if let Some((_, eviction_sender)) = &self.cordial_knowledge_senders {
             let mut eviction_rounds = vec![];
             for (authority_index, _) in self.context.committee.authorities() {
                 let eviction_round = self.calculate_authority_eviction_round(authority_index);
                 eviction_rounds.push(eviction_round);
             }
-            let cordial_message = CordialKnowledgeMessage::EvictBelow(eviction_rounds);
-            if let Err(e) = cordial_knowledge_sender.send(cordial_message) {
-                warn!("Failed to send cordial knowledge eviction message: {e}");
+            if eviction_sender.send(eviction_rounds).is_err() {
+                warn!("Failed to send cordial knowledge eviction message: channel closed");
             }
         }
     }
@@ -1814,7 +1865,7 @@ mod test {
                             .set_timestamp_ms(timestamp)
                             .build(),
                     );
-                    dag_state.accept_block_header(block_header.clone());
+                    dag_state.accept_block_header(block_header.clone(), BlockHeaderSource::Test);
                     block_headers.insert(block_header.reference(), block_header);
 
                     // Only write one block header per slot for own index
@@ -2045,7 +2096,7 @@ mod test {
             .chain(round_13_headers.iter())
             .chain([anchor.clone()].iter())
         {
-            dag_state.accept_block_header(bh.clone());
+            dag_state.accept_block_header(bh.clone(), BlockHeaderSource::Test);
         }
 
         // Check ancestors connected to anchor.
@@ -2099,7 +2150,7 @@ mod test {
                     .write(WriteBatch::default().block_headers(vec![block_header]))
                     .unwrap();
             } else {
-                dag_state.accept_block_headers(vec![block_header]);
+                dag_state.accept_block_headers(vec![block_header], BlockHeaderSource::Test);
             }
         });
 
@@ -2154,7 +2205,7 @@ mod test {
                 let block_header =
                     VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, author).build());
                 block_headers.push(block_header.clone());
-                dag_state.accept_block_header(block_header);
+                dag_state.accept_block_header(block_header, BlockHeaderSource::Test);
             }
         }
 
@@ -2222,7 +2273,7 @@ mod test {
             let block_header =
                 VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build());
             block_headers.push(block_header.clone());
-            dag_state.accept_block_header(block_header);
+            dag_state.accept_block_header(block_header, BlockHeaderSource::Test);
         }
 
         // Now add a commit and flush to trigger an eviction
@@ -2275,7 +2326,7 @@ mod test {
                     .write(WriteBatch::default().block_headers(vec![block_header]))
                     .unwrap();
             } else {
-                dag_state.accept_block_headers(vec![block_header]);
+                dag_state.accept_block_headers(vec![block_header], BlockHeaderSource::Test);
             }
         });
 
@@ -2363,7 +2414,7 @@ mod test {
         // 5 commits to the dag state; also add commit info after the second
         // commit.
         let later_commits = commits.split_off(5);
-        dag_state.accept_block_headers(dag_builder.block_headers(1..=5));
+        dag_state.accept_block_headers(dag_builder.block_headers(1..=5), BlockHeaderSource::Test);
         for verified_transactions in dag_builder.transactions(1..=5).into_iter() {
             dag_state.add_transactions(verified_transactions, TransactionSource::Test);
         }
@@ -2384,7 +2435,10 @@ mod test {
         assert_eq!(commit_info.committed_rounds, [1, 1, 2, 1]);
 
         // Add the rest of the block headers, transaction, and commits to the dag state
-        dag_state.accept_block_headers(dag_builder.block_headers(6..=num_rounds));
+        dag_state.accept_block_headers(
+            dag_builder.block_headers(6..=num_rounds),
+            BlockHeaderSource::Test,
+        );
         for verified_transactions in dag_builder.transactions(6..=num_rounds).into_iter() {
             dag_state.add_transactions(verified_transactions, TransactionSource::Test);
         }
@@ -2527,7 +2581,7 @@ mod test {
                     TestBlockHeader::new(round, author as u8).build(),
                 );
                 all_block_headers.push(block_header.clone());
-                dag_state.accept_block_header(block_header);
+                dag_state.accept_block_header(block_header, BlockHeaderSource::Test);
             }
         }
 
@@ -2689,7 +2743,7 @@ mod test {
             .into_iter()
             .chain(std::iter::once(block_header))
         {
-            dag_state.accept_block_header(block_header);
+            dag_state.accept_block_header(block_header, BlockHeaderSource::Test);
         }
 
         dag_state.add_commit(TrustedCommit::new_for_test(
@@ -2811,7 +2865,7 @@ mod test {
                     TestBlockHeader::new(round, author as u8).build(),
                 );
                 all_blocks_headers.push(block_header.clone());
-                dag_state.accept_block_header(block_header);
+                dag_state.accept_block_header(block_header, BlockHeaderSource::Test);
             }
         }
 
@@ -2882,7 +2936,9 @@ mod test {
         {
             let block_header =
                 VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 0).build());
-            dag_state.write().accept_block_header(block_header);
+            dag_state
+                .write()
+                .accept_block_header(block_header, BlockHeaderSource::Test);
 
             let round_4_block_headers = dag_state.read().get_uncommitted_block_headers_at_round(4);
 
@@ -2936,7 +2992,9 @@ mod test {
             // add block header 5 for authority 0
             let block_header =
                 VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 0).build());
-            dag_state.write().accept_block_header(block_header);
+            dag_state
+                .write()
+                .accept_block_header(block_header, BlockHeaderSource::Test);
 
             for (authority_index, _) in context.committee.authorities() {
                 let block_header = dag_state
@@ -3050,7 +3108,7 @@ mod test {
                 .set_timestamp_ms(future_timestamp)
                 .build(),
         );
-        dag_state.accept_block_header(block_header.clone());
+        dag_state.accept_block_header(block_header.clone(), BlockHeaderSource::Test);
 
         let accepted_header = dag_state
             .recent_block_headers
@@ -3080,7 +3138,10 @@ mod test {
             commits.push(commit);
         }
 
-        dag_state.accept_block_headers(dag_builder.block_headers(1..=num_rounds));
+        dag_state.accept_block_headers(
+            dag_builder.block_headers(1..=num_rounds),
+            BlockHeaderSource::Test,
+        );
         for verified_transactions in dag_builder.transactions(1..=num_rounds).into_iter() {
             dag_state.add_transactions(verified_transactions, TransactionSource::Test);
         }
@@ -3229,7 +3290,7 @@ mod test {
                 .build(),
         );
         // Try to accept the block - it should not panic
-        dag_state.accept_block_header(block);
+        dag_state.accept_block_header(block, BlockHeaderSource::Test);
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -92,27 +92,20 @@ impl std::fmt::Display for TransactionSource {
 /// the DAG state. This is used for metrics tracking and debugging.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum BlockHeaderSource {
-    /// Block headers from full blocks received via network streaming.
-    /// This is the primary method for receiving real-time blocks as they're
-    /// created by other validators in the network.
+    /// Block headers from full blocks received via bundle streaming.
     BlockStreaming,
 
-    /// Block headers received in block header bundle stream protocol.
-    /// Used by cordial knowledge dissemination to efficiently propagate headers
-    /// without full block data.
+    /// Block headers received in bundles via block bundle streaming.
     BlockHeaderBundleStream,
 
-    /// Block headers extracted from certified commits during synchronization.
-    /// These headers are part of already-finalized commits received from peers.
+    /// Block headers extracted from certified commits during commit syncing.
     CommitSyncer,
 
-    /// Block headers fetched by the periodic header synchronizer component.
-    /// This synchronizer actively requests missing headers to fill gaps in the
-    /// DAG.
+    /// Block headers fetched by the live/periodic header synchronizer
+    /// component.
     HeaderSynchronizer,
 
     /// Block headers loaded from persistent storage during node recovery.
-    /// Used when restarting a node to restore the in-memory DAG state.
     Recover,
 
     /// Only used in test code.

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -46,7 +46,7 @@ use crate::{
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
-    dag_state::DagState,
+    dag_state::{BlockHeaderSource, DagState},
     error::{ConsensusError, ConsensusResult},
     network::NetworkClient,
     transactions_synchronizer::TransactionsSynchronizerHandle,
@@ -715,7 +715,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         // we don't want this mechanism to keep feedback looping on fetching
         // more blocks. The periodic synchronization will take care of that.
         let (missing_blocks, missing_committed_txns) = core_dispatcher
-            .add_block_headers(block_headers)
+            .add_block_headers(block_headers, BlockHeaderSource::HeaderSynchronizer)
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
 
@@ -1531,7 +1531,7 @@ mod tests {
         context::Context,
         core::ReasonToCreateBlock,
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
-        dag_state::{DagState, TransactionSource},
+        dag_state::{BlockHeaderSource, DagState, TransactionSource},
         error::{ConsensusError, ConsensusResult},
         header_synchronizer::{
             FETCH_BLOCK_HEADERS_CONCURRENCY, FETCH_REQUEST_TIMEOUT, HeaderSynchronizer,
@@ -2723,6 +2723,7 @@ mod tests {
         async fn add_block_headers(
             &self,
             _blocks: Vec<VerifiedBlockHeader>,
+            _source: BlockHeaderSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -453,6 +453,7 @@ mod tests {
         CommitIndex, TestBlockHeader,
         commit::{CommitDigest, WAVE_LENGTH},
         context::Context,
+        dag_state::BlockHeaderSource,
         leader_schedule::{LeaderSchedule, LeaderSwapTable},
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
@@ -644,7 +645,7 @@ mod tests {
         );
         dag_state
             .write()
-            .accept_block_headers(block_headers_wave_1.clone());
+            .accept_block_headers(block_headers_wave_1.clone(), BlockHeaderSource::Test);
 
         let first_leader = dag_builder
             .leader_block(leader_round_wave_1)
@@ -681,7 +682,7 @@ mod tests {
         // Write them in dag state
         dag_state
             .write()
-            .accept_block_headers(block_headers_wave_2.clone());
+            .accept_block_headers(block_headers_wave_2.clone(), BlockHeaderSource::Test);
 
         let mut block_refs_wave_2: Vec<_> = block_headers_wave_2
             .into_iter()
@@ -994,7 +995,7 @@ mod tests {
         {
             let mut dag_state_guard = dag_state.write();
             for block in &ancestors {
-                dag_state_guard.accept_block_header(block.clone());
+                dag_state_guard.accept_block_header(block.clone(), BlockHeaderSource::Test);
             }
         }
         let last_commit_timestamp_ms = 0;

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -135,6 +135,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) highest_accepted_round: IntGauge,
     pub(crate) accepted_block_header_time_drift_ms: IntCounterVec,
     pub(crate) accepted_block_headers: IntCounterVec,
+    pub(crate) accepted_block_headers_source: IntCounterVec,
     pub(crate) cordial_knowledge_useful_headers_authors: IntCounterVec,
     pub(crate) cordial_knowledge_useful_shards_authors: IntCounterVec,
     pub(crate) dag_state_recent_transactions: IntGauge,
@@ -438,6 +439,12 @@ impl NodeMetrics {
             accepted_block_headers: register_int_counter_vec_with_registry!(
                 "accepted_block_headers",
                 "Number of accepted block headers by source (own, others)",
+                &["source"],
+                registry,
+            ).unwrap(),
+            accepted_block_headers_source: register_int_counter_vec_with_registry!(
+                "accepted_block_headers_source",
+                "Number of accepted block headers by ingestion source",
                 &["source"],
                 registry,
             ).unwrap(),

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -657,7 +657,7 @@ mod tests {
         context::Context,
         core::ReasonToCreateBlock,
         core_thread::{CoreError, CoreThreadDispatcher},
-        dag_state::{DagState, TransactionSource},
+        dag_state::{BlockHeaderSource, DagState, TransactionSource},
         encoder::create_encoder,
         shard_reconstructor::{
             FullTransactionMessage, ShardMessage, ShardReconstructor, TransactionMessage,
@@ -708,6 +708,7 @@ mod tests {
         async fn add_block_headers(
             &self,
             _blocks: Vec<VerifiedBlockHeader>,
+            _source: BlockHeaderSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,

--- a/crates/starfish/core/src/test_dag.rs
+++ b/crates/starfish/core/src/test_dag.rs
@@ -14,7 +14,7 @@ use crate::{
         genesis_block_headers,
     },
     context::Context,
-    dag_state::DagState,
+    dag_state::{BlockHeaderSource, DagState},
     test_dag_builder::DagBuilder,
 };
 
@@ -67,7 +67,9 @@ pub(crate) fn build_dag(
                 (block.reference(), block)
             })
             .unzip();
-        dag_state.write().accept_block_headers(blocks);
+        dag_state
+            .write()
+            .accept_block_headers(blocks, BlockHeaderSource::Test);
         ancestors = references;
     }
 
@@ -91,7 +93,9 @@ pub(crate) fn build_dag_layer(
                 .build(),
         );
         references.push(block.reference());
-        dag_state.write().accept_block_header(block);
+        dag_state
+            .write()
+            .accept_block_header(block, BlockHeaderSource::Test);
     }
     references
 }

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     commit::{CertifiedCommit, CommitDigest, TrustedCommit, WAVE_LENGTH},
     context::Context,
-    dag_state::{DagState, TransactionSource},
+    dag_state::{BlockHeaderSource, DagState, TransactionSource},
     encoder::{ShardEncoder, create_encoder},
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
     linearizer::{BlockStoreAPI, Linearizer},
@@ -412,9 +412,10 @@ impl DagBuilder {
     }
 
     pub(crate) fn persist_all_blocks(&self, dag_state: Arc<RwLock<DagState>>) {
-        dag_state
-            .write()
-            .accept_block_headers(self.block_headers.values().cloned().collect());
+        dag_state.write().accept_block_headers(
+            self.block_headers.values().cloned().collect(),
+            BlockHeaderSource::Test,
+        );
         for block_transactions in self.transactions.values() {
             dag_state
                 .write()
@@ -892,7 +893,7 @@ impl<'a> LayerBuilder<'a> {
             "Called to persist layers although no blocks have been created. Make sure you have called build before."
         );
         let mut dag_state = dag_state.write();
-        dag_state.accept_block_headers(self.block_headers.clone());
+        dag_state.accept_block_headers(self.block_headers.clone(), BlockHeaderSource::Test);
         for transactions in self.transactions.clone() {
             dag_state.add_transactions(transactions, TransactionSource::Test);
         }

--- a/crates/starfish/core/src/tests/base_committer_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_tests.rs
@@ -12,7 +12,7 @@ use crate::{
     block_header::{BlockHeaderAPI, TestBlockHeader, VerifiedBlockHeader},
     commit::LeaderStatus,
     context::Context,
-    dag_state::DagState,
+    dag_state::{BlockHeaderSource, DagState},
     storage::mem_store::MemStore,
     test_dag::{build_dag, build_dag_layer},
 };
@@ -633,7 +633,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_c13_1.clone());
+        .accept_block_header(byzantine_block_c13_1.clone(), BlockHeaderSource::Test);
 
     let byzantine_block_c13_2 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
@@ -642,7 +642,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_c13_2.clone());
+        .accept_block_header(byzantine_block_c13_2.clone(), BlockHeaderSource::Test);
 
     let byzantine_block_c13_3 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
@@ -651,7 +651,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_c13_3.clone());
+        .accept_block_header(byzantine_block_c13_3.clone(), BlockHeaderSource::Test);
 
     // Ancestors of decision blocks in round 14 should include multiple byzantine
     // non-votes C13 but there are enough good votes to prevent a skip.
@@ -664,7 +664,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(decision_block_a14.clone());
+        .accept_block_header(decision_block_a14.clone(), BlockHeaderSource::Test);
 
     let good_references_voting_round_wave_4_without_c13 = good_references_voting_round_wave_4
         .into_iter()
@@ -684,7 +684,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(decision_block_b14.clone());
+        .accept_block_header(decision_block_b14.clone(), BlockHeaderSource::Test);
 
     let decision_block_c14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 2)
@@ -699,7 +699,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(decision_block_c14.clone());
+        .accept_block_header(decision_block_c14.clone(), BlockHeaderSource::Test);
 
     let decision_block_d14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 3)
@@ -714,7 +714,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(decision_block_d14.clone());
+        .accept_block_header(decision_block_d14.clone(), BlockHeaderSource::Test);
 
     // DagState Update:
     // - We have A13, B13, D13 & C13 as good votes in the voting round of wave 4

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -11,7 +11,7 @@ use crate::{
     block_header::{BlockHeaderAPI, Slot, TestBlockHeader, VerifiedBlockHeader},
     commit::{DecidedLeader, WAVE_LENGTH},
     context::Context,
-    dag_state::DagState,
+    dag_state::{BlockHeaderSource, DagState},
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
     storage::mem_store::MemStore,
     test_dag::{build_dag, build_dag_layer},
@@ -628,7 +628,7 @@ async fn test_byzantine_validator() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_b13_1.clone());
+        .accept_block_header(byzantine_block_b13_1.clone(), BlockHeaderSource::Test);
 
     // Make equivocation through timestamp
     let timestamp = byzantine_block_b13_1.timestamp_ms();
@@ -641,7 +641,7 @@ async fn test_byzantine_validator() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_b13_2.clone());
+        .accept_block_header(byzantine_block_b13_2.clone(), BlockHeaderSource::Test);
 
     let byzantine_block_b13_3 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 1)
@@ -651,7 +651,7 @@ async fn test_byzantine_validator() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_b13_3.clone());
+        .accept_block_header(byzantine_block_b13_3.clone(), BlockHeaderSource::Test);
 
     // Ancestors of decision blocks in round 14 should include multiple byzantine
     // non-votes B13 but there are enough good votes to prevent a skip.
@@ -666,7 +666,7 @@ async fn test_byzantine_validator() {
     references_round_14.push(decision_block_a14.reference());
     dag_state
         .write()
-        .accept_block_header(decision_block_a14.clone());
+        .accept_block_header(decision_block_a14.clone(), BlockHeaderSource::Test);
 
     let good_references_voting_round_wave_4_without_b13 = good_references_voting_round_wave_4
         .into_iter()
@@ -687,7 +687,7 @@ async fn test_byzantine_validator() {
     references_round_14.push(decision_block_b14.reference());
     dag_state
         .write()
-        .accept_block_header(decision_block_b14.clone());
+        .accept_block_header(decision_block_b14.clone(), BlockHeaderSource::Test);
 
     let decision_block_c14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 2)
@@ -703,7 +703,7 @@ async fn test_byzantine_validator() {
     references_round_14.push(decision_block_c14.reference());
     dag_state
         .write()
-        .accept_block_header(decision_block_c14.clone());
+        .accept_block_header(decision_block_c14.clone(), BlockHeaderSource::Test);
 
     let decision_block_d14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 3)
@@ -719,7 +719,7 @@ async fn test_byzantine_validator() {
     references_round_14.push(decision_block_d14.reference());
     dag_state
         .write()
-        .accept_block_header(decision_block_d14.clone());
+        .accept_block_header(decision_block_d14.clone(), BlockHeaderSource::Test);
 
     // DagState Update:
     // - We have A13, B13, D13 & C13 as good votes in the voting round of leader A12

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -13,7 +13,7 @@ use crate::{
     block_manager::{BlockManager, block_suspender::tests::evaluate_block_headers},
     commit::DecidedLeader,
     context::Context,
-    dag_state::DagState,
+    dag_state::{BlockHeaderSource, DagState},
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
     storage::mem_store::MemStore,
     test_dag::create_random_dag,
@@ -127,7 +127,7 @@ async fn test_randomized_dag_and_decision_sequence() {
             seen_so_far.extend(chunk.iter().cloned());
             let _ = authority_1
                 .block_manager
-                .try_accept_block_headers(chunk.to_vec());
+                .try_accept_block_headers(chunk.to_vec(), BlockHeaderSource::Test);
             let sequence = authority_1.committer.try_decide(last_decided);
 
             if !sequence.is_empty() {
@@ -170,7 +170,7 @@ async fn test_randomized_dag_and_decision_sequence() {
 
             let _ = authority_2
                 .block_manager
-                .try_accept_block_headers(chunk.to_vec());
+                .try_accept_block_headers(chunk.to_vec(), BlockHeaderSource::Test);
             let sequence = authority_2.committer.try_decide(last_decided);
 
             if !sequence.is_empty() {

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -12,7 +12,7 @@ use crate::{
     block_header::{BlockHeaderAPI, Slot, TestBlockHeader, VerifiedBlockHeader},
     commit::{DecidedLeader, WaveNumber},
     context::Context,
-    dag_state::DagState,
+    dag_state::{BlockHeaderSource, DagState},
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
     storage::mem_store::MemStore,
     test_dag::build_dag,
@@ -622,7 +622,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_c13_1.clone());
+        .accept_block_header(byzantine_block_c13_1.clone(), BlockHeaderSource::Test);
 
     let byzantine_block_c13_2 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
@@ -631,7 +631,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_c13_2.clone());
+        .accept_block_header(byzantine_block_c13_2.clone(), BlockHeaderSource::Test);
 
     let byzantine_block_c13_3 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
@@ -640,7 +640,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_c13_3.clone());
+        .accept_block_header(byzantine_block_c13_3.clone(), BlockHeaderSource::Test);
 
     // Ancestors of certifying blocks in round 14 should include multiple byzantine
     // non-votes C13 but there are enough good votes to prevent a skip.
@@ -653,7 +653,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(certifying_block_a14.clone());
+        .accept_block_header(certifying_block_a14.clone(), BlockHeaderSource::Test);
 
     let good_references_voting_round_for_round_12_without_c13 =
         good_references_voting_round_for_round_12
@@ -674,7 +674,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(certifying_block_b14.clone());
+        .accept_block_header(certifying_block_b14.clone(), BlockHeaderSource::Test);
 
     let certifying_block_c14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 2)
@@ -689,7 +689,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(certifying_block_c14.clone());
+        .accept_block_header(certifying_block_c14.clone(), BlockHeaderSource::Test);
 
     let certifying_block_d14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 3)
@@ -704,7 +704,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(certifying_block_d14.clone());
+        .accept_block_header(certifying_block_d14.clone(), BlockHeaderSource::Test);
 
     // DagState Update:
     // - We have A13, B13, D13 & C13 as good votes in the voting round for round-12

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1153,7 +1153,7 @@ mod tests {
         context::Context,
         core::ReasonToCreateBlock,
         core_thread::CoreError,
-        dag_state::DagState,
+        dag_state::{BlockHeaderSource, DagState},
         network::{BlockBundleStream, NetworkClient, SerializedTransactions},
         storage::mem_store::MemStore,
     };
@@ -1227,7 +1227,9 @@ mod tests {
                 .await;
         }
 
-        dag_state.write().accept_block_headers(block_headers);
+        dag_state
+            .write()
+            .accept_block_headers(block_headers, BlockHeaderSource::Test);
 
         // WHEN
         // Request the transactions
@@ -1330,7 +1332,9 @@ mod tests {
         // Delay fetch transactions response to simulate saturation deterministically.
 
         // Add block headers to the dag state
-        dag_state.write().accept_block_headers(block_headers);
+        dag_state
+            .write()
+            .accept_block_headers(block_headers, BlockHeaderSource::Test);
 
         // WHEN
         // Send many requests to saturate the tasks
@@ -1455,7 +1459,9 @@ mod tests {
             .await;
 
         // Add block headers to the dag state
-        dag_state.write().accept_block_headers(block_headers);
+        dag_state
+            .write()
+            .accept_block_headers(block_headers, BlockHeaderSource::Test);
 
         // WHEN
         // Request the transactions
@@ -1572,7 +1578,9 @@ mod tests {
         }
 
         // Add block headers to the dag state
-        dag_state.write().accept_block_headers(block_headers);
+        dag_state
+            .write()
+            .accept_block_headers(block_headers, BlockHeaderSource::Test);
 
         // WHEN
         // Request the transactions
@@ -1682,7 +1690,9 @@ mod tests {
             .await;
 
         // Add block headers to the dag state
-        dag_state.write().accept_block_headers(block_headers);
+        dag_state
+            .write()
+            .accept_block_headers(block_headers, BlockHeaderSource::Test);
 
         // WHEN
         // Request the transactions
@@ -1792,7 +1802,9 @@ mod tests {
             .await;
 
         // Add block headers to the dag state
-        dag_state.write().accept_block_headers(block_headers);
+        dag_state
+            .write()
+            .accept_block_headers(block_headers, BlockHeaderSource::Test);
 
         // WHEN
         // Request the transactions
@@ -1898,7 +1910,9 @@ mod tests {
             .await;
 
         // Add block headers to the dag state
-        dag_state.write().accept_block_headers(block_headers);
+        dag_state
+            .write()
+            .accept_block_headers(block_headers, BlockHeaderSource::Test);
 
         // WHEN
         // Request the transactions
@@ -2177,6 +2191,7 @@ mod tests {
         async fn add_block_headers(
             &self,
             _block_headers: Vec<VerifiedBlockHeader>,
+            _source: BlockHeaderSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,


### PR DESCRIPTION
# Description of change

This PR fixes a problem of potentially growing RAM in the unbounded cordial knowledge channel, when performing commit syncing. The fix is two-fold:
 1. We add a source for block headers (for full blocks in streaming, block headers in bundles in streaming, header synchronizer and commit syncer). When the source is commit syncer, we don't update the cordial knowledge with such messages. Such messages are anyway outdated and will not improve cordial dissemination.
 2. We change the unbounded channel to bounded (with capacity 10_000) and use optimistic try_send. This is fine since the cordial knowledge can tolerate skips of block headers and will not panic. This in turn forces us to add a watcher channel for eviction for which we can't so simply skip messages (o/w this could lead to the unlimited grow of connection knowledge structures). 

As a benefit of this small refactor, we can now observe in metrics the number of headers contributed through each of the potential sources.


## Links to any relevant issues

Fixes #9911 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] I have added tests that prove my fix is effective or that my feature works: The fix was validated on the local deployment.
- [x] I have checked that new and existing unit tests pass locally with my changes

