### PR TITLE
upstream(core): Do not expose internal effects state

### DIFF
--- a/crates/iota-types/src/effects/effects_v1.rs
+++ b/crates/iota-types/src/effects/effects_v1.rs
@@ -50,6 +50,8 @@ pub struct TransactionEffectsV1 {
     /// The version number of all the written Move objects by this transaction.
     pub(crate) lamport_version: SequenceNumber,
     /// Objects whose state are changed in the object store.
+    /// This field should not be exposed to the public API.
+    /// Otherwise it will make it harder to use effects of different versions.
     pub(crate) changed_objects: Vec<(ObjectID, EffectsObjectChange)>,
     /// Shared objects that are not mutated in this transaction. Unlike owned
     /// objects, read-only shared objects' version are not committed in the
@@ -579,10 +581,6 @@ impl TransactionEffectsV1 {
                 "Duplicate object id: {id:?}\n{self:#?}"
             );
         }
-    }
-
-    pub fn changed_objects(&self) -> &[(ObjectID, EffectsObjectChange)] {
-        &self.changed_objects
     }
 
     pub fn aux_data_digest(&self) -> Option<EffectsAuxDataDigest> {

--- a/crates/iota-types/src/full_checkpoint_content.rs
+++ b/crates/iota-types/src/full_checkpoint_content.rs
@@ -9,10 +9,7 @@ use tap::Pipe;
 
 use crate::{
     base_types::{ObjectID, ObjectRef},
-    effects::{
-        IDOperation, ObjectIn, ObjectOut, TransactionEffects, TransactionEffectsAPI,
-        TransactionEvents,
-    },
+    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     iota_system_state::{IotaSystemStateTrait, get_iota_system_state},
     messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents},
     object::Object,
@@ -164,40 +161,18 @@ pub struct CheckpointTransaction {
 impl CheckpointTransaction {
     // provide an iterator over all deleted or wrapped objects in this transaction
     pub fn removed_objects_pre_version(&self) -> impl Iterator<Item = &Object> {
-        // Iterator over id and versions for all deleted or wrapped objects
-        match &self.effects {
-            TransactionEffects::V1(v1) => {
-                v1.changed_objects().iter().filter_map(|(id, change)| {
-                    match (
-                        &change.input_state,
-                        &change.output_state,
-                        &change.id_operation,
-                    ) {
-                        // Deleted Objects
-                        (
-                            ObjectIn::Exist(((version, _d), _o)),
-                            ObjectOut::NotExist,
-                            IDOperation::Deleted,
-                        ) => Some((id, version)),
-
-                        // Wrapped Objects
-                        (
-                            ObjectIn::Exist(((version, _), _)),
-                            ObjectOut::NotExist,
-                            IDOperation::None,
-                        ) => Some((id, version)),
-                        _ => None,
-                    }
-                })
-            }
-        }
-        // Use id and version to lookup in input Objects
-        .map(|(id, version)| {
-            self.input_objects
-                .iter()
-                .find(|o| &o.id() == id && &o.version() == version)
-                .expect("all removed objects should show up in input objects")
-        })
+        // Since each object ID can only show up once in the input_objects, we can just
+        // use the ids of deleted and wrapped objects to lookup the object in
+        // the input_objects.
+        self.effects
+            .all_removed_objects()
+            .into_iter() // Use id and version to lookup in input Objects
+            .map(|((id, _, _), _)| {
+                self.input_objects
+                    .iter()
+                    .find(|o| o.id() == id)
+                    .expect("all removed objects should show up in input objects")
+            })
     }
 
     pub fn removed_object_refs_post_version(&self) -> impl Iterator<Item = ObjectRef> {
@@ -208,96 +183,34 @@ impl CheckpointTransaction {
     }
 
     pub fn changed_objects(&self) -> impl Iterator<Item = (&Object, Option<&Object>)> {
-        // Iterator over ((ObjectId, new version), Option<old version>)
-        match &self.effects {
-            TransactionEffects::V1(v1) => {
-                v1.changed_objects().iter().filter_map(|(id, change)| {
-                    match (
-                        &change.input_state,
-                        &change.output_state,
-                        &change.id_operation,
-                    ) {
-                        // Created Objects
-                        (ObjectIn::NotExist, ObjectOut::ObjectWrite(_), IDOperation::Created) => {
-                            Some(((id, &v1.lamport_version), None))
-                        }
-                        (
-                            ObjectIn::NotExist,
-                            ObjectOut::PackageWrite((version, _)),
-                            IDOperation::Created,
-                        ) => Some(((id, version), None)),
-
-                        // Unwrapped Objects
-                        (ObjectIn::NotExist, ObjectOut::ObjectWrite(_), IDOperation::None) => {
-                            Some(((id, &v1.lamport_version), None))
-                        }
-
-                        // Mutated Objects
-                        (ObjectIn::Exist(((old_version, _), _)), ObjectOut::ObjectWrite(_), _) => {
-                            Some(((id, &v1.lamport_version), Some(old_version)))
-                        }
-                        (
-                            ObjectIn::Exist(((old_version, _), _)),
-                            ObjectOut::PackageWrite((version, _)),
-                            _,
-                        ) => Some(((id, version), Some(old_version))),
-
-                        _ => None,
-                    }
-                })
-            }
-        }
-        // Lookup Objects in output Objects as well as old versions for mutated objects
-        .map(|((id, version), old_version)| {
-            let object = self
-                .output_objects
-                .iter()
-                .find(|o| &o.id() == id && &o.version() == version)
-                .expect("changed objects should show up in output objects");
-
-            let old_object = old_version.map(|old_version| {
-                self.input_objects
+        self.effects
+            .all_changed_objects()
+            .into_iter()
+            .map(|((id, _, _), ..)| {
+                let object = self
+                    .output_objects
                     .iter()
-                    .find(|o| &o.id() == id && &o.version() == old_version)
-                    .expect("mutated objects should have a previous version in input objects")
-            });
+                    .find(|o| o.id() == id)
+                    .expect("changed objects should show up in output objects");
 
-            (object, old_object)
-        })
+                let old_object = self.input_objects.iter().find(|o| o.id() == id);
+
+                (object, old_object)
+            })
     }
 
     pub fn created_objects(&self) -> impl Iterator<Item = &Object> {
         // Iterator over (ObjectId, version) for created objects
-        match &self.effects {
-            TransactionEffects::V1(v1) => {
-                v1.changed_objects().iter().filter_map(|(id, change)| {
-                    match (
-                        &change.input_state,
-                        &change.output_state,
-                        &change.id_operation,
-                    ) {
-                        // Created Objects
-                        (ObjectIn::NotExist, ObjectOut::ObjectWrite(_), IDOperation::Created) => {
-                            Some((id, &v1.lamport_version))
-                        }
-                        (
-                            ObjectIn::NotExist,
-                            ObjectOut::PackageWrite((version, _)),
-                            IDOperation::Created,
-                        ) => Some((id, version)),
-
-                        _ => None,
-                    }
-                })
-            }
-        }
-        // Lookup Objects in output Objects as well as old versions for mutated objects
-        .map(|(id, version)| {
-            self.output_objects
-                .iter()
-                .find(|o| &o.id() == id && &o.version() == version)
-                .expect("created objects should show up in output objects")
-        })
+        self.effects
+            .created()
+            .into_iter()
+            // Lookup Objects in output Objects as well as old versions for mutated objects
+            .map(|((id, version, _), _)| {
+                self.output_objects
+                    .iter()
+                    .find(|o| o.id() == id && o.version() == version)
+                    .expect("created objects should show up in output objects")
+            })
     }
 }
 


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.45.3, v1.46.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/f361c5eedd7e67df6cb7f4fcd493d01cdc46eaf6
- Description:
This PR removes all direct uses of the `changed_objects` from effects
v2.
We should always access effects through APIs (i.e. effects trait) for
reads. Otherwise it will make it difficult to evolve effects.
Most changes are in full_checkpoint_contents. This PR also simplifies
these functions a bit.

## Links to any relevant issues

Part of #9768

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

