### PR TITLE
upstream(iota): add ability to specify network in command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,8 +1989,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -7694,7 +7694,7 @@ dependencies = [
 name = "iota-proto-build"
 version = "1.17.0-alpha"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.13.0",
  "petgraph 0.6.5",
  "prettyplease",
@@ -8770,9 +8770,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.9"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b26c20e2178756451cfeb0661fb74c47dd5988cb7e3939de7e9241fd604d42"
+checksum = "e281ae70cc3b98dac15fced3366a880949e65fc66e345ce857a5682d152f3e62"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -8788,9 +8788,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.24.9"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bacb85abf4117092455e1573625e21b8f8ef4dec8aff13361140b2dc266cdff2"
+checksum = "cc4280b709ac3bb5e16cf3bad5056a0ec8df55fa89edfe996361219aadc2c7ea"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -8813,9 +8813,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.9"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456196007ca3a14db478346f58c7238028d55ee15c1df15115596e411ff27925"
+checksum = "348ee569eaed52926b5e740aae20863762b16596476e943c9e415a6479021622"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8840,9 +8840,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.24.9"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c872b6c9961a4ccc543e321bb5b89f6b2d2c7fe8b61906918273a3333c95400c"
+checksum = "f50c389d6e6a52eb7c3548a6600c90cf74d9b71cb5912209833f00a5479e9a01"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8865,9 +8865,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.24.9"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e65763c942dfc9358146571911b0cd1c361c2d63e2d2305622d40d36376ca80"
+checksum = "7398cddf5013cca4702862a2692b66c48a3bd6cf6ec681a47453c93d63cf8de5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate 3.2.0",
@@ -8878,9 +8878,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.9"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e363146da18e50ad2b51a0a7925fc423137a0b1371af8235b1c231a0647328"
+checksum = "21429bcdda37dcf2d43b68621b994adede0e28061f816b038b0f18c70c143d51"
 dependencies = [
  "futures-util",
  "http 1.3.1",
@@ -8905,9 +8905,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.9"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a8e70baf945b6b5752fc8eb38c918a48f1234daf11355e07106d963f860089"
+checksum = "b0f05e0028e55b15dbd2107163b3c744cd3bb4474f193f95d9708acbf5677e44"
 dependencies = [
  "http 1.3.1",
  "serde",
@@ -8917,9 +8917,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.24.9"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6558a9586cad43019dafd0b6311d0938f46efc116b34b28c74778bc11a2edf6"
+checksum = "e9d745e4f543fc10fc0e2b11aa1f3be506b1e475d412167e7191a65ecd239f1c"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -8928,9 +8928,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.24.9"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b3323d890aa384f12148e8d2a1fd18eb66e9e7e825f9de4fa53bcc19b93eef"
+checksum = "78fc744f17e7926d57f478cf9ca6e1ee5d8332bf0514860b1a3cdf1742e614cc"
 dependencies = [
  "http 1.3.1",
  "jsonrpsee-client-transport",
@@ -9205,7 +9205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -10747,7 +10747,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -12146,7 +12146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -12166,7 +12166,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14119,7 +14119,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -15848,7 +15848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -16446,7 +16446,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -386,7 +386,7 @@ pub fn new_wallet_context_from_cluster(
         wallet_config_path
     );
 
-    WalletContext::new(&wallet_config_path, None, None).unwrap_or_else(|e| {
+    WalletContext::new(&wallet_config_path).unwrap_or_else(|e| {
         panic!("failed to init wallet context from path {wallet_config_path:?}, error: {e}")
     })
 }

--- a/crates/iota-faucet/src/bin/merge_coins.rs
+++ b/crates/iota-faucet/src/bin/merge_coins.rs
@@ -132,5 +132,5 @@ async fn _merge_coins(gas_coin: &str, wallet: WalletContext) -> Result<(), anyho
 pub fn create_wallet_context(timeout_secs: u64) -> Result<WalletContext, anyhow::Error> {
     let wallet_conf = iota_config_dir()?.join(IOTA_CLIENT_CONFIG);
     info!("Initialize wallet from config path: {wallet_conf:?}");
-    WalletContext::new(&wallet_conf, Some(Duration::from_secs(timeout_secs)), None)
+    Ok(WalletContext::new(&wallet_conf)?.with_request_timeout(Duration::from_secs(timeout_secs)))
 }

--- a/crates/iota-faucet/src/server.rs
+++ b/crates/iota-faucet/src/server.rs
@@ -258,11 +258,10 @@ pub fn create_wallet_context(
 ) -> Result<WalletContext, anyhow::Error> {
     let wallet_conf = config_dir.join(IOTA_CLIENT_CONFIG);
     info!("Initialize wallet from config path: {wallet_conf:?}");
-    WalletContext::new(
-        &wallet_conf,
-        Some(Duration::from_secs(timeout_secs)),
-        Some(1000),
-    )
+    WalletContext::new(&wallet_conf).map(|ctx| {
+        ctx.with_request_timeout(Duration::from_secs(timeout_secs))
+            .with_max_concurrent_requests(1000)
+    })
 }
 
 async fn handle_error(error: BoxError) -> impl IntoResponse {

--- a/crates/iota-sdk/examples/utils.rs
+++ b/crates/iota-sdk/examples/utils.rs
@@ -288,7 +288,8 @@ pub fn retrieve_wallet() -> Result<WalletContext, anyhow::Error> {
     client_config.set_active_address(default_active_address);
     client_config.save(&wallet_conf)?;
 
-    let wallet = WalletContext::new(&wallet_conf, std::time::Duration::from_secs(60), None)?;
+    let wallet =
+        WalletContext::new(&wallet_conf)?.with_request_timeout(std::time::Duration::from_secs(60));
 
     Ok(wallet)
 }

--- a/crates/iota-sdk/src/wallet_context.rs
+++ b/crates/iota-sdk/src/wallet_context.rs
@@ -38,16 +38,13 @@ pub struct WalletContext {
     request_timeout: Option<std::time::Duration>,
     client: Arc<RwLock<Option<IotaClient>>>,
     max_concurrent_requests: Option<u64>,
+    env_override: Option<String>,
 }
 
 impl WalletContext {
     /// Create a new [`WalletContext`] with the config path to an existing
     /// [`IotaClientConfig`] and optional parameters for the client.
-    pub fn new(
-        config_path: &Path,
-        request_timeout: impl Into<Option<std::time::Duration>>,
-        max_concurrent_requests: impl Into<Option<u64>>,
-    ) -> Result<Self, anyhow::Error> {
+    pub fn new(config_path: &Path) -> Result<Self, anyhow::Error> {
         let config: IotaClientConfig = PersistedConfig::read(config_path).map_err(|err| {
             anyhow!(
                 "Cannot open wallet config file at {:?}. Err: {err}",
@@ -78,16 +75,36 @@ impl WalletContext {
         let config = config.persisted(config_path);
         let context = Self {
             config,
-            request_timeout: request_timeout.into(),
+            request_timeout: None,
             client: Default::default(),
-            max_concurrent_requests: max_concurrent_requests.into(),
+            max_concurrent_requests: None,
+            env_override: None,
         };
         Ok(context)
+    }
+
+    pub fn with_request_timeout(mut self, request_timeout: std::time::Duration) -> Self {
+        self.request_timeout = Some(request_timeout);
+        self
+    }
+
+    pub fn with_max_concurrent_requests(mut self, max_concurrent_requests: u64) -> Self {
+        self.max_concurrent_requests = Some(max_concurrent_requests);
+        self
+    }
+
+    pub fn with_env_override(mut self, env_override: String) -> Self {
+        self.env_override = Some(env_override);
+        self
     }
 
     /// Get all addresses from the keystore.
     pub fn get_addresses(&self) -> Vec<IotaAddress> {
         self.config.keystore.addresses()
+    }
+
+    pub fn get_env_override(&self) -> Option<String> {
+        self.env_override.clone()
     }
 
     /// Get the configured [`IotaClient`].
@@ -131,11 +148,20 @@ impl WalletContext {
             bail!("No managed environments. Create new environment with the `new-env` command.");
         }
 
-        Ok(if self.config.active_env().is_some() {
-            self.config.get_active_env()?
+        if let Some(env_override) = &self.env_override {
+            self.config.get_env(env_override).ok_or_else(|| {
+                anyhow!(
+                    "Environment configuration not found for env [{}]",
+                    env_override
+                )
+            })
         } else {
-            &self.config.envs()[0]
-        })
+            Ok(if self.config.active_env().is_some() {
+                self.config.get_active_env()?
+            } else {
+                &self.config.envs()[0]
+            })
+        }
     }
 
     /// Get the latest object reference given a object id.

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -2085,12 +2085,12 @@ impl IotaClientCommands {
                 context.config().save()?;
                 IotaClientCommandResult::NewEnv(env)
             }
-            IotaClientCommands::ActiveEnv => {
-                IotaClientCommandResult::ActiveEnv(context.config().active_env().clone())
-            }
+            IotaClientCommands::ActiveEnv => IotaClientCommandResult::ActiveEnv(
+                context.active_env().ok().map(|e| e.alias().clone()),
+            ),
             IotaClientCommands::Envs => IotaClientCommandResult::Envs(
                 context.config().envs().clone(),
-                context.config().active_env().clone(),
+                context.active_env().ok().map(|e| e.alias().clone()),
             ),
             IotaClientCommands::VerifySource {
                 package_path,

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -152,11 +152,11 @@ pub struct IotaEnvConfig {
     /// Sets the file storing the state of our user accounts (an empty one will
     /// be created if missing)
     #[clap(long = "client.config")]
-    config: Option<PathBuf>,
+    pub config: Option<PathBuf>,
     /// The IOTA environment to use. This must be present in the current config
     /// file.
     #[clap(long = "client.env")]
-    env: Option<String>,
+    pub env: Option<String>,
 }
 
 #[derive(Parser)]
@@ -652,7 +652,9 @@ impl IotaCommand {
                         .bold()
                         .yellow()
                 );
-                let config_path = config.unwrap_or(iota_config_dir()?.join(IOTA_CLIENT_CONFIG));
+                let config_path = config
+                    .config
+                    .unwrap_or(iota_config_dir()?.join(IOTA_CLIENT_CONFIG));
                 prompt_if_no_config(&config_path, false, true, true)?;
                 let mut context = WalletContext::new(&config_path)?;
                 cmd.execute(&mut context).await?.print(!json);

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -147,6 +147,19 @@ impl IndexerFeatureArgs {
 }
 
 #[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
+pub struct IotaEnvConfig {
+    /// Sets the file storing the state of our user accounts (an empty one will
+    /// be created if missing)
+    #[clap(long = "client.config")]
+    config: Option<PathBuf>,
+    /// The IOTA environment to use. This must be present in the current config
+    /// file.
+    #[clap(long = "client.env")]
+    env: Option<String>,
+}
+
+#[derive(Parser)]
 pub enum IotaCommand {
     /// Start a local network in two modes: saving state between re-runs and not
     /// saving state between re-runs. Please use (--help) to see the full
@@ -326,10 +339,8 @@ pub enum IotaCommand {
     },
     /// Client for interacting with the IOTA network.
     Client {
-        /// Sets the file storing the state of our user accounts (an empty one
-        /// will be created if missing)
-        #[arg(long = "client.config")]
-        config: Option<PathBuf>,
+        #[clap(flatten)]
+        config: IotaEnvConfig,
         #[command(subcommand)]
         cmd: Option<IotaClientCommands>,
         /// Return command outputs in json format.
@@ -357,11 +368,8 @@ pub enum IotaCommand {
         /// Path to a package which the command should be run with respect to.
         #[arg(long = "path", short = 'p', global = true)]
         package_path: Option<PathBuf>,
-        /// Sets the file storing the state of our user accounts (an empty one
-        /// will be created if missing) Only used when the
-        /// `--dump-bytecode-as-base64` is set.
-        #[arg(long = "client.config")]
-        config: Option<PathBuf>,
+        #[clap(flatten)]
+        config: IotaEnvConfig,
         /// Package build options
         #[command(flatten)]
         build_config: BuildConfig,
@@ -374,9 +382,8 @@ pub enum IotaCommand {
     /// By using this service, you agree to the Terms & Conditions:
     /// iotanames.com/terms-of-service."
     Name {
-        /// The file storing the state of the user accounts
-        #[arg(long = "client.config")]
-        config: Option<PathBuf>,
+        #[clap(flatten)]
+        config: IotaEnvConfig,
         /// Return command outputs in json format.
         #[arg(long, global = true)]
         json: bool,
@@ -492,7 +499,9 @@ impl IotaCommand {
                 json,
                 accept_defaults,
             } => {
-                let config_path = config.unwrap_or(iota_config_dir()?.join(IOTA_CLIENT_CONFIG));
+                let config_path = config
+                    .config
+                    .unwrap_or(iota_config_dir()?.join(IOTA_CLIENT_CONFIG));
                 prompt_if_no_config(
                     &config_path,
                     accept_defaults,
@@ -500,7 +509,10 @@ impl IotaCommand {
                     !matches!(cmd, Some(IotaClientCommands::NewAddress { .. })),
                 )?;
                 if let Some(cmd) = cmd {
-                    let mut context = WalletContext::new(&config_path, None, None)?;
+                    let mut context = WalletContext::new(&config_path)?;
+                    if let Some(env_override) = config.env {
+                        context = context.with_env_override(env_override);
+                    }
                     cmd.execute(&mut context).await?.print(!json);
                 } else {
                     // Print help
@@ -518,7 +530,7 @@ impl IotaCommand {
             } => {
                 let config_path = config.unwrap_or(iota_config_dir()?.join(IOTA_CLIENT_CONFIG));
                 prompt_if_no_config(&config_path, accept_defaults, true, true)?;
-                let mut context = WalletContext::new(&config_path, None, None)?;
+                let mut context = WalletContext::new(&config_path)?;
                 if let Some(cmd) = cmd {
                     cmd.execute(&mut context, json).await?.print(!json);
                 } else {
@@ -544,10 +556,15 @@ impl IotaCommand {
                         // management. In addition, tree shaking also
                         // requires a network as it needs to fetch
                         // on-chain linkage table of package dependencies.
-                        let config =
-                            client_config.unwrap_or(iota_config_dir()?.join(IOTA_CLIENT_CONFIG));
+                        let config = client_config
+                            .config
+                            .unwrap_or(iota_config_dir()?.join(IOTA_CLIENT_CONFIG));
                         prompt_if_no_config(&config, false, true, true)?;
-                        let context = WalletContext::new(&config, None, None)?;
+                        let mut context = WalletContext::new(&config)?;
+
+                        if let Some(env_override) = client_config.env {
+                            context = context.with_env_override(env_override);
+                        }
 
                         let Ok(client) = context.get_client().await else {
                             bail!(
@@ -637,7 +654,7 @@ impl IotaCommand {
                 );
                 let config_path = config.unwrap_or(iota_config_dir()?.join(IOTA_CLIENT_CONFIG));
                 prompt_if_no_config(&config_path, false, true, true)?;
-                let mut context = WalletContext::new(&config_path, None, None)?;
+                let mut context = WalletContext::new(&config_path)?;
                 cmd.execute(&mut context).await?.print(!json);
                 Ok(())
             }

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -29,7 +29,7 @@ use iota::{
         SwitchResponse, TxProcessingArgs, estimate_gas_budget,
     },
     client_ptb::ptb::{PTB, PTBCommandResult},
-    iota_commands::{IotaCommand, parse_host_port},
+    iota_commands::{IotaCommand, IotaEnvConfig, parse_host_port},
     key_identity::{KeyIdentity, get_identity_address},
 };
 use iota_config::{
@@ -5271,7 +5271,7 @@ async fn test_faucet() -> Result<(), anyhow::Error> {
     // Wait for the faucet to be up
     sleep(Duration::from_secs(1)).await;
     let wallet_config = test_cluster.swarm.dir().join(IOTA_CLIENT_CONFIG);
-    let mut context = WalletContext::new(&wallet_config, None, None)?;
+    let mut context = WalletContext::new(&wallet_config)?;
 
     let (address, _): (_, AccountKeyPair) = get_key_pair();
 
@@ -5332,7 +5332,7 @@ async fn test_faucet_batch() -> Result<(), anyhow::Error> {
     // Wait for the faucet to be up
     sleep(Duration::from_secs(1)).await;
     let wallet_config = test_cluster.swarm.dir().join(IOTA_CLIENT_CONFIG);
-    let mut context = WalletContext::new(&wallet_config, None, None)?;
+    let mut context = WalletContext::new(&wallet_config)?;
 
     let (address_1, _): (_, AccountKeyPair) = get_key_pair();
     let (address_2, _): (_, AccountKeyPair) = get_key_pair();
@@ -5460,7 +5460,7 @@ async fn test_faucet_batch_concurrent_requests() -> Result<(), anyhow::Error> {
     sleep(Duration::from_secs(1)).await;
 
     let wallet_config = test_cluster.swarm.dir().join(IOTA_CLIENT_CONFIG);
-    let context = WalletContext::new(&wallet_config, None, None)?; // Use immutable context
+    let context = WalletContext::new(&wallet_config)?; // Use immutable context
 
     // Generate multiple addresses
     let addresses: Vec<_> = (0..6)
@@ -5483,7 +5483,7 @@ async fn test_faucet_batch_concurrent_requests() -> Result<(), anyhow::Error> {
     let first_batch_results: Vec<_> = futures::future::join_all(addresses.iter().map(|address| {
         let wallet_config = wallet_config.clone();
         async move {
-            let mut context = WalletContext::new(&wallet_config, None, None)?; // Use mutable context (for faucet requests)
+            let mut context = WalletContext::new(&wallet_config)?; // Use mutable context (for faucet requests)
             IotaClientCommands::Faucet {
                 address: Some(KeyIdentity::Address(*address)),
                 url: Some("http://127.0.0.1:5003/v1/gas".to_string()),
@@ -5518,7 +5518,7 @@ async fn test_faucet_batch_concurrent_requests() -> Result<(), anyhow::Error> {
     let second_batch_results: Vec<_> = futures::future::join_all(addresses.iter().map(|address| {
         let wallet_config = wallet_config.clone();
         async move {
-            let mut context = WalletContext::new(&wallet_config, None, None)?; // Use mutable context
+            let mut context = WalletContext::new(&wallet_config)?; // Use mutable context
             IotaClientCommands::Faucet {
                 address: Some(KeyIdentity::Address(*address)),
                 url: Some("http://127.0.0.1:5003/v1/gas".to_string()),
@@ -5558,7 +5558,10 @@ async fn test_move_new() -> Result<(), anyhow::Error> {
     let package_name = "test_move_new";
     IotaCommand::Move {
         package_path: None,
-        config: None,
+        config: IotaEnvConfig {
+            config: None,
+            env: None,
+        },
         build_config: move_package::BuildConfig::default(),
         cmd: iota_move::Command::New(iota_move::new::New {
             new: move_cli::base::new::New {
@@ -5586,7 +5589,10 @@ async fn test_move_new() -> Result<(), anyhow::Error> {
     // Test if the generated files are valid to build a package
     IotaCommand::Move {
         package_path: Some(package_name.parse()?),
-        config: None,
+        config: IotaEnvConfig {
+            config: None,
+            env: None,
+        },
         build_config: move_package::BuildConfig::default(),
         cmd: iota_move::Command::Build(iota_move::build::Build {
             chain_id: None,
@@ -5605,7 +5611,10 @@ async fn test_move_new() -> Result<(), anyhow::Error> {
 
     IotaCommand::Move {
         package_path: Some(package_name.parse()?),
-        config: None,
+        config: IotaEnvConfig {
+            config: None,
+            env: None,
+        },
         build_config: move_package::BuildConfig::default(),
         cmd: iota_move::Command::Test(iota_move::unit_test::Test {
             test: move_cli::base::test::Test {

--- a/crates/iota/tests/shell_tests/env_overrides/basic_override.sh‎
+++ b/crates/iota/tests/shell_tests/env_overrides/basic_override.sh‎
@@ -1,0 +1,17 @@
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2026 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+iota client --client.config config.yaml switch --env base
+
+iota client --client.config config.yaml envs
+iota client --client.config config.yaml --client.env one envs
+iota client --client.config config.yaml --client.env two envs
+
+iota client --client.config config.yaml active-env
+iota client --client.config config.yaml --client.env one active-env
+iota client --client.config config.yaml --client.env two active-env
+
+# Unknown name -- Should give you None and nothing active
+iota client --client.config config.yaml --client.env not_an_env envs
+iota client --client.config config.yaml --client.env not_an_env active-env

--- a/crates/iota/tests/shell_tests/env_overrides/config.yaml
+++ b/crates/iota/tests/shell_tests/env_overrides/config.yaml
@@ -1,0 +1,17 @@
+keystore:
+  File: ~
+envs:
+  - alias: base
+    rpc: "https://custom.rpc.node.base:443"
+    ws: ~
+    basic_auth: ~
+  - alias: one
+    rpc: "https://custom.rpc.node.one:443"
+    ws: ~
+    basic_auth: ~
+  - alias: two
+    rpc: "https://custom.rpc.node.two:443"
+    ws: ~
+    basic_auth: ~
+active_env: base
+active_address: "0x0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/iota/tests/snapshots/shell_tests__env_overrides__basic_override.sh.snap‎
+++ b/crates/iota/tests/snapshots/shell_tests__env_overrides__basic_override.sh.snap‎
@@ -1,0 +1,62 @@
+---
+source: crates/iota/tests/shell_tests.rs
+description: tests/shell_tests/env_overrides/basic_override.sh
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2026 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+iota client --client.config config.yaml switch --env base
+
+iota client --client.config config.yaml envs
+iota client --client.config config.yaml --client.env one envs
+iota client --client.config config.yaml --client.env two envs
+
+iota client --client.config config.yaml active-env
+iota client --client.config config.yaml --client.env one active-env
+iota client --client.config config.yaml --client.env two active-env
+
+# Unknown name -- Should give you None and nothing active
+iota client --client.config config.yaml --client.env not_an_env envs
+iota client --client.config config.yaml --client.env not_an_env active-env
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+Active environment switched to [base]
+╭───────┬──────────────────────────────────┬────────╮
+│ alias │ url                              │ active │
+├───────┼──────────────────────────────────┼────────┤
+│ base  │ https://custom.rpc.node.base:443 │ *      │
+│ one   │ https://custom.rpc.node.one:443  │        │
+│ two   │ https://custom.rpc.node.two:443  │        │
+╰───────┴──────────────────────────────────┴────────╯
+╭───────┬──────────────────────────────────┬────────╮
+│ alias │ url                              │ active │
+├───────┼──────────────────────────────────┼────────┤
+│ base  │ https://custom.rpc.node.base:443 │        │
+│ one   │ https://custom.rpc.node.one:443  │ *      │
+│ two   │ https://custom.rpc.node.two:443  │        │
+╰───────┴──────────────────────────────────┴────────╯
+╭───────┬──────────────────────────────────┬────────╮
+│ alias │ url                              │ active │
+├───────┼──────────────────────────────────┼────────┤
+│ base  │ https://custom.rpc.node.base:443 │        │
+│ one   │ https://custom.rpc.node.one:443  │        │
+│ two   │ https://custom.rpc.node.two:443  │ *      │
+╰───────┴──────────────────────────────────┴────────╯
+base
+one
+two
+╭───────┬──────────────────────────────────┬────────╮
+│ alias │ url                              │ active │
+├───────┼──────────────────────────────────┼────────┤
+│ base  │ https://custom.rpc.node.base:443 │        │
+│ one   │ https://custom.rpc.node.one:443  │        │
+│ two   │ https://custom.rpc.node.two:443  │        │
+╰───────┴──────────────────────────────────┴────────╯
+None
+
+----- stderr -----

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1385,7 +1385,7 @@ impl TestClusterBuilder {
             .unwrap();
 
         let wallet_conf = swarm.dir().join(IOTA_CLIENT_CONFIG);
-        let wallet = WalletContext::new(&wallet_conf, None, None).unwrap();
+        let wallet = WalletContext::new(&wallet_conf).unwrap();
 
         TestCluster {
             swarm,


### PR DESCRIPTION
# Description of change

This enables the ability for `move` and `client` subcommands to accept a `--client.env <network-name>` flag to use the specified `network-name` for the single command (overriding the current `active-env`).

`network-name` must be a valid environment in the current config in order to be used. E.g., a raw RPC URL for the `--client.env` name is invalid.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/10213

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Add `--client.env` flag to `client` and `move` subcommands to allow for selecting a specific environment for a single CLI command.
- [x] Rust SDK: Update arguments to `WalletContext::new` so it only takes the path to the config. Additional configurations (timeout, max concurrent connections, etc) can then be set on the context after it has been created.
- [ ] REST API: 
