### PR TITLE
feat: add Bigtable emulator support for data-ingestion and rest-kv

### DIFF
--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -34,6 +34,8 @@ struct BigTableTaskConfig {
     instance_id: String,
     column_family: String,
     timeout_secs: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    emulator_host: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -185,15 +187,24 @@ async fn main() -> Result<()> {
                 executor.register(worker_pool).await?;
             }
             Task::BigTableKv(kv_config) => {
-                let client = BigTableClient::new_remote(
-                    kv_config.instance_id,
-                    false,
-                    Some(Duration::from_secs(kv_config.timeout_secs as u64)),
-                    "ingestion".to_string(),
-                    kv_config.column_family.clone(),
-                    None,
-                )
-                .await?;
+                let client = if let Some(emulator_host) = kv_config.emulator_host {
+                    std::env::set_var("BIGTABLE_EMULATOR_HOST", &emulator_host);
+                    BigTableClient::new_local(
+                        kv_config.instance_id,
+                        kv_config.column_family.clone(),
+                    )
+                    .await?
+                } else {
+                    BigTableClient::new_remote(
+                        kv_config.instance_id,
+                        false,
+                        Some(Duration::from_secs(kv_config.timeout_secs as u64)),
+                        "ingestion".to_string(),
+                        kv_config.column_family.clone(),
+                        None,
+                    )
+                    .await?
+                };
                 let worker_pool = WorkerPool::new(
                     KvWorker { client },
                     task_config.name,

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -35,6 +35,8 @@ pub struct KvStoreConfig {
     instance_id: String,
     column_family: String,
     timeout_secs: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    emulator_host: Option<String>,
 }
 
 /// Provides read access to data ingested by the `iota-data-ingestion`
@@ -58,15 +60,20 @@ impl KvStoreClient {
     ///
     /// Internally it instantiates a BigTableDB client.
     pub async fn new(config: KvStoreConfig) -> Result<Self> {
-        let bigtable_client = BigTableClient::new_remote(
-            config.instance_id,
-            true,
-            Some(Duration::from_secs(config.timeout_secs as u64)),
-            "rest".to_string(),
-            config.column_family,
-            None,
-        )
-        .await?;
+        let bigtable_client = if let Some(emulator_host) = config.emulator_host {
+            std::env::set_var("BIGTABLE_EMULATOR_HOST", &emulator_host);
+            BigTableClient::new_local(config.instance_id, config.column_family).await?
+        } else {
+            BigTableClient::new_remote(
+                config.instance_id,
+                true,
+                Some(Duration::from_secs(config.timeout_secs as u64)),
+                "rest".to_string(),
+                config.column_family,
+                None,
+            )
+            .await?
+        };
 
         Ok(Self {
             bigtable_client,

--- a/dev-tools/iota-data-ingestion/kv-store/config/bigtable.yaml
+++ b/dev-tools/iota-data-ingestion/kv-store/config/bigtable.yaml
@@ -54,3 +54,4 @@ tasks:
       instance-id: "iota"
       column-family: "iota"
       timeout-secs: 60
+      # emulator-host: "localhost:8086"

--- a/dev-tools/iota-rest-kv/config/bigtable.yaml
+++ b/dev-tools/iota-rest-kv/config/bigtable.yaml
@@ -6,3 +6,4 @@ server-address: "0.0.0.0:3555"
 instance-id: "iota"
 column-family: "iota"
 timeout-secs: 60
+# emulator-host: "localhost:8086"


### PR DESCRIPTION
# Description of change

Add optional `emulator-host` configuration for Bigtable in `iota-data-ingestion` and `iota-rest-kv` crates to support with Bigtable emulator.

## Links to any relevant issues

x

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
