### PR TITLE
fix(consensus): changed bucket size for latency_to_process_stream metric

### DIFF
--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -248,7 +248,7 @@ impl NodeMetrics {
                 "latency_to_process_stream",
                 "The latency between block creation and processing stream from peer",
                 &["peer"],
-                exponential_buckets(1.0, 2.0, 14).unwrap(),
+                exponential_buckets(0.002, 1.5, 18).unwrap(),
                 registry,
             ).unwrap(),
             proposed_block_ancestors_depth: register_histogram_vec_with_registry!(

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -315,7 +315,7 @@ impl NodeMetrics {
                 "latency_to_process_stream",
                 "The latency between block creation and processing stream from peer",
                 &["peer"],
-                exponential_buckets(1.0, 2.0, 14).unwrap(),
+                exponential_buckets(0.002, 1.5, 18).unwrap(),
                 registry,
             ).unwrap(),
             highest_verified_authority_round: register_int_gauge_vec_with_registry!(


### PR DESCRIPTION
# Description of change

Changed the bucket size for the metric latency_to_process_stream metric

## Links to any relevant issues

fixes [#(10120).](https://github.com/iotaledger/iota/issues/10120)

## How the change has been tested

- [X] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes


