### PR TITLE
feat(docker): install heaptrack instead of jemalloc in all docker images

### DIFF
--- a/crates/telemetry-subscribers/observability.md
+++ b/crates/telemetry-subscribers/observability.md
@@ -200,7 +200,6 @@ See how to use Tokio console in this guide: [Live async inspection with Tokio Co
 
 ### Memory Profiling
 
-Memory profiling is might be useful to analyze the memory usage of an application, helping to identify memory leaks and optimize memory consumption.
-IOTA uses the [jemalloc](https://jemalloc.net/) memory allocator by default, which includes a lightweight sampling profiler suitable for production use.
+IOTA Docker images include [heaptrack](https://github.com/KDE/heaptrack), a heap memory profiler that tracks all memory allocations and can help identify memory leaks and excessive memory usage patterns. Heaptrack provides detailed information about where memory is allocated and can generate comprehensive reports for analysis.
 
-For detailed instructions on setting up and using memory profiling in IOTA, refer to the Memory Profiling Guide.
+For detailed instructions on setting up and using memory profiling in IOTA, refer to the [Memory Profiling Guide](observability_guides.md#memory-profiling).

--- a/crates/telemetry-subscribers/observability_guides.md
+++ b/crates/telemetry-subscribers/observability_guides.md
@@ -197,29 +197,49 @@ To exit the process on panic, set the `CRASH_ON_PANIC` environment variable when
 
 ### Memory Profiling
 
-IOTA uses the [jemalloc memory allocator](https://jemalloc.net/) by default on most platforms, and there is code that enables automatic memory profiling using jemalloc's sampling profiler, which is very lightweight and designed for production use. The profiling code spits out profiles, at most, every 5 minutes, and only when total memory has increased by a default 20%. Profiling files are named `jeprof.<TIMESTAMP>.<memorysize>MB.prof` so that it is easy to
-correlate to metrics and incidents, for ease of debugging.
+IOTA Docker images include [heaptrack](https://github.com/KDE/heaptrack), a heap memory profiler that tracks all memory allocations and can help identify memory leaks and excessive memory usage patterns. Heaptrack provides detailed information about where memory is allocated and can generate comprehensive reports for analysis.
 
-For the memory profiling to work, you need to set the environment variable `_RJEM_MALLOC_CONF=prof:true`. If you use the [Docker image](https://hub.docker.com/r/iotaledger/iota-node) they are set automatically.
+For optimal profiling results with readable stack traces and function names, build Docker images with debug symbols by setting RUSTFLAGS before building:
 
-Running some allocator-based heap profilers such as [Bytehound](https://github.com/koute/bytehound) will essentially disable automatic jemalloc profiling, because they interfere with or don't implement `jemalloc_ctl` stats APIs.
+```bash
+export RUSTFLAGS="-C debuginfo=2"
+# Then build your Docker image
+docker build --build-arg RUSTFLAGS="-C debuginfo=2" -t iotaledger/iota-node .
+```
 
-To view the profile files, one needs to do the following, on the same platform as where the profiles were gathered:
+Or use the provided debug build script:
 
-1. Install `libunwind`, the `dot` utility from graphviz, and jeprof. On Debian: `apt-get install libjemalloc-dev libunwind-dev graphviz`.
-2. Build with debug symbols: `cargo build --profile bench-profiling`.
-3. Change directory to `$IOTA_REPO/target/bench-profiling`.
-4. Run `jeprof --svg iota-node jeprof.xxyyzz.heap` - select the heap profile based on
-   timestamp and memory size in the filename.
+```bash
+./docker/iota-node/build_debuginfo.sh
+```
+
+To profile memory usage with Docker containers, you can run the container with heaptrack enabled:
+
+```bash
+docker run -it --rm \
+  -v $(pwd)/heaptrack-data:/tmp/heaptrack-data \
+  iotaledger/iota-node \
+  heaptrack -o /tmp/heaptrack-data/iota-profile iota-node [your-node-arguments]
+```
+
+This will:
+
+1. Run the IOTA node under heaptrack profiling
+2. Save the profiling data to a volume-mounted directory for analysis
+3. Generate a profile file named `iota-profile.heaptrack` in the mounted directory
+
+To analyze the generated profiles:
+
+1. Install heaptrack on your host system. On Debian/Ubuntu: `apt-get install heaptrack-gui heaptrack`.
+2. Open the profile file with the heaptrack GUI: `heaptrack_gui /path/to/iota-profile.heaptrack`.
+3. Or generate text reports: `heaptrack_print /path/to/iota-profile.heaptrack`.
 
 > **tip**
 >
-> With automatic memory profiling, it is no longer necessary to configure environment variables beyond those previously listed. It is possible to configure custom profiling options:
+> For production environments, consider the performance impact of memory profiling. Heaptrack can introduce overhead, so use it primarily for debugging memory issues or performance analysis in non-production environments.
 >
-> - [Heap Profiling](https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Heap-Profiling).
-> - [Heap Profiling with jemallocator](https://gist.github.com/ordian/928dc2bd45022cddd547528f64db9174).
+> You can also attach heaptrack to an already running process inside a Docker container:
 >
-> For example, set `_RJEM_MALLOC_CONF` to:
-> `prof:true,lg_prof_interval:24,lg_prof_sample:19`
->
-> The preceding setting means: turn on profiling, sample every 2^19 or 512KB bytes allocated, and dump out the profile every 2^24 or 16MB of memory allocated. However, the automatic profiling is designed to produce files that are better named and at less intervals, so overriding the default configuration is not usually recommended.
+> ```bash
+> docker exec -it <container-name> heaptrack -p <pid> -o /tmp/profile-name
+> ```

--- a/docker/iota-data-ingestion/Dockerfile
+++ b/docker/iota-data-ingestion/Dockerfile
@@ -8,6 +8,8 @@ ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
+# RUSTFLAGS can be passed as build argument to control compilation flags
+ARG RUSTFLAGS
 
 WORKDIR "/iota"
 
@@ -29,6 +31,9 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
+# Set RUSTFLAGS if provided via build argument
+ENV RUSTFLAGS=${RUSTFLAGS}
+
 # Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-data-ingestion \
@@ -39,7 +44,7 @@ RUN cargo build --profile ${PROFILE} \
 FROM debian:trixie-slim AS runtime
 
 # Install runtime dependencies and tools
-RUN apt update && apt install -y ca-certificates curl
+RUN apt update && apt install -y ca-certificates curl heaptrack
 
 COPY --from=builder /iota/iota-data-ingestion /usr/local/bin
 

--- a/docker/iota-graphql-rpc/Dockerfile
+++ b/docker/iota-graphql-rpc/Dockerfile
@@ -8,6 +8,8 @@ ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
+# RUSTFLAGS can be passed as build argument to control compilation flags
+ARG RUSTFLAGS
 
 WORKDIR "/iota"
 
@@ -29,6 +31,9 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
+# Set RUSTFLAGS if provided via build argument
+ENV RUSTFLAGS=${RUSTFLAGS}
+
 # Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-graphql-rpc \
@@ -42,7 +47,7 @@ ARG WORKDIR="/iota"
 WORKDIR "$WORKDIR"
 
 # Install runtime dependencies and tools
-RUN apt update && apt install -y libpq5 ca-certificates curl
+RUN apt update && apt install -y libpq5 ca-certificates curl heaptrack
 
 COPY --from=builder /iota/iota-graphql-rpc /usr/local/bin
 

--- a/docker/iota-indexer/Dockerfile
+++ b/docker/iota-indexer/Dockerfile
@@ -8,6 +8,8 @@ ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
+# RUSTFLAGS can be passed as build argument to control compilation flags
+ARG RUSTFLAGS
 
 WORKDIR "/iota"
 
@@ -29,6 +31,9 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
+# Set RUSTFLAGS if provided via build argument
+ENV RUSTFLAGS=${RUSTFLAGS}
+
 # Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-indexer \
@@ -42,21 +47,7 @@ ARG WORKDIR="/iota"
 WORKDIR "$WORKDIR"
 
 # Install runtime dependencies and tools
-RUN apt update && apt install -y libpq5 ca-certificates curl
-
-# Install jemalloc as the default allocator used for memory profiling on supported
-# architectures and create a symlink for the correct version based on the architecture
-RUN ARCH=$(dpkg --print-architecture) && \
-  if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "arm64" ]; then \
-    apt update && apt install -y libjemalloc-dev; \
-    ln -sf $(ldconfig -p | grep jemalloc | awk '{print $4}' | sort -u | head -n 1) /usr/lib/libjemalloc.so; \
-  else \
-    echo "Unsupported architecture: $ARCH. Only amd64 and arm64 are supported."; \
-  exit 1; \
-fi
-
-# Set LD_PRELOAD to the symlinked path
-ENV LD_PRELOAD=/usr/lib/libjemalloc.so
+RUN apt update && apt install -y libpq5 ca-certificates curl heaptrack
 
 COPY --from=builder /iota/iota-indexer /usr/local/bin
 

--- a/docker/iota-node/Dockerfile
+++ b/docker/iota-node/Dockerfile
@@ -8,6 +8,8 @@ ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
+# RUSTFLAGS can be passed as build argument to control compilation flags
+ARG RUSTFLAGS
 
 WORKDIR "/iota"
 
@@ -29,12 +31,14 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
+# Set RUSTFLAGS if provided via build argument
+ENV RUSTFLAGS=${RUSTFLAGS}
+
 # Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-node \
       --features ${CARGO_BUILD_FEATURES:=default} && \
     cp $TARGET_FOLDER/iota-node ./iota-node
-
 
 # Production image
 FROM debian:trixie-slim AS runtime
@@ -43,21 +47,7 @@ ARG WORKDIR="/iota"
 WORKDIR "$WORKDIR"
 
 # Install runtime dependencies and tools
-RUN apt update && apt install -y libpq5 ca-certificates curl
-
-# Install jemalloc as the default allocator used for memory profiling on supported
-# architectures and create a symlink for the correct version based on the architecture
-RUN ARCH=$(dpkg --print-architecture) && \
-  if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "arm64" ]; then \
-    apt update && apt install -y libjemalloc-dev; \
-    ln -sf $(ldconfig -p | grep jemalloc | awk '{print $4}' | sort -u | head -n 1) /usr/lib/libjemalloc.so; \
-  else \
-    echo "Unsupported architecture: $ARCH. Only amd64 and arm64 are supported."; \
-  exit 1; \
-fi
-
-# Set LD_PRELOAD to the symlinked path
-ENV LD_PRELOAD=/usr/lib/libjemalloc.so
+RUN apt update && apt install -y libpq5 ca-certificates curl heaptrack
 
 COPY --from=builder /iota/iota-node /usr/local/bin
 

--- a/docker/iota-node/build_debuginfo.sh
+++ b/docker/iota-node/build_debuginfo.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2026 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# Determine script's location to resolve the relative path correctly
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
+# The name of last directory in script's path is used for tag
+BASE_NAME="$(basename "$SCRIPT_DIR")"
+
+# Set RUSTFLAGS for debug info
+export RUSTFLAGS="-C debuginfo=2"
+
+DOCKER_BUILDKIT=1 "$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-proxy/Dockerfile
+++ b/docker/iota-proxy/Dockerfile
@@ -8,6 +8,8 @@ ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
+# RUSTFLAGS can be passed as build argument to control compilation flags
+ARG RUSTFLAGS
 
 WORKDIR "/iota"
 
@@ -29,6 +31,9 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
+# Set RUSTFLAGS if provided via build argument
+ENV RUSTFLAGS=${RUSTFLAGS}
+
 # Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-proxy \
@@ -42,21 +47,7 @@ ARG WORKDIR="/iota"
 WORKDIR "$WORKDIR"
 
 # Install runtime dependencies and tools
-RUN apt update && apt install -y libpq5 ca-certificates curl
-
-# Install jemalloc as the default allocator used for memory profiling on supported
-# architectures and create a symlink for the correct version based on the architecture
-RUN ARCH=$(dpkg --print-architecture) && \
-  if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "arm64" ]; then \
-    apt update && apt install -y libjemalloc-dev; \
-    ln -sf $(ldconfig -p | grep jemalloc | awk '{print $4}' | sort -u | head -n 1) /usr/lib/libjemalloc.so; \
-  else \
-    echo "Unsupported architecture: $ARCH. Only amd64 and arm64 are supported."; \
-  exit 1; \
-fi
-
-# Set LD_PRELOAD to the symlinked path
-ENV LD_PRELOAD=/usr/lib/libjemalloc.so
+RUN apt update && apt install -y libpq5 ca-certificates curl heaptrack
 
 COPY --from=builder /iota/iota-proxy /usr/local/bin
 

--- a/docker/iota-rest-kv/Dockerfile
+++ b/docker/iota-rest-kv/Dockerfile
@@ -8,6 +8,8 @@ ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
+# RUSTFLAGS can be passed as build argument to control compilation flags
+ARG RUSTFLAGS
 
 WORKDIR "/iota"
 
@@ -29,18 +31,20 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
+# Set RUSTFLAGS if provided via build argument
+ENV RUSTFLAGS=${RUSTFLAGS}
+
 # Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-rest-kv \
       --features ${CARGO_BUILD_FEATURES:=default} && \
     cp $TARGET_FOLDER/iota-rest-kv ./iota-rest-kv
 
-
 # Production image
 FROM debian:trixie-slim AS runtime
 
 # Install runtime dependencies and tools
-RUN apt update && apt install -y ca-certificates curl
+RUN apt update && apt install -y ca-certificates curl heaptrack
 
 COPY --from=builder /iota/iota-rest-kv /usr/local/bin
 

--- a/docker/iota-rosetta/Dockerfile
+++ b/docker/iota-rosetta/Dockerfile
@@ -8,6 +8,8 @@ ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
+# RUSTFLAGS can be passed as build argument to control compilation flags
+ARG RUSTFLAGS
 
 WORKDIR "/iota"
 
@@ -29,6 +31,9 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
+# Set RUSTFLAGS if provided via build argument
+ENV RUSTFLAGS=${RUSTFLAGS}
+
 # Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-rosetta \
@@ -42,7 +47,7 @@ ARG WORKDIR="/iota"
 WORKDIR "$WORKDIR"
 
 # Install runtime dependencies and tools
-RUN apt update && apt install -y libpq5 ca-certificates curl
+RUN apt update && apt install -y libpq5 ca-certificates curl heaptrack
 
 # Install rosetta-cli (workaround because the install script is broken after rename)
 RUN curl -sSfL https://raw.githubusercontent.com/coinbase/mesh-cli/master/scripts/install.sh | sed -e 's/^REPO=.*/REPO=mesh-cli/' | sh -s

--- a/docker/iota-source-validation-service/Dockerfile
+++ b/docker/iota-source-validation-service/Dockerfile
@@ -8,6 +8,8 @@ ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
+# RUSTFLAGS can be passed as build argument to control compilation flags
+ARG RUSTFLAGS
 
 WORKDIR "/iota"
 
@@ -29,6 +31,9 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
+# Set RUSTFLAGS if provided via build argument
+ENV RUSTFLAGS=${RUSTFLAGS}
+
 # Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota-source-validation-service \
@@ -42,7 +47,7 @@ ARG WORKDIR="/iota"
 WORKDIR "$WORKDIR"
 
 # Install runtime dependencies and tools
-RUN apt update && apt install -y libpq5 ca-certificates curl
+RUN apt update && apt install -y libpq5 ca-certificates curl heaptrack
 
 COPY --from=builder /iota/iota-source-validation-service /usr/local/bin
 COPY --from=builder /iota/crates/iota-source-validation-service/config.toml /var/iota/

--- a/docker/iota-tools/Dockerfile
+++ b/docker/iota-tools/Dockerfile
@@ -8,6 +8,8 @@ ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
+# RUSTFLAGS can be passed as build argument to control compilation flags
+ARG RUSTFLAGS
 
 WORKDIR "/iota"
 
@@ -30,6 +32,9 @@ COPY examples examples
 COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
+
+# Set RUSTFLAGS if provided via build argument
+ENV RUSTFLAGS=${RUSTFLAGS}
 
 # Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
@@ -58,7 +63,7 @@ ARG WORKDIR="/iota"
 WORKDIR "$WORKDIR"
 
 # Install runtime dependencies and tools
-RUN apt update && apt install -y libpq5 ca-certificates curl git
+RUN apt update && apt install -y libpq5 ca-certificates curl git heaptrack
 
 COPY --from=builder /iota/iota-node /usr/local/bin
 COPY --from=builder /iota/stress /usr/local/bin

--- a/docker/iota/Dockerfile
+++ b/docker/iota/Dockerfile
@@ -8,6 +8,8 @@ ARG CARGO_BUILD_FEATURES
 # The GIT_REVISION environment variable is used during build time inside the rust crates
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
+# RUSTFLAGS can be passed as build argument to control compilation flags
+ARG RUSTFLAGS
 
 WORKDIR "/iota"
 
@@ -30,6 +32,9 @@ COPY external-crates external-crates
 COPY iota-execution iota-execution
 COPY Cargo.toml Cargo.lock ./
 
+# Set RUSTFLAGS if provided via build argument
+ENV RUSTFLAGS=${RUSTFLAGS}
+
 # Build the binaries and copy them to the working directory
 RUN cargo build --profile ${PROFILE} \
       --bin iota \
@@ -43,7 +48,7 @@ ARG WORKDIR="/iota"
 WORKDIR "$WORKDIR"
 
 # Install runtime dependencies and tools
-RUN apt update && apt install -y libpq5 ca-certificates curl
+RUN apt update && apt install -y libpq5 ca-certificates curl heaptrack
 
 COPY --from=builder /iota/iota /usr/local/bin
 

--- a/docker/utils/build-script.sh
+++ b/docker/utils/build-script.sh
@@ -98,5 +98,6 @@ docker build -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg CARGO_BUILD_FEATURES="$CARGO_BUILD_FEATURES" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
+	${RUSTFLAGS:+--build-arg RUSTFLAGS="$RUSTFLAGS"} \
 	--target runtime \
 	"$@"


### PR DESCRIPTION
# Description of change

This PR introduces the `heaptrack` binary in all docker images, so that memory profiling becomes easier.

To create a profile, you need to build the docker image with rustflags set:
```bash
export RUSTFLAGS="-C debuginfo=2"
# Then build your Docker image
docker build --build-arg RUSTFLAGS="-C debuginfo=2" -t iotaledger/iota-node .
```

Or use the provided debug build script:

```bash
./docker/iota-node/build_debuginfo.sh
```

To profile memory usage with Docker containers, you can run the container with heaptrack enabled:

```bash
docker run -it --rm \
  -v $(pwd)/heaptrack-data:/tmp/heaptrack-data \
  iotaledger/iota-node \
  heaptrack -o /tmp/heaptrack-data/iota-profile iota-node [your-node-arguments]
```

You can also attach heaptrack to an already running process inside a Docker container:
```bash
docker exec -it <container-name> heaptrack -p <pid> -o /tmp/profile-name
```

This will:

1. Run the IOTA node under heaptrack profiling
2. Save the profiling data to a volume-mounted directory for analysis
3. Generate a profile file named `iota-profile.heaptrack` in the mounted directory

To analyze the generated profiles:

1. Install heaptrack on your host system. On Debian/Ubuntu: `apt-get install heaptrack-gui heaptrack`.
2. Open the profile file with the heaptrack GUI: `heaptrack_gui /path/to/iota-profile.heaptrack`.
3. Or generate text reports: `heaptrack_print /path/to/iota-profile.heaptrack`.

> **tip**
>
> For production environments, consider the performance impact of memory profiling. Heaptrack can introduce overhead, so use it primarily for debugging memory issues or performance analysis in non-production environments.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes