### PR TITLE
upstream(move): add .trace and .coverage to .gitignore

### DIFF
--- a/crates/iota/tests/snapshots/shell_tests__iota_move_new_tests__gitignore_exists.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__iota_move_new_tests__gitignore_exists.sh.snap
@@ -18,5 +18,7 @@ exit_code: 0
 ----- stdout -----
 existing_ignore
 build/*
+.trace
+.coverage*
 
 ----- stderr -----

--- a/crates/iota/tests/snapshots/shell_tests__iota_move_new_tests__gitignore_has_build.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__iota_move_new_tests__gitignore_has_build.sh.snap
@@ -24,6 +24,9 @@ exit_code: 0
 ignore1
 build/*
 ignore2
+build/*
+.trace
+.coverage*
 
 ==== files in example/ ====
 .gitignore

--- a/external-crates/move/crates/move-cli/src/base/new.rs
+++ b/external-crates/move/crates/move-cli/src/base/new.rs
@@ -61,7 +61,7 @@ impl New {
 
     /// add `build/*` to `{path}/.gitignore` if it doesn't already have it
     fn write_gitignore(&self, path: &Path) -> anyhow::Result<()> {
-        let gitignore_entry = "build/*";
+        let gitignore_entry = "build/*\n.trace\n.coverage*";
 
         let mut file = std::fs::OpenOptions::new()
             .create(true)

--- a/external-crates/move/crates/move-cli/tests/build_tests/new_clobber/gitignore_exists/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/new_clobber/gitignore_exists/args.exp
@@ -2,6 +2,8 @@ Command `new -p package example`:
 External Command `cat package/.gitignore`:
 existing_ignore
 build/*
+.trace
+.coverage*
 External Command `ls -A package`:
 .gitignore
 Move.toml

--- a/external-crates/move/crates/move-cli/tests/build_tests/new_simple/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/new_simple/args.exp
@@ -37,6 +37,8 @@ edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 External Command `cat P1/.gitignore`:
 build/*
+.trace
+.coverage*
 Command `new P2 -p other_dir`:
 External Command `cat other_dir/Move.toml`:
 [package]
@@ -76,3 +78,5 @@ edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 External Command `cat other_dir/.gitignore`:
 build/*
+.trace
+.coverage*


### PR DESCRIPTION
# Description of change

Extends default .gitignore with .trace and .coverage.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/10207

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
