### PR TITLE
fix(core): Fix the explorer URL when using a custom network

### DIFF
--- a/apps/core/src/utils/getExplorerPaths.ts
+++ b/apps/core/src/utils/getExplorerPaths.ts
@@ -15,7 +15,10 @@ function getExplorerUrl(
 
     const url = getUrlWithDeviceId(new URL(path, explorer));
     if (explorer) {
-        url.searchParams.append('network', network);
+        url.searchParams.append(
+            'network',
+            network === Network.Custom ? networkConfig?.url : network,
+        );
     }
 
     return url.href;


### PR DESCRIPTION
# Description of change

change append network when using a custom rpc

when clicking 'View on explorer" URL:
-> BEFORE: https://explorer.iota.org/?network=custom
-> NOW: https://explorer.iota.org/?network=custom-rpc-url

## Links to any relevant issues

fixes #10070

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.
