### PR TITLE
chore(wallet): Fix testId react warning

### DIFF
--- a/apps/wallet/src/ui/app/pages/accounts/PasskeyAccountPage.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/PasskeyAccountPage.tsx
@@ -114,7 +114,7 @@ export function PasskeyAccountPage() {
                             </p>
 
                             {RADIO_BUTTONS.map((radio) => (
-                                <div key={radio.label} data-testId={`passkey-radio-${radio.name}`}>
+                                <div key={radio.label} data-testid={`passkey-radio-${radio.name}`}>
                                     <RadioButton {...radio} />
                                 </div>
                             ))}


### PR DESCRIPTION
> react-dom.development.js:86 Warning: React does not recognize the `data-testId` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `data-testid` instead. If you accidentally passed it from a parent component, remove it from the DOM element.