### PR TITLE
feat(gRPC): error propagation to the user instead of silent error

### DIFF
--- a/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
@@ -139,11 +139,13 @@ pub(crate) fn get_checkpoint_data(
             service
                 .reader
                 .get_checkpoint_sequence_number_by_digest(&digest)
+                .map_err(|e| Status::internal(format!("failed to get checkpoint by digest: {e}")))?
                 .ok_or(Status::not_found("checkpoint not found"))?
         }
         Some(grpc_ledger_service::get_checkpoint_data_request::CheckpointId::Latest(_)) => service
             .reader
             .get_latest_checkpoint_sequence_number()
+            .map_err(|e| Status::internal(format!("failed to get latest checkpoint: {e}")))?
             .ok_or(Status::not_found("latest checkpoint not found"))?,
         None => {
             return Err(Status::invalid_argument("checkpoint_id must be provided").into());

--- a/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
@@ -68,7 +68,11 @@ pub fn get_epoch(
         message.epoch = Some(epoch);
     }
 
-    if let Some(epoch_info) = service.reader.get_epoch_info(epoch) {
+    if let Some(epoch_info) = service
+        .reader
+        .get_epoch_info(epoch)
+        .map_err(|e| Status::internal(format!("Failed to get epoch info: {e}")))?
+    {
         if read_mask.contains(Epoch::FIRST_CHECKPOINT_FIELD.name) {
             message.first_checkpoint = Some(epoch_info.start_checkpoint);
         }
@@ -108,9 +112,10 @@ pub fn get_epoch(
 
     if let Some(system_state) = system_state {
         if read_mask.contains(Epoch::BCS_SYSTEM_STATE_FIELD.name) {
-            if let Ok(bcs_data) = BcsData::serialize(&system_state) {
-                message.bcs_system_state = Some(bcs_data);
-            }
+            message.bcs_system_state =
+                Some(BcsData::serialize(&system_state).map_err(|e| {
+                    Status::internal(format!("Failed to serialize system state: {e}"))
+                })?);
         }
     }
 

--- a/crates/iota-grpc-server/src/ledger_service/get_objects.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_objects.rs
@@ -129,11 +129,11 @@ fn get_object_impl(
 ) -> Result<Object, RpcError> {
     let object = if let Some(version) = version {
         reader
-            .get_object_by_key(&object_id, version.into())
+            .get_object_by_key(&object_id, version.into())?
             .ok_or_else(|| ObjectNotFoundError::new_with_version(object_id, version))?
     } else {
         reader
-            .get_object(&object_id)
+            .get_object(&object_id)?
             .ok_or_else(|| ObjectNotFoundError::new(object_id))?
     };
 

--- a/crates/iota-grpc-server/src/merge.rs
+++ b/crates/iota-grpc-server/src/merge.rs
@@ -177,7 +177,7 @@ impl Merge<iota_sdk_types::UserSignature> for UserSignature {
         mask: &FieldMaskTree,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = BcsData::serialize(&source).ok();
+            self.bcs = Some(BcsData::serialize(&source)?);
         }
 
         Ok(())
@@ -291,7 +291,7 @@ impl Merge<&iota_sdk_types::Event> for Event {
         mask: &FieldMaskTree,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = BcsData::serialize(&source).ok();
+            self.bcs = Some(BcsData::serialize(&source)?);
         }
 
         if mask.contains(Self::PACKAGE_ID_FIELD.name) {
@@ -358,7 +358,7 @@ impl Merge<&iota_sdk_types::object::Object> for Object {
         mask: &FieldMaskTree,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = BcsData::serialize(source).ok();
+            self.bcs = Some(BcsData::serialize(source)?);
         }
 
         if mask.contains(Self::REFERENCE_FIELD.name) {
@@ -461,7 +461,7 @@ impl Merge<iota_sdk_types::CheckpointSummary> for CheckpointSummary {
         mask: &FieldMaskTree,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = BcsData::serialize(&source).ok();
+            self.bcs = Some(BcsData::serialize(&source)?);
         }
 
         if mask.contains(Self::DIGEST_FIELD.name) {
@@ -500,7 +500,7 @@ impl Merge<iota_sdk_types::CheckpointContents> for CheckpointContents {
     ) -> Result<(), Box<dyn std::error::Error>> {
         if mask.contains(Self::BCS_FIELD.name) {
             // TODO: add version
-            self.bcs = BcsData::serialize(&source).ok();
+            self.bcs = Some(BcsData::serialize(&source)?);
         }
 
         if mask.contains(Self::DIGEST_FIELD.name) {
@@ -646,7 +646,7 @@ impl Merge<&iota_sdk_types::TransactionEffects> for TransactionEffects {
 
         // Set BCS if requested
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = BcsData::serialize(source).ok();
+            self.bcs = Some(BcsData::serialize(source)?);
         }
 
         Ok(())

--- a/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
@@ -115,7 +115,7 @@ impl Merge<&TransactionReadSource<'_>> for grpc_tx::Transaction {
 
         // Set BCS if requested
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = grpc_bcs::BcsData::serialize(transaction).ok();
+            self.bcs = Some(grpc_bcs::BcsData::serialize(transaction)?);
         }
 
         Ok(())

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -134,30 +134,45 @@ pub type CheckpointStreamResult = Result<grpc_ledger_service::CheckpointData, St
 // making it easier to implement gRPC services with different storage types
 // (e.g., production database vs simulacrum for testing).
 
-/// Trait for reading checkpoint data from storage
+/// Trait for reading checkpoint data from storage.
+///
+/// All methods return `anyhow::Result<Option<T>>` for consistency:
+/// - `Ok(Some(value))`: The item was found
+/// - `Ok(None)`: The item does not exist (expected case)
+/// - `Err(e)`: A storage or other error occurred (unexpected)
 pub trait GrpcStateReader: Send + Sync + 'static {
-    /// Get the chain identifier
+    /// Get the chain identifier.
+    /// Returns `Err` on storage errors.
     fn get_chain_identifier(&self) -> anyhow::Result<iota_types::digests::ChainIdentifier>;
 
-    /// Get the latest checkpoint sequence number
-    fn get_latest_checkpoint_sequence_number(&self) -> Option<u64>;
+    /// Get the latest checkpoint sequence number.
+    /// Returns `Ok(None)` if no checkpoints exist yet (e.g., during startup).
+    fn get_latest_checkpoint_sequence_number(&self) -> anyhow::Result<Option<u64>>;
 
-    /// Get checkpoint summary by sequence number
-    fn get_checkpoint_summary(&self, seq: u64) -> Option<CertifiedCheckpointSummary>;
+    /// Get checkpoint summary by sequence number.
+    /// Returns `Ok(None)` if the checkpoint doesn't exist.
+    fn get_checkpoint_summary(
+        &self,
+        seq: u64,
+    ) -> anyhow::Result<Option<CertifiedCheckpointSummary>>;
 
-    /// Get checkpoint sequence number by digest
+    /// Get checkpoint sequence number by digest.
+    /// Returns `Ok(None)` if the checkpoint doesn't exist.
     fn get_checkpoint_sequence_number_by_digest(
         &self,
         digest: &iota_types::digests::CheckpointDigest,
-    ) -> Option<u64>;
+    ) -> anyhow::Result<Option<u64>>;
 
-    /// Get full checkpoint data by sequence number
-    fn get_checkpoint_data(&self, seq: u64) -> Option<IotaTypesCheckpointData>;
+    /// Get full checkpoint data by sequence number.
+    /// Returns `Ok(None)` if the checkpoint doesn't exist.
+    fn get_checkpoint_data(&self, seq: u64) -> anyhow::Result<Option<IotaTypesCheckpointData>>;
 
+    /// Get checkpoint summary and contents by sequence number.
+    /// Returns `Ok(None)` if the checkpoint doesn't exist.
     fn get_checkpoint_summary_and_contents(
         &self,
         seq: u64,
-    ) -> Option<(CertifiedCheckpointSummary, CheckpointContents)>;
+    ) -> anyhow::Result<Option<(CertifiedCheckpointSummary, CheckpointContents)>>;
 
     /// Stream checkpoint transactions individually to avoid large memory
     /// footprint. Returns a stream of individual CheckpointTransaction items
@@ -169,56 +184,80 @@ pub trait GrpcStateReader: Send + Sync + 'static {
         Box<dyn futures::Stream<Item = anyhow::Result<IotaTypesCheckpointTransaction>> + Send + '_>,
     >;
 
-    /// Get epoch's last checkpoint for epoch boundary calculations
+    /// Get epoch's last checkpoint for epoch boundary calculations.
+    /// Returns `Ok(None)` if the epoch doesn't exist or hasn't ended.
     fn get_epoch_last_checkpoint(
         &self,
         epoch: u64,
     ) -> anyhow::Result<Option<CertifiedCheckpointSummary>>;
 
     /// Get the lowest available checkpoint for which checkpoint and transaction
-    /// data are available
+    /// data are available.
     fn get_lowest_available_checkpoint(&self) -> anyhow::Result<u64>;
 
-    /// Get the lowest available checkpoint for which object data is available
+    /// Get the lowest available checkpoint for which object data is available.
     fn get_lowest_available_checkpoint_objects(&self) -> anyhow::Result<u64>;
 
-    /// Get an object by its ObjectID
-    fn get_object(&self, object_id: &ObjectID) -> Option<Object>;
+    /// Get an object by its ObjectID.
+    /// Returns `Ok(None)` if the object doesn't exist.
+    fn get_object(&self, object_id: &ObjectID) -> anyhow::Result<Option<Object>>;
 
-    /// Get an object by its ObjectID and version
-    fn get_object_by_key(&self, object_id: &ObjectID, version: VersionNumber) -> Option<Object>;
+    /// Get an object by its ObjectID and version.
+    /// Returns `Ok(None)` if the object at that version doesn't exist.
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> anyhow::Result<Option<Object>>;
 
-    /// Get committee for a specific epoch
+    /// Get committee for a specific epoch.
+    /// Returns `Ok(None)` if the epoch doesn't exist.
     fn get_committee(
         &self,
         epoch: u64,
     ) -> anyhow::Result<Option<Arc<iota_types::committee::Committee>>>;
 
-    /// Get the IOTA system state
-    /// This loads the system state including its dynamic fields
+    /// Get the IOTA system state.
+    /// This loads the system state including its dynamic fields.
     fn get_system_state(&self) -> anyhow::Result<iota_types::iota_system_state::IotaSystemState>;
 
-    /// Get indexed epoch information
-    fn get_epoch_info(&self, epoch: u64) -> Option<iota_types::storage::EpochInfo>;
+    /// Get indexed epoch information.
+    /// Returns `Ok(None)` if the epoch is not found, `Err` on storage errors.
+    fn get_epoch_info(&self, epoch: u64) -> anyhow::Result<Option<iota_types::storage::EpochInfo>>;
 
-    /// Get the Move type layout for a given TypeTag
+    /// Get the Move type layout for a given TypeTag.
+    /// Returns `Ok(None)` if the layout is not available.
     fn get_type_layout(
         &self,
         type_tag: &iota_types::TypeTag,
-    ) -> Result<Option<move_core_types::annotated_value::MoveTypeLayout>>;
+    ) -> anyhow::Result<Option<move_core_types::annotated_value::MoveTypeLayout>>;
 
-    /// Get a transaction by its digest
-    fn get_transaction(&self, digest: &TransactionDigest) -> Option<Arc<VerifiedTransaction>>;
+    /// Get a transaction by its digest.
+    /// Returns `Ok(None)` if the transaction doesn't exist.
+    fn get_transaction(
+        &self,
+        digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<Arc<VerifiedTransaction>>>;
 
-    /// Get transaction effects by digest
-    fn get_transaction_effects(&self, digest: &TransactionDigest) -> Option<TransactionEffects>;
+    /// Get transaction effects by digest.
+    /// Returns `Ok(None)` if the effects don't exist.
+    fn get_transaction_effects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<TransactionEffects>>;
 
-    /// Get transaction events by event digest
-    fn get_transaction_events(&self, digest: &TransactionEventsDigest)
-    -> Option<TransactionEvents>;
+    /// Get transaction events by event digest.
+    /// Returns `Ok(None)` if the events don't exist.
+    fn get_transaction_events(
+        &self,
+        digest: &TransactionEventsDigest,
+    ) -> anyhow::Result<Option<TransactionEvents>>;
 
-    /// Get checkpoint sequence number for a transaction
-    fn get_transaction_checkpoint(&self, digest: &TransactionDigest) -> Option<u64>;
+    /// Get checkpoint sequence number for a transaction.
+    /// Returns `Ok(None)` if the transaction is not found, `Err` on storage
+    /// errors.
+    fn get_transaction_checkpoint(&self, digest: &TransactionDigest)
+    -> anyhow::Result<Option<u64>>;
 }
 
 /// Adapter that implements GrpcStateReader for RestStateReader
@@ -231,47 +270,62 @@ impl GrpcStateReader for RestStateReaderAdapter {
         self.inner.get_chain_identifier().map_err(Into::into)
     }
 
-    fn get_latest_checkpoint_sequence_number(&self) -> Option<u64> {
+    fn get_latest_checkpoint_sequence_number(&self) -> anyhow::Result<Option<u64>> {
         match self.inner.try_get_latest_checkpoint() {
-            Ok(checkpoint) => Some(*checkpoint.sequence_number()),
+            Ok(checkpoint) => Ok(Some(*checkpoint.sequence_number())),
             Err(e) => match e.kind() {
                 // Expected during server initialization when no checkpoints have been executed yet
-                // Return None to indicate service is not ready rather than panicking
-                Kind::Missing => None,
-                // Unexpected storage errors
-                _ => panic!("Unexpected storage error: {e}"),
+                // Return None to indicate service is not ready
+                Kind::Missing => Ok(None),
+                // Unexpected storage errors - propagate instead of panicking
+                _ => Err(anyhow::anyhow!(
+                    "Storage error getting latest checkpoint: {e}"
+                )),
             },
         }
     }
 
-    fn get_checkpoint_summary(&self, seq: u64) -> Option<CertifiedCheckpointSummary> {
-        self.inner
+    fn get_checkpoint_summary(
+        &self,
+        seq: u64,
+    ) -> anyhow::Result<Option<CertifiedCheckpointSummary>> {
+        Ok(self
+            .inner
             .get_checkpoint_by_sequence_number(seq)
-            .map(CertifiedCheckpointSummary::from)
+            .map(CertifiedCheckpointSummary::from))
     }
 
     fn get_checkpoint_sequence_number_by_digest(
         &self,
         digest: &iota_types::digests::CheckpointDigest,
-    ) -> Option<u64> {
-        self.inner
+    ) -> anyhow::Result<Option<u64>> {
+        Ok(self
+            .inner
             .get_checkpoint_by_digest(digest)
-            .map(|checkpoint| *checkpoint.sequence_number())
+            .map(|checkpoint| *checkpoint.sequence_number()))
     }
 
     fn get_checkpoint_summary_and_contents(
         &self,
         seq: u64,
-    ) -> Option<(CertifiedCheckpointSummary, CheckpointContents)> {
-        let summary = self.inner.get_checkpoint_by_sequence_number(seq)?;
-        let contents = self.inner.get_checkpoint_contents_by_sequence_number(seq)?;
-        Some((CertifiedCheckpointSummary::from(summary), contents))
+    ) -> anyhow::Result<Option<(CertifiedCheckpointSummary, CheckpointContents)>> {
+        let Some(summary) = self.inner.get_checkpoint_by_sequence_number(seq) else {
+            return Ok(None);
+        };
+        let Some(contents) = self.inner.get_checkpoint_contents_by_sequence_number(seq) else {
+            return Ok(None);
+        };
+        Ok(Some((CertifiedCheckpointSummary::from(summary), contents)))
     }
 
-    fn get_checkpoint_data(&self, seq: u64) -> Option<IotaTypesCheckpointData> {
-        let summary = self.inner.get_checkpoint_by_sequence_number(seq)?;
-        let contents = self.inner.get_checkpoint_contents_by_sequence_number(seq)?;
-        Some(self.inner.get_checkpoint_data(summary, contents))
+    fn get_checkpoint_data(&self, seq: u64) -> anyhow::Result<Option<IotaTypesCheckpointData>> {
+        let Some(summary) = self.inner.get_checkpoint_by_sequence_number(seq) else {
+            return Ok(None);
+        };
+        let Some(contents) = self.inner.get_checkpoint_contents_by_sequence_number(seq) else {
+            return Ok(None);
+        };
+        Ok(Some(self.inner.get_checkpoint_data(summary, contents)))
     }
 
     fn stream_checkpoint_transactions(
@@ -307,12 +361,16 @@ impl GrpcStateReader for RestStateReaderAdapter {
             .map_err(Into::into)
     }
 
-    fn get_object(&self, object_id: &ObjectID) -> Option<Object> {
-        self.inner.get_object(object_id)
+    fn get_object(&self, object_id: &ObjectID) -> anyhow::Result<Option<Object>> {
+        Ok(self.inner.get_object(object_id))
     }
 
-    fn get_object_by_key(&self, object_id: &ObjectID, version: VersionNumber) -> Option<Object> {
-        self.inner.get_object_by_key(object_id, version)
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> anyhow::Result<Option<Object>> {
+        Ok(self.inner.get_object_by_key(object_id, version))
     }
 
     fn get_committee(
@@ -329,42 +387,52 @@ impl GrpcStateReader for RestStateReaderAdapter {
             .map_err(Into::into)
     }
 
-    fn get_epoch_info(&self, epoch: u64) -> Option<iota_types::storage::EpochInfo> {
-        self.inner
-            .indexes()
-            .and_then(|indexes| indexes.get_epoch_info(epoch).ok().flatten())
+    fn get_epoch_info(&self, epoch: u64) -> anyhow::Result<Option<iota_types::storage::EpochInfo>> {
+        match self.inner.indexes() {
+            Some(indexes) => indexes.get_epoch_info(epoch).map_err(Into::into),
+            None => Ok(None),
+        }
     }
 
     fn get_type_layout(
         &self,
         type_tag: &iota_types::TypeTag,
-    ) -> Result<Option<move_core_types::annotated_value::MoveTypeLayout>> {
-        Ok(self.inner.get_type_layout(type_tag)?)
+    ) -> anyhow::Result<Option<move_core_types::annotated_value::MoveTypeLayout>> {
+        self.inner.get_type_layout(type_tag).map_err(Into::into)
     }
 
-    fn get_transaction(&self, digest: &TransactionDigest) -> Option<Arc<VerifiedTransaction>> {
-        self.inner.get_transaction(digest)
+    fn get_transaction(
+        &self,
+        digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<Arc<VerifiedTransaction>>> {
+        Ok(self.inner.get_transaction(digest))
     }
 
-    fn get_transaction_effects(&self, digest: &TransactionDigest) -> Option<TransactionEffects> {
-        self.inner.get_transaction_effects(digest)
+    fn get_transaction_effects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<TransactionEffects>> {
+        Ok(self.inner.get_transaction_effects(digest))
     }
 
     fn get_transaction_events(
         &self,
         digest: &TransactionEventsDigest,
-    ) -> Option<TransactionEvents> {
-        self.inner.get_events(digest)
+    ) -> anyhow::Result<Option<TransactionEvents>> {
+        Ok(self.inner.get_events(digest))
     }
 
-    fn get_transaction_checkpoint(&self, digest: &TransactionDigest) -> Option<u64> {
-        self.inner.indexes().and_then(|indexes| {
-            indexes
+    fn get_transaction_checkpoint(
+        &self,
+        digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<u64>> {
+        match self.inner.indexes() {
+            Some(indexes) => indexes
                 .get_transaction_info(digest)
-                .ok()
-                .flatten()
-                .map(|info| info.checkpoint)
-        })
+                .map(|opt| opt.map(|info| info.checkpoint))
+                .map_err(Into::into),
+            None => Ok(None),
+        }
     }
 }
 
@@ -409,7 +477,7 @@ impl GrpcReader {
     pub fn get_checkpoint_sequence_number_by_digest(
         &self,
         digest: &iota_types::digests::CheckpointDigest,
-    ) -> Option<u64> {
+    ) -> anyhow::Result<Option<u64>> {
         self.state_reader
             .get_checkpoint_sequence_number_by_digest(digest)
     }
@@ -435,28 +503,35 @@ impl GrpcReader {
     ) -> std::pin::Pin<Box<dyn futures::Stream<Item = CheckpointStreamResult> + Send>> {
         let state_reader = self.state_reader.clone();
         match state_reader.get_checkpoint_summary_and_contents(sequence_number) {
-            Some((checkpoint_summary, checkpoint_contents)) => Box::pin(async_stream::stream! {
-                let transaction_stream = state_reader.stream_checkpoint_transactions(checkpoint_contents.clone());
-                let mut checkpoint_stream = Box::pin(Self::create_checkpoint_messages_stream(
-                    state_reader.clone(),
-                    checkpoint_summary,
-                    checkpoint_contents,
-                    transaction_stream,
-                    &checkpoint_mask,
-                    transactions_mask,
-                    events_mask,
-                    max_message_size_bytes as usize,
-                    transaction_filter,
-                    event_filter,
-                ));
+            Ok(Some((checkpoint_summary, checkpoint_contents))) => {
+                Box::pin(async_stream::stream! {
+                    let transaction_stream = state_reader.stream_checkpoint_transactions(checkpoint_contents.clone());
+                    let mut checkpoint_stream = Box::pin(Self::create_checkpoint_messages_stream(
+                        state_reader.clone(),
+                        checkpoint_summary,
+                        checkpoint_contents,
+                        transaction_stream,
+                        &checkpoint_mask,
+                        transactions_mask,
+                        events_mask,
+                        max_message_size_bytes as usize,
+                        transaction_filter,
+                        event_filter,
+                    ));
 
-                while let Some(result) = checkpoint_stream.next().await {
-                    yield result;
-                }
-            }),
-            None => Box::pin(async_stream::stream! {
+                    while let Some(result) = checkpoint_stream.next().await {
+                        yield result;
+                    }
+                })
+            }
+            Ok(None) => Box::pin(async_stream::stream! {
                 yield Err(Status::not_found(format!(
                     "Checkpoint {sequence_number} not found"
+                )));
+            }),
+            Err(e) => Box::pin(async_stream::stream! {
+                yield Err(Status::internal(format!(
+                    "Failed to get checkpoint {sequence_number}: {e}"
                 )));
             }),
         }
@@ -561,30 +636,30 @@ impl GrpcReader {
                                         }
 
                                         // Convert matching event to SDK type
-                                        let sdk_event: Result<iota_sdk_types::Event, _> =
-                                            raw_event.clone().try_into();
-                                        if let Ok(event) = sdk_event {
-                                            let grpc_event = grpc_event::Event::merge_from(&event, &events_submask)
-                                                .map_err(|e| Status::internal(format!("event merge error: {e}")))?;
-                                            let event_size = grpc_event.encoded_len();
+                                        let sdk_event: iota_sdk_types::Event = raw_event
+                                            .clone()
+                                            .try_into()
+                                            .map_err(|e| Status::internal(format!("event conversion error: {e}")))?;
+                                        let grpc_event = grpc_event::Event::merge_from(&sdk_event, &events_submask)
+                                            .map_err(|e| Status::internal(format!("event merge error: {e}")))?;
+                                        let event_size = grpc_event.encoded_len();
 
-                                            // Check if adding this event would exceed limit
-                                            if events_batch_size + event_size > max_message_size_bytes && !events_batch.is_empty() {
-                                                // Yield current event batch
-                                                let events_message = grpc_ledger_service::CheckpointData {
-                                                    payload: Some(Payload::Events(grpc_event::Events {
-                                                        events: events_batch,
-                                                    })),
-                                                };
-                                                yield Ok(events_message);
+                                        // Check if adding this event would exceed limit
+                                        if events_batch_size + event_size > max_message_size_bytes && !events_batch.is_empty() {
+                                            // Yield current event batch
+                                            let events_message = grpc_ledger_service::CheckpointData {
+                                                payload: Some(Payload::Events(grpc_event::Events {
+                                                    events: events_batch,
+                                                })),
+                                            };
+                                            yield Ok(events_message);
 
-                                                // Reset event batch
-                                                events_batch = vec![grpc_event];
-                                                events_batch_size = event_size;
-                                            } else {
-                                                events_batch.push(grpc_event);
-                                                events_batch_size += event_size;
-                                            }
+                                            // Reset event batch
+                                            events_batch = vec![grpc_event];
+                                            events_batch_size = event_size;
+                                        } else {
+                                            events_batch.push(grpc_event);
+                                            events_batch_size += event_size;
                                         }
                                     }
                                 }
@@ -669,19 +744,19 @@ impl GrpcReader {
     }
 
     /// Get the latest checkpoint sequence number
-    pub fn get_latest_checkpoint_sequence_number(&self) -> Option<u64> {
+    pub fn get_latest_checkpoint_sequence_number(&self) -> anyhow::Result<Option<u64>> {
         self.state_reader.get_latest_checkpoint_sequence_number()
     }
 
     pub fn get_latest_checkpoint(&self) -> anyhow::Result<CertifiedCheckpointSummary> {
         let seq = self
             .state_reader
-            .get_latest_checkpoint_sequence_number()
+            .get_latest_checkpoint_sequence_number()?
             .ok_or_else(|| {
                 anyhow::anyhow!("Unable to determine current epoch: no checkpoints available")
             })?;
         self.state_reader
-            .get_checkpoint_summary(seq)
+            .get_checkpoint_summary(seq)?
             .ok_or_else(|| anyhow::anyhow!("Checkpoint {seq} not found"))
     }
 
@@ -693,7 +768,7 @@ impl GrpcReader {
         self.state_reader.get_lowest_available_checkpoint_objects()
     }
 
-    pub fn get_object(&self, object_id: &ObjectID) -> Option<Object> {
+    pub fn get_object(&self, object_id: &ObjectID) -> anyhow::Result<Option<Object>> {
         self.state_reader.get_object(object_id)
     }
 
@@ -701,7 +776,7 @@ impl GrpcReader {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Option<Object> {
+    ) -> anyhow::Result<Option<Object>> {
         self.state_reader.get_object_by_key(object_id, version)
     }
 
@@ -731,14 +806,17 @@ impl GrpcReader {
         Ok(summary)
     }
 
-    pub fn get_epoch_info(&self, epoch: u64) -> Option<iota_types::storage::EpochInfo> {
+    pub fn get_epoch_info(
+        &self,
+        epoch: u64,
+    ) -> anyhow::Result<Option<iota_types::storage::EpochInfo>> {
         self.state_reader.get_epoch_info(epoch)
     }
 
     pub fn get_type_layout(
         &self,
         type_tag: &iota_types::TypeTag,
-    ) -> Result<Option<move_core_types::annotated_value::MoveTypeLayout>> {
+    ) -> anyhow::Result<Option<move_core_types::annotated_value::MoveTypeLayout>> {
         self.state_reader.get_type_layout(type_tag)
     }
 
@@ -750,7 +828,8 @@ impl GrpcReader {
         end_sequence_number: Option<u64>,
         cancellation_token: CancellationToken,
         data_type_name: &'static str,
-        fetch_historical: impl Fn(Arc<dyn GrpcStateReader>, u64) -> Option<Arc<S>> + Send,
+        fetch_historical: impl Fn(Arc<dyn GrpcStateReader>, u64) -> Result<Option<Arc<S>>, Status>
+        + Send,
         get_sequence_number_live: impl Fn(&Arc<T>) -> u64 + Send,
         process_item_historical: impl Fn(
             Arc<S>,
@@ -770,7 +849,10 @@ impl GrpcReader {
     {
         let state_reader = self.state_reader.clone();
         async_stream::try_stream! {
-            let mut latest = state_reader.get_latest_checkpoint_sequence_number().unwrap_or(0);
+            let mut latest = state_reader
+                .get_latest_checkpoint_sequence_number()
+                .map_err(|e| Status::internal(format!("Failed to get latest checkpoint: {e}")))?
+                .unwrap_or(0);
             debug!("[profile][grpc] Latest checkpoint index: {latest}.");
             let (mut start, end) = match (start_sequence_number, end_sequence_number) {
                 (None, None) => (latest, u64::MAX),
@@ -782,22 +864,25 @@ impl GrpcReader {
             while start <= end {
                 // Try fetching historical data from the DB first
                 if start <= latest {
-                    if let Some(item) = fetch_historical(state_reader.clone(), start) {
-                        debug!("[profile][grpc] Fetched checkpoint {data_type_name} for index {start} from DB.");
+                    match fetch_historical(state_reader.clone(), start)? {
+                        Some(item) => {
+                            debug!("[profile][grpc] Fetched checkpoint {data_type_name} for index {start} from DB.");
 
-                        // Process the item and yield all results
-                        let mut item_stream = process_item_historical(item);
-                        while let Some(result) = item_stream.next().await {
-                            yield result?;
-                        }
+                            // Process the item and yield all results
+                            let mut item_stream = process_item_historical(item);
+                            while let Some(result) = item_stream.next().await {
+                                yield result?;
+                            }
 
-                        if start == end {
-                            break;
+                            if start == end {
+                                break;
+                            }
+                            start += 1;
+                            continue;
                         }
-                        start += 1;
-                        continue;
-                    } else {
-                        Err(Status::internal(format!("Historical checkpoint {data_type_name} missing/pruned: index={start} latest={latest}.")))?;
+                        None => {
+                            Err(Status::not_found(format!("Historical checkpoint {data_type_name} missing/pruned: index={start} latest={latest}.")))?;
+                        }
                     }
                 }
 
@@ -841,7 +926,10 @@ impl GrpcReader {
                         break;
                     }
                 }
-                latest = state_reader.get_latest_checkpoint_sequence_number().unwrap_or(start);
+                latest = state_reader
+                    .get_latest_checkpoint_sequence_number()
+                    .map_err(|e| Status::internal(format!("Failed to get latest checkpoint: {e}")))?
+                    .unwrap_or(start);
                 debug!("[profile][grpc] Updating latest checkpoint index to {latest}.");
             }
         }
@@ -881,7 +969,10 @@ impl GrpcReader {
             |reader, seq| {
                 reader
                     .get_checkpoint_summary_and_contents(seq)
-                    .map(Arc::new)
+                    .map(|opt| opt.map(Arc::new))
+                    .map_err(|e| {
+                        Status::internal(format!("Failed to get checkpoint {seq}: {e}"))
+                    })
             },
             |item| *item.checkpoint_summary.sequence_number(),
             // Historical data processor - uses transaction stream from DB
@@ -958,9 +1049,10 @@ impl GrpcReader {
 
     /// Get transaction data for a single transaction digest.
     ///
-    /// Only fetches optional fields (events, checkpoint/timestamp, objects)
-    /// when indicated by `fields`. Transaction and effects are always fetched
-    /// as they are required prerequisites.
+    /// Only fetches data from storage when indicated by `fields`, enabling
+    /// callers to skip unnecessary reads. Effects are fetched when any of
+    /// effects/events/input_objects/output_objects are requested since they
+    /// provide the digests and references needed to fetch those fields.
     #[tracing::instrument(skip(self))]
     pub fn get_transaction_read(
         &self,
@@ -971,7 +1063,7 @@ impl GrpcReader {
             // Get the transaction if transaction data or signatures are requested
             let transaction = self
                 .state_reader
-                .get_transaction(digest)
+                .get_transaction(digest)?
                 .ok_or(crate::error::TransactionNotFoundError(*digest))?;
 
             let transaction_data = fields
@@ -996,18 +1088,31 @@ impl GrpcReader {
         };
 
         let (checkpoint, timestamp_ms) = if fields.include_checkpoint || fields.include_timestamp {
-            let checkpoint = self.state_reader.get_transaction_checkpoint(digest);
+            let checkpoint = self.state_reader.get_transaction_checkpoint(digest)?;
 
-            let timestamp_ms = fields
-                .include_timestamp
-                .then(|| {
-                    checkpoint.and_then(|checkpoint_seq| {
-                        self.state_reader
-                            .get_checkpoint_summary(checkpoint_seq)
-                            .map(|summary| summary.data().timestamp_ms)
-                    })
-                })
-                .flatten();
+            let timestamp_ms = if fields.include_timestamp {
+                match checkpoint {
+                    Some(checkpoint_seq) => {
+                        let summary = self
+                            .state_reader
+                            .get_checkpoint_summary(checkpoint_seq)?
+                            .ok_or_else(|| {
+                                crate::error::RpcError::new(
+                                    tonic::Code::Internal,
+                                    format!(
+                                        "Checkpoint summary {} not found for transaction {}",
+                                        checkpoint_seq, digest
+                                    ),
+                                )
+                            })?;
+                        Some(summary.data().timestamp_ms)
+                    }
+                    // Transaction not yet included in a checkpoint
+                    None => None,
+                }
+            } else {
+                None
+            };
             (checkpoint, timestamp_ms)
         } else {
             (None, None)
@@ -1024,42 +1129,49 @@ impl GrpcReader {
             // any of those are requested
             let effects = self
                 .state_reader
-                .get_transaction_effects(digest)
+                .get_transaction_effects(digest)?
                 .ok_or(crate::error::TransactionNotFoundError(*digest))?;
 
             // Get events only if requested
-            let events = fields
-                .include_events
-                .then(|| {
-                    effects.events_digest().and_then(|event_digest| {
-                        self.state_reader.get_transaction_events(event_digest)
-                    })
-                })
-                .flatten();
+            let events = if fields.include_events {
+                match effects.events_digest() {
+                    Some(event_digest) => self.state_reader.get_transaction_events(event_digest)?,
+                    None => None,
+                }
+            } else {
+                None
+            };
 
             // Get input objects only if requested
-            let input_objects = fields.include_input_objects.then(|| {
-                effects
-                    .modified_at_versions()
-                    .into_iter()
-                    .filter_map(|(object_id, version)| {
-                        self.state_reader.get_object_by_key(&object_id, version)
-                    })
-                    .collect()
-            });
+            let input_objects = if fields.include_input_objects {
+                let mut objects = Vec::new();
+                for (object_id, version) in effects.modified_at_versions() {
+                    if let Some(obj) = self.state_reader.get_object_by_key(&object_id, version)? {
+                        objects.push(obj);
+                    }
+                }
+                Some(objects)
+            } else {
+                None
+            };
 
             // Get output objects only if requested
-            let output_objects = fields.include_output_objects.then(|| {
-                effects
+            let output_objects = if fields.include_output_objects {
+                let mut objects = Vec::new();
+                for ((object_id, version, _digest), _owner) in effects
                     .created()
                     .into_iter()
                     .chain(effects.mutated())
                     .chain(effects.unwrapped())
-                    .filter_map(|((object_id, version, _digest), _owner)| {
-                        self.state_reader.get_object_by_key(&object_id, version)
-                    })
-                    .collect()
-            });
+                {
+                    if let Some(obj) = self.state_reader.get_object_by_key(&object_id, version)? {
+                        objects.push(obj);
+                    }
+                }
+                Some(objects)
+            } else {
+                None
+            };
 
             (Some(effects), events, input_objects, output_objects)
         } else {

--- a/crates/iota-grpc-server/src/utils.rs
+++ b/crates/iota-grpc-server/src/utils.rs
@@ -12,7 +12,12 @@ pub fn render_json(
     type_tag: &iota_types::TypeTag,
     contents: &[u8],
 ) -> Option<prost_types::Value> {
-    let layout = grpc_reader.get_type_layout(type_tag).ok().flatten()?;
+    // JSON rendering is best-effort - log errors but don't fail the request
+    let layout = grpc_reader
+        .get_type_layout(type_tag)
+        .map_err(|e| tracing::debug!("unable to get type layout for JSON rendering: {e}"))
+        .ok()
+        .flatten()?;
 
     iota_types::proto_value::ProtoVisitorBuilder::new(max_json_move_value_size)
         .deserialize_value(contents, &layout)

--- a/crates/simulacrum/src/state_reader.rs
+++ b/crates/simulacrum/src/state_reader.rs
@@ -70,45 +70,48 @@ impl GrpcStateReader for SimulacrumGrpcReader {
         Ok(self.chain_id)
     }
 
-    fn get_latest_checkpoint_sequence_number(&self) -> Option<u64> {
-        self.simulacrum.with_store(|store| {
+    fn get_latest_checkpoint_sequence_number(&self) -> Result<Option<u64>> {
+        Ok(self.simulacrum.with_store(|store| {
             store
                 .get_highest_checkpoint()
                 .map(|checkpoint| *checkpoint.sequence_number())
-        })
+        }))
     }
 
-    fn get_checkpoint_summary(&self, seq: u64) -> Option<CertifiedCheckpointSummary> {
-        self.simulacrum.with_store(|store| {
+    fn get_checkpoint_summary(&self, seq: u64) -> Result<Option<CertifiedCheckpointSummary>> {
+        Ok(self.simulacrum.with_store(|store| {
             store
                 .get_checkpoint_by_sequence_number(seq)
                 .cloned()
                 .map(CertifiedCheckpointSummary::from)
-        })
+        }))
     }
 
     fn get_checkpoint_sequence_number_by_digest(
         &self,
         digest: &iota_types::digests::CheckpointDigest,
-    ) -> Option<u64> {
-        self.simulacrum.with_store(|store| {
+    ) -> Result<Option<u64>> {
+        Ok(self.simulacrum.with_store(|store| {
             store
                 .get_checkpoint_by_digest(digest)
                 .map(|checkpoint| *checkpoint.sequence_number())
-        })
+        }))
     }
 
-    fn get_checkpoint_data(&self, seq: u64) -> Option<CheckpointData> {
+    fn get_checkpoint_data(&self, seq: u64) -> Result<Option<CheckpointData>> {
         self.simulacrum
             .with_store(|store| match store.get_checkpoint_by_sequence_number(seq) {
-                None => None,
+                None => Ok(None),
                 Some(checkpoint) => {
-                    let contents = store
+                    let Some(contents) = store
                         .get_checkpoint_contents(&checkpoint.content_digest)
-                        .cloned()?;
+                        .cloned()
+                    else {
+                        return Ok(None);
+                    };
                     store
                         .try_get_checkpoint_data(checkpoint.clone(), contents)
-                        .ok()
+                        .map(Some)
                 }
             })
     }
@@ -133,14 +136,20 @@ impl GrpcStateReader for SimulacrumGrpcReader {
         Ok(0)
     }
 
-    fn get_object(&self, object_id: &ObjectID) -> Option<Object> {
-        self.simulacrum
-            .with_store(|store| store.get_object(object_id).cloned())
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
+        Ok(self
+            .simulacrum
+            .with_store(|store| store.get_object(object_id).cloned()))
     }
 
-    fn get_object_by_key(&self, object_id: &ObjectID, version: VersionNumber) -> Option<Object> {
-        self.simulacrum
-            .with_store(|store| store.get_object_at_version(object_id, version).cloned())
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>> {
+        Ok(self
+            .simulacrum
+            .with_store(|store| store.get_object_at_version(object_id, version).cloned()))
     }
 
     fn get_committee(&self, epoch: u64) -> Result<Option<Arc<Committee>>> {
@@ -154,8 +163,8 @@ impl GrpcStateReader for SimulacrumGrpcReader {
         Ok(self.simulacrum.with_store(|store| store.get_system_state()))
     }
 
-    fn get_epoch_info(&self, epoch: u64) -> Option<EpochInfo> {
-        self.simulacrum.with_store(|store| {
+    fn get_epoch_info(&self, epoch: u64) -> Result<Option<EpochInfo>> {
+        Ok(self.simulacrum.with_store(|store| {
             // Get the start checkpoint of the epoch
             let start_checkpoint_seq = if epoch != 0 {
                 store
@@ -202,7 +211,7 @@ impl GrpcStateReader for SimulacrumGrpcReader {
                 reference_gas_price: system_state.reference_gas_price(),
                 system_state,
             })
-        })
+        }))
     }
 
     fn get_type_layout(&self, type_tag: &TypeTag) -> Result<Option<MoveTypeLayout>> {
@@ -211,26 +220,35 @@ impl GrpcStateReader for SimulacrumGrpcReader {
             .map_err(Into::into)
     }
 
-    fn get_transaction(&self, digest: &TransactionDigest) -> Option<Arc<VerifiedTransaction>> {
-        self.simulacrum
-            .with_store(|store| store.get_transaction(digest).cloned().map(Arc::new))
+    fn get_transaction(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Result<Option<Arc<VerifiedTransaction>>> {
+        Ok(self
+            .simulacrum
+            .with_store(|store| store.get_transaction(digest).cloned().map(Arc::new)))
     }
 
-    fn get_transaction_effects(&self, digest: &TransactionDigest) -> Option<TransactionEffects> {
-        self.simulacrum
-            .with_store(|store| store.get_transaction_effects(digest).cloned())
+    fn get_transaction_effects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Result<Option<TransactionEffects>> {
+        Ok(self
+            .simulacrum
+            .with_store(|store| store.get_transaction_effects(digest).cloned()))
     }
 
     fn get_transaction_events(
         &self,
         digest: &TransactionEventsDigest,
-    ) -> Option<TransactionEvents> {
-        self.simulacrum
-            .with_store(|store| store.get_transaction_events(digest).cloned())
+    ) -> Result<Option<TransactionEvents>> {
+        Ok(self
+            .simulacrum
+            .with_store(|store| store.get_transaction_events(digest).cloned()))
     }
 
-    fn get_transaction_checkpoint(&self, digest: &TransactionDigest) -> Option<u64> {
-        self.simulacrum.with_store(|store| {
+    fn get_transaction_checkpoint(&self, digest: &TransactionDigest) -> Result<Option<u64>> {
+        Ok(self.simulacrum.with_store(|store| {
             let highest_seq = store
                 .get_highest_checkpoint()
                 .map(|cp| *cp.sequence_number())?;
@@ -252,20 +270,20 @@ impl GrpcStateReader for SimulacrumGrpcReader {
                 }
             }
             None
-        })
+        }))
     }
 
     fn get_checkpoint_summary_and_contents(
         &self,
         seq: u64,
-    ) -> Option<(CertifiedCheckpointSummary, CheckpointContents)> {
-        self.simulacrum.with_store(|store| {
+    ) -> Result<Option<(CertifiedCheckpointSummary, CheckpointContents)>> {
+        Ok(self.simulacrum.with_store(|store| {
             let checkpoint = store.get_checkpoint_by_sequence_number(seq).cloned()?;
             let contents = store
                 .get_checkpoint_contents(&checkpoint.content_digest)
                 .cloned()?;
             Some((CertifiedCheckpointSummary::from(checkpoint), contents))
-        })
+        }))
     }
 
     fn stream_checkpoint_transactions(
@@ -296,11 +314,9 @@ impl GrpcStateReader for SimulacrumGrpcReader {
                         store.get_transaction_events(events_digest).cloned()
                     });
 
-                    // Extract input and output objects
-                    let input_objects =
-                        get_transaction_input_objects(store, &effects).unwrap_or_else(|_| vec![]);
-                    let output_objects =
-                        get_transaction_output_objects(store, &effects).unwrap_or_else(|_| vec![]);
+                    // Extract input and output objects with proper error propagation
+                    let input_objects = get_transaction_input_objects(store, &effects)?;
+                    let output_objects = get_transaction_output_objects(store, &effects)?;
 
                     Ok(CheckpointTransaction {
                         transaction,


### PR DESCRIPTION
# Description of change

- Removes the `panic` in `get_latest_checkpoint_sequence_number`
- Properly propagates errors instead of silently swallowing them with `.ok()`
- Modify the documentation of `GrpcStateReader` trait accordingly
- Maintains consistency across all implementations in `RestStateReaderAdapter` and `SimulacrumGrpcReader`
- Uses semantic error types (e.g., `Status::not_found` vs `Status::internal`) appropriately

## Links to any relevant issues

fixes #9996 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation