### PR TITLE
fix(docker/utils): strip tags while resolving dockerfile path

### DIFF
--- a/docker/utils/build-script.sh
+++ b/docker/utils/build-script.sh
@@ -49,7 +49,7 @@ if [ -z "$IMAGE_TAG" ]; then
     exit 1
 fi
 
-DOCKERFILE="$REPO_ROOT/docker/$(basename "$IMAGE_TAG")/Dockerfile"
+DOCKERFILE="$REPO_ROOT/docker/$(basename "${IMAGE_TAG%%:*}")/Dockerfile"
 
 print_step "Parse the rust toolchain version from 'rust-toolchain.toml'..."
 RUST_VERSION=$(grep -oE 'channel = "[^"]+' ${REPO_ROOT}/rust-toolchain.toml | sed 's/channel = "//')


### PR DESCRIPTION
# Description of change

This patch follows #9144 and strips off any explicit image tags given by the users while resolving the `Dockerfile` path in `docker/utils/build_script.sh`.

E.g. 
```
docker/utils/build_script.sh --image-tag iotaledger/iota-indexer:wat
```
would fail as it would try to find the docker file in `docker/iota-indexer:wat`.

## How the change has been tested
Tested manually
