### PR TITLE
fix(turbo): `sdk-packages` should no build by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"explorer": "turbo --filter iota-explorer",
 		"wallet": "turbo --filter ./apps/wallet",
 		"wallet-dashboard": "turbo --filter ./apps/wallet-dashboard",
-		"sdk-packages": "pnpm turbo run build --filter=./sdk/* --filter=./apps/ui-kit --filter=./apps/ui-icons",
+		"sdk-packages": "pnpm turbo run --filter=./sdk/* --filter=./apps/ui-kit --filter=./apps/ui-icons",
 		"sdk": "turbo --filter ./sdk/typescript",
 		"signers": "turbo --filter ./sdk/signers",
 		"bcs": "turbo --filter ./sdk/bcs",


### PR DESCRIPTION
read the title