### PR TITLE
fix(iota-rest-kv): replace 204 with 404 response code

### DIFF
--- a/crates/iota-rest-kv/src/routes/kv_store.rs
+++ b/crates/iota-rest-kv/src/routes/kv_store.rs
@@ -40,7 +40,7 @@ pub async fn data_as_bytes(
         .await
         .map(|res| match res {
             Some(bytes) => bytes.into_response(),
-            None => (StatusCode::NO_CONTENT, Body::empty()).into_response(),
+            None => (StatusCode::NOT_FOUND, Body::empty()).into_response(),
         })
 }
 


### PR DESCRIPTION
# Description of change

This patch replaces the `204` to `404` error code for not found resources.

## Links to any relevant issues

fixes #10249 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> this patch does not affect the normal operation of the indexer, thus no further tests were conducted