### PR TITLE
fix(indexer): enable partition pruning when fetching StoredTransactions

### DIFF
--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -2770,14 +2770,18 @@ impl<'a> DBReader<'a> {
     ) -> IndexerResult<Vec<StoredTransaction>> {
         let pool = self.main_reader.get_pool();
         run_query_async!(&pool, |conn| {
+            // using two-step query to allow partition pruning during execution.
+            let tx_sequence_numbers = tx_digests::table
+                .filter(tx_digests::tx_digest.eq_any(&digests))
+                .select(tx_digests::tx_sequence_number)
+                .load::<i64>(conn)?;
+
+            if tx_sequence_numbers.is_empty() {
+                return Ok(vec![]);
+            }
+
             transactions::table
-                .inner_join(
-                    tx_digests::table
-                        .on(transactions::tx_sequence_number.eq(tx_digests::tx_sequence_number)),
-                )
-                // we filter the tx_digests table because it is indexed by digest,
-                // transactions table is not
-                .filter(tx_digests::tx_digest.eq_any(digests))
+                .filter(transactions::tx_sequence_number.eq_any(tx_sequence_numbers))
                 .select(StoredTransaction::as_select())
                 .load::<StoredTransaction>(conn)
         })


### PR DESCRIPTION
# Description of change

This patch refactors the database query in order to use partition pruning when requesting one or multiple `StoredTransaction`.

The postgres query planner was not able to execute partition pruning when using `JOIN` or `IN` clauses.
This [response](https://www.postgresql.org/message-id/CAKJS1f9nWfAYDMF8-ysG%3DTQZ5r9vB%3Dpkk7-y7zQKdZExOraJ3w%40mail.gmail.com) does add some more context.

## Links to any relevant issues

fixes #9983

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Connected the indexer reader to `alphanet` database and executed the following JSON RPC query
```shell
curl --location 'localhost:9000' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "iota_multiGetTransactionBlocks",
    "params": [
        [
            "AUKbNtEvQzL8JJBTeLAwGV6z76C8829gtjgqVGDiRJP2",
            "Dgs1TReXNrM8fPpxbG56hM69Mmucvmm6b1xoHoc6NMq8",
            "AiTcsZFcxzBMCcKJWKnaHDoPq8Y5bVnHjGMheXFTiwXM"
        ],
        {
            "showInput": true,
            "showRawInput": false,
            "showEffects": true,
            "showEvents": true,
            "showObjectChanges": false,
            "showBalanceChanges": false,
            "showRawEffects": false
        }
    ]
}'
```
it takes around 120ms compared to 10s-13s.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

> [!NOTE]
> This patch does not impact the ingestion pipeline, only the JSON RPC part which was tested.
