### PR TITLE
chore: change ownership of `iota-open-rpc` to `infrastructure`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,7 +55,7 @@
 /crates/iota-network/ @iotaledger/node
 /crates/iota-network-stack/ @iotaledger/node
 /crates/iota-node/ @iotaledger/node
-/crates/iota-open-rpc/ @iotaledger/dev-tools
+/crates/iota-open-rpc/ @iotaledger/infrastructure
 /crates/iota-open-rpc-macros/ @iotaledger/dev-tools
 /crates/iota-package-alt/ @iotaledger/vm-language
 /crates/iota-package-dump/ @iotaledger/infrastructure


### PR DESCRIPTION
It makes more sense as infra should review changes to it to avoid breaking changes in the JSON RPC.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes