### PR TITLE
fix(iota-core, iota-types): [cherry-pick] use authority name and checkpoint number in misbehavior report key (#10005)

### DIFF
--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -136,6 +136,7 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
                 &misbehavior_report,
                 checkpoint_seq,
             );
+            info!(?transaction, "submitting misbehavior report to consensus");
             self.sender
                 .submit_to_consensus(&[transaction], epoch_store)?;
         }

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -91,7 +91,11 @@ pub enum ConsensusTransactionKey {
     NewJWKFetched(Box<(AuthorityName, JwkId, JWK)>),
     RandomnessDkgMessage(AuthorityName),
     RandomnessDkgConfirmation(AuthorityName),
-    MisbehaviorReport(MisbehaviorReportDigest),
+    MisbehaviorReport(
+        AuthorityName,
+        MisbehaviorReportDigest,
+        CheckpointSequenceNumber,
+    ),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -126,8 +130,14 @@ impl Debug for ConsensusTransactionKey {
             Self::RandomnessDkgConfirmation(name) => {
                 write!(f, "RandomnessDkgConfirmation({:?})", name.concise())
             }
-            Self::MisbehaviorReport(digest) => {
-                write!(f, "MisbehaviorReport({digest:?})")
+            Self::MisbehaviorReport(name, digest, checkpoint_seq) => {
+                write!(
+                    f,
+                    "MisbehaviorReport({:?}, {:?}, {:?})",
+                    name.concise(),
+                    digest,
+                    checkpoint_seq
+                )
             }
         }
     }
@@ -268,7 +278,7 @@ pub enum ConsensusTransactionKind {
     MisbehaviorReport(
         AuthorityName,
         VersionedMisbehaviorReport,
-        u64, // checkpoint_seq
+        CheckpointSequenceNumber,
     ),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
@@ -582,7 +592,7 @@ impl ConsensusTransaction {
     pub fn new_misbehavior_report(
         authority: AuthorityName,
         report: &VersionedMisbehaviorReport,
-        checkpoint_seq: u64,
+        checkpoint_seq: CheckpointSequenceNumber,
     ) -> Self {
         let serialized_report =
             bcs::to_bytes(report).expect("report serialization should not fail");
@@ -642,8 +652,12 @@ impl ConsensusTransaction {
             ConsensusTransactionKind::RandomnessDkgConfirmation(authority, _) => {
                 ConsensusTransactionKey::RandomnessDkgConfirmation(*authority)
             }
-            ConsensusTransactionKind::MisbehaviorReport(_, report, _) => {
-                ConsensusTransactionKey::MisbehaviorReport(*report.digest())
+            ConsensusTransactionKind::MisbehaviorReport(authority, report, checkpoint_seq) => {
+                ConsensusTransactionKey::MisbehaviorReport(
+                    *authority,
+                    *report.digest(),
+                    *checkpoint_seq,
+                )
             }
         }
     }


### PR DESCRIPTION
# Description of change

Added authority name and checkpoint sequence number to `MisbehaviorReport` consensus transaction key. This ensures reports issued by different authorities and at different points in time can be distinguished by their key, even if the report contents are identical.
