### PR TITLE
feat(gRPC): optimize data-fetching layer and validate `has_next` error

### DIFF
--- a/crates/iota-grpc-client/src/api/common.rs
+++ b/crates/iota-grpc-client/src/api/common.rs
@@ -30,6 +30,10 @@ pub enum Error {
     #[error("signature conversion error: {0}")]
     Signature(String),
 
+    /// The server stream ended unexpectedly while `has_next` was still true.
+    #[error("stream ended unexpectedly: server indicated more results with has_next=true")]
+    UnexpectedEndOfStream,
+
     /// gRPC transport or protocol error.
     #[error("grpc error: {0}")]
     Grpc(#[from] tonic::Status),
@@ -51,6 +55,9 @@ impl From<Error> for tonic::Status {
             Error::Server(msg) => tonic::Status::internal(format!("server error: {msg}")),
             Error::Signature(msg) => {
                 tonic::Status::internal(format!("signature conversion error: {msg}"))
+            }
+            Error::UnexpectedEndOfStream => {
+                tonic::Status::internal("stream ended unexpectedly: has_next was true")
             }
             Error::Grpc(status) => status,
         }

--- a/crates/iota-grpc-client/src/api/ledger/objects.rs
+++ b/crates/iota-grpc-client/src/api/ledger/objects.rs
@@ -12,7 +12,7 @@ use iota_sdk_types::{ObjectId, Version};
 
 use crate::{
     Client,
-    api::{OBJECTS_READ_MASK, ProtoResult, Result, field_mask_with_default},
+    api::{Error, OBJECTS_READ_MASK, ProtoResult, Result, field_mask_with_default},
 };
 
 impl Client {
@@ -89,11 +89,17 @@ impl Client {
 
         // Server guarantees results are returned in request order
         let mut results = Vec::with_capacity(refs.len());
+        let mut has_next = false;
 
         while let Some(response) = stream.message().await? {
+            has_next = response.has_next;
             for result in response.objects {
                 results.push(result.into_result()?);
             }
+        }
+
+        if has_next {
+            return Err(Error::UnexpectedEndOfStream);
         }
 
         Ok(results)

--- a/crates/iota-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-grpc-client/src/api/ledger/transactions.rs
@@ -11,7 +11,7 @@ use iota_sdk_types::Digest;
 
 use crate::{
     Client,
-    api::{ProtoResult, Result, TRANSACTIONS_READ_MASK, field_mask_with_default},
+    api::{Error, ProtoResult, Result, TRANSACTIONS_READ_MASK, field_mask_with_default},
 };
 
 impl Client {
@@ -99,11 +99,17 @@ impl Client {
 
         // Server guarantees results are returned in request order
         let mut results = Vec::with_capacity(digests.len());
+        let mut has_next = false;
 
         while let Some(response) = stream.message().await? {
+            has_next = response.has_next;
             for result in response.transactions {
                 results.push(result.into_result()?);
             }
+        }
+
+        if has_next {
+            return Err(Error::UnexpectedEndOfStream);
         }
 
         Ok(results)

--- a/crates/iota-grpc-server/src/error.rs
+++ b/crates/iota-grpc-server/src/error.rs
@@ -71,6 +71,26 @@ impl From<anyhow::Error> for RpcError {
     }
 }
 
+impl From<iota_types::iota_sdk_types_conversions::SdkTypeConversionError> for RpcError {
+    fn from(value: iota_types::iota_sdk_types_conversions::SdkTypeConversionError) -> Self {
+        Self {
+            code: Code::Internal,
+            message: Some(value.to_string()),
+            details: None,
+        }
+    }
+}
+
+impl From<bcs::Error> for RpcError {
+    fn from(value: bcs::Error) -> Self {
+        Self {
+            code: Code::Internal,
+            message: Some(value.to_string()),
+            details: None,
+        }
+    }
+}
+
 impl From<iota_grpc_types::google::rpc::bad_request::FieldViolation> for RpcError {
     fn from(value: iota_grpc_types::google::rpc::bad_request::FieldViolation) -> Self {
         BadRequest::from(value).into()

--- a/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
@@ -125,16 +125,13 @@ fn get_transaction_impl(
     // Get transaction data from storage, skipping unrequested fields
     let tx_read = reader.get_transaction_read(&digest, &fields)?;
 
-    let transaction_data = tx_read.transaction.transaction_data().clone();
-    let signatures = tx_read.transaction.tx_signatures().to_owned();
-
     // Create a source for the merge
     let source = TransactionReadSource {
         reader: reader.clone(),
         config,
-        transaction_data,
-        signatures: Some(signatures),
-        effects: Some(tx_read.effects),
+        transaction: tx_read.transaction,
+        signatures: tx_read.signatures,
+        effects: tx_read.effects,
         events: tx_read.events,
         checkpoint: tx_read.checkpoint,
         timestamp_ms: tx_read.timestamp_ms,

--- a/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
@@ -24,7 +24,7 @@ use crate::{
     error::RpcError,
     merge::Merge,
     transaction_execution_service::TransactionReadSource,
-    types::{GrpcReader, TransactionsStreamResult},
+    types::{GrpcReader, TransactionReadFields, TransactionsStreamResult},
 };
 
 pub const READ_MASK_DEFAULT: &str = crate::field_mask!("transaction.digest");
@@ -119,8 +119,11 @@ fn get_transaction_impl(
     digest: TransactionDigest,
     read_mask: &FieldMaskTree,
 ) -> Result<ExecutedTransaction, RpcError> {
-    // Get transaction data from storage
-    let tx_read = reader.get_transaction_read(&digest)?;
+    // Derive which optional fields to fetch based on the read_mask
+    let fields = TransactionReadFields::from_mask(read_mask);
+
+    // Get transaction data from storage, skipping unrequested fields
+    let tx_read = reader.get_transaction_read(&digest, &fields)?;
 
     let transaction_data = tx_read.transaction.transaction_data().clone();
     let signatures = tx_read.transaction.tx_signatures().to_owned();
@@ -135,8 +138,8 @@ fn get_transaction_impl(
         events: tx_read.events,
         checkpoint: tx_read.checkpoint,
         timestamp_ms: tx_read.timestamp_ms,
-        input_objects: Some(tx_read.input_objects),
-        output_objects: Some(tx_read.output_objects),
+        input_objects: tx_read.input_objects,
+        output_objects: tx_read.output_objects,
     };
 
     ExecutedTransaction::merge_from(&source, read_mask).map_err(|e| {

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -200,12 +200,9 @@ pub async fn execute_transaction(
         .map(|m| m.contains(ExecutedTransaction::OUTPUT_OBJECTS_FIELD.name))
         .unwrap_or(false);
 
-    let transaction_data = transaction.transaction_data().clone();
-    let signatures = transaction.tx_signatures().to_owned();
-
     // Create execution request
     let exec_request = ExecuteTransactionRequestV1 {
-        transaction,
+        transaction: transaction.clone(),
         include_events,
         include_input_objects,
         include_output_objects,
@@ -234,11 +231,20 @@ pub async fn execute_transaction(
 
     // Only include transaction if requested
     if let Some(tx_mask) = read_mask.subtree(ExecuteTransactionResponse::TRANSACTION_FIELD.name) {
+        let sdk_transaction: iota_sdk_types::Transaction =
+            transaction.transaction_data().clone().try_into()?;
+        let signatures: Vec<iota_sdk_types::UserSignature> = transaction
+            .tx_signatures()
+            .to_owned()
+            .into_iter()
+            .map(|sig| sig.try_into())
+            .collect::<Result<_, _>>()?;
+
         // Create a source for the merge
         let source = TransactionReadSource {
             reader: reader.clone(),
             config,
-            transaction_data,
+            transaction: Some(sdk_transaction),
             signatures: Some(signatures),
             effects: Some(effects.effects),
             events,

--- a/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
@@ -199,11 +199,13 @@ pub async fn simulate_transaction(
 
     // Only include transaction if requested
     if let Some(tx_mask) = read_mask.subtree(SimulateTransactionResponse::TRANSACTION_FIELD.name) {
+        let transaction: iota_sdk_types::Transaction = transaction_data.try_into()?;
+
         // Create a source for the merge
         let source = TransactionReadSource {
             reader: reader.clone(),
             config,
-            transaction_data,
+            transaction: Some(transaction),
             signatures: None,
             effects: Some(effects),
             events,

--- a/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
@@ -21,8 +21,8 @@ use crate::{GrpcReader, merge::Merge, utils::render_json};
 pub struct TransactionReadSource<'a> {
     pub reader: Arc<GrpcReader>,
     pub config: &'a iota_config::node::GrpcApiConfig,
-    pub transaction_data: iota_types::transaction::TransactionData,
-    pub signatures: Option<Vec<iota_types::signature::GenericSignature>>,
+    pub transaction: Option<iota_sdk_types::transaction::Transaction>,
+    pub signatures: Option<Vec<iota_sdk_types::UserSignature>>,
     pub effects: Option<iota_types::effects::TransactionEffects>,
     pub events: Option<iota_types::effects::TransactionEvents>,
     pub checkpoint: Option<u64>,
@@ -106,20 +106,16 @@ impl Merge<&TransactionReadSource<'_>> for grpc_tx::Transaction {
             return Ok(());
         }
 
-        let sdk_transaction: iota_sdk_types::Transaction = source
-            .transaction_data
-            .clone()
-            .try_into()
-            .map_err(|e| format!("failed to convert transaction to SDK type: {e}"))?;
+        let transaction = source.transaction.as_ref().ok_or("missing transaction")?;
 
         // Set digest if requested
         if mask.contains(Self::DIGEST_FIELD.name) {
-            self.digest = Some(sdk_transaction.digest().into());
+            self.digest = Some(transaction.digest().into());
         }
 
         // Set BCS if requested
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = grpc_bcs::BcsData::serialize(&sdk_transaction).ok();
+            self.bcs = grpc_bcs::BcsData::serialize(transaction).ok();
         }
 
         Ok(())

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -34,6 +34,33 @@ use tracing::debug;
 
 use crate::merge::Merge;
 
+/// Flags indicating which optional transaction fields to fetch from storage.
+///
+/// Derived from a `FieldMaskTree` to skip unnecessary storage reads.
+/// Follows the same pattern as `ExecuteTransactionRequestV1` which uses
+/// `include_events`, `include_input_objects`, `include_output_objects` flags.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TransactionReadFields {
+    pub include_events: bool,
+    pub include_checkpoint: bool,
+    pub include_input_objects: bool,
+    pub include_output_objects: bool,
+}
+
+impl TransactionReadFields {
+    /// Derive which fields to fetch from an `ExecutedTransaction` field mask.
+    pub fn from_mask(mask: &FieldMaskTree) -> Self {
+        use iota_grpc_types::v0::transaction::ExecutedTransaction;
+        Self {
+            include_events: mask.contains(ExecutedTransaction::EVENTS_FIELD.name),
+            include_checkpoint: mask.contains(ExecutedTransaction::CHECKPOINT_FIELD.name)
+                || mask.contains(ExecutedTransaction::TIMESTAMP_FIELD.name),
+            include_input_objects: mask.contains(ExecutedTransaction::INPUT_OBJECTS_FIELD.name),
+            include_output_objects: mask.contains(ExecutedTransaction::OUTPUT_OBJECTS_FIELD.name),
+        }
+    }
+}
+
 pub type GetObjectsStream = Pin<Box<dyn futures::Stream<Item = ObjectsStreamResult> + Send>>;
 pub type GetTransactionsStream =
     Pin<Box<dyn futures::Stream<Item = TransactionsStreamResult> + Send>>;
@@ -128,8 +155,8 @@ pub trait GrpcStateReader: Send + Sync + 'static {
     ) -> Option<(CertifiedCheckpointSummary, CheckpointContents)>;
 
     /// Stream checkpoint transactions individually to avoid large memory
-    /// footprint Returns a stream of individual CheckpointTransaction items
-    /// along with metadata
+    /// footprint. Returns a stream of individual CheckpointTransaction items
+    /// along with metadata.
     fn stream_checkpoint_transactions(
         &self,
         checkpoint_contents: CheckpointContents,
@@ -926,61 +953,80 @@ impl GrpcReader {
 
     /// Get transaction data for a single transaction digest.
     ///
-    /// Returns all transaction-related data needed to build a gRPC response.
+    /// Only fetches optional fields (events, checkpoint/timestamp, objects)
+    /// when indicated by `fields`. Transaction and effects are always fetched
+    /// as they are required prerequisites.
     #[tracing::instrument(skip(self))]
     pub fn get_transaction_read(
         &self,
         digest: &TransactionDigest,
+        fields: &TransactionReadFields,
     ) -> Result<TransactionReadData, crate::error::RpcError> {
-        // Get the transaction
+        // Get the transaction — always needed
         let transaction = self
             .state_reader
             .get_transaction(digest)
             .ok_or(crate::error::TransactionNotFoundError(*digest))?;
 
-        // Get the effects - required
+        // Get the effects — always needed as prerequisite
         let effects = self
             .state_reader
             .get_transaction_effects(digest)
             .ok_or(crate::error::TransactionNotFoundError(*digest))?;
 
-        // Get events if they exist
-        let events = effects
-            .events_digest()
-            .and_then(|event_digest| self.state_reader.get_transaction_events(event_digest));
+        // Get events only if requested
+        let events = if fields.include_events {
+            effects
+                .events_digest()
+                .and_then(|event_digest| self.state_reader.get_transaction_events(event_digest))
+        } else {
+            None
+        };
 
-        // Get checkpoint from indexes if available
-        let checkpoint = self.state_reader.get_transaction_checkpoint(digest);
+        // Get checkpoint and timestamp only if requested
+        let (checkpoint, timestamp_ms) = if fields.include_checkpoint {
+            let checkpoint = self.state_reader.get_transaction_checkpoint(digest);
+            let timestamp_ms = checkpoint.and_then(|checkpoint_seq| {
+                self.state_reader
+                    .get_checkpoint_summary(checkpoint_seq)
+                    .map(|summary| summary.data().timestamp_ms)
+            });
+            (checkpoint, timestamp_ms)
+        } else {
+            (None, None)
+        };
 
-        // Get timestamp from checkpoint if we have it
-        let timestamp_ms = checkpoint.and_then(|checkpoint_seq| {
-            self.state_reader
-                .get_checkpoint_summary(checkpoint_seq)
-                .map(|summary| summary.data().timestamp_ms)
-        });
+        // Get input objects only if requested
+        let input_objects = if fields.include_input_objects {
+            Some(
+                effects
+                    .modified_at_versions()
+                    .into_iter()
+                    .filter_map(|(object_id, version)| {
+                        self.state_reader.get_object_by_key(&object_id, version)
+                    })
+                    .collect(),
+            )
+        } else {
+            None
+        };
 
-        // Get input objects (objects at their state before the transaction)
-        // modified_at_versions() returns the object IDs and their versions before
-        // modification
-        let input_objects: Vec<Object> = effects
-            .modified_at_versions()
-            .into_iter()
-            .filter_map(|(object_id, version)| {
-                self.state_reader.get_object_by_key(&object_id, version)
-            })
-            .collect();
-
-        // Get output objects (created, mutated, unwrapped objects at their state after
-        // the transaction)
-        let output_objects: Vec<Object> = effects
-            .created()
-            .into_iter()
-            .chain(effects.mutated())
-            .chain(effects.unwrapped())
-            .filter_map(|((object_id, version, _digest), _owner)| {
-                self.state_reader.get_object_by_key(&object_id, version)
-            })
-            .collect();
+        // Get output objects only if requested
+        let output_objects = if fields.include_output_objects {
+            Some(
+                effects
+                    .created()
+                    .into_iter()
+                    .chain(effects.mutated())
+                    .chain(effects.unwrapped())
+                    .filter_map(|((object_id, version, _digest), _owner)| {
+                        self.state_reader.get_object_by_key(&object_id, version)
+                    })
+                    .collect(),
+            )
+        } else {
+            None
+        };
 
         Ok(TransactionReadData {
             digest: *digest,
@@ -1000,6 +1046,10 @@ impl GrpcReader {
 /// This struct holds owned data from storage, which is then converted to
 /// `iota-sdk-types` types and used with `Merge` trait to populate gRPC
 /// responses.
+///
+/// Optional fields (`events`, `checkpoint`, `timestamp_ms`, `input_objects`,
+/// `output_objects`) are `None` when the corresponding data was not requested
+/// via `TransactionReadFields`, meaning the storage read was skipped entirely.
 #[derive(Debug)]
 pub struct TransactionReadData {
     pub digest: TransactionDigest,
@@ -1008,8 +1058,8 @@ pub struct TransactionReadData {
     pub events: Option<TransactionEvents>,
     pub checkpoint: Option<u64>,
     pub timestamp_ms: Option<u64>,
-    pub input_objects: Vec<Object>,
-    pub output_objects: Vec<Object>,
+    pub input_objects: Option<Vec<Object>>,
+    pub output_objects: Option<Vec<Object>>,
 }
 
 /// Wrapper type that includes checkpoint context for a CheckpointTransaction.

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -35,14 +35,15 @@ use tracing::debug;
 use crate::merge::Merge;
 
 /// Flags indicating which optional transaction fields to fetch from storage.
-///
 /// Derived from a `FieldMaskTree` to skip unnecessary storage reads.
-/// Follows the same pattern as `ExecuteTransactionRequestV1` which uses
-/// `include_events`, `include_input_objects`, `include_output_objects` flags.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TransactionReadFields {
+    pub include_transaction: bool,
+    pub include_signatures: bool,
+    pub include_effects: bool,
     pub include_events: bool,
     pub include_checkpoint: bool,
+    pub include_timestamp: bool,
     pub include_input_objects: bool,
     pub include_output_objects: bool,
 }
@@ -51,10 +52,14 @@ impl TransactionReadFields {
     /// Derive which fields to fetch from an `ExecutedTransaction` field mask.
     pub fn from_mask(mask: &FieldMaskTree) -> Self {
         use iota_grpc_types::v0::transaction::ExecutedTransaction;
+
         Self {
+            include_transaction: mask.contains(ExecutedTransaction::TRANSACTION_FIELD.name),
+            include_signatures: mask.contains(ExecutedTransaction::SIGNATURES_FIELD.name),
+            include_effects: mask.contains(ExecutedTransaction::EFFECTS_FIELD.name),
             include_events: mask.contains(ExecutedTransaction::EVENTS_FIELD.name),
-            include_checkpoint: mask.contains(ExecutedTransaction::CHECKPOINT_FIELD.name)
-                || mask.contains(ExecutedTransaction::TIMESTAMP_FIELD.name),
+            include_checkpoint: mask.contains(ExecutedTransaction::CHECKPOINT_FIELD.name),
+            include_timestamp: mask.contains(ExecutedTransaction::TIMESTAMP_FIELD.name),
             include_input_objects: mask.contains(ExecutedTransaction::INPUT_OBJECTS_FIELD.name),
             include_output_objects: mask.contains(ExecutedTransaction::OUTPUT_OBJECTS_FIELD.name),
         }
@@ -962,58 +967,89 @@ impl GrpcReader {
         digest: &TransactionDigest,
         fields: &TransactionReadFields,
     ) -> Result<TransactionReadData, crate::error::RpcError> {
-        // Get the transaction — always needed
-        let transaction = self
-            .state_reader
-            .get_transaction(digest)
-            .ok_or(crate::error::TransactionNotFoundError(*digest))?;
+        let (transaction, signatures) = if fields.include_transaction || fields.include_signatures {
+            // Get the transaction if transaction data or signatures are requested
+            let transaction = self
+                .state_reader
+                .get_transaction(digest)
+                .ok_or(crate::error::TransactionNotFoundError(*digest))?;
 
-        // Get the effects — always needed as prerequisite
-        let effects = self
-            .state_reader
-            .get_transaction_effects(digest)
-            .ok_or(crate::error::TransactionNotFoundError(*digest))?;
+            let transaction_data = fields
+                .include_transaction
+                .then(|| transaction.transaction_data().clone().try_into())
+                .transpose()?;
 
-        // Get events only if requested
-        let events = if fields.include_events {
-            effects
-                .events_digest()
-                .and_then(|event_digest| self.state_reader.get_transaction_events(event_digest))
+            let signatures_data = fields
+                .include_signatures
+                .then(|| {
+                    transaction
+                        .tx_signatures()
+                        .iter()
+                        .map(|sig| sig.clone().try_into())
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?;
+
+            (transaction_data, signatures_data)
         } else {
-            None
+            (None, None)
         };
 
-        // Get checkpoint and timestamp only if requested
-        let (checkpoint, timestamp_ms) = if fields.include_checkpoint {
+        let (checkpoint, timestamp_ms) = if fields.include_checkpoint || fields.include_timestamp {
             let checkpoint = self.state_reader.get_transaction_checkpoint(digest);
-            let timestamp_ms = checkpoint.and_then(|checkpoint_seq| {
-                self.state_reader
-                    .get_checkpoint_summary(checkpoint_seq)
-                    .map(|summary| summary.data().timestamp_ms)
-            });
+
+            let timestamp_ms = fields
+                .include_timestamp
+                .then(|| {
+                    checkpoint.and_then(|checkpoint_seq| {
+                        self.state_reader
+                            .get_checkpoint_summary(checkpoint_seq)
+                            .map(|summary| summary.data().timestamp_ms)
+                    })
+                })
+                .flatten();
             (checkpoint, timestamp_ms)
         } else {
             (None, None)
         };
 
-        // Get input objects only if requested
-        let input_objects = if fields.include_input_objects {
-            Some(
+        // Get the effects if any of the following are requested: effects, events,
+        // checkpoint/timestamp, input/output objects
+        let (effects, events, input_objects, output_objects) = if fields.include_effects
+            || fields.include_events
+            || fields.include_input_objects
+            || fields.include_output_objects
+        {
+            // Effects are required for events and input/output objects, so we fetch them if
+            // any of those are requested
+            let effects = self
+                .state_reader
+                .get_transaction_effects(digest)
+                .ok_or(crate::error::TransactionNotFoundError(*digest))?;
+
+            // Get events only if requested
+            let events = fields
+                .include_events
+                .then(|| {
+                    effects.events_digest().and_then(|event_digest| {
+                        self.state_reader.get_transaction_events(event_digest)
+                    })
+                })
+                .flatten();
+
+            // Get input objects only if requested
+            let input_objects = fields.include_input_objects.then(|| {
                 effects
                     .modified_at_versions()
                     .into_iter()
                     .filter_map(|(object_id, version)| {
                         self.state_reader.get_object_by_key(&object_id, version)
                     })
-                    .collect(),
-            )
-        } else {
-            None
-        };
+                    .collect()
+            });
 
-        // Get output objects only if requested
-        let output_objects = if fields.include_output_objects {
-            Some(
+            // Get output objects only if requested
+            let output_objects = fields.include_output_objects.then(|| {
                 effects
                     .created()
                     .into_iter()
@@ -1022,15 +1058,19 @@ impl GrpcReader {
                     .filter_map(|((object_id, version, _digest), _owner)| {
                         self.state_reader.get_object_by_key(&object_id, version)
                     })
-                    .collect(),
-            )
+                    .collect()
+            });
+
+            (Some(effects), events, input_objects, output_objects)
         } else {
-            None
+            // If none of the above are requested, we can skip fetching effects entirely
+            (None, None, None, None)
         };
 
         Ok(TransactionReadData {
             digest: *digest,
             transaction,
+            signatures,
             effects,
             events,
             checkpoint,
@@ -1047,14 +1087,14 @@ impl GrpcReader {
 /// `iota-sdk-types` types and used with `Merge` trait to populate gRPC
 /// responses.
 ///
-/// Optional fields (`events`, `checkpoint`, `timestamp_ms`, `input_objects`,
-/// `output_objects`) are `None` when the corresponding data was not requested
+/// Optional fields are `None` when the corresponding data was not requested
 /// via `TransactionReadFields`, meaning the storage read was skipped entirely.
 #[derive(Debug)]
 pub struct TransactionReadData {
     pub digest: TransactionDigest,
-    pub transaction: Arc<VerifiedTransaction>,
-    pub effects: TransactionEffects,
+    pub transaction: Option<iota_sdk_types::transaction::Transaction>,
+    pub signatures: Option<Vec<iota_sdk_types::UserSignature>>,
+    pub effects: Option<TransactionEffects>,
     pub events: Option<TransactionEvents>,
     pub checkpoint: Option<u64>,
     pub timestamp_ms: Option<u64>,


### PR DESCRIPTION
# Description of change

- Propagate read_mask to the data-fetching layer to optimize the storage loading
- Add `has_next` validation to high-level gRPC client APIs

## Links to any relevant issues

fixes #10116, #10117 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation