### PR TITLE
feat(iota-core, consensus): Misbehavior report rate limit

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -4275,40 +4275,41 @@ impl AuthorityPerEpochStore {
                     );
                     return Ok(ConsensusCertificateResult::ConsensusMessage);
                 }
-                if self
+                if !self
                     .get_reconfig_state_read_lock_guard()
                     .should_accept_consensus_certs()
                 {
-                    let authority_index = self
-                        .committee
-                        .authority_index(authority)
-                        .expect("authority in committee");
-                    // Check validity of the report and update scores depending on the result. We
-                    // already have consensus on inclusion of this report in the DAG.
-                    if report.is_valid_version(self.protocol_config()) {
-                        if !report.verify(self.committee.num_members()) {
-                            self.scorer.increment_invalid_reports_count(authority_index);
-                            warn!(
-                                "Received invalid misbehavior report from {:?}",
-                                authority.concise()
-                            );
-                        } else {
-                            // Here we update all counts related to the information in the
-                            // reports.
-                            self.scorer.update_received_reports(authority_index, report);
-                        }
-                    } else {
-                        self.scorer.increment_invalid_reports_count(authority_index);
-                        warn!(
-                            "Received misbehavior report with unsupported version from {:?}",
-                            authority.concise()
-                        );
-                    }
-                } else {
                     debug!(
                         "Ignoring misbehavior report from {:?} because of end of epoch",
                         authority.concise()
                     );
+                    return Ok(ConsensusCertificateResult::ConsensusMessage);
+                }
+
+                // Safe: verify_consensus_transaction already confirmed that the
+                // report's authority matches the consensus block author, who is
+                // always a committee member.
+                let authority_index = self
+                    .committee
+                    .authority_index(authority)
+                    .expect("authority in committee");
+                // Check validity of the report and update scores depending on
+                // the result. We already have consensus on inclusion of this
+                // report in the DAG.
+                if !report.is_valid_version(self.protocol_config()) {
+                    self.scorer.increment_invalid_reports_count(authority_index);
+                    warn!(
+                        "Received misbehavior report with unsupported version from {:?}",
+                        authority.concise()
+                    );
+                } else if !report.verify(self.committee.num_members()) {
+                    self.scorer.increment_invalid_reports_count(authority_index);
+                    warn!(
+                        "Received invalid misbehavior report from {:?}",
+                        authority.concise()
+                    );
+                } else {
+                    self.scorer.update_received_reports(authority_index, report);
                 }
 
                 Ok(ConsensusCertificateResult::ConsensusMessage)

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -4268,22 +4268,54 @@ impl AuthorityPerEpochStore {
                 kind: ConsensusTransactionKind::MisbehaviorReport(authority, report, _),
                 ..
             }) => {
-                let authority_index = self
-                    .committee
-                    .authority_index(authority)
-                    .expect("authority in committee");
-                // Check validity of the report and update scores depending on the result. We
-                // already have consensus on inclusion of this report in the DAG.
-                if !report.verify(self.committee.num_members()) {
-                    self.scorer.update_invalid_reports_count(authority_index);
+                if !self.protocol_config().calculate_validator_scores() {
                     warn!(
-                        "Received invalid misbehavior report from {:?}",
+                        "Received misbehavior report from {:?} but validator scores are disabled, so the report is ignored",
                         authority.concise()
                     );
-                } else {
-                    // Here we update all counts related to the information in the reports.
-                    self.scorer.update_received_reports(authority_index, report);
+                    return Ok(ConsensusCertificateResult::ConsensusMessage);
                 }
+                if self
+                    .get_reconfig_state_read_lock_guard()
+                    .should_accept_consensus_certs()
+                {
+                    let authority_index = self
+                        .committee
+                        .authority_index(authority)
+                        .expect("authority in committee");
+
+                    // Check validity of the report and update scores depending on the result. We
+                    // already have consensus on inclusion of this report in the DAG.
+                    match (report, self.protocol_config().scorer_version_as_option()) {
+                        (VersionedMisbehaviorReport::V1(..), Some(1))
+                        | (VersionedMisbehaviorReport::V1(..), None) => {
+                            if !report.verify(self.committee.num_members()) {
+                                self.scorer.update_invalid_reports_count(authority_index);
+                                warn!(
+                                    "Received invalid misbehavior report from {:?}",
+                                    authority.concise()
+                                );
+                            } else {
+                                // Here we update all counts related to the information in the
+                                // reports.
+                                self.scorer.update_received_reports(authority_index, report);
+                            }
+                        }
+                        _ => {
+                            self.scorer.update_invalid_reports_count(authority_index);
+                            warn!(
+                                "Received misbehavior report with unsupported version from {:?}",
+                                authority.concise()
+                            );
+                        }
+                    }
+                } else {
+                    debug!(
+                        "Ignoring misbehavior report from {:?} because of end of epoch",
+                        authority.concise()
+                    );
+                }
+
                 Ok(ConsensusCertificateResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2941,7 +2941,7 @@ impl AuthorityPerEpochStore {
                         authority, transaction.certificate_author_index
                     );
                     self.scorer
-                        .update_invalid_reports_count(transaction.certificate_author_index);
+                        .increment_invalid_reports_count(transaction.certificate_author_index);
                     return None;
                 }
             }
@@ -4290,7 +4290,7 @@ impl AuthorityPerEpochStore {
                         (VersionedMisbehaviorReport::V1(..), Some(1))
                         | (VersionedMisbehaviorReport::V1(..), None) => {
                             if !report.verify(self.committee.num_members()) {
-                                self.scorer.update_invalid_reports_count(authority_index);
+                                self.scorer.increment_invalid_reports_count(authority_index);
                                 warn!(
                                     "Received invalid misbehavior report from {:?}",
                                     authority.concise()
@@ -4302,7 +4302,7 @@ impl AuthorityPerEpochStore {
                             }
                         }
                         _ => {
-                            self.scorer.update_invalid_reports_count(authority_index);
+                            self.scorer.increment_invalid_reports_count(authority_index);
                             warn!(
                                 "Received misbehavior report with unsupported version from {:?}",
                                 authority.concise()

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -4273,6 +4273,7 @@ impl AuthorityPerEpochStore {
                         "Received misbehavior report from {:?} but validator scores are disabled, so the report is ignored",
                         authority.concise()
                     );
+                    return Ok(ConsensusCertificateResult::ConsensusMessage);
                 }
                 if self
                     .get_reconfig_state_read_lock_guard()

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -4273,7 +4273,6 @@ impl AuthorityPerEpochStore {
                         "Received misbehavior report from {:?} but validator scores are disabled, so the report is ignored",
                         authority.concise()
                     );
-                    return Ok(ConsensusCertificateResult::ConsensusMessage);
                 }
                 if self
                     .get_reconfig_state_read_lock_guard()
@@ -4283,30 +4282,26 @@ impl AuthorityPerEpochStore {
                         .committee
                         .authority_index(authority)
                         .expect("authority in committee");
-
                     // Check validity of the report and update scores depending on the result. We
                     // already have consensus on inclusion of this report in the DAG.
-                    match report.is_valid_version(self.protocol_config()) {
-                        true => {
-                            if !report.verify(self.committee.num_members()) {
-                                self.scorer.increment_invalid_reports_count(authority_index);
-                                warn!(
-                                    "Received invalid misbehavior report from {:?}",
-                                    authority.concise()
-                                );
-                            } else {
-                                // Here we update all counts related to the information in the
-                                // reports.
-                                self.scorer.update_received_reports(authority_index, report);
-                            }
-                        }
-                        false => {
+                    if report.is_valid_version(self.protocol_config()) {
+                        if !report.verify(self.committee.num_members()) {
                             self.scorer.increment_invalid_reports_count(authority_index);
                             warn!(
-                                "Received misbehavior report with unsupported version from {:?}",
+                                "Received invalid misbehavior report from {:?}",
                                 authority.concise()
                             );
+                        } else {
+                            // Here we update all counts related to the information in the
+                            // reports.
+                            self.scorer.update_received_reports(authority_index, report);
                         }
+                    } else {
+                        self.scorer.increment_invalid_reports_count(authority_index);
+                        warn!(
+                            "Received misbehavior report with unsupported version from {:?}",
+                            authority.concise()
+                        );
                     }
                 } else {
                     debug!(

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -4286,9 +4286,8 @@ impl AuthorityPerEpochStore {
 
                     // Check validity of the report and update scores depending on the result. We
                     // already have consensus on inclusion of this report in the DAG.
-                    match (report, self.protocol_config().scorer_version_as_option()) {
-                        (VersionedMisbehaviorReport::V1(..), Some(1))
-                        | (VersionedMisbehaviorReport::V1(..), None) => {
+                    match report.is_valid_version(self.protocol_config()) {
+                        true => {
                             if !report.verify(self.committee.num_members()) {
                                 self.scorer.increment_invalid_reports_count(authority_index);
                                 warn!(
@@ -4301,7 +4300,7 @@ impl AuthorityPerEpochStore {
                                 self.scorer.update_received_reports(authority_index, report);
                             }
                         }
-                        _ => {
+                        false => {
                             self.scorer.increment_invalid_reports_count(authority_index);
                             warn!(
                                 "Received misbehavior report with unsupported version from {:?}",

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -31,7 +31,7 @@ pub struct Scorer {
     // The current scores of the authorities, updated after each received report. This score is
     // calculated based on the information in the received reports and the validity of the reports
     // themselves.
-    pub(crate) current_scores: Scores,
+    current_scores: Scores,
     // The count of invalid reports received from each authority. Validity here must be checked in
     // a deterministic way, since this information will not be propagated again to the rest of the
     // committee.
@@ -203,6 +203,13 @@ impl Scorer {
     pub(crate) fn mark_end_of_epoch_report_sent(&self) {
         self.has_sent_end_of_epoch_report
             .store(true, Ordering::Relaxed);
+    }
+
+    pub(crate) fn current_scores(&self) -> Vec<u64> {
+        self.current_scores
+            .iter()
+            .map(|x| x.load(std::sync::atomic::Ordering::Relaxed))
+            .collect()
     }
 }
 
@@ -580,9 +587,10 @@ mod tests {
         let scorer = Scorer::new(voting_power, &protocol_config);
 
         // Before calling update_scores, all scores should be MAX_SCORE
-        for score in scorer.current_scores.iter() {
-            assert_eq!(score.load(Ordering::Relaxed), MAX_SCORE,);
-        }
+        scorer
+            .current_scores
+            .iter()
+            .for_each(|score| assert_eq!(score.load(Ordering::Relaxed), MAX_SCORE));
 
         // Set some reports for testing
         let reports_and_authorities = vec![
@@ -622,11 +630,7 @@ mod tests {
 
         let expected_score = vec![0, 65536, 45876];
         // After calling update_scores, scores should be updated
-        let actual_score = scorer
-            .current_scores
-            .iter()
-            .map(|value| value.load(Ordering::Relaxed))
-            .collect::<Vec<u64>>();
+        let actual_score = scorer.current_scores();
         assert_eq!(actual_score, expected_score);
     }
 

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -46,6 +46,8 @@ pub struct Scorer {
     // Indicates the sequence number of the last checkpoint for which the authority sent a report.
     // This is used as part of the MisbehaviorReport rate limiting mechanism.
     last_report_checkpoint_seq: AtomicU64,
+    // Indicates whether the authority sent a report close to the epoch end.
+    has_sent_end_of_epoch_report: AtomicBool,
     // The version of the scorer being used with its parameters.
     version: ScorerVersion,
 }
@@ -140,6 +142,7 @@ impl Scorer {
                     voting_power,
                     last_report_summary: AtomicU64::new(0),
                     last_report_checkpoint_seq: AtomicU64::new(0),
+                    has_sent_end_of_epoch_report: AtomicBool::new(false),
                     version: ScorerVersion::V1(parameters),
                 }
             }
@@ -191,6 +194,15 @@ impl Scorer {
 
     pub(crate) fn store_last_report_summary(&self, summary: u64) {
         self.last_report_summary.store(summary, Ordering::Relaxed)
+    }
+
+    pub(crate) fn has_sent_end_of_epoch_report(&self) -> bool {
+        self.has_sent_end_of_epoch_report.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn mark_end_of_epoch_report_sent(&self) {
+        self.has_sent_end_of_epoch_report
+            .store(true, Ordering::Relaxed);
     }
 }
 

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -155,7 +155,7 @@ impl Scorer {
 
     // Boundary checks for this functions are done at a higher level. `authority``
     // should always be derived from a valid AuthorityIndex
-    pub(crate) fn update_invalid_reports_count(&self, authority: u32) {
+    pub(crate) fn increment_invalid_reports_count(&self, authority: u32) {
         self.invalid_reports_count[authority as usize].fetch_add(1, Ordering::Relaxed);
     }
 
@@ -509,7 +509,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_invalid_reports_count() {
+    fn test_increment_invalid_reports_count() {
         let voting_power = vec![10, 20, 30];
 
         let protocol_config = mock_protocol_config(ConsensusChoice::Mysticeti);
@@ -525,7 +525,7 @@ mod tests {
         );
 
         // Call the method
-        scorer.update_invalid_reports_count(authority_index);
+        scorer.increment_invalid_reports_count(authority_index);
 
         // After update
         assert_eq!(
@@ -543,8 +543,8 @@ mod tests {
 
         let authority_index = 1;
         // Call the method twice
-        scorer.update_invalid_reports_count(authority_index);
-        scorer.update_invalid_reports_count(authority_index);
+        scorer.increment_invalid_reports_count(authority_index);
+        scorer.increment_invalid_reports_count(authority_index);
 
         // After update
         assert_eq!(

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -208,7 +208,7 @@ impl Scorer {
     pub(crate) fn current_scores(&self) -> Vec<u64> {
         self.current_scores
             .iter()
-            .map(|x| x.load(std::sync::atomic::Ordering::Relaxed))
+            .map(|x| x.load(Ordering::Relaxed))
             .collect()
     }
 

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -211,6 +211,10 @@ impl Scorer {
             .map(|x| x.load(std::sync::atomic::Ordering::Relaxed))
             .collect()
     }
+
+    pub(crate) fn generate_report_with_current_local_metrics(&self) -> VersionedMisbehaviorReport {
+        self.current_local_metrics_count.to_report()
+    }
 }
 
 // Methods for ScorerVersion::V1

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -38,6 +38,14 @@ pub struct Scorer {
     invalid_reports_count: Vec<AtomicU64>,
     // The voting power of each authority in the committee.
     voting_power: Vec<u64>,
+    // A summary of the last MisbehaviorReport sent by the authority in the checkpoint creation.
+    // Since this particular report is meant to include misbehavior counts (instead of proofs), and
+    // those counts are always non-decreasing, the summary can be created by adding all metrics for
+    // all validators. This is used as part of the MisbehaviorReport rate limiting mechanism.
+    last_report_summary: AtomicU64,
+    // Indicates the sequence number of the last checkpoint for which the authority sent a report.
+    // This is used as part of the MisbehaviorReport rate limiting mechanism.
+    last_report_checkpoint_seq: AtomicU64,
     // The version of the scorer being used with its parameters.
     version: ScorerVersion,
 }
@@ -130,6 +138,8 @@ impl Scorer {
                     current_scores,
                     invalid_reports_count,
                     voting_power,
+                    last_report_summary: AtomicU64::new(0),
+                    last_report_checkpoint_seq: AtomicU64::new(0),
                     version: ScorerVersion::V1(parameters),
                 }
             }
@@ -164,6 +174,24 @@ impl Scorer {
         // metrics from them. Then, update the scores accordingly.
         self.received_metrics[authority as usize].update_from_report(report);
         self.has_not_sent_report[authority as usize].store(false, Ordering::Relaxed);
+    }
+
+    pub(crate) fn last_report_checkpoint_seq(&self) -> u64 {
+        self.last_report_checkpoint_seq.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn store_last_report_checkpoint_seq(&self, checkpoint_seq: u64) {
+        self.last_report_checkpoint_seq
+            .store(checkpoint_seq, Ordering::Relaxed)
+    }
+
+    pub(crate) fn last_report_summary(&self) -> u64 {
+        self.last_report_summary.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn store_last_report_summary(&self, summary: u64) {
+        self.last_report_checkpoint_seq
+            .store(summary, Ordering::Relaxed)
     }
 }
 

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -190,8 +190,7 @@ impl Scorer {
     }
 
     pub(crate) fn store_last_report_summary(&self, summary: u64) {
-        self.last_report_checkpoint_seq
-            .store(summary, Ordering::Relaxed)
+        self.last_report_summary.store(summary, Ordering::Relaxed)
     }
 }
 

--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -129,16 +129,29 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
         // choose to send the ones that include only unprovable counts at this
         // point, due to periodicity reasons and to ensure a (approximate)
         // synchronization with the score updates.
-        if epoch_store.protocol_config().calculate_validator_scores() {
+        // Reports are rate-limited: only sent when metrics have changed (different
+        // summaries) and at least 1000 checkpoints have passed since the last report.
+        if epoch_store.protocol_config().calculate_validator_scores()
+            && checkpoint_seq - epoch_store.scorer.last_report_checkpoint_seq() >= 1000
+        {
             let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
-            let transaction = ConsensusTransaction::new_misbehavior_report(
-                epoch_store.name,
-                &misbehavior_report,
-                checkpoint_seq,
-            );
-            info!(?transaction, "submitting misbehavior report to consensus");
-            self.sender
-                .submit_to_consensus(&[transaction], epoch_store)?;
+            let new_report_summary = misbehavior_report.summary();
+            if new_report_summary != epoch_store.scorer.last_report_summary() {
+                let transaction = ConsensusTransaction::new_misbehavior_report(
+                    epoch_store.name,
+                    &misbehavior_report,
+                    checkpoint_seq,
+                );
+                info!(?transaction, "submitting misbehavior report to consensus");
+                self.sender
+                    .submit_to_consensus(&[transaction], epoch_store)?;
+                epoch_store
+                    .scorer
+                    .store_last_report_summary(new_report_summary);
+                epoch_store
+                    .scorer
+                    .store_last_report_checkpoint_seq(checkpoint_seq);
+            }
         }
 
         if checkpoint_timestamp >= self.next_reconfiguration_timestamp_ms {

--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -123,16 +123,22 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
                 .set(checkpoint_seq as i64);
         }
 
-        // If scoring is enabled in protocol config, we also send misbehavior reports to
-        // consensus at this point. Misbehavior reports containing proofs of
-        // misbehaviour can be send whenever the misbehavior is detected, but we
-        // choose to send the ones that include only unprovable counts at this
-        // point, due to periodicity reasons and to ensure a (approximate)
+        // If `calculate_validator_scores` is enabled in protocol config, we also send
+        // misbehavior reports to consensus at this point. Misbehavior reports
+        // containing proofs of misbehaviour can be sent whenever the misbehavior is
+        // detected, but we choose to send the ones that include only unprovable counts
+        // at this point, due to periodicity reasons and to ensure a (approximate)
         // synchronization with the score updates.
+        //
         // Reports are rate-limited: only sent when metrics have changed (different
         // summaries) and at least 1000 checkpoints have passed since the last report.
+        //
+        // Additionally, we require that the checkpoint for which we want to send the
+        // report is at most 100 checkpoints behind the highest verified checkpoint, to
+        // avoid sending reports during resync.
         if epoch_store.protocol_config().calculate_validator_scores()
             && checkpoint_seq - epoch_store.scorer.last_report_checkpoint_seq() >= 1000
+            && Some(checkpoint_seq + 100) >= highest_verified_checkpoint
         {
             let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
             let new_report_summary = misbehavior_report.summary();

--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -132,13 +132,18 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
         //
         // Reports are rate-limited: only sent when metrics have changed (different
         // summaries) and at least 1000 checkpoints have passed since the last report.
+        // We also require that the checkpoint for which we want to send the report is
+        // at most 100 checkpoints behind the highest verified checkpoint, to avoid
+        // sending reports during resync.
         //
-        // Additionally, we require that the checkpoint for which we want to send the
-        // report is at most 100 checkpoints behind the highest verified checkpoint, to
-        // avoid sending reports during resync.
-        if epoch_store.protocol_config().calculate_validator_scores()
+        // Additionally to these periodic reports, we also send a report when the epoch
+        // is coming to an end. Since `close_epoch` is called according to local clocks,
+        // we use an analogous rule for the last reports, requiring that the checkpoint
+        // is close to the next reconfiguration timestamp.
+        if (epoch_store.protocol_config().calculate_validator_scores()
             && checkpoint_seq - epoch_store.scorer.last_report_checkpoint_seq() >= 1000
-            && Some(checkpoint_seq + 100) >= highest_verified_checkpoint
+            && Some(checkpoint_seq + 100) >= highest_verified_checkpoint)
+            || checkpoint_timestamp >= self.next_reconfiguration_timestamp_ms - 2000
         {
             let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
             let new_report_summary = misbehavior_report.summary();

--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -24,6 +24,9 @@ use crate::{
     epoch::reconfiguration::ReconfigurationInitiator,
 };
 
+const REPORT_END_OF_EPOCH_MARGIN_MS: u64 = 2000;
+const MIN_CHECKPOINTS_BETWEEN_REPORTS: u64 = 1000;
+const MAX_CHECKPOINT_LAG_FOR_REPORT: u64 = 100;
 #[async_trait]
 pub trait CheckpointOutput: Sync + Send + 'static {
     async fn checkpoint_created(
@@ -141,11 +144,13 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
         // we use an analogous rule for the last reports, requiring that the checkpoint
         // is close to the next reconfiguration timestamp.
         let should_send_last_report = checkpoint_timestamp
-            >= self.next_reconfiguration_timestamp_ms - 2000
+            >= self.next_reconfiguration_timestamp_ms - REPORT_END_OF_EPOCH_MARGIN_MS
             && !epoch_store.scorer.has_sent_end_of_epoch_report();
         if epoch_store.protocol_config().calculate_validator_scores()
-            && ((checkpoint_seq - epoch_store.scorer.last_report_checkpoint_seq() >= 1000
-                && Some(checkpoint_seq + 100) >= highest_verified_checkpoint)
+            && ((checkpoint_seq - epoch_store.scorer.last_report_checkpoint_seq()
+                >= MIN_CHECKPOINTS_BETWEEN_REPORTS
+                && Some(checkpoint_seq + MAX_CHECKPOINT_LAG_FOR_REPORT)
+                    >= highest_verified_checkpoint)
                 || should_send_last_report)
         {
             let misbehavior_report = epoch_store

--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -148,7 +148,9 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
                 && Some(checkpoint_seq + 100) >= highest_verified_checkpoint)
                 || should_send_last_report)
         {
-            let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
+            let misbehavior_report = epoch_store
+                .scorer
+                .generate_report_with_current_local_metrics();
             let new_report_summary = misbehavior_report.summary();
             if new_report_summary != epoch_store.scorer.last_report_summary()
                 || should_send_last_report

--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -144,10 +144,12 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
         // we use an analogous rule for the last reports, requiring that the checkpoint
         // is close to the next reconfiguration timestamp.
         let should_send_last_report = checkpoint_timestamp
-            >= self.next_reconfiguration_timestamp_ms - REPORT_END_OF_EPOCH_MARGIN_MS
+            >= self
+                .next_reconfiguration_timestamp_ms
+                .saturating_sub(REPORT_END_OF_EPOCH_MARGIN_MS)
             && !epoch_store.scorer.has_sent_end_of_epoch_report();
         if epoch_store.protocol_config().calculate_validator_scores()
-            && ((checkpoint_seq - epoch_store.scorer.last_report_checkpoint_seq()
+            && ((checkpoint_seq.saturating_sub(epoch_store.scorer.last_report_checkpoint_seq())
                 >= MIN_CHECKPOINTS_BETWEEN_REPORTS
                 && Some(checkpoint_seq + MAX_CHECKPOINT_LAG_FOR_REPORT)
                     >= highest_verified_checkpoint)

--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -140,8 +140,9 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
         // is coming to an end. Since `close_epoch` is called according to local clocks,
         // we use an analogous rule for the last reports, requiring that the checkpoint
         // is close to the next reconfiguration timestamp.
-        let should_send_last_report =
-            checkpoint_timestamp >= self.next_reconfiguration_timestamp_ms - 2000;
+        let should_send_last_report = checkpoint_timestamp
+            >= self.next_reconfiguration_timestamp_ms - 2000
+            && !epoch_store.scorer.has_sent_end_of_epoch_report();
         if epoch_store.protocol_config().calculate_validator_scores()
             && ((checkpoint_seq - epoch_store.scorer.last_report_checkpoint_seq() >= 1000
                 && Some(checkpoint_seq + 100) >= highest_verified_checkpoint)
@@ -166,6 +167,9 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
                 epoch_store
                     .scorer
                     .store_last_report_checkpoint_seq(checkpoint_seq);
+                if should_send_last_report {
+                    epoch_store.scorer.mark_end_of_epoch_report_sent();
+                }
             }
         }
 

--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -140,14 +140,18 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
         // is coming to an end. Since `close_epoch` is called according to local clocks,
         // we use an analogous rule for the last reports, requiring that the checkpoint
         // is close to the next reconfiguration timestamp.
-        if (epoch_store.protocol_config().calculate_validator_scores()
-            && checkpoint_seq - epoch_store.scorer.last_report_checkpoint_seq() >= 1000
-            && Some(checkpoint_seq + 100) >= highest_verified_checkpoint)
-            || checkpoint_timestamp >= self.next_reconfiguration_timestamp_ms - 2000
+        let should_send_last_report =
+            checkpoint_timestamp >= self.next_reconfiguration_timestamp_ms - 2000;
+        if epoch_store.protocol_config().calculate_validator_scores()
+            && ((checkpoint_seq - epoch_store.scorer.last_report_checkpoint_seq() >= 1000
+                && Some(checkpoint_seq + 100) >= highest_verified_checkpoint)
+                || should_send_last_report)
         {
             let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
             let new_report_summary = misbehavior_report.summary();
-            if new_report_summary != epoch_store.scorer.last_report_summary() {
+            if new_report_summary != epoch_store.scorer.last_report_summary()
+                || should_send_last_report
+            {
                 let transaction = ConsensusTransaction::new_misbehavior_report(
                     epoch_store.name,
                     &misbehavior_report,

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1588,12 +1588,7 @@ impl CheckpointBuilder {
                     .protocol_config()
                     .pass_calculated_validator_scores_to_advance_epoch()
                 {
-                    self.epoch_store
-                        .scorer
-                        .current_scores
-                        .iter()
-                        .map(|x| x.load(std::sync::atomic::Ordering::Relaxed))
-                        .collect()
+                    self.epoch_store.scorer.current_scores()
                 } else {
                     // Give everyone in the committee the max score
                     vec![MAX_SCORE; self.epoch_store.committee().num_members()]

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -884,38 +884,49 @@ impl ConsensusAdapter {
             false
         };
         if send_end_of_publish {
-            // Submit a final misbehavior report to consensus before EndOfPublish.
-            // This ensures the latest scoring metrics are always available at epoch
-            // boundary, regardless of the regular rate-limiting interval.
             if epoch_store.protocol_config().calculate_validator_scores() {
+                // Build final misbehavior report and EndOfPublish as a single batch so they are
+                // submitted to consensus in one call and end up in the same block.
+                let mut eop_transactions = Vec::new();
+                eop_transactions.push(ConsensusTransaction::new_end_of_publish(self.authority));
+
                 let checkpoint_seq = self
                     .checkpoint_store
                     .get_highest_executed_checkpoint_seq_number()
                     .ok()
-                    .flatten()
+                    .unwrap_or(None)
                     .unwrap_or(0);
                 let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
-                let transaction = ConsensusTransaction::new_misbehavior_report(
+                let report_tx = ConsensusTransaction::new_misbehavior_report(
                     epoch_store.name,
                     &misbehavior_report,
                     checkpoint_seq,
                 );
+
+                info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
                 info!(
-                    ?transaction,
-                    "submitting final misbehavior report before EndOfPublish"
+                    ?report_tx,
+                    "including final misbehavior report with EndOfPublish"
                 );
-                if let Err(err) = self.submit(transaction, None, epoch_store) {
-                    warn!("Error when sending final misbehavior report: {:?}", err);
+
+                eop_transactions.push(report_tx);
+
+                if let Err(err) = self.submit_batch(&eop_transactions, None, epoch_store) {
+                    warn!(
+                        "Error when sending EndOfPublish transaction with report: {:?}",
+                        err
+                    );
                 }
-            }
-            // sending message outside of any locks scope
-            info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
-            if let Err(err) = self.submit(
-                ConsensusTransaction::new_end_of_publish(self.authority),
-                None,
-                epoch_store,
-            ) {
-                warn!("Error when sending end of publish message: {:?}", err);
+            } else {
+                // sending message outside of any locks scope
+                info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
+                if let Err(err) = self.submit(
+                    ConsensusTransaction::new_end_of_publish(self.authority),
+                    None,
+                    epoch_store,
+                ) {
+                    warn!("Error when sending end of publish message: {:?}", err);
+                }
             }
         }
         self.metrics
@@ -1148,37 +1159,49 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
             // reconfig_guard lock is dropped here.
         };
         if send_end_of_publish {
-            // Submit a final misbehavior report to consensus before EndOfPublish.
-            // This ensures the latest scoring metrics are always available at epoch
-            // boundary, regardless of the regular rate-limiting interval.
             if epoch_store.protocol_config().calculate_validator_scores() {
+                // Build final misbehavior report and EndOfPublish as a single batch so they are
+                // submitted to consensus in one call and end up in the same block.
+                let mut eop_transactions = Vec::new();
+                eop_transactions.push(ConsensusTransaction::new_end_of_publish(self.authority));
+
                 let checkpoint_seq = self
                     .checkpoint_store
                     .get_highest_executed_checkpoint_seq_number()
                     .ok()
-                    .flatten()
+                    .unwrap_or(None)
                     .unwrap_or(0);
                 let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
-                let transaction = ConsensusTransaction::new_misbehavior_report(
+                let report_tx = ConsensusTransaction::new_misbehavior_report(
                     epoch_store.name,
                     &misbehavior_report,
                     checkpoint_seq,
                 );
+
+                info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
                 info!(
-                    ?transaction,
-                    "submitting final misbehavior report before EndOfPublish"
+                    ?report_tx,
+                    "including final misbehavior report with EndOfPublish"
                 );
-                if let Err(err) = self.submit(transaction, None, epoch_store) {
-                    warn!("Error when sending final misbehavior report: {:?}", err);
+
+                eop_transactions.push(report_tx);
+
+                if let Err(err) = self.submit_batch(&eop_transactions, None, epoch_store) {
+                    warn!(
+                        "Error when sending EndOfPublish transaction with report: {:?}",
+                        err
+                    );
                 }
-            }
-            info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
-            if let Err(err) = self.submit(
-                ConsensusTransaction::new_end_of_publish(self.authority),
-                None,
-                epoch_store,
-            ) {
-                warn!("Error when sending end of publish message: {:?}", err);
+            } else {
+                // sending message outside of any locks scope
+                info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
+                if let Err(err) = self.submit(
+                    ConsensusTransaction::new_end_of_publish(self.authority),
+                    None,
+                    epoch_store,
+                ) {
+                    warn!("Error when sending end of publish message: {:?}", err);
+                }
             }
         }
     }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -575,28 +575,16 @@ impl ConsensusAdapter {
     ) -> IotaResult<JoinHandle<()>> {
         if transactions.len() > 1 {
             // In soft bundle, we need to check if all transactions are of UserTransaction
-            // kind. The check is required because we assume this in submit_and_wait_inner.
-            // Note that an (EndOfPublish + MisbehaviorReport) batch is not considered a
-            // soft bundle.
-            let is_eop_batch = transactions.len() == 2
-                && matches!(
-                    transactions[0].kind,
-                    ConsensusTransactionKind::EndOfPublish(_)
-                )
-                && matches!(
-                    transactions[1].kind,
-                    ConsensusTransactionKind::MisbehaviorReport(_, _, _)
+            // kind. The check is required because we assume this in
+            // submit_and_wait_inner.
+            for transaction in transactions {
+                fp_ensure!(
+                    matches!(
+                        transaction.kind,
+                        ConsensusTransactionKind::CertifiedTransaction(_)
+                    ),
+                    IotaError::InvalidTxKindInSoftBundle
                 );
-            if !is_eop_batch {
-                for transaction in transactions {
-                    fp_ensure!(
-                        matches!(
-                            transaction.kind,
-                            ConsensusTransactionKind::CertifiedTransaction(_)
-                        ),
-                        IotaError::InvalidTxKindInSoftBundle
-                    );
-                }
             }
         }
 
@@ -676,16 +664,12 @@ impl ConsensusAdapter {
         }
 
         // Current code path ensures:
-        // - If transactions.len() > 1, it is either a soft bundle or a (EndOfPublish +
-        //   MisbehaviorReport) batch. Otherwise transactions should have been submitted
-        //   individually.
+        // - If transactions.len() > 1, it is a soft bundle. Otherwise transactions
+        //   should have been submitted individually.
         // - If is_soft_bundle, then all transactions are of UserTransaction kind.
-        // - If not is_soft_bundle, then either:
-        //     - transactions must contain exactly 1 tx, and transactions[0] can be of
-        //       any kind, or
-        //     - transactions is a (EndOfPublish + MisbehaviorReport) batch , and
-        //       transactions[0] is EndOfPublish.
-        let is_soft_bundle = transactions.len() > 1 && !transactions[0].is_end_of_publish();
+        // - If not is_soft_bundle, then transactions must contain exactly 1 tx, and
+        //   transactions[0] can be of any kind.
+        let is_soft_bundle = transactions.len() > 1;
 
         let mut transaction_keys = Vec::new();
 
@@ -699,7 +683,6 @@ impl ConsensusAdapter {
             transaction_keys.push(transaction_key);
         }
         let tx_type = if !is_soft_bundle {
-            // For non-soft-bundle batches, classify by the first transaction.
             classify(&transactions[0])
         } else {
             "soft_bundle"

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -884,49 +884,38 @@ impl ConsensusAdapter {
             false
         };
         if send_end_of_publish {
+            // Submit a final misbehavior report to consensus before EndOfPublish.
+            // This ensures the latest scoring metrics are always available at epoch
+            // boundary, regardless of the regular rate-limiting interval.
             if epoch_store.protocol_config().calculate_validator_scores() {
-                // Build final misbehavior report and EndOfPublish as a single batch so they are
-                // submitted to consensus in one call and end up in the same block.
-                let mut eop_transactions = Vec::new();
-                eop_transactions.push(ConsensusTransaction::new_end_of_publish(self.authority));
-
                 let checkpoint_seq = self
                     .checkpoint_store
                     .get_highest_executed_checkpoint_seq_number()
                     .ok()
-                    .unwrap_or(None)
+                    .flatten()
                     .unwrap_or(0);
                 let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
-                let report_tx = ConsensusTransaction::new_misbehavior_report(
+                let transaction = ConsensusTransaction::new_misbehavior_report(
                     epoch_store.name,
                     &misbehavior_report,
                     checkpoint_seq,
                 );
-
-                info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
                 info!(
-                    ?report_tx,
-                    "including final misbehavior report with EndOfPublish"
+                    ?transaction,
+                    "submitting final misbehavior report before EndOfPublish"
                 );
-
-                eop_transactions.push(report_tx);
-
-                if let Err(err) = self.submit_batch(&eop_transactions, None, epoch_store) {
-                    warn!(
-                        "Error when sending EndOfPublish transaction with report: {:?}",
-                        err
-                    );
+                if let Err(err) = self.submit(transaction, None, epoch_store) {
+                    warn!("Error when sending final misbehavior report: {:?}", err);
                 }
-            } else {
-                // sending message outside of any locks scope
-                info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
-                if let Err(err) = self.submit(
-                    ConsensusTransaction::new_end_of_publish(self.authority),
-                    None,
-                    epoch_store,
-                ) {
-                    warn!("Error when sending end of publish message: {:?}", err);
-                }
+            }
+            // sending message outside of any locks scope
+            info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
+            if let Err(err) = self.submit(
+                ConsensusTransaction::new_end_of_publish(self.authority),
+                None,
+                epoch_store,
+            ) {
+                warn!("Error when sending end of publish message: {:?}", err);
             }
         }
         self.metrics
@@ -1159,49 +1148,37 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
             // reconfig_guard lock is dropped here.
         };
         if send_end_of_publish {
+            // Submit a final misbehavior report to consensus before EndOfPublish.
+            // This ensures the latest scoring metrics are always available at epoch
+            // boundary, regardless of the regular rate-limiting interval.
             if epoch_store.protocol_config().calculate_validator_scores() {
-                // Build final misbehavior report and EndOfPublish as a single batch so they are
-                // submitted to consensus in one call and end up in the same block.
-                let mut eop_transactions = Vec::new();
-                eop_transactions.push(ConsensusTransaction::new_end_of_publish(self.authority));
-
                 let checkpoint_seq = self
                     .checkpoint_store
                     .get_highest_executed_checkpoint_seq_number()
                     .ok()
-                    .unwrap_or(None)
+                    .flatten()
                     .unwrap_or(0);
                 let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
-                let report_tx = ConsensusTransaction::new_misbehavior_report(
+                let transaction = ConsensusTransaction::new_misbehavior_report(
                     epoch_store.name,
                     &misbehavior_report,
                     checkpoint_seq,
                 );
-
-                info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
                 info!(
-                    ?report_tx,
-                    "including final misbehavior report with EndOfPublish"
+                    ?transaction,
+                    "submitting final misbehavior report before EndOfPublish"
                 );
-
-                eop_transactions.push(report_tx);
-
-                if let Err(err) = self.submit_batch(&eop_transactions, None, epoch_store) {
-                    warn!(
-                        "Error when sending EndOfPublish transaction with report: {:?}",
-                        err
-                    );
+                if let Err(err) = self.submit(transaction, None, epoch_store) {
+                    warn!("Error when sending final misbehavior report: {:?}", err);
                 }
-            } else {
-                // sending message outside of any locks scope
-                info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
-                if let Err(err) = self.submit(
-                    ConsensusTransaction::new_end_of_publish(self.authority),
-                    None,
-                    epoch_store,
-                ) {
-                    warn!("Error when sending end of publish message: {:?}", err);
-                }
+            }
+            info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
+            if let Err(err) = self.submit(
+                ConsensusTransaction::new_end_of_publish(self.authority),
+                None,
+                epoch_store,
+            ) {
+                warn!("Error when sending end of publish message: {:?}", err);
             }
         }
     }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -867,30 +867,6 @@ impl ConsensusAdapter {
             false
         };
         if send_end_of_publish {
-            // Submit a final misbehavior report to consensus before EndOfPublish.
-            // This ensures the latest scoring metrics are always available at epoch
-            // boundary, regardless of the regular rate-limiting interval.
-            if epoch_store.protocol_config().calculate_validator_scores() {
-                let checkpoint_seq = self
-                    .checkpoint_store
-                    .get_highest_executed_checkpoint_seq_number()
-                    .ok()
-                    .flatten()
-                    .unwrap_or(0);
-                let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
-                let transaction = ConsensusTransaction::new_misbehavior_report(
-                    epoch_store.name,
-                    &misbehavior_report,
-                    checkpoint_seq,
-                );
-                info!(
-                    ?transaction,
-                    "submitting final misbehavior report before EndOfPublish"
-                );
-                if let Err(err) = self.submit(transaction, None, epoch_store) {
-                    warn!("Error when sending final misbehavior report: {:?}", err);
-                }
-            }
             // sending message outside of any locks scope
             info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
             if let Err(err) = self.submit(
@@ -1131,30 +1107,6 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
             // reconfig_guard lock is dropped here.
         };
         if send_end_of_publish {
-            // Submit a final misbehavior report to consensus before EndOfPublish.
-            // This ensures the latest scoring metrics are always available at epoch
-            // boundary, regardless of the regular rate-limiting interval.
-            if epoch_store.protocol_config().calculate_validator_scores() {
-                let checkpoint_seq = self
-                    .checkpoint_store
-                    .get_highest_executed_checkpoint_seq_number()
-                    .ok()
-                    .flatten()
-                    .unwrap_or(0);
-                let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
-                let transaction = ConsensusTransaction::new_misbehavior_report(
-                    epoch_store.name,
-                    &misbehavior_report,
-                    checkpoint_seq,
-                );
-                info!(
-                    ?transaction,
-                    "submitting final misbehavior report before EndOfPublish"
-                );
-                if let Err(err) = self.submit(transaction, None, epoch_store) {
-                    warn!("Error when sending final misbehavior report: {:?}", err);
-                }
-            }
             info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
             if let Err(err) = self.submit(
                 ConsensusTransaction::new_end_of_publish(self.authority),

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -575,16 +575,28 @@ impl ConsensusAdapter {
     ) -> IotaResult<JoinHandle<()>> {
         if transactions.len() > 1 {
             // In soft bundle, we need to check if all transactions are of UserTransaction
-            // kind. The check is required because we assume this in
-            // submit_and_wait_inner.
-            for transaction in transactions {
-                fp_ensure!(
-                    matches!(
-                        transaction.kind,
-                        ConsensusTransactionKind::CertifiedTransaction(_)
-                    ),
-                    IotaError::InvalidTxKindInSoftBundle
+            // kind. The check is required because we assume this in submit_and_wait_inner.
+            // Note that an (EndOfPublish + MisbehaviorReport) batch is not considered a
+            // soft bundle.
+            let is_eop_batch = transactions.len() == 2
+                && matches!(
+                    transactions[0].kind,
+                    ConsensusTransactionKind::EndOfPublish(_)
+                )
+                && matches!(
+                    transactions[1].kind,
+                    ConsensusTransactionKind::MisbehaviorReport(_, _, _)
                 );
+            if !is_eop_batch {
+                for transaction in transactions {
+                    fp_ensure!(
+                        matches!(
+                            transaction.kind,
+                            ConsensusTransactionKind::CertifiedTransaction(_)
+                        ),
+                        IotaError::InvalidTxKindInSoftBundle
+                    );
+                }
             }
         }
 
@@ -664,12 +676,16 @@ impl ConsensusAdapter {
         }
 
         // Current code path ensures:
-        // - If transactions.len() > 1, it is a soft bundle. Otherwise transactions
-        //   should have been submitted individually.
+        // - If transactions.len() > 1, it is either a soft bundle or a (EndOfPublish +
+        //   MisbehaviorReport) batch. Otherwise transactions should have been submitted
+        //   individually.
         // - If is_soft_bundle, then all transactions are of UserTransaction kind.
-        // - If not is_soft_bundle, then transactions must contain exactly 1 tx, and
-        //   transactions[0] can be of any kind.
-        let is_soft_bundle = transactions.len() > 1;
+        // - If not is_soft_bundle, then either:
+        //     - transactions must contain exactly 1 tx, and transactions[0] can be of
+        //       any kind, or
+        //     - transactions is a (EndOfPublish + MisbehaviorReport) batch , and
+        //       transactions[0] is EndOfPublish.
+        let is_soft_bundle = transactions.len() > 1 && !transactions[0].is_end_of_publish();
 
         let mut transaction_keys = Vec::new();
 
@@ -683,6 +699,7 @@ impl ConsensusAdapter {
             transaction_keys.push(transaction_key);
         }
         let tx_type = if !is_soft_bundle {
+            // For non-soft-bundle batches, classify by the first transaction.
             classify(&transactions[0])
         } else {
             "soft_bundle"

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -867,6 +867,30 @@ impl ConsensusAdapter {
             false
         };
         if send_end_of_publish {
+            // Submit a final misbehavior report to consensus before EndOfPublish.
+            // This ensures the latest scoring metrics are always available at epoch
+            // boundary, regardless of the regular rate-limiting interval.
+            if epoch_store.protocol_config().calculate_validator_scores() {
+                let checkpoint_seq = self
+                    .checkpoint_store
+                    .get_highest_executed_checkpoint_seq_number()
+                    .ok()
+                    .flatten()
+                    .unwrap_or(0);
+                let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
+                let transaction = ConsensusTransaction::new_misbehavior_report(
+                    epoch_store.name,
+                    &misbehavior_report,
+                    checkpoint_seq,
+                );
+                info!(
+                    ?transaction,
+                    "submitting final misbehavior report before EndOfPublish"
+                );
+                if let Err(err) = self.submit(transaction, None, epoch_store) {
+                    warn!("Error when sending final misbehavior report: {:?}", err);
+                }
+            }
             // sending message outside of any locks scope
             info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
             if let Err(err) = self.submit(
@@ -1107,6 +1131,30 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
             // reconfig_guard lock is dropped here.
         };
         if send_end_of_publish {
+            // Submit a final misbehavior report to consensus before EndOfPublish.
+            // This ensures the latest scoring metrics are always available at epoch
+            // boundary, regardless of the regular rate-limiting interval.
+            if epoch_store.protocol_config().calculate_validator_scores() {
+                let checkpoint_seq = self
+                    .checkpoint_store
+                    .get_highest_executed_checkpoint_seq_number()
+                    .ok()
+                    .flatten()
+                    .unwrap_or(0);
+                let misbehavior_report = epoch_store.scorer.current_local_metrics_count.to_report();
+                let transaction = ConsensusTransaction::new_misbehavior_report(
+                    epoch_store.name,
+                    &misbehavior_report,
+                    checkpoint_seq,
+                );
+                info!(
+                    ?transaction,
+                    "submitting final misbehavior report before EndOfPublish"
+                );
+                if let Err(err) = self.submit(transaction, None, epoch_store) {
+                    warn!("Error when sending final misbehavior report: {:?}", err);
+                }
+            }
             info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
             if let Err(err) = self.submit(
                 ConsensusTransaction::new_end_of_publish(self.authority),

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -18,6 +18,7 @@ use iota_sdk_types::crypto::IntentScope;
 use once_cell::sync::OnceCell;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::{
     base_types::{
@@ -326,6 +327,20 @@ impl VersionedMisbehaviorReport {
                 digest.get_or_init(|| MisbehaviorReportDigest::new(default_hash(self)))
             }
         }
+    }
+    /// Returns the summary of the misbehavior report, defined as the sum of all
+    /// metrics for all authorities.
+    pub fn summary(&self) -> u64 {
+        let summary = match self {
+            VersionedMisbehaviorReport::V1(report, _) => report
+                .iter()
+                .flatten()
+                .fold(0u64, |acc, metric| acc.saturating_add(*metric)),
+        };
+        if summary == u64::MAX {
+            warn!("MisbehaviorReport summary reached its maximum value.");
+        }
+        summary
     }
 }
 

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -14,6 +14,7 @@ use byteorder::{BigEndian, ReadBytesExt};
 use fastcrypto::{error::FastCryptoResult, groups::bls12381, hash::HashFunction};
 use fastcrypto_tbls::dkg_v1;
 use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
+use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::crypto::IntentScope;
 use once_cell::sync::OnceCell;
 use schemars::JsonSchema;
@@ -341,6 +342,15 @@ impl VersionedMisbehaviorReport {
             warn!("MisbehaviorReport summary reached its maximum value.");
         }
         summary
+    }
+
+    pub fn is_valid_version(&self, protocol_config: &ProtocolConfig) -> bool {
+        let scorer_version = protocol_config.scorer_version_as_option();
+        match (self, scorer_version) {
+            (VersionedMisbehaviorReport::V1(_, _), None) => true,
+            (VersionedMisbehaviorReport::V1(_, _), Some(1)) => true,
+            (VersionedMisbehaviorReport::V1(_, _), _) => false,
+        }
     }
 }
 


### PR DESCRIPTION
# Description of change

- Adds information about the last submitted report (sequence number and summary) to `Scorer`.
- Rate-limit report submission: reports are only sent when all three conditions are met:
    1. Metrics have changed since the last report (according to report summary)
    2. At least 1000 checkpoints have passed since the last report
    3. The current checkpoint is at most 100 behind the highest verified checkpoint (avoids sending reports during resync)
- Forces a report to be sent when the epoch is coming to an end:
   1. A report is additionally sent when `checkpoint_timestamp >= next_reconfiguration_timestamp_ms - 2000`. This condition should be sufficient so that most authorities can have their reports included before the epoch closes.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes