### PR TITLE
feat(indexer): Reorganize "watermarks" table columns for clarity

### DIFF
--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -413,7 +413,7 @@ impl ExecutorCluster {
                     .get_latest_object_snapshot_watermark()
                     .await
                     .unwrap()
-                    .map(|watermark| watermark.checkpoint_hi_inclusive)
+                    .map(|watermark| watermark.max_committed_cp)
                     .unwrap_or_default();
             }
         })

--- a/crates/iota-indexer/migrations/pg/2026-01-26-095900_rename_watermarks_columns/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-01-26-095900_rename_watermarks_columns/down.sql
@@ -1,0 +1,49 @@
+-- Add reader_lo column back as nullable first
+ALTER TABLE watermarks
+ADD COLUMN reader_lo BIGINT;
+
+-- Populate reader_lo based on the entity type
+-- For checkpoint-based tables (objects_history, checkpoints, pruner_cp_watermark), use min_available_cp
+-- For transaction-based tables (transactions, events, and all others), use min_available_tx
+UPDATE watermarks
+SET reader_lo = CASE
+    WHEN entity IN ('objects_history', 'checkpoints', 'pruner_cp_watermark') THEN min_available_cp
+    ELSE min_available_tx
+END;
+
+-- Make reader_lo NOT NULL after populating
+ALTER TABLE watermarks
+ALTER COLUMN reader_lo SET NOT NULL;
+
+-- Rename min_bounds_updated_at_timestamp_ms back to timestamp_ms
+ALTER TABLE watermarks
+RENAME COLUMN min_bounds_updated_at_timestamp_ms TO timestamp_ms;
+
+-- Rename lowest_unpruned_key back to pruner_hi
+ALTER TABLE watermarks
+RENAME COLUMN lowest_unpruned_key TO pruner_hi;
+
+-- Rename min_available_epoch back to epoch_lo
+ALTER TABLE watermarks
+RENAME COLUMN min_available_epoch TO epoch_lo;
+
+-- Update max_committed_tx back to exclusive by adding 1 (was inclusive)
+UPDATE watermarks
+SET max_committed_tx = max_committed_tx + 1;
+
+-- Rename max_committed_tx back to tx_hi
+ALTER TABLE watermarks
+RENAME COLUMN max_committed_tx TO tx_hi;
+
+-- Rename max_committed_cp back to checkpoint_hi_inclusive
+ALTER TABLE watermarks
+RENAME COLUMN max_committed_cp TO checkpoint_hi_inclusive;
+
+-- Rename current_epoch back to epoch_hi_inclusive
+ALTER TABLE watermarks
+RENAME COLUMN current_epoch TO epoch_hi_inclusive;
+
+-- Remove min_available_tx and min_available_cp columns from watermarks table
+ALTER TABLE watermarks
+DROP COLUMN IF EXISTS min_available_tx,
+DROP COLUMN IF EXISTS min_available_cp;

