### PR TITLE
feat(aa): [cherry-pick] the field object for AuthenticatorFunctionRef is considered as loaded child (#9954)

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -56,7 +56,11 @@ use iota_types::committee::CommitteeTrait;
 use iota_types::{
     IOTA_SYSTEM_ADDRESS, TypeTag,
     account_abstraction::{
-        account::AuthenticatorFunctionRefV1Key, authenticator_function::AuthenticatorFunctionRefV1,
+        account::AuthenticatorFunctionRefV1Key,
+        authenticator_function::{
+            AuthenticatorFunctionRef, AuthenticatorFunctionRefForExecution,
+            AuthenticatorFunctionRefV1,
+        },
     },
     authenticator_state::get_authenticator_state,
     base_types::*,
@@ -1659,7 +1663,7 @@ impl AuthorityState {
             // that the account object is loaded.
             let account_object = account_object.expect("Account object must be provided");
 
-            let authenticator_function_ref = self.check_move_account(
+            let authenticator_function_ref_for_execution = self.check_move_account(
                 auth_account_object_id,
                 auth_account_object_seq_number,
                 auth_account_object_digest,
@@ -1709,7 +1713,7 @@ impl AuthorityState {
                     gas_status,
                     gas,
                     move_authenticator.to_owned(),
-                    authenticator_function_ref,
+                    authenticator_function_ref_for_execution,
                     authenticator_checked_input_objects,
                     authenticator_and_tx_checked_input_objects,
                     kind,
@@ -5298,7 +5302,7 @@ impl AuthorityState {
         auth_account_object_digest: Option<ObjectDigest>,
         account_object: ObjectReadResult,
         signer: &IotaAddress,
-    ) -> IotaResult<AuthenticatorFunctionRefV1> {
+    ) -> IotaResult<AuthenticatorFunctionRefForExecution> {
         let account_object = match account_object.object {
             ObjectReadResultKind::Object(object) => Ok(object),
             ObjectReadResultKind::DeletedSharedObject(version, digest) => {
@@ -5397,7 +5401,13 @@ impl AuthorityState {
                     },
                 )?;
 
-            Ok(field.value)
+            Ok(AuthenticatorFunctionRefForExecution::new_v1(
+                field.value,
+                authenticator_function_ref_field_obj.compute_object_reference(),
+                authenticator_function_ref_field_obj.owner,
+                authenticator_function_ref_field_obj.storage_rebate,
+                authenticator_function_ref_field_obj.previous_transaction,
+            ))
         } else {
             Err(UserInputError::MoveAuthenticatorNotFound {
                 authenticator_function_ref_id: authenticator_function_ref_field_id,
@@ -5451,7 +5461,7 @@ impl AuthorityState {
         IotaGasStatus,
         CheckedInputObjects,
         Option<CheckedInputObjects>,
-        Option<AuthenticatorFunctionRefV1>,
+        Option<AuthenticatorFunctionRef>,
     )> {
         let (
             auth_checked_input_objects_union,
@@ -5470,7 +5480,10 @@ impl AuthorityState {
             ) = move_authenticator.object_to_authenticate_components()?;
 
             // Make sure the sender is a Move account.
-            let authenticator_function_ref = self.check_move_account(
+            let AuthenticatorFunctionRefForExecution {
+                authenticator_function_ref,
+                ..
+            } = self.check_move_account(
                 auth_account_object_id,
                 auth_account_object_seq_number,
                 auth_account_object_digest,

--- a/crates/iota-types/src/account_abstraction/authenticator_function.rs
+++ b/crates/iota-types/src/account_abstraction/authenticator_function.rs
@@ -10,14 +10,22 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     IOTA_FRAMEWORK_ADDRESS,
-    base_types::ObjectID,
+    base_types::{ObjectID, ObjectRef, TransactionDigest},
     error::IotaError,
-    object::{Data, Object},
+    execution::DynamicallyLoadedObjectMetadata,
+    object::{Data, Object, Owner},
 };
 
 pub const AUTHENTICATOR_FUNCTION_MODULE_NAME: &IdentStr = ident_str!("authenticator_function");
 pub const AUTHENTICATOR_FUNCTION_REF_V1_STRUCT_NAME: &IdentStr =
     ident_str!("AuthenticatorFunctionRefV1");
+
+/// An enum representing different versions of AuthenticatorFunctionRef. This is
+/// used to represent the reference to an authenticator function in Move.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub enum AuthenticatorFunctionRef {
+    V1(AuthenticatorFunctionRefV1),
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct AuthenticatorFunctionRefV1 {
@@ -64,5 +72,37 @@ impl TryFrom<Object> for AuthenticatorFunctionRefV1 {
         Err(IotaError::Type {
             error: format!("Object type is not a AuthenticatorFunctionRefV1: {object:?}"),
         })
+    }
+}
+
+/// A struct used to hold AuthenticatorFunctionRef and
+/// DynamicallyLoadedObjectMetadata together, in order to pass this information
+/// to the execution side.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct AuthenticatorFunctionRefForExecution {
+    pub authenticator_function_ref: AuthenticatorFunctionRef,
+    pub loaded_object_id: ObjectID,
+    pub loaded_object_metadata: DynamicallyLoadedObjectMetadata,
+}
+
+impl AuthenticatorFunctionRefForExecution {
+    pub fn new_v1(
+        authenticator_function_ref: AuthenticatorFunctionRefV1,
+        loaded_object_ref: ObjectRef,
+        owner: Owner,
+        storage_rebate: u64,
+        previous_transaction: TransactionDigest,
+    ) -> Self {
+        Self {
+            authenticator_function_ref: AuthenticatorFunctionRef::V1(authenticator_function_ref),
+            loaded_object_id: loaded_object_ref.0,
+            loaded_object_metadata: DynamicallyLoadedObjectMetadata {
+                version: loaded_object_ref.1,
+                digest: loaded_object_ref.2,
+                owner,
+                storage_rebate,
+                previous_transaction,
+            },
+        }
     }
 }

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -8,7 +8,7 @@ pub use checked::*;
 mod checked {
 
     use std::{
-        collections::{BTreeSet, HashSet},
+        collections::{BTreeMap, BTreeSet, HashSet},
         sync::Arc,
     };
 
@@ -19,7 +19,10 @@ mod checked {
     use iota_types::{
         IOTA_AUTHENTICATOR_STATE_OBJECT_ID, IOTA_FRAMEWORK_ADDRESS, IOTA_FRAMEWORK_PACKAGE_ID,
         IOTA_RANDOMNESS_STATE_OBJECT_ID, IOTA_SYSTEM_PACKAGE_ID, Identifier,
-        account_abstraction::authenticator_function::AuthenticatorFunctionRefV1,
+        account_abstraction::authenticator_function::{
+            AuthenticatorFunctionRef, AuthenticatorFunctionRefForExecution,
+            AuthenticatorFunctionRefV1,
+        },
         auth_context::AuthContext,
         authenticator_state::{
             AUTHENTICATOR_STATE_CREATE_FUNCTION_NAME,
@@ -299,7 +302,7 @@ mod checked {
         gas_coins: Vec<ObjectRef>,
         // Authenticator
         authenticator: MoveAuthenticator,
-        authenticator_function_ref: AuthenticatorFunctionRefV1,
+        authenticator_function_ref_for_execution: AuthenticatorFunctionRefForExecution,
         authenticator_input_objects: CheckedInputObjects,
         authenticator_and_transaction_input_objects: CheckedInputObjects,
         // Transaction
@@ -365,21 +368,38 @@ mod checked {
         // It does not alter the state, if not for command execution gas charging, and
         // produces no effects other than possible errors.
 
-        // Run the authentication execution.
-        let authentication_execution_result = authenticate_transaction_inner(
-            &mut temporary_store,
-            protocol_config,
-            metrics.clone(),
-            &mut gas_charger,
-            authenticator,
+        let AuthenticatorFunctionRefForExecution {
             authenticator_function_ref,
-            &authenticator_input_objects.into_inner(),
-            transaction_kind.clone(),
-            transaction_digest,
-            &mut tx_ctx,
-            trace_builder_opt,
-            move_vm,
-        );
+            loaded_object_id,
+            loaded_object_metadata,
+        } = authenticator_function_ref_for_execution;
+
+        let authentication_execution_result = match authenticator_function_ref {
+            AuthenticatorFunctionRef::V1(authenticator_function_ref_v1) => {
+                // Save the loaded object metadata, i.e., the field object containing the
+                // AuthenticatorFunctionRef, in the temporary store.
+                temporary_store.save_loaded_runtime_objects(BTreeMap::from([(
+                    loaded_object_id,
+                    loaded_object_metadata,
+                )]));
+
+                // Run the authentication execution.
+                authenticate_transaction_inner(
+                    &mut temporary_store,
+                    protocol_config,
+                    metrics.clone(),
+                    &mut gas_charger,
+                    authenticator,
+                    authenticator_function_ref_v1,
+                    &authenticator_input_objects.into_inner(),
+                    transaction_kind.clone(),
+                    transaction_digest,
+                    &mut tx_ctx,
+                    trace_builder_opt,
+                    move_vm,
+                )
+            }
+        };
 
         // Transaction execution.
         // At this stage we arrive with gas charged for the execution of the
@@ -428,7 +448,7 @@ mod checked {
         gas_status: IotaGasStatus,
         // Authenticator
         authenticator: MoveAuthenticator,
-        authenticator_function_ref: AuthenticatorFunctionRefV1,
+        authenticator_function_ref: AuthenticatorFunctionRef,
         authenticator_input_objects: CheckedInputObjects,
         // Transaction
         transaction_kind: TransactionKind,
@@ -466,20 +486,24 @@ mod checked {
         );
 
         // Run the authentication.
-        authenticate_transaction_inner(
-            &mut temporary_store,
-            protocol_config,
-            metrics.clone(),
-            &mut gas_charger,
-            authenticator,
-            authenticator_function_ref,
-            &input_objects,
-            transaction_kind.clone(),
-            transaction_digest,
-            &mut tx_ctx,
-            trace_builder_opt,
-            move_vm,
-        )
+        match authenticator_function_ref {
+            AuthenticatorFunctionRef::V1(authenticator_function_ref_v1) => {
+                authenticate_transaction_inner(
+                    &mut temporary_store,
+                    protocol_config,
+                    metrics.clone(),
+                    &mut gas_charger,
+                    authenticator,
+                    authenticator_function_ref_v1,
+                    &input_objects,
+                    transaction_kind.clone(),
+                    transaction_digest,
+                    &mut tx_ctx,
+                    trace_builder_opt,
+                    move_vm,
+                )
+            }
+        }
     }
 
     // This function implements the authentication execution. It checks that the

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -6,7 +6,9 @@ use std::{collections::HashSet, sync::Arc};
 
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
-    account_abstraction::authenticator_function::AuthenticatorFunctionRefV1,
+    account_abstraction::authenticator_function::{
+        AuthenticatorFunctionRef, AuthenticatorFunctionRefForExecution,
+    },
     base_types::{IotaAddress, ObjectRef, TxContext},
     committee::EpochId,
     digests::TransactionDigest,
@@ -97,7 +99,7 @@ pub trait Executor {
         gas_coins: Vec<ObjectRef>,
         // Authenticator
         authenticator: MoveAuthenticator,
-        authenticator_function_ref: AuthenticatorFunctionRefV1,
+        authenticator_function_ref_for_execution: AuthenticatorFunctionRefForExecution,
         authenticator_input_objects: CheckedInputObjects,
         authenticator_and_transaction_input_objects: CheckedInputObjects,
         // Transaction
@@ -126,7 +128,7 @@ pub trait Executor {
         gas_status: IotaGasStatus,
         // Authenticator
         authenticator: MoveAuthenticator,
-        authenticator_function_ref: AuthenticatorFunctionRefV1,
+        authenticator_function_ref: AuthenticatorFunctionRef,
         authenticator_input_objects: CheckedInputObjects,
         // Transaction
         authenticated_transaction_kind: TransactionKind,

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -16,7 +16,9 @@ use iota_adapter_latest::{
 use iota_move_natives_latest::all_natives;
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
-    account_abstraction::authenticator_function::AuthenticatorFunctionRefV1,
+    account_abstraction::authenticator_function::{
+        AuthenticatorFunctionRef, AuthenticatorFunctionRefForExecution,
+    },
     base_types::{IotaAddress, ObjectRef, TxContext},
     committee::EpochId,
     digests::TransactionDigest,
@@ -186,7 +188,7 @@ impl executor::Executor for Executor {
         gas_coins: Vec<ObjectRef>,
         // Authenticator
         authenticator: MoveAuthenticator,
-        authenticator_function_ref: AuthenticatorFunctionRefV1,
+        authenticator_function_ref_for_execution: AuthenticatorFunctionRefForExecution,
         authenticator_input_objects: CheckedInputObjects,
         authenticator_and_transaction_input_objects: CheckedInputObjects,
         // Transaction
@@ -212,7 +214,7 @@ impl executor::Executor for Executor {
             gas_status,
             gas_coins,
             authenticator,
-            authenticator_function_ref,
+            authenticator_function_ref_for_execution,
             authenticator_input_objects,
             authenticator_and_transaction_input_objects,
             transaction_kind,
@@ -236,7 +238,7 @@ impl executor::Executor for Executor {
         gas_status: IotaGasStatus,
         // Authenticator
         authenticator: MoveAuthenticator,
-        authenticator_function_ref: AuthenticatorFunctionRefV1,
+        authenticator_function_ref: AuthenticatorFunctionRef,
         authenticator_input_objects: CheckedInputObjects,
         // Transaction
         authenticated_transaction_kind: TransactionKind,


### PR DESCRIPTION
# Description of change

This PR makes it so that the `TemporaryStore` is aware of the fact that the field object containing the `AuthenticatorFunctionRef` was loaded from the store as a child. An entry is created in the `TemporaryStore` field `loaded_runtime_objects`. This makes so that:
- `InnerTemporaryStore::loaded_runtime_objects` is aware of the `AuthenticatorFunctionRef` field object; however, [transaction outputs](https://github.com/iotaledger/iota/blob/5869933bce1786eebd66c2da9f67c6256063573e/crates/iota-core/src/transaction_outputs.rs#L45) do not make use of this field.
- `TemporaryStore::check_execution_results_consistency()` is aware of the `AuthenticatorFunctionRef` field object; however, the consistency here is for mutated objects (which is not the case of `AuthenticatorFunctionRefV1`).
- `TemporaryStore::get_object_modified_at` is aware of the `AuthenticatorFunctionRef` field object; however, this is used for mutated objects (which is, again, not the case).

Additionally: 
- `loaded_runtime_objects` is normally filled at the [end of the execution of a PTB
command](https://github.com/iotaledger/iota/blob/5869933bce1786eebd66c2da9f67c6256063573e/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs#L123), using the [ChildObjectStore's `cached_objects`
map](https://github.com/iotaledger/iota/blob/5869933bce1786eebd66c2da9f67c6256063573e/iota-execution/latest/iota-move-natives/src/object_runtime/mod.rs#L487).
- Object are cached there when [invoking `get_or_fetch_object_from_store`](https://github.com/iotaledger/iota/blob/5869933bce1786eebd66c2da9f67c6256063573e/iota-execution/latest/iota-move-natives/src/object_runtime/object_store.rs#L251).
- In this PR, this cache is not used. It could be pre-filled when initializing the execution context (e.g.,
[here](https://github.com/iotaledger/iota/blob/5869933bce1786eebd66c2da9f67c6256063573e/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs#L102)); but, it seems this would only increase the performances (caching) and not have further effects.

This means that, overall, the changes of this PR should not produce noticeable effects during or post execution; but, the change seems to be more conceptually aligned with the dynamic field operation of reading.

This change would enable having the `AuthenticatorFunctionRef` field object considered for the feature brought by the following upstream commit
https://github.com/MystenLabs/sui/commit/89b03a818d9bf19707e06e9df8b4992fcf36cec0

A versioning for the rust `AuthenticatorFunctionRef` type was also introduced.

## Links to any relevant issues

#9279 

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

Please go to the `Preview` tab and select the appropriate sub-template:

- [Default PR Template for External Contributors](?expand=1&template=default_external_contributors.md)
- [Default PR Template for Internal Contributors](?expand=1&template=default_internal_contributors.md)
- [Infrastructure Team](?expand=1&template=infra.md)
