### PR TITLE
feat(indexer): Prune cp based tables by range

### DIFF
--- a/crates/iota-indexer/src/pruning/pruner.rs
+++ b/crates/iota-indexer/src/pruning/pruner.rs
@@ -34,6 +34,10 @@ const PRUNING_DELAY_MS: u64 = 2 * 60 * 60 * 1000; // 2 hours for production
 /// strategy
 const MAX_TRANSACTIONS_PER_PRUNE_BATCH: u64 = 1000;
 
+/// Maximum number of checkpoints to prune in a single batch for ByCheckpoint
+/// strategy
+const MAX_CHECKPOINTS_PER_PRUNE_BATCH: u64 = 100;
+
 /// Interval for running the pruning task
 const PRUNING_TASK_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -117,8 +121,8 @@ pub enum PruningStrategy {
 enum PruningChunk {
     /// Prune an entire epoch partition
     Epoch(u64),
-    /// Prune a specific checkpoint
-    Checkpoint(u64),
+    /// Prune a range of checkpoints [start..=end] inclusive
+    CheckpointRange(u64, u64),
     /// Prune a range of transactions [start..=end] inclusive
     TransactionRange(u64, u64),
     /// Prune by global_sequence_number range [start..=end] inclusive
@@ -131,7 +135,7 @@ impl PruningChunk {
     fn next_chunk_start(&self) -> u64 {
         match self {
             PruningChunk::Epoch(epoch) => epoch + 1,
-            PruningChunk::Checkpoint(checkpoint) => checkpoint + 1,
+            PruningChunk::CheckpointRange(_, end) => end + 1,
             PruningChunk::TransactionRange(_, end) => end + 1,
             PruningChunk::GlobalSeqRange(_, end) => end + 1,
         }
@@ -327,7 +331,14 @@ impl<'a> TablePruner<'a> {
                     "pruning table {} in checkpoint range: [{lowest_unpruned_key}..{range_end})",
                     self.table.as_ref()
                 );
-                Box::new((lowest_unpruned_key..range_end).map(PruningChunk::Checkpoint))
+                Box::new(
+                    (lowest_unpruned_key..range_end)
+                        .step_by(MAX_CHECKPOINTS_PER_PRUNE_BATCH as usize)
+                        .map(move |start| {
+                            let end = (start + MAX_CHECKPOINTS_PER_PRUNE_BATCH).min(range_end);
+                            PruningChunk::CheckpointRange(start, end - 1)
+                        }),
+                )
             }
             PruningStrategy::ByTransaction => {
                 let range_end = min_available_tx;
@@ -412,20 +423,20 @@ impl<'a> TablePruner<'a> {
                 );
             }
 
-            PruningChunk::Checkpoint(checkpoint) => {
-                // Prune by checkpoint
+            PruningChunk::CheckpointRange(start, end) => {
+                // Prune by checkpoint range
                 if let Err(e) = self
                     .store
-                    .prune_table_by_checkpoint(&self.table, checkpoint)
+                    .prune_table_by_checkpoint_range(&self.table, start, end)
                     .await
                 {
                     error!(
-                        "failed to prune table {} for checkpoint {checkpoint}: {e}",
+                        "failed to prune table {} for checkpoint range [{start}..={end}]: {e}",
                         self.table.as_ref(),
                     );
                 }
                 info!(
-                    "pruned table {} for checkpoint {checkpoint}",
+                    "pruned table {} for checkpoint range [{start}..={end}]",
                     self.table.as_ref(),
                 );
             }

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -155,10 +155,11 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
 
     async fn persist_tx_indices(&self, indices: Vec<TxIndex>) -> Result<(), IndexerError>;
 
-    async fn prune_table_by_checkpoint(
+    async fn prune_table_by_checkpoint_range(
         &self,
         table: &PrunableTable,
-        checkpoint: u64,
+        min_checkpoint: u64,
+        max_checkpoint: u64,
     ) -> Result<(), IndexerError>;
 
     async fn prune_table_by_tx_range(

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1242,16 +1242,21 @@ impl PgIndexerStore {
         Ok(())
     }
 
-    fn prune_checkpoints_table(&self, cp: u64) -> Result<(), IndexerError> {
+    fn prune_checkpoints_table_by_range(
+        &self,
+        min_cp: u64,
+        max_cp: u64,
+    ) -> Result<(), IndexerError> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
                 diesel::delete(
-                    checkpoints::table.filter(checkpoints::sequence_number.eq(cp as i64)),
+                    checkpoints::table
+                        .filter(checkpoints::sequence_number.between(min_cp as i64, max_cp as i64)),
                 )
                 .execute(conn)
                 .map_err(IndexerError::from)
-                .context("Failed to prune checkpoints table")?;
+                .context("Failed to prune checkpoints table by range")?;
 
                 Ok::<(), IndexerError>(())
             },
@@ -1508,33 +1513,40 @@ impl PgIndexerStore {
         )
     }
 
-    fn prune_cp_tx_table(&self, cp: u64) -> Result<(), IndexerError> {
+    fn prune_cp_tx_table_by_range(&self, min_cp: u64, max_cp: u64) -> Result<(), IndexerError> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
                 diesel::delete(
-                    pruner_cp_watermark::table
-                        .filter(pruner_cp_watermark::checkpoint_sequence_number.eq(cp as i64)),
+                    pruner_cp_watermark::table.filter(
+                        pruner_cp_watermark::checkpoint_sequence_number
+                            .between(min_cp as i64, max_cp as i64),
+                    ),
                 )
                 .execute(conn)
                 .map_err(IndexerError::from)
-                .context("Failed to prune pruner_cp_watermark table")?;
+                .context("Failed to prune pruner_cp_watermark table by range")?;
                 Ok::<(), IndexerError>(())
             },
             PG_DB_COMMIT_SLEEP_DURATION
         )
     }
 
-    fn prune_table_by_checkpoint(
+    fn prune_table_by_checkpoint_range(
         &self,
         table: &crate::pruning::pruner::PrunableTable,
-        checkpoint: u64,
+        min_checkpoint: u64,
+        max_checkpoint: u64,
     ) -> Result<(), IndexerError> {
         use crate::pruning::pruner::PrunableTable;
 
         match table {
-            PrunableTable::Checkpoints => self.prune_checkpoints_table(checkpoint),
-            PrunableTable::PrunerCpWatermark => self.prune_cp_tx_table(checkpoint),
+            PrunableTable::Checkpoints => {
+                self.prune_checkpoints_table_by_range(min_checkpoint, max_checkpoint)
+            }
+            PrunableTable::PrunerCpWatermark => {
+                self.prune_cp_tx_table_by_range(min_checkpoint, max_checkpoint)
+            }
             _ => Err(IndexerError::InvalidArgument(format!(
                 "table {} is not pruned by checkpoint",
                 table.as_ref()
@@ -2453,14 +2465,15 @@ impl IndexerStore for PgIndexerStore {
             .await
     }
 
-    async fn prune_table_by_checkpoint(
+    async fn prune_table_by_checkpoint_range(
         &self,
         table: &crate::pruning::pruner::PrunableTable,
-        checkpoint: u64,
+        min_checkpoint: u64,
+        max_checkpoint: u64,
     ) -> Result<(), IndexerError> {
         let table_clone = *table;
         self.execute_in_blocking_worker(move |this| {
-            this.prune_table_by_checkpoint(&table_clone, checkpoint)
+            this.prune_table_by_checkpoint_range(&table_clone, min_checkpoint, max_checkpoint)
         })
         .await
     }


### PR DESCRIPTION
# Description of change

Increase pruning efficiency by pruning ranges of checkpoints instead of single checkpoints.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9900

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
