### PR TITLE
feat(aa): use protocol max_function_parameters for MoveAuthenticator inputs length

### DIFF
--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -158,15 +158,18 @@ impl MoveAuthenticator {
         // `validity_check` is not called for `object_to_authenticate` because it is
         // already validated with a dedicated function.
 
-        // `ProtocolConfig::max_arguments` is used to check the call arguments because
-        // MoveAuthenticator is considered as a simple programmable Move call.
+        // `ProtocolConfig::max_function_parameters` is used to check the call arguments
+        // because MoveAuthenticator is considered as a simple programmable call to a
+        // Move function.
         //
-        // The limit includes the object to authenticate, so we subtract 1 here.
+        // The limit includes the object to authenticate, the auth context and the tx
+        // context, so we subtract 3 here.
+        let max_args = (config.max_function_parameters() - 3) as usize;
         fp_ensure!(
-            self.call_args().len() < (config.max_arguments() - 1) as usize,
+            self.call_args().len() < max_args,
             UserInputError::SizeLimitExceeded {
                 limit: "maximum arguments in MoveAuthenticator".to_string(),
-                value: config.max_arguments().to_string()
+                value: max_args.to_string()
             }
         );
 


### PR DESCRIPTION
# Description of change

Used `max_function_parameters` (128) instead of `max_arguments` (512) as limit for the inputs to pass to the MoveAuthenticator.

## Links to any relevant issues

Fixes #9933 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes