### PR TITLE
feat(gRPC): selective accessor generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7326,6 +7326,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost 0.14.1",
+ "prost-reflect",
  "prost-types 0.14.1",
  "protox",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,11 +1907,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2974,7 +2974,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "mio 1.0.2",
  "parking_lot 0.12.3",
@@ -3506,7 +3506,7 @@ version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e130c806dccc85428c564f2dc5a96e05b6615a27c9a28776bd7761a9af4bb552"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "byteorder",
  "chrono",
  "diesel_derives",
@@ -7319,6 +7319,7 @@ dependencies = [
 name = "iota-proto-build"
 version = "1.17.0-alpha"
 dependencies = [
+ "bitflags 2.10.0",
  "heck 0.5.0",
  "itertools 0.13.0",
  "petgraph 0.6.5",
@@ -7804,7 +7805,7 @@ name = "iota-stardust-types"
 version = "1.17.0-alpha"
 dependencies = [
  "bech32",
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "derive_more 1.0.0",
  "getset",
  "iota-crypto",
@@ -8760,7 +8761,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.5.6",
 ]
@@ -10055,7 +10056,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -10834,7 +10835,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77144664f6aac5f629d7efa815f5098a054beeeca6ccafee5ec453fd2b0c53f9"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "ciborium",
  "coset",
  "data-encoding",
@@ -11564,7 +11565,7 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -11775,7 +11776,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "memchr",
  "unicase",
 ]
@@ -12069,7 +12070,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -12090,7 +12091,7 @@ version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -12180,7 +12181,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -12454,7 +12455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "serde",
  "serde_derive",
 ]
@@ -12551,7 +12552,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "async-trait",
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "byteorder",
  "cbc",
  "chacha20",
@@ -12713,7 +12714,7 @@ version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -12726,7 +12727,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -13072,7 +13073,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -13085,7 +13086,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -15172,7 +15173,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "bytes",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -16440,7 +16441,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,6 +252,7 @@ bcs = "0.1.4"
 better_any = "0.1.1"
 bincode = "1.3.3"
 bip32 = "0.5"
+bitflags = { version = "2.10.0", default-features = false }
 byteorder = "1.4.3"
 bytes = { version = "1.5.0", features = ["serde"] }
 cached = "0.43.0"

--- a/crates/iota-grpc-types/proto/iota/grpc/options.proto
+++ b/crates/iota-grpc-types/proto/iota/grpc/options.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package iota.grpc;
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.FieldOptions {
+  // Comma-separated list of accessor types to generate.
+  // Valid values: getter, getter_opt, set, with, mut, mut_opt
+  // Example: "set,with" generates set_field() and with_field()
+  optional string generate_accessors = 50000;
+}

--- a/crates/iota-proto-build/Cargo.toml
+++ b/crates/iota-proto-build/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
+bitflags.workspace = true
 heck = { version = ">=0.4, <=0.5" }
 itertools.workspace = true
 petgraph.workspace = true

--- a/crates/iota-proto-build/Cargo.toml
+++ b/crates/iota-proto-build/Cargo.toml
@@ -17,6 +17,7 @@ petgraph.workspace = true
 prettyplease = "0.2"
 proc-macro2.workspace = true
 prost.workspace = true
+prost-reflect = "0.16"
 prost-types.workspace = true
 protox = "0.9"
 quote.workspace = true

--- a/crates/iota-proto-build/README.md
+++ b/crates/iota-proto-build/README.md
@@ -39,3 +39,37 @@ Generated files are written to `crates/iota-grpc-types/src/proto/generated/`:
 ## Proto Files Location
 
 Source proto files: `crates/iota-grpc-types/proto/iota/grpc/v0/`
+
+## Selective Accessor Generation
+
+iota-protoc-build supports selective accessor generation via custom proto field options.
+
+Fields that need accessors are annotated in the `.proto` files using a custom option:
+
+```protobuf
+import "iota/grpc/options.proto";
+
+message ObjectRequest {
+  optional ObjectReference object_ref = 1 [(iota.grpc.generate_accessors) = "set,with"];
+}
+```
+
+The `generate_accessors` option accepts a comma-separated list of accessor types:
+
+**Individual Accessor Types:**
+
+- `getter` - `field()` returns value or default (see limitations below)
+- `getter_opt` - `field_opt()` returns `Option<&T>`
+- `set` - `set_field()` setter method (mutable, modifies in place)
+- `with` - `with_field()` builder-pattern setter (consumes self, returns modified self)
+- `mut` - `field_mut()` returns `&mut T`
+- `mut_opt` - `field_opt_mut()` returns `Option<&mut T>`
+
+**Special Keywords:**
+
+- `all` - Generates all accessor types (getter, getter_opt, set, with, mut, mut_opt)
+  - **Note:** Cannot be combined with other accessor types
+  - **Note:** Automatically includes default helpers when getter methods are generated
+- `default` - Generates only `const_default()` and `default_instance()` helper functions
+  - **Note:** Cannot be combined with `getter` or `all` (redundant, since getter includes defaults)
+  - **Use case:** For fields that need default helpers but don't want getter methods (e.g., `"set,with,default"`)

--- a/crates/iota-proto-build/src/codegen/accessor_config.rs
+++ b/crates/iota-proto-build/src/codegen/accessor_config.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-use std::{collections::HashMap, path::Path};
+use std::collections::HashMap;
 
 use bitflags::bitflags;
 use prost_types::FieldDescriptorProto;
@@ -141,87 +141,44 @@ impl AccessorTypes {
 /// Key is "message_name.field_name", value is the accessor types
 pub type AccessorMap = HashMap<String, AccessorTypes>;
 
-/// Parse proto files to extract generate_accessors annotations
-/// Returns a map of "MessageName.field_name" -> AccessorTypes
-pub fn parse_proto_accessors(proto_dir: &Path) -> AccessorMap {
+/// Parse proto files to extract generate_accessors annotations from the
+/// descriptor pool Returns a map of "MessageName.field_name" -> AccessorTypes
+pub fn parse_proto_accessors_from_pool(pool: &prost_reflect::DescriptorPool) -> AccessorMap {
     let mut map = HashMap::new();
 
-    // Walk through all .proto files
-    for entry in walkdir::WalkDir::new(proto_dir) {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-
-        if !entry.file_type().is_file() {
-            continue;
+    // Get the extension descriptor for iota.grpc.generate_accessors
+    let ext = match pool.get_extension_by_name("iota.grpc.generate_accessors") {
+        Some(ext) => ext,
+        None => {
+            panic!("Extension iota.grpc.generate_accessors not found in descriptor pool");
         }
+    };
 
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("proto") {
-            continue;
-        }
+    // Iterate all messages (including nested ones)
+    for message in pool.all_messages() {
+        let message_name = message.name();
 
-        // Read and parse the proto file
-        if let Ok(content) = std::fs::read_to_string(path) {
-            parse_proto_content(&content, &mut map);
+        // Iterate all fields in this message
+        for field in message.fields() {
+            let field_name = field.name();
+
+            // Get field options
+            let options = field.options();
+
+            // Check if the extension is set
+            if options.has_extension(&ext) {
+                if let Some(accessor_str) = options.get_extension(&ext).as_str() {
+                    let key = format!("{}.{}", message_name, field_name);
+
+                    if let Some(accessor_types) = AccessorTypes::parse(accessor_str) {
+                        map.insert(key, accessor_types);
+                    }
+                }
+            }
         }
     }
 
     map
-}
-
-/// Parse a proto file content to extract accessor annotations
-///
-/// Remark: We parse the file manually using regex to avoid adding a full proto
-/// parser dependency like proto-reflect, For our use case this is simpler and
-/// sufficient.
-fn parse_proto_content(content: &str, map: &mut AccessorMap) {
-    // First, find all message definitions and their fields with annotations
-    let message_re = regex::Regex::new(r#"(?m)^message\s+(\w+)\s*\{"#).unwrap();
-    let field_re = regex::Regex::new(
-        r#"(?m)^\s*(?:optional|required|repeated)?\s+\w+(?:\.\w+)*\s+(\w+)\s*=\s*\d+\s*\[\(iota\.grpc\.generate_accessors\)\s*=\s*"([^"]*)"\]"#
-    ).unwrap();
-
-    // Track the current message name
-    let mut current_message = String::new();
-    let mut last_message_pos = 0;
-
-    for message_cap in message_re.captures_iter(content) {
-        let message_name = message_cap.get(1).unwrap().as_str();
-        let message_start = message_cap.get(0).unwrap().start();
-
-        // Process fields from the previous message
-        if !current_message.is_empty() {
-            let message_content = &content[last_message_pos..message_start];
-            for field_cap in field_re.captures_iter(message_content) {
-                let field_name = field_cap.get(1).unwrap().as_str();
-                let accessor_str = field_cap.get(2).unwrap().as_str();
-                let key = format!("{}.{}", current_message, field_name);
-
-                if let Some(accessor_types) = AccessorTypes::parse(accessor_str) {
-                    map.insert(key, accessor_types);
-                }
-            }
-        }
-
-        current_message = message_name.to_string();
-        last_message_pos = message_start;
-    }
-
-    // Process fields from the last message
-    if !current_message.is_empty() {
-        let message_content = &content[last_message_pos..];
-        for field_cap in field_re.captures_iter(message_content) {
-            let field_name = field_cap.get(1).unwrap().as_str();
-            let accessor_str = field_cap.get(2).unwrap().as_str();
-            let key = format!("{}.{}", current_message, field_name);
-
-            if let Some(accessor_types) = AccessorTypes::parse(accessor_str) {
-                map.insert(key, accessor_types);
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/iota-proto-build/src/codegen/accessor_config.rs
+++ b/crates/iota-proto-build/src/codegen/accessor_config.rs
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+use std::{collections::HashMap, path::Path};
+
+use bitflags::bitflags;
+use prost_types::FieldDescriptorProto;
+
+bitflags! {
+    /// Flags for different types of accessor methods to generate
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct AccessorTypes: u8 {
+        /// Generate `field()` getter returning value or default
+        const GETTER = 0b0000_0001;
+        /// Generate `field_opt()` getter returning `Option<&T>`
+        const GETTER_OPT = 0b0000_0010;
+        /// Generate `set_field()` setter method
+        const SET = 0b0000_0100;
+        /// Generate `with_field()` builder-pattern setter
+        const WITH = 0b0000_1000;
+        /// Generate `field_mut()` returning `&mut T`
+        const MUT = 0b0001_0000;
+        /// Generate `field_opt_mut()` returning `Option<&mut T>`
+        const MUT_OPT = 0b0010_0000;
+        /// Generate `const_default()` and `default_instance()` helper functions
+        const DEFAULT = 0b0100_0000;
+    }
+}
+
+impl AccessorTypes {
+    /// Parse a comma-separated string of accessor types
+    /// Example: "set,with" -> AccessorTypes::SET | AccessorTypes::WITH
+    /// Special values:
+    /// - "all" -> generates all accessor types (getter, getter_opt, set, with,
+    ///   mut, mut_opt) Note: "all" cannot be combined with other accessor types
+    ///   Note: "all" includes getter, which automatically generates default
+    ///   helpers
+    /// - "default" -> generates const_default() and default_instance() helpers
+    ///   Note: Only use "default" with non-getter accessors (e.g.,
+    ///   "set,with,default") Note: "getter" and "all" already include default
+    ///   helpers, so don't combine
+    ///
+    /// Panics if:
+    /// - Unknown accessor type is encountered
+    /// - "all" is combined with other accessor types
+    /// - "default" is combined with "getter" or "all" (redundant, since getter
+    ///   includes defaults)
+    pub fn parse(s: &str) -> Option<Self> {
+        if s.is_empty() {
+            return None;
+        }
+
+        let mut result = AccessorTypes::empty();
+        let mut has_all = false;
+        let mut has_other_accessors = false;
+
+        for part in s.split(',') {
+            let part = part.trim();
+            match part {
+                "all" => {
+                    has_all = true;
+                    result |= AccessorTypes::GETTER
+                        | AccessorTypes::GETTER_OPT
+                        | AccessorTypes::SET
+                        | AccessorTypes::WITH
+                        | AccessorTypes::MUT
+                        | AccessorTypes::MUT_OPT;
+                }
+                "default" => result |= AccessorTypes::DEFAULT,
+                "getter" => {
+                    has_other_accessors = true;
+                    result |= AccessorTypes::GETTER;
+                }
+                "getter_opt" => {
+                    has_other_accessors = true;
+                    result |= AccessorTypes::GETTER_OPT;
+                }
+                "set" => {
+                    has_other_accessors = true;
+                    result |= AccessorTypes::SET;
+                }
+                "with" => {
+                    has_other_accessors = true;
+                    result |= AccessorTypes::WITH;
+                }
+                "mut" => {
+                    has_other_accessors = true;
+                    result |= AccessorTypes::MUT;
+                }
+                "mut_opt" => {
+                    has_other_accessors = true;
+                    result |= AccessorTypes::MUT_OPT;
+                }
+                _ => {
+                    panic!(
+                        "Unknown accessor type '{}'. Valid types are: getter, getter_opt, set, with, mut, mut_opt, all, default",
+                        part
+                    );
+                }
+            }
+        }
+
+        if has_all && has_other_accessors {
+            panic!(
+                "Cannot combine 'all' with other accessor types in '{}'. Use 'all' alone, or list specific types.",
+                s
+            );
+        }
+
+        // Validate that 'default' is not combined with 'getter' or 'all' (since getter
+        // already includes default)
+        if result.contains(AccessorTypes::DEFAULT) && result.contains(AccessorTypes::GETTER) {
+            panic!(
+                "Cannot combine 'default' with 'getter' or 'all' in '{}'. The 'getter' accessor already generates default helpers. Use 'default' only with non-getter accessors like 'set,with,default'.",
+                s
+            );
+        }
+
+        if result.is_empty() {
+            None
+        } else {
+            Some(result)
+        }
+    }
+
+    /// Extract accessor types from a protobuf field's custom options
+    /// Returns None if the field doesn't have the generate_accessors option
+    pub fn from_field(
+        field: &FieldDescriptorProto,
+        accessor_map: &AccessorMap,
+        message_name: &str,
+    ) -> Option<Self> {
+        // Build the key as "message_name.field_name"
+        let key = format!("{}.{}", message_name, field.name());
+
+        // Try to find in the map
+        accessor_map.get(&key).copied()
+    }
+}
+
+/// Map of field names to their accessor configurations
+/// Key is "message_name.field_name", value is the accessor types
+pub type AccessorMap = HashMap<String, AccessorTypes>;
+
+/// Parse proto files to extract generate_accessors annotations
+/// Returns a map of "MessageName.field_name" -> AccessorTypes
+pub fn parse_proto_accessors(proto_dir: &Path) -> AccessorMap {
+    let mut map = HashMap::new();
+
+    // Walk through all .proto files
+    for entry in walkdir::WalkDir::new(proto_dir) {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("proto") {
+            continue;
+        }
+
+        // Read and parse the proto file
+        if let Ok(content) = std::fs::read_to_string(path) {
+            parse_proto_content(&content, &mut map);
+        }
+    }
+
+    map
+}
+
+/// Parse a proto file content to extract accessor annotations
+///
+/// Remark: We parse the file manually using regex to avoid adding a full proto
+/// parser dependency like proto-reflect, For our use case this is simpler and
+/// sufficient.
+fn parse_proto_content(content: &str, map: &mut AccessorMap) {
+    // First, find all message definitions and their fields with annotations
+    let message_re = regex::Regex::new(r#"(?m)^message\s+(\w+)\s*\{"#).unwrap();
+    let field_re = regex::Regex::new(
+        r#"(?m)^\s*(?:optional|required|repeated)?\s+\w+(?:\.\w+)*\s+(\w+)\s*=\s*\d+\s*\[\(iota\.grpc\.generate_accessors\)\s*=\s*"([^"]*)"\]"#
+    ).unwrap();
+
+    // Track the current message name
+    let mut current_message = String::new();
+    let mut last_message_pos = 0;
+
+    for message_cap in message_re.captures_iter(content) {
+        let message_name = message_cap.get(1).unwrap().as_str();
+        let message_start = message_cap.get(0).unwrap().start();
+
+        // Process fields from the previous message
+        if !current_message.is_empty() {
+            let message_content = &content[last_message_pos..message_start];
+            for field_cap in field_re.captures_iter(message_content) {
+                let field_name = field_cap.get(1).unwrap().as_str();
+                let accessor_str = field_cap.get(2).unwrap().as_str();
+                let key = format!("{}.{}", current_message, field_name);
+
+                if let Some(accessor_types) = AccessorTypes::parse(accessor_str) {
+                    map.insert(key, accessor_types);
+                }
+            }
+        }
+
+        current_message = message_name.to_string();
+        last_message_pos = message_start;
+    }
+
+    // Process fields from the last message
+    if !current_message.is_empty() {
+        let message_content = &content[last_message_pos..];
+        for field_cap in field_re.captures_iter(message_content) {
+            let field_name = field_cap.get(1).unwrap().as_str();
+            let accessor_str = field_cap.get(2).unwrap().as_str();
+            let key = format!("{}.{}", current_message, field_name);
+
+            if let Some(accessor_types) = AccessorTypes::parse(accessor_str) {
+                map.insert(key, accessor_types);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_single() {
+        assert_eq!(AccessorTypes::parse("set"), Some(AccessorTypes::SET));
+        assert_eq!(AccessorTypes::parse("with"), Some(AccessorTypes::WITH));
+    }
+
+    #[test]
+    fn test_parse_multiple() {
+        let result = AccessorTypes::parse("set,with");
+        assert_eq!(result, Some(AccessorTypes::SET | AccessorTypes::WITH));
+    }
+
+    #[test]
+    fn test_parse_all() {
+        let result = AccessorTypes::parse("getter,getter_opt,set,with,mut,mut_opt");
+        assert_eq!(
+            result,
+            Some(
+                AccessorTypes::GETTER
+                    | AccessorTypes::GETTER_OPT
+                    | AccessorTypes::SET
+                    | AccessorTypes::WITH
+                    | AccessorTypes::MUT
+                    | AccessorTypes::MUT_OPT
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_whitespace() {
+        let result = AccessorTypes::parse("set , with ");
+        assert_eq!(result, Some(AccessorTypes::SET | AccessorTypes::WITH));
+    }
+
+    #[test]
+    fn test_parse_empty() {
+        assert_eq!(AccessorTypes::parse(""), None);
+    }
+
+    #[test]
+    fn test_parse_all_keyword() {
+        let result = AccessorTypes::parse("all");
+        assert_eq!(
+            result,
+            Some(
+                AccessorTypes::GETTER
+                    | AccessorTypes::GETTER_OPT
+                    | AccessorTypes::SET
+                    | AccessorTypes::WITH
+                    | AccessorTypes::MUT
+                    | AccessorTypes::MUT_OPT
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_default_keyword() {
+        let result = AccessorTypes::parse("default");
+        assert_eq!(result, Some(AccessorTypes::DEFAULT));
+    }
+
+    #[test]
+    #[should_panic(expected = "Unknown accessor type")]
+    fn test_parse_unknown_panics() {
+        AccessorTypes::parse("invalid");
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot combine 'all' with other accessor types")]
+    fn test_parse_all_with_set_panics() {
+        AccessorTypes::parse("all,set");
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot combine 'default' with 'getter' or 'all'")]
+    fn test_parse_getter_with_default_panics() {
+        // This should panic - getter already generates defaults
+        AccessorTypes::parse("getter,default");
+    }
+}

--- a/crates/iota-proto-build/src/codegen/accessors.rs
+++ b/crates/iota-proto-build/src/codegen/accessors.rs
@@ -335,24 +335,13 @@ fn generate_selective_accessors_for_field(
         }
 
         if accessor_types.contains(AccessorTypes::WITH) {
-            // If SET is also present, use the setter method; otherwise inline the logic
-            if accessor_types.contains(AccessorTypes::SET) {
-                accessors.extend(quote! {
-                    #( #[doc = #set_name_comments] )*
-                    pub fn #with_name(mut self, field: ::std::collections::BTreeMap<#key_type, #value_type>) -> Self {
-                        self.#set_name(field);
-                        self
-                    }
-                });
-            } else {
-                accessors.extend(quote! {
-                    #( #[doc = #set_name_comments] )*
-                    pub fn #with_name(mut self, field: ::std::collections::BTreeMap<#key_type, #value_type>) -> Self {
-                        self.#name = field;
-                        self
-                    }
-                });
-            }
+            accessors.extend(quote! {
+                #( #[doc = #set_name_comments] )*
+                pub fn #with_name(mut self, field: ::std::collections::BTreeMap<#key_type, #value_type>) -> Self {
+                    self.#name = field;
+                    self
+                }
+            });
         }
 
         accessors
@@ -395,24 +384,13 @@ fn generate_selective_accessors_for_field(
         }
 
         if accessor_types.contains(AccessorTypes::WITH) {
-            // If SET is also present, use the setter method; otherwise inline the logic
-            if accessor_types.contains(AccessorTypes::SET) {
-                accessors.extend(quote! {
-                    #( #[doc = #set_name_comments] )*
-                    pub fn #with_name(mut self, field: Vec<#storage_type>) -> Self {
-                        self.#set_name(field);
-                        self
-                    }
-                });
-            } else {
-                accessors.extend(quote! {
-                    #( #[doc = #set_name_comments] )*
-                    pub fn #with_name(mut self, field: Vec<#storage_type>) -> Self {
-                        self.#name = field;
-                        self
-                    }
-                });
-            }
+            accessors.extend(quote! {
+                #( #[doc = #set_name_comments] )*
+                pub fn #with_name(mut self, field: Vec<#storage_type>) -> Self {
+                    self.#name = field;
+                    self
+                }
+            });
         }
 
         accessors
@@ -486,20 +464,32 @@ fn generate_selective_accessors_for_field(
                 quote! {
                     #( #[doc = #name_mut_comments] )*
                     pub fn #name_mut(&mut self) -> &mut #field_type_path {
-                        if self.#name_opt_mut().is_none() {
+                        if let Some(#oneof_type_path::#variant(field)) = &mut self.#oneof_field {
+                            field as _
+                        } else {
                             self.#oneof_field = Some(#oneof_type_path::#variant(::prost::alloc::boxed::Box::default()));
+                            if let Some(#oneof_type_path::#variant(field)) = &mut self.#oneof_field {
+                                field as _
+                            } else {
+                                unreachable!()
+                            }
                         }
-                        self.#name_opt_mut().unwrap()
                     }
                 }
             } else {
                 quote! {
                     #( #[doc = #name_mut_comments] )*
                     pub fn #name_mut(&mut self) -> &mut #field_type_path {
-                        if self.#name_opt_mut().is_none() {
+                        if let Some(#oneof_type_path::#variant(field)) = &mut self.#oneof_field {
+                            field
+                        } else {
                             self.#oneof_field = Some(#oneof_type_path::#variant(#field_type_path::default()));
+                            if let Some(#oneof_type_path::#variant(field)) = &mut self.#oneof_field {
+                                field
+                            } else {
+                                unreachable!()
+                            }
                         }
-                        self.#name_opt_mut().unwrap()
                     }
                 }
             };
@@ -529,24 +519,13 @@ fn generate_selective_accessors_for_field(
                     });
                 }
                 if accessor_types.contains(AccessorTypes::WITH) {
-                    // If SET is also present, use the setter method; otherwise inline the logic
-                    if accessor_types.contains(AccessorTypes::SET) {
-                        s.extend(quote! {
-                            #( #[doc = #set_name_comments] )*
-                            pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
-                                self.#set_name(field.into());
-                                self
-                            }
-                        });
-                    } else {
-                        s.extend(quote! {
-                            #( #[doc = #set_name_comments] )*
-                            pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
-                                self.#oneof_field = Some(#oneof_type_path::#variant(#into_conversion));
-                                self
-                            }
-                        });
-                    }
+                    s.extend(quote! {
+                        #( #[doc = #set_name_comments] )*
+                        pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
+                            self.#oneof_field = Some(#oneof_type_path::#variant(#into_conversion));
+                            self
+                        }
+                    });
                 }
                 s
             } else {
@@ -560,24 +539,13 @@ fn generate_selective_accessors_for_field(
                     });
                 }
                 if accessor_types.contains(AccessorTypes::WITH) {
-                    // If SET is also present, use the setter method; otherwise inline the logic
-                    if accessor_types.contains(AccessorTypes::SET) {
-                        s.extend(quote! {
-                            #( #[doc = #set_name_comments] )*
-                            pub fn #with_name(mut self, field: #field_type_path) -> Self {
-                                self.#set_name(field);
-                                self
-                            }
-                        });
-                    } else {
-                        s.extend(quote! {
-                            #( #[doc = #set_name_comments] )*
-                            pub fn #with_name(mut self, field: #field_type_path) -> Self {
-                                self.#oneof_field = Some(#oneof_type_path::#variant(field));
-                                self
-                            }
-                        });
-                    }
+                    s.extend(quote! {
+                        #( #[doc = #set_name_comments] )*
+                        pub fn #with_name(mut self, field: #field_type_path) -> Self {
+                            self.#oneof_field = Some(#oneof_type_path::#variant(field));
+                            self
+                        }
+                    });
                 }
                 s
             };
@@ -690,26 +658,13 @@ fn generate_selective_accessors_for_field(
             }
 
             if accessor_types.contains(AccessorTypes::WITH) {
-                // If SET is also present, use the setter method; otherwise inline the logic
-                if accessor_types.contains(AccessorTypes::SET)
-                    && !matches!(field.inner.r#type(), Type::Enum)
-                {
-                    accessors.extend(quote! {
-                        #( #[doc = #set_name_comments] )*
-                        pub fn #with_name(mut self, field: #field_type_path) -> Self {
-                            self.#set_name(field);
-                            self
-                        }
-                    });
-                } else {
-                    accessors.extend(quote! {
-                        #( #[doc = #set_name_comments] )*
-                        pub fn #with_name(mut self, field: #field_type_path) -> Self {
-                            self.#name = Some(field);
-                            self
-                        }
-                    });
-                }
+                accessors.extend(quote! {
+                    #( #[doc = #set_name_comments] )*
+                    pub fn #with_name(mut self, field: #field_type_path) -> Self {
+                        self.#name = Some(field);
+                        self
+                    }
+                });
             }
         }
 
@@ -739,24 +694,13 @@ fn generate_selective_accessors_for_field(
             }
 
             if accessor_types.contains(AccessorTypes::WITH) {
-                // If SET is also present, use the setter method; otherwise inline the logic
-                if accessor_types.contains(AccessorTypes::SET) {
-                    accessors.extend(quote! {
-                        #( #[doc = #set_name_comments] )*
-                        pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
-                            self.#set_name(field.into());
-                            self
-                        }
-                    });
-                } else {
-                    accessors.extend(quote! {
-                        #( #[doc = #set_name_comments] )*
-                        pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
-                            self.#name = field.into().into();
-                            self
-                        }
-                    });
-                }
+                accessors.extend(quote! {
+                    #( #[doc = #set_name_comments] )*
+                    pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
+                        self.#name = field.into().into();
+                        self
+                    }
+                });
             }
         } else {
             if accessor_types.contains(AccessorTypes::SET) {
@@ -769,24 +713,13 @@ fn generate_selective_accessors_for_field(
             }
 
             if accessor_types.contains(AccessorTypes::WITH) {
-                // If SET is also present, use the setter method; otherwise inline the logic
-                if accessor_types.contains(AccessorTypes::SET) {
-                    accessors.extend(quote! {
-                        #( #[doc = #set_name_comments] )*
-                        pub fn #with_name(mut self, field: #field_type_path) -> Self {
-                            self.#set_name(field);
-                            self
-                        }
-                    });
-                } else {
-                    accessors.extend(quote! {
-                        #( #[doc = #set_name_comments] )*
-                        pub fn #with_name(mut self, field: #field_type_path) -> Self {
-                            self.#name = field;
-                            self
-                        }
-                    });
-                }
+                accessors.extend(quote! {
+                    #( #[doc = #set_name_comments] )*
+                    pub fn #with_name(mut self, field: #field_type_path) -> Self {
+                        self.#name = field;
+                        self
+                    }
+                });
             }
         }
 

