### PR TITLE
fix(ts-sdk): Fix `PureArg` type to match its BCS schema definition

### DIFF
--- a/sdk/typescript/src/bcs/types.ts
+++ b/sdk/typescript/src/bcs/types.ts
@@ -37,7 +37,7 @@ export type ObjectCallArg = {
 /**
  * A pure argument.
  */
-export type PureArg = { Pure: Array<number> };
+export type PureArg = { Pure: { bytes: Uint8Array | string } };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isPureArg(arg: any): arg is PureArg {


### PR DESCRIPTION
https://github.com/iotaledger/iota/blob/171030ee9504c7c33feb7f2131f1288b60578a20/sdk/typescript/src/bcs/bcs.ts#L88