--- a/crates/iota-indexer/migrations/pg/2026-01-26-095900_rename_watermarks_columns/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-01-26-095900_rename_watermarks_columns/up.sql
@@ -1,0 +1,60 @@
+-- Add min_available_tx and min_available_cp columns to watermarks table
+ALTER TABLE watermarks
+ADD COLUMN min_available_tx BIGINT,
+ADD COLUMN min_available_cp BIGINT;
+
+-- Populate initial values for min_available_tx and min_available_cp based on epoch_lo
+-- For each watermark entry, find the corresponding epoch and use its first_checkpoint_id
+-- and first_tx_sequence_number
+UPDATE watermarks w
+SET
+    min_available_cp = COALESCE(e.first_checkpoint_id, 0),
+    min_available_tx = COALESCE(e.first_tx_sequence_number, 0)
+FROM epochs e
+WHERE e.epoch = w.epoch_lo;
+
+-- For watermarks where epoch_lo doesn't exist in epochs table (shouldn't happen in normal operation),
+-- set to 0 as a safe default
+UPDATE watermarks
+SET
+    min_available_cp = COALESCE(min_available_cp, 0),
+    min_available_tx = COALESCE(min_available_tx, 0)
+WHERE min_available_cp IS NULL OR min_available_tx IS NULL;
+
+-- Make columns NOT NULL after populating them
+ALTER TABLE watermarks
+ALTER COLUMN min_available_tx SET NOT NULL,
+ALTER COLUMN min_available_cp SET NOT NULL;
+
+-- Drop reader_lo column as it's replaced by min_available_tx and min_available_cp
+ALTER TABLE watermarks
+DROP COLUMN reader_lo;
+
+-- Rename epoch_hi_inclusive to current_epoch for clarity
+ALTER TABLE watermarks
+RENAME COLUMN epoch_hi_inclusive TO current_epoch;
+
+-- Rename checkpoint_hi_inclusive to max_committed_cp for clarity
+ALTER TABLE watermarks
+RENAME COLUMN checkpoint_hi_inclusive TO max_committed_cp;
+
+-- Rename tx_hi to max_committed_tx and change from exclusive to inclusive
+ALTER TABLE watermarks
+RENAME COLUMN tx_hi TO max_committed_tx;
+
+-- Update max_committed_tx to be inclusive by subtracting 1 (was exclusive upper bound)
+UPDATE watermarks
+SET max_committed_tx = max_committed_tx - 1
+WHERE max_committed_tx > 0;
+
+-- Rename epoch_lo to min_available_epoch for clarity
+ALTER TABLE watermarks
+RENAME COLUMN epoch_lo TO min_available_epoch;
+
+-- Rename pruner_hi to lowest_unpruned_key for clarity
+ALTER TABLE watermarks
+RENAME COLUMN pruner_hi TO lowest_unpruned_key;
+
+-- Rename timestamp_ms to min_bounds_updated_at_timestamp_ms for clarity
+ALTER TABLE watermarks
+RENAME COLUMN timestamp_ms TO min_bounds_updated_at_timestamp_ms;

--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -114,8 +114,7 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
                             return Ok(());
                         }
                         for (watermark, data) in tuple_chunk {
-                            unprocessed
-                                .insert(watermark.checkpoint_hi_inclusive, (watermark, data));
+                            unprocessed.insert(watermark.max_committed_cp, (watermark, data));
                         }
                     }
                     Some(None) => break, // Stream has ended
@@ -166,31 +165,34 @@ pub trait Writer<T: Send + Sync + 'static>: Send + Sync {
 /// units will be used for a particular table.
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub struct CommitterWatermark {
-    /// Highest epoch written for given table. Doesn't mean that data for the
+    /// Current epoch for given table. Doesn't mean that data for the
     /// whole epoch is persisted as it still may be in progress.
-    pub epoch_hi_inclusive: u64,
-    /// Highest checkpoint for which all data is already written for given
-    /// table.
-    pub checkpoint_hi_inclusive: u64,
-    /// Exclusive upper transaction sequence number bound for this table's
-    /// data.
-    pub tx_hi: u64,
+    pub current_epoch: u64,
+    /// Maximum committed checkpoint for which all data is already written for
+    /// given table.
+    pub max_committed_cp: u64,
+    /// Maximum committed transaction sequence number for this table's data.
+    /// This is inclusive.
+    pub max_committed_tx: u64,
 }
 impl From<&IndexedCheckpoint> for CommitterWatermark {
     fn from(checkpoint: &IndexedCheckpoint) -> Self {
         Self {
-            epoch_hi_inclusive: checkpoint.epoch,
-            checkpoint_hi_inclusive: checkpoint.sequence_number,
-            tx_hi: checkpoint.network_total_transactions,
+            current_epoch: checkpoint.epoch,
+            max_committed_cp: checkpoint.sequence_number,
+            max_committed_tx: checkpoint.network_total_transactions.saturating_sub(1),
         }
     }
 }
 impl From<&CheckpointData> for CommitterWatermark {
     fn from(checkpoint: &CheckpointData) -> Self {
         Self {
-            epoch_hi_inclusive: checkpoint.checkpoint_summary.epoch,
-            checkpoint_hi_inclusive: checkpoint.checkpoint_summary.sequence_number,
-            tx_hi: checkpoint.checkpoint_summary.network_total_transactions,
+            current_epoch: checkpoint.checkpoint_summary.epoch,
+            max_committed_cp: checkpoint.checkpoint_summary.sequence_number,
+            max_committed_tx: checkpoint
+                .checkpoint_summary
+                .network_total_transactions
+                .saturating_sub(1),
         }
     }
 }

