### PR TITLE
fix(iota-data-ingestion-core): stop downloading checkpoints once shutdown is triggered

### DIFF
--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -300,14 +300,24 @@ impl CheckpointReaderActor {
                     .pipe(futures::stream::iter)
                     .buffered(batch_size);
 
-                while let Some(checkpoint_result) = checkpoint_stream.next().await {
+                while let Some(checkpoint_result) = self
+                    .token
+                    .run_until_cancelled(checkpoint_stream.next())
+                    .await
+                    .flatten()
+                {
                     let (checkpoint, size) = checkpoint_result?;
                     self.send_remote_checkpoint_with_capacity_check(checkpoint, size)
                         .await?;
                 }
             }
             RemoteStore::HybridHistoricalStore { historical, live } => {
-                if let Err(err) = self.fetch_historical(historical).await {
+                if let Some(Err(err)) = self
+                    .token
+                    .clone()
+                    .run_until_cancelled(self.fetch_historical(historical))
+                    .await
+                {
                     if matches!(err, IngestionError::CheckpointNotAvailableYet) {
                         let live = live.as_ref().ok_or(err)?;
                         let mut checkpoint_stream = (self.current_checkpoint_number..u64::MAX)
@@ -317,7 +327,12 @@ impl CheckpointReaderActor {
                             .pipe(futures::stream::iter)
                             .buffered(batch_size);
 
-                        while let Some(checkpoint_result) = checkpoint_stream.next().await {
+                        while let Some(checkpoint_result) = self
+                            .token
+                            .run_until_cancelled(checkpoint_stream.next())
+                            .await
+                            .flatten()
+                        {
                             let (checkpoint, size) = checkpoint_result?;
                             self.send_remote_checkpoint_with_capacity_check(checkpoint, size)
                                 .await?;
@@ -356,7 +371,14 @@ impl CheckpointReaderActor {
                                 duration.as_millis(),
                             );
                         }
-                        tokio::time::sleep(duration).await
+                        if self
+                            .token
+                            .run_until_cancelled(tokio::time::sleep(duration))
+                            .await
+                            .is_none()
+                        {
+                            break;
+                        }
                     }
                     None => {
                         break error!("remote reader transient error {err:?}");
@@ -378,9 +400,7 @@ impl CheckpointReaderActor {
         checkpoint: Arc<CheckpointData>,
         size: usize,
     ) -> IngestionResult<()> {
-        if self.exceeds_capacity(checkpoint.checkpoint_summary.sequence_number)
-            || self.token.is_cancelled()
-        {
+        if self.exceeds_capacity(checkpoint.checkpoint_summary.sequence_number) {
             return Err(IngestionError::MaxCheckpointsCapacityReached);
         }
         self.data_limiter.add(&checkpoint, size);

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -21,13 +21,11 @@ use object_store::ObjectStore;
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 use tokio::{
-    sync::{
-        mpsc::{self},
-        oneshot,
-    },
+    sync::mpsc::{self},
     task::JoinHandle,
     time::timeout,
 };
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
 #[cfg(not(target_os = "macos"))]
@@ -182,8 +180,8 @@ struct CheckpointReaderActor {
     gc_signal_rx: mpsc::Receiver<CheckpointSequenceNumber>,
     /// Remote checkpoint reader for fetching checkpoints from the network.
     remote_store: Option<Arc<RemoteStore>>,
-    /// Signal when the reader should exit.
-    shutdown_rx: oneshot::Receiver<()>,
+    /// Shutdown signal for the actor.
+    token: CancellationToken,
     /// Configures the behavior of the checkpoint reader.
     reader_options: ReaderOptions,
     /// Limit the amount of downloaded checkpoints held in memory to avoid OOM.
@@ -380,7 +378,9 @@ impl CheckpointReaderActor {
         checkpoint: Arc<CheckpointData>,
         size: usize,
     ) -> IngestionResult<()> {
-        if self.exceeds_capacity(checkpoint.checkpoint_summary.sequence_number) {
+        if self.exceeds_capacity(checkpoint.checkpoint_summary.sequence_number)
+            || self.token.is_cancelled()
+        {
             return Err(IngestionError::MaxCheckpointsCapacityReached);
         }
         self.data_limiter.add(&checkpoint, size);
@@ -465,7 +465,7 @@ impl CheckpointReaderActor {
 
         loop {
             tokio::select! {
-                _ = &mut self.shutdown_rx => break,
+                _ = self.token.cancelled() => break,
                 Some(watermark) = self.gc_signal_rx.recv() => {
                     self.data_limiter.gc(watermark);
                     self.gc_processed_files(watermark).expect("failed to clean the directory");
@@ -486,9 +486,9 @@ impl CheckpointReaderActor {
 /// the actual checkpoint fetching and streaming logic.
 pub(crate) struct CheckpointReader {
     handle: JoinHandle<()>,
-    shutdown_tx: oneshot::Sender<()>,
     gc_signal_tx: mpsc::Sender<CheckpointSequenceNumber>,
     checkpoint_rx: mpsc::Receiver<Arc<CheckpointData>>,
+    token: CancellationToken,
 }
 
 impl CheckpointReader {
@@ -498,7 +498,6 @@ impl CheckpointReader {
     ) -> IngestionResult<Self> {
         let (checkpoint_tx, checkpoint_rx) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         let (gc_signal_tx, gc_signal_rx) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
         let remote_store = if let Some(url) = config.remote_store_url {
             Some(Arc::new(
@@ -517,7 +516,7 @@ impl CheckpointReader {
             Some(p) => p,
             None => tempfile::tempdir()?.keep(),
         };
-
+        let token = CancellationToken::new();
         let reader = CheckpointReaderActor {
             path,
             current_checkpoint_number: starting_checkpoint_number,
@@ -525,7 +524,7 @@ impl CheckpointReader {
             checkpoint_tx,
             gc_signal_rx,
             remote_store,
-            shutdown_rx,
+            token: token.clone(),
             data_limiter: DataLimiter::new(config.reader_options.data_limit),
             reader_options: config.reader_options,
         };
@@ -535,8 +534,8 @@ impl CheckpointReader {
         Ok(Self {
             handle,
             gc_signal_tx,
-            shutdown_tx,
             checkpoint_rx,
+            token,
         })
     }
 
@@ -568,7 +567,7 @@ impl CheckpointReader {
     /// awaits its completion. Any in-progress checkpoint reading or streaming
     /// operations will be stopped as part of the shutdown process.
     pub(crate) async fn shutdown(self) -> IngestionResult<()> {
-        _ = self.shutdown_tx.send(());
+        self.token.cancel();
         self.handle.await.map_err(|err| IngestionError::Shutdown {
             component: "checkpoint reader".into(),
             msg: err.to_string(),


### PR DESCRIPTION
# Description of change

This patch fixes a bug in the CheckpointReader V2 where upon shutting down it would not respect it and keep downloading  checkpoints until the `LocalReade::exceeds_capacity` would resolve to true, subsequently make the `self.sync().await` to finish execution when lastly the `tokio::select` would check for shutdown signal.

## Links to any relevant issues

fixes #10129 

## How the change has been tested

- started the `live` service locally, since this bug was most noticeable in this particular use case.
- while syncing checkpoints from current epoch on testnet, the user would start the shutdown process by pressing `CRL+C`, Once all worker pools finished processing checkpoints the `CheckpointReader` V2 upon receiving the shutdown signal exists the `self.sync().await` promptly and subsequently terminates its operation.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch doe snot affect the normal operation of the indexer, thus no further tests were conducted. 