--- a/crates/iota-proto-build/src/codegen/accessors.rs
+++ b/crates/iota-proto-build/src/codegen/accessors.rs
@@ -133,11 +133,8 @@ fn message_needs_default_instance(message: &Message, accessor_map: &AccessorMap)
 
             // Check if GETTER is set AND will actually generate a getter method
             if accessor_types.contains(AccessorTypes::GETTER) {
-                // Maps and repeated fields always generate getters (except enum repeated)
-                if field.is_map() {
-                    return true;
-                }
-                if field.is_repeated() && !field.is_enum() {
+                // Maps and repeated fields always generate getters
+                if field.is_map() || field.is_repeated() {
                     return true;
                 }
                 // Optional fields only generate getters for message types (non-well-known)
@@ -360,16 +357,20 @@ fn generate_selective_accessors_for_field(
 
         accessors
     } else if field.is_repeated() {
-        if field.is_enum() {
-            return TokenStream::new();
-        }
-
         let mut accessors = TokenStream::new();
+
+        // For repeated enum fields, prost stores them as Vec<i32>
+        let is_enum = field.is_enum();
+        let storage_type = if is_enum {
+            TokenStream::from_str("i32").unwrap()
+        } else {
+            field_type_path.clone()
+        };
 
         if accessor_types.contains(AccessorTypes::GETTER) {
             accessors.extend(quote! {
                 #( #[doc = #name_comments] )*
-                pub fn #name(&self) -> &[#field_type_path] {
+                pub fn #name(&self) -> &[#storage_type] {
                     &self.#name
                 }
             });
@@ -378,7 +379,7 @@ fn generate_selective_accessors_for_field(
         if accessor_types.contains(AccessorTypes::MUT) {
             accessors.extend(quote! {
                 #( #[doc = #name_mut_comments] )*
-                pub fn #name_mut(&mut self) -> &mut Vec<#field_type_path> {
+                pub fn #name_mut(&mut self) -> &mut Vec<#storage_type> {
                     &mut self.#name
                 }
             });
@@ -387,7 +388,7 @@ fn generate_selective_accessors_for_field(
         if accessor_types.contains(AccessorTypes::SET) {
             accessors.extend(quote! {
                 #( #[doc = #set_name_comments] )*
-                pub fn #set_name(&mut self, field: Vec<#field_type_path>) {
+                pub fn #set_name(&mut self, field: Vec<#storage_type>) {
                     self.#name = field;
                 }
             });
@@ -398,7 +399,7 @@ fn generate_selective_accessors_for_field(
             if accessor_types.contains(AccessorTypes::SET) {
                 accessors.extend(quote! {
                     #( #[doc = #set_name_comments] )*
-                    pub fn #with_name(mut self, field: Vec<#field_type_path>) -> Self {
+                    pub fn #with_name(mut self, field: Vec<#storage_type>) -> Self {
                         self.#set_name(field);
                         self
                     }
@@ -406,7 +407,7 @@ fn generate_selective_accessors_for_field(
             } else {
                 accessors.extend(quote! {
                     #( #[doc = #set_name_comments] )*
-                    pub fn #with_name(mut self, field: Vec<#field_type_path>) -> Self {
+                    pub fn #with_name(mut self, field: Vec<#storage_type>) -> Self {
                         self.#name = field;
                         self
                     }
@@ -510,11 +511,20 @@ fn generate_selective_accessors_for_field(
         {
             let setters = if use_into_for_setter(field) {
                 let mut s = TokenStream::new();
+
+                // For boxed types in accessors, we accept Box<T> but need to unbox when storing
+                // because the oneof variant stores the unboxed type
+                let into_conversion = if is_boxed {
+                    quote! { *field.into() }
+                } else {
+                    quote! { field.into().into() }
+                };
+
                 if accessor_types.contains(AccessorTypes::SET) {
                     s.extend(quote! {
                         #( #[doc = #set_name_comments] )*
                         pub fn #set_name<T: Into<#field_type_path>>(&mut self, field: T) {
-                            self.#oneof_field = Some(#oneof_type_path::#variant(field.into().into()));
+                            self.#oneof_field = Some(#oneof_type_path::#variant(#into_conversion));
                         }
                     });
                 }
@@ -532,7 +542,7 @@ fn generate_selective_accessors_for_field(
                         s.extend(quote! {
                             #( #[doc = #set_name_comments] )*
                             pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
-                                self.#oneof_field = Some(#oneof_type_path::#variant(field.into().into()));
+                                self.#oneof_field = Some(#oneof_type_path::#variant(#into_conversion));
                                 self
                             }
                         });

--- a/crates/iota-proto-build/src/codegen/accessors.rs
+++ b/crates/iota-proto-build/src/codegen/accessors.rs
@@ -9,11 +9,17 @@ use prost_types::field_descriptor_proto::Type;
 use quote::quote;
 
 use crate::{
+    codegen::accessor_config::{AccessorMap, AccessorTypes},
     context::Context,
     message_graph::{Field, Message, OneofField},
 };
 
-pub(crate) fn generate_accessors(context: &Context, out_dir: &Path, boxed_types: &[String]) {
+pub(crate) fn generate_accessors(
+    context: &Context,
+    out_dir: &Path,
+    boxed_types: &[String],
+    accessor_map: &AccessorMap,
+) {
     for package in context.graph().packages.iter() {
         let mut buf = String::new();
         let mut stream = TokenStream::new();
@@ -28,6 +34,7 @@ pub(crate) fn generate_accessors(context: &Context, out_dir: &Path, boxed_types:
                 context,
                 message,
                 boxed_types,
+                accessor_map,
             ));
         }
 
@@ -61,6 +68,7 @@ fn generate_accessors_for_message(
     context: &Context,
     message: &Message,
     boxed_types: &[String],
+    accessor_map: &AccessorMap,
 ) -> TokenStream {
     let package = format!("{}.__accessors", message.package);
     let message_rust_path =
@@ -68,13 +76,31 @@ fn generate_accessors_for_message(
 
     let mut functions = TokenStream::new();
 
-    functions.extend(generate_const_default_functions(
+    // Check if any field in this message needs the default_instance function, and
+    // generate it if so. We do this at the message level (instead of per-field)
+    // to avoid generating multiple default_instance functions for the same message
+    // if multiple fields need it.
+    let needs_default_instance = message_needs_default_instance(message, accessor_map);
+
+    if needs_default_instance {
+        functions.extend(generate_const_default_functions(
+            context,
+            message,
+            &message_rust_path,
+        ));
+    }
+
+    functions.extend(generate_accessors_functions(
         context,
         message,
-        &message_rust_path,
+        boxed_types,
+        accessor_map,
     ));
 
-    functions.extend(generate_accessors_functions(context, message, boxed_types));
+    // Only generate the impl block if there are any functions
+    if functions.is_empty() {
+        return TokenStream::new();
+    }
 
     quote! {
         impl #message_rust_path {
@@ -84,10 +110,71 @@ fn generate_accessors_for_message(
     }
 }
 
+/// Check if any field in the message needs the default_instance function
+/// This is needed when:
+/// 1. DEFAULT is explicitly requested, OR
+/// 2. GETTER is requested AND a getter method will actually be generated
+fn message_needs_default_instance(message: &Message, accessor_map: &AccessorMap) -> bool {
+    let message_name = message
+        .type_name
+        .rsplit('.')
+        .next()
+        .unwrap_or(&message.type_name);
+
+    // Check regular fields
+    for field in &message.fields {
+        if let Some(accessor_types) =
+            AccessorTypes::from_field(&field.inner, accessor_map, message_name)
+        {
+            // Always generate if DEFAULT is explicitly set
+            if accessor_types.contains(AccessorTypes::DEFAULT) {
+                return true;
+            }
+
+            // Check if GETTER is set AND will actually generate a getter method
+            if accessor_types.contains(AccessorTypes::GETTER) {
+                // Maps and repeated fields always generate getters (except enum repeated)
+                if field.is_map() {
+                    return true;
+                }
+                if field.is_repeated() && !field.is_enum() {
+                    return true;
+                }
+                // Optional fields only generate getters for message types (non-well-known)
+                if field.is_optional() && field.is_message() && !field.is_well_known_type() {
+                    return true;
+                }
+                // Required/implicit optional fields don't generate getters, so
+                // no default needed
+            }
+        }
+    }
+
+    // Check oneof fields - these always generate getters if GETTER is set
+    for oneof_field in &message.oneof_fields {
+        for field in &oneof_field.fields {
+            if let Some(accessor_types) =
+                AccessorTypes::from_field(&field.inner, accessor_map, message_name)
+            {
+                if accessor_types.contains(AccessorTypes::DEFAULT) {
+                    return true;
+                }
+                // Oneof fields always generate getters when GETTER is set
+                if accessor_types.contains(AccessorTypes::GETTER) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
 fn generate_accessors_functions(
     context: &Context,
     message: &Message,
     boxed_types: &[String],
+    accessor_map: &AccessorMap,
 ) -> TokenStream {
     let mut accessors = TokenStream::new();
 
@@ -98,6 +185,7 @@ fn generate_accessors_functions(
             field,
             None,
             boxed_types,
+            accessor_map,
         ));
     }
 
@@ -109,6 +197,7 @@ fn generate_accessors_functions(
                 field,
                 Some(oneof_field),
                 boxed_types,
+                accessor_map,
             ));
         }
     }
@@ -131,6 +220,40 @@ fn generate_accessors_functions_for_field(
     field: &Field,
     oneof: Option<&OneofField>,
     boxed_types: &[String],
+    accessor_map: &AccessorMap,
+) -> TokenStream {
+    // Extract the simple message name from the fully qualified type name
+    // e.g., ".iota.grpc.v0.ledger_service.ObjectRequest" -> "ObjectRequest"
+    let message_name = message
+        .type_name
+        .rsplit('.')
+        .next()
+        .unwrap_or(&message.type_name);
+
+    // Check if this field has the generate_accessors custom option
+    let accessor_types = match AccessorTypes::from_field(&field.inner, accessor_map, message_name) {
+        Some(types) => types,
+        None => return TokenStream::new(), // No option, skip this field
+    };
+
+    // Generate only the requested accessor types
+    generate_selective_accessors_for_field(
+        context,
+        message,
+        field,
+        oneof,
+        boxed_types,
+        accessor_types,
+    )
+}
+
+fn generate_selective_accessors_for_field(
+    context: &Context,
+    message: &Message,
+    field: &Field,
+    oneof: Option<&OneofField>,
+    boxed_types: &[String],
+    accessor_types: AccessorTypes,
 ) -> TokenStream {
     let package = format!("{}.__accessors", message.package);
     let name = quote::format_ident!("{}", field.rust_struct_field_name());
@@ -185,55 +308,113 @@ fn generate_accessors_functions_for_field(
         let value_type =
             TokenStream::from_str(&resolve_rust_type_path(value, context, &package)).unwrap();
 
-        quote! {
-            #( #[doc = #name_comments] )*
-            pub fn #name(&self) -> &::std::collections::BTreeMap<#key_type, #value_type> {
-                &self.#name
-            }
+        let mut accessors = TokenStream::new();
 
-            #( #[doc = #name_mut_comments] )*
-            pub fn #name_mut(&mut self) -> &mut ::std::collections::BTreeMap<#key_type, #value_type> {
-                &mut self.#name
-            }
+        if accessor_types.contains(AccessorTypes::GETTER) {
+            accessors.extend(quote! {
+                #( #[doc = #name_comments] )*
+                pub fn #name(&self) -> &::std::collections::BTreeMap<#key_type, #value_type> {
+                    &self.#name
+                }
+            });
+        }
 
-            #( #[doc = #set_name_comments] )*
-            pub fn #set_name(&mut self, field: ::std::collections::BTreeMap<#key_type, #value_type>) {
-                self.#name = field;
-            }
+        if accessor_types.contains(AccessorTypes::MUT) {
+            accessors.extend(quote! {
+                #( #[doc = #name_mut_comments] )*
+                pub fn #name_mut(&mut self) -> &mut ::std::collections::BTreeMap<#key_type, #value_type> {
+                    &mut self.#name
+                }
+            });
+        }
 
-            #( #[doc = #set_name_comments] )*
-            pub fn #with_name(mut self, field: ::std::collections::BTreeMap<#key_type, #value_type>) -> Self {
-                self.#set_name(field);
-                self
+        if accessor_types.contains(AccessorTypes::SET) {
+            accessors.extend(quote! {
+                #( #[doc = #set_name_comments] )*
+                pub fn #set_name(&mut self, field: ::std::collections::BTreeMap<#key_type, #value_type>) {
+                    self.#name = field;
+                }
+            });
+        }
+
+        if accessor_types.contains(AccessorTypes::WITH) {
+            // If SET is also present, use the setter method; otherwise inline the logic
+            if accessor_types.contains(AccessorTypes::SET) {
+                accessors.extend(quote! {
+                    #( #[doc = #set_name_comments] )*
+                    pub fn #with_name(mut self, field: ::std::collections::BTreeMap<#key_type, #value_type>) -> Self {
+                        self.#set_name(field);
+                        self
+                    }
+                });
+            } else {
+                accessors.extend(quote! {
+                    #( #[doc = #set_name_comments] )*
+                    pub fn #with_name(mut self, field: ::std::collections::BTreeMap<#key_type, #value_type>) -> Self {
+                        self.#name = field;
+                        self
+                    }
+                });
             }
         }
+
+        accessors
     } else if field.is_repeated() {
         if field.is_enum() {
             return TokenStream::new();
         }
 
-        quote! {
-            #( #[doc = #name_comments] )*
-            pub fn #name(&self) -> &[#field_type_path] {
-                &self.#name
-            }
+        let mut accessors = TokenStream::new();
 
-            #( #[doc = #name_mut_comments] )*
-            pub fn #name_mut(&mut self) -> &mut Vec<#field_type_path> {
-                &mut self.#name
-            }
+        if accessor_types.contains(AccessorTypes::GETTER) {
+            accessors.extend(quote! {
+                #( #[doc = #name_comments] )*
+                pub fn #name(&self) -> &[#field_type_path] {
+                    &self.#name
+                }
+            });
+        }
 
-            #( #[doc = #set_name_comments] )*
-            pub fn #set_name(&mut self, field: Vec<#field_type_path>) {
-                self.#name = field;
-            }
+        if accessor_types.contains(AccessorTypes::MUT) {
+            accessors.extend(quote! {
+                #( #[doc = #name_mut_comments] )*
+                pub fn #name_mut(&mut self) -> &mut Vec<#field_type_path> {
+                    &mut self.#name
+                }
+            });
+        }
 
-            #( #[doc = #set_name_comments] )*
-            pub fn #with_name(mut self, field: Vec<#field_type_path>) -> Self {
-                self.#set_name(field);
-                self
+        if accessor_types.contains(AccessorTypes::SET) {
+            accessors.extend(quote! {
+                #( #[doc = #set_name_comments] )*
+                pub fn #set_name(&mut self, field: Vec<#field_type_path>) {
+                    self.#name = field;
+                }
+            });
+        }
+
+        if accessor_types.contains(AccessorTypes::WITH) {
+            // If SET is also present, use the setter method; otherwise inline the logic
+            if accessor_types.contains(AccessorTypes::SET) {
+                accessors.extend(quote! {
+                    #( #[doc = #set_name_comments] )*
+                    pub fn #with_name(mut self, field: Vec<#field_type_path>) -> Self {
+                        self.#set_name(field);
+                        self
+                    }
+                });
+            } else {
+                accessors.extend(quote! {
+                    #( #[doc = #set_name_comments] )*
+                    pub fn #with_name(mut self, field: Vec<#field_type_path>) -> Self {
+                        self.#name = field;
+                        self
+                    }
+                });
             }
         }
+
+        accessors
     } else if let Some(oneof) = oneof {
         if field.inner.type_name() == ".google.protobuf.Empty" {
             return TokenStream::new();
@@ -258,94 +439,150 @@ fn generate_accessors_functions_for_field(
             " If any other oneof field in the same oneof is set, it will be cleared.".to_owned(),
         );
 
-        let setters = if use_into_for_setter(field) {
-            quote! {
-                #( #[doc = #set_name_comments] )*
-                pub fn #set_name<T: Into<#field_type_path>>(&mut self, field: T) {
-                    self.#oneof_field = Some(#oneof_type_path::#variant(field.into().into()));
-                }
+        let mut accessors = TokenStream::new();
 
-                #( #[doc = #set_name_comments] )*
-                pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
-                    self.#set_name(field.into());
-                    self
-                }
-            }
-        } else {
-            quote! {
-                #( #[doc = #set_name_comments] )*
-                pub fn #set_name(&mut self, field: #field_type_path) {
-                    self.#oneof_field = Some(#oneof_type_path::#variant(field));
-                }
-
-                #( #[doc = #set_name_comments] )*
-                pub fn #with_name(mut self, field: #field_type_path) -> Self {
-                    self.#set_name(field);
-                    self
-                }
-            }
-        };
-
-        let name_mut_impl = if is_boxed {
-            quote! {
-                #( #[doc = #name_mut_comments] )*
-                pub fn #name_mut(&mut self) -> &mut #field_type_path {
-                    if self.#name_opt_mut().is_none() {
-                        self.#oneof_field = Some(#oneof_type_path::#variant(::prost::alloc::boxed::Box::default()));
+        if accessor_types.contains(AccessorTypes::GETTER) {
+            accessors.extend(quote! {
+                #( #[doc = #name_comments] )*
+                pub fn #name(&self) -> #ref_return_type {
+                    if let Some(#oneof_type_path::#variant(field)) = &self.#oneof_field {
+                        #field_as
+                    } else {
+                        #default_instance
                     }
-                    self.#name_opt_mut().unwrap()
                 }
-            }
-        } else {
-            quote! {
-                #( #[doc = #name_mut_comments] )*
-                pub fn #name_mut(&mut self) -> &mut #field_type_path {
-                    if self.#name_opt_mut().is_none() {
-                        self.#oneof_field = Some(#oneof_type_path::#variant(#field_type_path::default()));
-                    }
-                    self.#name_opt_mut().unwrap()
-                }
-            }
-        };
-
-        quote! {
-            #( #[doc = #name_comments] )*
-            pub fn #name(&self) -> #ref_return_type {
-                if let Some(#oneof_type_path::#variant(field)) = &self.#oneof_field {
-                    #field_as
-                } else {
-                    #default_instance
-                }
-            }
-
-            #( #[doc = #name_opt_comments] )*
-            pub fn #name_opt(&self) -> Option<#ref_return_type> {
-                if let Some(#oneof_type_path::#variant(field)) = &self.#oneof_field {
-                    Some(#field_as)
-                } else {
-                    None
-                }
-            }
-
-            #( #[doc = #name_opt_mut_comments] )*
-            pub fn #name_opt_mut(&mut self) -> Option<&mut #field_type_path> {
-                if let Some(#oneof_type_path::#variant(field)) = &mut self.#oneof_field {
-                    Some(field as _)
-                } else {
-                    None
-                }
-            }
-
-            #name_mut_impl
-
-            #setters
+            });
         }
+
+        if accessor_types.contains(AccessorTypes::GETTER_OPT) {
+            accessors.extend(quote! {
+                #( #[doc = #name_opt_comments] )*
+                pub fn #name_opt(&self) -> Option<#ref_return_type> {
+                    if let Some(#oneof_type_path::#variant(field)) = &self.#oneof_field {
+                        Some(#field_as)
+                    } else {
+                        None
+                    }
+                }
+            });
+        }
+
+        if accessor_types.contains(AccessorTypes::MUT_OPT) {
+            accessors.extend(quote! {
+                #( #[doc = #name_opt_mut_comments] )*
+                pub fn #name_opt_mut(&mut self) -> Option<&mut #field_type_path> {
+                    if let Some(#oneof_type_path::#variant(field)) = &mut self.#oneof_field {
+                        Some(field as _)
+                    } else {
+                        None
+                    }
+                }
+            });
+        }
+
+        if accessor_types.contains(AccessorTypes::MUT) {
+            let name_mut_impl = if is_boxed {
+                quote! {
+                    #( #[doc = #name_mut_comments] )*
+                    pub fn #name_mut(&mut self) -> &mut #field_type_path {
+                        if self.#name_opt_mut().is_none() {
+                            self.#oneof_field = Some(#oneof_type_path::#variant(::prost::alloc::boxed::Box::default()));
+                        }
+                        self.#name_opt_mut().unwrap()
+                    }
+                }
+            } else {
+                quote! {
+                    #( #[doc = #name_mut_comments] )*
+                    pub fn #name_mut(&mut self) -> &mut #field_type_path {
+                        if self.#name_opt_mut().is_none() {
+                            self.#oneof_field = Some(#oneof_type_path::#variant(#field_type_path::default()));
+                        }
+                        self.#name_opt_mut().unwrap()
+                    }
+                }
+            };
+            accessors.extend(name_mut_impl);
+        }
+
+        if accessor_types.contains(AccessorTypes::SET)
+            || accessor_types.contains(AccessorTypes::WITH)
+        {
+            let setters = if use_into_for_setter(field) {
+                let mut s = TokenStream::new();
+                if accessor_types.contains(AccessorTypes::SET) {
+                    s.extend(quote! {
+                        #( #[doc = #set_name_comments] )*
+                        pub fn #set_name<T: Into<#field_type_path>>(&mut self, field: T) {
+                            self.#oneof_field = Some(#oneof_type_path::#variant(field.into().into()));
+                        }
+                    });
+                }
+                if accessor_types.contains(AccessorTypes::WITH) {
+                    // If SET is also present, use the setter method; otherwise inline the logic
+                    if accessor_types.contains(AccessorTypes::SET) {
+                        s.extend(quote! {
+                            #( #[doc = #set_name_comments] )*
+                            pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
+                                self.#set_name(field.into());
+                                self
+                            }
+                        });
+                    } else {
+                        s.extend(quote! {
+                            #( #[doc = #set_name_comments] )*
+                            pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
+                                self.#oneof_field = Some(#oneof_type_path::#variant(field.into().into()));
+                                self
+                            }
+                        });
+                    }
+                }
+                s
+            } else {
+                let mut s = TokenStream::new();
+                if accessor_types.contains(AccessorTypes::SET) {
+                    s.extend(quote! {
+                        #( #[doc = #set_name_comments] )*
+                        pub fn #set_name(&mut self, field: #field_type_path) {
+                            self.#oneof_field = Some(#oneof_type_path::#variant(field));
+                        }
+                    });
+                }
+                if accessor_types.contains(AccessorTypes::WITH) {
+                    // If SET is also present, use the setter method; otherwise inline the logic
+                    if accessor_types.contains(AccessorTypes::SET) {
+                        s.extend(quote! {
+                            #( #[doc = #set_name_comments] )*
+                            pub fn #with_name(mut self, field: #field_type_path) -> Self {
+                                self.#set_name(field);
+                                self
+                            }
+                        });
+                    } else {
+                        s.extend(quote! {
+                            #( #[doc = #set_name_comments] )*
+                            pub fn #with_name(mut self, field: #field_type_path) -> Self {
+                                self.#oneof_field = Some(#oneof_type_path::#variant(field));
+                                self
+                            }
+                        });
+                    }
+                }
+                s
+            };
+            accessors.extend(setters);
+        }
+
+        accessors
     } else if field.is_optional() {
         let mut accessors = TokenStream::new();
-        let mut setters = TokenStream::new();
 
         // only include "bare getter" for message types
-        if field.is_message() && !field.is_well_known_type() {
+        if accessor_types.contains(AccessorTypes::GETTER)
+            && field.is_message()
+            && !field.is_well_known_type()
+        {
             accessors.extend(quote! {
                 #( #[doc = #name_comments] )*
                 pub fn #name(&self) -> #ref_return_type {
@@ -359,25 +596,33 @@ fn generate_accessors_functions_for_field(
 
         // Only include mut getters for non bytes/enum types
         if !matches!(field.inner.r#type(), Type::Bytes | Type::Enum) {
-            accessors.extend(quote! {
-                #( #[doc = #name_opt_mut_comments] )*
-                pub fn #name_opt_mut(&mut self) -> Option<&mut #field_type_path> {
-                    self.#name
-                        .as_mut()
-                        .map(|field| field as _)
-                }
+            if accessor_types.contains(AccessorTypes::MUT_OPT) {
+                accessors.extend(quote! {
+                    #( #[doc = #name_opt_mut_comments] )*
+                    pub fn #name_opt_mut(&mut self) -> Option<&mut #field_type_path> {
+                        self.#name
+                            .as_mut()
+                            .map(|field| field as _)
+                    }
+                });
+            }
 
-                #( #[doc = #name_mut_comments] )*
-                pub fn #name_mut(&mut self) -> &mut #field_type_path {
-                    self.#name
-                        .get_or_insert_default()
-                }
-            });
+            if accessor_types.contains(AccessorTypes::MUT) {
+                accessors.extend(quote! {
+                    #( #[doc = #name_mut_comments] )*
+                    pub fn #name_mut(&mut self) -> &mut #field_type_path {
+                        self.#name
+                            .get_or_insert_default()
+                    }
+                });
+            }
         }
 
         // only include _opt and set for non enums (as this already exists for enums
         // from prost)
-        if !matches!(field.inner.r#type(), Type::Enum) {
+        if !matches!(field.inner.r#type(), Type::Enum)
+            && accessor_types.contains(AccessorTypes::GETTER_OPT)
+        {
             accessors.extend(quote! {
                 #( #[doc = #name_opt_comments] )*
                 pub fn #name_opt(&self) -> Option<#ref_return_type> {
@@ -389,8 +634,10 @@ fn generate_accessors_functions_for_field(
         }
 
         if use_into_for_setter(field) {
-            if !matches!(field.inner.r#type(), Type::Enum) {
-                setters.extend(quote! {
+            if !matches!(field.inner.r#type(), Type::Enum)
+                && accessor_types.contains(AccessorTypes::SET)
+            {
+                accessors.extend(quote! {
                     #( #[doc = #set_name_comments] )*
                     pub fn #set_name<T: Into<#field_type_path>>(&mut self, field: T) {
                         self.#name = Some(field.into().into());
@@ -398,16 +645,33 @@ fn generate_accessors_functions_for_field(
                 });
             }
 
-            setters.extend(quote! {
-                #( #[doc = #set_name_comments] )*
-                pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
-                    self.#set_name(field.into());
-                    self
+            if accessor_types.contains(AccessorTypes::WITH) {
+                // If SET is also present, use the setter method; otherwise inline the logic
+                if accessor_types.contains(AccessorTypes::SET)
+                    && !matches!(field.inner.r#type(), Type::Enum)
+                {
+                    accessors.extend(quote! {
+                        #( #[doc = #set_name_comments] )*
+                        pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
+                            self.#set_name(field.into());
+                            self
+                        }
+                    });
+                } else {
+                    accessors.extend(quote! {
+                        #( #[doc = #set_name_comments] )*
+                        pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
+                            self.#name = Some(field.into().into());
+                            self
+                        }
+                    });
                 }
-            });
+            }
         } else {
-            if !matches!(field.inner.r#type(), Type::Enum) {
-                setters.extend(quote! {
+            if !matches!(field.inner.r#type(), Type::Enum)
+                && accessor_types.contains(AccessorTypes::SET)
+            {
+                accessors.extend(quote! {
                     #( #[doc = #set_name_comments] )*
                     pub fn #set_name(&mut self, field: #field_type_path) {
                         self.#name = Some(field);
@@ -415,26 +679,37 @@ fn generate_accessors_functions_for_field(
                 });
             }
 
-            setters.extend(quote! {
-                #( #[doc = #set_name_comments] )*
-                pub fn #with_name(mut self, field: #field_type_path) -> Self {
-                    self.#set_name(field);
-                    self
+            if accessor_types.contains(AccessorTypes::WITH) {
+                // If SET is also present, use the setter method; otherwise inline the logic
+                if accessor_types.contains(AccessorTypes::SET)
+                    && !matches!(field.inner.r#type(), Type::Enum)
+                {
+                    accessors.extend(quote! {
+                        #( #[doc = #set_name_comments] )*
+                        pub fn #with_name(mut self, field: #field_type_path) -> Self {
+                            self.#set_name(field);
+                            self
+                        }
+                    });
+                } else {
+                    accessors.extend(quote! {
+                        #( #[doc = #set_name_comments] )*
+                        pub fn #with_name(mut self, field: #field_type_path) -> Self {
+                            self.#name = Some(field);
+                            self
+                        }
+                    });
                 }
-            });
+            }
         }
 
-        quote! {
-            #accessors
-
-            #setters
-        }
+        accessors
     } else {
         // maybe required or implicit optional
 
         let mut accessors = TokenStream::new();
 
-        if field.inner.r#type() != Type::Bytes {
+        if field.inner.r#type() != Type::Bytes && accessor_types.contains(AccessorTypes::MUT) {
             accessors.extend(quote! {
             #( #[doc = #name_mut_comments] )*
                 pub fn #name_mut(&mut self) -> &mut #field_type_path {
@@ -442,39 +717,70 @@ fn generate_accessors_functions_for_field(
                 }
             });
         }
-        let setters = if use_into_for_setter(field) {
-            quote! {
-                #( #[doc = #set_name_comments] )*
-                pub fn #set_name<T: Into<#field_type_path>>(&mut self, field: T) {
-                    self.#name = field.into().into();
-                }
 
-                #( #[doc = #set_name_comments] )*
-                pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
-                    self.#set_name(field.into());
-                    self
+        if use_into_for_setter(field) {
+            if accessor_types.contains(AccessorTypes::SET) {
+                accessors.extend(quote! {
+                    #( #[doc = #set_name_comments] )*
+                    pub fn #set_name<T: Into<#field_type_path>>(&mut self, field: T) {
+                        self.#name = field.into().into();
+                    }
+                });
+            }
+
+            if accessor_types.contains(AccessorTypes::WITH) {
+                // If SET is also present, use the setter method; otherwise inline the logic
+                if accessor_types.contains(AccessorTypes::SET) {
+                    accessors.extend(quote! {
+                        #( #[doc = #set_name_comments] )*
+                        pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
+                            self.#set_name(field.into());
+                            self
+                        }
+                    });
+                } else {
+                    accessors.extend(quote! {
+                        #( #[doc = #set_name_comments] )*
+                        pub fn #with_name<T: Into<#field_type_path>>(mut self, field: T) -> Self {
+                            self.#name = field.into().into();
+                            self
+                        }
+                    });
                 }
             }
         } else {
-            quote! {
-                #( #[doc = #set_name_comments] )*
-                pub fn #set_name(&mut self, field: #field_type_path) {
-                    self.#name = field;
-                }
+            if accessor_types.contains(AccessorTypes::SET) {
+                accessors.extend(quote! {
+                    #( #[doc = #set_name_comments] )*
+                    pub fn #set_name(&mut self, field: #field_type_path) {
+                        self.#name = field;
+                    }
+                });
+            }
 
-                #( #[doc = #set_name_comments] )*
-                pub fn #with_name(mut self, field: #field_type_path) -> Self {
-                    self.#set_name(field);
-                    self
+            if accessor_types.contains(AccessorTypes::WITH) {
+                // If SET is also present, use the setter method; otherwise inline the logic
+                if accessor_types.contains(AccessorTypes::SET) {
+                    accessors.extend(quote! {
+                        #( #[doc = #set_name_comments] )*
+                        pub fn #with_name(mut self, field: #field_type_path) -> Self {
+                            self.#set_name(field);
+                            self
+                        }
+                    });
+                } else {
+                    accessors.extend(quote! {
+                        #( #[doc = #set_name_comments] )*
+                        pub fn #with_name(mut self, field: #field_type_path) -> Self {
+                            self.#name = field;
+                            self
+                        }
+                    });
                 }
             }
-        };
-
-        quote! {
-            #accessors
-
-            #setters
         }
+
+        accessors
     }
 }
 

--- a/crates/iota-proto-build/src/codegen/mod.rs
+++ b/crates/iota-proto-build/src/codegen/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+pub mod accessor_config;
 pub mod accessors;

--- a/crates/iota-proto-build/src/main.rs
+++ b/crates/iota-proto-build/src/main.rs
@@ -16,8 +16,6 @@ mod generate_fields;
 mod ident;
 mod message_graph;
 
-const GENERATE_ACCESSORS: bool = false;
-
 fn main() {
     let root_dir = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));
 
@@ -142,19 +140,19 @@ fn main() {
     }
 
     // Setup for extended codegen
-    if GENERATE_ACCESSORS {
-        let extern_paths = context::extern_paths::ExternPaths::new(&[], true).unwrap();
-        let files = fds
-            .file
-            .clone()
-            .into_iter()
-            // Filter files, there should only be accessors for google.rpc package
-            .filter(|file| file.package().starts_with("google.rpc"))
-            .collect::<Vec<_>>();
-        let graph = DescriptorGraph::new(files.iter());
-        let context = context::Context::new(extern_paths, graph);
-        codegen::accessors::generate_accessors(&context, &out_dir, &boxed_types_accessor);
-    }
+    // Parse proto files to extract accessor annotations
+    let accessor_map = codegen::accessor_config::parse_proto_accessors(&proto_dir);
+
+    let extern_paths = context::extern_paths::ExternPaths::new(&[], true).unwrap();
+    let files = fds.file.clone().into_iter().collect::<Vec<_>>();
+    let graph = DescriptorGraph::new(files.iter());
+    let context = context::Context::new(extern_paths, graph);
+    codegen::accessors::generate_accessors(
+        &context,
+        &out_dir,
+        &boxed_types_accessor,
+        &accessor_map,
+    );
 
     // Group files by package for field info generation
     let mut packages: HashMap<String, FileDescriptorWithPackageVersion> = HashMap::new();
@@ -192,7 +190,10 @@ fn main() {
         .arg(out_dir)
         .status();
     match status {
-        Ok(status) if !status.success() => panic!("You should commit the protobuf files"),
+        Ok(status) if !status.success() => {
+            eprintln!("Generated protobuf files have uncommitted changes. Please commit them.");
+            std::process::exit(2); // Custom exit code for uncommitted changes
+        }
         Err(error) => panic!("failed to run `git diff`: {error}"),
         Ok(_) => {}
     }

--- a/crates/iota-proto-build/src/main.rs
+++ b/crates/iota-proto-build/src/main.rs
@@ -50,13 +50,16 @@ fn main() {
         .collect::<Result<Vec<_>, walkdir::Error>>()
         .unwrap();
 
-    let mut fds = protox::Compiler::new(std::slice::from_ref(&proto_dir))
-        .unwrap()
+    let mut compiler_init = protox::Compiler::new(std::slice::from_ref(&proto_dir)).unwrap();
+    let compiler = compiler_init
         .include_source_info(true)
         .include_imports(true)
         .open_files(&proto_files)
-        .unwrap()
-        .file_descriptor_set();
+        .unwrap();
+
+    let descriptor_pool = compiler.descriptor_pool();
+    let mut fds = compiler.file_descriptor_set();
+
     // Sort files by name to have deterministic codegen output
     fds.file.sort_by(|a, b| a.name.cmp(&b.name));
 
@@ -75,12 +78,7 @@ fn main() {
     ];
 
     // for accessor generation
-    let mut boxed_types_accessor = vec![
-        ".iota.grpc.v0.filter.EventFilter.negation".to_string(),
-        ".iota.grpc.v0.filter.TransactionFilter.negation".to_string(),
-        ".iota.grpc.v0.ledger_service.TransactionResult.transaction".to_string(),
-        ".iota.grpc.v0.types.TypeTag.vector_tag".to_string(),
-    ];
+    let mut boxed_types_accessor = vec![];
     boxed_types_accessor.extend(boxed_types_prost.clone());
 
     let mut tonic_prost_builder = tonic_prost_build::configure()
@@ -141,7 +139,7 @@ fn main() {
 
     // Setup for extended codegen
     // Parse proto files to extract accessor annotations
-    let accessor_map = codegen::accessor_config::parse_proto_accessors(&proto_dir);
+    let accessor_map = codegen::accessor_config::parse_proto_accessors_from_pool(&descriptor_pool);
 
     let extern_paths = context::extern_paths::ExternPaths::new(&[], true).unwrap();
     let files = fds.file.clone().into_iter().collect::<Vec<_>>();

--- a/crates/iota-stardust-types/Cargo.toml
+++ b/crates/iota-stardust-types/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 bech32 = { version = "0.9.1", default-features = false }
-bitflags = { version = "2.4.2", default-features = false }
+bitflags.workspace = true
 derive_more = { workspace = true, features = ["from", "as_ref", "deref", "deref_mut", "display"] }
 getset.workspace = true
 iota-crypto = { version = "0.23.2", default-features = false, features = ["blake2b", "ed25519"] }

--- a/scripts/update_grpc_types.sh
+++ b/scripts/update_grpc_types.sh
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Update gRPC protobuf types.
-set -e
-
 SCRIPT_PATH=$(realpath "$0")
 SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
 ROOT="$SCRIPT_DIR/.."

--- a/scripts/update_grpc_types.sh
+++ b/scripts/update_grpc_types.sh
@@ -20,3 +20,13 @@ trap cleanup EXIT
 rm -Rf crates/iota-grpc-types/src/proto/generated/
 mkdir -p crates/iota-grpc-types/src/proto/generated/
 cargo run -p iota-proto-build
+exit_code=$?
+
+if [ $exit_code -eq 2 ]; then
+    echo "Warning: Generated protobuf files have uncommitted changes."
+    echo "The generation completed successfully, but you should commit the changes."
+    exit 0  # Treat as success since generation worked
+elif [ $exit_code -ne 0 ]; then
+    echo "Error: Failed to generate protobuf files (exit code: $exit_code)"
+    exit $exit_code
+fi


### PR DESCRIPTION
# Description of change

This PR enables the iota-protoc-build crate to generate accessors for the proto message fields.


Fields that need accessors are annotated in the `.proto` files using a custom option:

```protobuf
import "iota/grpc/options.proto";

message ObjectRequest {
  optional ObjectReference object_ref = 1 [(iota.grpc.generate_accessors) = "set,with"];
}
```

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes