### PR TITLE
feat: bump `iota` to `v1.16.1-rc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,7 +1801,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "const-str",
  "git-version",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "iota"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5569,7 +5569,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "arrow-array 53.1.0",
@@ -5611,7 +5611,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5651,7 +5651,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "iota-build-cache-server"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5824,7 +5824,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5843,7 +5843,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5872,7 +5872,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5973,7 +5973,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6006,7 +6006,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6039,7 +6039,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6073,7 +6073,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "serde_yaml",
 ]
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6217,7 +6217,7 @@ source = "git+https://github.com/iotaledger/flamegraph-svg?rev=ba681350dc9a72c9b
 
 [[package]]
 name = "iota-framework"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6237,7 +6237,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6255,7 +6255,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6276,7 +6276,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6333,7 +6333,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6343,7 +6343,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6351,7 +6351,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6364,7 +6364,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6439,7 +6439,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6452,14 +6452,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "axum 0.8.4",
 ]
 
 [[package]]
 name = "iota-grpc-client"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "futures",
@@ -6473,7 +6473,7 @@ dependencies = [
 
 [[package]]
 name = "iota-grpc-server"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6496,7 +6496,7 @@ dependencies = [
 
 [[package]]
 name = "iota-grpc-types"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "bcs",
  "iota-json-rpc-types",
@@ -6510,7 +6510,7 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "axum 0.8.4",
  "bytes",
@@ -6531,7 +6531,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6600,7 +6600,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6616,7 +6616,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-streaming"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "async-trait",
  "backoff",
@@ -6635,7 +6635,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6654,7 +6654,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6711,7 +6711,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6730,7 +6730,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6768,7 +6768,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6802,7 +6802,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "bip32",
@@ -6823,7 +6823,7 @@ dependencies = [
 
 [[package]]
 name = "iota-kvstore"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6841,7 +6841,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6862,7 +6862,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger-signer"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6879,7 +6879,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6912,7 +6912,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -6922,7 +6922,7 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6934,7 +6934,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "backoff",
@@ -6955,7 +6955,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6980,7 +6980,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -7019,7 +7019,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "bin-version",
  "clap",
@@ -7073,7 +7073,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7085,7 +7085,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -7126,7 +7126,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anemo",
  "bcs",
@@ -7155,7 +7155,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7209,7 +7209,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7233,7 +7233,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7245,7 +7245,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-alt"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "move-package-alt",
  "serde",
@@ -7253,7 +7253,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7269,7 +7269,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
@@ -7285,7 +7285,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7306,7 +7306,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -7316,7 +7316,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "clap",
  "insta",
@@ -7331,7 +7331,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7340,7 +7340,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7383,7 +7383,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7428,7 +7428,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7457,7 +7457,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-kv"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7484,7 +7484,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7525,7 +7525,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7550,7 +7550,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7629,7 +7629,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7651,7 +7651,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7685,7 +7685,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7712,7 +7712,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "colored",
@@ -7744,7 +7744,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7780,7 +7780,7 @@ dependencies = [
 
 [[package]]
 name = "iota-stardust-types"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "bech32",
  "bitflags 2.9.1",
@@ -7799,7 +7799,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7850,7 +7850,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "bcs",
  "clap",
@@ -7878,7 +7878,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "futures",
@@ -7905,7 +7905,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -7933,7 +7933,7 @@ dependencies = [
 
 [[package]]
 name = "iota-synthetic-ingestion"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7950,7 +7950,7 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
@@ -7963,7 +7963,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7985,7 +7985,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -8030,7 +8030,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8046,7 +8046,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -8059,7 +8059,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8104,7 +8104,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8178,7 +8178,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8207,7 +8207,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11467,7 +11467,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13441,7 +13441,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14180,7 +14180,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -14272,7 +14272,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -15210,7 +15210,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -15276,7 +15276,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "bcs",
  "bincode",
@@ -15305,7 +15305,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -15315,7 +15315,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "serde",
  "thiserror 1.0.64",
@@ -15323,7 +15323,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "1.16.1-beta"
+version = "1.16.1-rc"
 
 [workspace.metadata.cargo-udeps.ignore]
 normal = ["move-package-alt"]

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "1.16.1-beta"
+    "version": "1.16.1-rc"
   },
   "methods": [
     {


### PR DESCRIPTION
# Description of change

Bump `iota` to `v1.16.1-rc`.
