### PR TITLE
feat(consensus): Score integration to Starfish: dag state updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13963,6 +13963,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "iota-common",
  "iota-config",
  "iota-macros",
  "iota-metrics",

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -520,6 +520,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                                 e.clone(),
                                 ErrorSource::CommitSyncer,
                                 &inner.context.metrics.node_metrics,
+                                &inner.context.protocol_config,
                             );
                         warn!("Failed to fetch {commit_range:?} from {hostname}: {}", e);
                         let error: &'static str = e.into();

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -68,20 +68,16 @@ impl Context {
     pub(crate) fn new_for_test(
         committee_size: usize,
     ) -> (Self, Vec<(NetworkKeyPair, ProtocolKeyPair)>) {
-        use iota_common::scoring_metrics::{ScoringMetricsV1, VersionedScoringMetrics};
-
         let (committee, keypairs) =
             consensus_config::local_committee_and_keys(0, vec![1; committee_size]);
         let metrics = test_metrics();
         let temp_dir = TempDir::new().unwrap();
         let clock = Arc::new(Clock::default());
-        let current_local_metrics_count = Arc::new(VersionedScoringMetrics::V1(
-            ScoringMetricsV1::new(committee_size),
-        ));
-        let scoring_metrics_store = Arc::new(MysticetiScoringMetricsStore::new(
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+
+        let scoring_metrics_store = Arc::new(MysticetiScoringMetricsStore::dummy_for_test(
             committee_size,
-            current_local_metrics_count,
-            &ProtocolConfig::get_for_max_version_UNSAFE(),
+            &protocol_config,
         ));
         let context = Context::new(
             0,
@@ -91,7 +87,7 @@ impl Context {
                 db_path: temp_dir.keep(),
                 ..Default::default()
             },
-            ProtocolConfig::get_for_max_version_UNSAFE(),
+            protocol_config,
             metrics,
             scoring_metrics_store,
             clock,

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -257,7 +257,7 @@ impl DagState {
                 &state.recent_refs_by_authority,
                 state.threshold_clock_round(),
                 &state.evicted_rounds,
-                state.context.clone(),
+                &state.context,
             );
 
         if state.gc_enabled() {
@@ -1070,7 +1070,7 @@ impl DagState {
                     current_eviction_round,
                     last_eviction_round,
                     threshold_clock_round,
-                    &self.context.metrics.node_metrics,
+                    &self.context,
                 );
             if let Some(metrics_to_write_from_authority) = metrics_to_write_from_authority {
                 metrics_to_write.push((authority_index, metrics_to_write_from_authority));

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -13,7 +13,7 @@ use itertools::izip;
 
 use crate::{
     BlockRef, context::Context, error::ConsensusError, metrics::NodeMetrics,
-    storage::StorageScoringMetrics,
+    storage::VersionedStorageScoringMetrics,
 };
 /// Struct that holds the scoring metrics for all authorities in the committee,
 /// both cached and uncached. It also holds a shared reference to the current
@@ -41,7 +41,7 @@ impl MysticetiScoringMetricsStore {
     // recovered_scoring_metrics and blocks_in_cache_by_authority.
     pub(crate) fn initialize_scoring_metrics(
         &self,
-        mut recovered_scoring_metrics: Vec<(AuthorityIndex, StorageScoringMetrics)>,
+        mut recovered_scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
         blocks_in_cache_by_authority: &Vec<BTreeSet<BlockRef>>,
         threshold_clock_round: u32,
         eviction_rounds: &Vec<u32>,
@@ -58,10 +58,10 @@ impl MysticetiScoringMetricsStore {
         // example, will never have its metrics updated, so no metric will ever be
         // stored. For this reason, we manually "fill" this vector.
         if recovered_scoring_metrics.len() < context.committee.size() {
-            for i in 0..context.committee.size() {
+            for (i, _) in context.committee.authorities() {
                 if !recovered_scoring_metrics
                     .iter()
-                    .any(|(index, _)| index.value() == i)
+                    .any(|(index, _)| *index == i)
                 {
                     // We add a component with zeroed metrics for the authority with index i.
                     // This will ensure that every authority has its metrics initialized.
@@ -69,15 +69,10 @@ impl MysticetiScoringMetricsStore {
                     // recovered metrics, it means that it never misbehaved in a way that was
                     // detected by the node.
                     recovered_scoring_metrics.insert(
-                        i,
+                        i.value(),
                         (
-                            AuthorityIndex::new_for_test(i as u32),
-                            StorageScoringMetrics {
-                                faulty_blocks_provable: 0,
-                                faulty_blocks_unprovable: 0,
-                                equivocations: 0,
-                                missing_proposals: 0,
-                            },
+                            i,
+                            VersionedStorageScoringMetrics::new_zeroed(&context.protocol_config),
                         ),
                     );
                 }
@@ -91,22 +86,17 @@ impl MysticetiScoringMetricsStore {
         ) {
             // Initialize the uncached scoring metrics according to
             // recovered_scoring_metrics
-            let StorageScoringMetrics {
-                faulty_blocks_provable,
-                faulty_blocks_unprovable,
-                equivocations,
-                missing_proposals,
-            } = metrics;
+            let VersionedStorageScoringMetrics::V1(inner) = &metrics;
             self.initialize_faulty_blocks_metrics(
-                faulty_blocks_provable,
-                faulty_blocks_unprovable,
+                *inner.faulty_blocks_provable(),
+                *inner.faulty_blocks_unprovable(),
                 hostname,
                 authority_index,
                 &context.metrics.node_metrics,
             );
             self.update_missing_blocks_and_equivocations(
-                missing_proposals,
-                equivocations,
+                *inner.missing_proposals(),
+                *inner.equivocations(),
                 hostname,
                 authority_index,
                 StoreType::Uncached,
@@ -268,7 +258,7 @@ impl MysticetiScoringMetricsStore {
         last_eviction_round: u32,
         threshold_clock_round: u32,
         node_metrics: &NodeMetrics,
-    ) -> Option<StorageScoringMetrics> {
+    ) -> Option<VersionedStorageScoringMetrics> {
         // threshold_clock_round should be always at least 1.
         // Analogously, authority_index should be a valid index.
         if threshold_clock_round == 0
@@ -333,17 +323,10 @@ impl MysticetiScoringMetricsStore {
         // Update current local metrics count.
         self.update_current_local_metrics_count(authority_index);
 
-        Some(StorageScoringMetrics {
-            faulty_blocks_provable: self.uncached_metrics.faulty_blocks_provable()[authority_index]
-                .load(Ordering::Relaxed),
-            faulty_blocks_unprovable: self.uncached_metrics.faulty_blocks_unprovable()
-                [authority_index]
-                .load(Ordering::Relaxed),
-            equivocations: self.uncached_metrics.equivocations()[authority_index]
-                .load(Ordering::Relaxed),
-            missing_proposals: self.uncached_metrics.missing_proposals()[authority_index]
-                .load(Ordering::Relaxed),
-        })
+        Some(VersionedStorageScoringMetrics::new_from(
+            &self.uncached_metrics,
+            authority_index.value(),
+        ))
     }
 
     pub(crate) fn update_current_local_metrics_count(&self, authority_index: AuthorityIndex) {
@@ -538,7 +521,7 @@ mod tests {
         dag_state::DagState,
         error::ConsensusError,
         scoring_metrics_store::{ErrorSource, MysticetiScoringMetricsStore},
-        storage::{StorageScoringMetrics, mem_store::MemStore},
+        storage::{VersionedStorageScoringMetrics, mem_store::MemStore},
         synchronizer::Synchronizer,
         test_dag_builder::DagBuilder,
     };
@@ -804,15 +787,15 @@ mod tests {
             threshold_clock_round,
             node_metrics,
         );
-        assert!(matches!(
+        assert_eq!(
             stored_metrics,
-            Some(StorageScoringMetrics {
-                faulty_blocks_provable: 0,
-                faulty_blocks_unprovable: 0,
-                equivocations: 0,
-                missing_proposals: 3
-            })
-        ));
+            Some(VersionedStorageScoringMetrics::new_v1_for_test(
+                0, // faulty_blocks_provable
+                0, // faulty_blocks_unprovable
+                3, // missing_proposals
+                0, // equivocations
+            ))
+        );
 
         // Unexpected because: eviction_round < last_evicted_round means that blocks
         // below or in last_evicted_round were accepted.
@@ -830,15 +813,15 @@ mod tests {
             threshold_clock_round,
             node_metrics,
         );
-        assert!(matches!(
+        assert_eq!(
             stored_metrics,
-            Some(StorageScoringMetrics {
-                faulty_blocks_provable: 0,
-                faulty_blocks_unprovable: 0,
-                equivocations: 0,
-                missing_proposals: 3
-            })
-        ));
+            Some(VersionedStorageScoringMetrics::new_v1_for_test(
+                0, // faulty_blocks_provable
+                0, // faulty_blocks_unprovable
+                3, // missing_proposals
+                0, // equivocations
+            ))
+        );
 
         // Unexpected because: threshold_clock_round < eviction_round <
         // last_evicted_round and threshold_clock_round. Return: metrics won't
@@ -855,15 +838,15 @@ mod tests {
             threshold_clock_round,
             node_metrics,
         );
-        assert!(matches!(
+        assert_eq!(
             stored_metrics,
-            Some(StorageScoringMetrics {
-                faulty_blocks_provable: 0,
-                faulty_blocks_unprovable: 0,
-                equivocations: 0,
-                missing_proposals: 3
-            })
-        ));
+            Some(VersionedStorageScoringMetrics::new_v1_for_test(
+                0, // faulty_blocks_provable
+                0, // faulty_blocks_unprovable
+                3, // missing_proposals
+                0, // equivocations
+            ))
+        );
 
         // Unexpected because: threshold_clock_round < last_evicted_round means that a
         // round with blocks from less than 2f+1 stake was evicted.

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -45,14 +45,8 @@ impl MysticetiScoringMetricsStore {
         blocks_in_cache_by_authority: &Vec<BTreeSet<BlockRef>>,
         threshold_clock_round: u32,
         eviction_rounds: &Vec<u32>,
-        context: Arc<Context>,
+        context: &Arc<Context>,
     ) {
-        let hostnames = context
-            .committee
-            .authorities()
-            .map(|(_, x)| x.hostname.as_str())
-            .collect::<Vec<_>>();
-
         // It is possible that the vector recovered_scoring_metrics does not have a
         // component for every authority. A perfectly functioning validator, for
         // example, will never have its metrics updated, so no metric will ever be
@@ -78,6 +72,35 @@ impl MysticetiScoringMetricsStore {
                 }
             }
         }
+
+        match &context.protocol_config.scorer_version_as_option() {
+            None | Some(1) => self.initialize_scoring_metrics_v1(
+                recovered_scoring_metrics,
+                blocks_in_cache_by_authority,
+                threshold_clock_round,
+                eviction_rounds,
+                context,
+            ),
+            _ => panic!("Unsupported scorer version"),
+        }
+    }
+
+    // Initializes the scoring metrics store according to the
+    // recovered_scoring_metrics and blocks_in_cache_by_authority.
+    pub(crate) fn initialize_scoring_metrics_v1(
+        &self,
+        recovered_scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
+        blocks_in_cache_by_authority: &Vec<BTreeSet<BlockRef>>,
+        threshold_clock_round: u32,
+        eviction_rounds: &Vec<u32>,
+        context: &Arc<Context>,
+    ) {
+        let hostnames = context
+            .committee
+            .authorities()
+            .map(|(_, x)| x.hostname.as_str())
+            .collect::<Vec<_>>();
+
         for ((authority_index, metrics), hostname, blocks_in_cache, &eviction_round) in izip!(
             recovered_scoring_metrics,
             hostnames,
@@ -134,6 +157,7 @@ impl MysticetiScoringMetricsStore {
         error: ConsensusError,
         source: ErrorSource,
         node_metrics: &NodeMetrics,
+        protocol_config: &ProtocolConfig,
     ) {
         // authority_index will be always a valid index. However, this method will
         // panic if authority_index >= committee_size. We run this check only to avoid
@@ -142,11 +166,33 @@ impl MysticetiScoringMetricsStore {
             return;
         }
 
+        match protocol_config.scorer_version_as_option() {
+            None | Some(1) => self.update_scoring_metrics_on_block_receival_v1(
+                authority_index,
+                hostname,
+                error,
+                source,
+                node_metrics,
+            ),
+            _ => panic!("Unsupported scorer version"),
+        }
+    }
+
+    // Updates the scoring metrics according to the received block's
+    // authority and error encountered during its processing.
+    pub(crate) fn update_scoring_metrics_on_block_receival_v1(
+        &self,
+        authority_index: AuthorityIndex,
+        hostname: &str,
+        error: ConsensusError,
+        source: ErrorSource,
+        node_metrics: &NodeMetrics,
+    ) {
         let (metric_type, source_str) = match source {
-            ErrorSource::CommitSyncer => (classify_commit_syncer_error(&error), "fetch_once"),
-            ErrorSource::Subscriber => (classify_subscriber_error(&error), "handle_send_block"),
+            ErrorSource::CommitSyncer => (classify_commit_syncer_error_v1(&error), "fetch_once"),
+            ErrorSource::Subscriber => (classify_subscriber_error_v1(&error), "handle_send_block"),
             ErrorSource::Synchronizer => (
-                classify_synchronizer_error(&error),
+                classify_synchronizer_error_v1(&error),
                 "process_fetched_blocks",
             ),
         };
@@ -257,13 +303,13 @@ impl MysticetiScoringMetricsStore {
         eviction_round: u32,
         last_eviction_round: u32,
         threshold_clock_round: u32,
-        node_metrics: &NodeMetrics,
+        context: &Arc<Context>,
     ) -> Option<VersionedStorageScoringMetrics> {
-        // threshold_clock_round should be always at least 1.
-        // Analogously, authority_index should be a valid index.
-        if threshold_clock_round == 0
-            || authority_index.value() >= self.uncached_metrics.faulty_blocks_provable().len()
-        {
+        let committee_size = context.committee.size();
+        let node_metrics = &context.metrics.node_metrics;
+        // threshold_clock_round should be always at least 1.  Analogously,
+        // authority_index should be a valid index.
+        if threshold_clock_round == 0 || authority_index.value() >= committee_size {
             return None;
         }
 
@@ -330,23 +376,17 @@ impl MysticetiScoringMetricsStore {
     }
 
     pub(crate) fn update_current_local_metrics_count(&self, authority_index: AuthorityIndex) {
-        let faulty_blocks_provable =
-            self.uncached_metrics.faulty_blocks_provable()[authority_index].load(Ordering::Relaxed);
-        let faulty_blocks_unprovable = self.uncached_metrics.faulty_blocks_unprovable()
-            [authority_index]
-            .load(Ordering::Relaxed);
-        let equivocations =
-            self.uncached_metrics.equivocations()[authority_index].load(Ordering::Relaxed);
-        let missing_proposals =
-            self.uncached_metrics.missing_proposals()[authority_index].load(Ordering::Relaxed);
+        let uncached_metrics = &self
+            .uncached_metrics
+            .iterate_over_metrics()
+            .map(|metric_vec| metric_vec[authority_index].load(Ordering::Relaxed))
+            .collect::<Vec<u64>>();
         self.current_local_metrics_count
-            .store_faulty_blocks_provable(authority_index.value(), faulty_blocks_provable);
-        self.current_local_metrics_count
-            .store_faulty_blocks_unprovable(authority_index.value(), faulty_blocks_unprovable);
-        self.current_local_metrics_count
-            .store_equivocations(authority_index.value(), equivocations);
-        self.current_local_metrics_count
-            .store_missing_proposals(authority_index.value(), missing_proposals);
+            .iterate_over_metrics()
+            .zip(uncached_metrics)
+            .for_each(|(local_metric_vec, uncached_metric)| {
+                local_metric_vec[authority_index].store(*uncached_metric, Ordering::Relaxed);
+            });
     }
 }
 
@@ -395,7 +435,7 @@ pub(crate) enum MetricType {
 // returned by it as untracked. We do not classify any error as provable here
 // because we cannot prove to a third party that a block or commit was fetched
 // from a particular authority.
-fn classify_commit_syncer_error(error: &ConsensusError) -> MetricType {
+fn classify_commit_syncer_error_v1(error: &ConsensusError) -> MetricType {
     match error {
         ConsensusError::MalformedCommit(_) => MetricType::Unprovable,
         ConsensusError::UnexpectedStartCommit { .. } => MetricType::Unprovable,
@@ -406,7 +446,7 @@ fn classify_commit_syncer_error(error: &ConsensusError) -> MetricType {
         ConsensusError::UnexpectedNumberOfBlocksFetched { .. } => MetricType::Unprovable,
         ConsensusError::UnexpectedBlockForCommit { .. } => MetricType::Unprovable,
         // Overwrite block verifier classification to return unprovable.
-        error => match classify_block_verifier_error(error) {
+        error => match classify_block_verifier_error_v1(error) {
             MetricType::Provable => MetricType::Unprovable,
             metric_type => metric_type,
         },
@@ -417,7 +457,7 @@ fn classify_commit_syncer_error(error: &ConsensusError) -> MetricType {
 // and errors not returned by it as untracked. Errors classified as provable are
 // those that can be proven to a third party by providing the signed faulty
 // block itself
-fn classify_block_verifier_error(error: &ConsensusError) -> MetricType {
+fn classify_block_verifier_error_v1(error: &ConsensusError) -> MetricType {
     match error {
         ConsensusError::WrongEpoch { .. } => MetricType::Unprovable,
         ConsensusError::UnexpectedGenesisBlock => MetricType::Unprovable,
@@ -447,12 +487,12 @@ fn classify_block_verifier_error(error: &ConsensusError) -> MetricType {
 // block itself. Obs: BlockRejected errors are untracked because even though
 // the rejected block signature can be verified, the reason for the rejection
 // is not objective nor clearly the block author's fault.
-fn classify_subscriber_error(error: &ConsensusError) -> MetricType {
+fn classify_subscriber_error_v1(error: &ConsensusError) -> MetricType {
     match error {
         ConsensusError::MalformedBlock { .. } => MetricType::Unprovable,
         ConsensusError::UnexpectedAuthority(..) => MetricType::Unprovable,
         ConsensusError::BlockRejected { .. } => MetricType::Untracked,
-        error => classify_block_verifier_error(error),
+        error => classify_block_verifier_error_v1(error),
     }
 }
 
@@ -460,13 +500,13 @@ fn classify_subscriber_error(error: &ConsensusError) -> MetricType {
 // returned by it as untracked. We do not classify any error as provable here
 // because we cannot prove to a third party that a block was fetched from a
 // particular authority.
-fn classify_synchronizer_error(error: &ConsensusError) -> MetricType {
+fn classify_synchronizer_error_v1(error: &ConsensusError) -> MetricType {
     match error {
         ConsensusError::TooManyFetchedBlocksReturned { .. } => MetricType::Unprovable,
         ConsensusError::MalformedBlock { .. } => MetricType::Unprovable,
         ConsensusError::UnexpectedFetchedBlock { .. } => MetricType::Unprovable,
         // Overwrite block verifier classification to return unprovable.
-        error => match classify_block_verifier_error(error) {
+        error => match classify_block_verifier_error_v1(error) {
             MetricType::Provable => MetricType::Unprovable,
             metric_type => metric_type,
         },
@@ -727,12 +767,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_scoring_metrics_on_eviction_edge_cases() {
-        let context = Context::new_for_test(4);
-        let scoring_metrics_store = context.0.scoring_metrics_store;
+        let context = Arc::new(Context::new_for_test(4).0);
+        let scoring_metrics_store = context.scoring_metrics_store.clone();
         let authority_index = AuthorityIndex::new_for_test(0);
         let hostname = "test_host";
         let recent_refs_by_authority = BTreeSet::new();
-        let node_metrics = &context.0.metrics.node_metrics;
         // Test different unexpected combinations of eviction_round, last_evicted_round,
         // and threshold_clock_round. Since recent_refs_by_authority is empty, the
         // function should never panic or return more than zero equivocations.
@@ -752,7 +791,7 @@ mod tests {
             eviction_round,
             last_evicted_round,
             threshold_clock_round,
-            node_metrics,
+            &context,
         );
         assert!(stored_metrics.is_none());
 
@@ -768,7 +807,7 @@ mod tests {
             eviction_round,
             last_evicted_round,
             threshold_clock_round,
-            node_metrics,
+            &context,
         );
         assert!(stored_metrics.is_none());
 
@@ -785,7 +824,7 @@ mod tests {
             eviction_round,
             last_evicted_round,
             threshold_clock_round,
-            node_metrics,
+            &context,
         );
         assert_eq!(
             stored_metrics,
@@ -811,7 +850,7 @@ mod tests {
             eviction_round,
             last_evicted_round,
             threshold_clock_round,
-            node_metrics,
+            &context,
         );
         assert_eq!(
             stored_metrics,
@@ -836,7 +875,7 @@ mod tests {
             eviction_round,
             last_evicted_round,
             threshold_clock_round,
-            node_metrics,
+            &context,
         );
         assert_eq!(
             stored_metrics,
@@ -861,7 +900,7 @@ mod tests {
             eviction_round,
             last_evicted_round,
             threshold_clock_round,
-            node_metrics,
+            &context,
         );
         assert!(stored_metrics.is_none());
 
@@ -875,7 +914,7 @@ mod tests {
             eviction_round,
             last_evicted_round,
             threshold_clock_round,
-            node_metrics,
+            &context,
         );
         assert!(stored_metrics.is_none());
 
@@ -895,7 +934,7 @@ mod tests {
             eviction_round,
             last_evicted_round,
             threshold_clock_round,
-            node_metrics,
+            &context,
         );
         assert!(stored_metrics.is_none());
     }
@@ -1649,6 +1688,7 @@ mod tests {
                     ignored_error.clone(),
                     source.clone(),
                     &context.metrics.node_metrics,
+                    &context.protocol_config,
                 );
         }
         assert_eq!(
@@ -1687,6 +1727,7 @@ mod tests {
                     parsing_error.clone(),
                     source.clone(),
                     &context.metrics.node_metrics,
+                    &context.protocol_config,
                 );
         }
         assert_eq!(
@@ -1725,6 +1766,7 @@ mod tests {
                     block_verification_error.clone(),
                     source.clone(),
                     &context.metrics.node_metrics,
+                    &context.protocol_config,
                 );
         }
         assert_eq!(
@@ -1763,6 +1805,7 @@ mod tests {
                     block_rejected_error.clone(),
                     source.clone(),
                     &context.metrics.node_metrics,
+                    &context.protocol_config,
                 );
         }
         assert_eq!(
@@ -1814,6 +1857,7 @@ mod tests {
                     ignored_error.clone(),
                     source.clone(),
                     &context.metrics.node_metrics,
+                    &context.protocol_config,
                 );
         }
         assert_eq!(
@@ -1850,6 +1894,7 @@ mod tests {
                     parsing_error.clone(),
                     source.clone(),
                     &context.metrics.node_metrics,
+                    &context.protocol_config,
                 );
         }
         assert_eq!(
@@ -1888,6 +1933,7 @@ mod tests {
                     block_verification_error.clone(),
                     source.clone(),
                     &context.metrics.node_metrics,
+                    &context.protocol_config,
                 );
         }
         assert_eq!(
@@ -1937,6 +1983,7 @@ mod tests {
                     ignored_error.clone(),
                     source.clone(),
                     &context.metrics.node_metrics,
+                    &context.protocol_config,
                 );
         }
         assert_eq!(
@@ -1973,6 +2020,7 @@ mod tests {
                     parsing_error.clone(),
                     source.clone(),
                     &context.metrics.node_metrics,
+                    &context.protocol_config,
                 );
         }
         assert_eq!(
@@ -2011,6 +2059,7 @@ mod tests {
                     block_verification_error.clone(),
                     source.clone(),
                     &context.metrics.node_metrics,
+                    &context.protocol_config,
                 );
         }
         assert_eq!(

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -372,6 +372,9 @@ impl MysticetiScoringMetricsStore {
         ))
     }
 
+    // The `authority_index` should be a valid index, otherwise the function will
+    // panic. This check is not performed here, as it is assumed that the caller has
+    // already checked it.
     pub(crate) fn update_current_local_metrics_count(&self, authority_index: AuthorityIndex) {
         let uncached_metrics = &self
             .uncached_metrics

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -7,14 +7,11 @@ use std::{
 };
 
 use consensus_config::AuthorityIndex;
-use iota_common::scoring_metrics::VersionedScoringMetrics;
+use iota_common::scoring_metrics::{VersionedScoringMetrics, VersionedStorageScoringMetrics};
 use iota_protocol_config::ProtocolConfig;
 use itertools::izip;
 
-use crate::{
-    BlockRef, context::Context, error::ConsensusError, metrics::NodeMetrics,
-    storage::VersionedStorageScoringMetrics,
-};
+use crate::{BlockRef, context::Context, error::ConsensusError, metrics::NodeMetrics};
 /// Struct that holds the scoring metrics for all authorities in the committee,
 /// both cached and uncached. It also holds a shared reference to the current
 /// local metrics count used by Scorer.
@@ -545,6 +542,7 @@ mod tests {
     use std::{collections::BTreeSet, sync::Arc, vec};
 
     use consensus_config::{AuthorityIndex, NetworkKeyPair, ProtocolKeyPair};
+    use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
     use parking_lot::RwLock;
     use tokio::sync::broadcast;
 
@@ -561,7 +559,7 @@ mod tests {
         dag_state::DagState,
         error::ConsensusError,
         scoring_metrics_store::{ErrorSource, MysticetiScoringMetricsStore},
-        storage::{VersionedStorageScoringMetrics, mem_store::MemStore},
+        storage::mem_store::MemStore,
         synchronizer::Synchronizer,
         test_dag_builder::DagBuilder,
     };

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use consensus_config::AuthorityIndex;
-use iota_common::scoring_metrics::{ScoringMetricsV1, VersionedScoringMetrics};
+use iota_common::scoring_metrics::VersionedScoringMetrics;
 use iota_protocol_config::ProtocolConfig;
 use itertools::izip;
 
@@ -30,16 +30,10 @@ impl MysticetiScoringMetricsStore {
         current_local_metrics_count: Arc<VersionedScoringMetrics>,
         protocol_config: &ProtocolConfig,
     ) -> Self {
-        match protocol_config.scorer_version_as_option() {
-            None | Some(1) => Self {
-                current_local_metrics_count,
-                cached_metrics: VersionedScoringMetrics::V1(ScoringMetricsV1::new(committee_size)),
-
-                uncached_metrics: VersionedScoringMetrics::V1(ScoringMetricsV1::new(
-                    committee_size,
-                )),
-            },
-            _ => panic!("Unsupported scorer version"),
+        Self {
+            current_local_metrics_count,
+            cached_metrics: VersionedScoringMetrics::new(committee_size, protocol_config),
+            uncached_metrics: VersionedScoringMetrics::new(committee_size, protocol_config),
         }
     }
 
@@ -504,6 +498,23 @@ pub(crate) enum ErrorSource {
     Subscriber,
     // Errors returned from process_fetched_blocks.
     Synchronizer,
+}
+
+#[cfg(test)]
+impl MysticetiScoringMetricsStore {
+    // Creates a dummy scoring metrics store for testing purposes (i.e., without any
+    // connection to a Scorer)
+    pub(crate) fn dummy_for_test(committee_size: usize, protocol_config: &ProtocolConfig) -> Self {
+        let current_local_metrics_count = Arc::new(VersionedScoringMetrics::new(
+            committee_size,
+            protocol_config,
+        ));
+        MysticetiScoringMetricsStore::new(
+            committee_size,
+            current_local_metrics_count,
+            protocol_config,
+        )
+    }
 }
 
 #[cfg(test)]

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -18,7 +18,7 @@ use crate::{
         TrustedCommit,
     },
     error::ConsensusResult,
-    storage::StorageScoringMetrics,
+    storage::VersionedStorageScoringMetrics,
 };
 /// In-memory storage for testing.
 pub(crate) struct MemStore {
@@ -31,7 +31,7 @@ struct Inner {
     commits: BTreeMap<(CommitIndex, CommitDigest), TrustedCommit>,
     commit_votes: BTreeSet<(CommitIndex, CommitDigest, BlockRef)>,
     commit_info: BTreeMap<(CommitIndex, CommitDigest), CommitInfo>,
-    scoring_metrics: BTreeMap<AuthorityIndex, StorageScoringMetrics>,
+    scoring_metrics: BTreeMap<AuthorityIndex, VersionedStorageScoringMetrics>,
 }
 
 impl MemStore {
@@ -134,7 +134,7 @@ impl Store for MemStore {
 
     fn scan_scoring_metrics(
         &self,
-    ) -> ConsensusResult<Vec<(AuthorityIndex, StorageScoringMetrics)>> {
+    ) -> ConsensusResult<Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>> {
         let inner = self.inner.read();
         let metrics_by_author = inner
             .scoring_metrics

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use consensus_config::AuthorityIndex;
+use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
 use parking_lot::RwLock;
 
 use super::{Store, WriteBatch};
@@ -18,7 +19,6 @@ use crate::{
         TrustedCommit,
     },
     error::ConsensusResult,
-    storage::VersionedStorageScoringMetrics,
 };
 /// In-memory storage for testing.
 pub(crate) struct MemStore {

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -41,16 +41,16 @@ pub(crate) trait Store: Send + Sync {
         start_round: Round,
     ) -> ConsensusResult<Vec<VerifiedBlock>>;
 
-    // The method reads and returns all metrics stored. Used for restoring the
-    // scoring metrics in case of DagState initialization from storage
+    /// Reads and returns all metrics stored. Used for restoring the scoring
+    /// metrics in case of DagState initialization from storage
     fn scan_scoring_metrics(
         &self,
     ) -> ConsensusResult<Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>>;
 
-    // The method returns the last `num_of_rounds` rounds blocks by author in round
-    // ascending order. When a `before_round` is defined then the blocks of
-    // round `<=before_round` are returned. If not then the max value for round
-    // will be used as cut off.
+    /// Returns the last `num_of_rounds` rounds blocks by author in round
+    /// ascending order. When a `before_round` is defined then the blocks of
+    /// round `<=before_round` are returned. If not then the max value for round
+    /// will be used as cut off.
     #[allow(dead_code)]
     fn scan_last_blocks_by_author(
         &self,

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -10,9 +10,7 @@ pub(crate) mod rocksdb_store;
 mod store_tests;
 
 use consensus_config::AuthorityIndex;
-use iota_common::{misbehavior_counts::MisbehaviorsV1, scoring_metrics::VersionedScoringMetrics};
-use iota_protocol_config::ProtocolConfig;
-use serde::{Deserialize, Serialize};
+use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
 
 use crate::{
     CommitIndex,
@@ -125,55 +123,5 @@ impl WriteBatch {
     ) -> Self {
         self.scoring_metrics = scoring_metrics;
         self
-    }
-}
-
-// Re-exportMisbehaviorsV1<u64> as StorageScoringMetrics for storage use.
-pub(crate) type StorageScoringMetricsV1 = MisbehaviorsV1<u64>;
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub enum VersionedStorageScoringMetrics {
-    V1(StorageScoringMetricsV1),
-}
-
-impl VersionedStorageScoringMetrics {
-    pub fn new_zeroed(protocol_config: &ProtocolConfig) -> Self {
-        match protocol_config.scorer_version_as_option() {
-            None | Some(1) => {
-                VersionedStorageScoringMetrics::V1(StorageScoringMetricsV1::new_zeroed())
-            }
-            _ => panic!("Unsupported scorer version"),
-        }
-    }
-
-    pub fn new_from(scoring_metrics: &VersionedScoringMetrics, authority_index: usize) -> Self {
-        match scoring_metrics {
-            VersionedScoringMetrics::V1(misbehavior_vectors) => {
-                let inner = misbehavior_vectors.misbehaviors_from_authority(authority_index);
-                VersionedStorageScoringMetrics::V1(inner)
-            }
-        }
-    }
-
-    /// Returns an iterator over references to the metric values.
-    pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&u64> {
-        match self {
-            VersionedStorageScoringMetrics::V1(inner) => inner.iter(),
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn new_v1_for_test(
-        faulty_blocks_provable: u64,
-        faulty_blocks_unprovable: u64,
-        missing_proposals: u64,
-        equivocations: u64,
-    ) -> Self {
-        VersionedStorageScoringMetrics::V1(StorageScoringMetricsV1::new(
-            faulty_blocks_provable,
-            faulty_blocks_unprovable,
-            missing_proposals,
-            equivocations,
-        ))
     }
 }

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -10,6 +10,9 @@ pub(crate) mod rocksdb_store;
 mod store_tests;
 
 use consensus_config::AuthorityIndex;
+use iota_common::{misbehavior_counts::MisbehaviorsV1, scoring_metrics::VersionedScoringMetrics};
+use iota_protocol_config::ProtocolConfig;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     CommitIndex,
@@ -42,8 +45,9 @@ pub(crate) trait Store: Send + Sync {
 
     // The method reads and returns all metrics stored. Used for restoring the
     // scoring metrics in case of DagState initialization from storage
-    fn scan_scoring_metrics(&self)
-    -> ConsensusResult<Vec<(AuthorityIndex, StorageScoringMetrics)>>;
+    fn scan_scoring_metrics(
+        &self,
+    ) -> ConsensusResult<Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>>;
 
     // The method returns the last `num_of_rounds` rounds blocks by author in round
     // ascending order. When a `before_round` is defined then the blocks of
@@ -76,7 +80,7 @@ pub(crate) struct WriteBatch {
     pub(crate) blocks: Vec<VerifiedBlock>,
     pub(crate) commits: Vec<TrustedCommit>,
     pub(crate) commit_info: Vec<(CommitRef, CommitInfo)>,
-    pub(crate) scoring_metrics: Vec<(AuthorityIndex, StorageScoringMetrics)>,
+    pub(crate) scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
 }
 
 impl WriteBatch {
@@ -84,7 +88,7 @@ impl WriteBatch {
         blocks: Vec<VerifiedBlock>,
         commits: Vec<TrustedCommit>,
         commit_info: Vec<(CommitRef, CommitInfo)>,
-        scoring_metrics: Vec<(AuthorityIndex, StorageScoringMetrics)>,
+        scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
     ) -> Self {
         WriteBatch {
             blocks,
@@ -117,19 +121,59 @@ impl WriteBatch {
     #[cfg(test)]
     pub(crate) fn scoring_metrics(
         mut self,
-        scoring_metrics: Vec<(AuthorityIndex, StorageScoringMetrics)>,
+        scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
     ) -> Self {
         self.scoring_metrics = scoring_metrics;
         self
     }
 }
 
-// This struct is used in storage. It holds the same data as
-// `UncachedScoringMetrics`, but uses `u64` instead of `AtomicU64`.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
-pub(crate) struct StorageScoringMetrics {
-    pub(crate) faulty_blocks_provable: u64,
-    pub(crate) faulty_blocks_unprovable: u64,
-    pub(crate) equivocations: u64,
-    pub(crate) missing_proposals: u64,
+// Re-exportMisbehaviorsV1<u64> as StorageScoringMetrics for storage use.
+pub(crate) type StorageScoringMetricsV1 = MisbehaviorsV1<u64>;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum VersionedStorageScoringMetrics {
+    V1(StorageScoringMetricsV1),
+}
+
+impl VersionedStorageScoringMetrics {
+    pub fn new_zeroed(protocol_config: &ProtocolConfig) -> Self {
+        match protocol_config.scorer_version_as_option() {
+            None | Some(1) => {
+                VersionedStorageScoringMetrics::V1(StorageScoringMetricsV1::new_zeroed())
+            }
+            _ => panic!("Unsupported scorer version"),
+        }
+    }
+
+    pub fn new_from(scoring_metrics: &VersionedScoringMetrics, authority_index: usize) -> Self {
+        match scoring_metrics {
+            VersionedScoringMetrics::V1(misbehavior_vectors) => {
+                let inner = misbehavior_vectors.misbehaviors_from_authority(authority_index);
+                VersionedStorageScoringMetrics::V1(inner)
+            }
+        }
+    }
+
+    /// Returns an iterator over references to the metric values.
+    pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&u64> {
+        match self {
+            VersionedStorageScoringMetrics::V1(inner) => inner.iter(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_v1_for_test(
+        faulty_blocks_provable: u64,
+        faulty_blocks_unprovable: u64,
+        missing_proposals: u64,
+        equivocations: u64,
+    ) -> Self {
+        VersionedStorageScoringMetrics::V1(StorageScoringMetricsV1::new(
+            faulty_blocks_provable,
+            faulty_blocks_unprovable,
+            missing_proposals,
+            equivocations,
+        ))
+    }
 }

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -19,7 +19,7 @@ use crate::{
     block::{BlockAPI as _, BlockDigest, BlockRef, Round, SignedBlock, VerifiedBlock},
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
-    storage::StorageScoringMetrics,
+    storage::VersionedStorageScoringMetrics,
 };
 
 /// Persistent storage with RocksDB.
@@ -36,7 +36,7 @@ pub(crate) struct RocksDBStore {
     /// Stores info related to Commit that helps recovery.
     commit_info: DBMap<(CommitIndex, CommitDigest), CommitInfo>,
     /// Stores scoring metrics for each authority.
-    scoring_metrics: DBMap<AuthorityIndex, StorageScoringMetrics>,
+    scoring_metrics: DBMap<AuthorityIndex, VersionedStorageScoringMetrics>,
 }
 
 impl RocksDBStore {
@@ -84,7 +84,7 @@ impl RocksDBStore {
             Self::COMMITS_CF;<(CommitIndex, CommitDigest), Bytes>,
             Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
             Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>,
-            Self::SCORING_METRICS_CF;<AuthorityIndex, StorageScoringMetrics>
+            Self::SCORING_METRICS_CF;<AuthorityIndex, VersionedStorageScoringMetrics>
         );
 
         Self {
@@ -226,7 +226,7 @@ impl Store for RocksDBStore {
 
     fn scan_scoring_metrics(
         &self,
-    ) -> ConsensusResult<Vec<(AuthorityIndex, StorageScoringMetrics)>> {
+    ) -> ConsensusResult<Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>> {
         let mut metrics_by_author = vec![];
         for kv in self.scoring_metrics.safe_iter() {
             metrics_by_author.push(kv?);

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -6,6 +6,7 @@ use std::{ops::Bound::Included, time::Duration};
 
 use bytes::Bytes;
 use consensus_config::AuthorityIndex;
+use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
 use iota_macros::fail_point;
 use typed_store::{
     Map as _,
@@ -19,7 +20,6 @@ use crate::{
     block::{BlockAPI as _, BlockDigest, BlockRef, Round, SignedBlock, VerifiedBlock},
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
-    storage::VersionedStorageScoringMetrics,
 };
 
 /// Persistent storage with RocksDB.

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -304,7 +304,7 @@ async fn read_and_scan_commits(
 async fn scan_scoring_metrics(
     #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
-    use crate::storage::VersionedStorageScoringMetrics;
+    use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
 
     let store = test_store.store();
     let metrics_updates = [

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -304,22 +304,22 @@ async fn read_and_scan_commits(
 async fn scan_scoring_metrics(
     #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
-    use crate::storage::StorageScoringMetrics;
+    use crate::storage::VersionedStorageScoringMetrics;
 
     let store = test_store.store();
     let metrics_updates = [
-        StorageScoringMetrics {
-            faulty_blocks_provable: 1,
-            faulty_blocks_unprovable: 2,
-            equivocations: 3,
-            missing_proposals: 4,
-        },
-        StorageScoringMetrics {
-            faulty_blocks_provable: 0,
-            faulty_blocks_unprovable: 0,
-            equivocations: 0,
-            missing_proposals: 0,
-        },
+        VersionedStorageScoringMetrics::new_v1_for_test(
+            1, // faulty_blocks_provable
+            2, // faulty_blocks_unprovable
+            4, // missing_proposals
+            3, // equivocations
+        ),
+        VersionedStorageScoringMetrics::new_v1_for_test(
+            0, // faulty_blocks_provable
+            0, // faulty_blocks_unprovable
+            0, // missing_proposals
+            0, // equivocations
+        ),
     ];
     let authories = [
         AuthorityIndex::new_for_test(0),

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -239,6 +239,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                                     e.clone(),
                                     ErrorSource::Subscriber,
                                     &context.metrics.node_metrics,
+                                    &context.protocol_config,
                                 );
                             match e {
                                 ConsensusError::BlockRejected { block_ref, reason } => {

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -573,6 +573,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                     err.clone(),
                                     ErrorSource::Synchronizer,
                                     &context.metrics.node_metrics,
+                                    &context.protocol_config,
                                 );
                                 warn!("Error while processing fetched blocks from peer {peer_index} {peer_hostname}: {err}");
                                 context.metrics.node_metrics.synchronizer_process_fetched_failures_by_peer.with_label_values(&[peer_hostname.as_str(), "live"]).inc();

--- a/consensus/core/src/threshold_clock.rs
+++ b/consensus/core/src/threshold_clock.rs
@@ -99,8 +99,6 @@ impl ThresholdClock {
 #[cfg(test)]
 mod tests {
     use consensus_config::AuthorityIndex;
-    use iota_common::scoring_metrics::{ScoringMetricsV1, VersionedScoringMetrics};
-    use iota_protocol_config::ProtocolConfig;
 
     use super::*;
     use crate::{block::BlockDigest, scoring_metrics_store::MysticetiScoringMetricsStore};
@@ -225,12 +223,11 @@ mod tests {
         let committee_size = committee.size();
         let metrics = test_metrics();
         let temp_dir = TempDir::new().unwrap();
-        let current_local_metrics_count =
-            Arc::new(VersionedScoringMetrics::V1(ScoringMetricsV1::new(3)));
-        let scoring_metrics_store = Arc::new(MysticetiScoringMetricsStore::new(
+        let protocol_config = iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE();
+
+        let scoring_metrics_store = Arc::new(MysticetiScoringMetricsStore::dummy_for_test(
             committee_size,
-            current_local_metrics_count,
-            &ProtocolConfig::get_for_max_version_UNSAFE(),
+            &protocol_config,
         ));
 
         let context = Arc::new(crate::context::Context::new(
@@ -241,7 +238,7 @@ mod tests {
                 db_path: temp_dir.keep(),
                 ..Default::default()
             },
-            iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE(),
+            protocol_config,
             metrics,
             scoring_metrics_store,
             Arc::new(crate::context::Clock::default()),

--- a/crates/iota-common/src/lib.rs
+++ b/crates/iota-common/src/lib.rs
@@ -10,4 +10,4 @@ pub mod stream_ext;
 pub mod sync;
 pub mod try_iterator_ext;
 
-pub use iota_types::scoring_metrics;
+pub use iota_types::{misbehavior_counts, scoring_metrics};

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -8,7 +8,7 @@ use std::sync::{
 
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
-    messages_consensus::{MisbehaviorsV1, VersionedMisbehaviorReport},
+    messages_consensus::VersionedMisbehaviorReport, misbehavior_counts::MisbehaviorsV1,
     scoring_metrics::VersionedScoringMetrics,
 };
 
@@ -68,24 +68,24 @@ impl Scorer {
                         })
                         .collect();
                 let parameters = ParametersV1 {
-                    allowances: MisbehaviorsV1 {
-                        faulty_blocks_provable: 1,
-                        faulty_blocks_unprovable: 2,
-                        missing_proposals: 48_000, // roughly 3% of consensus rounds in an epoch
-                        equivocations: 0,
-                    },
-                    maximums: MisbehaviorsV1 {
-                        faulty_blocks_provable: 5,
-                        faulty_blocks_unprovable: 10,
-                        missing_proposals: 160_000, // roughly 10% of consensus rounds in an epoch
-                        equivocations: 1,
-                    },
-                    weights: MisbehaviorsV1 {
-                        faulty_blocks_provable: SCALE_FACTOR * 30 / 100,
-                        faulty_blocks_unprovable: SCALE_FACTOR * 10 / 100,
-                        missing_proposals: SCALE_FACTOR * 35 / 100,
-                        equivocations: 1,
-                    },
+                    allowances: MisbehaviorsV1::new(
+                        1,      // faulty_blocks_provable
+                        2,      // faulty_blocks_unprovable
+                        48_000, // missing_proposals - roughly 3% of consensus rounds in an epoch
+                        0,      // equivocations
+                    ),
+                    maximums: MisbehaviorsV1::new(
+                        5,       // faulty_blocks_provable
+                        10,      // faulty_blocks_unprovable
+                        160_000, // missing_proposals - roughly 10% of consensus rounds in an epoch
+                        1,       // equivocations
+                    ),
+                    weights: MisbehaviorsV1::new(
+                        SCALE_FACTOR * 30 / 100, // faulty_blocks_provable
+                        SCALE_FACTOR * 10 / 100, // faulty_blocks_unprovable
+                        SCALE_FACTOR * 35 / 100, // missing_proposals
+                        1,                       // equivocations
+                    ),
                 };
                 // Assert that the allowance for major misbehaviors is 0,
                 // maximum is 1 and weight is 1. This is because major misbehaviors should
@@ -445,7 +445,9 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     use iota_protocol_config::{ConsensusChoice, ProtocolConfig};
-    use iota_types::messages_consensus::{MisbehaviorsV1, VersionedMisbehaviorReport};
+    use iota_types::{
+        messages_consensus::VersionedMisbehaviorReport, misbehavior_counts::MisbehaviorsV1,
+    };
 
     use crate::authority::authority_per_epoch_store::scorer::{
         MAX_SCORE, ParametersV1, SCALE_FACTOR, Scorer, calculate_median_report, calculate_scores_v1,
@@ -548,30 +550,30 @@ mod tests {
         // Set some reports for testing
         let reports_and_authorities = vec![
             (
-                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
-                    faulty_blocks_provable: vec![5, 0, 0],
-                    faulty_blocks_unprovable: vec![0, 0, 0],
-                    missing_proposals: vec![0, 0, 0],
-                    equivocations: vec![0, 0, 0],
-                }),
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1::new(
+                    vec![5, 0, 0], // faulty_blocks_provable
+                    vec![0, 0, 0], // faulty_blocks_unprovable
+                    vec![0, 0, 0], // missing_proposals
+                    vec![0, 0, 0], // equivocations
+                )),
                 0_u32,
             ),
             (
-                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
-                    faulty_blocks_provable: vec![0, 10, 0],
-                    faulty_blocks_unprovable: vec![0, 0, 0],
-                    missing_proposals: vec![0, 0, 0],
-                    equivocations: vec![0, 0, 0],
-                }),
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1::new(
+                    vec![0, 10, 0], // faulty_blocks_provable
+                    vec![0, 0, 0],  // faulty_blocks_unprovable
+                    vec![0, 0, 0],  // missing_proposals
+                    vec![0, 0, 0],  // equivocations
+                )),
                 1_u32,
             ),
             (
-                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
-                    faulty_blocks_provable: vec![0, 0, 15],
-                    faulty_blocks_unprovable: vec![0, 0, 0],
-                    missing_proposals: vec![0, 0, 0],
-                    equivocations: vec![5, 0, 0],
-                }),
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1::new(
+                    vec![0, 0, 15], // faulty_blocks_provable
+                    vec![0, 0, 0],  // faulty_blocks_unprovable
+                    vec![0, 0, 0],  // missing_proposals
+                    vec![5, 0, 0],  // equivocations
+                )),
                 2_u32,
             ),
         ];
@@ -594,43 +596,43 @@ mod tests {
     #[test]
     fn test_calculate_median_report() {
         let reports_and_voting_power = vec![(
-            VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
-                faulty_blocks_provable: vec![7, 8, 9],
-                faulty_blocks_unprovable: vec![10, 11, 12],
-                missing_proposals: vec![4, 5, 6],
-                equivocations: vec![1, 2, 3],
-            }),
+            VersionedMisbehaviorReport::new_v1(MisbehaviorsV1::new(
+                vec![7, 8, 9],    // faulty_blocks_provable
+                vec![10, 11, 12], // faulty_blocks_unprovable
+                vec![4, 5, 6],    // missing_proposals
+                vec![1, 2, 3],    // equivocations
+            )),
             10_u64,
         )];
         let median_report = calculate_median_report(&reports_and_voting_power);
 
         assert_eq!(
             median_report,
-            MisbehaviorsV1 {
-                faulty_blocks_provable: vec![7, 8, 9],
-                faulty_blocks_unprovable: vec![10, 11, 12],
-                missing_proposals: vec![4, 5, 6],
-                equivocations: vec![1, 2, 3]
-            }
+            MisbehaviorsV1::new(
+                vec![7, 8, 9],    // faulty_blocks_provable
+                vec![10, 11, 12], // faulty_blocks_unprovable
+                vec![4, 5, 6],    // missing_proposals
+                vec![1, 2, 3]     // equivocations
+            )
         );
 
         let reports_and_voting_power = vec![
             (
-                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
-                    faulty_blocks_provable: vec![7, 8, 9],
-                    faulty_blocks_unprovable: vec![10, 11, 12],
-                    missing_proposals: vec![4, 5, 6],
-                    equivocations: vec![1, 2, 3],
-                }),
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1::new(
+                    vec![7, 8, 9],    // faulty_blocks_provable
+                    vec![10, 11, 12], // faulty_blocks_unprovable
+                    vec![4, 5, 6],    // missing_proposals
+                    vec![1, 2, 3],    // equivocations
+                )),
                 20_u64,
             ),
             (
-                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
-                    faulty_blocks_provable: vec![70, 80, 90],
-                    faulty_blocks_unprovable: vec![100, 110, 120],
-                    missing_proposals: vec![40, 50, 60],
-                    equivocations: vec![10, 20, 30],
-                }),
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1::new(
+                    vec![70, 80, 90],    // faulty_blocks_provable
+                    vec![100, 110, 120], // faulty_blocks_unprovable
+                    vec![40, 50, 60],    // missing_proposals
+                    vec![10, 20, 30],    // equivocations
+                )),
                 10_u64,
             ),
         ];
@@ -639,40 +641,40 @@ mod tests {
 
         assert_eq!(
             median_report,
-            MisbehaviorsV1 {
-                faulty_blocks_provable: vec![7, 8, 9],
-                faulty_blocks_unprovable: vec![10, 11, 12],
-                missing_proposals: vec![4, 5, 6],
-                equivocations: vec![1, 2, 3]
-            }
+            MisbehaviorsV1::new(
+                vec![7, 8, 9],    // faulty_blocks_provable
+                vec![10, 11, 12], // faulty_blocks_unprovable
+                vec![4, 5, 6],    // missing_proposals
+                vec![1, 2, 3]     // equivocations
+            )
         );
 
         let reports_and_voting_power = vec![
             (
-                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
-                    faulty_blocks_provable: vec![1, 8, 9],
-                    faulty_blocks_unprovable: vec![10, 15, 12],
-                    missing_proposals: vec![4, 5, 6],
-                    equivocations: vec![1, 20, 3],
-                }),
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1::new(
+                    vec![1, 8, 9],    // faulty_blocks_provable
+                    vec![10, 15, 12], // faulty_blocks_unprovable
+                    vec![4, 5, 6],    // missing_proposals
+                    vec![1, 20, 3],   // equivocations
+                )),
                 10_u64,
             ),
             (
-                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
-                    faulty_blocks_provable: vec![7, 8, 9],
-                    faulty_blocks_unprovable: vec![10, 11, 12],
-                    missing_proposals: vec![4, 5, 6],
-                    equivocations: vec![1, 2, 0],
-                }),
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1::new(
+                    vec![7, 8, 9],    //   faulty_blocks_provable
+                    vec![10, 11, 12], // faulty_blocks_unprovable
+                    vec![4, 5, 6],    // missing_proposals
+                    vec![1, 2, 0],    // equivocations
+                )),
                 10_u64,
             ),
             (
-                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
-                    faulty_blocks_provable: vec![6, 8, 9],
-                    faulty_blocks_unprovable: vec![10, 11, 12],
-                    missing_proposals: vec![4, 22, 6],
-                    equivocations: vec![1, 2, 30],
-                }),
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1::new(
+                    vec![6, 8, 9],    //  faulty_blocks_provable
+                    vec![10, 11, 12], // faulty_blocks_unprovable
+                    vec![4, 22, 6],   // missing_proposals
+                    vec![1, 2, 30],   // equivocations
+                )),
                 10_u64,
             ),
         ];
@@ -681,44 +683,44 @@ mod tests {
 
         assert_eq!(
             median_report,
-            MisbehaviorsV1 {
-                faulty_blocks_provable: vec![6, 8, 9],
-                faulty_blocks_unprovable: vec![10, 11, 12],
-                missing_proposals: vec![4, 5, 6],
-                equivocations: vec![1, 2, 3]
-            }
+            MisbehaviorsV1::new(
+                vec![6, 8, 9],    // faulty_blocks_provable
+                vec![10, 11, 12], // faulty_blocks_unprovable
+                vec![4, 5, 6],    // missing_proposals
+                vec![1, 2, 3]     // equivocations
+            )
         );
     }
 
     #[test]
     fn test_calculate_scores_v1() {
         let parameters = ParametersV1 {
-            allowances: MisbehaviorsV1 {
-                faulty_blocks_provable: 1,
-                faulty_blocks_unprovable: 2,
-                missing_proposals: 1000,
-                equivocations: 0,
-            },
-            maximums: MisbehaviorsV1 {
-                faulty_blocks_provable: 5,
-                faulty_blocks_unprovable: 10,
-                missing_proposals: 5000,
-                equivocations: 1,
-            },
-            weights: MisbehaviorsV1 {
-                faulty_blocks_provable: SCALE_FACTOR * 30 / 100,
-                faulty_blocks_unprovable: SCALE_FACTOR * 10 / 100,
-                missing_proposals: SCALE_FACTOR * 35 / 100,
-                equivocations: 1,
-            },
+            allowances: MisbehaviorsV1::new(
+                1,    // faulty_blocks_provable
+                2,    // faulty_blocks_unprovable
+                1000, // missing_proposals
+                0,    // equivocations
+            ),
+            maximums: MisbehaviorsV1::new(
+                5,    // faulty_blocks_provable
+                10,   // faulty_blocks_unprovable
+                5000, // missing_proposals
+                1,    // equivocations
+            ),
+            weights: MisbehaviorsV1::new(
+                SCALE_FACTOR * 30 / 100, // faulty_blocks_provable
+                SCALE_FACTOR * 10 / 100, // faulty_blocks_unprovable
+                SCALE_FACTOR * 35 / 100, // missing_proposals
+                1,                       // equivocations
+            ),
         };
 
-        let median_reports = MisbehaviorsV1 {
-            faulty_blocks_provable: vec![6, 7, 8],
-            faulty_blocks_unprovable: vec![9, 10, 11],
-            missing_proposals: vec![3, 4, 5],
-            equivocations: vec![0, 1, 2],
-        };
+        let median_reports = MisbehaviorsV1::new(
+            vec![6, 7, 8],   // faulty_blocks_provable
+            vec![9, 10, 11], // faulty_blocks_unprovable
+            vec![3, 4, 5],   // missing_proposals
+            vec![0, 1, 2],   // equivocations
+        );
 
         let scores = calculate_scores_v1(median_reports, parameters);
 

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -193,33 +193,33 @@ impl Scorer {
     }
 }
 
-/// Given a vector of pairs (VersionedMisbehaviorReport, VotingPower), calculate
-/// the medians for all metrics in VersionedMisbehaviorReport and authorities:
-///
-/// - Assume we have N authorities in the committee, but n<=N reports R_1, R_2,
-///   ..., R_n from authorities with voting powers VP_1, VP_2, ..., VP_n.
-/// - For each metric M in VersionedMisbehaviorReport, we'll have n vectors of
-///   metric values: M_1, M_2, ..., M_n, where M_i is the vector of metric
-///   values for report R_i.
-/// - Each M_i is a vector of length N, where the j-th value corresponds to the
-///   metric value for authority j.
-///
-/// Example: If we have 4 authorities in the committee, and we receive 3
-/// reports:
-/// - Report R_1 from authority A_1 with voting power VP_1 = 1:
-///     - Metric M1: [0, 0, 0, 0] (values for authorities A_1, A_2, A_3, A_4)
-///     - Metric M2: [0, 0, 0, 0] (values for authorities A_1, A_2, A_3, A_4)
-/// - Report R_2 from authority A_2 with voting power VP_2 = 1:
-///     - Metric M1: [1, 1, 1, 1] (values for authorities A_1, A_2, A_3, A_4)
-///     - Metric M2: [2, 2, 2, 2] (values for authorities A_1, A_2, A_3, A_4)
-/// - Report R_3 from authority A_3 with voting power VP_3 = 1:
-///     - Metric M1: [2, 2, 2, 2] (values for authorities A_1, A_2, A_3, A_4)
-///     - Metric M2: [1, 1, 1, 1] (values for authorities A_1, A_2, A_3, A_4)
-///
-/// For Metric M1, we have that the median metric vector is [1, 1, 1, 1].
-///
-/// This method returns a vector of MedianMetricVec, one per metric in
-/// VersionedMisbehaviorReport
+// Given a vector of pairs (VersionedMisbehaviorReport, VotingPower), calculate
+// the medians for all metrics in VersionedMisbehaviorReport and authorities:
+//
+// - Assume we have N authorities in the committee, but n<=N reports R_1, R_2,
+//   ..., R_n from authorities with voting powers VP_1, VP_2, ..., VP_n.
+// - For each metric M in VersionedMisbehaviorReport, we'll have n vectors of
+//   metric values: M_1, M_2, ..., M_n, where M_i is the vector of metric values
+//   for report R_i.
+// - Each M_i is a vector of length N, where the j-th value corresponds to the
+//   metric value for authority j.
+//
+// Example: If we have 4 authorities in the committee, and we receive 3
+// reports:
+// - Report R_1 from authority A_1 with voting power VP_1 = 1:
+//     - Metric M1: [0, 0, 0, 0] (values for authorities A_1, A_2, A_3, A_4)
+//     - Metric M2: [0, 0, 0, 0] (values for authorities A_1, A_2, A_3, A_4)
+// - Report R_2 from authority A_2 with voting power VP_2 = 1:
+//     - Metric M1: [1, 1, 1, 1] (values for authorities A_1, A_2, A_3, A_4)
+//     - Metric M2: [2, 2, 2, 2] (values for authorities A_1, A_2, A_3, A_4)
+// - Report R_3 from authority A_3 with voting power VP_3 = 1:
+//     - Metric M1: [2, 2, 2, 2] (values for authorities A_1, A_2, A_3, A_4)
+//     - Metric M2: [1, 1, 1, 1] (values for authorities A_1, A_2, A_3, A_4)
+//
+// For Metric M1, we have that the median metric vector is [1, 1, 1, 1].
+//
+// This method returns a vector of MedianMetricVec, one per metric in
+// VersionedMisbehaviorReport
 fn calculate_median_report(
     reports_and_voting_power: &[(VersionedMisbehaviorReport, VotingPower)],
 ) -> MisbehaviorsV1<MedianMetricVec> {

--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -184,6 +184,7 @@ impl ConsensusManagerTrait for StarfishManager {
             Arc::new(tx_validator.clone()),
             consumer,
             registry.clone(),
+            epoch_store.scorer.current_local_metrics_count.clone(),
             *boot_counter,
         )
         .await;

--- a/crates/iota-types/src/lib.rs
+++ b/crates/iota-types/src/lib.rs
@@ -74,6 +74,7 @@ pub mod messages_consensus;
 pub mod messages_grpc;
 pub mod messages_safe_client;
 pub mod metrics;
+pub mod misbehavior_counts;
 pub mod mock_checkpoint_builder;
 pub mod move_authenticator;
 pub mod move_package;

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -27,6 +27,7 @@ use crate::{
     digests::{ConsensusCommitDigest, Digest, MisbehaviorReportDigest},
     message_envelope::{Envelope, Message, VerifiedEnvelope},
     messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage},
+    misbehavior_counts::MisbehaviorsV1,
     supported_protocol_versions::{
         Chain, SupportedProtocolVersions, SupportedProtocolVersionsWithHashes,
     },
@@ -312,12 +313,14 @@ impl VersionedMisbehaviorReport {
             VersionedMisbehaviorReport::V1(report, _) => report.verify(committee_size),
         }
     }
-    /// Returns an iterator over references to some of the fields in the report.
+
+    /// Returns an iterator over references to the fields in the report.
     pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&Vec<u64>> {
         match self {
             VersionedMisbehaviorReport::V1(report, _) => report.iter(),
         }
     }
+
     /// Returns the digest of the misbehavior report, caching it if it has not
     /// been computed yet.
     pub fn digest(&self) -> &MisbehaviorReportDigest {
@@ -325,76 +328,6 @@ impl VersionedMisbehaviorReport {
             VersionedMisbehaviorReport::V1(_, digest) => {
                 digest.get_or_init(|| MisbehaviorReportDigest::new(default_hash(self)))
             }
-        }
-    }
-}
-
-// MisbehaviorsV1 contains lists of all metrics used in v1 of misbehavior
-// reports, with a value for each metric. The metrics (misbeheaviors) include,
-// faulty blocks, equivocation and missing proposal counts for each authority.
-// This first version does not include any type of proof.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct MisbehaviorsV1<T> {
-    pub faulty_blocks_provable: T,
-    pub faulty_blocks_unprovable: T,
-    pub missing_proposals: T,
-    pub equivocations: T,
-}
-
-impl MisbehaviorsV1<Vec<u64>> {
-    pub fn verify(&self, committee_size: usize) -> bool {
-        // This version of reports are valid as long as they contain the counts for all
-        // authorities. Future versions may contain proofs that need verification.
-        // However, since the validity of a proof is deeply coupled with the protocol
-        // version and the consensus mechanism being used, we cannot verify it here. In
-        // the future, reports should be unwrapped (or translated) to a type verifiable
-        // by the consensus crate, which means that the verification logic will probably
-        // move out of this crate.
-        if (self.faulty_blocks_provable.len() != committee_size)
-            | (self.faulty_blocks_unprovable.len() != committee_size)
-            | (self.equivocations.len() != committee_size)
-            | (self.missing_proposals.len() != committee_size)
-        {
-            return false;
-        }
-        true
-    }
-}
-impl<T> MisbehaviorsV1<T> {
-    pub fn iter(&self) -> std::vec::IntoIter<&T> {
-        vec![
-            &self.faulty_blocks_provable,
-            &self.faulty_blocks_unprovable,
-            &self.missing_proposals,
-            &self.equivocations,
-        ]
-        .into_iter()
-    }
-    // Returns an iterator over references to major misbehavior fields in the
-    // report. Major misbehaviors carry a higher penalty in the scoring system.
-    pub fn iter_major_misbehaviors(&self) -> std::vec::IntoIter<&T> {
-        vec![&self.equivocations].into_iter()
-    }
-    // Returns an iterator over references to minor misbehavior fields in the
-    // report. Minor misbehaviors carry a lower penalty in the scoring system.
-    pub fn iter_minor_misbehaviors(&self) -> std::vec::IntoIter<&T> {
-        vec![
-            &self.faulty_blocks_provable,
-            &self.faulty_blocks_unprovable,
-            &self.missing_proposals,
-        ]
-        .into_iter()
-    }
-}
-
-impl<T> FromIterator<T> for MisbehaviorsV1<T> {
-    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        let mut iterator = iter.into_iter();
-        Self {
-            faulty_blocks_provable: iterator.next().expect("Not enough elements in iterator"),
-            faulty_blocks_unprovable: iterator.next().expect("Not enough elements in iterator"),
-            missing_proposals: iterator.next().expect("Not enough elements in iterator"),
-            equivocations: iterator.next().expect("Not enough elements in iterator"),
         }
     }
 }

--- a/crates/iota-types/src/misbehavior_counts.rs
+++ b/crates/iota-types/src/misbehavior_counts.rs
@@ -1,0 +1,169 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::atomic::AtomicU64;
+
+use serde::{Deserialize, Serialize};
+
+// MisbehaviorsV1 contains lists of all metrics used in v1 of the validator
+// scoring mechanism, with a value for each metric. The metrics (misbeheaviors)
+// include, faulty blocks, equivocation and missing proposal counts for each
+// authority. This first version does not include any type of proof. Any metric
+// contained in this struct must be guaranteed to be monotonically increasing,
+// because of the way updates are applied from reports.
+//
+// The type parameter `T` determines the storage type for the metrics:
+// - `T = Vec<u64>` for reports (one value per authority)
+// - `T = Vec<AtomicU64>` for atomic metrics collected and stored locally (one
+//   atomic per authority)
+// - `T = u64` for per-authority persistent storage
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MisbehaviorsV1<T> {
+    faulty_blocks_provable: T,
+    faulty_blocks_unprovable: T,
+    missing_proposals: T,
+    equivocations: T,
+}
+
+impl<T> MisbehaviorsV1<T> {
+    pub fn new(
+        faulty_blocks_provable: T,
+        faulty_blocks_unprovable: T,
+        missing_proposals: T,
+        equivocations: T,
+    ) -> Self {
+        Self {
+            faulty_blocks_provable,
+            faulty_blocks_unprovable,
+            missing_proposals,
+            equivocations,
+        }
+    }
+
+    // Returns a reference to the faulty_blocks_provable field.
+    pub fn faulty_blocks_provable(&self) -> &T {
+        &self.faulty_blocks_provable
+    }
+
+    // Returns a reference to the faulty_blocks_unprovable field.
+    pub fn faulty_blocks_unprovable(&self) -> &T {
+        &self.faulty_blocks_unprovable
+    }
+
+    // Returns a reference to the missing_proposals field.
+    pub fn missing_proposals(&self) -> &T {
+        &self.missing_proposals
+    }
+
+    // Returns a reference to the equivocations field.
+    pub fn equivocations(&self) -> &T {
+        &self.equivocations
+    }
+
+    // Returns an iterator over references to all misbehavior fields.
+    pub fn iter(&self) -> std::vec::IntoIter<&T> {
+        vec![
+            &self.faulty_blocks_provable,
+            &self.faulty_blocks_unprovable,
+            &self.missing_proposals,
+            &self.equivocations,
+        ]
+        .into_iter()
+    }
+
+    // Returns an iterator over references to major misbehavior fields.
+    // Major misbehaviors carry a higher penalty in the scoring system.
+    pub fn iter_major_misbehaviors(&self) -> std::vec::IntoIter<&T> {
+        vec![&self.equivocations].into_iter()
+    }
+
+    // Returns an iterator over references to minor misbehavior fields.
+    // Minor misbehaviors carry a lower penalty in the scoring system.
+    pub fn iter_minor_misbehaviors(&self) -> std::vec::IntoIter<&T> {
+        vec![
+            &self.faulty_blocks_provable,
+            &self.faulty_blocks_unprovable,
+            &self.missing_proposals,
+        ]
+        .into_iter()
+    }
+
+    pub fn misbehaviors(&self) -> (&T, &T, &T, &T) {
+        (
+            &self.faulty_blocks_provable,
+            &self.faulty_blocks_unprovable,
+            &self.missing_proposals,
+            &self.equivocations,
+        )
+    }
+}
+
+impl<T> FromIterator<T> for MisbehaviorsV1<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut iterator = iter.into_iter();
+        Self {
+            faulty_blocks_provable: iterator.next().expect("Not enough elements in iterator"),
+            faulty_blocks_unprovable: iterator.next().expect("Not enough elements in iterator"),
+            missing_proposals: iterator.next().expect("Not enough elements in iterator"),
+            equivocations: iterator.next().expect("Not enough elements in iterator"),
+        }
+    }
+}
+
+impl MisbehaviorsV1<u64> {
+    pub fn new_zeroed() -> Self {
+        Self::new(0, 0, 0, 0)
+    }
+}
+
+impl MisbehaviorsV1<Vec<u64>> {
+    // Verifies that all fields have the expected committee size.
+    pub fn verify(&self, committee_size: usize) -> bool {
+        self.iter().all(|metric| metric.len() == committee_size)
+    }
+
+    pub fn as_atomic(&self) -> MisbehaviorsV1<Vec<AtomicU64>> {
+        self.iter()
+            .map(|metric| {
+                metric
+                    .iter()
+                    .map(|&x| AtomicU64::new(x))
+                    .collect::<Vec<AtomicU64>>()
+            })
+            .collect::<MisbehaviorsV1<Vec<AtomicU64>>>()
+    }
+
+    pub fn misbehaviors_from_authority(&self, authority: usize) -> MisbehaviorsV1<u64> {
+        self.iter()
+            .map(|metric| metric[authority])
+            .collect::<MisbehaviorsV1<u64>>()
+    }
+}
+
+impl MisbehaviorsV1<Vec<AtomicU64>> {
+    pub fn new_zeroed(committee_size: usize) -> Self {
+        Self::new(
+            (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
+            (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
+            (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
+            (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
+        )
+    }
+
+    pub fn as_non_atomic(&self) -> MisbehaviorsV1<Vec<u64>> {
+        self.iter()
+            .map(|metric| {
+                metric
+                    .iter()
+                    .map(|x| x.load(std::sync::atomic::Ordering::Relaxed))
+                    .collect::<Vec<u64>>()
+            })
+            .collect::<MisbehaviorsV1<Vec<u64>>>()
+    }
+
+    pub fn misbehaviors_from_authority(&self, authority: usize) -> MisbehaviorsV1<u64> {
+        self.iter()
+            .map(|metric| metric[authority].load(std::sync::atomic::Ordering::Relaxed))
+            .collect::<MisbehaviorsV1<u64>>()
+    }
+}

--- a/crates/iota-types/src/misbehavior_counts.rs
+++ b/crates/iota-types/src/misbehavior_counts.rs
@@ -167,3 +167,63 @@ impl MisbehaviorsV1<Vec<AtomicU64>> {
             .collect::<MisbehaviorsV1<u64>>()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_iter_u64() {
+        let original = MisbehaviorsV1::new(1_u64, 2, 3, 4);
+        let new: MisbehaviorsV1<u64> = original.iter().copied().collect();
+        assert_eq!(original, new);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_iter_u64_major() {
+        let original = MisbehaviorsV1::new(1_u64, 2, 3, 4);
+        let _: MisbehaviorsV1<u64> = original.iter_major_misbehaviors().copied().collect();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_iter_u64_minor() {
+        let original = MisbehaviorsV1::new(1_u64, 2, 3, 4);
+        let _: MisbehaviorsV1<u64> = original.iter_minor_misbehaviors().copied().collect();
+    }
+
+    #[test]
+    fn test_iter_vec_u64() {
+        let original = MisbehaviorsV1::new(
+            vec![1_u64, 2, 3],
+            vec![4, 5, 6],
+            vec![7, 8, 9],
+            vec![10, 11, 12],
+        );
+        let new: MisbehaviorsV1<Vec<u64>> = original.iter().cloned().collect();
+        assert_eq!(original, new);
+    }
+    #[test]
+    #[should_panic]
+    fn test_iter_vec_u64_major() {
+        let original = MisbehaviorsV1::new(
+            vec![1_u64, 2, 3],
+            vec![4, 5, 6],
+            vec![7, 8, 9],
+            vec![10, 11, 12],
+        );
+        let _: MisbehaviorsV1<Vec<u64>> = original.iter_major_misbehaviors().cloned().collect();
+    }
+    #[test]
+    #[should_panic]
+    fn test_iter_vec_u64_minor() {
+        let original = MisbehaviorsV1::new(
+            vec![1_u64, 2, 3],
+            vec![4, 5, 6],
+            vec![7, 8, 9],
+            vec![10, 11, 12],
+        );
+        let _: MisbehaviorsV1<Vec<u64>> = original.iter_minor_misbehaviors().cloned().collect();
+    }
+}

--- a/crates/iota-types/src/scoring_metrics.rs
+++ b/crates/iota-types/src/scoring_metrics.rs
@@ -8,11 +8,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::{messages_consensus::VersionedMisbehaviorReport, misbehavior_counts::MisbehaviorsV1};
 
-/// Misbehavior counts using atomic counters, for in-memory concurrent updates.
-/// Each field is a `Vec<AtomicU64>` with one entry per authority.
+// Misbehavior counts using atomic counters, for in-memory concurrent updates.
+// Each field is a `Vec<AtomicU64>` with one entry per authority.
 type ScoringMetricsV1 = MisbehaviorsV1<Vec<AtomicU64>>;
 
-/// Versioned container for scoring metrics using atomic counters.
+// Versioned container for scoring metrics using atomic counters.
 pub enum VersionedScoringMetrics {
     V1(ScoringMetricsV1),
 }
@@ -31,6 +31,8 @@ impl VersionedScoringMetrics {
         }
     }
 
+    // Validity checks are done at a higher level to ensure authority_index is
+    // valid.
     pub fn increment_faulty_blocks_provable(&self, authority_index: usize, increment: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
@@ -40,6 +42,8 @@ impl VersionedScoringMetrics {
         }
     }
 
+    // Validity checks are done at a higher level to ensure authority_index is
+    // valid.
     pub fn increment_faulty_blocks_unprovable(&self, authority_index: usize, increment: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
@@ -49,6 +53,8 @@ impl VersionedScoringMetrics {
         }
     }
 
+    // Validity checks are done at a higher level to ensure authority_index is
+    // valid.
     pub fn increment_equivocations(&self, authority_index: usize, increment: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
@@ -57,6 +63,8 @@ impl VersionedScoringMetrics {
         }
     }
 
+    // Validity checks are done at a higher level to ensure authority_index is
+    // valid.
     pub fn increment_missing_proposals(&self, authority_index: usize, increment: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
@@ -66,6 +74,8 @@ impl VersionedScoringMetrics {
         }
     }
 
+    // Validity checks are done at a higher level to ensure authority_index is
+    // valid.
     pub fn store_faulty_blocks_provable(&self, authority_index: usize, value: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
@@ -74,6 +84,8 @@ impl VersionedScoringMetrics {
         }
     }
 
+    // Validity checks are done at a higher level to ensure authority_index is
+    // valid.
     pub fn store_faulty_blocks_unprovable(&self, authority_index: usize, value: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
@@ -82,6 +94,8 @@ impl VersionedScoringMetrics {
         }
     }
 
+    // Validity checks are done at a higher level to ensure authority_index is
+    // valid.
     pub fn store_equivocations(&self, authority_index: usize, value: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
@@ -90,6 +104,8 @@ impl VersionedScoringMetrics {
         }
     }
 
+    // Validity checks are done at a higher level to ensure authority_index is
+    // valid.
     pub fn store_missing_proposals(&self, authority_index: usize, value: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
@@ -241,9 +257,8 @@ impl VersionedScoringMetrics {
     }
 }
 
-/// Misbehavior counts using u64, used for storage. Given an authrity, each
-/// field of this type is a u64 with the metric value for that specific
-/// authority.
+// Misbehavior counts using u64, used for storage. Given an authrity, each field
+// of this type is a u64 with the metric value for that specific authority.
 type StorageScoringMetricsV1 = MisbehaviorsV1<u64>;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -270,7 +285,7 @@ impl VersionedStorageScoringMetrics {
         }
     }
 
-    /// Returns an iterator over references to the metric values.
+    // Returns an iterator over references to the metric values.
     pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&u64> {
         match self {
             VersionedStorageScoringMetrics::V1(inner) => inner.iter(),

--- a/crates/iota-types/src/scoring_metrics.rs
+++ b/crates/iota-types/src/scoring_metrics.rs
@@ -7,23 +7,25 @@ use iota_protocol_config::ProtocolConfig;
 
 use crate::{messages_consensus::VersionedMisbehaviorReport, misbehavior_counts::MisbehaviorsV1};
 
-// This struct represents the scoring metrics collected by all authorities. They
-// are stored locally by each authority and then converted to a misbehavior
-// report when they share their metrics with the network. When a report is
-// received, it is also used to update a variable of this type stored in the
-// Scorer. Any metric contained in this struct must be guaranteed to be
-// monotonically increasing, because of the way updates are applied from
-// reports.
+/// Misbehavior counts using atomic counters, for in-memory concurrent updates.
+/// Each field is a `Vec<AtomicU64>` with one entry per authority.
+type ScoringMetricsV1 = MisbehaviorsV1<Vec<AtomicU64>>;
+
+/// Versioned container for scoring metrics using atomic counters.
 pub enum VersionedScoringMetrics {
     V1(ScoringMetricsV1),
 }
 
-// Basic getters, setters and increments for the metrics.
+// Basic getters, setters and increments for the metrics. We also introduce
+// methods to convert to/from VersionedMisbehaviorReport.
 impl VersionedScoringMetrics {
     pub fn new(committee_size: usize, protocol_config: &ProtocolConfig) -> Self {
-        // Any version of ScoringMetrics created here must be initialized to zero.
+        // All metrics must be initialized to zero independently of the Misbehaviors
+        // version.
         match protocol_config.scorer_version_as_option() {
-            None | Some(1) => VersionedScoringMetrics::V1(ScoringMetricsV1::new(committee_size)),
+            None | Some(1) => {
+                VersionedScoringMetrics::V1(ScoringMetricsV1::new_zeroed(committee_size))
+            }
             _ => panic!("Unsupported scorer version"),
         }
     }
@@ -31,7 +33,7 @@ impl VersionedScoringMetrics {
     pub fn increment_faulty_blocks_provable(&self, authority_index: usize, increment: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
-                metrics.faulty_blocks_provable[authority_index]
+                metrics.faulty_blocks_provable()[authority_index]
                     .fetch_add(increment, Ordering::Relaxed);
             }
         }
@@ -40,7 +42,7 @@ impl VersionedScoringMetrics {
     pub fn increment_faulty_blocks_unprovable(&self, authority_index: usize, increment: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
-                metrics.faulty_blocks_unprovable[authority_index]
+                metrics.faulty_blocks_unprovable()[authority_index]
                     .fetch_add(increment, Ordering::Relaxed);
             }
         }
@@ -49,7 +51,7 @@ impl VersionedScoringMetrics {
     pub fn increment_equivocations(&self, authority_index: usize, increment: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
-                metrics.equivocations[authority_index].fetch_add(increment, Ordering::Relaxed);
+                metrics.equivocations()[authority_index].fetch_add(increment, Ordering::Relaxed);
             }
         }
     }
@@ -57,7 +59,8 @@ impl VersionedScoringMetrics {
     pub fn increment_missing_proposals(&self, authority_index: usize, increment: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
-                metrics.missing_proposals[authority_index].fetch_add(increment, Ordering::Relaxed);
+                metrics.missing_proposals()[authority_index]
+                    .fetch_add(increment, Ordering::Relaxed);
             }
         }
     }
@@ -65,7 +68,7 @@ impl VersionedScoringMetrics {
     pub fn store_faulty_blocks_provable(&self, authority_index: usize, value: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
-                metrics.faulty_blocks_provable[authority_index].store(value, Ordering::Relaxed);
+                metrics.faulty_blocks_provable()[authority_index].store(value, Ordering::Relaxed);
             }
         }
     }
@@ -73,7 +76,7 @@ impl VersionedScoringMetrics {
     pub fn store_faulty_blocks_unprovable(&self, authority_index: usize, value: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
-                metrics.faulty_blocks_unprovable[authority_index].store(value, Ordering::Relaxed);
+                metrics.faulty_blocks_unprovable()[authority_index].store(value, Ordering::Relaxed);
             }
         }
     }
@@ -81,7 +84,7 @@ impl VersionedScoringMetrics {
     pub fn store_equivocations(&self, authority_index: usize, value: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
-                metrics.equivocations[authority_index].store(value, Ordering::Relaxed);
+                metrics.equivocations()[authority_index].store(value, Ordering::Relaxed);
             }
         }
     }
@@ -89,7 +92,7 @@ impl VersionedScoringMetrics {
     pub fn store_missing_proposals(&self, authority_index: usize, value: u64) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
-                metrics.missing_proposals[authority_index].store(value, Ordering::Relaxed);
+                metrics.missing_proposals()[authority_index].store(value, Ordering::Relaxed);
             }
         }
     }
@@ -97,7 +100,7 @@ impl VersionedScoringMetrics {
     pub fn load_faulty_blocks_provable(&self) -> Vec<u64> {
         match self {
             VersionedScoringMetrics::V1(metrics) => metrics
-                .faulty_blocks_provable
+                .faulty_blocks_provable()
                 .iter()
                 .map(|metric| metric.load(Ordering::Relaxed))
                 .collect(),
@@ -107,7 +110,7 @@ impl VersionedScoringMetrics {
     pub fn load_faulty_blocks_unprovable(&self) -> Vec<u64> {
         match self {
             VersionedScoringMetrics::V1(metrics) => metrics
-                .faulty_blocks_unprovable
+                .faulty_blocks_unprovable()
                 .iter()
                 .map(|metric| metric.load(Ordering::Relaxed))
                 .collect(),
@@ -117,7 +120,7 @@ impl VersionedScoringMetrics {
     pub fn load_equivocations(&self) -> Vec<u64> {
         match self {
             VersionedScoringMetrics::V1(metrics) => metrics
-                .equivocations
+                .equivocations()
                 .iter()
                 .map(|metric| metric.load(Ordering::Relaxed))
                 .collect(),
@@ -127,7 +130,7 @@ impl VersionedScoringMetrics {
     pub fn load_missing_proposals(&self) -> Vec<u64> {
         match self {
             VersionedScoringMetrics::V1(metrics) => metrics
-                .missing_proposals
+                .missing_proposals()
                 .iter()
                 .map(|metric| metric.load(Ordering::Relaxed))
                 .collect(),
@@ -136,49 +139,53 @@ impl VersionedScoringMetrics {
 
     pub fn faulty_blocks_provable(&self) -> &Vec<AtomicU64> {
         match self {
-            VersionedScoringMetrics::V1(metrics) => &metrics.faulty_blocks_provable,
+            VersionedScoringMetrics::V1(metrics) => metrics.faulty_blocks_provable(),
         }
     }
 
     pub fn faulty_blocks_unprovable(&self) -> &Vec<AtomicU64> {
         match self {
-            VersionedScoringMetrics::V1(metrics) => &metrics.faulty_blocks_unprovable,
+            VersionedScoringMetrics::V1(metrics) => metrics.faulty_blocks_unprovable(),
         }
     }
 
     pub fn equivocations(&self) -> &Vec<AtomicU64> {
         match self {
-            VersionedScoringMetrics::V1(metrics) => &metrics.equivocations,
+            VersionedScoringMetrics::V1(metrics) => metrics.equivocations(),
         }
     }
 
     pub fn missing_proposals(&self) -> &Vec<AtomicU64> {
         match self {
-            VersionedScoringMetrics::V1(metrics) => &metrics.missing_proposals,
+            VersionedScoringMetrics::V1(metrics) => metrics.missing_proposals(),
         }
     }
 
     pub fn reset(&self) {
         match self {
             VersionedScoringMetrics::V1(metrics) => {
-                for metric in &metrics.faulty_blocks_provable {
+                for metric in metrics.faulty_blocks_provable() {
                     metric.store(0, Ordering::Relaxed);
                 }
-                for metric in &metrics.faulty_blocks_unprovable {
+                for metric in metrics.faulty_blocks_unprovable() {
                     metric.store(0, Ordering::Relaxed);
                 }
-                for metric in &metrics.equivocations {
+                for metric in metrics.equivocations() {
                     metric.store(0, Ordering::Relaxed);
                 }
-                for metric in &metrics.missing_proposals {
+                for metric in metrics.missing_proposals() {
                     metric.store(0, Ordering::Relaxed);
                 }
             }
         }
     }
-}
 
-impl VersionedScoringMetrics {
+    pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&Vec<AtomicU64>> {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => metrics.iter(),
+        }
+    }
+
     // Given a VersionedMisbehaviorReport received from another authority, we use
     // this method to update the received scoring metrics counts. To avoid
     // updates to be dependent on the order they are applied, we only effectively
@@ -188,24 +195,15 @@ impl VersionedScoringMetrics {
     // is monotonically increasing by design; average faulty blocks per minute is
     // not.
     pub fn update_from_report(&self, report: &VersionedMisbehaviorReport) {
-        match (self, report) {
-            (
-                VersionedScoringMetrics::V1(metrics),
-                VersionedMisbehaviorReport::V1(report_v1, _),
-            ) => {
-                for (i, value) in report_v1.faulty_blocks_provable().iter().enumerate() {
-                    metrics.faulty_blocks_provable[i].fetch_max(*value, Ordering::Relaxed);
-                }
-                for (i, value) in report_v1.faulty_blocks_unprovable().iter().enumerate() {
-                    metrics.faulty_blocks_unprovable[i].fetch_max(*value, Ordering::Relaxed);
-                }
-                for (i, value) in report_v1.equivocations().iter().enumerate() {
-                    metrics.equivocations[i].fetch_max(*value, Ordering::Relaxed);
-                }
-                for (i, value) in report_v1.missing_proposals().iter().enumerate() {
-                    metrics.missing_proposals[i].fetch_max(*value, Ordering::Relaxed);
-                }
-            }
+        if !self.has_compatible_version(report) {
+            panic!("Incompatible scorer version");
+        }
+        for (current_value, new_value) in self
+            .iterate_over_metrics()
+            .flatten()
+            .zip(report.iterate_over_metrics().flatten())
+        {
+            current_value.fetch_max(*new_value, Ordering::Relaxed);
         }
     }
 
@@ -214,22 +212,9 @@ impl VersionedScoringMetrics {
     // network and needs to create a local copy of the metrics contained in it.
     pub fn from_report(report: &VersionedMisbehaviorReport) -> Self {
         match report {
-            VersionedMisbehaviorReport::V1(report_v1, _) => {
-                let committee_size = report_v1.faulty_blocks_provable().len();
-                let metrics = ScoringMetricsV1::new(committee_size);
-                for (i, value) in report_v1.faulty_blocks_provable().iter().enumerate() {
-                    metrics.faulty_blocks_provable[i].store(*value, Ordering::Relaxed);
-                }
-                for (i, value) in report_v1.faulty_blocks_unprovable().iter().enumerate() {
-                    metrics.faulty_blocks_unprovable[i].store(*value, Ordering::Relaxed);
-                }
-                for (i, value) in report_v1.equivocations().iter().enumerate() {
-                    metrics.equivocations[i].store(*value, Ordering::Relaxed);
-                }
-                for (i, value) in report_v1.missing_proposals().iter().enumerate() {
-                    metrics.missing_proposals[i].store(*value, Ordering::Relaxed);
-                }
-                VersionedScoringMetrics::V1(metrics)
+            VersionedMisbehaviorReport::V1(non_atomic_metrics, _) => {
+                let atomic_metrics = non_atomic_metrics.as_atomic();
+                VersionedScoringMetrics::V1(atomic_metrics)
             }
         }
     }
@@ -239,57 +224,18 @@ impl VersionedScoringMetrics {
     // metrics with the network.
     pub fn to_report(&self) -> VersionedMisbehaviorReport {
         match self {
-            VersionedScoringMetrics::V1(metrics) => {
-                let faulty_blocks_provable = metrics
-                    .faulty_blocks_provable
-                    .iter()
-                    .map(|metric| metric.load(Ordering::Relaxed))
-                    .collect();
-                let faulty_blocks_unprovable = metrics
-                    .faulty_blocks_unprovable
-                    .iter()
-                    .map(|metric| metric.load(Ordering::Relaxed))
-                    .collect();
-                let equivocations = metrics
-                    .equivocations
-                    .iter()
-                    .map(|metric| metric.load(Ordering::Relaxed))
-                    .collect();
-                let missing_proposals = metrics
-                    .missing_proposals
-                    .iter()
-                    .map(|metric| metric.load(Ordering::Relaxed))
-                    .collect();
-                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1::new(
-                    faulty_blocks_provable,
-                    faulty_blocks_unprovable,
-                    missing_proposals,
-                    equivocations,
-                ))
+            VersionedScoringMetrics::V1(atomic_metrics) => {
+                let non_atomic_metrics = atomic_metrics.as_non_atomic();
+                VersionedMisbehaviorReport::new_v1(non_atomic_metrics)
             }
         }
     }
-}
 
-pub struct ScoringMetricsV1 {
-    faulty_blocks_provable: Vec<AtomicU64>,
-    faulty_blocks_unprovable: Vec<AtomicU64>,
-    missing_proposals: Vec<AtomicU64>,
-    equivocations: Vec<AtomicU64>,
-}
-
-impl ScoringMetricsV1 {
-    pub fn new(committee_size: usize) -> Self {
-        Self {
-            // Blocks considered faulty with provable evidence, i.e., they pass the signature check.
-            faulty_blocks_provable: (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
-            // Blocks considered faulty before passing the signature check.
-            faulty_blocks_unprovable: (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
-            // Number or rounds that the authority did not propose any block
-            missing_proposals: (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
-            // Number of additional blocks issued by a validator within rounds where another block
-            // was already produced by them.
-            equivocations: (0..committee_size).map(|_| AtomicU64::new(0)).collect(),
+    // Checks if the version of the scoring metrics is compatible with the version
+    // of the misbehavior report.
+    pub fn has_compatible_version(&self, report: &VersionedMisbehaviorReport) -> bool {
+        match (self, report) {
+            (VersionedScoringMetrics::V1(_), VersionedMisbehaviorReport::V1(_, _)) => true,
         }
     }
 }

--- a/crates/iota-types/src/scoring_metrics.rs
+++ b/crates/iota-types/src/scoring_metrics.rs
@@ -4,6 +4,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use iota_protocol_config::ProtocolConfig;
+use serde::{Deserialize, Serialize};
 
 use crate::{messages_consensus::VersionedMisbehaviorReport, misbehavior_counts::MisbehaviorsV1};
 
@@ -237,5 +238,56 @@ impl VersionedScoringMetrics {
         match (self, report) {
             (VersionedScoringMetrics::V1(_), VersionedMisbehaviorReport::V1(_, _)) => true,
         }
+    }
+}
+
+/// Misbehavior counts using u64, used for storage. Given an authrity, each
+/// field of this type is a u64 with the metric value for that specific
+/// authority.
+type StorageScoringMetricsV1 = MisbehaviorsV1<u64>;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum VersionedStorageScoringMetrics {
+    V1(StorageScoringMetricsV1),
+}
+
+impl VersionedStorageScoringMetrics {
+    pub fn new_zeroed(protocol_config: &ProtocolConfig) -> Self {
+        match protocol_config.scorer_version_as_option() {
+            None | Some(1) => {
+                VersionedStorageScoringMetrics::V1(StorageScoringMetricsV1::new_zeroed())
+            }
+            _ => panic!("Unsupported scorer version"),
+        }
+    }
+
+    pub fn new_from(scoring_metrics: &VersionedScoringMetrics, authority_index: usize) -> Self {
+        match scoring_metrics {
+            VersionedScoringMetrics::V1(misbehavior_vectors) => {
+                let inner = misbehavior_vectors.misbehaviors_from_authority(authority_index);
+                VersionedStorageScoringMetrics::V1(inner)
+            }
+        }
+    }
+
+    /// Returns an iterator over references to the metric values.
+    pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&u64> {
+        match self {
+            VersionedStorageScoringMetrics::V1(inner) => inner.iter(),
+        }
+    }
+
+    pub fn new_v1_for_test(
+        faulty_blocks_provable: u64,
+        faulty_blocks_unprovable: u64,
+        missing_proposals: u64,
+        equivocations: u64,
+    ) -> Self {
+        VersionedStorageScoringMetrics::V1(StorageScoringMetricsV1::new(
+            faulty_blocks_provable,
+            faulty_blocks_unprovable,
+            missing_proposals,
+            equivocations,
+        ))
     }
 }

--- a/crates/iota-types/src/scoring_metrics.rs
+++ b/crates/iota-types/src/scoring_metrics.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use iota_protocol_config::ProtocolConfig;
 
-use crate::messages_consensus::{MisbehaviorsV1, VersionedMisbehaviorReport};
+use crate::{messages_consensus::VersionedMisbehaviorReport, misbehavior_counts::MisbehaviorsV1};
 
 // This struct represents the scoring metrics collected by all authorities. They
 // are stored locally by each authority and then converted to a misbehavior
@@ -193,16 +193,16 @@ impl VersionedScoringMetrics {
                 VersionedScoringMetrics::V1(metrics),
                 VersionedMisbehaviorReport::V1(report_v1, _),
             ) => {
-                for (i, value) in report_v1.faulty_blocks_provable.iter().enumerate() {
+                for (i, value) in report_v1.faulty_blocks_provable().iter().enumerate() {
                     metrics.faulty_blocks_provable[i].fetch_max(*value, Ordering::Relaxed);
                 }
-                for (i, value) in report_v1.faulty_blocks_unprovable.iter().enumerate() {
+                for (i, value) in report_v1.faulty_blocks_unprovable().iter().enumerate() {
                     metrics.faulty_blocks_unprovable[i].fetch_max(*value, Ordering::Relaxed);
                 }
-                for (i, value) in report_v1.equivocations.iter().enumerate() {
+                for (i, value) in report_v1.equivocations().iter().enumerate() {
                     metrics.equivocations[i].fetch_max(*value, Ordering::Relaxed);
                 }
-                for (i, value) in report_v1.missing_proposals.iter().enumerate() {
+                for (i, value) in report_v1.missing_proposals().iter().enumerate() {
                     metrics.missing_proposals[i].fetch_max(*value, Ordering::Relaxed);
                 }
             }
@@ -215,18 +215,18 @@ impl VersionedScoringMetrics {
     pub fn from_report(report: &VersionedMisbehaviorReport) -> Self {
         match report {
             VersionedMisbehaviorReport::V1(report_v1, _) => {
-                let committee_size = report_v1.faulty_blocks_provable.len();
+                let committee_size = report_v1.faulty_blocks_provable().len();
                 let metrics = ScoringMetricsV1::new(committee_size);
-                for (i, value) in report_v1.faulty_blocks_provable.iter().enumerate() {
+                for (i, value) in report_v1.faulty_blocks_provable().iter().enumerate() {
                     metrics.faulty_blocks_provable[i].store(*value, Ordering::Relaxed);
                 }
-                for (i, value) in report_v1.faulty_blocks_unprovable.iter().enumerate() {
+                for (i, value) in report_v1.faulty_blocks_unprovable().iter().enumerate() {
                     metrics.faulty_blocks_unprovable[i].store(*value, Ordering::Relaxed);
                 }
-                for (i, value) in report_v1.equivocations.iter().enumerate() {
+                for (i, value) in report_v1.equivocations().iter().enumerate() {
                     metrics.equivocations[i].store(*value, Ordering::Relaxed);
                 }
-                for (i, value) in report_v1.missing_proposals.iter().enumerate() {
+                for (i, value) in report_v1.missing_proposals().iter().enumerate() {
                     metrics.missing_proposals[i].store(*value, Ordering::Relaxed);
                 }
                 VersionedScoringMetrics::V1(metrics)
@@ -260,12 +260,12 @@ impl VersionedScoringMetrics {
                     .iter()
                     .map(|metric| metric.load(Ordering::Relaxed))
                     .collect();
-                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
+                VersionedMisbehaviorReport::new_v1(MisbehaviorsV1::new(
                     faulty_blocks_provable,
                     faulty_blocks_unprovable,
                     missing_proposals,
                     equivocations,
-                })
+                ))
             }
         }
     }

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -4,6 +4,7 @@
 
 use std::{sync::Arc, time::Instant};
 
+use iota_common::scoring_metrics::VersionedScoringMetrics;
 use iota_protocol_config::ProtocolConfig;
 use itertools::Itertools;
 use parking_lot::RwLock;
@@ -29,6 +30,7 @@ use crate::{
     leader_timeout::{LeaderTimeoutTask, LeaderTimeoutTaskHandle},
     metrics::initialise_metrics,
     network::tonic_network::{TonicClient, TonicManager},
+    scoring_metrics_store::ScoringMetricsStore,
     shard_reconstructor::{ShardReconstructor, ShardReconstructorHandle},
     storage::rocksdb_store::RocksDBStore,
     subscriber::Subscriber,
@@ -72,6 +74,7 @@ impl ConsensusAuthority {
         transaction_verifier: Arc<dyn TransactionVerifier>,
         commit_consumer: CommitConsumer,
         registry: Registry,
+        current_local_metrics_count: Arc<VersionedScoringMetrics>,
         boot_counter: u64,
     ) -> Self {
         assert!(
@@ -92,6 +95,13 @@ impl ConsensusAuthority {
         );
         info!("Consensus parameters: {:?}", parameters);
         info!("Consensus committee: {:?}", committee);
+
+        let scoring_metrics_store = Arc::new(ScoringMetricsStore::new(
+            committee.size(),
+            current_local_metrics_count,
+            &protocol_config,
+        ));
+
         let context = Arc::new(Context::new(
             epoch_start_timestamp_ms,
             own_index,
@@ -99,6 +109,7 @@ impl ConsensusAuthority {
             parameters,
             protocol_config,
             initialise_metrics(registry),
+            scoring_metrics_store,
             clock,
         ));
         let start_time = Instant::now();
@@ -398,19 +409,25 @@ mod tests {
 
         let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_consumer = CommitConsumer::new(sender, 0);
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+        let current_local_metrics_count = Arc::new(VersionedScoringMetrics::new(
+            committee.size(),
+            &protocol_config,
+        ));
 
         let authority = ConsensusAuthority::start(
             0,
             own_index,
             committee,
             parameters,
-            ProtocolConfig::get_for_max_version_UNSAFE(),
+            protocol_config,
             protocol_keypair,
             network_keypair,
             Arc::new(Clock::default()),
             Arc::new(txn_verifier),
             commit_consumer,
             registry,
+            current_local_metrics_count,
             0,
         )
         .await;
@@ -934,6 +951,10 @@ mod tests {
         let commit_consumer = CommitConsumer::new(sender, 0);
 
         let consensus_consumer_monitor = commit_consumer.monitor();
+        let current_local_metrics_count = Arc::new(VersionedScoringMetrics::new(
+            committee.size(),
+            &protocol_config,
+        ));
 
         let authority = ConsensusAuthority::start(
             0,
@@ -947,6 +968,7 @@ mod tests {
             Arc::new(txn_verifier),
             commit_consumer,
             registry,
+            current_local_metrics_count,
             boot_counter,
         )
         .await;

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -447,7 +447,8 @@ mod tests {
     use super::*;
     use crate::{
         block_header::BlockRef, context::Context, dag_state::DagState,
-        storage::mem_store::MemStore, test_dag_builder::DagBuilder,
+        scoring_metrics_store::ScoringMetricsStore, storage::mem_store::MemStore,
+        test_dag_builder::DagBuilder,
     };
 
     #[tokio::test]
@@ -852,6 +853,11 @@ mod tests {
         let metrics = crate::metrics::test_metrics();
         let temp_dir = tempfile::TempDir::new().unwrap();
         let clock = Arc::new(crate::context::Clock::default());
+        let scoring_metrics_store = Arc::new(ScoringMetricsStore::dummy_for_test(
+            committee.size(),
+            &protocol_config,
+        ));
+
         let context = Arc::new(Context::new(
             0,
             starfish_config::AuthorityIndex::new_for_test(0),
@@ -862,6 +868,7 @@ mod tests {
             },
             protocol_config,
             metrics,
+            scoring_metrics_store,
             clock,
         ));
 

--- a/crates/starfish/core/src/context.rs
+++ b/crates/starfish/core/src/context.rs
@@ -14,7 +14,9 @@ use tokio::time::Instant;
 
 #[cfg(test)]
 use crate::metrics::test_metrics;
-use crate::{block_header::BlockTimestampMs, metrics::Metrics};
+use crate::{
+    block_header::BlockTimestampMs, metrics::Metrics, scoring_metrics_store::ScoringMetricsStore,
+};
 
 /// Context contains per-epoch configuration and metrics shared by all
 /// components of this authority.
@@ -32,6 +34,9 @@ pub(crate) struct Context {
     pub protocol_config: ProtocolConfig,
     /// Metrics of this authority.
     pub metrics: Arc<Metrics>,
+    /// Store for scoring metrics collected by this authority.
+    #[expect(dead_code)]
+    pub(crate) scoring_metrics_store: Arc<ScoringMetricsStore>,
     /// Access to local clock
     pub clock: Arc<Clock>,
 }
@@ -44,6 +49,7 @@ impl Context {
         parameters: Parameters,
         protocol_config: ProtocolConfig,
         metrics: Arc<Metrics>,
+        scoring_metrics_store: Arc<ScoringMetricsStore>,
         clock: Arc<Clock>,
     ) -> Self {
         Self {
@@ -53,6 +59,7 @@ impl Context {
             parameters,
             protocol_config,
             metrics,
+            scoring_metrics_store,
             clock,
         }
     }
@@ -66,12 +73,19 @@ impl Context {
     pub(crate) fn new_for_test(
         committee_size: usize,
     ) -> (Self, Vec<(NetworkKeyPair, ProtocolKeyPair)>) {
+        use crate::scoring_metrics_store::ScoringMetricsStore;
+
         let (committee, keypairs) =
             starfish_config::local_committee_and_keys(0, vec![1; committee_size]);
         let metrics = test_metrics();
         let temp_dir = TempDir::new().unwrap();
         let clock = Arc::new(Clock::default());
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
 
+        let scoring_metrics_store = Arc::new(ScoringMetricsStore::dummy_for_test(
+            committee_size,
+            &protocol_config,
+        ));
         let context = Context::new(
             0,
             AuthorityIndex::new_for_test(0),
@@ -80,8 +94,9 @@ impl Context {
                 db_path: temp_dir.keep(),
                 ..Default::default()
             },
-            ProtocolConfig::get_for_max_version_UNSAFE(),
+            protocol_config,
             metrics,
+            scoring_metrics_store,
             clock,
         );
         (context, keypairs)

--- a/crates/starfish/core/src/context.rs
+++ b/crates/starfish/core/src/context.rs
@@ -35,7 +35,6 @@ pub(crate) struct Context {
     /// Metrics of this authority.
     pub metrics: Arc<Metrics>,
     /// Store for scoring metrics collected by this authority.
-    #[expect(dead_code)]
     pub(crate) scoring_metrics_store: Arc<ScoringMetricsStore>,
     /// Access to local clock
     pub clock: Arc<Clock>,

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 use bytes::Bytes;
+use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
 use iota_metrics::monitored_mpsc::Sender;
 use itertools::Itertools as _;
 use starfish_config::AuthorityIndex;
@@ -1676,6 +1677,10 @@ impl DagState {
                 .join(","),
         );
 
+        // Updates scoring metrics according to eviction round and returns updates that
+        // should be written in storage.
+        let score_updates = self.score_updates_to_write();
+
         // Write all buffered data to storage
         self.store
             .write(WriteBatch::new(
@@ -1683,6 +1688,7 @@ impl DagState {
                 block_headers,
                 commits,
                 commit_info,
+                score_updates,
             ))
             .unwrap_or_else(|e| panic!("Failed to write to storage: {e:?}"));
 
@@ -1779,6 +1785,11 @@ impl DagState {
     /// Any blocks with round <= the evict round have been cleaned up.
     fn eviction_round(commit_round: Round, cached_rounds: Round) -> Round {
         commit_round.saturating_sub(cached_rounds)
+    }
+
+    /// Buffers validator score updates to be written to storage.
+    fn score_updates_to_write(&mut self) -> Vec<(AuthorityIndex, VersionedStorageScoringMetrics)> {
+        vec![] // Placeholder for future implementation of scoring updates
     }
 
     /// Detects and returns the blocks of the round that forms the last quorum.

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1804,7 +1804,28 @@ impl DagState {
 
     /// Buffers validator score updates to be written to storage.
     fn score_updates_to_write(&mut self) -> Vec<(AuthorityIndex, VersionedStorageScoringMetrics)> {
-        vec![] // Placeholder for future implementation of scoring updates
+        let mut metrics_to_write = vec![];
+        let threshold_clock_round = self.threshold_clock_round();
+        for (authority_index, authority) in self.context.committee.authorities() {
+            let last_eviction_round = self.evicted_rounds[authority_index];
+            let current_eviction_round = self.calculate_authority_eviction_round(authority_index);
+            let metrics_to_write_from_authority = self
+                .context
+                .scoring_metrics_store
+                .update_scoring_metrics_on_eviction(
+                    authority_index,
+                    authority.hostname.as_str(),
+                    &self.recent_headers_refs_by_authority[authority_index],
+                    current_eviction_round,
+                    last_eviction_round,
+                    threshold_clock_round,
+                    &self.context,
+                );
+            if let Some(metrics_to_write_from_authority) = metrics_to_write_from_authority {
+                metrics_to_write.push((authority_index, metrics_to_write_from_authority));
+            }
+        }
+        metrics_to_write
     }
 
     /// Detects and returns the blocks of the round that forms the last quorum.
@@ -1857,6 +1878,11 @@ impl DagState {
     #[cfg(test)]
     pub(crate) fn set_pending_acknowledgments(&mut self, acknowledgments: Vec<BlockRef>) {
         self.pending_acknowledgments = acknowledgments.into_iter().collect::<BTreeSet<_>>();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn evicted_rounds(&self) -> Vec<Round> {
+        self.evicted_rounds.clone()
     }
 }
 #[cfg(test)]

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -326,6 +326,7 @@ impl DagState {
                     .collect::<Vec<BlockRef>>()
             );
         }
+
         state
     }
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -327,6 +327,20 @@ impl DagState {
             );
         }
 
+        // Initialize scoring metrics according to the metrics in store and the block
+        // headers that were loaded to cache.
+        let recovered_scoring_metrics = state.store.scan_scoring_metrics().expect("Database error");
+        state
+            .context
+            .scoring_metrics_store
+            .initialize_scoring_metrics(
+                recovered_scoring_metrics,
+                &state.recent_headers_refs_by_authority,
+                state.threshold_clock_round(),
+                &state.evicted_rounds,
+                &state.context,
+            );
+
         state
     }
 

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -27,6 +27,7 @@ mod metrics;
 mod network;
 #[cfg(msim)]
 pub mod network;
+mod scoring_metrics_store;
 
 mod header_synchronizer;
 mod stake_aggregator;

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -232,17 +232,11 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_fetch_missing_block_headers: IntCounterVec,
     pub(crate) commit_sync_fetch_missing_transactions: IntCounterVec,
     pub(crate) uptime: Histogram,
-    #[expect(dead_code)]
     pub(crate) faulty_blocks_provable_by_authority: IntCounterVec,
-    #[expect(dead_code)]
     pub(crate) faulty_blocks_unprovable_by_authority: IntCounterVec,
-    #[expect(dead_code)]
     pub(crate) uncached_equivocations_by_authority: IntCounterVec,
-    #[expect(dead_code)]
     pub(crate) uncached_missing_proposals_by_authority: IntCounterVec,
-    #[expect(dead_code)]
     pub(crate) equivocations_in_cache_by_authority: IntGaugeVec,
-    #[expect(dead_code)]
     pub(crate) missing_proposals_in_cache_by_authority: IntGaugeVec,
     #[expect(dead_code)]
     pub(crate) score_by_authority: IntGaugeVec,

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -232,6 +232,22 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_fetch_missing_block_headers: IntCounterVec,
     pub(crate) commit_sync_fetch_missing_transactions: IntCounterVec,
     pub(crate) uptime: Histogram,
+    #[expect(dead_code)]
+    pub(crate) faulty_blocks_provable_by_authority: IntCounterVec,
+    #[expect(dead_code)]
+    pub(crate) faulty_blocks_unprovable_by_authority: IntCounterVec,
+    #[expect(dead_code)]
+    pub(crate) uncached_equivocations_by_authority: IntCounterVec,
+    #[expect(dead_code)]
+    pub(crate) uncached_missing_proposals_by_authority: IntCounterVec,
+    #[expect(dead_code)]
+    pub(crate) equivocations_in_cache_by_authority: IntGaugeVec,
+    #[expect(dead_code)]
+    pub(crate) missing_proposals_in_cache_by_authority: IntGaugeVec,
+    #[expect(dead_code)]
+    pub(crate) score_by_authority: IntGaugeVec,
+    #[expect(dead_code)]
+    pub(crate) invalid_misbehavior_reports_by_authority: IntCounterVec,
 }
 
 impl NodeMetrics {
@@ -1001,6 +1017,54 @@ impl NodeMetrics {
             transactions_synchronizer_inflight_requests: register_int_gauge_with_registry!(
                 "transaction_synchronizer_concurrent_requests",
                 "Number of concurrent transaction fetch requests",
+                registry,
+            ).unwrap(),
+            faulty_blocks_provable_by_authority: register_int_counter_vec_with_registry!(
+                "faulty_blocks_provable_by_authority",
+                "Number of provably faulty blocks per peer authority",
+                &["authority", "source", "error"],
+                registry,
+             ).unwrap(),
+            faulty_blocks_unprovable_by_authority: register_int_counter_vec_with_registry!(
+                "faulty_blocks_unprovable_by_authority",
+                "Number of unprovably faulty blocks per peer authority",
+                &["authority", "source", "error"],
+                registry,
+            ).unwrap(),
+            uncached_equivocations_by_authority: register_int_counter_vec_with_registry!(
+                "uncached_equivocations_by_authority",
+                "Registers the number of equivocations per authority that were already evicted from cache.",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            uncached_missing_proposals_by_authority: register_int_counter_vec_with_registry!(
+                "uncached_missing_proposals_by_authority",
+                "Registers the number of blocks that should be already evicted from cache but authority failed to send.",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            equivocations_in_cache_by_authority: register_int_gauge_vec_with_registry!(
+                "equivocations_in_cache_by_authority",
+                "Registers the number of equivocations per authority stored on cache.",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            missing_proposals_in_cache_by_authority: register_int_gauge_vec_with_registry!(
+                "missing_proposals_in_cache_by_authority",
+                "Registers the number of blocks on the cache that an authority failed to send.",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            score_by_authority: register_int_gauge_vec_with_registry!(
+                "score_by_authority",
+                "Registers the authority score.",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            invalid_misbehavior_reports_by_authority: register_int_counter_vec_with_registry!(
+                "invalid_misbehavior_reports_by_authority",
+                "Number of invalid misbehavior reports received from each authority",
+                &["authority"],
                 registry,
             ).unwrap(),
         }

--- a/crates/starfish/core/src/scoring_metrics_store.rs
+++ b/crates/starfish/core/src/scoring_metrics_store.rs
@@ -1,7 +1,10 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeSet, sync::Arc};
+use std::{
+    collections::BTreeSet,
+    sync::{Arc, atomic::Ordering},
+};
 
 use iota_common::scoring_metrics::{VersionedScoringMetrics, VersionedStorageScoringMetrics};
 use iota_protocol_config::ProtocolConfig;
@@ -14,7 +17,6 @@ use crate::{BlockRef, context::Context, metrics::NodeMetrics};
 /// both cached and uncached. It also holds a shared reference to the current
 /// local metrics count used by Scorer.
 pub(crate) struct ScoringMetricsStore {
-    #[expect(dead_code)]
     pub current_local_metrics_count: Arc<VersionedScoringMetrics>,
     pub cached_metrics: VersionedScoringMetrics,
     pub uncached_metrics: VersionedScoringMetrics,
@@ -218,6 +220,106 @@ impl ScoringMetricsStore {
             }
         }
     }
+    // Updates the authority's scoring metrics according to the recent changes in
+    // the DAG state, i.e., recent evictions and additions to cache. It also
+    // updates the current local metrics count used by Scorer. It returns metrics
+    // changes that should be updated in disk storage.
+    pub(crate) fn update_scoring_metrics_on_eviction(
+        &self,
+        authority_index: AuthorityIndex,
+        hostname: &str,
+        recent_refs: &BTreeSet<BlockRef>,
+        eviction_round: u32,
+        last_eviction_round: u32,
+        threshold_clock_round: u32,
+        context: &Arc<Context>,
+    ) -> Option<VersionedStorageScoringMetrics> {
+        let committee_size = context.committee.size();
+        let node_metrics = &context.metrics.node_metrics;
+        // threshold_clock_round should be always at least 1. Analogously,
+        // authority_index should be a valid index.
+        if threshold_clock_round == 0 || authority_index.value() >= committee_size {
+            return None;
+        }
+
+        // Get the blocks rounds that were not evicted.
+        let cached_block_rounds = recent_refs
+            .iter()
+            .map(|block| block.round)
+            .filter(|&round| round > eviction_round && round < threshold_clock_round)
+            .collect::<Vec<u32>>();
+
+        // Update metrics according to the blocks from rounds still in cache.
+        let (cached_equivocations, missing_blocks_in_cached_rounds) =
+            calculate_scoring_metrics_for_range(
+                cached_block_rounds,
+                eviction_round + 1,
+                threshold_clock_round.saturating_sub(1),
+            );
+
+        self.update_missing_blocks_and_equivocations(
+            missing_blocks_in_cached_rounds,
+            cached_equivocations,
+            hostname,
+            authority_index,
+            StoreType::Cached,
+            node_metrics,
+        );
+
+        // If no eviction happened, we do not update the metrics on storage.
+        if eviction_round == last_eviction_round {
+            return None;
+        }
+
+        // Get the evicted blocks rounds.
+        let evicted_block_rounds = recent_refs
+            .iter()
+            .map(|block| block.round)
+            .filter(|&round| round <= eviction_round)
+            .collect::<Vec<u32>>();
+
+        // Update metrics according to the blocks from evicted rounds.
+        let (evicted_equivocations, missing_blocks_in_evicted_rounds) =
+            calculate_scoring_metrics_for_range(
+                evicted_block_rounds,
+                last_eviction_round + 1,
+                eviction_round,
+            );
+
+        self.update_missing_blocks_and_equivocations(
+            missing_blocks_in_evicted_rounds,
+            evicted_equivocations,
+            hostname,
+            authority_index,
+            StoreType::Uncached,
+            node_metrics,
+        );
+
+        // Update current local metrics count.
+        self.update_current_local_metrics_count(authority_index);
+
+        Some(VersionedStorageScoringMetrics::new_from(
+            &self.uncached_metrics,
+            authority_index.value(),
+        ))
+    }
+
+    // The `authority_index` should be a valid index, otherwise the function will
+    // panic. This check is not performed here, as it is assumed that the caller has
+    // already checked it.
+    pub(crate) fn update_current_local_metrics_count(&self, authority_index: AuthorityIndex) {
+        let uncached_metrics = &self
+            .uncached_metrics
+            .iterate_over_metrics()
+            .map(|metric_vec| metric_vec[authority_index].load(Ordering::Relaxed))
+            .collect::<Vec<u64>>();
+        self.current_local_metrics_count
+            .iterate_over_metrics()
+            .zip(uncached_metrics)
+            .for_each(|(local_metric_vec, uncached_metric)| {
+                local_metric_vec[authority_index].store(*uncached_metric, Ordering::Relaxed);
+            });
+    }
 }
 
 // Given the set of blocks issued by an authority in rounds in the inclusive
@@ -260,5 +362,647 @@ impl ScoringMetricsStore {
             protocol_config,
         ));
         ScoringMetricsStore::new(committee_size, current_local_metrics_count, protocol_config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeSet, sync::Arc, vec};
+
+    use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
+    use starfish_config::{AuthorityIndex, Parameters};
+
+    use crate::{
+        context::Context,
+        dag_state::{DagState, DataSource},
+        scoring_metrics_store::ScoringMetricsStore,
+        storage::mem_store::MemStore,
+        test_dag_builder::DagBuilder,
+    };
+
+    impl ScoringMetricsStore {
+        pub(crate) fn uncached_missing_proposals_by_authority(&self) -> Vec<u64> {
+            self.uncached_metrics.load_missing_proposals()
+        }
+
+        pub(crate) fn equivocations_in_cache_by_authority(&self) -> Vec<u64> {
+            self.cached_metrics.load_equivocations()
+        }
+
+        pub(crate) fn missing_proposals_in_cache_by_authority(&self) -> Vec<u64> {
+            self.cached_metrics.load_missing_proposals()
+        }
+
+        pub(crate) fn uncached_equivocations_by_authority(&self) -> Vec<u64> {
+            self.uncached_metrics.load_equivocations()
+        }
+    }
+
+    fn get_uncached_missing_proposals(context: &Arc<Context>) -> Vec<u64> {
+        let mut metrics = Vec::new();
+        for authority in context.committee.authorities() {
+            let hostname = authority.1.hostname.as_str();
+            metrics.push(
+                context
+                    .metrics
+                    .node_metrics
+                    .uncached_missing_proposals_by_authority
+                    .get_metric_with_label_values(&[hostname])
+                    .unwrap()
+                    .get(),
+            )
+        }
+        metrics
+    }
+
+    fn get_missing_proposals_in_cache(context: &Arc<Context>) -> Vec<u64> {
+        let mut metrics = Vec::new();
+        for authority in context.committee.authorities() {
+            let hostname = authority.1.hostname.as_str();
+            metrics.push(
+                context
+                    .metrics
+                    .node_metrics
+                    .missing_proposals_in_cache_by_authority
+                    .get_metric_with_label_values(&[hostname])
+                    .unwrap()
+                    .get()
+                    .unsigned_abs(),
+            )
+        }
+        metrics
+    }
+
+    fn get_uncached_equivocations(context: &Arc<Context>) -> Vec<u64> {
+        let mut metrics = Vec::new();
+        for authority in context.committee.authorities() {
+            let hostname = authority.1.hostname.as_str();
+            metrics.push(
+                context
+                    .metrics
+                    .node_metrics
+                    .uncached_equivocations_by_authority
+                    .get_metric_with_label_values(&[hostname])
+                    .unwrap()
+                    .get(),
+            )
+        }
+        metrics
+    }
+
+    fn get_equivocations_in_cache(context: &Arc<Context>) -> Vec<u64> {
+        let mut metrics = Vec::new();
+        for authority in context.committee.authorities() {
+            let hostname = authority.1.hostname.as_str();
+            metrics.push(
+                context
+                    .metrics
+                    .node_metrics
+                    .equivocations_in_cache_by_authority
+                    .get_metric_with_label_values(&[hostname])
+                    .unwrap()
+                    .get()
+                    .unsigned_abs(),
+            )
+        }
+        metrics
+    }
+
+    #[tokio::test]
+    async fn test_update_scoring_metrics_on_eviction_edge_cases() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let scoring_metrics_store = context.scoring_metrics_store.clone();
+        let authority_index = AuthorityIndex::new_for_test(0);
+        let hostname = "test_host";
+        let recent_refs_by_authority = BTreeSet::new();
+        // Test different unexpected combinations of eviction_round, last_evicted_round,
+        // and threshold_clock_round. Since recent_refs_by_authority is empty, the
+        // function should never panic or return more than zero equivocations.
+        // Each of the cases below have a small explanation of why they are unexpected
+        // and why they are supposed to return what they return.
+
+        // Unexpected because: threshold_clock_round = last_evicted_round means that a
+        // round with blocks from less than 2f+1 stake was evicted.
+        // Return: None, because nothing is currently being evicted.
+        let last_evicted_round = 5;
+        let eviction_round = 5;
+        let threshold_clock_round = 5;
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+            authority_index,
+            hostname,
+            &recent_refs_by_authority,
+            eviction_round,
+            last_evicted_round,
+            threshold_clock_round,
+            &context,
+        );
+        assert!(stored_metrics.is_none());
+
+        // Unexpected because: threshold_clock_round = 0 means that genesis is missing.
+        // Return: None, because nothing is currently being evicted.
+        let last_evicted_round = 0;
+        let eviction_round = 0;
+        let threshold_clock_round = 0;
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+            authority_index,
+            hostname,
+            &recent_refs_by_authority,
+            eviction_round,
+            last_evicted_round,
+            threshold_clock_round,
+            &context,
+        );
+        assert!(stored_metrics.is_none());
+
+        // Unexpected because: threshold_clock_round < eviction_round means that a round
+        // with blocks from less than 2f+1 stake in being evicted.
+        // Return: 3 missing proposals, from rounds 1 to 3(eviction_round).
+        let last_evicted_round = 0;
+        let eviction_round = 3;
+        let threshold_clock_round = 2;
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+            authority_index,
+            hostname,
+            &recent_refs_by_authority,
+            eviction_round,
+            last_evicted_round,
+            threshold_clock_round,
+            &context,
+        );
+        assert_eq!(
+            stored_metrics,
+            Some(VersionedStorageScoringMetrics::new_v1_for_test(
+                0, // faulty_blocks_provable
+                0, // faulty_blocks_unprovable
+                3, // missing_proposals
+                0, // equivocations
+            ))
+        );
+
+        // Unexpected because: eviction_round < last_evicted_round means that blocks
+        // below or in last_evicted_round were accepted.
+        // Return: metrics won't be updated here, so it should return the same as in the
+        // last step.
+        let last_evicted_round = 1;
+        let eviction_round = 0;
+        let threshold_clock_round = 2;
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+            authority_index,
+            hostname,
+            &recent_refs_by_authority,
+            eviction_round,
+            last_evicted_round,
+            threshold_clock_round,
+            &context,
+        );
+        assert_eq!(
+            stored_metrics,
+            Some(VersionedStorageScoringMetrics::new_v1_for_test(
+                0, // faulty_blocks_provable
+                0, // faulty_blocks_unprovable
+                3, // missing_proposals
+                0, // equivocations
+            ))
+        );
+
+        // Unexpected because: threshold_clock_round < eviction_round <
+        // last_evicted_round and threshold_clock_round. Return: metrics won't be
+        // updated here, so it should return the same as in the last step.
+        let last_evicted_round = 2;
+        let eviction_round = 0;
+        let threshold_clock_round = 1;
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+            authority_index,
+            hostname,
+            &recent_refs_by_authority,
+            eviction_round,
+            last_evicted_round,
+            threshold_clock_round,
+            &context,
+        );
+        assert_eq!(
+            stored_metrics,
+            Some(VersionedStorageScoringMetrics::new_v1_for_test(
+                0, // faulty_blocks_provable
+                0, // faulty_blocks_unprovable
+                3, // missing_proposals
+                0, // equivocations
+            ))
+        );
+
+        // Unexpected because: threshold_clock_round < last_evicted_round means that a
+        // round with blocks from less than 2f+1 stake was evicted.
+        // Return: None, because nothing is currently being evicted.
+        let last_evicted_round = 1;
+        let eviction_round = 2;
+        let threshold_clock_round = 0;
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+            authority_index,
+            hostname,
+            &recent_refs_by_authority,
+            eviction_round,
+            last_evicted_round,
+            threshold_clock_round,
+            &context,
+        );
+        assert!(stored_metrics.is_none());
+
+        let last_evicted_round = 2;
+        let eviction_round = 1;
+        let threshold_clock_round = 0;
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+            authority_index,
+            hostname,
+            &recent_refs_by_authority,
+            eviction_round,
+            last_evicted_round,
+            threshold_clock_round,
+            &context,
+        );
+        assert!(stored_metrics.is_none());
+
+        // The function should not panic if the authority index is out of bounds.
+        // Unexpected because: threshold_clock_round = last_evicted_round means that a
+        // round with blocks from less than 2f+1 stake was evicted.
+        // Return: None, because nothing is currently being evicted.
+        let out_of_bounds_authority_index = AuthorityIndex::new_for_test(4);
+        let last_evicted_round = 1;
+        let eviction_round = 2;
+        let threshold_clock_round = 3;
+        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+            out_of_bounds_authority_index,
+            hostname,
+            &recent_refs_by_authority,
+            eviction_round,
+            last_evicted_round,
+            threshold_clock_round,
+            &context,
+        );
+        assert!(stored_metrics.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_metrics_flush_and_recovery() {
+        //   telemetry_subscribers::init_for_testing();
+        let committee_size = 4;
+        let (context, _) = Context::new_for_test(committee_size);
+        let context = context.with_parameters(Parameters {
+            dag_state_cached_rounds: 5,
+            ..Default::default()
+        });
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        let hostnames: Vec<&str> = context
+            .committee
+            .authorities()
+            .map(|a| a.1.hostname.as_str())
+            .collect();
+        let scoring_metrics = &context.scoring_metrics_store;
+        let node_metrics = &context.metrics.node_metrics;
+
+        // Initialize the DAG builder with 20 layers. Blocks in the DAG will reference
+        // all blocks from the previous round.
+        // - Rounds 1 to 5 will have unique blocks from all authorities.
+        // - Rounds 6 to 8 will have unique blocks from all authorities, except 0, who
+        //   will not propose any block.
+        // - Rounds 9 to 10 will have unique blocks from all authorities.
+        // - Rounds 11 to 20 will have unique blocks from all authorities, except:
+        //      - Authority 1, who will produce 1 equivocating blocks at round 11 (i.e.,
+        //        1+1 blocks)
+        //      - Authority 2, who will produce 2 equivocating blocks at round 13 (i.e.,
+        //        1+2 blocks)
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=5).build();
+        dag_builder
+            .layers(6..=8)
+            .authorities(vec![AuthorityIndex::new_for_test(0)])
+            .skip_block()
+            .build();
+        dag_builder.layers(9..=10).build();
+        dag_builder
+            .layers(11..=11)
+            .authorities(vec![AuthorityIndex::new_for_test(1)])
+            .equivocate(1)
+            .build();
+        dag_builder.layers(12..=12).build();
+        dag_builder
+            .layers(13..=13)
+            .authorities(vec![AuthorityIndex::new_for_test(2)])
+            .equivocate(2)
+            .build();
+        dag_builder.layers(14..=20).build();
+
+        let mut commits = dag_builder
+            .get_sub_dag_and_commits(1..=20)
+            .into_iter()
+            .map(|(_subdag, commit)| commit)
+            .collect::<Vec<_>>();
+
+        // Add the blocks and commits from first 10 rounds to the dag state. Since
+        // authority 0 skipped a leader round, we use the 9 first items of the commits
+        // vector
+        let mut temp_commits = commits.split_off(9);
+        dag_state.accept_block_headers(dag_builder.block_headers(1..=10), DataSource::Test);
+        for commit in commits.clone() {
+            dag_state.add_commit(commit);
+        }
+
+        assert_eq!(dag_state.last_commit_index(), 9);
+        assert_eq!(dag_state.last_committed_rounds(), [9, 9, 10, 9]);
+        assert_eq!(dag_state.evicted_rounds(), [0, 0, 0, 0]);
+
+        // Checks that metrics are still all zeroed, since even though we accepted
+        // blocks to the dag state, the metrics updates are done when the dag state is
+        // flushed.
+        assert_eq!(
+            [
+                scoring_metrics.uncached_equivocations_by_authority(),
+                scoring_metrics.uncached_missing_proposals_by_authority(),
+                scoring_metrics.equivocations_in_cache_by_authority(),
+                scoring_metrics.missing_proposals_in_cache_by_authority(),
+                get_uncached_equivocations(&context),
+                get_uncached_missing_proposals(&context),
+                get_equivocations_in_cache(&context),
+                get_missing_proposals_in_cache(&context)
+            ],
+            [
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size]
+            ]
+        );
+
+        // Flush the dag state
+        dag_state.flush();
+
+        // Check that metrics were updated correctly after flushing.
+        //
+        // Equivocations:
+        // - We only accepted blocks from rounds <= 10, thus, no equivocations were
+        //   accepted yet. Equivocations metrics, then, should be still all zeroed.
+        //
+        // Missing proposals:
+        // - The last committed round is 10, so the eviction round should be 5 for
+        //   authority 2 (leader of round 10) and 4 for all other authorities.
+        // - The threshold_clock_round should be 11, since we already accepted all
+        //   blocks from epoch 10.
+        // - Then, finally, we should have counted:
+        //      - 0 uncached missing proposals for authority 0;
+        //      - 3 missing proposal in cache for authority 0;
+        //      - 0 missing proposals for authorities 1, 2, and 3.
+        assert_eq!(dag_state.evicted_rounds(), [4, 4, 5, 4]);
+        assert_eq!(
+            [
+                scoring_metrics.uncached_equivocations_by_authority(),
+                scoring_metrics.uncached_missing_proposals_by_authority(),
+                scoring_metrics.equivocations_in_cache_by_authority(),
+                scoring_metrics.missing_proposals_in_cache_by_authority(),
+                get_uncached_equivocations(&context),
+                get_uncached_missing_proposals(&context),
+                get_equivocations_in_cache(&context),
+                get_missing_proposals_in_cache(&context)
+            ],
+            [
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![3, 0, 0, 0],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![3, 0, 0, 0],
+            ]
+        );
+
+        // Clear and check all metrics
+        scoring_metrics.uncached_metrics.reset();
+        scoring_metrics.cached_metrics.reset();
+        node_metrics
+            .uncached_missing_proposals_by_authority
+            .with_label_values(&[hostnames[0]])
+            .reset();
+        node_metrics
+            .missing_proposals_in_cache_by_authority
+            .with_label_values(&[hostnames[0]])
+            .set(0);
+        assert_eq!(
+            [
+                scoring_metrics.uncached_equivocations_by_authority(),
+                scoring_metrics.uncached_missing_proposals_by_authority(),
+                scoring_metrics.equivocations_in_cache_by_authority(),
+                scoring_metrics.missing_proposals_in_cache_by_authority(),
+                get_uncached_equivocations(&context),
+                get_uncached_missing_proposals(&context),
+                get_equivocations_in_cache(&context),
+                get_missing_proposals_in_cache(&context)
+            ],
+            [
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size]
+            ]
+        );
+
+        // Destroy and recover dag state from storage.
+        drop(dag_state);
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        assert_eq!(dag_state.last_commit_index(), 9);
+        assert_eq!(dag_state.last_committed_rounds(), [9, 9, 10, 9]);
+
+        // Metrics should have been initialized as before the recovery.
+        assert_eq!(
+            [
+                scoring_metrics.uncached_equivocations_by_authority(),
+                scoring_metrics.uncached_missing_proposals_by_authority(),
+                scoring_metrics.equivocations_in_cache_by_authority(),
+                scoring_metrics.missing_proposals_in_cache_by_authority()
+            ],
+            [
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![3, 0, 0, 0],
+            ]
+        );
+
+        // Add blocks and commits from rounds 11 and 12 to the dag state.
+        let second_temp_commits = temp_commits.split_off(2);
+        dag_state.accept_block_headers(dag_builder.block_headers(11..=12), DataSource::Test);
+        for commit in temp_commits.clone() {
+            dag_state.add_commit(commit);
+        }
+
+        // Flush the dag state
+        dag_state.flush();
+
+        assert_eq!(dag_state.last_commit_index(), 11);
+        assert_eq!(dag_state.last_committed_rounds(), [12, 11, 11, 11]);
+        assert_eq!(dag_state.evicted_rounds(), [7, 6, 6, 6]);
+
+        // Check that metrics were updated correctly after flushing.
+        //
+        // Missing proposals:
+        // - The last commit round is 12, so the eviction round should be 7 for
+        //   authority 0 (leader of round 12) and 6 for all other authorities. Then, we
+        //   should have counted:
+        //      - 2 uncached missing proposals for authority 0;
+        //      - 1 missing proposal in cache for authority 0;
+        //      - 0 missing proposals for authorities 1, 2, and 3.
+        //
+        // Equivocations:
+        // - We only removed from cache blocks from rounds <= 7, thus, no equivocations
+        //   should be uncached. Then, we should have counted:
+        //      - 0 uncached equivocations;
+        //      - 1 equivocation in cache for authority 1;
+        //      - 0 equivocations in cache for authorities 0, 2 and 3;
+
+        assert_eq!(
+            [
+                scoring_metrics.uncached_equivocations_by_authority(),
+                scoring_metrics.uncached_missing_proposals_by_authority(),
+                scoring_metrics.equivocations_in_cache_by_authority(),
+                scoring_metrics.missing_proposals_in_cache_by_authority(),
+                get_uncached_equivocations(&context),
+                get_uncached_missing_proposals(&context),
+                get_equivocations_in_cache(&context),
+                get_missing_proposals_in_cache(&context)
+            ],
+            [
+                vec![0; committee_size],
+                vec![2, 0, 0, 0],
+                vec![0, 1, 0, 0],
+                vec![1, 0, 0, 0],
+                vec![0; committee_size],
+                vec![2, 0, 0, 0],
+                vec![0, 1, 0, 0],
+                vec![1, 0, 0, 0],
+            ]
+        );
+
+        // Accept all the rest of blocks and commits.
+        dag_state.accept_block_headers(dag_builder.block_headers(13..=20), DataSource::Test);
+        for commit in second_temp_commits.clone() {
+            dag_state.add_commit(commit);
+        }
+
+        // Clear and check all metrics
+        scoring_metrics.uncached_metrics.reset();
+        scoring_metrics.cached_metrics.reset();
+        node_metrics
+            .uncached_missing_proposals_by_authority
+            .with_label_values(&[hostnames[0]])
+            .reset();
+        node_metrics
+            .missing_proposals_in_cache_by_authority
+            .with_label_values(&[hostnames[0]])
+            .set(0);
+        node_metrics
+            .equivocations_in_cache_by_authority
+            .with_label_values(&[hostnames[1]])
+            .set(0);
+
+        assert_eq!(
+            [
+                scoring_metrics.uncached_equivocations_by_authority(),
+                scoring_metrics.uncached_missing_proposals_by_authority(),
+                scoring_metrics.equivocations_in_cache_by_authority(),
+                scoring_metrics.missing_proposals_in_cache_by_authority(),
+                get_uncached_equivocations(&context),
+                get_uncached_missing_proposals(&context),
+                get_equivocations_in_cache(&context),
+                get_missing_proposals_in_cache(&context)
+            ],
+            [
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0; committee_size]
+            ]
+        );
+
+        // Destroy and recover dag state from storage.
+        drop(dag_state);
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        assert_eq!(dag_state.last_commit_index(), 11);
+        assert_eq!(dag_state.last_committed_rounds(), [12, 11, 11, 11]);
+
+        // Since the last accepted blocks were not flushed, the equivocations from
+        // rounds 13 to 20 should not be accounted for. The metrics should remain the
+        // same as before this acceptance.
+        assert_eq!(
+            [
+                scoring_metrics.uncached_equivocations_by_authority(),
+                scoring_metrics.uncached_missing_proposals_by_authority(),
+                scoring_metrics.equivocations_in_cache_by_authority(),
+                scoring_metrics.missing_proposals_in_cache_by_authority(),
+                get_uncached_equivocations(&context),
+                get_uncached_missing_proposals(&context),
+                get_equivocations_in_cache(&context),
+                get_missing_proposals_in_cache(&context)
+            ],
+            [
+                vec![0; committee_size],
+                vec![2, 0, 0, 0],
+                vec![0, 1, 0, 0],
+                vec![1, 0, 0, 0],
+                vec![0; committee_size],
+                vec![2, 0, 0, 0],
+                vec![0, 1, 0, 0],
+                vec![1, 0, 0, 0],
+            ]
+        );
+
+        // Now we accept those lost blocks again and flush the dag state
+        dag_state.accept_block_headers(dag_builder.block_headers(13..=20), DataSource::Test);
+        for commit in second_temp_commits.clone() {
+            dag_state.add_commit(commit);
+        }
+        dag_state.flush();
+
+        assert_eq!(dag_state.last_commit_index(), 19);
+        assert_eq!(dag_state.last_committed_rounds(), [20, 19, 19, 19]);
+        assert_eq!(dag_state.evicted_rounds(), [15, 14, 14, 14]);
+
+        // Now all misbehaviors should be accounted for in the uncached metrics.
+        assert_eq!(
+            [
+                scoring_metrics.uncached_equivocations_by_authority(),
+                scoring_metrics.uncached_missing_proposals_by_authority(),
+                scoring_metrics.equivocations_in_cache_by_authority(),
+                scoring_metrics.missing_proposals_in_cache_by_authority(),
+                get_uncached_equivocations(&context),
+                get_uncached_missing_proposals(&context),
+                get_equivocations_in_cache(&context),
+                get_missing_proposals_in_cache(&context)
+            ],
+            [
+                vec![0, 1, 2, 0],
+                vec![3, 0, 0, 0],
+                vec![0; committee_size],
+                vec![0; committee_size],
+                vec![0, 1, 2, 0],
+                vec![3, 0, 0, 0],
+                vec![0; committee_size],
+                vec![0; committee_size],
+            ]
+        );
     }
 }

--- a/crates/starfish/core/src/scoring_metrics_store.rs
+++ b/crates/starfish/core/src/scoring_metrics_store.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use iota_common::scoring_metrics::VersionedScoringMetrics;
+use iota_protocol_config::ProtocolConfig;
+
+/// Struct that holds the scoring metrics for all authorities in the committee,
+/// both cached and uncached. It also holds a shared reference to the current
+/// local metrics count used by Scorer.
+pub(crate) struct ScoringMetricsStore {
+    #[expect(dead_code)]
+    pub current_local_metrics_count: Arc<VersionedScoringMetrics>,
+    #[expect(dead_code)]
+    pub cached_metrics: VersionedScoringMetrics,
+    #[expect(dead_code)]
+    pub uncached_metrics: VersionedScoringMetrics,
+}
+
+impl ScoringMetricsStore {
+    pub(crate) fn new(
+        committee_size: usize,
+        current_local_metrics_count: Arc<VersionedScoringMetrics>,
+        protocol_config: &ProtocolConfig,
+    ) -> Self {
+        Self {
+            current_local_metrics_count,
+            cached_metrics: VersionedScoringMetrics::new(committee_size, protocol_config),
+            uncached_metrics: VersionedScoringMetrics::new(committee_size, protocol_config),
+        }
+    }
+}
+
+#[cfg(test)]
+impl ScoringMetricsStore {
+    // Creates a dummy scoring metrics store for testing purposes (i.e., without any
+    // connection to a Scorer)
+    pub(crate) fn dummy_for_test(committee_size: usize, protocol_config: &ProtocolConfig) -> Self {
+        let current_local_metrics_count = Arc::new(VersionedScoringMetrics::new(
+            committee_size,
+            protocol_config,
+        ));
+        ScoringMetricsStore::new(committee_size, current_local_metrics_count, protocol_config)
+    }
+}

--- a/crates/starfish/core/src/scoring_metrics_store.rs
+++ b/crates/starfish/core/src/scoring_metrics_store.rs
@@ -1,10 +1,14 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
-use iota_common::scoring_metrics::VersionedScoringMetrics;
+use iota_common::scoring_metrics::{VersionedScoringMetrics, VersionedStorageScoringMetrics};
 use iota_protocol_config::ProtocolConfig;
+use itertools::izip;
+use starfish_config::AuthorityIndex;
+
+use crate::{BlockRef, context::Context, metrics::NodeMetrics};
 
 /// Struct that holds the scoring metrics for all authorities in the committee,
 /// both cached and uncached. It also holds a shared reference to the current
@@ -12,9 +16,7 @@ use iota_protocol_config::ProtocolConfig;
 pub(crate) struct ScoringMetricsStore {
     #[expect(dead_code)]
     pub current_local_metrics_count: Arc<VersionedScoringMetrics>,
-    #[expect(dead_code)]
     pub cached_metrics: VersionedScoringMetrics,
-    #[expect(dead_code)]
     pub uncached_metrics: VersionedScoringMetrics,
 }
 
@@ -30,6 +32,222 @@ impl ScoringMetricsStore {
             uncached_metrics: VersionedScoringMetrics::new(committee_size, protocol_config),
         }
     }
+
+    // Initializes the scoring metrics store according to the
+    // recovered_scoring_metrics and headers_in_cache_by_authority.
+    pub(crate) fn initialize_scoring_metrics(
+        &self,
+        mut recovered_scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
+        headers_in_cache_by_authority: &Vec<BTreeSet<BlockRef>>,
+        threshold_clock_round: u32,
+        eviction_rounds: &Vec<u32>,
+        context: &Arc<Context>,
+    ) {
+        // It is possible that the vector recovered_scoring_metrics does not have a
+        // component for every authority. A perfectly functioning validator, for
+        // example, will never have its metrics updated, so no metric will ever be
+        // stored. For this reason, we manually "fill" this vector.
+        if recovered_scoring_metrics.len() < context.committee.size() {
+            for (i, _) in context.committee.authorities() {
+                if !recovered_scoring_metrics
+                    .iter()
+                    .any(|(index, _)| *index == i)
+                {
+                    // We add a component with zeroed metrics for the authority with index i.
+                    // This will ensure that every authority has its metrics initialized.
+                    // They are initialized as zero because if an authority does not have any
+                    // recovered metrics, it means that it never misbehaved in a way that was
+                    // detected by the node.
+                    recovered_scoring_metrics.insert(
+                        i.value(),
+                        (
+                            i,
+                            VersionedStorageScoringMetrics::new_zeroed(&context.protocol_config),
+                        ),
+                    );
+                }
+            }
+        }
+
+        match &context.protocol_config.scorer_version_as_option() {
+            None | Some(1) => self.initialize_scoring_metrics_v1(
+                recovered_scoring_metrics,
+                headers_in_cache_by_authority,
+                threshold_clock_round,
+                eviction_rounds,
+                context,
+            ),
+            _ => panic!("Unsupported scorer version"),
+        }
+    }
+
+    // Initializes the scoring metrics store according to the
+    // recovered_scoring_metrics and headers_in_cache_by_authority, for scorer
+    // version 1. This function should only be called if the scorer version in the
+    // protocol config is 1 or None (i.e., defaulting to version 1), otherwise it
+    // will panic.
+    pub(crate) fn initialize_scoring_metrics_v1(
+        &self,
+        recovered_scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
+        headers_in_cache_by_authority: &Vec<BTreeSet<BlockRef>>,
+        threshold_clock_round: u32,
+        eviction_rounds: &Vec<u32>,
+        context: &Arc<Context>,
+    ) {
+        let hostnames = context
+            .committee
+            .authorities()
+            .map(|(_, x)| x.hostname.as_str())
+            .collect::<Vec<_>>();
+
+        for ((authority_index, metrics), hostname, headers_in_cache, &eviction_round) in izip!(
+            recovered_scoring_metrics,
+            hostnames,
+            headers_in_cache_by_authority,
+            eviction_rounds
+        ) {
+            // Initialize the uncached scoring metrics according to
+            // recovered_scoring_metrics
+            let VersionedStorageScoringMetrics::V1(inner) = &metrics;
+            self.initialize_faulty_blocks_metrics(
+                *inner.faulty_blocks_provable(),
+                *inner.faulty_blocks_unprovable(),
+                hostname,
+                authority_index,
+                &context.metrics.node_metrics,
+            );
+            self.update_missing_blocks_and_equivocations(
+                *inner.missing_proposals(),
+                *inner.equivocations(),
+                hostname,
+                authority_index,
+                StoreType::Uncached,
+                &context.metrics.node_metrics,
+            );
+
+            // Initialize the cached scoring metrics according to headers_in_cache.
+            let headers_rounds_in_cache = headers_in_cache
+                .iter()
+                .map(|block_ref| block_ref.round)
+                .collect();
+            let (cached_equivocations, missing_headers_in_cached_rounds) =
+                calculate_scoring_metrics_for_range(
+                    headers_rounds_in_cache,
+                    eviction_round + 1,
+                    threshold_clock_round - 1,
+                );
+            self.update_missing_blocks_and_equivocations(
+                missing_headers_in_cached_rounds,
+                cached_equivocations,
+                hostname,
+                authority_index,
+                StoreType::Cached,
+                &context.metrics.node_metrics,
+            );
+        }
+    }
+
+    // Auxiliary function to initialize scoring metrics relative to faulty blocks.
+    // The `authority` parameter should be a valid index, otherwise the function
+    // will panic. This check is not performed here, as it is assumed that the
+    // caller has already checked it.
+    pub(crate) fn initialize_faulty_blocks_metrics(
+        &self,
+        faulty_blocks_provable: u64,
+        faulty_blocks_unprovable: u64,
+        hostname: &str,
+        authority_index: AuthorityIndex,
+        node_metrics: &NodeMetrics,
+    ) {
+        node_metrics
+            .faulty_blocks_provable_by_authority
+            .with_label_values(&[hostname, "loaded from storage", "loaded from storage"])
+            .inc_by(faulty_blocks_provable);
+        node_metrics
+            .faulty_blocks_unprovable_by_authority
+            .with_label_values(&[hostname, "loaded from storage", "loaded from storage"])
+            .inc_by(faulty_blocks_unprovable);
+        self.uncached_metrics
+            .store_faulty_blocks_provable(authority_index.value(), faulty_blocks_provable);
+        self.uncached_metrics
+            .store_faulty_blocks_unprovable(authority_index.value(), faulty_blocks_unprovable);
+    }
+
+    // Auxiliary function to update scoring metrics relative to missing blocks
+    // and equivocations. The `authority` parameter should be a valid index,
+    // otherwise the function will panic. This check is not performed here, as
+    // it is assumed that the caller has already checked it.
+    pub(crate) fn update_missing_blocks_and_equivocations(
+        &self,
+        missing_blocks: u64,
+        equivocations: u64,
+        hostname: &str,
+        authority: AuthorityIndex,
+        metric_type: StoreType,
+        node_metrics: &NodeMetrics,
+    ) {
+        match metric_type {
+            StoreType::Cached => {
+                self.cached_metrics
+                    .store_equivocations(authority.value(), equivocations);
+                self.cached_metrics
+                    .store_missing_proposals(authority.value(), missing_blocks);
+                node_metrics
+                    .equivocations_in_cache_by_authority
+                    .with_label_values(&[hostname])
+                    .set(equivocations as i64);
+                node_metrics
+                    .missing_proposals_in_cache_by_authority
+                    .with_label_values(&[hostname])
+                    .set(missing_blocks as i64);
+            }
+
+            StoreType::Uncached => {
+                self.uncached_metrics
+                    .increment_equivocations(authority.value(), equivocations);
+                self.uncached_metrics
+                    .increment_missing_proposals(authority.value(), missing_blocks);
+                node_metrics
+                    .uncached_equivocations_by_authority
+                    .with_label_values(&[hostname])
+                    .inc_by(equivocations);
+                node_metrics
+                    .uncached_missing_proposals_by_authority
+                    .with_label_values(&[hostname])
+                    .inc_by(missing_blocks);
+            }
+        }
+    }
+}
+
+// Given the set of blocks issued by an authority in rounds in the inclusive
+// range [start, end], this function calculates and returns the number of
+// equivocations and missing blocks in that range . The function should receive
+// the vector with the rounds of such blocks and the range start and end points.
+fn calculate_scoring_metrics_for_range(
+    mut block_rounds: Vec<u32>,
+    start: u32,
+    end: u32,
+) -> (u64, u64) {
+    // Filter out rounds that are not in the range [start, end].
+    block_rounds.retain(|&round| round >= start && round <= end);
+    let number_of_blocks = block_rounds.len();
+    block_rounds.dedup();
+    let unique_block_rounds = block_rounds.len();
+    // We use saturating_sub to avoid unexpected underflows, but the subtractions
+    // below should never result in negative values by construction:
+    // 1) unique_block_rounds <= number_of_blocks
+    // 2) end - start + 1 >= unique_block_rounds
+    let number_of_equivocations = number_of_blocks.saturating_sub(unique_block_rounds) as u64;
+    let number_of_missing_blocks =
+        (end + 1).saturating_sub(start + unique_block_rounds as u32) as u64;
+
+    (number_of_equivocations, number_of_missing_blocks)
+}
+
+pub(crate) enum StoreType {
+    Cached,
+    Uncached,
 }
 
 #[cfg(test)]

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use bytes::Bytes;
+use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
 
@@ -36,6 +37,7 @@ struct Inner {
     commits: BTreeMap<(CommitIndex, CommitDigest), TrustedCommit>,
     commit_votes: BTreeSet<(CommitIndex, CommitDigest, BlockRef)>,
     commit_info: BTreeMap<(CommitIndex, CommitDigest), CommitInfo>,
+    scoring_metrics: BTreeMap<AuthorityIndex, VersionedStorageScoringMetrics>,
 }
 
 impl MemStore {
@@ -48,6 +50,7 @@ impl MemStore {
                 commits: BTreeMap::new(),
                 commit_votes: BTreeSet::new(),
                 commit_info: BTreeMap::new(),
+                scoring_metrics: BTreeMap::new(),
             }),
         }
     }
@@ -95,6 +98,10 @@ impl Store for MemStore {
             inner
                 .commit_info
                 .insert((commit_ref.index, commit_ref.digest), commit_info);
+        }
+
+        for (authority, metrics) in write_batch.scoring_metrics {
+            inner.scoring_metrics.insert(authority, metrics);
         }
 
         Ok(())
@@ -227,6 +234,18 @@ impl Store for MemStore {
             );
         }
         Ok(blocks)
+    }
+
+    fn scan_scoring_metrics(
+        &self,
+    ) -> ConsensusResult<Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>> {
+        let inner = self.inner.read();
+        let metrics_by_author = inner
+            .scoring_metrics
+            .iter()
+            .map(|(&authority_index, metrics)| (authority_index, metrics.clone()))
+            .collect::<Vec<_>>();
+        Ok(metrics_by_author)
     }
 
     fn read_verified_block_headers(

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -121,7 +121,6 @@ pub(crate) trait Store: Send + Sync {
 
     /// Reads and returns all metrics stored. Used for restoring the scoring
     /// metrics in case of DagState initialization from storage
-    #[allow(dead_code)]
     fn scan_scoring_metrics(
         &self,
     ) -> ConsensusResult<Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>>;

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod rocksdb_store;
 mod store_tests;
 
 use bytes::Bytes;
+use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
 use starfish_config::AuthorityIndex;
 
 use crate::{
@@ -118,6 +119,13 @@ pub(crate) trait Store: Send + Sync {
         Ok(block_headers)
     }
 
+    /// Reads and returns all metrics stored. Used for restoring the scoring
+    /// metrics in case of DagState initialization from storage
+    #[allow(dead_code)]
+    fn scan_scoring_metrics(
+        &self,
+    ) -> ConsensusResult<Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>>;
+
     /// Reads the last commit.
     fn read_last_commit(&self) -> ConsensusResult<Option<TrustedCommit>>;
 
@@ -138,6 +146,7 @@ pub(crate) struct WriteBatch {
     pub(crate) block_headers: Vec<VerifiedBlockHeader>,
     pub(crate) commits: Vec<TrustedCommit>,
     pub(crate) commit_info: Vec<(CommitRef, CommitInfo)>,
+    pub(crate) scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
 }
 
 impl WriteBatch {
@@ -146,12 +155,14 @@ impl WriteBatch {
         block_headers: Vec<VerifiedBlockHeader>,
         commits: Vec<TrustedCommit>,
         commit_info: Vec<(CommitRef, CommitInfo)>,
+        scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
     ) -> Self {
         WriteBatch {
             transactions,
             block_headers,
             commits,
             commit_info,
+            scoring_metrics,
         }
     }
 
@@ -178,6 +189,15 @@ impl WriteBatch {
     #[cfg(test)]
     pub(crate) fn commit_info(mut self, commit_info: Vec<(CommitRef, CommitInfo)>) -> Self {
         self.commit_info = commit_info;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn scoring_metrics(
+        mut self,
+        scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
+    ) -> Self {
+        self.scoring_metrics = scoring_metrics;
         self
     }
 }

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -5,6 +5,7 @@
 use std::{ops::Bound::Included, time::Duration};
 
 use bytes::Bytes;
+use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
 use iota_macros::fail_point;
 use starfish_config::AuthorityIndex;
 use tracing::debug;
@@ -41,6 +42,8 @@ pub(crate) struct RocksDBStore {
     commit_votes: DBMap<(CommitIndex, CommitDigest, BlockRef), ()>,
     /// Stores info related to Commit that helps recovery.
     commit_info: DBMap<(CommitIndex, CommitDigest), CommitInfo>,
+    /// Stores scoring metrics for each authority.
+    scoring_metrics: DBMap<AuthorityIndex, VersionedStorageScoringMetrics>,
 }
 
 impl RocksDBStore {
@@ -50,6 +53,7 @@ impl RocksDBStore {
     const COMMITS_CF: &'static str = "commits";
     const COMMIT_VOTES_CF: &'static str = "commit_votes";
     const COMMIT_INFO_CF: &'static str = "commit_info";
+    const SCORING_METRICS_CF: &'static str = "scoring_metrics";
 
     /// Creates a new instance of RocksDB storage.
     pub(crate) fn new(path: &str) -> Self {
@@ -80,6 +84,7 @@ impl RocksDBStore {
             (Self::COMMITS_CF, cf_options.clone()),
             (Self::COMMIT_VOTES_CF, cf_options.clone()),
             (Self::COMMIT_INFO_CF, cf_options.clone()),
+            (Self::SCORING_METRICS_CF, cf_options.clone()),
         ];
         let rocksdb = open_cf_opts(
             path,
@@ -96,13 +101,15 @@ impl RocksDBStore {
             commits,
             commit_votes,
             commit_info,
+            scoring_metrics,
         ) = reopen!(&rocksdb,
             Self::BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
             Self::TRANSACTIONS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
             Self::DIGESTS_BY_AUTHORITIES_CF;<(AuthorityIndex, Round, BlockHeaderDigest), ()>,
             Self::COMMITS_CF;<(CommitIndex, CommitDigest), Bytes>,
             Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
-            Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>
+            Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>,
+            Self::SCORING_METRICS_CF;<AuthorityIndex, VersionedStorageScoringMetrics>
         );
 
         Self {
@@ -112,6 +119,7 @@ impl RocksDBStore {
             commits,
             commit_votes,
             commit_info,
+            scoring_metrics,
         }
     }
 }
@@ -185,6 +193,12 @@ impl Store for RocksDBStore {
                     &self.commit_info,
                     [((commit_ref.index, commit_ref.digest), commit_info)],
                 )
+                .map_err(ConsensusError::RocksDBFailure)?;
+        }
+
+        for (authority, metrics) in write_batch.scoring_metrics {
+            batch
+                .insert_batch(&self.scoring_metrics, [(authority, metrics)])
                 .map_err(ConsensusError::RocksDBFailure)?;
         }
 
@@ -429,6 +443,16 @@ impl Store for RocksDBStore {
             );
         }
         Ok(blocks)
+    }
+
+    fn scan_scoring_metrics(
+        &self,
+    ) -> ConsensusResult<Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>> {
+        let mut metrics_by_author = vec![];
+        for kv in self.scoring_metrics.safe_iter() {
+            metrics_by_author.push(kv?);
+        }
+        Ok(metrics_by_author)
     }
 
     fn read_last_commit(&self) -> ConsensusResult<Option<TrustedCommit>> {

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -474,3 +474,67 @@ async fn read_and_scan_commits(
         assert_eq!(scanned_commits, written_commits,);
     }
 }
+
+#[rstest]
+#[tokio::test]
+async fn scan_scoring_metrics(
+    #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
+) {
+    use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
+
+    let store = test_store.store();
+    let metrics_updates = [
+        VersionedStorageScoringMetrics::new_v1_for_test(
+            1, // faulty_blocks_provable
+            2, // faulty_blocks_unprovable
+            4, // missing_proposals
+            3, // equivocations
+        ),
+        VersionedStorageScoringMetrics::new_v1_for_test(
+            0, // faulty_blocks_provable
+            0, // faulty_blocks_unprovable
+            0, // missing_proposals
+            0, // equivocations
+        ),
+    ];
+    let authories = [
+        AuthorityIndex::new_for_test(0),
+        AuthorityIndex::new_for_test(1),
+        AuthorityIndex::new_for_test(2),
+    ];
+
+    let metrics_to_write = vec![
+        (authories[0], metrics_updates[0].clone()),
+        (authories[1], metrics_updates[1].clone()),
+    ];
+
+    store
+        .write(WriteBatch::default().scoring_metrics(metrics_to_write.clone()))
+        .unwrap();
+
+    {
+        let scanned_metrics = store
+            .scan_scoring_metrics()
+            .expect("Scan scoring_metrics should not fail");
+        assert_eq!(&scanned_metrics, &metrics_to_write);
+    }
+
+    let metrics_to_write = vec![(authories[0], metrics_updates[1].clone())];
+
+    store
+        .write(WriteBatch::default().scoring_metrics(metrics_to_write.clone()))
+        .unwrap();
+
+    {
+        let scanned_metrics = store
+            .scan_scoring_metrics()
+            .expect("Scan scoring_metrics should not fail");
+        assert_eq!(
+            &scanned_metrics,
+            &vec![
+                (authories[0], metrics_updates[1].clone()),
+                (authories[1], metrics_updates[1].clone())
+            ]
+        );
+    }
+}

--- a/crates/starfish/core/src/threshold_clock.rs
+++ b/crates/starfish/core/src/threshold_clock.rs
@@ -103,7 +103,7 @@ mod tests {
     use starfish_config::AuthorityIndex;
 
     use super::*;
-    use crate::block_header::BlockHeaderDigest;
+    use crate::{block_header::BlockHeaderDigest, scoring_metrics_store::ScoringMetricsStore};
 
     #[tokio::test]
     async fn test_threshold_clock_add_block() {
@@ -256,6 +256,11 @@ mod tests {
         let (committee, _) = starfish_config::local_committee_and_keys(0, vec![5, 1, 1]);
         let metrics = test_metrics();
         let temp_dir = TempDir::new().unwrap();
+        let protocol_config = iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE();
+        let scoring_metrics_store = Arc::new(ScoringMetricsStore::dummy_for_test(
+            committee.size(),
+            &protocol_config,
+        ));
 
         let context = Arc::new(crate::context::Context::new(
             0,
@@ -265,8 +270,9 @@ mod tests {
                 db_path: temp_dir.keep(),
                 ..Default::default()
             },
-            iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE(),
+            protocol_config,
             metrics,
+            scoring_metrics_store,
             Arc::new(crate::context::Clock::default()),
         ));
 

--- a/crates/starfish/simtests/Cargo.toml
+++ b/crates/starfish/simtests/Cargo.toml
@@ -23,6 +23,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 
 # internal dependencies
+iota-common.workspace = true
 iota-config.workspace = true
 iota-macros.workspace = true
 iota-metrics.workspace = true

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -9,6 +9,7 @@ use std::{
 
 use anyhow::Result;
 use arc_swap::ArcSwapOption;
+use iota_common::scoring_metrics::VersionedScoringMetrics;
 use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
 use iota_protocol_config::{ConsensusNetwork, ProtocolConfig};
 use parking_lot::Mutex;
@@ -271,6 +272,10 @@ pub(crate) async fn make_authority(
 
     let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
 
+    let current_local_metrics_count = Arc::new(VersionedScoringMetrics::new(
+        committee.size(),
+        &protocol_config,
+    ));
     let commit_consumer = CommitConsumer::new(commit_sender, 0);
     let commit_consumer_monitor = commit_consumer.monitor();
 
@@ -286,6 +291,7 @@ pub(crate) async fn make_authority(
         Arc::new(txn_verifier),
         commit_consumer,
         registry,
+        current_local_metrics_count,
         boot_counter,
     )
     .await;


### PR DESCRIPTION
## Intent (clean summary, separate from the polluted current diff)

> The current PR diff includes a large amount of unrelated upstream churn because the branch has not been rebased onto current `develop` after the Starfish migration / scorer refactor. The summary below extracts the actual scoring-related intent from Olivia's commits.

Make the Starfish `ScoringMetricsStore` durable across restarts and drive updates from DAG-state eviction. Three pillars:

### 1. Eviction-driven updates (Starfish)
- When `DagState::flush()` runs, compute scoring-metric deltas from blocks about to be evicted and persist them via the `ScoringMetricsStore`.
- Main commit: `e7e713a5` — `+748` in `crates/starfish/core/src/scoring_metrics_store.rs`, `+28` in `dag_state.rs`.

### 2. Recovery from storage on restart (Starfish)
- Initialize the in-memory `ScoringMetricsStore` from persisted storage at authority start, so accumulated metrics survive restart.
- Main commit: `b0c90991` — `+226` in `scoring_metrics_store.rs`, `+14` in `dag_state.rs`.

### 3. Persistent storage layer for metrics (Starfish)
- Add a scoring-metrics column to the starfish storage layer (mem + rocksdb) with versioned encoding so the on-disk format can evolve.
- Commits: `1eb6f6bc` (storage scaffolding +139 across `mem_store`/`rocksdb_store`/`mod`/`store_tests`), `29eadd87` (small follow-up).

### 4. Simtest + comment polish
- `a6c7be16` — wire the new dependency into starfish simtests.
- `9c6be669` — comments.

## Out-of-scope / will drop on rebase

These commits parallel the work in the **consensus** (Mysticeti) crate or in `iota-types` and are obsolete because:
- **Mysticeti is gone from `develop`** — all `consensus/core/*` changes (`2ea2f09a` versioned storage type, `791d4649` versioned update methods, `67707fc9` type relocation, `e1d5d574` `MisbehaviorsV1` alias) drop out on rebase.
- **`iota-types` / `iota-core/scorer.rs` refactor is already absorbed** by PR #10779 (scorer refactoring): commit `97c57229` ("new misbehavior count module") overlaps heavily with the new `MisbehaviorObservations` introduced there. `548ba3f5` (iterator tests) needs to be re-targeted at the post-refactor types.

## Tracking

- Issue: https://github.com/iotaledger/iota-private/issues/278
- Part of feature branch: https://github.com/iotaledger/iota/pull/10083
- Depends on: #10086 (`ScoringMetricsStore` skeleton), #10088 (storage scaffolding)

## Re-application plan

1. Starfish-side changes (pillars 1, 2, 3, 4) port mechanically once #10086 + #10088 are landed on top of #10779.
2. `iota-core/authority/scorer.rs` and `iota-types` slices need rewriting against `Scoreboard` / `ReportAggregator` / `VersionedMisbehaviorReport` from #10779 — not a rebase.
3. `consensus/core/*` slice is dropped.