### PR TITLE
feat(indexer): Prune tx_global_order

### DIFF
--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -244,6 +244,7 @@ pub enum CommitterTables {
     TxRecipients,
     TxSenders,
     TxWrappedOrDeletedObjects,
+    TxGlobalOrder,
     Checkpoints,
     PrunerCpWatermark,
 }

--- a/crates/iota-indexer/src/pruning/pruner.rs
+++ b/crates/iota-indexer/src/pruning/pruner.rs
@@ -92,6 +92,7 @@ pub enum PrunableTable {
     TxRecipients,
     TxSenders,
     TxWrappedOrDeletedObjects,
+    TxGlobalOrder,
 
     Checkpoints,
     PrunerCpWatermark,
@@ -171,7 +172,8 @@ impl PrunableTable {
             | PrunableTable::TxKinds
             | PrunableTable::TxRecipients
             | PrunableTable::TxSenders
-            | PrunableTable::TxWrappedOrDeletedObjects => PruningStrategy::ByTransaction,
+            | PrunableTable::TxWrappedOrDeletedObjects
+            | PrunableTable::TxGlobalOrder => PruningStrategy::ByTransaction,
 
             // Optimistic transactions table - pruned by global sequence number
             PrunableTable::OptimisticTransactions => PruningStrategy::ByGlobalSeq,

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1259,6 +1259,24 @@ impl PgIndexerStore {
         )
     }
 
+    /// Prunes tx_global_order table by transaction range using
+    /// chk_tx_sequence_number
+    fn prune_tx_global_order(
+        &self,
+        conn: &mut PgConnection,
+        min_tx: i64,
+        max_tx: i64,
+    ) -> Result<(), IndexerError> {
+        diesel::delete(
+            tx_global_order::table
+                .filter(tx_global_order::chk_tx_sequence_number.between(min_tx, max_tx)),
+        )
+        .execute(conn)
+        .map_err(IndexerError::from)
+        .context("Failed to prune tx_global_order table")
+        .map(|_| ())
+    }
+
     /// Prunes a single transaction or event index table by transaction range
     fn prune_single_tx_or_event_table(
         &self,
@@ -1429,6 +1447,9 @@ impl PgIndexerStore {
                             max_tx,
                             "Failed to prune tx_kinds table"
                         );
+                    }
+                    PrunableTable::TxGlobalOrder => {
+                        self.prune_tx_global_order(conn, min_tx, max_tx)?;
                     }
                     _ => {
                         return Err(IndexerError::InvalidArgument(format!(


### PR DESCRIPTION
# Description of change

Prune tx_global_order using the generic pruner.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9892

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
