### PR TITLE
fix(ci): deny license and advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -59,8 +59,6 @@ ignore = [
   "RUSTSEC-2025-0056",
   # bincode is unmaintained
   "RUSTSEC-2025-0141",
-  # `IterMut` violates Stacked Borrows by invalidating internal pointer (FIX ASAP)
-  "RUSTSEC-2026-0002",
   # rustls-pemfile is unmaintained
   "RUSTSEC-2025-0134",
 ]
@@ -93,10 +91,10 @@ allow = [
   "Unlicense",
   "BSL-1.0",
   "Unicode-DFS-2016",
-  "OpenSSL",
   "Unicode-3.0",
   "CDLA-Permissive-2.0",
   "CDDL-1.0",
+  "Zlib",
   # "Apache-2.0 WITH LLVM-exception",
 ]
 # The confidence threshold for detecting a license from license text.


### PR DESCRIPTION
# Description of change

Fixes 

```
thibault@Mac ~/i/iota (develop)> cargo deny check advisories
warning[advisory-not-detected]: advisory was not encountered
   ┌─ /Users/thibault/iota/iota/deny.toml:63:4
   │
63 │   "RUSTSEC-2026-0002",
   │    ━━━━━━━━━━━━━━━━━ no crate matched advisory criteria
```

and

```
error[rejected]: failed to satisfy license requirements
   ┌─ /Users/thibault/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/foldhash-0.2.0/Cargo.toml:40:12
   │
40 │ license = "Zlib"
   │            ━━━━
   │            │
   │            rejected: license is not explicitly allowed
   │
   ├ Zlib - zlib License:
   ├   - OSI approved
   ├   - FSF Free/Libre
```