### PR TITLE
feat(iota-framework): record validator score history in the system state

### DIFF
--- a/crates/iota-framework/packages/iota-system/sources/validator.move
+++ b/crates/iota-framework/packages/iota-system/sources/validator.move
@@ -9,12 +9,12 @@ use iota::bag::{Self, Bag};
 use iota::balance::Balance;
 use iota::event;
 use iota::iota::IOTA;
+use iota::table::{Self, Table};
 use iota::url::{Self, Url};
 use iota_system::staking_pool::{Self, PoolTokenExchangeRate, StakedIota, StakingPoolV1};
 use iota_system::validator_cap;
 use std::bcs;
 use std::string::String;
-use iota::table::{Self, Table};
 
 /// Invalid proof_of_possession field in ValidatorMetadata
 const EInvalidProofOfPossession: u64 = 0;
@@ -951,26 +951,26 @@ public(package) fun new_for_testing(
 // ==== Validator score history ====
 
 // Records a score in the score history table for this validator.
-// This function should only be called from the advance_epoch function in validator_set, and the score is score will be set for the corresponding epoch as provided by the TxContext.
-public(package) fun record_score(
-    self: &mut ValidatorV1,
-    score: u64,
-    ctx: &mut TxContext,
-) {
-    if (self.extra_fields.contains_with_type<ScoreHistoryKey, Table<u64, u64>>(ScoreHistoryKey{})) {
-        let score_history: &mut Table<u64, u64> = self.extra_fields.borrow_mut(ScoreHistoryKey{});
+// This function should only be called from the advance_epoch function in validator_set, and the score will be set for the corresponding epoch as provided by the TxContext.
+public(package) fun record_score(self: &mut ValidatorV1, score: u64, ctx: &mut TxContext) {
+    if (
+        self.extra_fields.contains_with_type<ScoreHistoryKey, Table<u64, u64>>(ScoreHistoryKey {})
+    ) {
+        let score_history: &mut Table<u64, u64> = self.extra_fields.borrow_mut(ScoreHistoryKey {});
         score_history.add(ctx.epoch(), score)
     } else {
         let mut score_history = table::new(ctx);
         score_history.add(ctx.epoch(), score);
-        self.extra_fields.add(ScoreHistoryKey{}, score_history);
+        self.extra_fields.add(ScoreHistoryKey {}, score_history);
     }
 }
 
 // Returns the score given to this validator at the given epoch, if exists. Otherwise returns None.
 public fun get_historical_score_for_epoch(self: &ValidatorV1, epoch: u64): Option<u64> {
-    if (self.extra_fields.contains_with_type<ScoreHistoryKey, Table<u64, u64>>(ScoreHistoryKey{})) {
-        let score_history: &Table<u64, u64> = self.extra_fields.borrow(ScoreHistoryKey{});
+    if (
+        self.extra_fields.contains_with_type<ScoreHistoryKey, Table<u64, u64>>(ScoreHistoryKey {})
+    ) {
+        let score_history: &Table<u64, u64> = self.extra_fields.borrow(ScoreHistoryKey {});
         if (score_history.contains(epoch)) {
             let score = score_history.borrow(epoch);
             option::some(*score)
@@ -983,12 +983,20 @@ public fun get_historical_score_for_epoch(self: &ValidatorV1, epoch: u64): Optio
 }
 
 // Returns the scores given to this validator over a given range of epochs, if they exist. Epochs for which no score was recorded will be None.
-public fun get_historical_score_for_epoch_range(self: &ValidatorV1, start_epoch: u64, end_epoch: u64): vector<Option<u64>> {
+public fun get_historical_score_for_epoch_range(
+    self: &ValidatorV1,
+    start_epoch: u64,
+    end_epoch: u64,
+): vector<Option<u64>> {
     let mut i = start_epoch;
     let mut scores = vector::empty<Option<u64>>();
     while (i <= end_epoch) {
-        if (self.extra_fields.contains_with_type<ScoreHistoryKey, Table<u64, u64>>(ScoreHistoryKey{})) {
-            let score_history: &Table<u64, u64> = self.extra_fields.borrow(ScoreHistoryKey{});
+        if (
+            self
+                .extra_fields
+                .contains_with_type<ScoreHistoryKey, Table<u64, u64>>(ScoreHistoryKey {})
+        ) {
+            let score_history: &Table<u64, u64> = self.extra_fields.borrow(ScoreHistoryKey {});
             if (score_history.contains(i)) {
                 let score = score_history.borrow(i);
                 scores.push_back(option::some(*score));

--- a/crates/iota-framework/packages/iota-system/sources/validator.move
+++ b/crates/iota-framework/packages/iota-system/sources/validator.move
@@ -73,8 +73,8 @@ const MAX_VALIDATOR_METADATA_LENGTH: u64 = 256;
 /// Max gas price a validator can set is 100K NANOS.
 const MAX_VALIDATOR_GAS_PRICE: u64 = 100_000;
 
-// A unique key to identify the score history of a validator stored as a dynamic field in extra_fields of ValidatorV1.
-public struct ScoreHistoryKey has copy, drop, store {}
+// A unique key to identify the score record of a validator stored as a dynamic field in extra_fields of ValidatorV1.
+public struct ScoreRecordKey has copy, drop, store {}
 
 public struct ValidatorMetadataV1 has store {
     /// The IOTA Address of the validator. This is the sender that created the ValidatorV1 object,
@@ -948,31 +948,27 @@ public(package) fun new_for_testing(
     validator
 }
 
-// ==== Validator score history ====
+// ==== Validator score recording ====
 
-// Records a score in the score history table for this validator.
+// Records a score in the score record table for this validator.
 // This function should only be called from the advance_epoch function in validator_set, and the score will be set for the corresponding epoch as provided by the TxContext.
 public(package) fun record_score(self: &mut ValidatorV1, score: u64, ctx: &mut TxContext) {
-    if (
-        self.extra_fields.contains_with_type<ScoreHistoryKey, Table<u64, u64>>(ScoreHistoryKey {})
-    ) {
-        let score_history: &mut Table<u64, u64> = self.extra_fields.borrow_mut(ScoreHistoryKey {});
-        score_history.add(ctx.epoch(), score)
+    if (self.extra_fields.contains_with_type<ScoreRecordKey, Table<u64, u64>>(ScoreRecordKey {})) {
+        let score_record: &mut Table<u64, u64> = self.extra_fields.borrow_mut(ScoreRecordKey {});
+        score_record.add(ctx.epoch(), score)
     } else {
-        let mut score_history = table::new(ctx);
-        score_history.add(ctx.epoch(), score);
-        self.extra_fields.add(ScoreHistoryKey {}, score_history);
+        let mut score_record = table::new(ctx);
+        score_record.add(ctx.epoch(), score);
+        self.extra_fields.add(ScoreRecordKey {}, score_record);
     }
 }
 
-// Returns the score given to this validator at the given epoch, if exists. Otherwise returns None.
-public fun get_historical_score_for_epoch(self: &ValidatorV1, epoch: u64): Option<u64> {
-    if (
-        self.extra_fields.contains_with_type<ScoreHistoryKey, Table<u64, u64>>(ScoreHistoryKey {})
-    ) {
-        let score_history: &Table<u64, u64> = self.extra_fields.borrow(ScoreHistoryKey {});
-        if (score_history.contains(epoch)) {
-            let score = score_history.borrow(epoch);
+// Returns the score recorded for this validator at the given epoch, if exists. Otherwise returns None.
+public fun get_recorded_score_for_epoch(self: &ValidatorV1, epoch: u64): Option<u64> {
+    if (self.extra_fields.contains_with_type<ScoreRecordKey, Table<u64, u64>>(ScoreRecordKey {})) {
+        let score_record: &Table<u64, u64> = self.extra_fields.borrow(ScoreRecordKey {});
+        if (score_record.contains(epoch)) {
+            let score = score_record.borrow(epoch);
             option::some(*score)
         } else {
             option::none()
@@ -983,7 +979,7 @@ public fun get_historical_score_for_epoch(self: &ValidatorV1, epoch: u64): Optio
 }
 
 // Returns the scores given to this validator over a given range of epochs, if they exist. Epochs for which no score was recorded will be None.
-public fun get_historical_score_for_epoch_range(
+public fun get_recorded_score_for_epoch_range(
     self: &ValidatorV1,
     start_epoch: u64,
     end_epoch: u64,
@@ -992,13 +988,11 @@ public fun get_historical_score_for_epoch_range(
     let mut scores = vector::empty<Option<u64>>();
     while (i <= end_epoch) {
         if (
-            self
-                .extra_fields
-                .contains_with_type<ScoreHistoryKey, Table<u64, u64>>(ScoreHistoryKey {})
+            self.extra_fields.contains_with_type<ScoreRecordKey, Table<u64, u64>>(ScoreRecordKey {})
         ) {
-            let score_history: &Table<u64, u64> = self.extra_fields.borrow(ScoreHistoryKey {});
-            if (score_history.contains(i)) {
-                let score = score_history.borrow(i);
+            let score_record: &Table<u64, u64> = self.extra_fields.borrow(ScoreRecordKey {});
+            if (score_record.contains(i)) {
+                let score = score_record.borrow(i);
                 scores.push_back(option::some(*score));
             } else {
                 scores.push_back(option::none());

--- a/crates/iota-framework/packages/iota-system/sources/validator.move
+++ b/crates/iota-framework/packages/iota-system/sources/validator.move
@@ -64,6 +64,9 @@ const EGasPriceHigherThanThreshold: u64 = 102;
 // The committee member index is not within the range of validators number
 const ECommitteeMembersOutOfRange: u64 = 103;
 
+// The epoch range start is greater than epoch range end
+const EInvalidEpochRange: u64 = 104;
+
 // TODO: potentially move this value to onchain config.
 const MAX_COMMISSION_RATE: u64 = 2_000; // Max rate is 20%, which is 2000 base points
 
@@ -953,54 +956,40 @@ public(package) fun new_for_testing(
 // Records a score in the score record table for this validator.
 // This function should only be called from the advance_epoch function in validator_set, and the score will be set for the corresponding epoch as provided by the TxContext.
 public(package) fun record_score(self: &mut ValidatorV1, score: u64, ctx: &mut TxContext) {
-    if (self.extra_fields.contains_with_type<ScoreRecordKey, Table<u64, u64>>(ScoreRecordKey {})) {
-        let score_record: &mut Table<u64, u64> = self.extra_fields.borrow_mut(ScoreRecordKey {});
-        score_record.add(ctx.epoch(), score)
-    } else {
-        let mut score_record = table::new(ctx);
-        score_record.add(ctx.epoch(), score);
-        self.extra_fields.add(ScoreRecordKey {}, score_record);
-    }
+    if (!self.extra_fields.contains_with_type<ScoreRecordKey, Table<u64, u64>>(ScoreRecordKey {})) {
+        self.extra_fields.add(ScoreRecordKey {}, table::new<u64, u64>(ctx));
+    };
+    let score_record: &mut Table<u64, u64> = self.extra_fields.borrow_mut(ScoreRecordKey {});
+    score_record.add(ctx.epoch(), score)
 }
 
 // Returns the score recorded for this validator at the given epoch, if exists. Otherwise returns None.
 public fun get_recorded_score_for_epoch(self: &ValidatorV1, epoch: u64): Option<u64> {
-    if (self.extra_fields.contains_with_type<ScoreRecordKey, Table<u64, u64>>(ScoreRecordKey {})) {
-        let score_record: &Table<u64, u64> = self.extra_fields.borrow(ScoreRecordKey {});
-        if (score_record.contains(epoch)) {
-            let score = score_record.borrow(epoch);
-            option::some(*score)
-        } else {
-            option::none()
-        }
-    } else {
+    let scores = get_recorded_score_for_epoch_range(self, epoch, epoch);
+    if (vector::is_empty(&scores)) {
         option::none()
+    } else {
+        scores[0]
     }
 }
 
-// Returns the scores given to this validator over a given range of epochs, if they exist. Epochs for which no score was recorded will be None.
 public fun get_recorded_score_for_epoch_range(
     self: &ValidatorV1,
     start_epoch: u64,
     end_epoch: u64,
 ): vector<Option<u64>> {
-    let mut i = start_epoch;
-    let mut scores = vector::empty<Option<u64>>();
-    while (i <= end_epoch) {
-        if (
-            self.extra_fields.contains_with_type<ScoreRecordKey, Table<u64, u64>>(ScoreRecordKey {})
-        ) {
-            let score_record: &Table<u64, u64> = self.extra_fields.borrow(ScoreRecordKey {});
-            if (score_record.contains(i)) {
-                let score = score_record.borrow(i);
-                scores.push_back(option::some(*score));
-            } else {
-                scores.push_back(option::none());
-            }
-        } else {
-            scores.push_back(option::none());
-        };
-        i = i + 1;
+    assert!(start_epoch <= end_epoch, EInvalidEpochRange);
+    let mut scores = vector::tabulate!(end_epoch - start_epoch + 1, |_| option::none());
+    if (self.extra_fields.contains_with_type<ScoreRecordKey, Table<u64, u64>>(ScoreRecordKey {})) {
+        let score_record: &Table<u64, u64> = self.extra_fields.borrow(ScoreRecordKey {});
+        let mut i = 0;
+        scores.do_mut!(|score| {
+            let epoch = i + start_epoch;
+            if (score_record.contains(epoch)) {
+                *score = option::some(*score_record.borrow(epoch));
+            };
+            i = i + 1;
+        });
     };
     scores
 }

--- a/crates/iota-framework/packages/iota-system/sources/validator.move
+++ b/crates/iota-framework/packages/iota-system/sources/validator.move
@@ -14,6 +14,7 @@ use iota_system::staking_pool::{Self, PoolTokenExchangeRate, StakedIota, Staking
 use iota_system::validator_cap;
 use std::bcs;
 use std::string::String;
+use iota::table::{Self, Table};
 
 /// Invalid proof_of_possession field in ValidatorMetadata
 const EInvalidProofOfPossession: u64 = 0;
@@ -71,6 +72,9 @@ const MAX_VALIDATOR_METADATA_LENGTH: u64 = 256;
 // TODO: Move this to onchain config when we have a good way to do it.
 /// Max gas price a validator can set is 100K NANOS.
 const MAX_VALIDATOR_GAS_PRICE: u64 = 100_000;
+
+// A unique key to identify the score history of a validator stored as a dynamic field in extra_fields of ValidatorV1.
+public struct ScoreHistoryKey has copy, drop, store {}
 
 public struct ValidatorMetadataV1 has store {
     /// The IOTA Address of the validator. This is the sender that created the ValidatorV1 object,
@@ -942,4 +946,59 @@ public(package) fun new_for_testing(
     };
 
     validator
+}
+
+// ==== Validator score history ====
+
+// Records a score in the score history table for this validator.
+// This function should only be called from the advance_epoch function in validator_set, and the score is score will be set for the corresponding epoch as provided by the TxContext.
+public(package) fun record_score(
+    self: &mut ValidatorV1,
+    score: u64,
+    ctx: &mut TxContext,
+) {
+    if (self.extra_fields.contains_with_type<ScoreHistoryKey, Table<u64, u64>>(ScoreHistoryKey{})) {
+        let score_history: &mut Table<u64, u64> = self.extra_fields.borrow_mut(ScoreHistoryKey{});
+        score_history.add(ctx.epoch(), score)
+    } else {
+        let mut score_history = table::new(ctx);
+        score_history.add(ctx.epoch(), score);
+        self.extra_fields.add(ScoreHistoryKey{}, score_history);
+    }
+}
+
+// Returns the score given to this validator at the given epoch, if exists. Otherwise returns None.
+public fun get_historical_score_for_epoch(self: &ValidatorV1, epoch: u64): Option<u64> {
+    if (self.extra_fields.contains_with_type<ScoreHistoryKey, Table<u64, u64>>(ScoreHistoryKey{})) {
+        let score_history: &Table<u64, u64> = self.extra_fields.borrow(ScoreHistoryKey{});
+        if (score_history.contains(epoch)) {
+            let score = score_history.borrow(epoch);
+            option::some(*score)
+        } else {
+            option::none()
+        }
+    } else {
+        option::none()
+    }
+}
+
+// Returns the scores given to this validator over a given range of epochs, if they exist. Epochs for which no score was recorded will be None.
+public fun get_historical_score_for_epoch_range(self: &ValidatorV1, start_epoch: u64, end_epoch: u64): vector<Option<u64>> {
+    let mut i = start_epoch;
+    let mut scores = vector::empty<Option<u64>>();
+    while (i <= end_epoch) {
+        if (self.extra_fields.contains_with_type<ScoreHistoryKey, Table<u64, u64>>(ScoreHistoryKey{})) {
+            let score_history: &Table<u64, u64> = self.extra_fields.borrow(ScoreHistoryKey{});
+            if (score_history.contains(i)) {
+                let score = score_history.borrow(i);
+                scores.push_back(option::some(*score));
+            } else {
+                scores.push_back(option::none());
+            }
+        } else {
+            scores.push_back(option::none());
+        };
+        i = i + 1;
+    };
+    scores
 }

--- a/crates/iota-framework/packages/iota-system/sources/validator_set.move
+++ b/crates/iota-framework/packages/iota-system/sources/validator_set.move
@@ -583,15 +583,10 @@ fun record_scores(
     committee_members: &vector<u64>,
     ctx: &mut TxContext,
 ) {
-    let num_committee_members = committee_members.length();
-    assert!(scores.length() == num_committee_members, EInvalidScoresData);
-    let mut i = 0;
-    while (i < num_committee_members) {
-        let validator_index = committee_members[i];
-        let committee_validator = &mut active_validators[validator_index];
-        committee_validator.record_score(scores[i], ctx);
-        i = i + 1;
-    }
+    assert!(scores.length() == committee_members.length(), EInvalidScoresData);
+    active_validators.take_do_with_ix_mut!(committee_members, |i, _, validator| {
+        validator.record_score(scores[i], ctx);
+    });
 }
 
 fun update_and_process_low_stake_departures(

--- a/crates/iota-framework/packages/iota-system/sources/validator_set.move
+++ b/crates/iota-framework/packages/iota-system/sources/validator_set.move
@@ -506,6 +506,8 @@ public(package) fun advance_epoch(
 
     process_pending_stakes_and_withdraws(&mut self.active_validators, ctx);
 
+    record_scores(scores, &mut self.active_validators, &self.committee_members, ctx);
+
     // Emit events after we have processed all the rewards distribution and pending stakes.
     emit_validator_epoch_events(
         new_epoch,
@@ -572,6 +574,24 @@ public(package) fun advance_epoch(
     // At this point, self.active_validators and the self.committee_members are updated for next epoch.
     // Now we process the staged validator metadata.
     effectuate_staged_metadata(self);
+}
+
+// Record the scores for all committee validators for this epoch in the system state.
+fun record_scores(
+    scores: vector<u64>,
+    active_validators: &mut vector<ValidatorV1>,
+    committee_members: &vector<u64>,
+    ctx: &mut TxContext,
+) {
+    let num_committee_members = committee_members.length();
+    assert!(scores.length() == num_committee_members, EInvalidScoresData);
+    let mut i = 0;
+    while (i < num_committee_members) {
+        let validator_index = committee_members[i];
+        let committee_validator = &mut active_validators[validator_index];
+        committee_validator.record_score(scores[i], ctx);
+        i = i + 1;
+    }
 }
 
 fun update_and_process_low_stake_departures(

--- a/crates/iota-framework/packages/iota-system/tests/validator_set_tests.move
+++ b/crates/iota-framework/packages/iota-system/tests/validator_set_tests.move
@@ -1754,7 +1754,7 @@ fun test_record_scores() {
     );
     // Check the recorded scores for epoch 1
     validator_set.active_validators_inner().zip_do_ref!(&expected_scores, |validator, score| {
-        assert_eq(validator.get_historical_score_for_epoch(1), score[0]);
+        assert_eq(validator.get_recorded_score_for_epoch(1), score[0]);
     });
 
     // Epoch 2
@@ -1775,7 +1775,7 @@ fun test_record_scores() {
     );
     // Check the recorded scores for epoch 2
     validator_set.active_validators_inner().zip_do_ref!(&expected_scores, |validator, score| {
-        assert_eq(validator.get_historical_score_for_epoch(2), score[1]);
+        assert_eq(validator.get_recorded_score_for_epoch(2), score[1]);
     });
 
     // Epoch 3
@@ -1793,12 +1793,12 @@ fun test_record_scores() {
     );
     // Check the recorded scores for epoch 3
     validator_set.active_validators_inner().zip_do_ref!(&expected_scores, |validator, score| {
-        assert_eq(validator.get_historical_score_for_epoch(3), score[2]);
+        assert_eq(validator.get_recorded_score_for_epoch(3), score[2]);
     });
 
     // Check the correct scores over a range are retrieved.
     validator_set.active_validators_inner().zip_do_ref!(&expected_scores, |validator, score| {
-        assert_eq(validator.get_historical_score_for_epoch_range(1, 3), *score);
+        assert_eq(validator.get_recorded_score_for_epoch_range(1, 3), *score);
     });
 
     test_utils::destroy(validator_set);

--- a/crates/iota-framework/packages/iota-system/tests/validator_set_tests.move
+++ b/crates/iota-framework/packages/iota-system/tests/validator_set_tests.move
@@ -975,9 +975,41 @@ fun advance_epoch_with_dummy_rewards(
         |i| i,
     );
 
-   let scores = vector::tabulate!(
+    let scores = vector::tabulate!(
         validator_set.committee_validator_addresses().length(),
-        |_| 65536u64,    
+        |_| 65536u64,
+    );
+
+    validator_set.advance_epoch(
+        &mut dummy_computation_charge,
+        &mut vec_map::empty(),
+        0, // reward_slashing_rate
+        0, // low_stake_threshold
+        0, // very_low_stake_threshold
+        0, // low_stake_grace_period
+        committee_size,
+        eligible_validators,
+        scores,
+        true,
+        scenario.ctx(),
+    );
+
+    dummy_computation_charge.destroy_zero();
+}
+
+fun advance_epoch_with_dummy_rewards_and_score(
+    validator_set: &mut ValidatorSetV2,
+    committee_size: u64,
+    scores: vector<u64>,
+    scenario: &mut Scenario,
+) {
+    scenario.next_epoch(@0x0);
+    let mut dummy_computation_charge = balance::zero();
+
+    // Default: all validators are eligible (indices 0 to n-1)
+    let eligible_validators = vector::tabulate!(
+        validator_set.active_validators_inner().length(),
+        |i| i,
     );
 
     validator_set.advance_epoch(
@@ -1006,11 +1038,9 @@ fun advance_epoch_with_eligible_validators(
     scenario.next_epoch(@0x0);
     let mut dummy_computation_charge = balance::zero();
 
-
-
     let scores = vector::tabulate!(
         validator_set.committee_validator_addresses().length(),
-        |_| 65536u64,    
+        |_| 65536u64,
     );
 
     validator_set.advance_epoch(
@@ -1047,9 +1077,9 @@ fun advance_epoch_with_low_stake_params(
         |i| i,
     );
 
-   let scores = vector::tabulate!(
+    let scores = vector::tabulate!(
         validator_set.committee_validator_addresses().length(),
-        |_| 65536u64,    
+        |_| 65536u64,
     );
 
     validator_set.advance_epoch(
@@ -1672,4 +1702,127 @@ fun test_eligible_committee_selection_duplicate_indices() {
 
     test_utils::destroy(validator_set);
     scenario_val.end();
+}
+
+#[test]
+fun test_record_scores() {
+    let mut scenario_val = test_scenario::begin(@0x0);
+    let scenario = &mut scenario_val;
+    let ctx = scenario.ctx();
+    let active_validator_addresses = vector[@0x1, @0x2, @0x3, @0x4, @0x5];
+
+    // create 5 validators
+    let v1 = create_validator(active_validator_addresses[0], 2, 1, true, ctx); // 200 IOTA
+    let v2 = create_validator(active_validator_addresses[1], 4, 1, true, ctx); // 400 IOTA
+    let v3 = create_validator(active_validator_addresses[2], 6, 1, true, ctx); // 600 IOTA
+    let v4 = create_validator(active_validator_addresses[3], 8, 1, true, ctx); // 800 IOTA
+    let v5 = create_validator(active_validator_addresses[4], 10, 1, true, ctx); // 1000 IOTA
+    let mut committee_size = 3;
+    let mut validator_set = validator_set::new_v2(vector[v1, v2, v3, v4, v5], committee_size, ctx);
+    scenario_val.end();
+
+    let mut scenario_val = test_scenario::begin(@0x1);
+    let scenario = &mut scenario_val;
+    assert_same_elems(
+        active_validator_addresses(&validator_set),
+        vector[@0x1, @0x2, @0x3, @0x4, @0x5],
+    );
+    assert_same_elems(
+        committee_validator_addresses(&validator_set),
+        vector[@0x3, @0x4, @0x5],
+    );
+    let expected_scores = vector[
+        vector[option::none(), option::none(), option::none()], // validator 1 not on the committee in any epoch, so no scores
+        vector[option::none(), option::none(), option::some(32768u64)], // validator 2 only on the committee in epoch 3, so only has a score for epoch 3
+        vector[option::some(65536u64), option::some(0u64), option::some(32768u64)], // validator 3 on the committee for all epochs, so has scores for all epochs
+        vector[option::some(65536u64), option::some(100u64), option::some(32768u64)], // validator 4 on the committee for all epochs, so has scores for all epochs
+        vector[option::some(65536u64), option::some(65536u64), option::some(32768u64)], // validator 5 on the committee for all epochs, so has scores for all epochs
+    ];
+
+    // Epoch 1
+    let scores = committee_validator_scores(
+        validator_set.committee_validator_addresses(),
+        active_validator_addresses,
+        expected_scores,
+        1,
+    );
+    advance_epoch_with_dummy_rewards_and_score(
+        &mut validator_set,
+        committee_size,
+        scores,
+        scenario,
+    );
+    // Check the recorded scores for epoch 1
+    validator_set.active_validators_inner().zip_do_ref!(&expected_scores, |validator, score| {
+        assert_eq(validator.get_historical_score_for_epoch(1), score[0]);
+    });
+
+    // Epoch 2
+    // give validator 3 a score of 0, validator 4 a score of 100, and validator 5 a score of 65536 for the second epoch
+    let scores = committee_validator_scores(
+        validator_set.committee_validator_addresses(),
+        active_validator_addresses,
+        expected_scores,
+        2,
+    );
+    // Add an additional committee member (validator 2) for the next epoch
+    committee_size = 4;
+    advance_epoch_with_dummy_rewards_and_score(
+        &mut validator_set,
+        committee_size,
+        scores,
+        scenario,
+    );
+    // Check the recorded scores for epoch 2
+    validator_set.active_validators_inner().zip_do_ref!(&expected_scores, |validator, score| {
+        assert_eq(validator.get_historical_score_for_epoch(2), score[1]);
+    });
+
+    // Epoch 3
+    let scores = committee_validator_scores(
+        validator_set.committee_validator_addresses(),
+        active_validator_addresses,
+        expected_scores,
+        3,
+    );
+    advance_epoch_with_dummy_rewards_and_score(
+        &mut validator_set,
+        committee_size,
+        scores,
+        scenario,
+    );
+    // Check the recorded scores for epoch 3
+    validator_set.active_validators_inner().zip_do_ref!(&expected_scores, |validator, score| {
+        assert_eq(validator.get_historical_score_for_epoch(3), score[2]);
+    });
+
+    // Check the correct scores over a range are retrieved.
+    validator_set.active_validators_inner().zip_do_ref!(&expected_scores, |validator, score| {
+        assert_eq(validator.get_historical_score_for_epoch_range(1, 3), *score);
+    });
+
+    test_utils::destroy(validator_set);
+    scenario_val.end();
+}
+
+fun committee_validator_scores(
+    committee_addresses: vector<address>,
+    active_validator_addresses: vector<address>,
+    active_validator_scores: vector<vector<Option<u64>>>,
+    epoch: u64,
+): vector<u64> {
+    committee_addresses.map!(|address| {
+        let index = active_validator_addresses.find_index!(
+            |active_address| active_address==address,
+        );
+        if (index.is_some()) {
+            if (active_validator_scores[*index.borrow()][epoch-1].is_some()) {
+                *active_validator_scores[*index.borrow()][epoch-1].borrow()
+            } else {
+                abort 0
+            }
+        } else {
+            abort 0
+        }
+    })
 }


### PR DESCRIPTION
# Description of change

Records the score history for every epoch for all committee validators in their corresponding `ValidatorV1` object in the system state. The scores are stored in a table with the epoch as the key, and this table is stored dynamically in the `extra_fields` of `ValidatorV1`. 

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
