### PR TITLE
feat(indexer): extend planner statistic for object types

### DIFF
--- a/crates/iota-indexer/migrations/pg/2026-01-29-092516_extend-object-type-statistics/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-01-29-092516_extend-object-type-statistics/down.sql
@@ -1,0 +1,23 @@
+--- Your SQL goes here
+DROP STATISTICS IF EXISTS objects_snapshot_type_stats;
+DROP STATISTICS IF EXISTS objects_type_stats;
+
+-- Extend statistics for each partition 
+DO $$
+DECLARE
+    partition_name TEXT;
+BEGIN
+    FOR partition_name IN 
+        SELECT tablename 
+        FROM pg_tables 
+        WHERE schemaname = 'public' 
+          AND tablename LIKE 'objects_history_%'
+    LOOP
+        EXECUTE format(
+            'DROP STATISTICS IF EXISTS %I',
+            partition_name || '_type_stats'
+        );
+    END LOOP;
+END $$;
+
+DROP STATISTICS IF EXISTS objects_history_type_stats;

--- a/crates/iota-indexer/migrations/pg/2026-01-29-092516_extend-object-type-statistics/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-01-29-092516_extend-object-type-statistics/up.sql
@@ -27,7 +27,7 @@ BEGIN
     LOOP
         EXECUTE format(
             'CREATE STATISTICS IF NOT EXISTS %I (dependencies, mcv)
-             ON object_type_package, object_type_module, object_type_name
+             ON object_type_package, object_type_module, object_type_name, object_type
              FROM %I',
             partition_name || '_type_stats',
             partition_name

--- a/crates/iota-indexer/migrations/pg/2026-01-29-092516_extend-object-type-statistics/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-01-29-092516_extend-object-type-statistics/up.sql
@@ -1,0 +1,41 @@
+-- We introduce additional statistics to help the planner use better estimates
+-- on closely correlated columns.
+--
+-- See https://www.postgresql.org/docs/current/planner-stats.html#PLANNER-STATS-EXTENDED
+CREATE STATISTICS IF NOT EXISTS objects_snapshot_type_stats (dependencies, mcv)
+ON object_type_package, object_type_module, object_type_name, object_type
+FROM objects_snapshot;
+
+CREATE STATISTICS IF NOT EXISTS objects_type_stats (dependencies, mcv)
+ON object_type_package, object_type_module, object_type_name, object_type
+FROM objects;
+
+CREATE STATISTICS IF NOT EXISTS objects_history_type_stats (dependencies, mcv)
+ON object_type_package, object_type_module, object_type_name, object_type
+FROM objects_history;
+
+-- Extend statistics for each partition
+DO $$
+DECLARE
+    partition_name TEXT;
+BEGIN
+    FOR partition_name IN
+        SELECT tablename
+        FROM pg_tables
+        WHERE schemaname = 'public'
+          AND tablename LIKE 'objects_history_%'
+    LOOP
+        EXECUTE format(
+            'CREATE STATISTICS IF NOT EXISTS %I (dependencies, mcv)
+             ON object_type_package, object_type_module, object_type_name
+             FROM %I',
+            partition_name || '_type_stats',
+            partition_name
+        );
+    END LOOP;
+END $$;
+
+-- Initialize the statistics
+ANALYZE objects (object_type_package, object_type_module, object_type_name, object_type),
+        objects_snapshot(object_type_package, object_type_module, object_type_name, object_type),
+        objects_history(object_type_package, object_type_module, object_type_name, object_type);


### PR DESCRIPTION
# Description of change

This patch extends statistics on tables of the backing database of the IOTA Indexer that store granular and dependent information about object types. These are `objects`, `objects_snapshot`, `objects_history`.

Column dependencies like the `(package, module, name)` are not taken into account by default when Postgres collects statistics. This may lead in poor estimates of actual matches of a particular filter, and result in the query planning choosing a suboptimal plan.

## Links to any relevant issues

Fixes #9913,#9721

## How the change has been tested

Tested the effectiveness of the extended statistics on a staging environment

Before the migration
```
EXPLAIN ANALYZE SELECT object_id                                                                                                                                                              
                                                 
    FROM objects_snapshot
    WHERE object_type_package = '\x0000000000000000000000000000000000000000000000000000000000000002'::bytea
      AND object_type_module = 'dynamic_field'
      AND object_type_name = 'Field'
ORDER BY object_id LIMIT 30;
                                                                                                       QUERY PLAN                                                                             
                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------
 Limit  (cost=2974.16..2974.23 rows=30 width=33) (actual time=1610.076..1610.080 rows=30 loops=1)
   ->  Sort  (cost=2974.16..2995.96 rows=8722 width=33) (actual time=1610.074..1610.076 rows=30 loops=1)
         Sort Key: object_id
         Sort Method: top-N heapsort  Memory: 29kB
         ->  Index Only Scan using objects_snapshot_type_id on objects_snapshot  (cost=0.81..2716.56 rows=8722 width=33) (actual time=1.049..1592.524 rows=239289 loops=1)
               Index Cond: ((object_type_package = '\x0000000000000000000000000000000000000000000000000000000000000002'::bytea) AND (object_type_module = 'dynamic_field'::text) AND (object_type_name = 'Field'::text))
               Heap Fetches: 149898
 Planning Time: 0.221 ms
 Execution Time: 1610.105 ms
```

and after

```
EXPLAIN ANALYZE SELECT object_id
    FROM objects_snapshot
    WHERE object_type_package = '\x0000000000000000000000000000000000000000000000000000000000000002'::bytea
      AND object_type_module = 'dynamic_field'
      AND object_type_name = 'Field'
ORDER BY object_id LIMIT 30;
                                                                                                    QUERY PLAN                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.56..126.54 rows=30 width=33) (actual time=34.727..38.923 rows=30 loops=1)
   ->  Index Only Scan using objects_snapshot_id_type on objects_snapshot  (cost=0.56..1040871.34 rows=247866 width=33) (actual time=34.725..38.918 rows=30 loops=1)
         Index Cond: ((object_type_package = '\x0000000000000000000000000000000000000000000000000000000000000002'::bytea) AND (object_type_module = 'dynamic_field'::text) AND (object_type_name = 'Field'::text))
         Heap Fetches: 2
 Planning Time: 1.092 ms
 Execution Time: 38.943 ms
(6 rows)
```

Note that the planner chooses a different plan this time (`objects_snapshot_id_type` as opposed to `objects_snapshot_type_id`)
### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Restart of indexer synchronization locally without resetting the database.
- [x] Deployment of services using Docker.


### Release Notes

- [x] Indexer: Extended statistics to account for dependencies of columns representing object types. :warning::warning::warning: The migration may incur a downtime of several minutes upon restart of the writer service, so operators are requested to stage it according to their SLA needs.:warning::warning::warning:

