### PR TITLE
fix(docs): remove breaking brackets from docs

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -8927,7 +8927,7 @@
         ]
       },
       "IotaSystemStateSummaryV1": {
-        "description": "This is the JSON-RPC type for the [`IotaSystemStateV1`](super::iota_system_state_inner_v1::IotaSystemStateV1) object. It flattens all fields to make them top-level fields such that it as minimum dependencies to the internal data structures of the IOTA system state type.",
+        "description": "This is the JSON-RPC type for the `IotaSystemStateV1`(super::iota_system_state_inner_v1::IotaSystemStateV1) object. It flattens all fields to make them top-level fields such that it as minimum dependencies to the internal data structures of the IOTA system state type.",
         "type": "object",
         "required": [
           "activeValidators",
@@ -9256,7 +9256,7 @@
         }
       },
       "IotaSystemStateSummaryV2": {
-        "description": "This is the JSON-RPC type for the [`IotaSystemStateV2`](super::iota_system_state_inner_v2::IotaSystemStateV2) object. It flattens all fields to make them top-level fields such that it as minimum dependencies to the internal data structures of the IOTA system state type.",
+        "description": "This is the JSON-RPC type for the `IotaSystemStateV2`(super::iota_system_state_inner_v2::IotaSystemStateV2) object. It flattens all fields to make them top-level fields such that it as minimum dependencies to the internal data structures of the IOTA system state type.",
         "type": "object",
         "required": [
           "activeValidators",

--- a/crates/iota-types/src/iota_system_state/iota_system_state_summary.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_summary.rs
@@ -33,7 +33,7 @@ pub enum IotaSystemStateSummary {
 }
 
 /// This is the JSON-RPC type for the
-/// [`IotaSystemStateV1`](super::iota_system_state_inner_v1::IotaSystemStateV1)
+/// `IotaSystemStateV1`(super::iota_system_state_inner_v1::IotaSystemStateV1)
 /// object. It flattens all fields to make them top-level fields such that it as
 /// minimum dependencies to the internal data structures of the IOTA system
 /// state type.
@@ -197,7 +197,7 @@ pub struct IotaSystemStateSummaryV1 {
 }
 
 /// This is the JSON-RPC type for the
-/// [`IotaSystemStateV2`](super::iota_system_state_inner_v2::IotaSystemStateV2)
+/// `IotaSystemStateV2`(super::iota_system_state_inner_v2::IotaSystemStateV2)
 /// object. It flattens all fields to make them top-level fields such that it as
 /// minimum dependencies to the internal data structures of the IOTA system
 /// state type.

--- a/sdk/typescript/src/client/types/generated.ts
+++ b/sdk/typescript/src/client/types/generated.ts
@@ -763,7 +763,7 @@ export type IotaSystemStateSummary =
       };
 /**
  * This is the JSON-RPC type for the
- * [`IotaSystemStateV1`](super::iota_system_state_inner_v1::IotaSystemStateV1) object. It flattens all
+ * `IotaSystemStateV1`(super::iota_system_state_inner_v1::IotaSystemStateV1) object. It flattens all
  * fields to make them top-level fields such that it as minimum dependencies to the internal data
  * structures of the IOTA system state type.
  */
@@ -868,7 +868,7 @@ export interface IotaSystemStateSummaryV1 {
 }
 /**
  * This is the JSON-RPC type for the
- * [`IotaSystemStateV2`](super::iota_system_state_inner_v2::IotaSystemStateV2) object. It flattens all
+ * `IotaSystemStateV2`(super::iota_system_state_inner_v2::IotaSystemStateV2) object. It flattens all
  * fields to make them top-level fields such that it as minimum dependencies to the internal data
  * structures of the IOTA system state type.
  */


### PR DESCRIPTION
# Description of change

This is currently breaking the docs in some builds. Not sure if this is any special syntax but I think it should be safe to remove it