### PR TITLE
fix(dashboard,explorer): enable sentry only in production

### DIFF
--- a/apps/explorer/src/lib/utils/sentry.ts
+++ b/apps/explorer/src/lib/utils/sentry.ts
@@ -11,17 +11,22 @@ import {
     useNavigationType,
 } from 'react-router-dom';
 
-const SENTRY_ENABLED = import.meta.env.VITE_BUILD_ENV === 'production';
+const IS_PROD = import.meta.env.VITE_BUILD_ENV === 'production';
+const IS_SENTRY_ENABLED = import.meta.env.VITE_SENTRY_ENABLED === 'true';
+const SENTRY_DSN = IS_SENTRY_ENABLED
+    ? IS_PROD
+        ? 'https://ce107602e4d122f0639332c7c43fdc08@o4508279186718720.ingest.de.sentry.io/4508279962140752'
+        : 'https://c8085701fa2650fb2a090ed6aba6bc62@o4508279186718720.ingest.de.sentry.io/4508279963320400'
+    : undefined;
+
 const SENTRY_SAMPLE_RATE = import.meta.env.VITE_SENTRY_SAMPLE_RATE
     ? parseFloat(import.meta.env.VITE_SENTRY_SAMPLE_RATE)
     : 0;
 
 export function initSentry() {
     Sentry.init({
-        enabled: SENTRY_ENABLED,
-        dsn: SENTRY_ENABLED
-            ? 'https://ce107602e4d122f0639332c7c43fdc08@o4508279186718720.ingest.de.sentry.io/4508279962140752'
-            : 'https://c8085701fa2650fb2a090ed6aba6bc62@o4508279186718720.ingest.de.sentry.io/4508279963320400',
+        enabled: IS_SENTRY_ENABLED && Boolean(SENTRY_DSN),
+        dsn: SENTRY_DSN,
         environment: import.meta.env.VITE_VERCEL_ENV,
         integrations: [
             Sentry.reactRouterV6BrowserTracingIntegration({

--- a/apps/wallet-dashboard/sentry.common.config.mjs
+++ b/apps/wallet-dashboard/sentry.common.config.mjs
@@ -3,10 +3,13 @@
 
 export const IS_PROD =
     process.env.BUILD_ENV === 'production' || process.env.NEXT_PUBLIC_BUILD_ENV === 'production';
+export const IS_SENTRY_ENABLED = process.env.NEXT_PUBLIC_SENTRY_ENABLED === 'true';
 
-export const SENTRY_DSN = IS_PROD
-    ? 'https://cb83626ca07d6cf66ca2f901cf53c051@o4508279186718720.ingest.de.sentry.io/4508647247249488'
-    : 'https://ba5d6596291f12e88625e02eb942b742@o4508279186718720.ingest.de.sentry.io/4508647248691280';
+export const SENTRY_DSN = IS_SENTRY_ENABLED
+    ? IS_PROD
+        ? 'https://cb83626ca07d6cf66ca2f901cf53c051@o4508279186718720.ingest.de.sentry.io/4508647247249488'
+        : 'https://ba5d6596291f12e88625e02eb942b742@o4508279186718720.ingest.de.sentry.io/4508647248691280'
+    : undefined;
 
 export const SENTRY_PROJECT_NAME = IS_PROD ? 'iota-wallet-dashboard' : 'iota-wallet-dashboard-dev';
 export const SENTRY_ORG_NAME = 'iota-foundation-eu';

--- a/apps/wallet-dashboard/sentry.edge.config.ts
+++ b/apps/wallet-dashboard/sentry.edge.config.ts
@@ -3,10 +3,10 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
-import { IS_PROD, SENTRY_DSN } from './sentry.common.config.mjs';
+import { IS_SENTRY_ENABLED, SENTRY_DSN } from './sentry.common.config.mjs';
 
 Sentry.init({
-    enabled: IS_PROD,
+    enabled: IS_SENTRY_ENABLED && Boolean(SENTRY_DSN),
     dsn: SENTRY_DSN,
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.


### PR DESCRIPTION
# Description of change

Needs envs:
- `VITE_SENTRY_ENABLED` for explorer
- `NEXT_PUBLIC_SENTRY_ENABLED` for dashboard

edit by @begonaalvarezd : envs added ✅ 

## Links to any relevant issues

Fixes #9980 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.
