### PR TITLE
chore(indexer): add logs when running migrations

### DIFF
--- a/crates/iota-indexer/src/db.rs
+++ b/crates/iota-indexer/src/db.rs
@@ -287,12 +287,10 @@ pub mod setup_postgres {
         let pending_migrations = conn
             .pending_migrations(MIGRATIONS)
             .map_err(|e| anyhow!("failed to identify pending migrations {e}"))?;
-        if !pending_migrations.is_empty() {
-            for migration in pending_migrations {
-                info!("Applying migration {}", migration.name());
-                conn.run_migration(&migration)
-                    .map_err(|e| anyhow!("failed to run migration {e}"))?;
-            }
+        for migration in pending_migrations {
+            info!("Applying migration {}", migration.name());
+            conn.run_migration(&migration)
+                .map_err(|e| anyhow!("failed to run migration {e}"))?;
         }
         Ok(())
     }

--- a/crates/iota-indexer/src/db.rs
+++ b/crates/iota-indexer/src/db.rs
@@ -284,8 +284,16 @@ pub mod setup_postgres {
 
     /// Execute all unapplied migrations.
     pub fn run_migrations(conn: &mut PoolConnection) -> Result<(), anyhow::Error> {
-        conn.run_pending_migrations(MIGRATIONS)
-            .map_err(|e| anyhow!("failed to run migrations {e}"))?;
+        let pending_migrations = conn
+            .pending_migrations(MIGRATIONS)
+            .map_err(|e| anyhow!("failed to identify pending migrations {e}"))?;
+        if !pending_migrations.is_empty() {
+            for migration in pending_migrations {
+                info!("Applying migration {}", migration.name());
+                conn.run_migration(&migration)
+                    .map_err(|e| anyhow!("failed to run migration {e}"))?;
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
# Description of change

This patch adds logs when running migrations on the IOTA Indexer.

## How the change has been tested

Manually tested.

### Upon reset

```sh
2026-02-06T13:17:17.954318Z  INFO iota_indexer::db::setup_postgres: Created __diesel_schema_migrations table.                                                                                                                                                 
2026-02-06T13:17:17.955452Z  INFO iota_indexer::db::setup_postgres: Applying migration 00000000000000_diesel_initial_setup                                                                                                                                    
2026-02-06T13:17:17.956798Z  INFO iota_indexer::db::setup_postgres: Applying migration 2023-08-19-044020_events                                                                                                                                               
2026-02-06T13:17:17.963794Z  INFO iota_indexer::db::setup_postgres: Applying migration 2023-08-19-044023_objects                                                                                                                                              
2026-02-06T13:17:18.001652Z  INFO iota_indexer::db::setup_postgres: Applying migration 2023-08-19-044026_transactions          
2026-02-06T13:17:18.004828Z  INFO iota_indexer::db::setup_postgres: Applying migration 2023-08-19-044044_checkpoints                                                                                                                                          
2026-02-06T13:17:18.008839Z  INFO iota_indexer::db::setup_postgres: Applying migration 2023-08-19-044052_epochs                                                                                                                                               
2026-02-06T13:17:18.015794Z  INFO iota_indexer::db::setup_postgres: Applying migration 2023-08-19-060729_packages              
2026-02-06T13:17:18.020940Z  INFO iota_indexer::db::setup_postgres: Applying migration 2023-10-04-161058_tx_count_metrics                                                                                                                                     
2026-02-06T13:17:18.026510Z  INFO iota_indexer::db::setup_postgres: Applying migration 2023-10-04-161107_move_call_metrics     
2026-02-06T13:17:18.032126Z  INFO iota_indexer::db::setup_postgres: Applying migration 2023-10-04-161115_address_metrics                                                                                                                                      
2026-02-06T13:17:18.037397Z  INFO iota_indexer::db::setup_postgres: Applying migration 2023-10-04-161244_network_metrics                                                                                                                                      
2026-02-06T13:17:18.039828Z  INFO iota_indexer::db::setup_postgres: Applying migration 2023-10-06-204335_tx_indices                                                                                                                                           
2026-02-06T13:17:18.062174Z  INFO iota_indexer::db::setup_postgres: Applying migration 2023-10-07-160139_display                                                                                                                                              
2026-02-06T13:17:18.065364Z  INFO iota_indexer::db::setup_postgres: Applying migration 2023-11-29-193859_advance_partition
2026-02-06T13:17:18.066061Z  INFO iota_indexer::db::setup_postgres: Applying migration 2024-05-05-155158_obj_indices                                                                                                                                          
2026-02-06T13:17:18.536755Z  INFO iota_indexer::db::setup_postgres: Applying migration 2024-06-14-045801_event_indices                                                                                                                                        
2026-02-06T13:17:18.555346Z  INFO iota_indexer::db::setup_postgres: Applying migration 2024-07-11-144921_minting_burning_tokens_info                                                                                                                          
2026-02-06T13:17:18.556086Z  INFO iota_indexer::db::setup_postgres: Applying migration 2024-07-13-003534_chain_identifier                                                                                                                                     
2026-02-06T13:17:18.558226Z  INFO iota_indexer::db::setup_postgres: Applying migration 2024-07-16-092139_remove_stake_subsidy_amount                                                                                                                          
2026-02-06T13:17:18.558766Z  INFO iota_indexer::db::setup_postgres: Applying migration 2024-07-23-075345_remove_reinvestment                                                                                                                                  
2026-02-06T13:17:18.559104Z  INFO iota_indexer::db::setup_postgres: Applying migration 2024-08-05-100929_remove_burnt_leftover_amount                                                                                                                         
2026-02-06T13:17:18.559474Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-02-07-081500_drop_df_columns                                                                                                                                      
2026-02-06T13:17:18.560927Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-02-18-124652_checkpoints-add-computation-cost-burned            
2026-02-06T13:17:18.561328Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-02-26-153234_update_network_metrics_tps_30_days                 
2026-02-06T13:17:18.562512Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-03-13-081550_insertion_order
2026-02-06T13:17:18.565617Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-03-13-081552_optimistic_transactions
2026-02-06T13:17:18.584983Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-03-13-113634_optimistic_events     
2026-02-06T13:17:18.605788Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-03-21-081552_participation_metrics                                                                                                                                
2026-02-06T13:17:18.607709Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-05-28-174842_index_wrapped_or_deleted_objects                    
2026-02-06T13:17:18.611082Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-05-29-072412_insertion-order-revisited
2026-02-06T13:17:18.623003Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-06-02-122046_calculate_tx_count_metrics   
2026-02-06T13:17:18.624296Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-06-05-054854_persist_address_analytics                                                                               
2026-02-06T13:17:18.625187Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-06-12-144204_fix-epoch-system-state
2026-02-06T13:17:18.625915Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-07-23-091650_add_epoch_first_tx_sequence_number                                                                                                                   
2026-02-06T13:17:18.627099Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-09-10-071522_events_and_transactions_triggers                                                                                                                     
2026-02-06T13:17:18.627684Z  INFO iota_indexer::db::setup_postgres: Applying migration 2025-10-01-090835_watermarks            
2026-02-06T13:17:18.629848Z  INFO iota_indexer::db::setup_postgres: Applying migration 2026-01-29-092516_extend-object-type-statistics
2026-02-06T13:17:18.631780Z  INFO iota_indexer::db::setup_postgres: Reset database complete.                     
```

### Upon restart

```sh
2026-02-06T13:18:17.856387Z  WARN iota_indexer: WARNING: IOTA indexer is still experimental and we expect occasional breaking changes that require backfills.
2026-02-06T13:18:17.856696Z  INFO iota_indexer::metrics: Starting prometheus server address=0.0.0.0:9184
2026-02-06T13:18:18.070211Z  INFO iota_indexer::db::setup_postgres: Applying migration 2026-01-29-092516_extend-object-type-statistics
2026-02-06T13:18:18.078088Z  INFO iota_indexer::store::pg_partition_manager: Found 4 tables with partitions : [{"events": (0, 0), "objects_history": (0, 0), "objects_version": (0, 99), "transactions": (0, 0)}]
```