### PR TITLE
feat(indexer): Do dependency checking in optimistic indexing using input objects

### DIFF
--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -136,7 +136,7 @@ impl OptimisticTransactionExecutor {
             .iter()
             .map(|ob| (ob.id(), ob.version()))
             .collect::<Vec<_>>();
-        if let Ok(_) = self.wait_for_dependencies(input_obj_keys).await {
+        if self.wait_for_dependencies(input_obj_keys).await.is_ok() {
             deps_timer.stop_and_record();
         } else {
             deps_timer.stop_and_discard();

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -1,9 +1,6 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-use std::{
-    collections::{BTreeMap, HashSet},
-    time::Duration,
-};
+use std::{collections::BTreeMap, time::Duration};
 
 use diesel::{PgConnection, RunQueryDsl, result::DatabaseErrorKind, sql_query, sql_types};
 use downcast::Any;
@@ -11,8 +8,8 @@ use fastcrypto::{encoding::Base64, error::FastCryptoError, traits::ToFromBytes};
 use iota_json_rpc_types::{IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions};
 use iota_rest_api::{ExecuteTransactionQueryParameters, client::TransactionExecutionResponse};
 use iota_types::{
-    base_types::TransactionDigest,
-    effects::{TransactionEffects, TransactionEffectsAPI},
+    base_types::{ObjectID, SequenceNumber, TransactionDigest},
+    effects::TransactionEffectsAPI,
     full_checkpoint_content::CheckpointTransaction,
     signature::GenericSignature,
     transaction::{Transaction, TransactionData},
@@ -72,37 +69,22 @@ impl OptimisticTransactionExecutor {
         }
     }
 
-    /// Wait until all dependencies are indexed through the `tx_global_order`
-    /// table.
-    ///
-    /// It uses exponential backoff to retry the check.
-    ///
-    /// This does not cover old transactions that do not have
-    /// entries in `tx_global_order`.
-    pub(crate) async fn wait_for_tx_dependencies(
+    pub(crate) async fn wait_for_dependencies(
         &self,
-        effects: &TransactionEffects,
+        input_obj_keys: Vec<(ObjectID, SequenceNumber)>,
     ) -> Result<(), IndexerError> {
-        let expected_dependencies = effects
-            .dependencies()
-            .iter()
-            .copied()
-            .collect::<HashSet<_>>();
+        let expected_count = input_obj_keys.len();
         let backoff = backoff::ExponentialBackoff {
             max_elapsed_time: Some(WAIT_FOR_DEPS_MAX_ELAPSED_TIME),
             ..Default::default()
         };
 
         backoff::future::retry(backoff, async || {
-            let digests: Vec<Vec<u8>> = expected_dependencies
-                .iter()
-                .map(|d| d.inner().to_vec())
-                .collect();
             let count = self
                 .read
-                .count_indexed_tx_global_orders_in_blocking_task(digests.into_iter())
+                .count_existing_object_keys_in_blocking_task(input_obj_keys.clone())
                 .await?;
-            if count as usize != expected_dependencies.len() {
+            if count as usize != expected_count {
                 return Err(IndexerError::TransactionDependenciesNotIndexed)?;
             }
             Ok(())
@@ -150,22 +132,22 @@ impl OptimisticTransactionExecutor {
             .metrics
             .optimistic_tx_dependencies_wait_time
             .start_timer();
-        tokio::select! {
-            Ok(_) = self.wait_for_tx_dependencies(&effects) => {
-                deps_timer.stop_and_record();
-            },
-            Ok(true) = self.deep_check_all_dependencies_are_indexed(&effects) => {
-                deps_timer.stop_and_record();
-            },
-            else => {
-                deps_timer.stop_and_discard();
-                tracing::warn!(
-                    "transaction {tx_digest} dependencies are not indexed, skipping optimistic indexing",
-                );
-                self.metrics.optimistic_tx_with_missing_dependencies_count.inc();
-                return Ok(());
-            }
-        };
+        let input_obj_keys = input_objects
+            .iter()
+            .map(|ob| (ob.id(), ob.version()))
+            .collect::<Vec<_>>();
+        if let Ok(_) = self.wait_for_dependencies(input_obj_keys).await {
+            deps_timer.stop_and_record();
+        } else {
+            deps_timer.stop_and_discard();
+            tracing::warn!(
+                "transaction {tx_digest} dependencies are not indexed, skipping optimistic indexing",
+            );
+            self.metrics
+                .optimistic_tx_with_missing_dependencies_count
+                .inc();
+            return Ok(());
+        }
         let full_tx_data = CheckpointTransaction {
             transaction,
             effects,
@@ -175,22 +157,6 @@ impl OptimisticTransactionExecutor {
         };
 
         self.index_transaction_in_blocking_task(&full_tx_data).await
-    }
-
-    /// Expensive operation that checks if all transactions
-    /// are indexed.
-    ///
-    /// This queries both `tx_global_order` which represents
-    /// the index status for newer transactions, and the `checkpoints`
-    /// table for older transactions that do not have entries
-    /// in `tx_global_order`.
-    pub(crate) async fn deep_check_all_dependencies_are_indexed(
-        &self,
-        effects: &TransactionEffects,
-    ) -> Result<bool, IndexerError> {
-        self.read
-            .deep_check_all_transactions_are_indexed_in_blocking_task(effects.dependencies())
-            .await
     }
 
     pub async fn execute_and_index_transaction(

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use cached::{Cached, SizedCache};
 use diesel::{
     BoolExpressionMethods, ExpressionMethods, JoinOnDsl, NullableExpressionMethods,
-    OptionalExtension, PgConnection, QueryDsl, RunQueryDsl, SelectableHelper,
+    OptionalExtension, PgConnection, QueryDsl, QueryableByName, RunQueryDsl, SelectableHelper,
     TextExpressionMethods,
     dsl::sql,
     r2d2::ConnectionManager,
@@ -71,7 +71,7 @@ use crate::{
         objects::{CoinBalance, StoredHistoryObject, StoredObject},
         participation_metrics::StoredParticipationMetrics,
         transactions::{
-            IndexStatus, OptimisticTransaction, StoredTransaction, StoredTransactionEvents,
+            OptimisticTransaction, StoredTransaction, StoredTransactionEvents,
             stored_events_to_events, tx_events_to_iota_tx_events,
         },
         tx_indices::TxSequenceNumber,
@@ -706,77 +706,6 @@ impl IndexerReader {
             .collect()
     }
 
-    /// Expensive check to assert whether all transactions
-    /// are indexed.
-    ///
-    /// It uses both the `tx_global_order` table
-    /// and the `checkpoints` table to cover old transactions.
-    pub(crate) async fn deep_check_all_transactions_are_indexed_in_blocking_task(
-        &self,
-        digests: &[TransactionDigest],
-    ) -> Result<bool, IndexerError> {
-        let stored_transactions = self.multi_get_transactions(digests).await?;
-        if stored_transactions.len() != digests.len() {
-            return Ok(false);
-        }
-        let (checkpointed, optimistic) = stored_transactions
-            .into_iter()
-            .partition::<Vec<_>, _>(|tx| tx.checkpoint_sequence_number >= 0);
-        if !optimistic.is_empty() {
-            let num_optimistic = optimistic.len();
-            let optimistic_digests = optimistic
-                .into_iter()
-                .map(|tx| tx.transaction_digest)
-                .collect::<HashSet<_>>();
-            let num_indexed = self
-                .count_indexed_tx_global_orders_in_blocking_task(optimistic_digests.into_iter())
-                .await?;
-            if num_indexed as usize != num_optimistic {
-                return Ok(false);
-            }
-        }
-        let Some(max_transaction_checkpoint) = checkpointed
-            .iter()
-            .map(|tx| tx.checkpoint_sequence_number)
-            .max()
-        else {
-            return Ok(true);
-        };
-        let checkpoint = self
-            .db()
-            .get_checkpoint(CheckpointId::SequenceNumber(
-                max_transaction_checkpoint as u64,
-            ))
-            .await?;
-        Ok(checkpoint.is_some())
-    }
-
-    /// Count how many entries in `tx_global_order` correspond
-    /// to indexed transactions.
-    ///
-    /// Any transaction with a non-zero optimistic sequence number
-    /// is considered as indexed.
-    fn count_indexed_tx_global_orders(
-        &self,
-        digests: impl Iterator<Item = Vec<u8>>,
-    ) -> Result<i64, IndexerError> {
-        run_query!(&self.pool, |conn| {
-            tx_global_order::table
-                .filter(tx_global_order::tx_digest.eq_any(digests))
-                .filter(tx_global_order::optimistic_sequence_number.ne(IndexStatus::Started))
-                .count()
-                .get_result(conn)
-        })
-    }
-
-    pub(crate) async fn count_indexed_tx_global_orders_in_blocking_task(
-        &self,
-        digests: impl Iterator<Item = Vec<u8>> + Send + 'static,
-    ) -> Result<i64, IndexerError> {
-        self.spawn_blocking(move |this| this.count_indexed_tx_global_orders(digests))
-            .await
-    }
-
     /// Fetches multiple transactions from the database.
     ///
     ///  Retrieval order:
@@ -1065,6 +994,52 @@ impl IndexerReader {
             objects::dsl::objects
                 .filter(objects::object_id.eq_any(object_ids))
                 .load::<StoredObject>(conn)
+        })
+    }
+
+    pub async fn count_existing_object_keys_in_blocking_task(
+        &self,
+        object_keys: Vec<(ObjectID, SequenceNumber)>,
+    ) -> Result<i64, IndexerError> {
+        self.spawn_blocking(move |this| this.count_existing_object_keys(object_keys))
+            .await
+    }
+
+    fn count_existing_object_keys(
+        &self,
+        object_keys: Vec<(ObjectID, SequenceNumber)>,
+    ) -> Result<i64, IndexerError> {
+        if object_keys.is_empty() {
+            return Ok(0);
+        }
+
+        let values_clause = object_keys
+            .iter()
+            .map(|(id, version)| {
+                format!(
+                    "('\\x{}'::bytea, {}::bigint)",
+                    Hex::encode(id.to_vec()),
+                    version.value()
+                )
+            })
+            .join(", ");
+
+        let query = format!(
+            "SELECT COUNT(*) as count FROM objects \
+             WHERE (object_id, object_version) IN (VALUES {})",
+            values_clause
+        );
+
+        #[derive(QueryableByName)]
+        struct Count {
+            #[diesel(sql_type = BigInt)]
+            count: i64,
+        }
+
+        run_query!(&self.pool, |conn| {
+            diesel::sql_query(query)
+                .get_result::<Count>(conn)
+                .map(|result| result.count)
         })
     }
 


### PR DESCRIPTION
# Description of change

Do dependency checking of transactions based on input objects instead of previous transactions.
To make the dependency checking process resilient to pruning.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9891

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

