### PR TITLE
fix(starfish): start fast sync fetching from last solid commit

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -357,8 +357,8 @@ impl ConsensusAuthority {
         self.commit_consumer_monitor.replay_complete().await;
     }
 
-    #[cfg(any(test, msim))]
-    pub(crate) fn context(&self) -> &Arc<Context> {
+    #[cfg(test)]
+    fn context(&self) -> &Arc<Context> {
         &self.context
     }
 

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -357,8 +357,8 @@ impl ConsensusAuthority {
         self.commit_consumer_monitor.replay_complete().await;
     }
 
-    #[cfg(test)]
-    fn context(&self) -> &Arc<Context> {
+    #[cfg(any(test, msim))]
+    pub(crate) fn context(&self) -> &Arc<Context> {
         &self.context
     }
 

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -24,6 +24,7 @@ use crate::{
     core::{Core, CoreSignals},
     core_thread::{ChannelCoreThreadDispatcher, CoreThreadHandle},
     dag_state::DagState,
+    error::ConsensusResult,
     header_synchronizer::{HeaderSynchronizer, HeaderSynchronizerHandle},
     leader_schedule::LeaderSchedule,
     leader_timeout::{LeaderTimeoutTask, LeaderTimeoutTaskHandle},
@@ -51,6 +52,8 @@ pub struct ConsensusAuthority {
     core_thread_handle: CoreThreadHandle,
     subscriber: Subscriber<TonicClient, AuthorityService<ChannelCoreThreadDispatcher>>,
     network_manager: TonicManager<AuthorityService<ChannelCoreThreadDispatcher>>,
+    #[cfg(msim)]
+    store: Arc<RocksDBStore>,
     #[cfg(test)]
     sync_last_known_own_block: bool,
 }
@@ -241,7 +244,7 @@ impl ConsensusAuthority {
             core_dispatcher,
             signals_receivers.block_broadcast_receiver(),
             dag_state.clone(),
-            store,
+            store.clone(),
             shard_reconstructor.transaction_message_sender(),
             cordial_knowledge.clone(),
         ));
@@ -280,6 +283,8 @@ impl ConsensusAuthority {
             core_thread_handle,
             subscriber,
             network_manager,
+            #[cfg(msim)]
+            store,
             #[cfg(test)]
             sync_last_known_own_block,
         }
@@ -347,6 +352,15 @@ impl ConsensusAuthority {
             .node_metrics
             .uptime
             .observe(self.start_time.elapsed().as_secs_f64());
+    }
+
+    #[cfg(msim)]
+    pub async fn stop_and_clear_transactions(self) -> Result<(), String> {
+        let store = self.store.clone();
+        self.stop().await;
+        store
+            .delete_all_transactions()
+            .map_err(|err| err.to_string())
     }
 
     pub fn transaction_client(&self) -> Arc<TransactionClient> {

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -24,7 +24,6 @@ use crate::{
     core::{Core, CoreSignals},
     core_thread::{ChannelCoreThreadDispatcher, CoreThreadHandle},
     dag_state::DagState,
-    error::ConsensusResult,
     header_synchronizer::{HeaderSynchronizer, HeaderSynchronizerHandle},
     leader_schedule::LeaderSchedule,
     leader_timeout::{LeaderTimeoutTask, LeaderTimeoutTaskHandle},

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -222,7 +222,6 @@ impl CommitObserver {
             self.update_and_evict_with_solid_subdags(&committed_subdags);
             self.dag_state.write().flush();
         }
-
         // Send committed sub-dags through the channel
         let _sent_indices = self.send_sub_dags(&committed_subdags, source)?;
 
@@ -479,6 +478,9 @@ impl CommitObserver {
 
             committed_subdags.push(committed_subdag);
         }
+
+        // Evict linearizer and update dag_state with solid subdags
+        self.update_and_evict_with_solid_subdags(&committed_subdags);
 
         let sent_indices = self
             .send_sub_dags(&committed_subdags, source)

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -193,6 +193,21 @@ impl CommitObserver {
         self.handle_committed_sub_dags_internal(&[], committed_subdags, source)
     }
 
+    /// Evicts linearizer and updates dag_state with the last solid subdag.
+    fn update_and_evict_with_solid_subdags(&mut self, solid_subdags: &[CommittedSubDag]) {
+        if solid_subdags.is_empty() {
+            return;
+        }
+        let last_solid_subdag = solid_subdags
+            .last()
+            .expect("There should be at least one solid subdag");
+        self.linearizer
+            .evict_linearizer(last_solid_subdag.leader.round);
+        self.dag_state
+            .write()
+            .update_last_solid_subdag_base(last_solid_subdag.base.clone());
+    }
+
     fn handle_committed_sub_dags_internal(
         &mut self,
         pending_sub_dags: &[PendingSubDag],
@@ -202,21 +217,10 @@ impl CommitObserver {
         // Committed headers and sequenced transactions must be persisted to storage
         // before sending them outside consensus.
         if !pending_sub_dags.is_empty() || !committed_subdags.is_empty() {
-            let mut dag_state_guard = self.dag_state.write();
             // Evict the ack tracker and update GC round BEFORE flush so that eviction
             // uses the correct GC round.
-            if !committed_subdags.is_empty() {
-                let max_solid_commit_leader_round = committed_subdags
-                    .last()
-                    .expect("There should be at least one solid subdag")
-                    .leader
-                    .round;
-                self.linearizer
-                    .evict_linearizer(max_solid_commit_leader_round);
-                dag_state_guard
-                    .update_last_solid_commit_leader_round(max_solid_commit_leader_round);
-            }
-            dag_state_guard.flush();
+            self.update_and_evict_with_solid_subdags(&committed_subdags);
+            self.dag_state.write().flush();
         }
 
         // Send committed sub-dags through the channel
@@ -331,6 +335,7 @@ impl CommitObserver {
             let (solid_sub_dags, _missing) = self
                 .commit_solidifier
                 .try_get_solid_sub_dags(&pending_for_solidifier);
+            self.update_and_evict_with_solid_subdags(&solid_sub_dags);
             self.send_sub_dags(&solid_sub_dags, source)
                 .expect("We should successfully send solid commits during recovery");
             self.report_metrics(&[], &solid_sub_dags, source);

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -406,6 +406,30 @@ impl CommitObserver {
     ) -> Vec<CommitIndex> {
         if last_processed_commit_index >= last_commit_index {
             info!("No unprocessed commits to resend");
+
+            // Even though there are no commits to resend, we still need to initialize
+            // last_solid_subdag_base so that fast sync knows where to start fetching.
+            if last_processed_commit_index > 0 {
+                if let Some(commit) = self
+                    .store
+                    .scan_commits(
+                        (last_processed_commit_index..=last_processed_commit_index).into(),
+                    )
+                    .ok()
+                    .and_then(|commits| commits.into_iter().next())
+                {
+                    let pending_subdag =
+                        load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]);
+                    info!(
+                        "Initializing last_solid_subdag_base from last processed commit {}",
+                        last_processed_commit_index
+                    );
+                    self.dag_state
+                        .write()
+                        .update_last_solid_subdag_base(pending_subdag.base);
+                }
+            }
+
             return Vec::new();
         }
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -100,7 +100,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             dag_state,
             sync_type: CommitSyncType::Fast,
         });
-        let synced_commit_index = inner.dag_state.read().last_commit_index();
+        let last_solid_commit_index = inner.dag_state.read().last_solid_commit_index();
         FastCommitSyncer {
             inner,
             inflight_fetches: JoinSet::new(),
@@ -108,7 +108,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             fetched_ranges: BTreeMap::new(),
             highest_scheduled_index: None,
             highest_fetched_commit_index: 0,
-            synced_commit_index,
+            synced_commit_index: last_solid_commit_index,
             close_to_quorum_mode: false,
             has_fetched_data: false,
         }
@@ -217,7 +217,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
 
     fn try_schedule_once(&mut self) {
         let quorum_commit_index = self.inner.commit_vote_monitor.quorum_commit_index();
-        let dag_state_commit_index = self.inner.dag_state.read().last_commit_index();
+        let last_solid_commit_index = self.inner.dag_state.read().last_solid_commit_index();
         let highest_handled_index = self.inner.commit_consumer_monitor.highest_handled_commit();
         let highest_scheduled_index = self.highest_scheduled_index.unwrap_or(0);
         let unhandled_commits_threshold = self.inner.unhandled_commits_threshold();
@@ -227,7 +227,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             .commit_sync_batch_size(&self.inner.context);
 
         // Skip scheduling depending on sync type and gap threshold.
-        let gap = quorum_commit_index.saturating_sub(dag_state_commit_index);
+        let gap = quorum_commit_index.saturating_sub(last_solid_commit_index);
         let should_schedule = self.has_fetched_data
             || self.inner.sync_type.should_schedule(
                 gap,
@@ -245,10 +245,10 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 .set(quorum_commit_index as i64);
             metrics
                 .commit_sync_local_index
-                .set(dag_state_commit_index as i64);
+                .set(last_solid_commit_index as i64);
             // Update synced_commit_index periodically to make sure it is not smaller than
-            // local commit index.
-            self.synced_commit_index = self.synced_commit_index.max(dag_state_commit_index);
+            // local solid commit index.
+            self.synced_commit_index = self.synced_commit_index.max(last_solid_commit_index);
 
             // TODO: cleanup inflight fetches that are no longer needed.
             let fetch_after_index = self
@@ -371,7 +371,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // Make sure the synced_commit_index is up to date.
         self.synced_commit_index = self
             .synced_commit_index
-            .max(self.inner.dag_state.read().last_commit_index());
+            .max(self.inner.dag_state.read().last_solid_commit_index());
         // Only add new blocks if at least some of them are not already synced.
         if self.synced_commit_index < commit_end {
             self.fetched_ranges

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -145,12 +145,13 @@ pub(crate) struct DagState {
     /// restarts.
     last_commit_round_advancement_time: Option<std::time::Instant>,
 
-    /// Round of the last committed leader which created a commit with available
-    /// transactions. Does not persist across restarts and after recovery.
+    /// The last solid SubDagBase - a commit where all transactions are locally
+    /// available. Does not persist across restarts and after recovery.
     /// All transactions below this round minus MAX_TRANSACTIONS_ACK_DEPTH
     /// (protocol_config.gc_depth) minus MAX_LINEARIZER_DEPTH
     /// (protocol_config.gc_depth) are evicted from memory.
-    last_solid_commit_leader_round: Option<Round>,
+    /// Used for GC calculations and as a starting point for fast sync.
+    last_solid_subdag_base: Option<SubDagBase>,
 
     /// Rounds for latest blocks traversed by linearizer per authority.
     last_committed_rounds: Vec<Round>,
@@ -271,8 +272,8 @@ impl DagState {
             last_commit: last_commit.clone(),
             last_commit_round_advancement_time: None,
             last_committed_rounds: last_committed_rounds.clone(),
-            last_solid_commit_leader_round: None, /* Later the commit observer might update
-                                                   * this value during recovery process. */
+            last_solid_subdag_base: None, /* Later the commit observer might update
+                                           * this value during recovery process. */
             pending_commit_votes: VecDeque::new(),
             transactions_to_write: vec![],
             block_headers_to_write: vec![],
@@ -543,15 +544,26 @@ impl DagState {
         self.voting_block_headers_to_write.extend(headers);
     }
 
+    /// Returns the leader round of the last solid commit (backward
+    /// compatibility).
     #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn last_solid_commit_leader_round(&self) -> Option<Round> {
-        self.last_solid_commit_leader_round
+        self.last_solid_subdag_base.as_ref().map(|s| s.leader.round)
     }
 
-    pub(crate) fn update_last_solid_commit_leader_round(
-        &mut self,
-        last_solid_commit_leader_round: Round,
-    ) {
+    /// Returns the commit index of the last solid commit.
+    /// Used by fast sync to determine the starting point for fetching.
+    pub(crate) fn last_solid_commit_index(&self) -> CommitIndex {
+        self.last_solid_subdag_base
+            .as_ref()
+            .map(|s| s.commit_ref.index)
+            .unwrap_or(0)
+    }
+
+    /// Updates the last solid SubDagBase - the most recent commit where all
+    /// transactions are locally available.
+    pub(crate) fn update_last_solid_subdag_base(&mut self, subdag_base: SubDagBase) {
+        let last_solid_commit_leader_round = subdag_base.leader.round;
         let max_commit_round = self
             .last_committed_rounds
             .iter()
@@ -560,13 +572,13 @@ impl DagState {
         debug!(
             "Last solid commit has leader at round {last_solid_commit_leader_round}; last commit has leader at round {max_commit_round}",
         );
-        self.last_solid_commit_leader_round = Some(last_solid_commit_leader_round);
         let gap = (*max_commit_round).saturating_sub(last_solid_commit_leader_round);
         self.context
             .metrics
             .node_metrics
             .gap_to_available_commit
             .set(gap as i64);
+        self.last_solid_subdag_base = Some(subdag_base);
     }
     pub(crate) fn update_pending_commit_votes(&mut self, solid_commit_refs: Vec<CommitRef>) {
         self.pending_commit_votes.extend(solid_commit_refs);
@@ -1523,8 +1535,8 @@ impl DagState {
 
         self.last_commit = Some(commit.clone());
 
-        if let Some(last_solid_commit_leader_round) = self.last_solid_commit_leader_round {
-            let gap = (commit.leader().round).saturating_sub(last_solid_commit_leader_round);
+        if let Some(last_solid_subdag_base) = &self.last_solid_subdag_base {
+            let gap = (commit.leader().round).saturating_sub(last_solid_subdag_base.leader.round);
             self.context
                 .metrics
                 .node_metrics
@@ -1674,9 +1686,8 @@ impl DagState {
     /// commit's leader round. Transactions of blocks at or below this round
     /// can be evicted from memory
     pub(crate) fn gc_round_for_last_solid_commit(&self) -> Round {
-        let last_solid_leader_round = self.last_solid_commit_leader_round;
-        if let Some(round) = last_solid_leader_round {
-            self.gc_round(round)
+        if let Some(subdag_base) = &self.last_solid_subdag_base {
+            self.gc_round(subdag_base.leader.round)
         } else {
             GENESIS_ROUND
         }
@@ -2652,7 +2663,9 @@ mod test {
         let mut dag_builder = DagBuilder::new(context.clone());
         dag_builder.layers(1..=num_rounds).build();
         let mut commits = vec![];
-        for (_subdag, commit) in dag_builder.get_sub_dag_and_commits(1..=num_rounds) {
+        let mut subdag_bases = vec![];
+        for (subdag, commit) in dag_builder.get_sub_dag_and_commits(1..=num_rounds) {
+            subdag_bases.push(subdag.base);
             commits.push(commit);
         }
 
@@ -2660,6 +2673,7 @@ mod test {
         // 5 commits to the dag state; also add commit info after the second
         // commit.
         let later_commits = commits.split_off(5);
+        let _later_subdag_bases = subdag_bases.split_off(5);
         dag_state.accept_block_headers(dag_builder.block_headers(1..=5));
         for verified_transactions in dag_builder.transactions(1..=5).into_iter() {
             dag_state.add_transactions(verified_transactions, TransactionSource::Test);
@@ -2671,7 +2685,7 @@ mod test {
                 dag_state.add_commit_info(ReputationScores::default());
             }
         }
-        dag_state.update_last_solid_commit_leader_round(5);
+        dag_state.update_last_solid_subdag_base(subdag_bases.last().unwrap().clone());
 
         // Flush the dag state
         dag_state.flush();
@@ -3436,7 +3450,9 @@ mod test {
         let mut dag_builder = DagBuilder::new(context.clone());
         dag_builder.layers(1..=num_rounds).build();
         let mut commits = vec![];
-        for (_subdag, commit) in dag_builder.get_sub_dag_and_commits(1..=num_rounds) {
+        let mut subdag_bases = vec![];
+        for (subdag, commit) in dag_builder.get_sub_dag_and_commits(1..=num_rounds) {
+            subdag_bases.push(subdag.base);
             commits.push(commit);
         }
 
@@ -3448,7 +3464,7 @@ mod test {
         for commit in commits.clone() {
             dag_state.add_commit(commit.clone());
         }
-        dag_state.update_last_solid_commit_leader_round(num_rounds);
+        dag_state.update_last_solid_subdag_base(subdag_bases.last().unwrap().clone());
 
         // Flush the dag state (eviction is happening inside the flush)
         dag_state.flush();

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -258,6 +258,21 @@ impl LeaderSchedule {
         if range_end == GENESIS_COMMIT_INDEX {
             return;
         }
+
+        // Skip stale scores: if the incoming scores are for a range we've already
+        // processed (i.e., range_end <= last_commit_info_index), don't update.
+        // This can happen after a crash when fast sync fetches old commits that
+        // the node already has, while the node has recovered scoring_subdag from
+        // commits after the last persisted CommitInfo.
+        let last_commit_info_index = dag_state.last_commit_info_index();
+        if range_end <= last_commit_info_index {
+            tracing::debug!(
+                "[AUTH {}] Skipping stale scores from commit {commit_index} (range_end={range_end} <= last_commit_info_index={last_commit_info_index})",
+                self.context.own_index
+            );
+            return;
+        }
+
         let range_start = range_end.saturating_sub(self.num_commits_per_schedule as u32 - 1);
         let commit_range = CommitRange::new(range_start..=range_end);
 

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -68,6 +68,8 @@ pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
 pub use context::Clock;
 pub use network::tonic_network::to_socket_addr;
 #[cfg(msim)]
+pub use storage::RocksDBStore;
+#[cfg(msim)]
 pub use transaction::NoopTransactionVerifier;
 pub use transaction::{
     BlockStatus, ClientError, TransactionClient, TransactionVerifier, ValidationError,

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -68,7 +68,7 @@ pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
 pub use context::Clock;
 pub use network::tonic_network::to_socket_addr;
 #[cfg(msim)]
-pub use storage::RocksDBStore;
+pub use storage::delete_all_transactions_from_store;
 #[cfg(msim)]
 pub use transaction::NoopTransactionVerifier;
 pub use transaction::{

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -6,6 +6,9 @@
 pub(crate) mod mem_store;
 pub(crate) mod rocksdb_store;
 
+#[cfg(msim)]
+pub use rocksdb_store::RocksDBStore;
+
 #[cfg(test)]
 mod store_tests;
 

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -6,15 +6,14 @@
 pub(crate) mod mem_store;
 pub(crate) mod rocksdb_store;
 
-#[cfg(msim)]
-pub use rocksdb_store::RocksDBStore;
-
 #[cfg(test)]
 mod store_tests;
 
 use std::sync::Arc;
 
 use bytes::Bytes;
+#[cfg(msim)]
+pub use rocksdb_store::RocksDBStore;
 use starfish_config::AuthorityIndex;
 
 use crate::{

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -12,8 +12,6 @@ mod store_tests;
 use std::sync::Arc;
 
 use bytes::Bytes;
-#[cfg(msim)]
-pub use rocksdb_store::RocksDBStore;
 use starfish_config::AuthorityIndex;
 
 use crate::{
@@ -237,4 +235,22 @@ impl WriteBatch {
         self.voting_block_headers = voting_block_headers;
         self
     }
+}
+
+/// Simulation-test-only helper that deletes all transactions from the consensus
+/// RocksDB store while preserving commits, block headers, and other data.
+#[cfg(msim)]
+pub fn delete_all_transactions_from_store(
+    db_path: &std::path::Path,
+    authority_index: starfish_config::AuthorityIndex,
+    committee: starfish_config::Committee,
+    protocol_config: iota_protocol_config::ProtocolConfig,
+) -> Result<(), String> {
+    rocksdb_store::RocksDBStore::delete_all_transactions_from_store(
+        db_path,
+        authority_index,
+        committee,
+        protocol_config,
+    )
+    .map_err(|e| format!("failed to delete transactions: {}", e))
 }

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -787,3 +787,26 @@ pub(crate) fn check_ref_consistency(refs: &[GenericTransactionRef]) -> bool {
     let first = std::mem::discriminant(&refs[0]);
     refs.iter().all(|r| std::mem::discriminant(r) == first)
 }
+
+#[cfg(msim)]
+impl RocksDBStore {
+    /// Deletes all transactions from the store.
+    /// Preserves commits, block headers, and other data.
+    /// Only available in simulation tests.
+    pub fn delete_all_transactions(&self) -> ConsensusResult<()> {
+        use typed_store::Map as _;
+
+        self.transactions
+            .unsafe_clear()
+            .map_err(ConsensusError::RocksDBFailure)?;
+        self.transactions_by_tx_refs
+            .unsafe_clear()
+            .map_err(ConsensusError::RocksDBFailure)?;
+        self.transaction_commitments_by_authorities
+            .unsafe_clear()
+            .map_err(ConsensusError::RocksDBFailure)?;
+
+        debug!("Deleted all transactions from store");
+        Ok(())
+    }
+}

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -793,7 +793,7 @@ impl RocksDBStore {
     /// Deletes all transactions from the store.
     /// Preserves commits, block headers, and other data.
     /// Only available in simulation tests.
-    pub fn delete_all_transactions(&self) -> ConsensusResult<()> {
+    pub(crate) fn delete_all_transactions(&self) -> ConsensusResult<()> {
         use typed_store::Map as _;
 
         self.transactions
@@ -808,5 +808,45 @@ impl RocksDBStore {
 
         debug!("Deleted all transactions from store");
         Ok(())
+    }
+
+    /// Simulation-test-only helper that creates a store and deletes all
+    /// transactions.
+    ///
+    /// Deletes all transactions from the consensus RocksDB store while
+    /// preserving commits, block headers, and other data.
+    pub fn delete_all_transactions_from_store(
+        db_path: &std::path::Path,
+        authority_index: AuthorityIndex,
+        committee: starfish_config::Committee,
+        protocol_config: iota_protocol_config::ProtocolConfig,
+    ) -> ConsensusResult<()> {
+        use prometheus::Registry;
+        use starfish_config::Parameters;
+
+        use crate::{Clock, context::Context, metrics::initialise_metrics};
+
+        let metrics = initialise_metrics(Registry::new());
+        let clock = Arc::new(Clock::default());
+        let context = Arc::new(Context::new(
+            0,
+            authority_index,
+            committee,
+            Parameters {
+                db_path: db_path.to_path_buf(),
+                ..Default::default()
+            },
+            protocol_config,
+            metrics,
+            clock,
+        ));
+
+        let store = RocksDBStore::new(
+            db_path
+                .to_str()
+                .expect("consensus DB path should be valid UTF-8"),
+            context,
+        );
+        store.delete_all_transactions()
     }
 }

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -107,10 +107,9 @@ impl AuthorityNode {
 
     /// Restart the node with the specified mode
     pub async fn restart(&self, mode: RestartMode) -> Result<()> {
-        self.stop().await;
-
         match mode {
             RestartMode::CleanAll => {
+                self.stop().await;
                 // Erase consensus DB and all node tracking
                 *self.db_dir.lock() = Arc::new(TempDir::new()?);
                 self.last_processed_commit.store(0, Ordering::SeqCst);
@@ -122,6 +121,7 @@ impl AuthorityNode {
                 self.committed_transactions.write().await.clear();
             }
             RestartMode::ResetLastProcessed => {
+                self.stop().await;
                 // Keep consensus DB, reset node tracking state
                 self.last_processed_commit.store(0, Ordering::SeqCst);
                 self.commit_digests.write().await.clear();
@@ -129,16 +129,11 @@ impl AuthorityNode {
                 // Keep boot_counter incrementing (not a fresh node)
             }
             RestartMode::PersistAll => {
+                self.stop().await;
                 // Keep both consensus DB and node tracking (no changes)
             }
             RestartMode::EraseAllTransactions => {
-                starfish_core::delete_all_transactions_from_store(
-                    self.db_dir.lock().path(),
-                    self.config.authority_index,
-                    self.config.committee.clone(),
-                    self.config.protocol_config.clone(),
-                )
-                .expect("Failed to delete transactions");
+                self.stop_and_clear_transactions().await;
 
                 // Reset tracking state (transactions will be re-synced)
                 self.last_processed_commit.store(0, Ordering::SeqCst);
@@ -219,6 +214,28 @@ impl AuthorityNode {
         if let Some(mut inner) = inner {
             if let Some(consensus_authority) = inner.consensus_authority.take() {
                 consensus_authority.stop().await;
+            }
+
+            if let Some(handle) = inner.handle.take() {
+                tracing::info!("shutting down {}", handle.node_id);
+                iota_simulator::runtime::Handle::try_current()
+                    .map(|h| h.delete_node(handle.node_id));
+            }
+        }
+        info!(index =% self.config.authority_index, "node stopped");
+    }
+
+    /// Stop this Node and clear all transactions from the consensus store.
+    /// Only used by simtests.
+    pub async fn stop_and_clear_transactions(&self) {
+        info!(index =% self.config.authority_index, "stopping in-memory node");
+        let inner = self.inner.lock().take();
+        if let Some(mut inner) = inner {
+            if let Some(consensus_authority) = inner.consensus_authority.take() {
+                consensus_authority
+                    .stop_and_clear_transactions()
+                    .await
+                    .expect("Failed to delete transactions");
             }
 
             if let Some(handle) = inner.handle.take() {

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -38,6 +38,9 @@ pub(crate) enum RestartMode {
     /// Keep consensus DB but reset last_processed_commit to 0.
     /// Tests recovery when consensus state is intact but node tracking is lost.
     ResetLastProcessed,
+    /// Erase all transactions from the DB, preserving commits and block
+    /// headers. Tests transaction recovery via sync from peers.
+    EraseAllTransactions,
 }
 
 #[derive(Clone)]
@@ -104,7 +107,15 @@ impl AuthorityNode {
 
     /// Restart the node with the specified mode
     pub async fn restart(&self, mode: RestartMode) -> Result<()> {
+        // Save context before stopping (may be needed for some restart modes)
+        let saved_context = self
+            .inner
+            .lock()
+            .as_ref()
+            .map(|inner| inner.consensus_authority.context().clone());
+
         self.stop();
+
         match mode {
             RestartMode::CleanAll => {
                 // Erase consensus DB and all node tracking
@@ -126,6 +137,28 @@ impl AuthorityNode {
             }
             RestartMode::PersistAll => {
                 // Keep both consensus DB and node tracking (no changes)
+            }
+            RestartMode::EraseAllTransactions => {
+                // Use saved context to create store and delete transactions
+                let context = saved_context
+                    .clone()
+                    .expect("Context should be available for EraseAllTransactions");
+                let db_path = self
+                    .db_dir
+                    .lock()
+                    .path()
+                    .to_str()
+                    .expect("DB path should be valid UTF-8")
+                    .to_string();
+                let store = starfish_core::RocksDBStore::new(&db_path, context);
+                store
+                    .delete_all_transactions()
+                    .expect("Failed to delete transactions");
+
+                // Reset tracking state (transactions will be re-synced)
+                self.last_processed_commit.store(0, Ordering::SeqCst);
+                self.commit_digests.write().await.clear();
+                self.committed_transactions.write().await.clear();
             }
         }
         self.start().await

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -107,14 +107,7 @@ impl AuthorityNode {
 
     /// Restart the node with the specified mode
     pub async fn restart(&self, mode: RestartMode) -> Result<()> {
-        // Save context before stopping (may be needed for some restart modes)
-        let saved_context = self
-            .inner
-            .lock()
-            .as_ref()
-            .map(|inner| inner.consensus_authority.context().clone());
-
-        self.stop();
+        self.stop().await;
 
         match mode {
             RestartMode::CleanAll => {
@@ -139,21 +132,13 @@ impl AuthorityNode {
                 // Keep both consensus DB and node tracking (no changes)
             }
             RestartMode::EraseAllTransactions => {
-                // Use saved context to create store and delete transactions
-                let context = saved_context
-                    .clone()
-                    .expect("Context should be available for EraseAllTransactions");
-                let db_path = self
-                    .db_dir
-                    .lock()
-                    .path()
-                    .to_str()
-                    .expect("DB path should be valid UTF-8")
-                    .to_string();
-                let store = starfish_core::RocksDBStore::new(&db_path, context);
-                store
-                    .delete_all_transactions()
-                    .expect("Failed to delete transactions");
+                starfish_core::RocksDBStore::delete_all_transactions_from_store(
+                    self.db_dir.lock().path(),
+                    self.config.authority_index,
+                    self.config.committee.clone(),
+                    self.config.protocol_config.clone(),
+                )
+                .expect("Failed to delete transactions");
 
                 // Reset tracking state (transactions will be re-synced)
                 self.last_processed_commit.store(0, Ordering::SeqCst);
@@ -228,9 +213,20 @@ impl AuthorityNode {
     }
 
     /// Stop this Node
-    pub fn stop(&self) {
+    pub async fn stop(&self) {
         info!(index =% self.config.authority_index, "stopping in-memory node");
-        *self.inner.lock() = None;
+        let inner = self.inner.lock().take();
+        if let Some(mut inner) = inner {
+            if let Some(consensus_authority) = inner.consensus_authority.take() {
+                consensus_authority.stop().await;
+            }
+
+            if let Some(handle) = inner.handle.take() {
+                tracing::info!("shutting down {}", handle.node_id);
+                iota_simulator::runtime::Handle::try_current()
+                    .map(|h| h.delete_node(handle.node_id));
+            }
+        }
         info!(index =% self.config.authority_index, "node stopped");
     }
 
@@ -253,7 +249,7 @@ impl AuthorityNode {
 pub(crate) struct AuthorityNodeInner {
     handle: Option<NodeHandle>,
     cancel_sender: Option<tokio::sync::watch::Sender<bool>>,
-    consensus_authority: ConsensusAuthority,
+    consensus_authority: Option<ConsensusAuthority>,
     commit_receiver: ArcSwapOption<UnboundedReceiver<CommittedSubDag>>,
     commit_consumer_monitor: Arc<CommitConsumerMonitor>,
 }
@@ -339,7 +335,7 @@ impl AuthorityNodeInner {
         Self {
             handle: Some(NodeHandle { node_id: node.id() }),
             cancel_sender: Some(cancel_sender),
-            consensus_authority,
+            consensus_authority: Some(consensus_authority),
             commit_receiver: ArcSwapOption::new(Some(Arc::new(commit_receiver))),
             commit_consumer_monitor,
         }
@@ -376,7 +372,10 @@ impl AuthorityNodeInner {
     }
 
     pub fn transaction_client(&self) -> Arc<TransactionClient> {
-        self.consensus_authority.transaction_client()
+        self.consensus_authority
+            .as_ref()
+            .expect("consensus authority should be available")
+            .transaction_client()
     }
 }
 

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -132,7 +132,7 @@ impl AuthorityNode {
                 // Keep both consensus DB and node tracking (no changes)
             }
             RestartMode::EraseAllTransactions => {
-                starfish_core::RocksDBStore::delete_all_transactions_from_store(
+                starfish_core::delete_all_transactions_from_store(
                     self.db_dir.lock().path(),
                     self.config.authority_index,
                     self.config.committee.clone(),

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -496,4 +496,12 @@ mod test {
     async fn test_sequential_restarts_reset_last_processed_long_run_long_stop() {
         run_sequential_restarts_test(RestartMode::ResetLastProcessed, true, true).await;
     }
+
+    /// Erase all transactions from DB, preserving commits and block headers.
+    /// Tests transaction recovery via sync from peers.
+    /// Long run before stop, long stop duration.
+    #[sim_test(config = "test_config()")]
+    async fn test_sequential_restarts_erase_transactions_long_run_long_stop() {
+        run_sequential_restarts_test(RestartMode::EraseAllTransactions, true, true).await;
+    }
 }

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -161,7 +161,7 @@ mod test {
 
         // Timing constants
         const LONG_DURATION_SECS: u64 = 120;
-        const SHORT_DURATION_SECS: u64 = 2;
+        const SHORT_DURATION_SECS: u64 = 5;
         const TXN_SUBMIT_INTERVAL_MS: u64 = 10;
         const PRE_FINAL_RUN_SECS: u64 = 2 * LONG_DURATION_SECS;
         const FINAL_SETTLEMENT_WAIT_SECS: u64 = LONG_DURATION_SECS;

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -317,7 +317,7 @@ mod test {
                     .map(|a| a.commit_consumer_monitor().highest_handled_commit())
                     .max()
                     .unwrap_or(commit_at_stop);
-                authorities[authority_idx].stop();
+                authorities[authority_idx].stop().await;
                 assert!(!authorities[authority_idx].is_running());
 
                 // Wait while stopped (other authorities make progress)


### PR DESCRIPTION
## Description

Previously we tracked last commit leader round in the DAG state. But it was not sufficient for fast sync fetching logic. We now store `last_solid_subdag_base` in DagState so fast sync knows where to start fetching commit indices after restart.

**Changes:**
- Track `last_solid_subdag_base` in DagState, updated when commits become solid
- Initialize it correctly on restart even when node has no committed sub DAGs to resend to the handlerr
- Fast sync uses last solid commit index to fetch committed subDAGs
- Skip stale leader schedule score updates from already-processed commits after crash recovery
- Add simtest for restart scenarios where transactions are cleared but headers remain in the consensus DB
- Consolidate simtest helpers into `RocksDBStore`

## Links to any relevant issues

Fixes #9920

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes