### PR TITLE
chore(ts-sdk): bring back unsupported filters for `getOwnedObjects`

### DIFF
--- a/.changeset/thirty-buses-burn.md
+++ b/.changeset/thirty-buses-burn.md
@@ -1,0 +1,5 @@
+---
+'@iota/graphql-transport': patch
+---
+
+Bring back unsupportedFilters for `getOwnedObjects`

--- a/sdk/graphql-transport/src/methods.ts
+++ b/sdk/graphql-transport/src/methods.ts
@@ -473,7 +473,9 @@ export const RPC_METHODS: {
                           ? inputFilter.AddressOwner
                           : undefined,
             };
-            const unsupportedFilters: string[] = [];
+
+            // GraphQL's ObjectFilter doesn't support complex filter composition or version filtering.
+            const unsupportedFilters = ['MatchAll', 'MatchAny', 'MatchNone', 'Version'];
 
             for (const unsupportedFilter of unsupportedFilters) {
                 if (unsupportedFilter in inputFilter) {


### PR DESCRIPTION
# Description of change

When passing `unsupportedMethods` to the iota graphql client one might omit `getOwnedObjects` (like in https://github.com/iotaledger/iota-names/pull/968/changes) but this method contains filters not supported by graphql, and the filters will silently be ignored. This brings back the filters removed in https://github.com/iotaledger/iota/pull/7413/changes#diff-fc74fd1b6dc04eaf5da6be64fae5402e3c8ed5c78a53b4563fff0f377641e289L459 so that it fails in case the method is used.
[Graphql filter reference](https://github.com/iotaledger/iota/blob/cf7ca0265f705c16e00f30f91cfe14762f7c6ae3/crates/iota-graphql-rpc/schema.graphql#L3260)

## Links to any relevant issues

Closes #9418 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.
