### PR TITLE
feat(gRPC): re-enable checkpoint executor tests

### DIFF
--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -58,9 +58,8 @@ mod data_ingestion_handler;
 pub mod metrics;
 pub(crate) mod utils;
 
-// TODO: re-enable or remove these tests https://github.com/iotaledger/iota/issues/9257
-//#[cfg(test)]
-// pub(crate) mod tests;
+#[cfg(test)]
+pub(crate) mod tests;
 
 use data_ingestion_handler::{load_checkpoint_data, store_checkpoint_locally};
 use metrics::CheckpointExecutorMetrics;

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -11,7 +11,9 @@ use iota_types::{
     committee::ProtocolVersion,
     gas::GasCostSummary,
     iota_system_state::epoch_start_iota_system_state::EpochStartSystemState,
-    messages_checkpoint::{ECMHLiveObjectSetDigest, EndOfEpochData, VerifiedCheckpoint},
+    messages_checkpoint::{
+        ECMHLiveObjectSetDigest, EndOfEpochData, VerifiedCheckpoint, VerifiedCheckpointContents,
+    },
     supported_protocol_versions::SupportedProtocolVersions,
 };
 use tempfile::tempdir;
@@ -432,11 +434,11 @@ fn sync_new_checkpoints(
     previous_checkpoint: Option<VerifiedCheckpoint>,
     committee: &CommitteeFixture,
 ) -> Vec<VerifiedCheckpoint> {
-    let (ordered_checkpoints, _, _sequence_number_to_digest, _checkpoints) =
+    let (ordered_checkpoints, contents, _sequence_number_to_digest, _checkpoints) =
         committee.make_empty_checkpoints(number_of_checkpoints, previous_checkpoint);
 
-    for checkpoint in ordered_checkpoints.iter() {
-        sync_checkpoint(checkpoint, checkpoint_store);
+    for (checkpoint, content) in ordered_checkpoints.iter().zip(contents.iter()) {
+        sync_checkpoint(checkpoint_store, checkpoint, content);
     }
 
     ordered_checkpoints
@@ -472,16 +474,20 @@ async fn sync_end_of_epoch_checkpoint(
         )
         .await
         .expect("Failed to create and execute advance epoch tx");
-    sync_checkpoint(&checkpoint, checkpoint_store);
+    sync_checkpoint(checkpoint_store, &checkpoint, &empty_contents());
     (checkpoint, new_committee)
 }
 
-fn sync_checkpoint(checkpoint: &VerifiedCheckpoint, checkpoint_store: &CheckpointStore) {
+fn sync_checkpoint(
+    checkpoint_store: &CheckpointStore,
+    checkpoint: &VerifiedCheckpoint,
+    contents: &VerifiedCheckpointContents,
+) {
     checkpoint_store
         .insert_verified_checkpoint(checkpoint)
         .unwrap();
     checkpoint_store
-        .insert_checkpoint_contents(empty_contents().into_inner().into_checkpoint_contents())
+        .insert_checkpoint_contents(contents.clone().into_inner().into_checkpoint_contents())
         .unwrap();
     checkpoint_store
         .update_highest_synced_checkpoint(checkpoint)

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -487,7 +487,7 @@ fn sync_checkpoint(
         .insert_verified_checkpoint(checkpoint)
         .unwrap();
     checkpoint_store
-        .insert_checkpoint_contents(contents.clone().into_inner().into_checkpoint_contents())
+        .insert_checkpoint_contents(contents.clone().into_checkpoint_contents())
         .unwrap();
     checkpoint_store
         .update_highest_synced_checkpoint(checkpoint)

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -152,13 +152,16 @@ pub struct CheckpointStoreTables {
     /// Maps checkpoint contents digest to checkpoint contents
     pub(crate) checkpoint_content: DBMap<CheckpointContentsDigest, CheckpointContents>,
 
-    /// Maps checkpoint contents digest to checkpoint sequence number
+    /// Maps checkpoint contents digest to checkpoint sequence number.
+    /// Entries from this table are deleted after state accumulation has
+    /// completed together with the corresponding full_checkpoint_content.
     pub(crate) checkpoint_sequence_by_contents_digest:
         DBMap<CheckpointContentsDigest, CheckpointSequenceNumber>,
 
     /// Stores entire checkpoint contents from state sync, indexed by sequence
     /// number, for efficient reads of full checkpoints. Entries from this
-    /// table are deleted after state accumulation has completed.
+    /// table are deleted after state accumulation has completed. See
+    /// NUM_SAVED_FULL_CHECKPOINT_CONTENTS.
     full_checkpoint_content: DBMap<CheckpointSequenceNumber, FullCheckpointContents>,
 
     /// Stores certified checkpoints
@@ -299,6 +302,10 @@ impl CheckpointStore {
             .get(&sequence_number)
     }
 
+    /// Get checkpoint sequence number by contents digest.
+    ///
+    /// Entries from this table are deleted after state accumulation has
+    /// completed together with the corresponding full_checkpoint_content.
     pub fn get_sequence_number_by_contents_digest(
         &self,
         digest: &CheckpointContentsDigest,
@@ -750,6 +757,12 @@ impl CheckpointStore {
             .insert(contents.digest(), &contents)
     }
 
+    /// Inserts the full checkpoint contents along with the mapping from
+    /// contents digest to sequence number, and the checkpoint contents.
+    ///
+    /// The entries for mapping the contents digest to sequence number,
+    /// and the full_checkpoint_content are deleted after state accumulation has
+    /// completed. See NUM_SAVED_FULL_CHECKPOINT_CONTENTS.
     pub fn insert_verified_checkpoint_contents(
         &self,
         checkpoint: &VerifiedCheckpoint,

--- a/crates/iota-swarm-config/src/test_utils.rs
+++ b/crates/iota-swarm-config/src/test_utils.rs
@@ -2,11 +2,12 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
+use iota_config::genesis::Genesis;
 use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope};
 use iota_types::{
-    base_types::AuthorityName,
+    base_types::{AuthorityName, ExecutionData},
     committee::{Committee, EpochId, StakeUnit},
     crypto::{
         AuthorityKeyPair, AuthoritySignInfo, AuthoritySignature, IotaAuthoritySignature,
@@ -25,6 +26,7 @@ pub struct CommitteeFixture {
     epoch: EpochId,
     validators: HashMap<AuthorityName, (AuthorityKeyPair, StakeUnit)>,
     committee: Committee,
+    genesis: Option<Arc<Genesis>>,
 }
 
 type MakeCheckpointResults = (
@@ -57,6 +59,7 @@ impl CommitteeFixture {
             epoch,
             validators,
             committee,
+            genesis: None,
         }
     }
 
@@ -83,6 +86,7 @@ impl CommitteeFixture {
                 })
                 .collect(),
             committee,
+            genesis: Some(Arc::new(network_config.genesis.clone())),
         }
     }
 
@@ -92,14 +96,33 @@ impl CommitteeFixture {
 
     fn create_root_checkpoint(&self) -> (VerifiedCheckpoint, VerifiedCheckpointContents) {
         assert_eq!(self.epoch, 0, "root checkpoint must be epoch 0");
+
+        let mut contents = empty_contents();
+        if let Some(genesis) = &self.genesis {
+            // if genesis is provided, create checkpoint contents with the genesis
+            // transaction
+            let tx = genesis.transaction().clone();
+            let effects = genesis.effects().clone();
+            let execution_data = ExecutionData::new(tx, effects);
+
+            contents = VerifiedCheckpointContents::new_unchecked(
+                FullCheckpointContents::new_with_causally_ordered_transactions(std::iter::once(
+                    execution_data,
+                )),
+            );
+        }
+
+        let content_digest = *contents
+            .clone()
+            .into_inner()
+            .into_checkpoint_contents()
+            .digest();
+
         let checkpoint = CheckpointSummary {
             epoch: 0,
             sequence_number: 0,
-            network_total_transactions: 0,
-            content_digest: *empty_contents()
-                .into_inner()
-                .into_checkpoint_contents()
-                .digest(),
+            network_total_transactions: contents.num_of_transactions() as u64,
+            content_digest,
             previous_digest: None,
             epoch_rolling_gas_cost_summary: Default::default(),
             end_of_epoch_data: None,
@@ -109,10 +132,7 @@ impl CommitteeFixture {
             checkpoint_commitments: Default::default(),
         };
 
-        (
-            self.create_certified_checkpoint(checkpoint),
-            empty_contents(),
-        )
+        (self.create_certified_checkpoint(checkpoint), contents)
     }
 
     fn create_certified_checkpoint(&self, checkpoint: CheckpointSummary) -> VerifiedCheckpoint {

--- a/crates/iota-types/src/storage/shared_in_memory_store.rs
+++ b/crates/iota-types/src/storage/shared_in_memory_store.rs
@@ -273,6 +273,7 @@ impl InMemoryStore {
             .and_then(|digest| self.get_checkpoint_by_digest(digest))
     }
 
+    /// Get checkpoint sequence number by contents digest.
     pub fn get_sequence_number_by_contents_digest(
         &self,
         digest: &CheckpointContentsDigest,


### PR DESCRIPTION
# Description of change

This PR fixes the swarm test utils to correctly insert the checkpoint contents for the genesis. The checkpoint executor tests were broken because we index the genesis now for gRPC.

## Links to any relevant issues

#9257

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes