### PR TITLE
fix(node): handle SIGTERM correctly for Backup or Archive nodes

### DIFF
--- a/crates/iota-archival/src/tests.rs
+++ b/crates/iota-archival/src/tests.rs
@@ -199,9 +199,11 @@ async fn test_archive_shutdown_on_send() -> Result<(), anyhow::Error> {
     // Let the writer run briefly
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    // Send explicit shutdown signal and verify it completes within timeout
+    // Send explicit shutdown signal and verify it completes within timeout.
+    // The blocking tailing task uses std::thread::sleep(3s) between retries,
+    // so it may take up to ~3s to notice the signal.
     kill.send(())?;
-    let shutdown_result = tokio::time::timeout(Duration::from_secs(5), async {
+    let shutdown_result = tokio::time::timeout(Duration::from_secs(10), async {
         // The writer tasks should stop; verify by checking the sender has
         // no more active receivers (all tasks exited).
         loop {
@@ -215,7 +217,7 @@ async fn test_archive_shutdown_on_send() -> Result<(), anyhow::Error> {
 
     assert!(
         shutdown_result.is_ok(),
-        "Archive writer did not shut down within 5 seconds after send()"
+        "Archive writer did not shut down within 10 seconds after send()"
     );
     Ok(())
 }
@@ -252,17 +254,17 @@ async fn test_archive_shutdown_on_drop() -> Result<(), anyhow::Error> {
             // Drop the sender (simulates IotaNode being dropped on SIGTERM)
             drop(kill);
         });
-        // Wait for blocking tasks to finish. With the correct implementation
-        // (tokio::spawn), there's nothing to wait for since async tasks are
-        // cancelled when the runtime shuts down above.
+        // Wait for blocking tasks to finish. The tailing task runs via
+        // spawn_blocking with std::thread::sleep(3s), so it may take up
+        // to ~3s to notice the sender was dropped and exit.
         rt.shutdown_timeout(Duration::from_secs(10));
         let _ = tx.send(());
     });
 
-    let shutdown_result = tokio::time::timeout(Duration::from_secs(5), rx).await;
+    let shutdown_result = tokio::time::timeout(Duration::from_secs(10), rx).await;
     assert!(
         matches!(shutdown_result, Ok(Ok(()))),
-        "Archive writer did not shut down within 5 seconds after drop()"
+        "Archive writer did not shut down within 10 seconds after drop()"
     );
     Ok(())
 }

--- a/crates/iota-archival/src/tests.rs
+++ b/crates/iota-archival/src/tests.rs
@@ -188,6 +188,85 @@ async fn test_archive_resumes() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Verifies that the archive writer shuts down promptly when an explicit
+/// kill signal is sent via `kill.send(())`.
+#[tokio::test]
+async fn test_archive_shutdown_on_send() -> Result<(), anyhow::Error> {
+    let test_store = SharedInMemoryStore::default();
+    let test_state = setup_test_state(temp_dir()).await?;
+    let kill = test_state.archive_writer.start(test_store.clone()).await?;
+
+    // Let the writer run briefly
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Send explicit shutdown signal and verify it completes within timeout
+    kill.send(())?;
+    let shutdown_result = tokio::time::timeout(Duration::from_secs(5), async {
+        // The writer tasks should stop; verify by checking the sender has
+        // no more active receivers (all tasks exited).
+        loop {
+            if kill.receiver_count() == 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+
+    assert!(
+        shutdown_result.is_ok(),
+        "Archive writer did not shut down within 5 seconds after send()"
+    );
+    Ok(())
+}
+
+/// Verifies that the archive writer shuts down promptly when the kill sender
+/// is dropped (simulating the SIGTERM path where IotaNode is dropped without
+/// calling send).
+#[tokio::test]
+async fn test_archive_shutdown_on_drop() -> Result<(), anyhow::Error> {
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let test_store = SharedInMemoryStore::default();
+            let test_state = setup_test_state(temp_dir()).await.unwrap();
+            let kill = test_state
+                .archive_writer
+                .start(test_store.clone())
+                .await
+                .unwrap();
+
+            // Let the writer run briefly
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            assert!(
+                kill.receiver_count() > 0,
+                "Expected active receivers before drop"
+            );
+
+            // Drop the sender (simulates IotaNode being dropped on SIGTERM)
+            drop(kill);
+        });
+        // Wait for blocking tasks to finish. With the correct implementation
+        // (tokio::spawn), there's nothing to wait for since async tasks are
+        // cancelled when the runtime shuts down above.
+        rt.shutdown_timeout(Duration::from_secs(10));
+        let _ = tx.send(());
+    });
+
+    let shutdown_result = tokio::time::timeout(Duration::from_secs(5), rx).await;
+    assert!(
+        matches!(shutdown_result, Ok(Ok(()))),
+        "Archive writer did not shut down within 5 seconds after drop()"
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_manifest_serde() -> Result<()> {
     let original_manifest = Manifest::new(0, 100);

--- a/crates/iota-archival/src/writer.rs
+++ b/crates/iota-archival/src/writer.rs
@@ -11,6 +11,7 @@ use std::{
     ops::Range,
     path::{Path, PathBuf},
     sync::Arc,
+    thread::sleep,
     time::Duration,
 };
 
@@ -411,12 +412,14 @@ impl ArchiveWriter {
         ));
 
         // Tails checkpoints from the store and writes them to the CheckpointWriter.
-        tokio::spawn(Self::start_tailing_checkpoints(
-            start_checkpoint_sequence_number,
-            checkpoint_writer,
-            store,
-            kill_receiver,
-        ));
+        tokio::task::spawn_blocking(move || {
+            Self::start_tailing_checkpoints(
+                start_checkpoint_sequence_number,
+                checkpoint_writer,
+                store,
+                kill_receiver,
+            )
+        });
         Ok(kill_sender)
     }
 
@@ -424,7 +427,7 @@ impl ArchiveWriter {
     /// to read from store, if not, sleeps for some time (3 secs) and retries.
     /// If the checkpoint is available, writes the checkpoint contents and
     /// summary to the CheckpointWriter.
-    async fn start_tailing_checkpoints<S>(
+    fn start_tailing_checkpoints<S>(
         start_checkpoint_sequence_number: CheckpointSequenceNumber,
         mut checkpoint_writer: CheckpointWriter,
         store: S,
@@ -436,7 +439,9 @@ impl ArchiveWriter {
         let mut checkpoint_sequence_number = start_checkpoint_sequence_number;
         info!("Starting checkpoint tailing from sequence number: {checkpoint_sequence_number}");
 
-        loop {
+        while kill.try_recv()
+            == Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        {
             if let Some(checkpoint_summary) = store
                 .try_get_checkpoint_by_sequence_number(checkpoint_sequence_number)
                 .map_err(|_| anyhow!("Failed to read checkpoint summary from store"))?
@@ -456,11 +461,10 @@ impl ArchiveWriter {
             }
             // Checkpoint with `checkpoint_sequence_number` is not available to read from
             // store yet, sleep for sometime and then retry
-            tokio::select! {
-                _ = kill.recv() => break,
-                _ = tokio::time::sleep(Duration::from_secs(3)) => {}
-            }
+            sleep(Duration::from_secs(3));
         }
+
+        info!("Checkpoint tailing stopped (shutdown signal received)");
         Ok(())
     }
 

--- a/crates/iota-archival/src/writer.rs
+++ b/crates/iota-archival/src/writer.rs
@@ -439,9 +439,7 @@ impl ArchiveWriter {
         let mut checkpoint_sequence_number = start_checkpoint_sequence_number;
         info!("Starting checkpoint tailing from sequence number: {checkpoint_sequence_number}");
 
-        while kill.try_recv()
-            == Err(tokio::sync::broadcast::error::TryRecvError::Empty)
-        {
+        while kill.try_recv() == Err(tokio::sync::broadcast::error::TryRecvError::Empty) {
             if let Some(checkpoint_summary) = store
                 .try_get_checkpoint_by_sequence_number(checkpoint_sequence_number)
                 .map_err(|_| anyhow!("Failed to read checkpoint summary from store"))?

--- a/crates/iota-archival/src/writer.rs
+++ b/crates/iota-archival/src/writer.rs
@@ -11,7 +11,6 @@ use std::{
     ops::Range,
     path::{Path, PathBuf},
     sync::Arc,
-    thread::sleep,
     time::Duration,
 };
 
@@ -412,14 +411,12 @@ impl ArchiveWriter {
         ));
 
         // Tails checkpoints from the store and writes them to the CheckpointWriter.
-        tokio::task::spawn_blocking(move || {
-            Self::start_tailing_checkpoints(
-                start_checkpoint_sequence_number,
-                checkpoint_writer,
-                store,
-                kill_receiver,
-            )
-        });
+        tokio::spawn(Self::start_tailing_checkpoints(
+            start_checkpoint_sequence_number,
+            checkpoint_writer,
+            store,
+            kill_receiver,
+        ));
         Ok(kill_sender)
     }
 
@@ -427,7 +424,7 @@ impl ArchiveWriter {
     /// to read from store, if not, sleeps for some time (3 secs) and retries.
     /// If the checkpoint is available, writes the checkpoint contents and
     /// summary to the CheckpointWriter.
-    fn start_tailing_checkpoints<S>(
+    async fn start_tailing_checkpoints<S>(
         start_checkpoint_sequence_number: CheckpointSequenceNumber,
         mut checkpoint_writer: CheckpointWriter,
         store: S,
@@ -439,7 +436,7 @@ impl ArchiveWriter {
         let mut checkpoint_sequence_number = start_checkpoint_sequence_number;
         info!("Starting checkpoint tailing from sequence number: {checkpoint_sequence_number}");
 
-        while kill.try_recv().is_err() {
+        loop {
             if let Some(checkpoint_summary) = store
                 .try_get_checkpoint_by_sequence_number(checkpoint_sequence_number)
                 .map_err(|_| anyhow!("Failed to read checkpoint summary from store"))?
@@ -459,7 +456,10 @@ impl ArchiveWriter {
             }
             // Checkpoint with `checkpoint_sequence_number` is not available to read from
             // store yet, sleep for sometime and then retry
-            sleep(Duration::from_secs(3));
+            tokio::select! {
+                _ = kill.recv() => break,
+                _ = tokio::time::sleep(Duration::from_secs(3)) => {}
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
# Description of change

Fullnodes running as normal nodes or validators handle SIGTERM correctly and shut down gracefully. However, when a node is operated with `state-archive-write-config`, `db-checkpoint-config`, or `state-snapshot-write-config` enabled, the SIGTERM signal was not handled correctly.

The `ArchiveWriter` spawns a blocking task via `tokio::task::spawn_blocking` that tails checkpoints in a loop controlled by `while kill.try_recv().is_err()`. On SIGTERM, the node drops the broadcast sender rather than explicitly calling `send(())`, so `try_recv()` returns `Err(TryRecvError::Closed)`. Since `.is_err()` is `true` for both `Empty` and `Closed`, the while loop never exits on shutdown. Because `tokio::Runtime::drop()` waits for all `spawn_blocking` tasks to complete, the runtime drop blocks indefinitely, causing the node to hang until Docker sends SIGKILL after the grace period timeout.

This change fixes the while condition to only continue on `Err(TryRecvError::Empty)`.

## Links to any relevant issues

fixes #5341 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Fix SIGTERM handing bugs for Backup/Archive nodes
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: