### PR TITLE
upstream(core): Introduce events_2 table to store events keyed by transaction digest

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -220,6 +220,7 @@ pub mod authority_test_utils;
 pub mod authority_per_epoch_store;
 pub mod authority_per_epoch_store_pruner;
 
+mod authority_store_migrations;
 pub mod authority_store_pruner;
 pub mod authority_store_tables;
 pub mod authority_store_types;
@@ -3061,6 +3062,7 @@ impl AuthorityState {
             rx_ready_certificates,
             rx_execution_shutdown,
         ));
+        spawn_monitored_task!(authority_store_migrations::migrate_events(store));
 
         // TODO: This doesn't belong to the constructor of AuthorityState.
         state

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3062,7 +3062,7 @@ impl AuthorityState {
             rx_ready_certificates,
             rx_execution_shutdown,
         ));
-        spawn_monitored_task!(authority_store_migrations::migrate_events(store));
+        authority_store_migrations::migrate_events(store).await;
 
         // TODO: This doesn't belong to the constructor of AuthorityState.
         state

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -70,7 +70,7 @@ use iota_types::{
         default_hash,
     },
     deny_list_v1::check_coin_deny_list_v1_during_signing,
-    digests::{ChainIdentifier, Digest, TransactionEventsDigest},
+    digests::{ChainIdentifier, Digest},
     dynamic_field::{self, DynamicFieldInfo, DynamicFieldName, Field, visitor as DFV},
     effects::{
         InputSharedObject, SignedTransactionEffects, TransactionEffects, TransactionEffectsAPI,
@@ -3940,7 +3940,7 @@ impl AuthorityState {
     #[instrument(level = "trace", skip_all)]
     pub fn get_transaction_events(
         &self,
-        digest: &TransactionEventsDigest,
+        digest: &TransactionDigest,
     ) -> IotaResult<TransactionEvents> {
         self.get_transaction_cache_reader()
             .try_get_events(digest)?
@@ -4285,11 +4285,13 @@ impl AuthorityState {
                         .and_then(|e| e.data.get(k.2).cloned()),
                 )
             })
-            .map(|((digest, tx_digest, event_seq, timestamp), event)| {
-                event
-                    .map(|e| (e, tx_digest, event_seq, timestamp))
-                    .ok_or(IotaError::TransactionEventsNotFound { digest })
-            })
+            .map(
+                |((_event_digest, tx_digest, event_seq, timestamp), event)| {
+                    event
+                        .map(|e| (e, tx_digest, event_seq, timestamp))
+                        .ok_or(IotaError::TransactionEventsNotFound { digest: tx_digest })
+                },
+            )
             .collect::<Result<Vec<_>, _>>()?;
 
         let epoch_store = self.load_epoch_store_one_call_per_task();
@@ -4341,8 +4343,8 @@ impl AuthorityState {
                 .try_get_transaction_block(transaction_digest)?
             {
                 let cert_sig = epoch_store.get_transaction_cert_sig(transaction_digest)?;
-                let events = if let Some(digest) = effects.events_digest() {
-                    self.get_transaction_events(digest)?
+                let events = if effects.events_digest().is_some() {
+                    self.get_transaction_events(effects.transaction_digest())?
                 } else {
                     TransactionEvents::default()
                 };
@@ -5787,21 +5789,10 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
         if digests.is_empty() {
             return Ok(vec![]);
         }
-        let events_digests: Vec<_> = self
+
+        Ok(self
             .get_transaction_cache_reader()
-            .try_multi_get_executed_effects(digests)?
-            .into_iter()
-            .map(|t| t.and_then(|t| t.events_digest().cloned()))
-            .collect();
-        let non_empty_events: Vec<_> = events_digests.iter().filter_map(|e| *e).collect();
-        let mut events = self
-            .get_transaction_cache_reader()
-            .try_multi_get_events(&non_empty_events)?
-            .into_iter();
-        Ok(events_digests
-            .into_iter()
-            .map(|ev| ev.and_then(|_| events.next()?))
-            .collect())
+            .multi_get_events(digests))
     }
 }
 

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3062,7 +3062,7 @@ impl AuthorityState {
             rx_ready_certificates,
             rx_execution_shutdown,
         ));
-        authority_store_migrations::migrate_events(store).await;
+        spawn_monitored_task!(authority_store_migrations::migrate_events(store));
 
         // TODO: This doesn't belong to the constructor of AuthorityState.
         state

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -399,18 +399,11 @@ impl AuthorityStore {
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<TransactionEvents>, TypedStoreError> {
-        // For now, during this transition period, if we don't find events for a
-        // particular Transaction we need to fallback to try and read from the
-        // older table. Once the migration has finished and we've removed the
-        // older events table we can stop doing the fallback
         if let Some(events) = self.perpetual_tables.events_2.get(digest)? {
             return Ok(Some(events));
         }
 
-        self.get_executed_effects(digest)?
-            .and_then(|effects| effects.events_digest().copied())
-            .and_then(|events_digest| self.get_events_by_events_digest(&events_digest).transpose())
-            .transpose()
+        Ok(None)
     }
 
     pub fn get_events_by_events_digest(

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -401,11 +401,18 @@ impl AuthorityStore {
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<TransactionEvents>, TypedStoreError> {
+        // For now, during this transition period, if we don't find events for a
+        // particular Transaction we need to fallback to try and read from the
+        // older table. Once the migration has finished and we've removed the
+        // older events table we can stop doing the fallback
         if let Some(events) = self.perpetual_tables.events_2.get(digest)? {
             return Ok(Some(events));
         }
 
-        Ok(None)
+        self.get_executed_effects(digest)?
+            .and_then(|effects| effects.events_digest().copied())
+            .and_then(|events_digest| self.get_events_by_events_digest(&events_digest).transpose())
+            .transpose()
     }
 
     pub fn get_events_by_events_digest(

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -345,11 +345,13 @@ impl AuthorityStore {
                         .unwrap();
 
                     // Insert to events_2 table
-                    store
-                        .perpetual_tables
-                        .events_2
-                        .insert(transaction.digest(), events)
-                        .unwrap();
+                    if effects.events_digest().is_some() {
+                        store
+                            .perpetual_tables
+                            .events_2
+                            .insert(transaction.digest(), events)
+                            .unwrap();
+                    }
                 }
             }
         }

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -333,12 +333,23 @@ impl AuthorityStore {
                         .effects
                         .insert(&effects.digest(), effects)
                         .expect("cannot insert migration effects");
-                    let events = events
+                    let events_iter = events
                         .data
                         .iter()
                         .enumerate()
                         .map(|(i, e)| ((events.digest(), i), e));
-                    store.perpetual_tables.events.multi_insert(events).unwrap();
+                    store
+                        .perpetual_tables
+                        .events
+                        .multi_insert(events_iter)
+                        .unwrap();
+
+                    // Insert to events_2 table
+                    store
+                        .perpetual_tables
+                        .events_2
+                        .insert(transaction.digest(), events)
+                        .unwrap();
                 }
             }
         }

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -276,6 +276,13 @@ impl AuthorityStore {
             // because the genesis tx hasn't but will be executed. This is
             // important for fullnodes to be able to generate indexing data
             // right now.
+            if genesis.effects().events_digest().is_some() {
+                store
+                    .perpetual_tables
+                    .events_2
+                    .insert(transaction.digest(), genesis.events())
+                    .unwrap();
+            }
             let event_digests = genesis.events().digest();
             let events = genesis
                 .events()
@@ -379,6 +386,24 @@ impl AuthorityStore {
 
     pub fn get_events(
         &self,
+        digest: &TransactionDigest,
+    ) -> Result<Option<TransactionEvents>, TypedStoreError> {
+        // For now, during this transition period, if we don't find events for a
+        // particular Transaction we need to fallback to try and read from the
+        // older table. Once the migration has finished and we've removed the
+        // older events table we can stop doing the fallback
+        if let Some(events) = self.perpetual_tables.events_2.get(digest)? {
+            return Ok(Some(events));
+        }
+
+        self.get_executed_effects(digest)?
+            .and_then(|effects| effects.events_digest().copied())
+            .and_then(|events_digest| self.get_events_by_events_digest(&events_digest).transpose())
+            .transpose()
+    }
+
+    pub fn get_events_by_events_digest(
+        &self,
         event_digest: &TransactionEventsDigest,
     ) -> Result<Option<TransactionEvents>, TypedStoreError> {
         let data = self
@@ -392,7 +417,7 @@ impl AuthorityStore {
 
     pub fn multi_get_events(
         &self,
-        event_digests: &[TransactionEventsDigest],
+        event_digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEvents>>> {
         Ok(event_digests
             .iter()
@@ -410,7 +435,7 @@ impl AuthorityStore {
     pub fn get_executed_effects(
         &self,
         tx_digest: &TransactionDigest,
-    ) -> IotaResult<Option<TransactionEffects>> {
+    ) -> Result<Option<TransactionEffects>, TypedStoreError> {
         let effects_digest = self.perpetual_tables.executed_effects.get(tx_digest)?;
         match effects_digest {
             Some(digest) => Ok(self.perpetual_tables.effects.get(&digest)?),
@@ -869,6 +894,15 @@ impl AuthorityStore {
 
         write_batch.insert_batch(&self.perpetual_tables.objects, new_objects)?;
 
+        // Write events into the new table keyed off of transaction_digest
+        if effects.events_digest().is_some() {
+            write_batch.insert_batch(
+                &self.perpetual_tables.events_2,
+                [(transaction_digest, events)],
+            )?;
+        }
+
+        // Continue writing events into the old table for now keyed off of events digest
         let event_digest = events.digest();
         let events = events
             .data
@@ -1167,6 +1201,7 @@ impl AuthorityStore {
             iter::once(tx_digest),
         )?;
         if let Some(events_digest) = effects.events_digest() {
+            write_batch.delete_batch(&self.perpetual_tables.events_2, [tx_digest])?;
             write_batch.schedule_delete_range(
                 &self.perpetual_tables.events,
                 &(*events_digest, usize::MIN),

--- a/crates/iota-core/src/authority/authority_store_migrations.rs
+++ b/crates/iota-core/src/authority/authority_store_migrations.rs
@@ -16,19 +16,10 @@ pub async fn migrate_events(store: Arc<AuthorityStore>) {
     tracing::info!("Starting events table migration");
 
     let result = tokio::task::spawn_blocking(move || {
-        let span = tracing::info_span!(
-            "migrate_events",
-            transaction = tracing::field::Empty,
-            effects = tracing::field::Empty,
-        );
-        let _entered = span.enter();
-
         let mut batch = store.perpetual_tables.events_2.batch();
 
         for entry in store.perpetual_tables.executed_effects.safe_iter() {
             let (txn_digest, effects_digest) = entry?;
-            span.record("transaction", tracing::field::debug(&txn_digest));
-            span.record("effects", tracing::field::debug(&effects_digest));
 
             // If there's already an entry for this transaction in the new table we can skip
             // it

--- a/crates/iota-core/src/authority/authority_store_migrations.rs
+++ b/crates/iota-core/src/authority/authority_store_migrations.rs
@@ -58,7 +58,7 @@ pub async fn migrate_events(store: Arc<AuthorityStore>) {
                     tracing::warn!(
                         expected_events_digest =? events_digest,
                         fetched_events_digest =? fetched_events_digest,
-                        "fetched events don't matched expected digest; skipping",
+                        "fetched events don't match expected digest; skipping",
                     );
                     continue;
                 }

--- a/crates/iota-core/src/authority/authority_store_migrations.rs
+++ b/crates/iota-core/src/authority/authority_store_migrations.rs
@@ -27,38 +27,33 @@ pub async fn migrate_events(store: Arc<AuthorityStore>) {
                 continue;
             }
 
-            let effects = if let Some(effects) = store.get_effects(&effects_digest)? {
-                effects
-            } else {
+            let Some(effects) = store.get_effects(&effects_digest)? else {
                 // Skip this one if we can't find the effects
                 continue;
             };
 
-            let events_digest = if let Some(events_digest) = effects.events_digest() {
-                events_digest
-            } else {
+            let Some(events_digest) = effects.events_digest() else {
                 // There are no events so we can continue to the next entry
                 continue;
             };
 
-            let events = if let Some(events) = store.get_events_by_events_digest(events_digest)? {
-                // Check that the events we're loading do match the expected events digest for
-                // this transaction
-                let fetched_events_digest = events.digest();
-                if &fetched_events_digest != events_digest {
-                    tracing::warn!(
-                        expected_events_digest =? events_digest,
-                        fetched_events_digest =? fetched_events_digest,
-                        "fetched events don't match expected digest; skipping",
-                    );
-                    continue;
-                }
-                events
-            } else {
+            let Some(events) = store.get_events_by_events_digest(events_digest)? else {
                 // Skip this one if we can't find the events. This means they were liked already
                 // pruned
                 continue;
             };
+
+            // Check that the events we're loading do match the expected events digest for
+            // this transaction
+            let fetched_events_digest = events.digest();
+            if &fetched_events_digest != events_digest {
+                tracing::warn!(
+                    expected_events_digest =? events_digest,
+                    fetched_events_digest =? fetched_events_digest,
+                    "fetched events don't match expected digest; skipping",
+                );
+                continue;
+            }
 
             batch.insert_batch(&store.perpetual_tables.events_2, [(&txn_digest, &events)])?;
 

--- a/crates/iota-core/src/authority/authority_store_migrations.rs
+++ b/crates/iota-core/src/authority/authority_store_migrations.rs
@@ -1,0 +1,93 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use iota_types::effects::TransactionEffectsAPI;
+use typed_store::traits::Map;
+
+use crate::authority::AuthorityStore;
+
+// Temporary migration task that can be removed in a release or two once we've
+// removed the old events table and are sure we don't need to revert to using
+// the old events table
+pub async fn migrate_events(store: Arc<AuthorityStore>) {
+    tracing::info!("Starting events table migration");
+
+    let result = tokio::task::spawn_blocking(move || {
+        let span = tracing::info_span!(
+            "migrate_events",
+            transaction = tracing::field::Empty,
+            effects = tracing::field::Empty,
+        );
+        let _entered = span.enter();
+
+        let mut batch = store.perpetual_tables.events_2.batch();
+
+        for entry in store.perpetual_tables.executed_effects.safe_iter() {
+            let (txn_digest, effects_digest) = entry?;
+            span.record("transaction", tracing::field::debug(&txn_digest));
+            span.record("effects", tracing::field::debug(&effects_digest));
+
+            // If there's already an entry for this transaction in the new table we can skip
+            // it
+            if store.perpetual_tables.events_2.contains_key(&txn_digest)? {
+                continue;
+            }
+
+            let effects = if let Some(effects) = store.get_effects(&effects_digest)? {
+                effects
+            } else {
+                // Skip this one if we can't find the effects
+                continue;
+            };
+
+            let events_digest = if let Some(events_digest) = effects.events_digest() {
+                events_digest
+            } else {
+                // There are no events so we can continue to the next entry
+                continue;
+            };
+
+            let events = if let Some(events) = store.get_events_by_events_digest(events_digest)? {
+                // Check that the events we're loading do match the expected events digest for
+                // this transaction
+                let fetched_events_digest = events.digest();
+                if &fetched_events_digest != events_digest {
+                    tracing::warn!(
+                        expected_events_digest =? events_digest,
+                        fetched_events_digest =? fetched_events_digest,
+                        "fetched events don't matched expected digest; skipping",
+                    );
+                    continue;
+                }
+                events
+            } else {
+                // Skip this one if we can't find the events. This means they were liked already
+                // pruned
+                continue;
+            };
+
+            batch.insert_batch(&store.perpetual_tables.events_2, [(&txn_digest, &events)])?;
+
+            // If the batch size grows to greater that 128MB then write out to the DB so
+            // that the data we need to hold in memory doesn't grown unbounded.
+            if batch.size_in_bytes() >= 1 << 27 {
+                std::mem::replace(&mut batch, store.perpetual_tables.events_2.batch()).write()?;
+            }
+        }
+
+        batch.write()?;
+
+        Ok::<_, anyhow::Error>(())
+    })
+    .await
+    .unwrap();
+
+    if let Err(e) = result {
+        tracing::warn!("Error encountered while Finished events table migration: {e}");
+    }
+
+    tracing::info!("Finished events table migration");
+}

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -281,6 +281,8 @@ impl AuthorityStorePruner {
             effect_digests.push(effects_digest);
 
             if let Some(event_digest) = effects.events_digest() {
+                perpetual_batch
+                    .delete_batch(&perpetual_db.events_2, [effects.transaction_digest()])?;
                 if let Some(next_digest) = event_digest.next_lexicographical() {
                     perpetual_batch.schedule_delete_range(
                         &perpetual_db.events,

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -5,8 +5,11 @@
 use std::path::Path;
 
 use iota_types::{
-    accumulator::Accumulator, base_types::SequenceNumber, digests::TransactionEventsDigest,
-    effects::TransactionEffects, storage::MarkerValue,
+    accumulator::Accumulator,
+    base_types::SequenceNumber,
+    digests::TransactionEventsDigest,
+    effects::{TransactionEffects, TransactionEvents},
+    storage::MarkerValue,
 };
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -108,6 +111,9 @@ pub struct AuthorityPerpetualTables {
     // TODO: Figure out what to do with this table in the long run.
     // Also we need a pruning policy for this table. We can prune this table along with tx/effects.
     pub(crate) events: DBMap<(TransactionEventsDigest, usize), Event>,
+
+    // Events keyed by the digest of the transaction that produced them.
+    pub(crate) events_2: DBMap<TransactionDigest, TransactionEvents>,
 
     /// Epoch and checkpoint of transactions finalized by checkpoint
     /// executor. Currently, mainly used to implement JSON RPC `ReadApi`.
@@ -476,6 +482,7 @@ impl AuthorityPerpetualTables {
         self.objects.unsafe_clear()?;
         self.live_owned_object_markers.unsafe_clear()?;
         self.executed_effects.unsafe_clear()?;
+        self.events_2.unsafe_clear()?;
         self.events.unsafe_clear()?;
         self.executed_transactions_to_checkpoint.unsafe_clear()?;
         self.root_state_hash_by_epoch.unsafe_clear()?;

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -560,8 +560,11 @@ impl ValidatorService {
                 .get_signed_effects_and_maybe_resign(&tx_digest, epoch_store)?
             {
                 let events = if include_events {
-                    if let Some(digest) = signed_effects.events_digest() {
-                        Some(self.state.get_transaction_events(digest)?)
+                    if signed_effects.events_digest().is_some() {
+                        Some(
+                            self.state
+                                .get_transaction_events(signed_effects.transaction_digest())?,
+                        )
                     } else {
                         None
                     }
@@ -677,8 +680,11 @@ impl ValidatorService {
                     .execute_certificate(&certificate, epoch_store)
                     .await?;
                 let events = if include_events {
-                    if let Some(digest) = effects.events_digest() {
-                        Some(self.state.get_transaction_events(digest)?)
+                    if effects.events_digest().is_some() {
+                        Some(
+                            self.state
+                                .get_transaction_events(effects.transaction_digest())?,
+                        )
                     } else {
                         None
                     }

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
@@ -23,31 +23,32 @@ pub(crate) fn load_checkpoint_data(
     object_store: &dyn ObjectStore,
     transaction_cache_reader: &dyn TransactionCacheRead,
 ) -> IotaResult<CheckpointData> {
-    let event_digests = checkpoint_tx_data
+    let event_tx_digests = checkpoint_tx_data
         .effects
         .iter()
-        .flat_map(|fx| fx.events_digest().copied())
+        .flat_map(|fx| fx.events_digest().map(|_| fx.transaction_digest()).copied())
         .collect::<Vec<_>>();
 
     let events = transaction_cache_reader
-        .try_multi_get_events(&event_digests)?
+        .try_multi_get_events(&event_tx_digests)?
         .into_iter()
-        .zip(&event_digests)
-        .map(|(event, digest)| {
-            event.ok_or(IotaError::TransactionEventsNotFound { digest: *digest })
+        .zip(event_tx_digests)
+        .map(|(maybe_event, tx_digest)| {
+            maybe_event
+                .ok_or(IotaError::TransactionEventsNotFound { digest: tx_digest })
+                .map(|event| (tx_digest, event))
         })
-        .collect::<IotaResult<Vec<_>>>()?;
+        .collect::<IotaResult<HashMap<_, _>>>()?;
 
-    let events: HashMap<_, _> = event_digests.into_iter().zip(events).collect();
     let mut full_transactions = Vec::with_capacity(checkpoint_tx_data.transactions.len());
     for (tx, fx) in checkpoint_tx_data
         .transactions
         .iter()
         .zip(checkpoint_tx_data.effects.iter())
     {
-        let events = fx.events_digest().map(|event_digest| {
+        let events = fx.events_digest().map(|_event_digest| {
             events
-                .get(event_digest)
+                .get(fx.transaction_digest())
                 .cloned()
                 .expect("event was already checked to be present")
         });

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -2668,7 +2668,6 @@ mod tests {
     use iota_types::{
         base_types::{ObjectID, SequenceNumber, TransactionEffectsDigest},
         crypto::Signature,
-        digests::TransactionEventsDigest,
         effects::{TransactionEffects, TransactionEvents},
         messages_checkpoint::SignedCheckpointSummary,
         move_package::MovePackage,
@@ -2972,7 +2971,7 @@ mod tests {
 
         fn try_multi_get_events(
             &self,
-            _: &[TransactionEventsDigest],
+            _: &[TransactionDigest],
         ) -> IotaResult<Vec<Option<TransactionEvents>>> {
             unimplemented!()
         }

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -840,15 +840,12 @@ pub trait TransactionCacheRead: Send + Sync {
 
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionDigest],
+        digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEvents>>>;
 
     /// Non-fallible version of `try_multi_get_events`.
-    fn multi_get_events(
-        &self,
-        event_digests: &[TransactionDigest],
-    ) -> Vec<Option<TransactionEvents>> {
-        self.try_multi_get_events(event_digests)
+    fn multi_get_events(&self, digests: &[TransactionDigest]) -> Vec<Option<TransactionEvents>> {
+        self.try_multi_get_events(digests)
             .expect("storage access failed")
     }
 

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -9,7 +9,7 @@ use iota_common::fatal;
 use iota_config::{ExecutionCacheConfig, ExecutionCacheType};
 use iota_types::{
     base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber, VerifiedExecutionData},
-    digests::{TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest},
+    digests::{TransactionDigest, TransactionEffectsDigest},
     effects::{TransactionEffects, TransactionEvents},
     error::{IotaError, IotaResult, UserInputError},
     executable_transaction::VerifiedExecutableTransaction,
@@ -840,22 +840,19 @@ pub trait TransactionCacheRead: Send + Sync {
 
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionEventsDigest],
+        event_digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEvents>>>;
 
     /// Non-fallible version of `try_multi_get_events`.
     fn multi_get_events(
         &self,
-        event_digests: &[TransactionEventsDigest],
+        event_digests: &[TransactionDigest],
     ) -> Vec<Option<TransactionEvents>> {
         self.try_multi_get_events(event_digests)
             .expect("storage access failed")
     }
 
-    fn try_get_events(
-        &self,
-        digest: &TransactionEventsDigest,
-    ) -> IotaResult<Option<TransactionEvents>> {
+    fn try_get_events(&self, digest: &TransactionDigest) -> IotaResult<Option<TransactionEvents>> {
         self.try_multi_get_events(&[*digest]).map(|mut events| {
             events
                 .pop()
@@ -864,7 +861,7 @@ pub trait TransactionCacheRead: Send + Sync {
     }
 
     /// Non-fallible version of `try_get_events`.
-    fn get_events(&self, digest: &TransactionEventsDigest) -> Option<TransactionEvents> {
+    fn get_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.try_get_events(digest).expect("storage access failed")
     }
 

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -10,7 +10,7 @@ use iota_storage::package_object_cache::PackageObjectCache;
 use iota_types::{
     accumulator::Accumulator,
     base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber, VerifiedExecutionData},
-    digests::{TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest},
+    digests::{TransactionDigest, TransactionEffectsDigest},
     effects::{TransactionEffects, TransactionEvents},
     error::{IotaError, IotaResult},
     executable_transaction::VerifiedExecutableTransaction,
@@ -255,7 +255,7 @@ impl TransactionCacheRead for PassthroughCache {
     #[instrument(level = "trace", skip_all)]
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionEventsDigest],
+        event_digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEvents>>> {
         self.store.multi_get_events(event_digests)
     }

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -255,9 +255,9 @@ impl TransactionCacheRead for PassthroughCache {
     #[instrument(level = "trace", skip_all)]
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionDigest],
+        tx_digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEvents>>> {
-        self.store.multi_get_events(event_digests)
+        self.store.multi_get_events(tx_digests)
     }
 }
 

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -9,7 +9,7 @@ use iota_config::node::ExecutionCacheTypeAtomicU8;
 use iota_types::{
     accumulator::Accumulator,
     base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber, VerifiedExecutionData},
-    digests::{TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest},
+    digests::{TransactionDigest, TransactionEffectsDigest},
     effects::{TransactionEffects, TransactionEvents},
     error::{IotaError, IotaResult},
     executable_transaction::VerifiedExecutableTransaction,
@@ -251,7 +251,7 @@ impl TransactionCacheRead for ProxyCache {
     #[instrument(level = "trace", skip_all)]
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionEventsDigest],
+        event_digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEvents>>> {
         delegate_method!(self.try_multi_get_events(event_digests))
     }

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     future::Future,
     path::PathBuf,
     sync::{
@@ -154,9 +154,7 @@ impl Scenario {
         let tx = VerifiedTransaction::new_unchecked(tx);
         let events: TransactionEvents = Default::default();
 
-        let effects = TestEffectsBuilder::new(tx.inner())
-            .with_events_digest(events.digest())
-            .build();
+        let effects = TestEffectsBuilder::new(tx.inner()).build();
 
         TransactionOutputs {
             transaction: Arc::new(tx),
@@ -644,42 +642,42 @@ async fn test_extra_outputs() {
 
         s.cache.get_transaction_block(&tx).unwrap();
         let fx = s.cache.get_executed_effects(&tx).unwrap();
-        let events_digest = fx.events_digest().unwrap();
-        s.cache.get_events(events_digest).unwrap();
+        let _events_digest = fx.events_digest().unwrap();
+        s.cache.get_events(&tx).unwrap();
 
         s.commit(tx).await;
 
         s.cache.get_transaction_block(&tx).unwrap();
         s.cache.get_executed_effects(&tx).unwrap();
-        s.cache.get_events(events_digest).unwrap();
+        s.cache.get_events(&tx).unwrap();
 
         // clear cache
         s.reset_cache();
 
         s.cache.get_transaction_block(&tx).unwrap();
         s.cache.get_executed_effects(&tx).unwrap();
-        s.cache.get_events(events_digest).unwrap();
+        s.cache.get_events(&tx).unwrap();
 
         s.with_created(&[3]);
         let tx = s.do_tx().await;
 
         // when Events is empty, it should be treated as None
         let fx = s.cache.get_executed_effects(&tx).unwrap();
-        let events_digest = fx.events_digest().unwrap();
+        assert!(fx.events_digest().is_none());
         assert!(
-            s.cache.get_events(events_digest).is_none(),
+            s.cache.get_events(&tx).is_none(),
             "empty events should be none"
         );
 
         s.commit(tx).await;
         assert!(
-            s.cache.get_events(events_digest).is_none(),
+            s.cache.get_events(&tx).is_none(),
             "empty events should be none"
         );
 
         s.reset_cache();
         assert!(
-            s.cache.get_events(events_digest).is_none(),
+            s.cache.get_events(&tx).is_none(),
             "empty events should be none"
         );
     })

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -929,7 +929,7 @@ impl WritebackCache {
 
         // note: if events.data.is_empty(), then there are no events for this
         // transaction. We store it anyway to avoid special cases in
-        // commint_transaction_outputs, and translate an empty events structure
+        // commit_transaction_outputs, and translate an empty events structure
         // to None when reading.
         self.metrics.record_cache_write("transaction_events");
         self.dirty
@@ -2031,7 +2031,7 @@ impl TransactionCacheRead for WritebackCache {
     #[instrument(level = "trace", skip_all)]
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionDigest],
+        tx_digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEvents>>> {
         fn map_events(events: TransactionEvents) -> Option<TransactionEvents> {
             if events.data.is_empty() {
@@ -2041,7 +2041,7 @@ impl TransactionCacheRead for WritebackCache {
             }
         }
 
-        let digests_and_tickets: Vec<_> = event_digests
+        let digests_and_tickets: Vec<_> = tx_digests
             .iter()
             .map(|d| (*d, self.cached.transaction_events.get_ticket_for_read(d)))
             .collect();

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -48,7 +48,7 @@
 //! The above design is used for both objects and markers.
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     hash::Hash,
     sync::{Arc, atomic::AtomicU64},
 };
@@ -61,7 +61,7 @@ use iota_macros::fail_point;
 use iota_types::{
     accumulator::Accumulator,
     base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber, VerifiedExecutionData},
-    digests::{ObjectDigest, TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest},
+    digests::{ObjectDigest, TransactionDigest, TransactionEffectsDigest},
     effects::{TransactionEffects, TransactionEvents},
     error::{IotaError, IotaResult, UserInputError},
     executable_transaction::VerifiedExecutableTransaction,
@@ -229,12 +229,7 @@ struct UncommittedData {
 
     transaction_effects: DashMap<TransactionEffectsDigest, TransactionEffects>,
 
-    // Because TransactionEvents are not unique to the transaction that created them, we must
-    // reference count them in order to know when we can remove them from the cache. For now
-    // we track all referrers explicitly, but we can use a ref count when we are confident in
-    // the correctness of the code.
-    transaction_events:
-        DashMap<TransactionEventsDigest, (BTreeSet<TransactionDigest>, TransactionEvents)>,
+    transaction_events: DashMap<TransactionDigest, TransactionEvents>,
 
     executed_effects_digests: DashMap<TransactionDigest, TransactionEffectsDigest>,
 
@@ -337,8 +332,7 @@ struct CachedCommittedData {
     transaction_effects:
         MonotonicCache<TransactionEffectsDigest, PointCacheItem<Arc<TransactionEffects>>>,
 
-    transaction_events:
-        MonotonicCache<TransactionEventsDigest, PointCacheItem<Arc<TransactionEvents>>>,
+    transaction_events: MonotonicCache<TransactionDigest, PointCacheItem<Arc<TransactionEvents>>>,
 
     executed_effects_digests:
         MonotonicCache<TransactionDigest, PointCacheItem<TransactionEffectsDigest>>,
@@ -938,16 +932,9 @@ impl WritebackCache {
         // commint_transaction_outputs, and translate an empty events structure
         // to None when reading.
         self.metrics.record_cache_write("transaction_events");
-        match self.dirty.transaction_events.entry(events.digest()) {
-            DashMapEntry::Occupied(mut occupied) => {
-                occupied.get_mut().0.insert(tx_digest);
-            }
-            DashMapEntry::Vacant(entry) => {
-                let mut txns = BTreeSet::new();
-                txns.insert(tx_digest);
-                entry.insert((txns, events.clone()));
-            }
-        }
+        self.dirty
+            .transaction_events
+            .insert(tx_digest, events.clone());
 
         self.metrics.record_cache_write("executed_effects_digests");
         self.dirty
@@ -1100,7 +1087,6 @@ impl WritebackCache {
         } = outputs;
 
         let effects_digest = effects.digest();
-        let events_digest = events.digest();
 
         // Update cache before removing from self.dirty to avoid
         // unnecessary cache misses
@@ -1131,7 +1117,7 @@ impl WritebackCache {
         self.cached
             .transaction_events
             .insert(
-                &events_digest,
+                &tx_digest,
                 PointCacheItem::Some(events.clone().into()),
                 Ticket::Write,
             )
@@ -1142,18 +1128,10 @@ impl WritebackCache {
             .remove(&effects_digest)
             .expect("effects must exist");
 
-        match self.dirty.transaction_events.entry(events.digest()) {
-            DashMapEntry::Occupied(mut occupied) => {
-                let txns = &mut occupied.get_mut().0;
-                assert!(txns.remove(&tx_digest), "transaction must exist");
-                if txns.is_empty() {
-                    occupied.remove();
-                }
-            }
-            DashMapEntry::Vacant(_) => {
-                panic!("events must exist");
-            }
-        }
+        self.dirty
+            .transaction_events
+            .remove(&tx_digest)
+            .expect("events must exist");
 
         self.dirty
             .executed_effects_digests
@@ -2053,7 +2031,7 @@ impl TransactionCacheRead for WritebackCache {
     #[instrument(level = "trace", skip_all)]
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionEventsDigest],
+        event_digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEvents>>> {
         fn map_events(events: TransactionEvents) -> Option<TransactionEvents> {
             if events.data.is_empty() {
@@ -2072,12 +2050,7 @@ impl TransactionCacheRead for WritebackCache {
             |(digest, _)| {
                 self.metrics
                     .record_cache_request("transaction_events", "uncommitted");
-                if let Some(events) = self
-                    .dirty
-                    .transaction_events
-                    .get(digest)
-                    .map(|e| e.1.clone())
-                {
+                if let Some(events) = self.dirty.transaction_events.get(digest).map(|e| e.clone()) {
                     self.metrics
                         .record_cache_hit("transaction_events", "uncommitted");
 

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use iota_types::{
     base_types::{IotaAddress, ObjectID, TransactionDigest},
     committee::{Committee, EpochId},
-    digests::TransactionEventsDigest,
     effects::{TransactionEffects, TransactionEvents},
     error::IotaError,
     messages_checkpoint::{
@@ -225,7 +224,7 @@ impl ReadStore for RocksDbStore {
 
     fn try_get_events(
         &self,
-        digest: &TransactionEventsDigest,
+        digest: &TransactionDigest,
     ) -> Result<Option<TransactionEvents>, StorageError> {
         self.cache_traits
             .transaction_cache_reader
@@ -479,7 +478,7 @@ impl ReadStore for RestReadStore {
 
     fn try_get_events(
         &self,
-        digest: &TransactionEventsDigest,
+        digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
         self.rocks.try_get_events(digest)
     }

--- a/crates/iota-core/src/test_authority_clients.rs
+++ b/crates/iota-core/src/test_authority_clients.rs
@@ -217,8 +217,8 @@ impl LocalAuthorityClient {
         .into_inner();
 
         let events = if request.include_events {
-            if let Some(digest) = signed_effects.events_digest() {
-                Some(state.get_transaction_events(digest)?)
+            if signed_effects.events_digest().is_some() {
+                Some(state.get_transaction_events(signed_effects.transaction_digest())?)
             } else {
                 None
             }

--- a/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -1252,10 +1252,10 @@ async fn test_upgraded_types_in_one_txn() {
     let e1_type = StructTag::from_str(&format!("{package_v2}::base::BModEvent")).unwrap();
     let e2_type = StructTag::from_str(&format!("{package_v3}::base::CModEvent")).unwrap();
 
-    let event_digest = effects.events_digest().unwrap();
+    let _event_digest = effects.events_digest().unwrap();
     let mut events = runner
         .authority_state
-        .get_transaction_events(event_digest)
+        .get_transaction_events(effects.transaction_digest())
         .unwrap()
         .data;
     events.sort_by(|a, b| a.type_.name.as_str().cmp(b.type_.name.as_str()));

--- a/crates/iota-core/src/validator_tx_finalizer.rs
+++ b/crates/iota-core/src/validator_tx_finalizer.rs
@@ -364,9 +364,11 @@ mod tests {
                 None,
                 &epoch_store,
             )?;
-            let events = match effects.events_digest() {
-                None => TransactionEvents::default(),
-                Some(digest) => self.authority.get_transaction_events(digest)?,
+            let events = if effects.events_digest().is_some() {
+                self.authority
+                    .get_transaction_events(effects.transaction_digest())?
+            } else {
+                TransactionEvents::default()
             };
             let signed_effects = self
                 .authority

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -16,7 +16,7 @@ use iota_grpc_types::{
 };
 use iota_types::{
     base_types::{ObjectID, VersionNumber},
-    digests::{TransactionDigest, TransactionEventsDigest},
+    digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     full_checkpoint_content::{
         CheckpointData as IotaTypesCheckpointData,
@@ -251,7 +251,7 @@ pub trait GrpcStateReader: Send + Sync + 'static {
     /// Returns `Ok(None)` if the events don't exist.
     fn get_transaction_events(
         &self,
-        digest: &TransactionEventsDigest,
+        digest: &TransactionDigest,
     ) -> anyhow::Result<Option<TransactionEvents>>;
 
     /// Get checkpoint sequence number for a transaction.
@@ -418,7 +418,7 @@ impl GrpcStateReader for RestStateReaderAdapter {
 
     fn get_transaction_events(
         &self,
-        digest: &TransactionEventsDigest,
+        digest: &TransactionDigest,
     ) -> anyhow::Result<Option<TransactionEvents>> {
         Ok(self.inner.get_events(digest))
     }
@@ -1110,7 +1110,7 @@ impl GrpcReader {
             // Get events only if requested
             let events = if fields.include_events {
                 match effects.events_digest() {
-                    Some(event_digest) => self.state_reader.get_transaction_events(event_digest)?,
+                    Some(_) => self.state_reader.get_transaction_events(digest)?,
                     None => None,
                 }
             } else {

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -342,14 +342,14 @@ impl iota_types::storage::ReadStore for MockRestStateReader {
 
     fn try_get_events(
         &self,
-        _digest: &iota_types::digests::TransactionEventsDigest,
+        _digest: &iota_types::digests::TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEvents>> {
         unimplemented!()
     }
 
     fn get_events(
         &self,
-        digest: &iota_types::digests::TransactionEventsDigest,
+        digest: &iota_types::digests::TransactionDigest,
     ) -> Option<iota_types::effects::TransactionEvents> {
         self.try_get_events(digest).expect("storage access failed")
     }

--- a/crates/iota-light-client/src/checkpoint.rs
+++ b/crates/iota-light-client/src/checkpoint.rs
@@ -492,7 +492,7 @@ impl ReadStore for CheckpointSummaryFileStore {
 
     fn try_get_events(
         &self,
-        _: &iota_types::digests::TransactionEventsDigest,
+        _: &iota_types::digests::TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEvents>> {
         unimplemented!()
     }

--- a/crates/iota-rest-api/src/reader.rs
+++ b/crates/iota-rest-api/src/reader.rs
@@ -92,9 +92,9 @@ impl StateReader {
             .inner()
             .try_get_transaction_effects(&transaction_digest)?
             .ok_or(TransactionNotFoundError(digest))?;
-        let events = if let Some(event_digest) = effects.events_digest() {
+        let events = if effects.events_digest().is_some() {
             self.inner()
-                .try_get_events(event_digest)?
+                .try_get_events(effects.transaction_digest())?
                 .ok_or(TransactionNotFoundError(digest))?
                 .pipe(Some)
         } else {

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -23,7 +23,7 @@ use iota_storage::key_value_store::TransactionKeyValueStore;
 use iota_types::{
     base_types::{IotaAddress, ObjectID, VersionNumber},
     committee::EpochId,
-    digests::{TransactionDigest, TransactionEventsDigest},
+    digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEvents},
     error::{ExecutionError, IotaError, IotaResult},
     event::Event,
@@ -365,11 +365,11 @@ impl ReadStore for ValidatorWithFullnode {
 
     fn try_get_events(
         &self,
-        event_digest: &TransactionEventsDigest,
+        digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
         self.validator
             .get_transaction_cache_reader()
-            .try_get_events(event_digest)
+            .try_get_events(digest)
             .map_err(iota_types::storage::error::Error::custom)
     }
 
@@ -454,12 +454,10 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
         tx_digest: &TransactionDigest,
         _limit: usize,
     ) -> IotaResult<Vec<Event>> {
-        Ok(self.with_store(|store| {
-            store
-                .get_transaction_events_by_tx_digest(tx_digest)
-                .map(|x| x.data)
-                .unwrap_or_default()
-        }))
+        match self.try_get_events(tx_digest)? {
+            Some(events) => Ok(events.data),
+            None => Ok(Vec::new()),
+        }
     }
 
     async fn create_checkpoint(&mut self) -> anyhow::Result<VerifiedCheckpoint> {

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -571,12 +571,12 @@ impl ReadStore for PersistedStore {
 
     fn try_get_events(
         &self,
-        event_digest: &TransactionDigest,
+        digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
         Ok(self
             .read_write
             .events
-            .get(event_digest)
+            .get(digest)
             .expect("Fatal: DB read failed"))
     }
 
@@ -745,14 +745,14 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
 
     fn try_get_events(
         &self,
-        event_digest: &TransactionDigest,
+        digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
         self.sync();
 
         Ok(self
             .inner
             .events
-            .get(event_digest)
+            .get(digest)
             .expect("Fatal: DB read failed"))
     }
 

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -11,7 +11,7 @@ use iota_types::{
     base_types::{IotaAddress, ObjectID, SequenceNumber, VersionNumber},
     committee::{Committee, EpochId},
     crypto::AccountKeyPair,
-    digests::{ObjectDigest, TransactionDigest, TransactionEventsDigest},
+    digests::{ObjectDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::{IotaError, UserInputError},
     messages_checkpoint::{
@@ -60,8 +60,7 @@ pub struct PersistedStoreInner {
     // Transaction data
     transactions: DBMap<TransactionDigest, iota_types::transaction::TrustedTransaction>,
     effects: DBMap<TransactionDigest, TransactionEffects>,
-    events: DBMap<TransactionEventsDigest, TransactionEvents>,
-    events_tx_digest_index: DBMap<TransactionDigest, TransactionEventsDigest>,
+    events: DBMap<TransactionDigest, TransactionEvents>,
 
     // Committee data
     epoch_to_committee: DBMap<EpochId, Committee>,
@@ -176,22 +175,6 @@ impl SimulatorStore for PersistedStore {
             .transpose()
             .expect("failed to fetch highest checkpoint")
             .map(|(_, checkpoint)| checkpoint.into())
-    }
-
-    fn get_transaction_events_by_tx_digest(
-        &self,
-        tx_digest: &TransactionDigest,
-    ) -> Option<TransactionEvents> {
-        self.read_write
-            .events_tx_digest_index
-            .get(tx_digest)
-            .expect("Fatal: DB read failed")
-            .and_then(|x| {
-                self.read_write
-                    .events
-                    .get(&x)
-                    .expect("Fatal: DB read failed")
-            })
     }
 
     fn get_object(&self, id: &ObjectID) -> Option<Object> {
@@ -315,12 +298,8 @@ impl SimulatorStore for PersistedStore {
 
     fn insert_events(&mut self, tx_digest: &TransactionDigest, events: TransactionEvents) {
         self.read_write
-            .events_tx_digest_index
-            .insert(tx_digest, &events.digest())
-            .expect("Fatal: DB write failed");
-        self.read_write
             .events
-            .insert(&events.digest(), &events)
+            .insert(tx_digest, &events)
             .expect("Fatal: DB write failed");
     }
 
@@ -592,7 +571,7 @@ impl ReadStore for PersistedStore {
 
     fn try_get_events(
         &self,
-        event_digest: &TransactionEventsDigest,
+        event_digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
         Ok(self
             .read_write
@@ -766,7 +745,7 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
 
     fn try_get_events(
         &self,
-        event_digest: &TransactionEventsDigest,
+        event_digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
         self.sync();
 

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -2891,9 +2891,9 @@ impl ReadStore for IotaTestAdapter {
 
     fn try_get_events(
         &self,
-        event_digest: &TransactionDigest,
+        digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
-        self.executor.try_get_events(event_digest)
+        self.executor.try_get_events(digest)
     }
 
     fn try_get_full_checkpoint_contents_by_sequence_number(

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -46,7 +46,7 @@ use iota_types::{
     },
     committee::EpochId,
     crypto::{AccountKeyPair, RandomnessRound, get_authority_key_pair, get_key_pair_from_rng},
-    digests::{ConsensusCommitDigest, TransactionDigest, TransactionEventsDigest},
+    digests::{ConsensusCommitDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     event::Event,
     execution_status::ExecutionStatus,
@@ -2891,7 +2891,7 @@ impl ReadStore for IotaTestAdapter {
 
     fn try_get_events(
         &self,
-        event_digest: &TransactionEventsDigest,
+        event_digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
         self.executor.try_get_events(event_digest)
     }

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -40,10 +40,7 @@ macro_rules! fp_ensure {
     };
 }
 
-use crate::{
-    digests::TransactionEventsDigest,
-    execution_status::{CommandIndex, ExecutionFailureStatus},
-};
+use crate::execution_status::{CommandIndex, ExecutionFailureStatus};
 
 #[macro_export]
 macro_rules! exit_main {
@@ -596,7 +593,7 @@ pub enum IotaError {
     #[error("{TRANSACTIONS_NOT_FOUND_MSG_PREFIX} [{:?}].", digests)]
     TransactionsNotFound { digests: Vec<TransactionDigest> },
     #[error("Could not find the referenced transaction events [{digest:?}].")]
-    TransactionEventsNotFound { digest: TransactionEventsDigest },
+    TransactionEventsNotFound { digest: TransactionDigest },
     #[error(
         "Attempt to move to `Executed` state an transaction that has already been executed: {:?}.",
         digest

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -248,31 +248,26 @@ pub trait ReadStore: ObjectStore {
             .expect("storage access failed")
     }
 
-    fn try_get_events(&self, event_digest: &TransactionDigest)
-    -> Result<Option<TransactionEvents>>;
+    fn try_get_events(&self, digest: &TransactionDigest) -> Result<Option<TransactionEvents>>;
 
     /// Non-fallible version of `try_get_events`.
-    fn get_events(&self, event_digest: &TransactionDigest) -> Option<TransactionEvents> {
-        self.try_get_events(event_digest)
-            .expect("storage access failed")
+    fn get_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
+        self.try_get_events(digest).expect("storage access failed")
     }
 
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionDigest],
+        digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEvents>>> {
-        event_digests
+        digests
             .iter()
             .map(|digest| self.try_get_events(digest))
             .collect::<Result<Vec<_>, _>>()
     }
 
     /// Non-fallible version of `try_multi_get_events`.
-    fn multi_get_events(
-        &self,
-        event_digests: &[TransactionDigest],
-    ) -> Vec<Option<TransactionEvents>> {
-        self.try_multi_get_events(event_digests)
+    fn multi_get_events(&self, digests: &[TransactionDigest]) -> Vec<Option<TransactionEvents>> {
+        self.try_multi_get_events(digests)
             .expect("storage access failed")
     }
 
@@ -545,18 +540,15 @@ impl<T: ReadStore + ?Sized> ReadStore for &T {
         (*self).try_multi_get_transaction_effects(tx_digests)
     }
 
-    fn try_get_events(
-        &self,
-        event_digest: &TransactionDigest,
-    ) -> Result<Option<TransactionEvents>> {
-        (*self).try_get_events(event_digest)
+    fn try_get_events(&self, digest: &TransactionDigest) -> Result<Option<TransactionEvents>> {
+        (*self).try_get_events(digest)
     }
 
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionDigest],
+        digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEvents>>> {
-        (*self).try_multi_get_events(event_digests)
+        (*self).try_multi_get_events(digests)
     }
 
     fn try_get_full_checkpoint_contents_by_sequence_number(
@@ -667,18 +659,15 @@ impl<T: ReadStore + ?Sized> ReadStore for Box<T> {
         (**self).try_multi_get_transaction_effects(tx_digests)
     }
 
-    fn try_get_events(
-        &self,
-        event_digest: &TransactionDigest,
-    ) -> Result<Option<TransactionEvents>> {
-        (**self).try_get_events(event_digest)
+    fn try_get_events(&self, digest: &TransactionDigest) -> Result<Option<TransactionEvents>> {
+        (**self).try_get_events(digest)
     }
 
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionDigest],
+        digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEvents>>> {
-        (**self).try_multi_get_events(event_digests)
+        (**self).try_multi_get_events(digests)
     }
 
     fn try_get_full_checkpoint_contents_by_sequence_number(
@@ -789,18 +778,15 @@ impl<T: ReadStore + ?Sized> ReadStore for Arc<T> {
         (**self).try_multi_get_transaction_effects(tx_digests)
     }
 
-    fn try_get_events(
-        &self,
-        event_digest: &TransactionDigest,
-    ) -> Result<Option<TransactionEvents>> {
-        (**self).try_get_events(event_digest)
+    fn try_get_events(&self, digest: &TransactionDigest) -> Result<Option<TransactionEvents>> {
+        (**self).try_get_events(digest)
     }
 
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionDigest],
+        digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEvents>>> {
-        (**self).try_multi_get_events(event_digests)
+        (**self).try_multi_get_events(digests)
     }
 
     fn try_get_full_checkpoint_contents_by_sequence_number(

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -15,10 +15,7 @@ use super::{ObjectStore, error::Result};
 use crate::{
     base_types::{EpochId, IotaAddress, MoveObjectType, ObjectID, ObjectType, SequenceNumber},
     committee::Committee,
-    digests::{
-        ChainIdentifier, CheckpointContentsDigest, CheckpointDigest, TransactionDigest,
-        TransactionEventsDigest,
-    },
+    digests::{ChainIdentifier, CheckpointContentsDigest, CheckpointDigest, TransactionDigest},
     dynamic_field::DynamicFieldType,
     effects::{TransactionEffects, TransactionEvents},
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
@@ -251,20 +248,18 @@ pub trait ReadStore: ObjectStore {
             .expect("storage access failed")
     }
 
-    fn try_get_events(
-        &self,
-        event_digest: &TransactionEventsDigest,
-    ) -> Result<Option<TransactionEvents>>;
+    fn try_get_events(&self, event_digest: &TransactionDigest)
+    -> Result<Option<TransactionEvents>>;
 
     /// Non-fallible version of `try_get_events`.
-    fn get_events(&self, event_digest: &TransactionEventsDigest) -> Option<TransactionEvents> {
+    fn get_events(&self, event_digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.try_get_events(event_digest)
             .expect("storage access failed")
     }
 
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionEventsDigest],
+        event_digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEvents>>> {
         event_digests
             .iter()
@@ -275,7 +270,7 @@ pub trait ReadStore: ObjectStore {
     /// Non-fallible version of `try_multi_get_events`.
     fn multi_get_events(
         &self,
-        event_digests: &[TransactionEventsDigest],
+        event_digests: &[TransactionDigest],
     ) -> Vec<Option<TransactionEvents>> {
         self.try_multi_get_events(event_digests)
             .expect("storage access failed")
@@ -332,47 +327,40 @@ pub trait ReadStore: ObjectStore {
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
 
-        // Batch read all effects and collect with event digests
-        let effects_with_events_digests: Vec<(
-            TransactionEffects,
-            Option<TransactionEventsDigest>,
-        )> = self
+        // Batch read all effects
+        let effects = self
             .try_multi_get_transaction_effects(&transaction_digests)?
             .into_iter()
             .map(|maybe_effects| maybe_effects.ok_or_else(|| anyhow::anyhow!("missing effects")))
-            .collect::<anyhow::Result<Vec<_>>>()?
-            .into_iter()
-            .map(|fx| {
-                let events_digest = fx.events_digest().copied();
-                (fx, events_digest)
-            })
-            .collect();
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
-        // Extract event digests for batch reading
-        let event_digests: Vec<TransactionEventsDigest> = effects_with_events_digests
+        // Extract transaction digests for transactions that have events
+        let event_tx_digests = transaction_digests
             .iter()
-            .filter_map(|(_, events_digest)| *events_digest)
-            .collect();
+            .zip(effects.iter())
+            .filter_map(|(tx_digest, fx)| fx.events_digest().map(|_| *tx_digest))
+            .collect::<Vec<_>>();
 
         // Batch read all events
         let events = self
-            .try_multi_get_events(&event_digests)?
+            .try_multi_get_events(&event_tx_digests)?
             .into_iter()
-            .map(|maybe_event| maybe_event.ok_or_else(|| anyhow::anyhow!("missing event")))
-            .collect::<anyhow::Result<Vec<_>>>()?;
-
-        // Create a HashMap for fast event lookup
-        let events_map = event_digests
-            .into_iter()
-            .zip(events)
-            .collect::<HashMap<_, _>>();
+            .zip(event_tx_digests)
+            .map(|(maybe_event, tx_digest)| {
+                maybe_event
+                    .ok_or_else(|| anyhow::anyhow!("missing event"))
+                    .map(|event| (tx_digest, event))
+            })
+            .collect::<anyhow::Result<HashMap<_, _>>>()?;
 
         // Collect the final result
         let result = transactions
             .into_iter()
-            .zip(effects_with_events_digests)
-            .map(|(transaction, (effects, event_digest))| {
-                let events = event_digest.and_then(|d| events_map.get(&d).cloned());
+            .zip(effects)
+            .map(|(transaction, effects)| {
+                let events = effects
+                    .events_digest()
+                    .and_then(|_| events.get(effects.transaction_digest()).cloned());
 
                 TransactionWithEffectsAndEvents {
                     transaction,
@@ -559,14 +547,14 @@ impl<T: ReadStore + ?Sized> ReadStore for &T {
 
     fn try_get_events(
         &self,
-        event_digest: &TransactionEventsDigest,
+        event_digest: &TransactionDigest,
     ) -> Result<Option<TransactionEvents>> {
         (*self).try_get_events(event_digest)
     }
 
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionEventsDigest],
+        event_digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEvents>>> {
         (*self).try_multi_get_events(event_digests)
     }
@@ -681,14 +669,14 @@ impl<T: ReadStore + ?Sized> ReadStore for Box<T> {
 
     fn try_get_events(
         &self,
-        event_digest: &TransactionEventsDigest,
+        event_digest: &TransactionDigest,
     ) -> Result<Option<TransactionEvents>> {
         (**self).try_get_events(event_digest)
     }
 
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionEventsDigest],
+        event_digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEvents>>> {
         (**self).try_multi_get_events(event_digests)
     }
@@ -803,14 +791,14 @@ impl<T: ReadStore + ?Sized> ReadStore for Arc<T> {
 
     fn try_get_events(
         &self,
-        event_digest: &TransactionEventsDigest,
+        event_digest: &TransactionDigest,
     ) -> Result<Option<TransactionEvents>> {
         (**self).try_get_events(event_digest)
     }
 
     fn try_multi_get_events(
         &self,
-        event_digests: &[TransactionEventsDigest],
+        event_digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEvents>>> {
         (**self).try_multi_get_events(event_digests)
     }

--- a/crates/iota-types/src/storage/shared_in_memory_store.rs
+++ b/crates/iota-types/src/storage/shared_in_memory_store.rs
@@ -11,7 +11,7 @@ use super::{ObjectStore, error::Result};
 use crate::{
     base_types::{EpochId, TransactionDigest},
     committee::Committee,
-    digests::{CheckpointContentsDigest, CheckpointDigest, TransactionEventsDigest},
+    digests::{CheckpointContentsDigest, CheckpointDigest},
     effects::{TransactionEffects, TransactionEvents},
     messages_checkpoint::{
         CheckpointContents, CheckpointSequenceNumber, FullCheckpointContents, VerifiedCheckpoint,
@@ -137,10 +137,7 @@ impl ReadStore for SharedInMemoryStore {
             .pipe(Ok)
     }
 
-    fn try_get_events(
-        &self,
-        digest: &TransactionEventsDigest,
-    ) -> Result<Option<TransactionEvents>> {
+    fn try_get_events(&self, digest: &TransactionDigest) -> Result<Option<TransactionEvents>> {
         self.inner()
             .get_transaction_events(digest)
             .cloned()
@@ -237,7 +234,7 @@ pub struct InMemoryStore {
     checkpoint_contents: HashMap<CheckpointContentsDigest, CheckpointContents>,
     transactions: HashMap<TransactionDigest, VerifiedTransaction>,
     effects: HashMap<TransactionDigest, TransactionEffects>,
-    events: HashMap<TransactionEventsDigest, TransactionEvents>,
+    events: HashMap<TransactionDigest, TransactionEvents>,
 
     epoch_to_committee: Vec<Committee>,
 
@@ -456,10 +453,7 @@ impl InMemoryStore {
         self.effects.get(digest)
     }
 
-    pub fn get_transaction_events(
-        &self,
-        digest: &TransactionEventsDigest,
-    ) -> Option<&TransactionEvents> {
+    pub fn get_transaction_events(&self, digest: &TransactionDigest) -> Option<&TransactionEvents> {
         self.events.get(digest)
     }
 }
@@ -559,10 +553,7 @@ impl ReadStore for SingleCheckpointSharedInMemoryStore {
         self.0.try_get_transaction_effects(digest)
     }
 
-    fn try_get_events(
-        &self,
-        digest: &TransactionEventsDigest,
-    ) -> Result<Option<TransactionEvents>> {
+    fn try_get_events(&self, digest: &TransactionDigest) -> Result<Option<TransactionEvents>> {
         self.0.try_get_events(digest)
     }
 

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -647,9 +647,9 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
 
     fn try_get_events(
         &self,
-        event_digest: &iota_types::digests::TransactionDigest,
+        digest: &iota_types::digests::TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEvents>> {
-        Ok(self.with_store(|store| store.get_events(event_digest)))
+        Ok(self.with_store(|store| store.get_events(digest)))
     }
 
     fn try_get_full_checkpoint_contents_by_sequence_number(

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -647,7 +647,7 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
 
     fn try_get_events(
         &self,
-        event_digest: &iota_types::digests::TransactionEventsDigest,
+        event_digest: &iota_types::digests::TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEvents>> {
         Ok(self.with_store(|store| store.get_events(event_digest)))
     }

--- a/crates/simulacrum/src/state_reader.rs
+++ b/crates/simulacrum/src/state_reader.rs
@@ -14,7 +14,7 @@ use iota_types::{
     TypeTag,
     base_types::{ObjectID, VersionNumber},
     committee::Committee,
-    digests::{ChainIdentifier, TransactionDigest, TransactionEventsDigest},
+    digests::{ChainIdentifier, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
     iota_system_state::{IotaSystemState, IotaSystemStateTrait},
@@ -240,7 +240,7 @@ impl GrpcStateReader for SimulacrumGrpcReader {
 
     fn get_transaction_events(
         &self,
-        digest: &TransactionEventsDigest,
+        digest: &TransactionDigest,
     ) -> Result<Option<TransactionEvents>> {
         Ok(self
             .simulacrum
@@ -310,9 +310,13 @@ impl GrpcStateReader for SimulacrumGrpcReader {
                         .clone();
 
                     // Get events from effects if they exist
-                    let events = effects.events_digest().and_then(|events_digest| {
-                        store.get_transaction_events(events_digest).cloned()
-                    });
+                    let events = if effects.events_digest().is_some() {
+                        store
+                            .get_transaction_events(effects.transaction_digest())
+                            .cloned()
+                    } else {
+                        None
+                    };
 
                     // Extract input and output objects with proper error propagation
                     let input_objects = get_transaction_input_objects(store, &effects)?;

--- a/crates/simulacrum/src/store/in_mem_store.rs
+++ b/crates/simulacrum/src/store/in_mem_store.rs
@@ -475,9 +475,9 @@ impl ReadStore for InMemoryStore {
 
     fn try_get_events(
         &self,
-        event_digest: &iota_types::digests::TransactionDigest,
+        digest: &iota_types::digests::TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEvents>> {
-        Ok(self.get_transaction_events(event_digest).cloned())
+        Ok(self.get_transaction_events(digest).cloned())
     }
 
     fn try_get_full_checkpoint_contents_by_sequence_number(

--- a/crates/simulacrum/src/store/in_mem_store.rs
+++ b/crates/simulacrum/src/store/in_mem_store.rs
@@ -12,7 +12,7 @@ use iota_types::{
     base_types::{AuthorityName, IotaAddress, ObjectID, SequenceNumber},
     committee::{Committee, EpochId},
     crypto::{AccountKeyPair, AuthorityKeyPair},
-    digests::{ObjectDigest, TransactionDigest, TransactionEventsDigest},
+    digests::{ObjectDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::IotaError,
     messages_checkpoint::{
@@ -42,9 +42,7 @@ pub struct InMemoryStore {
     // Transaction data
     transactions: HashMap<TransactionDigest, VerifiedTransaction>,
     effects: HashMap<TransactionDigest, TransactionEffects>,
-    events: HashMap<TransactionEventsDigest, TransactionEvents>,
-    // Map from transaction digest to events digest for easy lookup
-    events_tx_digest_index: HashMap<TransactionDigest, TransactionEventsDigest>,
+    events: HashMap<TransactionDigest, TransactionEvents>,
 
     // Committee data
     epoch_to_committee: Vec<Committee>,
@@ -116,10 +114,7 @@ impl InMemoryStore {
         self.effects.get(digest)
     }
 
-    pub fn get_transaction_events(
-        &self,
-        digest: &TransactionEventsDigest,
-    ) -> Option<&TransactionEvents> {
+    pub fn get_transaction_events(&self, digest: &TransactionDigest) -> Option<&TransactionEvents> {
         self.events.get(digest)
     }
 
@@ -259,9 +254,7 @@ impl InMemoryStore {
     }
 
     pub fn insert_events(&mut self, tx_digest: &TransactionDigest, events: TransactionEvents) {
-        self.events_tx_digest_index
-            .insert(*tx_digest, events.digest());
-        self.events.insert(events.digest(), events);
+        self.events.insert(*tx_digest, events);
     }
 
     pub fn update_objects(
@@ -482,7 +475,7 @@ impl ReadStore for InMemoryStore {
 
     fn try_get_events(
         &self,
-        event_digest: &iota_types::digests::TransactionEventsDigest,
+        event_digest: &iota_types::digests::TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEvents>> {
         Ok(self.get_transaction_events(event_digest).cloned())
     }
@@ -582,16 +575,6 @@ impl KeyStore {
 impl SimulatorStore for InMemoryStore {
     fn get_highest_checkpoint(&self) -> Option<VerifiedCheckpoint> {
         self.get_highest_checkpoint().cloned()
-    }
-
-    fn get_transaction_events_by_tx_digest(
-        &self,
-        tx_digest: &TransactionDigest,
-    ) -> Option<TransactionEvents> {
-        self.events_tx_digest_index
-            .get(tx_digest)
-            .and_then(|x| self.events.get(x))
-            .cloned()
     }
 
     fn get_object(&self, id: &ObjectID) -> Option<Object> {

--- a/crates/simulacrum/src/store/mod.rs
+++ b/crates/simulacrum/src/store/mod.rs
@@ -52,11 +52,6 @@ pub trait SimulatorStore:
 
     fn get_highest_checkpoint(&self) -> Option<VerifiedCheckpoint>;
 
-    fn get_transaction_events_by_tx_digest(
-        &self,
-        tx_digest: &TransactionDigest,
-    ) -> Option<TransactionEvents>;
-
     fn get_object(&self, id: &ObjectID) -> Option<Object>;
 
     fn get_object_at_version(&self, id: &ObjectID, version: SequenceNumber) -> Option<Object>;

--- a/crates/simulacrum/src/transaction_executor.rs
+++ b/crates/simulacrum/src/transaction_executor.rs
@@ -88,7 +88,7 @@ impl TransactionExecutorTrait for TransactionExecutor {
             events: if request.include_events {
                 self.simulacrum.with_store(|store| {
                     store
-                        .get_transaction_events(effects.events_digest().unwrap())
+                        .get_transaction_events(effects.transaction_digest())
                         .cloned()
                 })
             } else {


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.45.3, v1.46.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/c023028e52147f7de0c14b62b7f591806bd5ea82
  - https://github.com/MystenLabs/sui/pull/21566/changes/38f0d3285b987efee5bda496820b1d19df5bd629
  - https://github.com/MystenLabs/sui/commit/8bbdf9fa93552603dc4251bf2894c2d246748192
- Description:

In Sui TransactionEvents are not unique and multiple transactions can
produce the exact same set of TransactionEvents. Today these events are
stored in a table keyed by TransactionEventsDigest which can lead to an
unfortunate scenario when pruning is enabled. If we have two
transactions `A` and `B`, both of which produced events `E`, when the
pruner goes to prune transaction `A` it will also remove events `E` from
the database. This will lead to a situation where the node will be
unable to find locally the events produced by transaction `B`.

In order to fix this bug this patch introduces a new `events_2` table to
store events keyed by the transaction digest of the transaction that
produced them. It also updates the interface used to read events from
the db to require a `TransactionDigest` instead of a
`TransactionEventsDigest`. Internally the `events_2` table is first checked
but then there is fallback logic to lookup the events from the `events`
table. This fallback logic can eventually be removed once we've
completed a db migration and deprecate the `events` table.

[run-ci]
## Links to any relevant issues

Part of #9768

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

