### PR TITLE
fix: external-crates compilation warnings

### DIFF
--- a/external-crates/move/crates/move-model/src/model.rs
+++ b/external-crates/move/crates/move-model/src/model.rs
@@ -622,7 +622,7 @@ impl GlobalEnv {
     }
 
     /// Find all target modules and return in a vector
-    pub fn get_target_modules(&self) -> Vec<ModuleEnv> {
+    pub fn get_target_modules(&self) -> Vec<ModuleEnv<'_>> {
         let mut target_modules: Vec<ModuleEnv> = vec![];
         for module_env in self.get_modules() {
             if module_env.is_target() {
@@ -1376,7 +1376,7 @@ impl GlobalEnv {
     }
 
     /// Produce a TypeDisplayContext to print types within the scope of this env
-    pub fn get_type_display_ctx(&self) -> TypeDisplayContext {
+    pub fn get_type_display_ctx(&self) -> TypeDisplayContext<'_> {
         TypeDisplayContext::WithEnv {
             env: self,
             type_param_names: None,
@@ -3469,7 +3469,7 @@ impl<'env> FunctionEnv<'env> {
     }
 
     /// Produce a TypeDisplayContext to print types within the scope of this env
-    pub fn get_type_display_ctx(&self) -> TypeDisplayContext {
+    pub fn get_type_display_ctx(&self) -> TypeDisplayContext<'_> {
         let type_param_names = self
             .get_type_parameters()
             .iter()

--- a/external-crates/move/crates/move-stackless-bytecode/src/access_path_trie.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/src/access_path_trie.rs
@@ -102,7 +102,7 @@ impl<T: FootprintDomain> TrieNode<T> {
         &self.children
     }
 
-    pub fn entry(&mut self, o: Offset) -> Entry<Offset, TrieNode<T>> {
+    pub fn entry(&mut self, o: Offset) -> Entry<'_, Offset, TrieNode<T>> {
         self.children.entry(o)
     }
 

--- a/external-crates/move/crates/move-stackless-bytecode/src/function_target.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/src/function_target.rs
@@ -114,7 +114,7 @@ impl<'env> FunctionTarget<'env> {
     }
 
     /// Shortcut for accessing the module env of this function.
-    pub fn module_env(&self) -> &ModuleEnv {
+    pub fn module_env(&self) -> &ModuleEnv<'_> {
         &self.func_env.module_env
     }
 


### PR DESCRIPTION
# Description of change

While doing https://github.com/iotaledger/iota/pull/10084, I noticed some compilation warnings on the external crates so I'm fixing them here.

An example of a warning
```
warning: hiding a lifetime that's elided elsewhere is confusing
    --> crates/move-model/src/model.rs:1379:33
     |
1379 |     pub fn get_type_display_ctx(&self) -> TypeDisplayContext {
     |                                 ^^^^^     ^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
     |                                 |
     |                                 the lifetime is elided here
     |
     = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
     |
1379 |     pub fn get_type_display_ctx(&self) -> TypeDisplayContext<'_> {
```