### PR TITLE
fix(iota-rest-kv): fix transaction events deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7868,6 +7868,7 @@ dependencies = [
  "iota-storage",
  "iota-types",
  "object_store 0.13.1",
+ "rustls 0.23.35",
  "serde",
  "serde_yaml",
  "thiserror 1.0.64",

--- a/crates/iota-rest-kv/Cargo.toml
+++ b/crates/iota-rest-kv/Cargo.toml
@@ -17,6 +17,7 @@ bcs.workspace = true
 bytes.workspace = true
 clap = { workspace = true, features = ["env"] }
 object_store.workspace = true
+rustls.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 thiserror.workspace = true

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -22,7 +22,7 @@ use iota_kvstore::{
     proto::bigtable::v2::{RowFilter, row_filter::Filter},
 };
 use iota_storage::http_key_value_store::Key;
-use iota_types::storage::ObjectKey;
+use iota_types::{effects::TransactionEvents, storage::ObjectKey};
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
@@ -243,15 +243,22 @@ impl KvStoreClient {
                 )
                 .await?;
 
-                Ok(response
+                response
                     .into_iter()
-                    .map(|value| {
-                        value.map(|bytes|
-                        // we strip the first byte which represents the Option<T>, returning only
-                        // the bytes which represent the contained value in the Option<T>
-                        bytes.slice(1..))
+                    .map(|cell| {
+                        cell.map(|bytes| {
+                            bcs::from_bytes::<Option<TransactionEvents>>(&bytes)
+                                .and_then(|opt_events| {
+                                    opt_events
+                                        .map(|e| bcs::to_bytes(&e).map(Bytes::from))
+                                        .transpose()
+                                })
+                                .map_err(anyhow::Error::from)
+                        })
+                        .transpose()
+                        .map(Option::flatten)
                     })
-                    .collect())
+                    .collect::<Result<Vec<Option<Bytes>>, _>>()
             }
         }
         .map_err(Into::into)

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -243,22 +243,17 @@ impl KvStoreClient {
                 )
                 .await?;
 
-                response
+                Ok(response
                     .into_iter()
                     .map(|cell| {
-                        cell.map(|bytes| {
-                            bcs::from_bytes::<Option<TransactionEvents>>(&bytes)
-                                .and_then(|opt_events| {
-                                    opt_events
-                                        .map(|e| bcs::to_bytes(&e).map(Bytes::from))
-                                        .transpose()
-                                })
-                                .map_err(anyhow::Error::from)
+                        cell.and_then(|bytes| {
+                            match bcs::from_bytes::<Option<TransactionEvents>>(&bytes) {
+                                Ok(None) | Err(_) => None,
+                                Ok(Some(events)) => bcs::to_bytes(&events).map(Bytes::from).ok(),
+                            }
                         })
-                        .transpose()
-                        .map(Option::flatten)
                     })
-                    .collect::<Result<Vec<Option<Bytes>>, _>>()
+                    .collect())
             }
         }
         .map_err(Into::into)

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -235,13 +235,23 @@ impl KvStoreClient {
 
                 let keys = digests.iter().map(|tx| Some(tx.inner().to_vec())).collect();
 
-                multi_get_cell(
+                let response = multi_get_cell(
                     &mut client,
                     TRANSACTIONS_TABLE,
                     keys,
                     EVENTS_COLUMN_QUALIFIER,
                 )
-                .await
+                .await?;
+
+                Ok(response
+                    .into_iter()
+                    .map(|value| {
+                        value.map(|bytes|
+                        // we strip the first byte which represents the Option<T>, returning only
+                        // the bytes which represent the contained value in the Option<T>
+                        bytes.slice(1..))
+                    })
+                    .collect())
             }
         }
         .map_err(Into::into)

--- a/crates/iota-rest-kv/src/main.rs
+++ b/crates/iota-rest-kv/src/main.rs
@@ -57,7 +57,7 @@ fn default_multiget_max_items() -> NonZeroUsize {
 async fn main() -> Result<()> {
     rustls::crypto::ring::default_provider()
         .install_default()
-        .expect("Failed to install rustls crypto provider");
+        .expect("failed to install rustls crypto provider");
 
     let cli = Cli::parse();
 

--- a/crates/iota-rest-kv/src/main.rs
+++ b/crates/iota-rest-kv/src/main.rs
@@ -55,6 +55,10 @@ fn default_multiget_max_items() -> NonZeroUsize {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     let cli = Cli::parse();
 
     init_tracing(cli.log_level);


### PR DESCRIPTION
# Description of change

This patch fixes the deserialization issue on the `iota-rest-kv` for the TransactionEvents and also fixes a runtime issue encountered in the newest version 1.17.0 of missing process-level CryptoProvider.

## Links to any relevant issues

fixes #10269 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- started locally the `iota-rest-kv` server connected to the actual testnet BigTable database
- executed the same test Bing provided in the [commit](https://github.com/bingyanglin/iota/commit/c805cd6e9af5f0444cb577cbfb7f75f0dcd324d5#diff-0a2e6fd5dcd4514822cc6ff7d0932710d95af9fc0203d958928460e6226a6fabR358)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.