--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -264,12 +264,12 @@ impl PrimaryWriter {
             elapsed,
             "Checkpoint {}-{} committed with {} transactions.",
             first_checkpoint_seq,
-            committer_watermark.checkpoint_hi_inclusive,
+            committer_watermark.max_committed_cp,
             tx_count,
         );
         self.metrics
             .latest_tx_checkpoint_sequence_number
-            .set(committer_watermark.checkpoint_hi_inclusive as i64);
+            .set(committer_watermark.max_committed_cp as i64);
         self.metrics
             .total_tx_checkpoint_committed
             .inc_by(checkpoint_num as u64);
@@ -278,7 +278,7 @@ impl PrimaryWriter {
             .inc_by(tx_count as u64);
         self.metrics.transaction_per_checkpoint.observe(
             tx_count as f64
-                / (committer_watermark.checkpoint_hi_inclusive - first_checkpoint_seq + 1) as f64,
+                / (committer_watermark.max_committed_cp - first_checkpoint_seq + 1) as f64,
         );
         // 1000.0 is not necessarily the batch size, it's to roughly map average tx
         // commit latency to [0.1, 1] seconds, which is well covered by

--- a/crates/iota-indexer/src/ingestion/snapshot/persist.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/persist.rs
@@ -65,7 +65,7 @@ impl Writer<TransactionObjectChangesToCommit> for ObjectSnapshotWriter {
             .await?;
         self.metrics
             .latest_object_snapshot_sequence_number
-            .set(watermark.checkpoint_hi_inclusive as i64);
+            .set(watermark.max_committed_cp as i64);
         Ok(())
     }
 

--- a/crates/iota-indexer/src/models/watermarks.rs
+++ b/crates/iota-indexer/src/models/watermarks.rs
@@ -19,53 +19,59 @@ pub struct StoredWatermark {
     /// The table governed by this watermark, i.e `epochs`, `checkpoints`,
     /// `transactions`.
     pub entity: String,
-    /// Inclusive upper epoch bound for this entity's data. Committer updates
-    /// this field. Pruner uses this to determine if pruning is necessary
-    /// based on the retention policy.
-    pub epoch_hi_inclusive: i64,
-    /// Inclusive upper checkpoint bound for this entity's data. Committer
+    /// Current epoch for this entity's data. Committer updates this field.
+    /// Pruner uses this to determine if pruning is necessary based on the
+    /// retention policy.
+    pub current_epoch: i64,
+    /// Maximum committed checkpoint for this entity's data. Committer
     /// updates this field. All data of this entity in the checkpoint must
     /// be persisted before advancing this watermark. The committer refers
     /// to this on disaster recovery to resume writing.
-    pub checkpoint_hi_inclusive: i64,
-    /// Exclusive upper transaction sequence number bound for this entity's
-    /// data. Committer updates this field.
-    pub tx_hi: i64,
-    /// Inclusive lower epoch bound for this entity's data. Pruner updates this
+    pub max_committed_cp: i64,
+    /// Maximum committed transaction sequence number for this entity's data.
+    /// Committer updates this field. This is inclusive.
+    pub max_committed_tx: i64,
+    /// Minimum available epoch for this entity's data. Pruner updates this
     /// field when the epoch range exceeds the retention policy.
-    pub epoch_lo: i64,
-    /// Inclusive low watermark that the pruner advances. Corresponds to the
-    /// epoch id, checkpoint sequence number, or tx sequence number
-    /// depending on the entity. Data before this watermark is considered
-    /// pruned by a reader. The underlying data may still exist in the db
-    /// instance.
-    pub reader_lo: i64,
-    /// Updated using the database's current timestamp when the pruner sees that
-    /// some data needs to be dropped. The pruner uses this column to
-    /// determine whether to prune or wait long enough that all in-flight
-    /// reads complete or timeout before it acts on an updated watermark.
-    pub timestamp_ms: i64,
-    /// Column used by the pruner to track its true progress. Data below this
-    /// watermark can be immediately pruned.
-    pub pruner_hi: i64,
+    pub min_available_epoch: i64,
+    /// Timestamp in milliseconds of the last update to the min_available_*
+    /// columns. The pruner uses this to determine whether to prune or wait
+    /// long enough that all in-flight reads complete or timeout before it
+    /// acts on an updated watermark.
+    pub min_bounds_updated_at_timestamp_ms: i64,
+    /// Lowest key (epoch, checkpoint, or tx) that has not been pruned yet.
+    /// The pruner uses this to track its progress.
+    pub lowest_unpruned_key: i64,
+    /// Minimum available transaction sequence number for this entity's data.
+    /// Pruner updates this field based on min_available_epoch.
+    pub min_available_tx: i64,
+    /// Minimum available checkpoint sequence number for this entity's data.
+    /// Pruner updates this field based on min_available_epoch.
+    pub min_available_cp: i64,
 }
 
 impl StoredWatermark {
     pub fn from_upper_bound_update(entity: &str, watermark: CommitterWatermark) -> Self {
         StoredWatermark {
             entity: entity.to_string(),
-            epoch_hi_inclusive: watermark.epoch_hi_inclusive as i64,
-            checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive as i64,
-            tx_hi: watermark.tx_hi as i64,
+            current_epoch: watermark.current_epoch as i64,
+            max_committed_cp: watermark.max_committed_cp as i64,
+            max_committed_tx: watermark.max_committed_tx as i64,
             ..StoredWatermark::default()
         }
     }
 
-    pub fn from_lower_bound_update(entity: &str, epoch_lo: u64, reader_lo: u64) -> Self {
+    pub fn from_lower_bound_update(
+        entity: &str,
+        min_available_epoch: u64,
+        min_available_cp: u64,
+        min_available_tx: u64,
+    ) -> Self {
         StoredWatermark {
             entity: entity.to_string(),
-            epoch_lo: epoch_lo as i64,
-            reader_lo: reader_lo as i64,
+            min_available_epoch: min_available_epoch as i64,
+            min_available_cp: min_available_cp as i64,
+            min_available_tx: min_available_tx as i64,
             ..StoredWatermark::default()
         }
     }
@@ -74,11 +80,11 @@ impl StoredWatermark {
         PrunableTable::from_str(&self.entity).ok()
     }
 
-    /// Determine whether to set a new epoch lower bound based on the retention
-    /// policy.
-    pub fn new_epoch_lo(&self, retention: u64) -> Option<u64> {
-        if self.epoch_lo as u64 + retention <= self.epoch_hi_inclusive as u64 {
-            Some((self.epoch_hi_inclusive as u64).saturating_sub(retention - 1))
+    /// Determine whether to set a new minimum available epoch based on the
+    /// retention policy.
+    pub fn new_min_available_epoch(&self, retention: u64) -> Option<u64> {
+        if self.min_available_epoch as u64 + retention <= self.current_epoch as u64 {
+            Some((self.current_epoch as u64).saturating_sub(retention - 1))
         } else {
             None
         }

--- a/crates/iota-indexer/src/pruning/pruner.rs
+++ b/crates/iota-indexer/src/pruning/pruner.rs
@@ -132,34 +132,6 @@ impl PruningChunk {
 }
 
 impl PrunableTable {
-    pub fn select_reader_lo(&self, cp: u64, tx: u64) -> u64 {
-        match self {
-            PrunableTable::ObjectsHistory
-            | PrunableTable::Checkpoints
-            | PrunableTable::PrunerCpWatermark => cp,
-
-            PrunableTable::Transactions
-            | PrunableTable::Events
-            | PrunableTable::EventEmitPackage
-            | PrunableTable::EventEmitModule
-            | PrunableTable::EventSenders
-            | PrunableTable::EventStructInstantiation
-            | PrunableTable::EventStructModule
-            | PrunableTable::EventStructName
-            | PrunableTable::EventStructPackage
-            | PrunableTable::TxCallsPkg
-            | PrunableTable::TxCallsMod
-            | PrunableTable::TxCallsFun
-            | PrunableTable::TxChangedObjects
-            | PrunableTable::TxDigests
-            | PrunableTable::TxInputObjects
-            | PrunableTable::TxKinds
-            | PrunableTable::TxRecipients
-            | PrunableTable::TxSenders
-            | PrunableTable::TxWrappedOrDeletedObjects => tx,
-        }
-    }
-
     /// Returns the pruning strategy for this table
     pub fn pruning_strategy(&self) -> PruningStrategy {
         match self {
@@ -273,7 +245,8 @@ impl<'a> TablePruner<'a> {
             }
         };
         // Wait for in-flight reads to timeout before pruning
-        self.wait_for_pruning_delay(watermark.timestamp_ms).await?;
+        self.wait_for_pruning_delay(watermark.min_bounds_updated_at_timestamp_ms)
+            .await?;
 
         let pruning_chunks = self.create_pruning_chunks(&watermark);
 
@@ -292,15 +265,15 @@ impl<'a> TablePruner<'a> {
                 break;
             }
 
-            // Update pruner_hi to the next chunk to prune
+            // Update lowest_unpruned_key to the next chunk to prune
             let next_chunk_start = pruning_chunk.next_chunk_start();
             if let Err(err) = self
                 .store
-                .update_watermark_pruner_hi(&self.table, next_chunk_start)
+                .update_watermark_lowest_unpruned_key(&self.table, next_chunk_start)
                 .await
             {
                 error!(
-                    "failed to update pruner_hi for table {} to next chunk {}: {err}",
+                    "failed to update lowest_unpruned_key for table {} to next chunk {}: {err}",
                     self.table.as_ref(),
                     next_chunk_start
                 );
@@ -310,7 +283,9 @@ impl<'a> TablePruner<'a> {
             tokio::time::sleep(DELAY_BETWEEN_PRUNING_CHUNKS).await;
         }
 
-        self.metrics.last_pruned_epoch.set(watermark.epoch_lo - 1);
+        self.metrics
+            .last_pruned_epoch
+            .set(watermark.min_available_epoch - 1);
 
         Ok(())
     }
@@ -321,35 +296,36 @@ impl<'a> TablePruner<'a> {
         &self,
         watermark: &crate::models::watermarks::StoredWatermark,
     ) -> Box<dyn Iterator<Item = PruningChunk> + Send> {
-        let epoch_lo = watermark.epoch_lo as u64;
-        let pruner_hi = watermark.pruner_hi as u64;
-        let reader_lo = watermark.reader_lo as u64;
+        let min_available_epoch = watermark.min_available_epoch as u64;
+        let lowest_unpruned_key = watermark.lowest_unpruned_key as u64;
+        let min_available_cp = watermark.min_available_cp as u64;
+        let min_available_tx = watermark.min_available_tx as u64;
 
         match self.table.pruning_strategy() {
             PruningStrategy::ByEpochPartition => {
-                let range_end = epoch_lo;
+                let range_end = min_available_epoch;
                 info!(
-                    "pruning table {} in epoch range: [{pruner_hi}..{range_end})",
+                    "pruning table {} in epoch range: [{lowest_unpruned_key}..{range_end})",
                     self.table.as_ref()
                 );
-                Box::new((pruner_hi..range_end).map(PruningChunk::Epoch))
+                Box::new((lowest_unpruned_key..range_end).map(PruningChunk::Epoch))
             }
             PruningStrategy::ByCheckpoint => {
-                let range_end = reader_lo;
+                let range_end = min_available_cp;
                 info!(
-                    "pruning table {} in checkpoint range: [{pruner_hi}..{range_end})",
+                    "pruning table {} in checkpoint range: [{lowest_unpruned_key}..{range_end})",
                     self.table.as_ref()
                 );
-                Box::new((pruner_hi..range_end).map(PruningChunk::Checkpoint))
+                Box::new((lowest_unpruned_key..range_end).map(PruningChunk::Checkpoint))
             }
             PruningStrategy::ByTransaction => {
-                let range_end = reader_lo;
+                let range_end = min_available_tx;
                 info!(
-                    "pruning table {} in transaction range: [{pruner_hi}..{range_end})",
+                    "pruning table {} in transaction range: [{lowest_unpruned_key}..{range_end})",
                     self.table.as_ref()
                 );
                 Box::new(
-                    (pruner_hi..range_end)
+                    (lowest_unpruned_key..range_end)
                         .step_by(MAX_TRANSACTIONS_PER_PRUNE_BATCH as usize)
                         .map(move |start| {
                             let end = (start + MAX_TRANSACTIONS_PER_PRUNE_BATCH).min(range_end);
@@ -528,8 +504,9 @@ async fn update_watermarks_lower_bounds_task(
     }
 }
 
-/// Fetches all entries from the `watermarks` table, and updates the `reader_lo`
-/// for each entry if its epoch range exceeds the respective retention policy.
+/// Fetches all entries from the `watermarks` table, and updates the
+/// `min_available_*` columns for each entry if its epoch range exceeds the
+/// respective retention policy.
 async fn update_watermarks_lower_bounds(
     store: &PgIndexerStore,
     retention_policies: &HashMap<PrunableTable, u64>,
@@ -551,8 +528,8 @@ async fn update_watermarks_lower_bounds(
             error!("no retention policy found for prunable table {prunable_table}");
             continue;
         };
-        if let Some(new_epoch_lo) = watermark.new_epoch_lo(*epochs_to_keep) {
-            lower_bound_updates.push((prunable_table, new_epoch_lo));
+        if let Some(new_min_available_epoch) = watermark.new_min_available_epoch(*epochs_to_keep) {
+            lower_bound_updates.push((prunable_table, new_min_available_epoch));
         };
     }
     if !lower_bound_updates.is_empty() {

--- a/crates/iota-indexer/src/pruning/watermark_task.rs
+++ b/crates/iota-indexer/src/pruning/watermark_task.rs
@@ -144,19 +144,21 @@ mod tests {
 
         let watermark = StoredWatermark {
             entity: CommitterTables::Transactions.as_ref().to_string(),
-            epoch_hi_inclusive: 100,
-            checkpoint_hi_inclusive: 1000,
-            tx_hi: 10000,
-            epoch_lo: 50,
-            reader_lo: 500,
-            timestamp_ms: 123456789,
-            pruner_hi: 400,
+            current_epoch: 100,
+            max_committed_cp: 1000,
+            max_committed_tx: 10000,
+            min_available_epoch: 50,
+            min_bounds_updated_at_timestamp_ms: 123456789,
+            lowest_unpruned_key: 400,
+            min_available_tx: 5000,
+            min_available_cp: 500,
         };
 
         cache.update(vec![watermark.clone()]);
 
         let retrieved = cache.get(CommitterTables::Transactions).unwrap();
-        assert_eq!(retrieved.reader_lo, 500);
-        assert_eq!(retrieved.epoch_lo, 50);
+        assert_eq!(retrieved.min_available_cp, 500);
+        assert_eq!(retrieved.min_available_tx, 5000);
+        assert_eq!(retrieved.min_available_epoch, 50);
     }
 }

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -444,13 +444,14 @@ diesel::table! {
 diesel::table! {
     watermarks (entity) {
         entity -> Text,
-        epoch_hi_inclusive -> Int8,
-        checkpoint_hi_inclusive -> Int8,
-        tx_hi -> Int8,
-        epoch_lo -> Int8,
-        reader_lo -> Int8,
-        timestamp_ms -> Int8,
-        pruner_hi -> Int8,
+        current_epoch -> Int8,
+        max_committed_cp -> Int8,
+        max_committed_tx -> Int8,
+        min_available_epoch -> Int8,
+        min_bounds_updated_at_timestamp_ms -> Int8,
+        lowest_unpruned_key -> Int8,
+        min_available_tx -> Int8,
+        min_available_cp -> Int8,
     }
 }
 

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -168,10 +168,10 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         max_tx: u64,
     ) -> Result<(), IndexerError>;
 
-    async fn update_watermark_pruner_hi(
+    async fn update_watermark_lowest_unpruned_key(
         &self,
         table: &PrunableTable,
-        pruner_hi: u64,
+        lowest_unpruned_key: u64,
     ) -> Result<(), IndexerError>;
 
     async fn get_watermark_by_entity(

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -359,9 +359,9 @@ impl PgIndexerStore {
         read_only_blocking!(&self.blocking_cp, |conn| {
             watermarks::table
                 .select((
-                    watermarks::epoch_hi_inclusive,
-                    watermarks::checkpoint_hi_inclusive,
-                    watermarks::tx_hi,
+                    watermarks::current_epoch,
+                    watermarks::max_committed_cp,
+                    watermarks::max_committed_tx,
                 ))
                 .filter(
                     watermarks::entity
@@ -372,9 +372,9 @@ impl PgIndexerStore {
                 .optional()
                 .map(|v| {
                     v.map(|(epoch, cp, tx)| CommitterWatermark {
-                        epoch_hi_inclusive: epoch as u64,
-                        checkpoint_hi_inclusive: cp as u64,
-                        tx_hi: tx as u64,
+                        current_epoch: epoch as u64,
+                        max_committed_cp: cp as u64,
+                        max_committed_tx: tx as u64,
                     })
                 })
         })
@@ -1629,10 +1629,9 @@ impl PgIndexerStore {
                     .on_conflict(watermarks::entity)
                     .do_update()
                     .set((
-                        watermarks::epoch_hi_inclusive.eq(excluded(watermarks::epoch_hi_inclusive)),
-                        watermarks::checkpoint_hi_inclusive
-                            .eq(excluded(watermarks::checkpoint_hi_inclusive)),
-                        watermarks::tx_hi.eq(excluded(watermarks::tx_hi)),
+                        watermarks::current_epoch.eq(excluded(watermarks::current_epoch)),
+                        watermarks::max_committed_cp.eq(excluded(watermarks::max_committed_cp)),
+                        watermarks::max_committed_tx.eq(excluded(watermarks::max_committed_tx)),
                     ))
                     .execute(conn)
                     .map_err(IndexerError::from)
@@ -1692,7 +1691,8 @@ impl PgIndexerStore {
                 Ok(StoredWatermark::from_lower_bound_update(
                     table.as_ref(),
                     epoch,
-                    table.select_reader_lo(*checkpoint, *tx),
+                    *checkpoint,
+                    *tx,
                 ))
             })
             .collect();
@@ -1709,19 +1709,27 @@ impl PgIndexerStore {
                     .on_conflict(watermarks::entity)
                     .do_update()
                     .set((
-                        watermarks::reader_lo.eq(excluded(watermarks::reader_lo)),
-                        watermarks::epoch_lo.eq(excluded(watermarks::epoch_lo)),
-                        watermarks::timestamp_ms.eq(sql::<diesel::sql_types::BigInt>(
+                        watermarks::min_available_cp.eq(excluded(watermarks::min_available_cp)),
+                        watermarks::min_available_tx.eq(excluded(watermarks::min_available_tx)),
+                        watermarks::min_available_epoch
+                            .eq(excluded(watermarks::min_available_epoch)),
+                        watermarks::min_bounds_updated_at_timestamp_ms.eq(sql::<
+                            diesel::sql_types::BigInt,
+                        >(
                             "(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000)::bigint",
                         )),
                     ))
-                    .filter(excluded(watermarks::reader_lo).gt(watermarks::reader_lo))
-                    .filter(excluded(watermarks::epoch_lo).gt(watermarks::epoch_lo))
+                    .filter(excluded(watermarks::min_available_cp).gt(watermarks::min_available_cp))
+                    .filter(excluded(watermarks::min_available_tx).gt(watermarks::min_available_tx))
+                    .filter(
+                        excluded(watermarks::min_available_epoch)
+                            .gt(watermarks::min_available_epoch),
+                    )
                     .filter(
                         diesel::dsl::sql::<diesel::sql_types::BigInt>(
                             "(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000)::bigint",
                         )
-                        .gt(watermarks::timestamp_ms),
+                        .gt(watermarks::min_bounds_updated_at_timestamp_ms),
                     )
                     .execute(conn)
             },
@@ -1759,19 +1767,19 @@ impl PgIndexerStore {
         )
     }
 
-    fn update_watermark_pruner_hi(
+    fn update_watermark_lowest_unpruned_key(
         &self,
         table: &PrunableTable,
-        pruner_hi: u64,
+        lowest_unpruned_key: u64,
     ) -> Result<(), IndexerError> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
                 diesel::update(watermarks::table.filter(watermarks::entity.eq(table.as_ref())))
-                    .set(watermarks::pruner_hi.eq(pruner_hi as i64))
+                    .set(watermarks::lowest_unpruned_key.eq(lowest_unpruned_key as i64))
                     .execute(conn)
                     .map_err(IndexerError::from)
-                    .context("failed to update watermark pruner_hi")?;
+                    .context("failed to update watermark lowest_unpruned_key")?;
                 Ok::<(), IndexerError>(())
             },
             PG_DB_COMMIT_SLEEP_DURATION
@@ -2496,14 +2504,14 @@ impl IndexerStore for PgIndexerStore {
         .await
     }
 
-    async fn update_watermark_pruner_hi(
+    async fn update_watermark_lowest_unpruned_key(
         &self,
         table: &PrunableTable,
-        pruner_hi: u64,
+        lowest_unpruned_key: u64,
     ) -> Result<(), IndexerError> {
         let table = *table;
         self.execute_in_blocking_worker(move |this| {
-            this.update_watermark_pruner_hi(&table, pruner_hi)
+            this.update_watermark_lowest_unpruned_key(&table, lowest_unpruned_key)
         })
         .await
     }

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -499,7 +499,7 @@ pub async fn wait_for_objects_snapshot(
                 .get_latest_object_snapshot_watermark()
                 .await
                 .unwrap()
-                .map(|watermark| watermark.checkpoint_hi_inclusive);
+                .map(|watermark| watermark.max_committed_cp);
             cp_opt.is_none() || (cp_opt.unwrap() < checkpoint_sequence_number)
         } {
             tokio::time::sleep(Duration::from_millis(100)).await;


### PR DESCRIPTION
# Description of change

Reorganize "watermarks" table columns for clarity

Column Renames:
- `checkpoint_hi_inclusive` → `max_committed_cp`
- `tx_hi` → `max_committed_tx` (exclusive → inclusive, with adjustment)
- `epoch_hi_inclusive` → `current_epoch`
- `epoch_lo` → `min_available_epoch`
- `pruner_hi` → `lowest_unpruned_key`
- `timestamp_ms` → `min_bounds_updated_at_timestamp_ms`
- `reader_lo` → split into `min_available_cp` and `min_available_tx`

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9902

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
