### PR TITLE
feat(protocol-config): enable passkey authentication support in mainnet

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -104,6 +104,7 @@ pub const MAX_PROTOCOL_VERSION: u64 = 19;
 //             Enable Move-based account authentication in devnet.
 //             Increase the base cost for transfer receive object in devnet.
 //             Switch consensus protocol to Starfish in testnet.
+//             Enable passkey authentication support in mainnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -2417,6 +2418,9 @@ impl ProtocolConfig {
                         // Switch consensus protocol to Starfish in testnet.
                         cfg.feature_flags.consensus_choice = ConsensusChoice::Starfish;
                     }
+
+                    // Enable passkey authentication support in mainnet
+                    cfg.feature_flags.passkey_auth = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_19.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_19.snap
@@ -1,12 +1,14 @@
 ---
 source: crates/iota-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+snapshot_kind: text
 ---
 version: 19
 feature_flags:
   consensus_transaction_ordering: ByGasPrice
   per_object_congestion_control_mode: TotalTxCount
   zklogin_max_epoch_upper_bound_delta: 30
+  passkey_auth: true
   relocate_event_module: true
   protocol_defined_base_fee: true
   disallow_new_modules_in_deps_only_packages: true


### PR DESCRIPTION
# Description of change

Enable passkey authentication support in mainnet with protocol v19.

## Links to any relevant issues

fixes #9758

### Release Notes

- [x] Protocol: Enable passkey authentication support in mainnet.
