### PR TITLE
refactor(starfish): unify source for transactions and headers

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -33,7 +33,7 @@ use crate::{
     context::Context,
     cordial_knowledge::CordialKnowledgeHandle,
     core_thread::CoreThreadDispatcher,
-    dag_state::{BlockHeaderSource, DagState},
+    dag_state::{DagState, DataSource},
     encoder::ShardEncoder,
     error::{ConsensusError, ConsensusResult},
     header_synchronizer::HeaderSynchronizerHandle,
@@ -562,7 +562,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .core_dispatcher
             .add_block_headers(
                 additional_block_headers.clone(),
-                BlockHeaderSource::BlockHeaderBundleStream,
+                DataSource::BlockBundleStream,
             )
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
@@ -576,7 +576,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // 10. Add the block to dag, add its missing ancestors to the set
         let (missing_block_ancestors, missing_block_committed_transactions) = self
             .core_dispatcher
-            .add_blocks(vec![verified_block])
+            .add_blocks(vec![verified_block], DataSource::BlockStreaming)
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
         self.context
@@ -1327,7 +1327,7 @@ mod tests {
         cordial_knowledge::{ConnectionKnowledgeMessage, CordialKnowledge},
         core::{Core, CoreSignals, ReasonToCreateBlock},
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
-        dag_state::{BlockHeaderSource, DagState, TransactionSource},
+        dag_state::{DagState, DataSource},
         encoder::create_encoder,
         error::{ConsensusError, ConsensusResult},
         header_synchronizer::HeaderSynchronizer,
@@ -1964,10 +1964,7 @@ mod tests {
 
         for round in 1..=rounds / 2 {
             core_dispatcher
-                .add_block_headers(
-                    all_block_headers[round as usize].clone(),
-                    BlockHeaderSource::Test,
-                )
+                .add_block_headers(all_block_headers[round as usize].clone(), DataSource::Test)
                 .await
                 .expect("block headers are expected to be added successfully");
         }
@@ -1990,7 +1987,7 @@ mod tests {
         for round in rounds / 2 + 1..=rounds {
             let headers = &all_block_headers[round as usize];
             core_dispatcher
-                .add_block_headers(headers[..2].to_vec(), BlockHeaderSource::Test)
+                .add_block_headers(headers[..2].to_vec(), DataSource::Test)
                 .await
                 .expect("block headers are expected to be added successfully");
         }
@@ -2010,7 +2007,7 @@ mod tests {
         for round in rounds / 2 + 1..=rounds {
             let headers = &all_block_headers[round as usize];
             core_dispatcher
-                .add_block_headers(headers[2..].to_vec(), BlockHeaderSource::Test)
+                .add_block_headers(headers[2..].to_vec(), DataSource::Test)
                 .await
                 .expect("block headers are expected to be added successfully");
         }
@@ -2033,6 +2030,7 @@ mod tests {
         async fn add_blocks(
             &self,
             blocks: Vec<VerifiedBlock>,
+            source: DataSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,
@@ -2046,14 +2044,14 @@ mod tests {
                 let entry = &mut vec[block.author()];
                 *entry = max(*entry, block.round());
             }
-            let _ = guard.add_blocks(blocks);
+            let _ = guard.add_blocks(blocks, source);
             Ok((BTreeSet::new(), BTreeMap::new()))
         }
 
         async fn add_block_headers(
             &self,
             block_headers: Vec<VerifiedBlockHeader>,
-            source: BlockHeaderSource,
+            source: DataSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,
@@ -2074,7 +2072,7 @@ mod tests {
         async fn add_transactions(
             &self,
             _transactions: Vec<VerifiedTransactions>,
-            _source: TransactionSource,
+            _source: DataSource,
         ) -> Result<(), CoreError> {
             unimplemented!("Unimplemented")
         }
@@ -2234,7 +2232,7 @@ mod tests {
             core_dispatcher
                 .add_block_headers(
                     vec![all_headers[round as usize][0].clone()],
-                    BlockHeaderSource::Test,
+                    DataSource::Test,
                 )
                 .await
                 .expect("blocks header is expected to be added successfully");
@@ -2392,7 +2390,7 @@ mod tests {
             core_dispatcher
                 .add_block_headers(
                     vec![all_headers[round as usize][0].clone()],
-                    BlockHeaderSource::Test,
+                    DataSource::Test,
                 )
                 .await
                 .expect("blocks header is expected to be added successfully");
@@ -2569,11 +2567,14 @@ mod tests {
         let first_batch_end_exclusive = 5;
         for round in 1..first_batch_end_exclusive {
             core_dispatcher
-                .add_blocks(all_blocks[round as usize - 1].clone())
+                .add_blocks(all_blocks[round as usize - 1].clone(), DataSource::Test)
                 .await
                 .expect("blocks are expected to be added successfully");
             core_dispatcher
-                .add_blocks(vec![all_blocks[round as usize][0].clone()])
+                .add_blocks(
+                    vec![all_blocks[round as usize][0].clone()],
+                    DataSource::Test,
+                )
                 .await
                 .expect("blocks are expected to be added successfully");
             sleep(Duration::from_millis(50)).await;
@@ -2681,11 +2682,14 @@ mod tests {
 
         for round in first_batch_end_exclusive..=rounds {
             core_dispatcher
-                .add_blocks(all_blocks[round as usize - 1].clone())
+                .add_blocks(all_blocks[round as usize - 1].clone(), DataSource::Test)
                 .await
                 .expect("blocks are expected to be added successfully");
             core_dispatcher
-                .add_blocks(vec![all_blocks[round as usize][0].clone()])
+                .add_blocks(
+                    vec![all_blocks[round as usize][0].clone()],
+                    DataSource::Test,
+                )
                 .await
                 .expect("blocks are expected to be added successfully");
             sleep(Duration::from_millis(50)).await;
@@ -3184,10 +3188,7 @@ mod tests {
 
         for round in 1..=rounds {
             core_dispatcher
-                .add_block_headers(
-                    all_block_headers[round as usize].clone(),
-                    BlockHeaderSource::Test,
-                )
+                .add_block_headers(all_block_headers[round as usize].clone(), DataSource::Test)
                 .await
                 .expect("block headers are expected to be added successfully");
         }
@@ -3218,7 +3219,7 @@ mod tests {
         }
         all_block_headers.push(new_block_headers.clone());
         core_dispatcher
-            .add_block_headers(new_block_headers.clone(), BlockHeaderSource::Test)
+            .add_block_headers(new_block_headers.clone(), DataSource::Test)
             .await
             .expect("block headers are expected to be added successfully");
 
@@ -3240,7 +3241,7 @@ mod tests {
             }
             all_block_headers.push(new_block_headers.clone());
             core_dispatcher
-                .add_block_headers(new_block_headers.clone(), BlockHeaderSource::Test)
+                .add_block_headers(new_block_headers.clone(), DataSource::Test)
                 .await
                 .expect("block headers are expected to be added successfully");
         }

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     },
     block_manager::block_suspender::BlockSuspender,
     context::Context,
-    dag_state::{BlockHeaderSource, DagState, TransactionSource},
+    dag_state::{DagState, DataSource},
 };
 
 /// Block manager suspends incoming blocks until they are connected to the
@@ -69,6 +69,7 @@ impl BlockManager {
     pub(crate) fn try_accept_blocks(
         &mut self,
         blocks: Vec<VerifiedBlock>,
+        source: DataSource,
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_blocks");
         let block_headers: Vec<_> = blocks
@@ -84,7 +85,7 @@ impl BlockManager {
         self.write_block_headers_and_transactions_to_dag_state(
             block_headers_to_accept.clone(),
             accepted_transactions,
-            BlockHeaderSource::BlockStreaming,
+            source,
         );
 
         (block_headers_to_accept, missing_block_headers)
@@ -100,7 +101,7 @@ impl BlockManager {
     pub(crate) fn try_accept_block_headers(
         &mut self,
         block_headers: Vec<VerifiedBlockHeader>,
-        source: BlockHeaderSource,
+        source: DataSource,
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_block_headers");
         // Headers are added through synchronizer, commit syncer and cordial
@@ -142,12 +143,12 @@ impl BlockManager {
         &self,
         block_headers: Vec<VerifiedBlockHeader>,
         transactions: Vec<VerifiedTransactions>,
-        source: BlockHeaderSource,
+        source: DataSource,
     ) {
         let mut write_guard = self.dag_state.write();
         write_guard.accept_block_headers(block_headers, source);
         for verified_transaction in transactions {
-            write_guard.add_transactions(verified_transaction, TransactionSource::BlockStreaming);
+            write_guard.add_transactions(verified_transaction, source);
         }
     }
 
@@ -374,7 +375,7 @@ mod tests {
         block_header::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader},
         block_manager::BlockManager,
         context::Context,
-        dag_state::{BlockHeaderSource, DagState},
+        dag_state::{DagState, DataSource},
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
     };
@@ -407,8 +408,8 @@ mod tests {
             .collect::<Vec<VerifiedBlockHeader>>();
 
         // WHEN
-        let (accepted_blocks, missing) = block_manager
-            .try_accept_block_headers(round_2_block_headers.clone(), BlockHeaderSource::Test);
+        let (accepted_blocks, missing) =
+            block_manager.try_accept_block_headers(round_2_block_headers.clone(), DataSource::Test);
 
         // THEN
         assert!(accepted_blocks.is_empty());
@@ -481,7 +482,7 @@ mod tests {
         {
             // WHEN
             let (accepted_blocks, missing) = block_manager
-                .try_accept_block_headers(vec![block_header.clone()], BlockHeaderSource::Test);
+                .try_accept_block_headers(vec![block_header.clone()], DataSource::Test);
 
             // THEN
             assert!(accepted_blocks.is_empty());
@@ -516,8 +517,8 @@ mod tests {
             .collect::<Vec<_>>();
 
         // WHEN
-        let (accepted_block_headers, missing) = block_manager
-            .try_accept_block_headers(all_block_headers.clone(), BlockHeaderSource::Test);
+        let (accepted_block_headers, missing) =
+            block_manager.try_accept_block_headers(all_block_headers.clone(), DataSource::Test);
 
         // THEN
         assert_eq!(accepted_block_headers.len(), 8);
@@ -535,7 +536,7 @@ mod tests {
         // WHEN trying to accept same block headers again, then none will be returned as
         // those have been already accepted
         let (accepted_block_headers, _) =
-            block_manager.try_accept_block_headers(all_block_headers, BlockHeaderSource::Test);
+            block_manager.try_accept_block_headers(all_block_headers, DataSource::Test);
         assert!(accepted_block_headers.is_empty());
     }
 
@@ -573,7 +574,7 @@ mod tests {
             let mut all_accepted_block_headers = vec![];
             for block_header in &all_block_headers {
                 let (accepted_block_headers, _) = block_manager
-                    .try_accept_block_headers(vec![block_header.clone()], BlockHeaderSource::Test);
+                    .try_accept_block_headers(vec![block_header.clone()], DataSource::Test);
 
                 all_accepted_block_headers.extend(accepted_block_headers);
             }
@@ -626,7 +627,7 @@ mod tests {
         let mut block_manager = BlockManager::new(context.clone(), dag_state);
 
         let (_, missing_blocks) = block_manager
-            .try_accept_block_headers(vec![blocks_round_2[0].clone()], BlockHeaderSource::Test);
+            .try_accept_block_headers(vec![blocks_round_2[0].clone()], DataSource::Test);
         // Blocks from round 1 are all missing, since the DAG is fully connected
         assert_eq!(missing_blocks, blocks_round_1);
 
@@ -658,8 +659,7 @@ mod tests {
 
         // Add a new block from round 2 from authority 1, which updates the set of
         // authorities that are aware of the missing blocks
-        block_manager
-            .try_accept_block_headers(vec![blocks_round_2[1].clone()], BlockHeaderSource::Test);
+        block_manager.try_accept_block_headers(vec![blocks_round_2[1].clone()], DataSource::Test);
         let missing_blocks_with_authorities = block_manager.blocks_to_fetch();
         assert_eq!(
             missing_blocks_with_authorities[&block_round_1_authority_0],
@@ -704,7 +704,7 @@ mod tests {
                 .filter(|block_header| block_header.round() > 1)
                 .cloned()
                 .collect(),
-            BlockHeaderSource::Test,
+            DataSource::Test,
         );
         // Missing refs should all come from round 1.
         assert!(accepted_block_headers.is_empty());
@@ -720,7 +720,7 @@ mod tests {
                 .filter(|block_header| block_header.round() == 1)
                 .cloned()
                 .collect(),
-            BlockHeaderSource::Test,
+            DataSource::Test,
         );
         // With median-based timestamp, all blocks should be accepted regardless of
         // timestamp violations.
@@ -775,8 +775,8 @@ mod tests {
 
         // Try to accept blocks which will cause blocks to be suspended and added to
         // missing in block manager.
-        let (accepted_blocks_headers, missing) = block_manager
-            .try_accept_block_headers(round_2_block_headers.clone(), BlockHeaderSource::Test);
+        let (accepted_blocks_headers, missing) =
+            block_manager.try_accept_block_headers(round_2_block_headers.clone(), DataSource::Test);
         assert!(accepted_blocks_headers.is_empty());
 
         let missing_block_refs = round_2_block_headers.first().unwrap().ancestors();

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -227,7 +227,7 @@ mod tests {
         block_header::{BlockRef, genesis_block_headers, genesis_blocks},
         commit::{CommitRef, PendingSubDag},
         context::Context,
-        dag_state::{BlockHeaderSource, DagState, TransactionSource},
+        dag_state::{DagState, DataSource},
         test_dag_builder::DagBuilder,
     };
 
@@ -284,14 +284,12 @@ mod tests {
             if included_rounds.contains(&0) {
                 let genesis_blocks = genesis_blocks(&self.context);
                 for (i, block) in genesis_blocks.iter().enumerate() {
-                    state.accept_block_header(
-                        block.verified_block_header.clone(),
-                        BlockHeaderSource::Test,
-                    );
+                    state
+                        .accept_block_header(block.verified_block_header.clone(), DataSource::Test);
                     if !excluded_transactions.contains(&(0, i)) {
                         state.add_transactions(
                             block.verified_transactions.clone(),
-                            TransactionSource::Test,
+                            DataSource::Test,
                         );
                     }
                 }
@@ -305,14 +303,12 @@ mod tests {
 
                 let blocks = self.dag_builder.blocks(round..=round);
                 for (i, block) in blocks.iter().enumerate() {
-                    state.accept_block_header(
-                        block.verified_block_header.clone(),
-                        BlockHeaderSource::Test,
-                    );
+                    state
+                        .accept_block_header(block.verified_block_header.clone(), DataSource::Test);
                     if !excluded_transactions.contains(&(round, i)) {
                         state.add_transactions(
                             block.verified_transactions.clone(),
-                            TransactionSource::Test,
+                            DataSource::Test,
                         );
                     }
                 }
@@ -347,7 +343,7 @@ mod tests {
                     if let Some(block) = genesis_blocks.get(block_index) {
                         state.add_transactions(
                             block.verified_transactions.clone(),
-                            TransactionSource::Test,
+                            DataSource::Test,
                         );
                     }
                 } else {
@@ -355,7 +351,7 @@ mod tests {
                     if let Some(block) = blocks.get(block_index) {
                         state.add_transactions(
                             block.verified_transactions.clone(),
-                            TransactionSource::Test,
+                            DataSource::Test,
                         );
                     }
                 }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -16,7 +16,7 @@ use tokio::{
     sync::{Mutex, mpsc::error::TrySendError},
     task::JoinError,
 };
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::{
     BlockHeaderAPI, BlockRef, Round, VerifiedBlockHeader,
@@ -399,6 +399,11 @@ impl CordialKnowledge {
         }
         let evicted_rounds = self.eviction_rounds_receiver.borrow_and_update().clone();
         if evicted_rounds.len() != self.context.committee.size() {
+            warn!(
+                "Eviction rounds length {} does not match committee size {}; skipping eviction",
+                evicted_rounds.len(),
+                self.context.committee.size()
+            );
             return;
         }
         if let Some(vec_connection_knowledge_msgs) = self.handle_evict_below(evicted_rounds) {
@@ -1114,7 +1119,7 @@ mod tests {
         TestBlockHeader,
         block_header::{GENESIS_ROUND, VerifiedBlock, VerifiedOwnShard},
         context::Context,
-        dag_state::{BlockHeaderSource, DagState},
+        dag_state::{DagState, DataSource},
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
         test_dag_parser::parse_dag,
@@ -1227,7 +1232,7 @@ mod tests {
                     } = block.clone();
                     dag_state
                         .write()
-                        .accept_block_header(verified_block_header, BlockHeaderSource::Test);
+                        .accept_block_header(verified_block_header, DataSource::Test);
                     let shard_for_core = VerifiedOwnShard {
                         serialized_shard: Bytes::from([0u8; 32].to_vec()), /* put some dummy
                                                                             * shard data */
@@ -1248,7 +1253,7 @@ mod tests {
                 } = block.clone();
                 dag_state
                     .write()
-                    .accept_block_header(verified_block_header, BlockHeaderSource::Test);
+                    .accept_block_header(verified_block_header, DataSource::Test);
                 let shard_for_core = VerifiedOwnShard {
                     serialized_shard: Bytes::from([0u8; 32].to_vec()), // put some dummy shard data
                     block_ref: verified_transactions.block_ref(),

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -42,7 +42,7 @@ use crate::{
     commit::{CertifiedCommits, PendingSubDag},
     commit_observer::CommitObserver,
     context::Context,
-    dag_state::{BlockHeaderSource, DagState, TransactionSource},
+    dag_state::{DagState, DataSource},
     encoder::{ShardEncoder, create_encoder},
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
@@ -292,6 +292,7 @@ impl Core {
     pub(crate) fn add_blocks(
         &mut self,
         blocks: Vec<VerifiedBlock>,
+        source: DataSource,
     ) -> ConsensusResult<(
         BTreeSet<BlockRef>,
         BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
@@ -310,7 +311,7 @@ impl Core {
             .core_add_blocks_batch_size
             .observe(blocks.len() as f64);
         let (accepted_blocks_headers, missing_block_refs) =
-            self.block_manager.try_accept_blocks(blocks);
+            self.block_manager.try_accept_blocks(blocks, source);
 
         let missing_committed_txns = if !accepted_blocks_headers.is_empty() {
             debug!(
@@ -354,7 +355,7 @@ impl Core {
     pub(crate) fn add_block_headers(
         &mut self,
         block_headers: Vec<VerifiedBlockHeader>,
-        source: BlockHeaderSource,
+        source: DataSource,
     ) -> ConsensusResult<(
         BTreeSet<BlockRef>,
         BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
@@ -415,7 +416,7 @@ impl Core {
     pub(crate) fn add_transactions(
         &mut self,
         transactions: Vec<VerifiedTransactions>,
-        source: TransactionSource,
+        source: DataSource,
     ) -> ConsensusResult<()> {
         let _scope = monitored_scope("Core::add_transactions");
         let _s = self
@@ -493,7 +494,7 @@ impl Core {
             .collect();
 
         if !all_transactions.is_empty() {
-            self.add_transactions(all_transactions, TransactionSource::CommitSyncer)?;
+            self.add_transactions(all_transactions, DataSource::CommitSyncer)?;
         }
 
         // Then collect and add block headers.
@@ -505,7 +506,7 @@ impl Core {
             .collect::<Vec<_>>();
 
         // Add block headers in certified commits to the block manager.
-        self.add_block_headers(block_headers, BlockHeaderSource::CommitSyncer)
+        self.add_block_headers(block_headers, DataSource::CommitSyncer)
     }
 
     /// If needed, signals a new clock round and sets up leader timeout.
@@ -804,7 +805,7 @@ impl Core {
         // Accept the block into BlockManager and DagState.
         let (accepted_blocks, missing) = self
             .block_manager
-            .try_accept_blocks(vec![verified_block.clone()]);
+            .try_accept_blocks(vec![verified_block.clone()], DataSource::OwnBlock);
         assert_eq!(accepted_blocks.len(), 1);
         assert!(missing.is_empty());
         // Ensure the new block and its ancestors are persisted, before broadcasting it.
@@ -1812,7 +1813,7 @@ mod test {
         // Wait for min block delay to allow blocks to be proposed.
         sleep(context.parameters.min_block_delay).await;
         // add blocks to trigger proposal.
-        _ = core.add_blocks(vec![verified_block]);
+        _ = core.add_blocks(vec![verified_block], DataSource::Test);
 
         assert_eq!(core.last_proposed_round(), 1);
         expected_ancestors.insert(core.last_proposed_block_header().reference());
@@ -1830,7 +1831,7 @@ mod test {
         // Wait for min block delay to allow blocks to be proposed.
         sleep(context.parameters.min_block_delay).await;
         // add blocks to trigger proposal.
-        _ = core.add_blocks(vec![block_3]);
+        _ = core.add_blocks(vec![block_3], DataSource::Test);
 
         assert_eq!(core.last_proposed_round(), 2);
 
@@ -1914,8 +1915,9 @@ mod test {
         builder.layers(1..=10).build();
 
         // Process all the blocks
-        let (missing_ancestors, missing_committed_txns) =
-            core.add_blocks(builder.blocks(1..=10)).unwrap();
+        let (missing_ancestors, missing_committed_txns) = core
+            .add_blocks(builder.blocks(1..=10), DataSource::Test)
+            .unwrap();
 
         assert!(missing_ancestors.is_empty());
         assert!(missing_committed_txns.is_empty());
@@ -1993,7 +1995,7 @@ mod test {
 
                 core_fixture
                     .core
-                    .add_block_headers(last_round_blocks.clone(), BlockHeaderSource::Test)
+                    .add_block_headers(last_round_blocks.clone(), DataSource::Test)
                     .unwrap();
 
                 // Only when round > 1 and using non-genesis parents.
@@ -2028,7 +2030,7 @@ mod test {
 
             core_fixture
                 .core
-                .add_block_headers(last_round_blocks.clone(), BlockHeaderSource::Test)
+                .add_block_headers(last_round_blocks.clone(), DataSource::Test)
                 .unwrap();
             let (new_block_opt, missing_committed_txns) = core_fixture
                 .core
@@ -2159,7 +2161,7 @@ mod test {
                 // emitted
                 core_fixture
                     .core
-                    .add_block_headers(last_round_block_headers.clone(), BlockHeaderSource::Test)
+                    .add_block_headers(last_round_block_headers.clone(), DataSource::Test)
                     .unwrap();
 
                 // A "new round" signal should be received given that all the blocks of previous
@@ -2322,7 +2324,7 @@ mod test {
 
         let (mut core_own, mut commit_receiver_own) =
             (core_fixture_own.core, core_fixture_own.commit_receiver);
-        let _ = core_own.add_blocks(dag_builder.blocks(1..=total_rounds));
+        let _ = core_own.add_blocks(dag_builder.blocks(1..=total_rounds), DataSource::Test);
         let mut existing_headers = HashSet::new();
         let mut all_traversed_headers = Vec::new();
         let mut all_sequenced_transactions = Vec::new();
@@ -2415,7 +2417,7 @@ mod test {
         core_catch_up
             .add_transactions(
                 missing_verified_transactions,
-                crate::dag_state::TransactionSource::TransactionSynchronizer,
+                crate::dag_state::DataSource::TransactionSynchronizer,
             )
             .unwrap();
 
@@ -2486,7 +2488,7 @@ mod test {
         for block_header in block_headers {
             core.dag_state
                 .write()
-                .accept_block_header(block_header, BlockHeaderSource::Test);
+                .accept_block_header(block_header, DataSource::Test);
         }
 
         // Get all the committed sub dags up to round 10
@@ -2532,7 +2534,7 @@ mod test {
         for block_header in block_headers {
             core.dag_state
                 .write()
-                .accept_block_header(block_header, BlockHeaderSource::Test);
+                .accept_block_header(block_header, DataSource::Test);
         }
 
         // The corresponding blocks of the certified commits should be accepted and
@@ -2574,7 +2576,7 @@ mod test {
                 // emitted
                 core_fixture
                     .core
-                    .add_block_headers(last_round_block_headers.clone(), BlockHeaderSource::Test)
+                    .add_block_headers(last_round_block_headers.clone(), DataSource::Test)
                     .unwrap();
                 // A "new round" signal should be received given that all the blocks of previous
                 // round have been processed
@@ -2706,7 +2708,7 @@ mod test {
                 // emitted
                 core_fixture
                     .core
-                    .add_block_headers(last_round_block_headers.clone(), BlockHeaderSource::Test)
+                    .add_block_headers(last_round_block_headers.clone(), DataSource::Test)
                     .unwrap();
 
                 // A "new round" signal should be received given that all the blocks of previous
@@ -2802,7 +2804,7 @@ mod test {
                 // leader authority 3
                 core_fixture
                     .core
-                    .add_block_headers(last_round_block_headers.clone(), BlockHeaderSource::Test)
+                    .add_block_headers(last_round_block_headers.clone(), DataSource::Test)
                     .unwrap();
                 core_fixture
                     .core
@@ -2831,7 +2833,7 @@ mod test {
         // add blocks to trigger proposal.
         core_fixture
             .core
-            .add_block_headers(all_block_headers, BlockHeaderSource::Test)
+            .add_block_headers(all_block_headers, DataSource::Test)
             .unwrap();
 
         // Assert that a block has been created for round 11 and it references to blocks

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -29,7 +29,7 @@ use crate::{
     context::Context,
     core::{Core, ReasonToCreateBlock},
     core_thread::CoreError::Shutdown,
-    dag_state::{BlockHeaderSource, DagState, TransactionSource},
+    dag_state::{DagState, DataSource},
     error::{ConsensusError, ConsensusResult},
 };
 
@@ -39,6 +39,7 @@ enum CoreThreadCommand {
     /// Add blocks to be processed and accepted
     AddBlocks(
         Vec<VerifiedBlock>,
+        DataSource,
         oneshot::Sender<(
             BTreeSet<BlockRef>,
             BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
@@ -47,7 +48,7 @@ enum CoreThreadCommand {
     /// Add block headers to be processed and accepted
     AddBlockHeaders(
         Vec<VerifiedBlockHeader>,
-        BlockHeaderSource,
+        DataSource,
         oneshot::Sender<(
             BTreeSet<BlockRef>,
             BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
@@ -75,11 +76,7 @@ enum CoreThreadCommand {
     /// that have these blocks.
     GetMissingBlocks(oneshot::Sender<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>),
     /// Add transactions to be processed and accepted
-    AddTransactions(
-        Vec<VerifiedTransactions>,
-        oneshot::Sender<()>,
-        TransactionSource,
-    ),
+    AddTransactions(Vec<VerifiedTransactions>, oneshot::Sender<()>, DataSource),
     /// Add shards to the dag_state
     AddShards(Vec<VerifiedOwnShard>, oneshot::Sender<()>),
     /// Get missing transaction data that need to be synced
@@ -99,6 +96,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
     async fn add_blocks(
         &self,
         blocks: Vec<VerifiedBlock>,
+        source: DataSource,
     ) -> Result<
         (
             BTreeSet<BlockRef>,
@@ -110,7 +108,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
     async fn add_block_headers(
         &self,
         blocks: Vec<VerifiedBlockHeader>,
-        source: BlockHeaderSource,
+        source: DataSource,
     ) -> Result<
         (
             BTreeSet<BlockRef>,
@@ -122,7 +120,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
     async fn add_transactions(
         &self,
         transactions: Vec<VerifiedTransactions>,
-        source: TransactionSource,
+        source: DataSource,
     ) -> Result<(), CoreError>;
 
     async fn add_shards(&self, shards: Vec<VerifiedOwnShard>) -> Result<(), CoreError>;
@@ -198,9 +196,9 @@ impl CoreThread {
                     };
                     self.context.metrics.node_metrics.core_lock_dequeued.inc();
                     match command {
-                        CoreThreadCommand::AddBlocks(blocks, sender) => {
+                        CoreThreadCommand::AddBlocks(blocks, source, sender) => {
                             let _scope = monitored_scope("CoreThread::loop::add_blocks");
-                            let (missing_block_refs, missing_committed_txns) = self.core.add_blocks(blocks)?;
+                            let (missing_block_refs, missing_committed_txns) = self.core.add_blocks(blocks, source)?;
                             sender.send((missing_block_refs, missing_committed_txns)).ok();
                         }
                         CoreThreadCommand::AddBlockHeaders(block_headers, source, sender) => {
@@ -354,6 +352,7 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
     async fn add_blocks(
         &self,
         blocks: Vec<VerifiedBlock>,
+        source: DataSource,
     ) -> Result<
         (
             BTreeSet<BlockRef>,
@@ -365,7 +364,7 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
             self.highest_received_rounds[block.author()].fetch_max(block.round(), Ordering::AcqRel);
         }
         let (sender, receiver) = oneshot::channel();
-        self.send(CoreThreadCommand::AddBlocks(blocks, sender))
+        self.send(CoreThreadCommand::AddBlocks(blocks, source, sender))
             .await;
         Ok(receiver.await.map_err(|e| Shutdown(e.to_string()))?)
     }
@@ -373,7 +372,7 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
     async fn add_block_headers(
         &self,
         block_headers: Vec<VerifiedBlockHeader>,
-        source: BlockHeaderSource,
+        source: DataSource,
     ) -> Result<
         (
             BTreeSet<BlockRef>,
@@ -394,7 +393,7 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
     async fn add_transactions(
         &self,
         transactions: Vec<VerifiedTransactions>,
-        source: TransactionSource,
+        source: DataSource,
     ) -> Result<(), CoreError> {
         let (sender, receiver) = oneshot::channel();
         self.send(CoreThreadCommand::AddTransactions(
@@ -558,6 +557,7 @@ pub(crate) mod tests {
         async fn add_blocks(
             &self,
             blocks: Vec<VerifiedBlock>,
+            _source: DataSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,
@@ -572,7 +572,7 @@ pub(crate) mod tests {
         async fn add_block_headers(
             &self,
             block_headers: Vec<VerifiedBlockHeader>,
-            _source: BlockHeaderSource,
+            _source: DataSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,
@@ -593,7 +593,7 @@ pub(crate) mod tests {
         async fn add_transactions(
             &self,
             _transactions: Vec<VerifiedTransactions>,
-            _source: TransactionSource,
+            _source: DataSource,
         ) -> Result<(), CoreError> {
             unimplemented!()
         }
@@ -704,18 +704,28 @@ pub(crate) mod tests {
         let dispatcher_2 = core_dispatcher.clone();
 
         // Try to send some commands
-        assert!(dispatcher_1.add_blocks(vec![]).await.is_ok());
-        assert!(dispatcher_2.add_blocks(vec![]).await.is_ok());
-
         assert!(
             dispatcher_1
-                .add_block_headers(vec![], BlockHeaderSource::Test)
+                .add_blocks(vec![], DataSource::Test)
                 .await
                 .is_ok()
         );
         assert!(
             dispatcher_2
-                .add_block_headers(vec![], BlockHeaderSource::Test)
+                .add_blocks(vec![], DataSource::Test)
+                .await
+                .is_ok()
+        );
+
+        assert!(
+            dispatcher_1
+                .add_block_headers(vec![], DataSource::Test)
+                .await
+                .is_ok()
+        );
+        assert!(
+            dispatcher_2
+                .add_block_headers(vec![], DataSource::Test)
                 .await
                 .is_ok()
         );
@@ -724,17 +734,27 @@ pub(crate) mod tests {
         handle.stop().await;
 
         // Try to send some commands
-        assert!(dispatcher_1.add_blocks(vec![]).await.is_err());
-        assert!(dispatcher_2.add_blocks(vec![]).await.is_err());
         assert!(
             dispatcher_1
-                .add_block_headers(vec![], BlockHeaderSource::Test)
+                .add_blocks(vec![], DataSource::Test)
                 .await
                 .is_err()
         );
         assert!(
             dispatcher_2
-                .add_block_headers(vec![], BlockHeaderSource::Test)
+                .add_blocks(vec![], DataSource::Test)
+                .await
+                .is_err()
+        );
+        assert!(
+            dispatcher_1
+                .add_block_headers(vec![], DataSource::Test)
+                .await
+                .is_err()
+        );
+        assert!(
+            dispatcher_2
+                .add_block_headers(vec![], DataSource::Test)
                 .await
                 .is_err()
         );

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -38,68 +38,25 @@ use crate::{
     threshold_clock::ThresholdClock,
 };
 
-/// Represents the source from which transactions were received and added to the
-/// DAG state. This is used for metrics tracking and debugging.
+/// Represents the source from which data (block headers or transactions) was
+/// received and added to the DAG state. Used for metrics tracking and
+/// debugging.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum TransactionSource {
+pub(crate) enum DataSource {
+    // Transaction-specific sources
     /// Transactions received via the transaction synchronizer component.
     /// This synchronizer periodically fetches missing transactions to ensure
     /// nodes stay up-to-date.
     TransactionSynchronizer,
-
-    /// Data received via block streaming from peers in the network.
-    /// This is the primary method for receiving real-time blocks and
-    /// transactions as they're created.
-    BlockStreaming,
 
     /// Transactions reconstructed from erasure-coded shards.
     /// Used when full transaction data isn't available, but enough shards
     /// have been collected to reconstruct it.
     ShardReconstructor,
 
-    /// Transactions received via commit synchronization. Transactions are
-    /// fetched for all the committed blocks in synced commits.
-    CommitSyncer,
-
-    /// Data added during testing.
-    /// Only used in test code.
-    #[cfg(test)]
-    Test,
-}
-
-impl TransactionSource {
-    /// Returns the string label used for metrics reporting.
-    /// This ensures consistency with existing metrics that may be monitored.
-    pub(crate) fn as_str(&self) -> &'static str {
-        match self {
-            TransactionSource::TransactionSynchronizer => "Transactions synchronizer",
-            TransactionSource::BlockStreaming => "Block streaming",
-            TransactionSource::ShardReconstructor => "Shard reconstructor",
-            TransactionSource::CommitSyncer => "Commit syncer",
-            #[cfg(test)]
-            TransactionSource::Test => "test",
-        }
-    }
-}
-
-impl std::fmt::Display for TransactionSource {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-/// Represents the source from which block headers were received and added to
-/// the DAG state. This is used for metrics tracking and debugging.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum BlockHeaderSource {
-    /// Block headers from full blocks received via bundle streaming.
-    BlockStreaming,
-
+    // Block header-specific sources
     /// Block headers received in bundles via block bundle streaming.
-    BlockHeaderBundleStream,
-
-    /// Block headers extracted from certified commits during commit syncing.
-    CommitSyncer,
+    BlockBundleStream,
 
     /// Block headers fetched by the live/periodic header synchronizer
     /// component.
@@ -108,24 +65,48 @@ pub(crate) enum BlockHeaderSource {
     /// Block headers loaded from persistent storage during node recovery.
     Recover,
 
+    // Shared sources (used for both block headers and transactions)
+    /// Block created by this node itself. Used when accepting our own
+    /// newly-created block into the DAG before broadcasting it.
+    OwnBlock,
+
+    /// Data received via block streaming from peers in the network.
+    /// This is the primary method for receiving real-time blocks and
+    /// transactions as they're created.
+    BlockStreaming,
+
+    /// Data received via commit synchronization. Block headers and transactions
+    /// are fetched for all the committed blocks in synced commits.
+    CommitSyncer,
+
+    /// Data added during testing.
     /// Only used in test code.
     #[cfg(test)]
     Test,
 }
 
-impl BlockHeaderSource {
+impl DataSource {
     /// Returns the string label used for metrics reporting.
     /// This ensures consistency with existing metrics that may be monitored.
     pub(crate) fn as_str(&self) -> &'static str {
         match self {
-            BlockHeaderSource::HeaderSynchronizer => "Header synchronizer",
-            BlockHeaderSource::BlockHeaderBundleStream => "Block headers in streaming",
-            BlockHeaderSource::BlockStreaming => "Full blocks in streaming",
-            BlockHeaderSource::CommitSyncer => "Commit syncer",
-            BlockHeaderSource::Recover => "Recover",
+            DataSource::TransactionSynchronizer => "Transactions synchronizer",
+            DataSource::ShardReconstructor => "Shard reconstructor",
+            DataSource::BlockBundleStream => "Block headers in streaming",
+            DataSource::HeaderSynchronizer => "Header synchronizer",
+            DataSource::Recover => "Recover",
+            DataSource::OwnBlock => "Own block",
+            DataSource::BlockStreaming => "Block streaming",
+            DataSource::CommitSyncer => "Commit syncer",
             #[cfg(test)]
-            BlockHeaderSource::Test => "Test",
+            DataSource::Test => "Test",
         }
+    }
+}
+
+impl std::fmt::Display for DataSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
     }
 }
 
@@ -329,10 +310,10 @@ impl DagState {
 
             // Update the block metadata for the authority.
             for block_header in &block_headers {
-                state.update_block_header_metadata(block_header, BlockHeaderSource::Recover);
+                state.update_block_header_metadata(block_header, DataSource::Recover);
             }
             for transactions in &transactions_by_author {
-                state.update_transaction_metadata(transactions);
+                state.update_transaction_metadata(transactions, DataSource::Recover);
             }
 
             info!(
@@ -359,7 +340,7 @@ impl DagState {
     pub(crate) fn accept_block_header(
         &mut self,
         block_header: VerifiedBlockHeader,
-        source: BlockHeaderSource,
+        source: DataSource,
     ) {
         assert_ne!(
             block_header.round(),
@@ -422,46 +403,15 @@ impl DagState {
     pub(crate) fn add_transactions(
         &mut self,
         transactions: VerifiedTransactions,
-        source: TransactionSource,
+        source: DataSource,
     ) {
         let block_ref = transactions.block_ref();
         if self.recent_transactions_by_authority[block_ref.author]
             .insert(block_ref, transactions.clone())
             .is_none()
         {
-            self.context
-                .metrics
-                .node_metrics
-                .accepted_transactions
-                .with_label_values(&[source.as_str()])
-                .inc();
-            tracing::debug!("Adding transactions for block ref: {block_ref}");
-            let has_transactions = transactions.has_transactions();
-            self.transactions_to_write.push(transactions);
-            // If a block is not very old, add it to pending acknowledgments
-            let clock_round = self.threshold_clock_round();
-            let min_round: Round =
-                clock_round.saturating_sub(self.context.protocol_config.gc_depth());
-
-            if block_ref.round >= min_round {
-                if has_transactions {
-                    self.add_pending_acknowledgment(block_ref);
-                } else {
-                    // report skipped acknowledgment
-                    let hostname = self
-                        .context
-                        .committee
-                        .authority(block_ref.author)
-                        .hostname
-                        .as_str();
-                    self.context
-                        .metrics
-                        .node_metrics
-                        .skipped_empty_transaction_acknowledgments
-                        .with_label_values(&[hostname])
-                        .inc()
-                }
-            }
+            self.transactions_to_write.push(transactions.clone());
+            self.update_transaction_metadata(&transactions, source);
         }
     }
 
@@ -514,7 +464,7 @@ impl DagState {
     fn update_block_header_metadata(
         &mut self,
         block_header: &VerifiedBlockHeader,
-        source: BlockHeaderSource,
+        source: DataSource,
     ) {
         let block_ref = block_header.reference();
         self.recent_block_headers
@@ -546,7 +496,7 @@ impl DagState {
             .accepted_block_headers_source
             .with_label_values(&[source.as_str()])
             .inc();
-        if source != BlockHeaderSource::CommitSyncer && source != BlockHeaderSource::Recover {
+        if source != DataSource::CommitSyncer && source != DataSource::Recover {
             if let Some((sender, _)) = &self.cordial_knowledge_senders {
                 let cordial_message = CordialKnowledgeMessage::NewHeader(block_header.clone());
                 if let Err(TrySendError::Closed(_)) = sender.try_send(cordial_message) {
@@ -556,16 +506,54 @@ impl DagState {
         }
     }
 
-    fn update_transaction_metadata(&mut self, transaction: &VerifiedTransactions) {
-        self.recent_transactions_by_authority[transaction.block_ref().author]
-            .insert(transaction.block_ref(), transaction.clone());
+    /// Updates internal metadata for accepted transactions.
+    fn update_transaction_metadata(
+        &mut self,
+        transactions: &VerifiedTransactions,
+        source: DataSource,
+    ) {
+        let block_ref = transactions.block_ref();
+
+        // Record metrics
+        self.context
+            .metrics
+            .node_metrics
+            .accepted_transactions
+            .with_label_values(&[source.as_str()])
+            .inc();
+
+        tracing::debug!("Adding transactions for block ref: {block_ref}");
+
+        // Handle pending acknowledgments for recent blocks
+        let has_transactions = transactions.has_transactions();
+        let clock_round = self.threshold_clock_round();
+        let min_round: Round = clock_round.saturating_sub(self.context.protocol_config.gc_depth());
+
+        if block_ref.round >= min_round {
+            if has_transactions {
+                self.add_pending_acknowledgment(block_ref);
+            } else {
+                let hostname = self
+                    .context
+                    .committee
+                    .authority(block_ref.author)
+                    .hostname
+                    .as_str();
+                self.context
+                    .metrics
+                    .node_metrics
+                    .skipped_empty_transaction_acknowledgments
+                    .with_label_values(&[hostname])
+                    .inc()
+            }
+        }
     }
 
     /// Accepts block headers into DagState and keeps it in memory.
     pub(crate) fn accept_block_headers(
         &mut self,
         block_headers: Vec<VerifiedBlockHeader>,
-        source: BlockHeaderSource,
+        source: DataSource,
     ) {
         debug!(
             "Accepting block headers: {}",
@@ -1878,7 +1866,7 @@ mod test {
                             .set_timestamp_ms(timestamp)
                             .build(),
                     );
-                    dag_state.accept_block_header(block_header.clone(), BlockHeaderSource::Test);
+                    dag_state.accept_block_header(block_header.clone(), DataSource::Test);
                     block_headers.insert(block_header.reference(), block_header);
 
                     // Only write one block header per slot for own index
@@ -2109,7 +2097,7 @@ mod test {
             .chain(round_13_headers.iter())
             .chain([anchor.clone()].iter())
         {
-            dag_state.accept_block_header(bh.clone(), BlockHeaderSource::Test);
+            dag_state.accept_block_header(bh.clone(), DataSource::Test);
         }
 
         // Check ancestors connected to anchor.
@@ -2163,7 +2151,7 @@ mod test {
                     .write(WriteBatch::default().block_headers(vec![block_header]))
                     .unwrap();
             } else {
-                dag_state.accept_block_headers(vec![block_header], BlockHeaderSource::Test);
+                dag_state.accept_block_headers(vec![block_header], DataSource::Test);
             }
         });
 
@@ -2218,7 +2206,7 @@ mod test {
                 let block_header =
                     VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, author).build());
                 block_headers.push(block_header.clone());
-                dag_state.accept_block_header(block_header, BlockHeaderSource::Test);
+                dag_state.accept_block_header(block_header, DataSource::Test);
             }
         }
 
@@ -2286,7 +2274,7 @@ mod test {
             let block_header =
                 VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build());
             block_headers.push(block_header.clone());
-            dag_state.accept_block_header(block_header, BlockHeaderSource::Test);
+            dag_state.accept_block_header(block_header, DataSource::Test);
         }
 
         // Now add a commit and flush to trigger an eviction
@@ -2339,7 +2327,7 @@ mod test {
                     .write(WriteBatch::default().block_headers(vec![block_header]))
                     .unwrap();
             } else {
-                dag_state.accept_block_headers(vec![block_header], BlockHeaderSource::Test);
+                dag_state.accept_block_headers(vec![block_header], DataSource::Test);
             }
         });
 
@@ -2427,9 +2415,9 @@ mod test {
         // 5 commits to the dag state; also add commit info after the second
         // commit.
         let later_commits = commits.split_off(5);
-        dag_state.accept_block_headers(dag_builder.block_headers(1..=5), BlockHeaderSource::Test);
+        dag_state.accept_block_headers(dag_builder.block_headers(1..=5), DataSource::Test);
         for verified_transactions in dag_builder.transactions(1..=5).into_iter() {
-            dag_state.add_transactions(verified_transactions, TransactionSource::Test);
+            dag_state.add_transactions(verified_transactions, DataSource::Test);
         }
 
         for commit in commits.clone() {
@@ -2448,12 +2436,9 @@ mod test {
         assert_eq!(commit_info.committed_rounds, [1, 1, 2, 1]);
 
         // Add the rest of the block headers, transaction, and commits to the dag state
-        dag_state.accept_block_headers(
-            dag_builder.block_headers(6..=num_rounds),
-            BlockHeaderSource::Test,
-        );
+        dag_state.accept_block_headers(dag_builder.block_headers(6..=num_rounds), DataSource::Test);
         for verified_transactions in dag_builder.transactions(6..=num_rounds).into_iter() {
-            dag_state.add_transactions(verified_transactions, TransactionSource::Test);
+            dag_state.add_transactions(verified_transactions, DataSource::Test);
         }
         for commit in later_commits.clone() {
             dag_state.add_commit(commit);
@@ -2594,7 +2579,7 @@ mod test {
                     TestBlockHeader::new(round, author as u8).build(),
                 );
                 all_block_headers.push(block_header.clone());
-                dag_state.accept_block_header(block_header, BlockHeaderSource::Test);
+                dag_state.accept_block_header(block_header, DataSource::Test);
             }
         }
 
@@ -2756,7 +2741,7 @@ mod test {
             .into_iter()
             .chain(std::iter::once(block_header))
         {
-            dag_state.accept_block_header(block_header, BlockHeaderSource::Test);
+            dag_state.accept_block_header(block_header, DataSource::Test);
         }
 
         dag_state.add_commit(TrustedCommit::new_for_test(
@@ -2878,7 +2863,7 @@ mod test {
                     TestBlockHeader::new(round, author as u8).build(),
                 );
                 all_blocks_headers.push(block_header.clone());
-                dag_state.accept_block_header(block_header, BlockHeaderSource::Test);
+                dag_state.accept_block_header(block_header, DataSource::Test);
             }
         }
 
@@ -2951,7 +2936,7 @@ mod test {
                 VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 0).build());
             dag_state
                 .write()
-                .accept_block_header(block_header, BlockHeaderSource::Test);
+                .accept_block_header(block_header, DataSource::Test);
 
             let round_4_block_headers = dag_state.read().get_uncommitted_block_headers_at_round(4);
 
@@ -3007,7 +2992,7 @@ mod test {
                 VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 0).build());
             dag_state
                 .write()
-                .accept_block_header(block_header, BlockHeaderSource::Test);
+                .accept_block_header(block_header, DataSource::Test);
 
             for (authority_index, _) in context.committee.authorities() {
                 let block_header = dag_state
@@ -3054,8 +3039,7 @@ mod test {
                     )
                     .unwrap();
             } else {
-                dag_state
-                    .add_transactions(block.verified_transactions.clone(), TransactionSource::Test);
+                dag_state.add_transactions(block.verified_transactions.clone(), DataSource::Test);
             }
         });
 
@@ -3121,7 +3105,7 @@ mod test {
                 .set_timestamp_ms(future_timestamp)
                 .build(),
         );
-        dag_state.accept_block_header(block_header.clone(), BlockHeaderSource::Test);
+        dag_state.accept_block_header(block_header.clone(), DataSource::Test);
 
         let accepted_header = dag_state
             .recent_block_headers
@@ -3151,12 +3135,9 @@ mod test {
             commits.push(commit);
         }
 
-        dag_state.accept_block_headers(
-            dag_builder.block_headers(1..=num_rounds),
-            BlockHeaderSource::Test,
-        );
+        dag_state.accept_block_headers(dag_builder.block_headers(1..=num_rounds), DataSource::Test);
         for verified_transactions in dag_builder.transactions(1..=num_rounds).into_iter() {
-            dag_state.add_transactions(verified_transactions, TransactionSource::Test);
+            dag_state.add_transactions(verified_transactions, DataSource::Test);
         }
 
         for commit in commits.clone() {
@@ -3303,7 +3284,7 @@ mod test {
                 .build(),
         );
         // Try to accept the block - it should not panic
-        dag_state.accept_block_header(block, BlockHeaderSource::Test);
+        dag_state.accept_block_header(block, DataSource::Test);
     }
 
     #[tokio::test]
@@ -3328,7 +3309,7 @@ mod test {
 
         // add transactions for all blocks
         blocks.into_iter().for_each(|block| {
-            dag_state.add_transactions(block.verified_transactions, TransactionSource::Test);
+            dag_state.add_transactions(block.verified_transactions, DataSource::Test);
         });
 
         assert!(dag_state.pending_acknowledgments.is_empty());
@@ -3370,7 +3351,7 @@ mod test {
                     transaction_commitment,
                     serialized,
                 );
-                dag_state.add_transactions(verified_transaction, TransactionSource::Test);
+                dag_state.add_transactions(verified_transaction, DataSource::Test);
             }
         }
         assert_eq!(

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -406,13 +406,11 @@ impl DagState {
         source: DataSource,
     ) {
         let block_ref = transactions.block_ref();
-        if self.recent_transactions_by_authority[block_ref.author]
-            .insert(block_ref, transactions.clone())
-            .is_none()
-        {
-            self.transactions_to_write.push(transactions.clone());
-            self.update_transaction_metadata(&transactions, source);
+        if self.recent_transactions_by_authority[block_ref.author].contains_key(&block_ref) {
+            return;
         }
+        self.update_transaction_metadata(&transactions, source);
+        self.transactions_to_write.push(transactions);
     }
 
     pub(crate) fn add_shard(&mut self, shard: VerifiedOwnShard) {
@@ -513,6 +511,9 @@ impl DagState {
         source: DataSource,
     ) {
         let block_ref = transactions.block_ref();
+        
+        self.recent_transactions_by_authority[block_ref.author]
+            .insert(block_ref, transactions.clone());
 
         // Record metrics
         self.context

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -511,7 +511,7 @@ impl DagState {
         source: DataSource,
     ) {
         let block_ref = transactions.block_ref();
-        
+
         self.recent_transactions_by_authority[block_ref.author]
             .insert(block_ref, transactions.clone());
 

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -46,7 +46,7 @@ use crate::{
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
-    dag_state::{BlockHeaderSource, DagState},
+    dag_state::{DagState, DataSource},
     error::{ConsensusError, ConsensusResult},
     network::NetworkClient,
     transactions_synchronizer::TransactionsSynchronizerHandle,
@@ -715,7 +715,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         // we don't want this mechanism to keep feedback looping on fetching
         // more blocks. The periodic synchronization will take care of that.
         let (missing_blocks, missing_committed_txns) = core_dispatcher
-            .add_block_headers(block_headers, BlockHeaderSource::HeaderSynchronizer)
+            .add_block_headers(block_headers, DataSource::HeaderSynchronizer)
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
 
@@ -1531,7 +1531,7 @@ mod tests {
         context::Context,
         core::ReasonToCreateBlock,
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
-        dag_state::{BlockHeaderSource, DagState, TransactionSource},
+        dag_state::{DagState, DataSource},
         error::{ConsensusError, ConsensusResult},
         header_synchronizer::{
             FETCH_BLOCK_HEADERS_CONCURRENCY, FETCH_REQUEST_TIMEOUT, HeaderSynchronizer,
@@ -2706,6 +2706,7 @@ mod tests {
         async fn add_blocks(
             &self,
             blocks: Vec<VerifiedBlock>,
+            _source: DataSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,
@@ -2723,7 +2724,7 @@ mod tests {
         async fn add_block_headers(
             &self,
             _blocks: Vec<VerifiedBlockHeader>,
-            _source: BlockHeaderSource,
+            _source: DataSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,
@@ -2737,7 +2738,7 @@ mod tests {
         async fn add_transactions(
             &self,
             _transactions: Vec<VerifiedTransactions>,
-            _source: TransactionSource,
+            _source: DataSource,
         ) -> Result<(), CoreError> {
             unimplemented!("Unimplemented")
         }

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -453,7 +453,7 @@ mod tests {
         CommitIndex, TestBlockHeader,
         commit::{CommitDigest, WAVE_LENGTH},
         context::Context,
-        dag_state::BlockHeaderSource,
+        dag_state::DataSource,
         leader_schedule::{LeaderSchedule, LeaderSwapTable},
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
@@ -645,7 +645,7 @@ mod tests {
         );
         dag_state
             .write()
-            .accept_block_headers(block_headers_wave_1.clone(), BlockHeaderSource::Test);
+            .accept_block_headers(block_headers_wave_1.clone(), DataSource::Test);
 
         let first_leader = dag_builder
             .leader_block(leader_round_wave_1)
@@ -682,7 +682,7 @@ mod tests {
         // Write them in dag state
         dag_state
             .write()
-            .accept_block_headers(block_headers_wave_2.clone(), BlockHeaderSource::Test);
+            .accept_block_headers(block_headers_wave_2.clone(), DataSource::Test);
 
         let mut block_refs_wave_2: Vec<_> = block_headers_wave_2
             .into_iter()
@@ -995,7 +995,7 @@ mod tests {
         {
             let mut dag_state_guard = dag_state.write();
             for block in &ancestors {
-                dag_state_guard.accept_block_header(block.clone(), BlockHeaderSource::Test);
+                dag_state_guard.accept_block_header(block.clone(), DataSource::Test);
             }
         }
         let last_commit_timestamp_ms = 0;

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -27,7 +27,7 @@ use crate::{
     },
     context::Context,
     core_thread::CoreThreadDispatcher,
-    dag_state::{DagState, TransactionSource},
+    dag_state::{DagState, DataSource},
     decoder::{ShardsDecoder, create_decoder},
     encoder::{ShardEncoder, create_encoder},
     error::{ConsensusError, ConsensusResult},
@@ -561,7 +561,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
 
             // Add the transactions to the core
             self.core_dispatcher
-                .add_transactions(transactions, TransactionSource::ShardReconstructor)
+                .add_transactions(transactions, DataSource::ShardReconstructor)
                 .await
                 .map_err(|_| ConsensusError::Shutdown)?;
         }
@@ -657,7 +657,7 @@ mod tests {
         context::Context,
         core::ReasonToCreateBlock,
         core_thread::{CoreError, CoreThreadDispatcher},
-        dag_state::{BlockHeaderSource, DagState, TransactionSource},
+        dag_state::{DagState, DataSource},
         encoder::create_encoder,
         shard_reconstructor::{
             FullTransactionMessage, ShardMessage, ShardReconstructor, TransactionMessage,
@@ -686,7 +686,7 @@ mod tests {
         async fn add_transactions(
             &self,
             txs: Vec<VerifiedTransactions>,
-            _source: TransactionSource,
+            _source: DataSource,
         ) -> Result<(), CoreError> {
             let mut guard = self.transactions.lock().await;
             guard.extend(txs);
@@ -695,6 +695,7 @@ mod tests {
         async fn add_blocks(
             &self,
             _blocks: Vec<VerifiedBlock>,
+            _source: DataSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,
@@ -708,7 +709,7 @@ mod tests {
         async fn add_block_headers(
             &self,
             _blocks: Vec<VerifiedBlockHeader>,
-            _source: BlockHeaderSource,
+            _source: DataSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,

--- a/crates/starfish/core/src/test_dag.rs
+++ b/crates/starfish/core/src/test_dag.rs
@@ -14,7 +14,7 @@ use crate::{
         genesis_block_headers,
     },
     context::Context,
-    dag_state::{BlockHeaderSource, DagState},
+    dag_state::{DagState, DataSource},
     test_dag_builder::DagBuilder,
 };
 
@@ -69,7 +69,7 @@ pub(crate) fn build_dag(
             .unzip();
         dag_state
             .write()
-            .accept_block_headers(blocks, BlockHeaderSource::Test);
+            .accept_block_headers(blocks, DataSource::Test);
         ancestors = references;
     }
 
@@ -95,7 +95,7 @@ pub(crate) fn build_dag_layer(
         references.push(block.reference());
         dag_state
             .write()
-            .accept_block_header(block, BlockHeaderSource::Test);
+            .accept_block_header(block, DataSource::Test);
     }
     references
 }

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     commit::{CertifiedCommit, CommitDigest, TrustedCommit, WAVE_LENGTH},
     context::Context,
-    dag_state::{BlockHeaderSource, DagState, TransactionSource},
+    dag_state::{DagState, DataSource},
     encoder::{ShardEncoder, create_encoder},
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
     linearizer::{BlockStoreAPI, Linearizer},
@@ -414,12 +414,12 @@ impl DagBuilder {
     pub(crate) fn persist_all_blocks(&self, dag_state: Arc<RwLock<DagState>>) {
         dag_state.write().accept_block_headers(
             self.block_headers.values().cloned().collect(),
-            BlockHeaderSource::Test,
+            DataSource::Test,
         );
         for block_transactions in self.transactions.values() {
             dag_state
                 .write()
-                .add_transactions(block_transactions.clone(), TransactionSource::Test);
+                .add_transactions(block_transactions.clone(), DataSource::Test);
         }
     }
 
@@ -893,9 +893,9 @@ impl<'a> LayerBuilder<'a> {
             "Called to persist layers although no blocks have been created. Make sure you have called build before."
         );
         let mut dag_state = dag_state.write();
-        dag_state.accept_block_headers(self.block_headers.clone(), BlockHeaderSource::Test);
+        dag_state.accept_block_headers(self.block_headers.clone(), DataSource::Test);
         for transactions in self.transactions.clone() {
-            dag_state.add_transactions(transactions, TransactionSource::Test);
+            dag_state.add_transactions(transactions, DataSource::Test);
         }
     }
 

--- a/crates/starfish/core/src/tests/base_committer_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_tests.rs
@@ -12,7 +12,7 @@ use crate::{
     block_header::{BlockHeaderAPI, TestBlockHeader, VerifiedBlockHeader},
     commit::LeaderStatus,
     context::Context,
-    dag_state::{BlockHeaderSource, DagState},
+    dag_state::{DagState, DataSource},
     storage::mem_store::MemStore,
     test_dag::{build_dag, build_dag_layer},
 };
@@ -633,7 +633,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_c13_1.clone(), BlockHeaderSource::Test);
+        .accept_block_header(byzantine_block_c13_1.clone(), DataSource::Test);
 
     let byzantine_block_c13_2 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
@@ -642,7 +642,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_c13_2.clone(), BlockHeaderSource::Test);
+        .accept_block_header(byzantine_block_c13_2.clone(), DataSource::Test);
 
     let byzantine_block_c13_3 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
@@ -651,7 +651,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_c13_3.clone(), BlockHeaderSource::Test);
+        .accept_block_header(byzantine_block_c13_3.clone(), DataSource::Test);
 
     // Ancestors of decision blocks in round 14 should include multiple byzantine
     // non-votes C13 but there are enough good votes to prevent a skip.
@@ -664,7 +664,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(decision_block_a14.clone(), BlockHeaderSource::Test);
+        .accept_block_header(decision_block_a14.clone(), DataSource::Test);
 
     let good_references_voting_round_wave_4_without_c13 = good_references_voting_round_wave_4
         .into_iter()
@@ -684,7 +684,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(decision_block_b14.clone(), BlockHeaderSource::Test);
+        .accept_block_header(decision_block_b14.clone(), DataSource::Test);
 
     let decision_block_c14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 2)
@@ -699,7 +699,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(decision_block_c14.clone(), BlockHeaderSource::Test);
+        .accept_block_header(decision_block_c14.clone(), DataSource::Test);
 
     let decision_block_d14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 3)
@@ -714,7 +714,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(decision_block_d14.clone(), BlockHeaderSource::Test);
+        .accept_block_header(decision_block_d14.clone(), DataSource::Test);
 
     // DagState Update:
     // - We have A13, B13, D13 & C13 as good votes in the voting round of wave 4

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -11,7 +11,7 @@ use crate::{
     block_header::{BlockHeaderAPI, Slot, TestBlockHeader, VerifiedBlockHeader},
     commit::{DecidedLeader, WAVE_LENGTH},
     context::Context,
-    dag_state::{BlockHeaderSource, DagState},
+    dag_state::{DagState, DataSource},
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
     storage::mem_store::MemStore,
     test_dag::{build_dag, build_dag_layer},
@@ -628,7 +628,7 @@ async fn test_byzantine_validator() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_b13_1.clone(), BlockHeaderSource::Test);
+        .accept_block_header(byzantine_block_b13_1.clone(), DataSource::Test);
 
     // Make equivocation through timestamp
     let timestamp = byzantine_block_b13_1.timestamp_ms();
@@ -641,7 +641,7 @@ async fn test_byzantine_validator() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_b13_2.clone(), BlockHeaderSource::Test);
+        .accept_block_header(byzantine_block_b13_2.clone(), DataSource::Test);
 
     let byzantine_block_b13_3 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 1)
@@ -651,7 +651,7 @@ async fn test_byzantine_validator() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_b13_3.clone(), BlockHeaderSource::Test);
+        .accept_block_header(byzantine_block_b13_3.clone(), DataSource::Test);
 
     // Ancestors of decision blocks in round 14 should include multiple byzantine
     // non-votes B13 but there are enough good votes to prevent a skip.
@@ -666,7 +666,7 @@ async fn test_byzantine_validator() {
     references_round_14.push(decision_block_a14.reference());
     dag_state
         .write()
-        .accept_block_header(decision_block_a14.clone(), BlockHeaderSource::Test);
+        .accept_block_header(decision_block_a14.clone(), DataSource::Test);
 
     let good_references_voting_round_wave_4_without_b13 = good_references_voting_round_wave_4
         .into_iter()
@@ -687,7 +687,7 @@ async fn test_byzantine_validator() {
     references_round_14.push(decision_block_b14.reference());
     dag_state
         .write()
-        .accept_block_header(decision_block_b14.clone(), BlockHeaderSource::Test);
+        .accept_block_header(decision_block_b14.clone(), DataSource::Test);
 
     let decision_block_c14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 2)
@@ -703,7 +703,7 @@ async fn test_byzantine_validator() {
     references_round_14.push(decision_block_c14.reference());
     dag_state
         .write()
-        .accept_block_header(decision_block_c14.clone(), BlockHeaderSource::Test);
+        .accept_block_header(decision_block_c14.clone(), DataSource::Test);
 
     let decision_block_d14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 3)
@@ -719,7 +719,7 @@ async fn test_byzantine_validator() {
     references_round_14.push(decision_block_d14.reference());
     dag_state
         .write()
-        .accept_block_header(decision_block_d14.clone(), BlockHeaderSource::Test);
+        .accept_block_header(decision_block_d14.clone(), DataSource::Test);
 
     // DagState Update:
     // - We have A13, B13, D13 & C13 as good votes in the voting round of leader A12

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -13,7 +13,7 @@ use crate::{
     block_manager::{BlockManager, block_suspender::tests::evaluate_block_headers},
     commit::DecidedLeader,
     context::Context,
-    dag_state::{BlockHeaderSource, DagState},
+    dag_state::{DagState, DataSource},
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
     storage::mem_store::MemStore,
     test_dag::create_random_dag,
@@ -127,7 +127,7 @@ async fn test_randomized_dag_and_decision_sequence() {
             seen_so_far.extend(chunk.iter().cloned());
             let _ = authority_1
                 .block_manager
-                .try_accept_block_headers(chunk.to_vec(), BlockHeaderSource::Test);
+                .try_accept_block_headers(chunk.to_vec(), DataSource::Test);
             let sequence = authority_1.committer.try_decide(last_decided);
 
             if !sequence.is_empty() {
@@ -170,7 +170,7 @@ async fn test_randomized_dag_and_decision_sequence() {
 
             let _ = authority_2
                 .block_manager
-                .try_accept_block_headers(chunk.to_vec(), BlockHeaderSource::Test);
+                .try_accept_block_headers(chunk.to_vec(), DataSource::Test);
             let sequence = authority_2.committer.try_decide(last_decided);
 
             if !sequence.is_empty() {

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -12,7 +12,7 @@ use crate::{
     block_header::{BlockHeaderAPI, Slot, TestBlockHeader, VerifiedBlockHeader},
     commit::{DecidedLeader, WaveNumber},
     context::Context,
-    dag_state::{BlockHeaderSource, DagState},
+    dag_state::{DagState, DataSource},
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
     storage::mem_store::MemStore,
     test_dag::build_dag,
@@ -622,7 +622,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_c13_1.clone(), BlockHeaderSource::Test);
+        .accept_block_header(byzantine_block_c13_1.clone(), DataSource::Test);
 
     let byzantine_block_c13_2 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
@@ -631,7 +631,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_c13_2.clone(), BlockHeaderSource::Test);
+        .accept_block_header(byzantine_block_c13_2.clone(), DataSource::Test);
 
     let byzantine_block_c13_3 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
@@ -640,7 +640,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(byzantine_block_c13_3.clone(), BlockHeaderSource::Test);
+        .accept_block_header(byzantine_block_c13_3.clone(), DataSource::Test);
 
     // Ancestors of certifying blocks in round 14 should include multiple byzantine
     // non-votes C13 but there are enough good votes to prevent a skip.
@@ -653,7 +653,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(certifying_block_a14.clone(), BlockHeaderSource::Test);
+        .accept_block_header(certifying_block_a14.clone(), DataSource::Test);
 
     let good_references_voting_round_for_round_12_without_c13 =
         good_references_voting_round_for_round_12
@@ -674,7 +674,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(certifying_block_b14.clone(), BlockHeaderSource::Test);
+        .accept_block_header(certifying_block_b14.clone(), DataSource::Test);
 
     let certifying_block_c14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 2)
@@ -689,7 +689,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(certifying_block_c14.clone(), BlockHeaderSource::Test);
+        .accept_block_header(certifying_block_c14.clone(), DataSource::Test);
 
     let certifying_block_d14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 3)
@@ -704,7 +704,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block_header(certifying_block_d14.clone(), BlockHeaderSource::Test);
+        .accept_block_header(certifying_block_d14.clone(), DataSource::Test);
 
     // DagState Update:
     // - We have A13, B13, D13 & C13 as good votes in the voting round for round-12

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -36,7 +36,7 @@ use crate::{
     block_header::{BlockRef, TransactionsCommitment, VerifiedTransactions},
     context::Context,
     core_thread::CoreThreadDispatcher,
-    dag_state::{DagState, TransactionSource},
+    dag_state::{DagState, DataSource},
     encoder::create_encoder,
     error::{ConsensusError, ConsensusResult},
     network::{NetworkClient, SerializedTransactions},
@@ -1045,7 +1045,7 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
 
         // Add the transactions to the core
         core_dispatcher
-            .add_transactions(transactions, TransactionSource::TransactionSynchronizer)
+            .add_transactions(transactions, DataSource::TransactionSynchronizer)
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
 
@@ -1153,7 +1153,7 @@ mod tests {
         context::Context,
         core::ReasonToCreateBlock,
         core_thread::CoreError,
-        dag_state::{BlockHeaderSource, DagState},
+        dag_state::{DagState, DataSource},
         network::{BlockBundleStream, NetworkClient, SerializedTransactions},
         storage::mem_store::MemStore,
     };
@@ -1229,7 +1229,7 @@ mod tests {
 
         dag_state
             .write()
-            .accept_block_headers(block_headers, BlockHeaderSource::Test);
+            .accept_block_headers(block_headers, DataSource::Test);
 
         // WHEN
         // Request the transactions
@@ -1334,7 +1334,7 @@ mod tests {
         // Add block headers to the dag state
         dag_state
             .write()
-            .accept_block_headers(block_headers, BlockHeaderSource::Test);
+            .accept_block_headers(block_headers, DataSource::Test);
 
         // WHEN
         // Send many requests to saturate the tasks
@@ -1461,7 +1461,7 @@ mod tests {
         // Add block headers to the dag state
         dag_state
             .write()
-            .accept_block_headers(block_headers, BlockHeaderSource::Test);
+            .accept_block_headers(block_headers, DataSource::Test);
 
         // WHEN
         // Request the transactions
@@ -1580,7 +1580,7 @@ mod tests {
         // Add block headers to the dag state
         dag_state
             .write()
-            .accept_block_headers(block_headers, BlockHeaderSource::Test);
+            .accept_block_headers(block_headers, DataSource::Test);
 
         // WHEN
         // Request the transactions
@@ -1692,7 +1692,7 @@ mod tests {
         // Add block headers to the dag state
         dag_state
             .write()
-            .accept_block_headers(block_headers, BlockHeaderSource::Test);
+            .accept_block_headers(block_headers, DataSource::Test);
 
         // WHEN
         // Request the transactions
@@ -1804,7 +1804,7 @@ mod tests {
         // Add block headers to the dag state
         dag_state
             .write()
-            .accept_block_headers(block_headers, BlockHeaderSource::Test);
+            .accept_block_headers(block_headers, DataSource::Test);
 
         // WHEN
         // Request the transactions
@@ -1912,7 +1912,7 @@ mod tests {
         // Add block headers to the dag state
         dag_state
             .write()
-            .accept_block_headers(block_headers, BlockHeaderSource::Test);
+            .accept_block_headers(block_headers, DataSource::Test);
 
         // WHEN
         // Request the transactions
@@ -2178,6 +2178,7 @@ mod tests {
         async fn add_blocks(
             &self,
             _blocks: Vec<VerifiedBlock>,
+            _source: DataSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,
@@ -2191,7 +2192,7 @@ mod tests {
         async fn add_block_headers(
             &self,
             _block_headers: Vec<VerifiedBlockHeader>,
-            _source: BlockHeaderSource,
+            _source: DataSource,
         ) -> Result<
             (
                 BTreeSet<BlockRef>,
@@ -2205,7 +2206,7 @@ mod tests {
         async fn add_transactions(
             &self,
             transactions: Vec<VerifiedTransactions>,
-            _source: TransactionSource,
+            _source: DataSource,
         ) -> Result<(), CoreError> {
             let mut txns = self.transactions.lock().await;
 


### PR DESCRIPTION
# Description of change

This PR consolidates BlockHeaderSource and TransactionSource enums into a single DataSource enum for consistent tracking of data origins across the consensus Starfish layer.  

We also unify the function update_transaction_metadata to behave similarly to the one for headers.

## Links to any relevant issues
Fixes #9931 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] I have checked that new and existing unit tests pass locally with my changes