### PR TITLE
feat(gRPC): cleanup convenience functions

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/client/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/execute.rs
@@ -22,7 +22,9 @@ async fn execute_transaction_transfer() {
 
     let effects = result
         .effects()
-        .expect("Failed to get SDK effects from execution result");
+        .expect("Failed to get effects from execution result")
+        .effects()
+        .expect("Failed to get inner effects from execution result");
 
     assert!(
         is_success(effects.status()),
@@ -63,6 +65,8 @@ async fn execute_transaction_minimal_mask() {
             result
                 .effects()
                 .expect("Failed to get SDK effects from execution result with minimal mask")
+                .effects()
+                .expect("Failed to get inner effects from execution result with minimal mask")
                 .status()
         ),
         "Effects should show successful execution"
@@ -127,6 +131,8 @@ async fn execute_transaction_idempotency() {
             result1
                 .effects()
                 .expect("Failed to get SDK effects from first execution result")
+                .effects()
+                .expect("Failed to get inner effects from first execution result")
                 .status()
         ),
         "First execution should succeed"
@@ -145,6 +151,8 @@ async fn execute_transaction_idempotency() {
             result2
                 .effects()
                 .expect("Failed to get SDK effects from re-execution result")
+                .effects()
+                .expect("Failed to get inner effects from re-execution result")
                 .status()
         ),
         "Re-execution should show success (cached result)"

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -29,7 +29,9 @@ async fn simulate_transaction_scenarios() {
             .executed_transaction()
             .expect("Failed to get executed_transaction from simulation result")
             .effects()
-            .expect("Failed to get effects from simulation result");
+            .expect("Failed to get effects from simulation result")
+            .effects()
+            .expect("Failed to get inner effects from simulation result");
         assert!(
             is_success(effects.status()),
             "{mode_name} simulation should succeed"
@@ -53,7 +55,9 @@ async fn simulate_transaction_scenarios() {
         .executed_transaction()
         .expect("Failed to get executed_transaction from simulation result")
         .effects()
-        .expect("Failed to get effects from simulation result with minimal mask");
+        .expect("Failed to get effects from simulation result")
+        .effects()
+        .expect("Failed to get inner effects from simulation result");
 
     assert!(
         is_success(effects.status()),
@@ -105,7 +109,9 @@ async fn simulate_transaction_scenarios() {
         .executed_transaction()
         .expect("Failed to get executed_transaction from simulation result")
         .effects()
-        .expect("Failed to get SDK effects from simulation result");
+        .expect("Failed to get effects from simulation result")
+        .effects()
+        .expect("Failed to get inner effects from simulation result");
 
     assert!(
         !is_success(effects.status()),

--- a/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::panic;
-
 use iota_macros::sim_test;
 use iota_sdk_types::Digest;
 
@@ -31,8 +29,10 @@ async fn get_transactions_scenarios() {
     assert_eq!(transactions.len(), 1, "Expected exactly one transaction");
     assert_eq!(
         transactions[0]
+            .transaction()
+            .expect("Failed to get transaction from executed transaction")
             .digest()
-            .unwrap_or_else(|_| panic!("Failed to get digest from transaction")),
+            .expect("Failed to get digest from transaction"),
         digest1,
         "Transaction digest should match requested digest"
     );
@@ -40,6 +40,7 @@ async fn get_transactions_scenarios() {
         !transactions[0]
             .signatures()
             .expect("Failed to get signatures from transaction")
+            .signatures
             .is_empty(),
         "Signatures should be present"
     );
@@ -52,6 +53,8 @@ async fn get_transactions_scenarios() {
     assert_eq!(transactions.len(), 2, "Expected exactly two transactions");
     assert_eq!(
         transactions[0]
+            .transaction()
+            .expect("Failed to get transaction from executed transaction")
             .digest()
             .expect("Failed to get digest from first transaction"),
         digest1,
@@ -59,6 +62,8 @@ async fn get_transactions_scenarios() {
     );
     assert_eq!(
         transactions[1]
+            .transaction()
+            .expect("Failed to get transaction from executed transaction")
             .digest()
             .expect("Failed to get digest from second transaction"),
         digest2,
@@ -95,13 +100,17 @@ async fn get_transactions_scenarios() {
         .expect("Failed to get transaction");
     let tx = &transactions[0];
     assert_eq!(
-        tx.digest().expect("Failed to get digest from transaction"),
+        tx.transaction()
+            .expect("Failed to get transaction from executed transaction")
+            .digest()
+            .expect("Failed to get digest from transaction"),
         digest1,
         "Digest should match"
     );
     assert!(
         !tx.signatures()
             .expect("Failed to get signatures from transaction")
+            .signatures
             .is_empty(),
         "Signatures should be present"
     );
@@ -109,6 +118,8 @@ async fn get_transactions_scenarios() {
         is_success(
             tx.effects()
                 .expect("Failed to get effects from transaction")
+                .effects()
+                .expect("Failed to get inner effects from effects")
                 .status()
         ),
         "Transaction should have succeeded"
@@ -129,9 +140,8 @@ async fn get_transactions_scenarios() {
         .get_transactions(&[digest1], Some("transaction.digest"))
         .await;
 
-    let conversion_result = result.expect("request should work")[0]
-        .transaction()
-        .map_err(Into::into);
+    let transactions = result.expect("request should work");
+    let conversion_result = transactions[0].transaction().map_err(Into::into);
 
     assert_proto_conversion_error(conversion_result);
 }

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_checkpoints.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_checkpoints.rs
@@ -36,7 +36,11 @@ async fn test_get_checkpoint() {
 
     // Verify the checkpoint data structure
     assert_eq!(response.sequence_number(), 0);
-    let summary = response.summary().expect("should have summary");
+    let summary = response
+        .summary()
+        .expect("should have summary")
+        .summary()
+        .expect("should deserialize summary");
     assert_eq!(summary.epoch, 0);
     assert!(!response.transactions.is_empty());
     assert!(response.contents.is_some());
@@ -49,7 +53,11 @@ async fn test_get_checkpoint() {
         .expect("gRPC call");
 
     assert_eq!(response_1.sequence_number(), 1);
-    let summary_1 = response_1.summary().expect("should have summary");
+    let summary_1 = response_1
+        .summary()
+        .expect("should have summary")
+        .summary()
+        .expect("should deserialize summary");
     assert_eq!(summary_1.epoch, 0);
     let digest_1 = summary_1.content_digest;
 
@@ -226,18 +234,18 @@ async fn test_event_filtering() {
         while let Some(checkpoint_result) = sender_stream.next().await {
             match checkpoint_result {
                 Ok(response) => {
-                    let events = response.events().expect("should deserialize events");
+                    let events = response.events();
                     for event in events {
                         // Verify BCS serialization integrity
-                        assert!(!event.contents.is_empty(), "BCS data must be valid");
+                        assert!(event.bcs_contents.is_some(), "BCS data must be valid");
                         // Verify sender filter logic: only events from sender_1
                         assert_eq!(
-                            event.sender,
-                            sender_1.into(),
+                            event.sender.as_ref().unwrap().address.as_ref(),
+                            sender_1.as_ref(),
                             "SenderFilter should only match sender_1 events"
                         );
 
-                        sender_events.push(event);
+                        sender_events.push(event.clone());
                     }
                 }
                 Err(e) => panic!("SenderFilter client error: {e}"),
@@ -270,19 +278,19 @@ async fn test_event_filtering() {
         while let Some(checkpoint_result) = nft_stream.next().await {
             match checkpoint_result {
                 Ok(response) => {
-                    let events = response.events().expect("should deserialize events");
+                    let events = response.events();
                     for event in events {
                         // Verify BCS serialization integrity
-                        assert!(!event.contents.is_empty(), "BCS data must be valid");
+                        assert!(event.bcs_contents.is_some(), "BCS data must be valid");
 
                         // Verify NFT filter logic: only NFT events
                         assert_eq!(
-                            event.package_id,
-                            nft_package_id.into(),
+                            event.package_id.as_ref().unwrap().address.as_ref(),
+                            nft_package_id.as_ref(),
                             "MoveEventTypeFilter should only match NFT package events"
                         );
 
-                        nft_events.push(event);
+                        nft_events.push(event.clone());
                     }
                 }
                 Err(e) => panic!("MoveEventTypeFilter client error: {e}"),
@@ -315,20 +323,22 @@ async fn test_event_filtering() {
         while let Some(checkpoint_result) = any_stream.next().await {
             match checkpoint_result {
                 Ok(response) => {
-                    let events = response.events().expect("should deserialize events");
+                    let events = response.events();
                     for event in events {
                         // Verify BCS serialization integrity
-                        assert!(!event.contents.is_empty());
+                        assert!(event.bcs_contents.is_some());
 
                         // Verify AnyEventFilter logic: events from sender_1 and NFT events
                         assert!(
-                            event.sender == sender_1.into()
-                                || event.package_id == nft_package_id.into(),
-                            "AnyEventFilter should receive events from both events: {}",
-                            event.package_id
+                            (event.sender.as_ref().map(|s| &s.address)
+                                == Some(&sender_1.as_ref().to_vec().into()))
+                                || (event.package_id.as_ref().map(|p| &p.address)
+                                    == Some(&nft_package_id.as_ref().to_vec().into())),
+                            "AnyEventFilter should receive events from both events: {:?}",
+                            event.package_id.as_ref().map(|p| &p.address)
                         );
 
-                        any_events.push(event);
+                        any_events.push(event.clone());
                     }
                 }
                 Err(e) => panic!("AnyEventFilter client error: {e}"),

--- a/crates/iota-grpc-client/src/api/execution/execute.rs
+++ b/crates/iota-grpc-client/src/api/execution/execute.rs
@@ -57,10 +57,10 @@ impl Client {
     /// let result = client.execute_transaction(signed_tx, None).await?;
     ///
     /// // Lazy conversion - only deserialize what you need
-    /// let effects = result.effects()?;
+    /// let effects = result.effects()?.effects()?;
     /// println!("Status: {:?}", effects.status());
     ///
-    /// let events = result.events()?;
+    /// let events = result.events()?.events()?;
     /// if !events.0.is_empty() {
     ///     println!("Events: {}", events.0.len());
     /// }

--- a/crates/iota-grpc-client/src/api/execution/simulate.rs
+++ b/crates/iota-grpc-client/src/api/execution/simulate.rs
@@ -68,11 +68,11 @@ impl Client {
     ///
     /// // Lazy conversion - only deserialize what you need
     /// let executed_tx = result.executed_transaction()?;
-    /// let effects = executed_tx.effects()?;
+    /// let effects = executed_tx.effects()?.effects()?;
     /// println!("Simulation status: {:?}", effects.status());
     ///
     /// let output_objs = executed_tx.output_objects()?;
-    /// println!("Would create {} objects", output_objs.objects()?.len());
+    /// println!("Would create {} objects", output_objs.objects.len());
     /// # Ok(())
     /// # }
     /// ```

--- a/crates/iota-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-grpc-client/src/api/ledger/transactions.rs
@@ -59,7 +59,7 @@ impl Client {
     ///
     /// for tx in txs {
     ///     // Lazy conversion - only deserialize what you need
-    ///     let effects = tx.effects()?;
+    ///     let effects = tx.effects()?.effects()?;
     ///     println!("Status: {:?}", effects.status());
     ///
     ///     // Access checkpoint number

--- a/crates/iota-grpc-client/src/api/mod.rs
+++ b/crates/iota-grpc-client/src/api/mod.rs
@@ -20,15 +20,6 @@ pub use common::{
 pub(crate) use common::{
     ProtoResult, TryFromProtoError, build_proto_transaction, field_mask_with_default,
 };
-// Re-export proto types as the primary API
-pub use iota_grpc_types::v0::{
-    checkpoint::Checkpoint,
-    epoch::Epoch,
-    event::Event,
-    ledger_service::GetServiceInfoResponse,
-    object::{Object, Objects},
-    transaction::{ExecutedTransaction, Transaction, TransactionEffects, TransactionEvents},
-};
 
 /// Response for a checkpoint query.
 ///
@@ -50,9 +41,9 @@ pub struct CheckpointResponse {
     pub contents: Option<iota_grpc_types::v0::checkpoint::CheckpointContents>,
     /// Proto executed transactions. Use methods like `tx.effects()?`,
     /// `tx.transaction()?`, etc.
-    pub transactions: Vec<ExecutedTransaction>,
+    pub transactions: Vec<iota_grpc_types::v0::transaction::ExecutedTransaction>,
     /// Proto events. Use `event.events()` to convert to SDK type.
-    pub events: Vec<Event>,
+    pub events: Vec<iota_grpc_types::v0::event::Event>,
 }
 
 impl CheckpointResponse {
@@ -64,7 +55,7 @@ impl CheckpointResponse {
         self.summary
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing("summary"))?
-            .try_into()
+            .summary()
             .map_err(Into::into)
     }
 
@@ -72,7 +63,7 @@ impl CheckpointResponse {
         self.signature
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing("signature"))?
-            .try_into()
+            .signature()
             .map_err(Into::into)
     }
 
@@ -80,11 +71,13 @@ impl CheckpointResponse {
         self.contents
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing("contents"))?
-            .try_into()
+            .contents()
             .map_err(Into::into)
     }
 
-    pub fn transactions(&self) -> Result<Vec<&ExecutedTransaction>> {
+    pub fn transactions(
+        &self,
+    ) -> Result<Vec<&iota_grpc_types::v0::transaction::ExecutedTransaction>> {
         Ok(self.transactions.iter().collect())
     }
 

--- a/crates/iota-grpc-client/src/api/mod.rs
+++ b/crates/iota-grpc-client/src/api/mod.rs
@@ -24,25 +24,27 @@ pub(crate) use common::{
 /// Response for a checkpoint query.
 ///
 /// Contains checkpoint summary, signature, contents, transactions, and events.
-/// Fields are proto types that can be lazily converted to SDK types using their
-/// conversion methods (e.g., `response.summary()?`, `response.effects()?`).
+/// Fields are proto types that can be accessed directly or converted to SDK
+/// types using their conversion methods (e.g.,
+/// `response.summary()?.summary()?`, `response.contents()?.contents()?`).
 #[derive(Debug, Clone)]
 pub struct CheckpointResponse {
     /// The checkpoint sequence number.
     pub sequence_number: CheckpointSequenceNumber,
-    /// Proto checkpoint summary. Use `summary.summary()` to convert to SDK
-    /// type.
+    /// Proto checkpoint summary. Use `response.summary()?.summary()` to convert
+    /// to SDK type.
     pub summary: Option<iota_grpc_types::v0::checkpoint::CheckpointSummary>,
-    /// Proto validator signature. Use TryInto or
-    /// ValidatorAggregatedSignature::try_from to convert.
+    /// Proto validator signature. Use `response.signature()?.signature()` to
+    /// convert to SDK type.
     pub signature: Option<iota_grpc_types::v0::signatures::ValidatorAggregatedSignature>,
-    /// Proto checkpoint contents. Use `contents.contents()` to convert to
-    /// SDK type.
+    /// Proto checkpoint contents. Use `response.contents()?.contents()` to
+    /// convert to SDK type.
     pub contents: Option<iota_grpc_types::v0::checkpoint::CheckpointContents>,
     /// Proto executed transactions. Use methods like `tx.effects()?`,
     /// `tx.transaction()?`, etc.
     pub transactions: Vec<iota_grpc_types::v0::transaction::ExecutedTransaction>,
-    /// Proto events. Use `event.events()` to convert to SDK type.
+    /// Proto events. Use `event.try_into()` or `event.events()` to convert to
+    /// SDK types.
     pub events: Vec<iota_grpc_types::v0::event::Event>,
 }
 
@@ -51,59 +53,44 @@ impl CheckpointResponse {
         self.sequence_number
     }
 
-    pub fn summary(&self) -> Result<iota_sdk_types::checkpoint::CheckpointSummary> {
+    pub fn summary(&self) -> Result<&iota_grpc_types::v0::checkpoint::CheckpointSummary> {
         self.summary
             .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing("summary"))?
-            .summary()
-            .map_err(Into::into)
+            .ok_or_else(|| TryFromProtoError::missing("summary").into())
     }
 
-    pub fn signature(&self) -> Result<iota_sdk_types::ValidatorAggregatedSignature> {
+    pub fn signature(
+        &self,
+    ) -> Result<&iota_grpc_types::v0::signatures::ValidatorAggregatedSignature> {
         self.signature
             .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing("signature"))?
-            .signature()
-            .map_err(Into::into)
+            .ok_or_else(|| TryFromProtoError::missing("signature").into())
     }
 
-    pub fn contents(&self) -> Result<iota_sdk_types::checkpoint::CheckpointContents> {
+    pub fn contents(&self) -> Result<&iota_grpc_types::v0::checkpoint::CheckpointContents> {
         self.contents
             .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing("contents"))?
-            .contents()
-            .map_err(Into::into)
+            .ok_or_else(|| TryFromProtoError::missing("contents").into())
     }
 
-    pub fn transactions(
-        &self,
-    ) -> Result<Vec<&iota_grpc_types::v0::transaction::ExecutedTransaction>> {
-        Ok(self.transactions.iter().collect())
+    pub fn transactions(&self) -> &Vec<iota_grpc_types::v0::transaction::ExecutedTransaction> {
+        &self.transactions
     }
 
-    pub fn events(&self) -> Result<Vec<iota_sdk_types::Event>> {
-        self.events
-            .iter()
-            .enumerate()
-            .map(|(i, e)| {
-                e.try_into().map_err(|e: TryFromProtoError| {
-                    e.nested_at(iota_grpc_types::v0::event::Events::EVENTS_FIELD.name, i)
-                })
-            })
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(Into::into)
+    pub fn events(&self) -> &Vec<iota_grpc_types::v0::event::Event> {
+        &self.events
     }
 
     pub fn checkpoint_data(&self) -> Result<iota_sdk_types::checkpoint::CheckpointData> {
         Ok(iota_sdk_types::checkpoint::CheckpointData {
-            checkpoint_contents: self.contents()?,
+            checkpoint_contents: self.contents()?.contents()?,
             checkpoint_summary: iota_sdk_types::SignedCheckpointSummary {
-                checkpoint: self.summary()?,
-                signature: self.signature()?,
+                checkpoint: self.summary()?.summary()?,
+                signature: self.signature()?.signature()?,
             },
             transactions: self
-                .transactions()?
-                .into_iter()
+                .transactions()
+                .iter()
                 .map(TryInto::try_into)
                 .collect::<std::result::Result<Vec<_>, _>>()?,
         })

--- a/crates/iota-grpc-client/src/lib.rs
+++ b/crates/iota-grpc-client/src/lib.rs
@@ -20,7 +20,7 @@
 //! let digest: Digest = todo!();
 //! let txs = client.get_transactions(&[digest], None).await?;
 //! if let Some(tx) = txs.first() {
-//!     println!("Transaction digest: {:?}", tx.digest()?);
+//!     println!("Transaction digest: {:?}", tx.transaction()?.digest()?);
 //! }
 //!
 //! // Get an object (None = use default field mask)

--- a/crates/iota-grpc-client/src/lib.rs
+++ b/crates/iota-grpc-client/src/lib.rs
@@ -37,9 +37,8 @@ pub mod api;
 
 // Re-export types for convenience
 pub use api::{
-    CHECKPOINT_READ_MASK, CheckpointResponse, EPOCH_READ_MASK, EXECUTION_READ_MASK, Epoch, Error,
-    GetServiceInfoResponse, OBJECTS_READ_MASK, Result, SERVICE_INFO_READ_MASK,
-    TRANSACTIONS_READ_MASK,
+    CHECKPOINT_READ_MASK, CheckpointResponse, EPOCH_READ_MASK, EXECUTION_READ_MASK, Error,
+    OBJECTS_READ_MASK, Result, SERVICE_INFO_READ_MASK, TRANSACTIONS_READ_MASK,
 };
 
 mod client;

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -916,7 +916,9 @@ async fn test_chunked_checkpoint_streaming() {
     assert_eq!(individual_checkpoint.sequence_number(), 0);
     let summary = individual_checkpoint
         .summary()
-        .expect("should have summary");
+        .expect("should have summary")
+        .summary()
+        .expect("should have checkpoint summary");
     assert_eq!(summary.epoch, 0);
 
     // Test streaming checkpoints - this should also work with small chunks
@@ -935,7 +937,11 @@ async fn test_chunked_checkpoint_streaming() {
 
     // Verify the streamed checkpoint data matches
     assert_eq!(streamed_checkpoint.sequence_number(), 0);
-    let streamed_summary = streamed_checkpoint.summary().expect("should have summary");
+    let streamed_summary = streamed_checkpoint
+        .summary()
+        .expect("should have summary")
+        .summary()
+        .expect("should have checkpoint summary");
     assert_eq!(streamed_summary.epoch, 0);
 
     // Clean up

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/checkpoint.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/checkpoint.rs
@@ -36,22 +36,14 @@ impl TryFrom<&CheckpointSummary> for iota_sdk_types::CheckpointSummary {
 }
 
 impl CheckpointSummary {
+    /// Get the digest of this checkpoint summary.
+    pub fn digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
+        get_inner_field!(self.digest, Self::DIGEST_FIELD, try_into)
+    }
+
     /// Deserialize checkpoint summary.
     pub fn summary(&self) -> Result<iota_sdk_types::CheckpointSummary, TryFromProtoError> {
         self.try_into()
-    }
-
-    /// Get the raw BCS bytes of this checkpoint summary.
-    pub fn summary_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        self.bcs
-            .as_ref()
-            .map(BcsData::as_bytes)
-            .ok_or_else(|| TryFromProtoError::missing(Self::BCS_FIELD.name))
-    }
-
-    /// Get the digest of this checkpoint summary.
-    pub fn summary_digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
-        get_inner_field!(self.digest, Self::DIGEST_FIELD, try_into)
     }
 }
 
@@ -74,90 +66,13 @@ impl TryFrom<&CheckpointContents> for iota_sdk_types::CheckpointContents {
 }
 
 impl CheckpointContents {
+    /// Get the digest of this checkpoint contents.
+    pub fn digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
+        get_inner_field!(self.digest, Self::DIGEST_FIELD, try_into)
+    }
+
     /// Deserialize checkpoint contents.
     pub fn contents(&self) -> Result<iota_sdk_types::CheckpointContents, TryFromProtoError> {
         self.try_into()
-    }
-
-    /// Get the raw BCS bytes of this checkpoint contents.
-    pub fn contents_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        self.bcs
-            .as_ref()
-            .map(BcsData::as_bytes)
-            .ok_or_else(|| TryFromProtoError::missing(Self::BCS_FIELD.name))
-    }
-
-    /// Get the digest of this checkpoint contents.
-    pub fn contents_digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
-        get_inner_field!(self.digest, Self::DIGEST_FIELD, try_into)
-    }
-}
-
-// Checkpoint
-//
-
-impl Checkpoint {
-    /// Get the checkpoint sequence number (height).
-    pub fn checkpoint_sequence_number(&self) -> Result<u64, TryFromProtoError> {
-        self.sequence_number
-            .ok_or_else(|| TryFromProtoError::missing(Self::SEQUENCE_NUMBER_FIELD.name))
-    }
-
-    /// Get the raw BCS bytes of the checkpoint summary.
-    pub fn summary_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        get_inner_field!(self.summary, Self::SUMMARY_FIELD, summary_bcs)
-    }
-
-    /// Get the raw BCS bytes of the checkpoint contents.
-    pub fn contents_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        get_inner_field!(self.contents, Self::CONTENTS_FIELD, contents_bcs)
-    }
-
-    /// Deserialize checkpoint summary.
-    pub fn summary(&self) -> Result<iota_sdk_types::CheckpointSummary, TryFromProtoError> {
-        get_inner_field!(self.summary, Self::SUMMARY_FIELD, summary)
-    }
-
-    /// Deserialize checkpoint contents.
-    pub fn contents(&self) -> Result<iota_sdk_types::CheckpointContents, TryFromProtoError> {
-        get_inner_field!(self.contents, Self::CONTENTS_FIELD, contents)
-    }
-
-    /// Deserialize validator signature.
-    pub fn signature(
-        &self,
-    ) -> Result<iota_sdk_types::ValidatorAggregatedSignature, TryFromProtoError> {
-        let sig = self
-            .signature
-            .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::SIGNATURE_FIELD.name))?;
-        <&super::signatures::ValidatorAggregatedSignature as TryInto<
-            iota_sdk_types::ValidatorAggregatedSignature,
-        >>::try_into(sig)
-        .map_err(|e: TryFromProtoError| e.nested(Self::SIGNATURE_FIELD.name))
-    }
-
-    /// Get the raw BCS bytes of the validator signature.
-    pub fn signature_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        let sig = self
-            .signature
-            .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::SIGNATURE_FIELD.name))?;
-        sig.bcs.as_ref().map(BcsData::as_bytes).ok_or_else(|| {
-            TryFromProtoError::missing(
-                super::signatures::ValidatorAggregatedSignature::BCS_FIELD.name,
-            )
-            .nested(Self::SIGNATURE_FIELD.name)
-        })
-    }
-
-    /// Get the summary digest directly from the nested summary.
-    pub fn summary_digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
-        get_inner_field!(self.summary, Self::SUMMARY_FIELD, summary_digest)
-    }
-
-    /// Get the contents digest directly from the nested contents.
-    pub fn contents_digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
-        get_inner_field!(self.contents, Self::CONTENTS_FIELD, contents_digest)
     }
 }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/command.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/command.rs
@@ -120,15 +120,6 @@ impl CommandOutput {
     }
 }
 
-// CommandOutputs
-//
-
-impl CommandOutputs {
-    pub fn outputs(&self) -> &Vec<CommandOutput> {
-        &self.outputs
-    }
-}
-
 // CommandResult
 //
 
@@ -143,14 +134,5 @@ impl CommandResult {
         self.return_values
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Self::RETURN_VALUES_FIELD.name))
-    }
-}
-
-// CommandResults
-//
-
-impl CommandResults {
-    pub fn results(&self) -> &Vec<CommandResult> {
-        &self.results
     }
 }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/command.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/command.rs
@@ -124,54 +124,8 @@ impl CommandOutput {
 //
 
 impl CommandOutputs {
-    /// Deserialize all arguments to SDK types.
-    pub fn arguments(
-        &self,
-    ) -> Result<Vec<iota_sdk_types::transaction::Argument>, TryFromProtoError> {
-        self.outputs
-            .iter()
-            .enumerate()
-            .map(|(i, o)| {
-                o.argument()
-                    .map_err(|e| e.nested_at(Self::OUTPUTS_FIELD.name, i))
-            })
-            .collect()
-    }
-
-    /// Deserialize all type tags to SDK types.
-    pub fn type_tags(&self) -> Result<Vec<iota_sdk_types::TypeTag>, TryFromProtoError> {
-        self.outputs
-            .iter()
-            .enumerate()
-            .map(|(i, o)| {
-                o.type_tag()
-                    .map_err(|e| e.nested_at(Self::OUTPUTS_FIELD.name, i))
-            })
-            .collect()
-    }
-
-    /// Get all BCS bytes.
-    pub fn all_bcs(&self) -> Result<Vec<&[u8]>, TryFromProtoError> {
-        self.outputs
-            .iter()
-            .enumerate()
-            .map(|(i, o)| {
-                o.output_bcs()
-                    .map_err(|e| e.nested_at(Self::OUTPUTS_FIELD.name, i))
-            })
-            .collect()
-    }
-
-    /// Get all JSON values.
-    pub fn all_json(&self) -> Result<Vec<serde_json::Value>, TryFromProtoError> {
-        self.outputs
-            .iter()
-            .enumerate()
-            .map(|(i, o)| {
-                o.output_json()
-                    .map_err(|e| e.nested_at(Self::OUTPUTS_FIELD.name, i))
-            })
-            .collect()
+    pub fn outputs(&self) -> &Vec<CommandOutput> {
+        &self.outputs
     }
 }
 
@@ -179,52 +133,16 @@ impl CommandOutputs {
 //
 
 impl CommandResult {
-    /// Get the arguments for outputs mutated by reference.
-    pub fn mutated_by_ref_arguments(
-        &self,
-    ) -> Result<Vec<iota_sdk_types::transaction::Argument>, TryFromProtoError> {
-        get_inner_field!(self.mutated_by_ref, Self::MUTATED_BY_REF_FIELD, arguments)
+    pub fn mutated_by_ref(&self) -> Result<&CommandOutputs, TryFromProtoError> {
+        self.mutated_by_ref
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::MUTATED_BY_REF_FIELD.name))
     }
 
-    /// Get the type tags for outputs mutated by reference.
-    pub fn mutated_by_ref_type_tags(
-        &self,
-    ) -> Result<Vec<iota_sdk_types::TypeTag>, TryFromProtoError> {
-        get_inner_field!(self.mutated_by_ref, Self::MUTATED_BY_REF_FIELD, type_tags)
-    }
-
-    /// Get the BCS bytes for outputs mutated by reference.
-    pub fn mutated_by_ref_bcs(&self) -> Result<Vec<&[u8]>, TryFromProtoError> {
-        get_inner_field!(self.mutated_by_ref, Self::MUTATED_BY_REF_FIELD, all_bcs)
-    }
-
-    /// Get the JSON values for outputs mutated by reference.
-    pub fn mutated_by_ref_json(&self) -> Result<Vec<serde_json::Value>, TryFromProtoError> {
-        get_inner_field!(self.mutated_by_ref, Self::MUTATED_BY_REF_FIELD, all_json)
-    }
-
-    /// Get the arguments for return values.
-    pub fn return_values_arguments(
-        &self,
-    ) -> Result<Vec<iota_sdk_types::transaction::Argument>, TryFromProtoError> {
-        get_inner_field!(self.return_values, Self::RETURN_VALUES_FIELD, arguments)
-    }
-
-    /// Get the type tags for return values.
-    pub fn return_values_type_tags(
-        &self,
-    ) -> Result<Vec<iota_sdk_types::TypeTag>, TryFromProtoError> {
-        get_inner_field!(self.return_values, Self::RETURN_VALUES_FIELD, type_tags)
-    }
-
-    /// Get the BCS bytes for return values.
-    pub fn return_values_bcs(&self) -> Result<Vec<&[u8]>, TryFromProtoError> {
-        get_inner_field!(self.return_values, Self::RETURN_VALUES_FIELD, all_bcs)
-    }
-
-    /// Get the JSON values for return values.
-    pub fn return_values_json(&self) -> Result<Vec<serde_json::Value>, TryFromProtoError> {
-        get_inner_field!(self.return_values, Self::RETURN_VALUES_FIELD, all_json)
+    pub fn return_values(&self) -> Result<&CommandOutputs, TryFromProtoError> {
+        self.return_values
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::RETURN_VALUES_FIELD.name))
     }
 }
 
@@ -232,59 +150,7 @@ impl CommandResult {
 //
 
 impl CommandResults {
-    /// Get all mutated-by-reference arguments across all commands.
-    pub fn all_mutated_by_ref_arguments(
-        &self,
-    ) -> Result<Vec<Vec<iota_sdk_types::transaction::Argument>>, TryFromProtoError> {
-        self.results
-            .iter()
-            .enumerate()
-            .map(|(i, r)| {
-                r.mutated_by_ref_arguments()
-                    .map_err(|e| e.nested_at(Self::RESULTS_FIELD.name, i))
-            })
-            .collect()
-    }
-
-    /// Get all return value arguments across all commands.
-    pub fn all_return_values_arguments(
-        &self,
-    ) -> Result<Vec<Vec<iota_sdk_types::transaction::Argument>>, TryFromProtoError> {
-        self.results
-            .iter()
-            .enumerate()
-            .map(|(i, r)| {
-                r.return_values_arguments()
-                    .map_err(|e| e.nested_at(Self::RESULTS_FIELD.name, i))
-            })
-            .collect()
-    }
-
-    /// Get all mutated-by-reference type tags across all commands.
-    pub fn all_mutated_by_ref_type_tags(
-        &self,
-    ) -> Result<Vec<Vec<iota_sdk_types::TypeTag>>, TryFromProtoError> {
-        self.results
-            .iter()
-            .enumerate()
-            .map(|(i, r)| {
-                r.mutated_by_ref_type_tags()
-                    .map_err(|e| e.nested_at(Self::RESULTS_FIELD.name, i))
-            })
-            .collect()
-    }
-
-    /// Get all return value type tags across all commands.
-    pub fn all_return_values_type_tags(
-        &self,
-    ) -> Result<Vec<Vec<iota_sdk_types::TypeTag>>, TryFromProtoError> {
-        self.results
-            .iter()
-            .enumerate()
-            .map(|(i, r)| {
-                r.return_values_type_tags()
-                    .map_err(|e| e.nested_at(Self::RESULTS_FIELD.name, i))
-            })
-            .collect()
+    pub fn results(&self) -> &Vec<CommandResult> {
+        &self.results
     }
 }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/epoch.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/epoch.rs
@@ -84,7 +84,7 @@ impl TryFrom<&ValidatorCommittee> for iota_sdk_types::ValidatorCommittee {
 
 impl Epoch {
     /// Get the epoch number.
-    pub fn epoch_number(&self) -> Result<u64, TryFromProtoError> {
+    pub fn epoch_number(&self) -> Result<iota_sdk_types::EpochId, TryFromProtoError> {
         self.epoch
             .ok_or_else(|| TryFromProtoError::missing(Self::EPOCH_FIELD.name))
     }
@@ -97,8 +97,29 @@ impl Epoch {
         }
     }
 
+    /// Get the raw BCS-encoded system state bytes.
+    ///
+    /// This is a snapshot of IOTA's SystemState
+    /// (`0x3::iota_system::SystemState`) at the beginning of the epoch (for
+    /// past epochs) or the current state (for the current epoch).
+    // TODO: Implement when IotaSystemState type is available in iota-sdk-types.
+    // Use `system_state_bcs()` for raw bytes access in the meantime.
+    // See https://github.com/iotaledger/iota/issues/10077
+    //
+    // pub fn system_state(&self) -> Result<iota_sdk_types::IotaSystemState,
+    // TryFromProtoError> {     ...
+    // }
+    pub fn system_state_bcs(&self) -> Result<&[u8], TryFromProtoError> {
+        self.bcs_system_state
+            .as_ref()
+            .map(BcsData::as_bytes)
+            .ok_or_else(|| TryFromProtoError::missing(Self::BCS_SYSTEM_STATE_FIELD.name))
+    }
+
     /// Get the first checkpoint sequence number in this epoch.
-    pub fn first_checkpoint_sequence_number(&self) -> Result<u64, TryFromProtoError> {
+    pub fn first_checkpoint_sequence_number(
+        &self,
+    ) -> Result<iota_sdk_types::CheckpointSequenceNumber, TryFromProtoError> {
         self.first_checkpoint
             .ok_or_else(|| TryFromProtoError::missing(Self::FIRST_CHECKPOINT_FIELD.name))
     }
@@ -107,12 +128,14 @@ impl Epoch {
     ///
     /// Returns `Ok(None)` for the current in-progress epoch (field not yet
     /// set).
-    pub fn last_checkpoint_sequence_number(&self) -> Result<Option<u64>, TryFromProtoError> {
+    pub fn last_checkpoint_sequence_number(
+        &self,
+    ) -> Result<Option<iota_sdk_types::CheckpointSequenceNumber>, TryFromProtoError> {
         Ok(self.last_checkpoint)
     }
 
     /// Get the epoch start time in milliseconds.
-    pub fn start_ms(&self) -> Result<u64, TryFromProtoError> {
+    pub fn start_ms(&self) -> Result<iota_sdk_types::CheckpointTimestamp, TryFromProtoError> {
         let ts = self
             .start
             .ok_or_else(|| TryFromProtoError::missing(Self::START_FIELD.name))?;
@@ -123,7 +146,7 @@ impl Epoch {
     ///
     /// Returns `Ok(None)` for the current in-progress epoch (field not yet
     /// set).
-    pub fn end_ms(&self) -> Result<Option<u64>, TryFromProtoError> {
+    pub fn end_ms(&self) -> Result<Option<iota_sdk_types::CheckpointTimestamp>, TryFromProtoError> {
         self.end
             .map(|ts| {
                 crate::proto::proto_to_timestamp_ms(ts).map_err(|e| e.nested(Self::END_FIELD.name))
@@ -137,68 +160,6 @@ impl Epoch {
             .ok_or_else(|| TryFromProtoError::missing(Self::REFERENCE_GAS_PRICE_FIELD.name))
     }
 
-    /// Get the raw BCS-encoded system state bytes.
-    ///
-    /// This is a snapshot of IOTA's SystemState
-    /// (`0x3::iota_system::SystemState`) at the beginning of the epoch (for
-    /// past epochs) or the current state (for the current epoch).
-    pub fn system_state_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        self.bcs_system_state
-            .as_ref()
-            .map(BcsData::as_bytes)
-            .ok_or_else(|| TryFromProtoError::missing(Self::BCS_SYSTEM_STATE_FIELD.name))
-    }
-
-    /// Get the protocol version number.
-    pub fn protocol_version(&self) -> Result<u64, TryFromProtoError> {
-        self.protocol_config
-            .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::PROTOCOL_CONFIG_FIELD.name))?
-            .protocol_version
-            .ok_or_else(|| {
-                TryFromProtoError::missing(ProtocolConfig::PROTOCOL_VERSION_FIELD.name)
-                    .nested(Self::PROTOCOL_CONFIG_FIELD.name)
-            })
-    }
-
-    /// Get the feature flags map.
-    pub fn feature_flags(
-        &self,
-    ) -> Result<&std::collections::BTreeMap<String, bool>, TryFromProtoError> {
-        let config = self
-            .protocol_config
-            .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::PROTOCOL_CONFIG_FIELD.name))?;
-        let flags = config.feature_flags.as_ref().ok_or_else(|| {
-            TryFromProtoError::missing(ProtocolConfig::FEATURE_FLAGS_FIELD.name)
-                .nested(Self::PROTOCOL_CONFIG_FIELD.name)
-        })?;
-        Ok(&flags.flags)
-    }
-
-    /// Get the protocol attributes map.
-    pub fn protocol_attributes(
-        &self,
-    ) -> Result<&std::collections::BTreeMap<String, String>, TryFromProtoError> {
-        let config = self
-            .protocol_config
-            .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::PROTOCOL_CONFIG_FIELD.name))?;
-        let attrs = config.attributes.as_ref().ok_or_else(|| {
-            TryFromProtoError::missing(ProtocolConfig::ATTRIBUTES_FIELD.name)
-                .nested(Self::PROTOCOL_CONFIG_FIELD.name)
-        })?;
-        Ok(&attrs.attributes)
-    }
-
-    // TODO: Implement when IotaSystemState type is available in iota-sdk-types.
-    // Use `system_state_bcs()` for raw bytes access in the meantime.
-    // See https://github.com/iotaledger/iota/issues/10077
-    //
-    // pub fn system_state(&self) -> Result<iota_sdk_types::IotaSystemState,
-    // TryFromProtoError> {     ...
-    // }
-
     // TODO: Implement when ProtocolConfig conversion is available.
     // Use `protocol_version()`, `feature_flags()`, and `protocol_attributes()`
     // for individual field access in the meantime.
@@ -207,6 +168,12 @@ impl Epoch {
     // pub fn protocol_config(&self) -> Result<iota_protocol_config::ProtocolConfig,
     // TryFromProtoError> {     ...
     // }
+    pub fn protocol_config(&self) -> Result<ProtocolConfig, TryFromProtoError> {
+        self.protocol_config
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::PROTOCOL_CONFIG_FIELD.name))
+            .cloned()
+    }
 }
 
 // ProtocolConfig
@@ -214,13 +181,15 @@ impl Epoch {
 
 impl ProtocolConfig {
     /// Get the protocol version number.
-    pub fn version(&self) -> Result<u64, TryFromProtoError> {
+    pub fn version(&self) -> Result<iota_sdk_types::ProtocolVersion, TryFromProtoError> {
         self.protocol_version
             .ok_or_else(|| TryFromProtoError::missing(Self::PROTOCOL_VERSION_FIELD.name))
     }
 
     /// Get the feature flags map.
-    pub fn flags(&self) -> Result<&std::collections::BTreeMap<String, bool>, TryFromProtoError> {
+    pub fn feature_flags(
+        &self,
+    ) -> Result<&std::collections::BTreeMap<String, bool>, TryFromProtoError> {
         self.feature_flags
             .as_ref()
             .map(|f| &f.flags)
@@ -228,7 +197,9 @@ impl ProtocolConfig {
     }
 
     /// Get the protocol attributes map.
-    pub fn attrs(&self) -> Result<&std::collections::BTreeMap<String, String>, TryFromProtoError> {
+    pub fn attributes(
+        &self,
+    ) -> Result<&std::collections::BTreeMap<String, String>, TryFromProtoError> {
         self.attributes
             .as_ref()
             .map(|a| &a.attributes)
@@ -288,29 +259,17 @@ impl ValidatorCommitteeMembers {
 //
 
 impl ValidatorCommittee {
+    /// Get the epoch number.
+    pub fn epoch_number(&self) -> Result<iota_sdk_types::EpochId, TryFromProtoError> {
+        self.epoch
+            .ok_or_else(|| TryFromProtoError::missing(Self::EPOCH_FIELD.name))
+    }
+
     /// Deserialize the validator committee.
     pub fn validator_committee(
         &self,
     ) -> Result<iota_sdk_types::ValidatorCommittee, TryFromProtoError> {
         self.try_into()
-    }
-
-    /// Get the epoch number.
-    pub fn epoch_number(&self) -> Result<u64, TryFromProtoError> {
-        self.epoch
-            .ok_or_else(|| TryFromProtoError::missing(Self::EPOCH_FIELD.name))
-    }
-
-    /// Deserialize all committee members.
-    pub fn committee_members(
-        &self,
-    ) -> Result<Vec<iota_sdk_types::ValidatorCommitteeMember>, TryFromProtoError> {
-        match &self.members {
-            Some(members) => members
-                .committee_members()
-                .map_err(|e| e.nested(Self::MEMBERS_FIELD.name)),
-            None => Err(TryFromProtoError::missing(Self::MEMBERS_FIELD.name)),
-        }
     }
 }
 
@@ -323,29 +282,5 @@ impl ValidatorCommitteeMember {
         &self,
     ) -> Result<iota_sdk_types::ValidatorCommitteeMember, TryFromProtoError> {
         self.try_into()
-    }
-
-    /// Get the BLS public key.
-    pub fn bls_public_key(&self) -> Result<iota_sdk_types::Bls12381PublicKey, TryFromProtoError> {
-        let pk = self
-            .public_key
-            .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::PUBLIC_KEY_FIELD.name))?;
-        iota_sdk_types::Bls12381PublicKey::from_bytes(pk.as_ref())
-            .map_err(|e| TryFromProtoError::invalid(Self::PUBLIC_KEY_FIELD, e))
-    }
-
-    /// Get the raw public key bytes.
-    pub fn public_key_bytes(&self) -> Result<&[u8], TryFromProtoError> {
-        self.public_key
-            .as_ref()
-            .map(|pk| pk.as_ref())
-            .ok_or_else(|| TryFromProtoError::missing(Self::PUBLIC_KEY_FIELD.name))
-    }
-
-    /// Get the voting weight (stake).
-    pub fn voting_weight(&self) -> Result<u64, TryFromProtoError> {
-        self.weight
-            .ok_or_else(|| TryFromProtoError::missing(Self::WEIGHT_FIELD.name))
     }
 }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/epoch.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/epoch.rs
@@ -160,19 +160,11 @@ impl Epoch {
             .ok_or_else(|| TryFromProtoError::missing(Self::REFERENCE_GAS_PRICE_FIELD.name))
     }
 
-    // TODO: Implement when ProtocolConfig conversion is available.
-    // Use `protocol_version()`, `feature_flags()`, and `protocol_attributes()`
-    // for individual field access in the meantime.
-    // See https://github.com/iotaledger/iota/issues/10077
-    //
-    // pub fn protocol_config(&self) -> Result<iota_protocol_config::ProtocolConfig,
-    // TryFromProtoError> {     ...
-    // }
-    pub fn protocol_config(&self) -> Result<ProtocolConfig, TryFromProtoError> {
+    /// Get the protocol configuration for this epoch.
+    pub fn protocol_config(&self) -> Result<&ProtocolConfig, TryFromProtoError> {
         self.protocol_config
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Self::PROTOCOL_CONFIG_FIELD.name))
-            .cloned()
     }
 }
 
@@ -204,83 +196,5 @@ impl ProtocolConfig {
             .as_ref()
             .map(|a| &a.attributes)
             .ok_or_else(|| TryFromProtoError::missing(Self::ATTRIBUTES_FIELD.name))
-    }
-
-    // TODO: Implement when ProtocolConfig conversion is available.
-    // Use `version()`, `flags()`, and `attrs()` for individual field access in the
-    // meantime.
-    // See https://github.com/iotaledger/iota/issues/10077
-    //
-    // pub fn to_protocol_config(&self) ->
-    // Result<iota_protocol_config::ProtocolConfig, TryFromProtoError> {     ...
-    // }
-}
-
-// ProtocolFeatureFlags
-//
-
-impl ProtocolFeatureFlags {
-    /// Get the feature flags map.
-    pub fn feature_flags(&self) -> &std::collections::BTreeMap<String, bool> {
-        &self.flags
-    }
-}
-
-// ProtocolAttributes
-//
-
-impl ProtocolAttributes {
-    /// Get the attributes map.
-    pub fn protocol_attributes(&self) -> &std::collections::BTreeMap<String, String> {
-        &self.attributes
-    }
-}
-
-// ValidatorCommitteeMembers
-//
-
-impl ValidatorCommitteeMembers {
-    /// Deserialize all committee members.
-    pub fn committee_members(
-        &self,
-    ) -> Result<Vec<iota_sdk_types::ValidatorCommitteeMember>, TryFromProtoError> {
-        self.members
-            .iter()
-            .enumerate()
-            .map(|(i, m)| {
-                m.committee_member()
-                    .map_err(|e| e.nested_at(Self::MEMBERS_FIELD.name, i))
-            })
-            .collect()
-    }
-}
-
-// ValidatorCommittee
-//
-
-impl ValidatorCommittee {
-    /// Get the epoch number.
-    pub fn epoch_number(&self) -> Result<iota_sdk_types::EpochId, TryFromProtoError> {
-        self.epoch
-            .ok_or_else(|| TryFromProtoError::missing(Self::EPOCH_FIELD.name))
-    }
-
-    /// Deserialize the validator committee.
-    pub fn validator_committee(
-        &self,
-    ) -> Result<iota_sdk_types::ValidatorCommittee, TryFromProtoError> {
-        self.try_into()
-    }
-}
-
-// ValidatorCommitteeMember
-//
-
-impl ValidatorCommitteeMember {
-    /// Deserialize the committee member.
-    pub fn committee_member(
-        &self,
-    ) -> Result<iota_sdk_types::ValidatorCommitteeMember, TryFromProtoError> {
-        self.try_into()
     }
 }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/event.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/event.rs
@@ -30,22 +30,6 @@ impl TryFrom<&Event> for iota_sdk_types::Event {
     }
 }
 
-impl TryFrom<&Events> for Vec<iota_sdk_types::Event> {
-    type Error = TryFromProtoError;
-
-    fn try_from(value: &Events) -> Result<Self, Self::Error> {
-        value
-            .events
-            .iter()
-            .enumerate()
-            .map(|(i, event)| {
-                <&Event as TryInto<iota_sdk_types::Event>>::try_into(event)
-                    .map_err(|e: TryFromProtoError| e.nested_at(Events::EVENTS_FIELD.name, i))
-            })
-            .collect()
-    }
-}
-
 // Convenience methods for Event (delegate to TryFrom)
 impl Event {
     /// Deserialize the event from BCS.
@@ -53,47 +37,43 @@ impl Event {
         self.try_into()
     }
 
-    /// Get the raw BCS bytes of the full event structure.
-    ///
-    /// This contains the entire `iota_sdk_types::Event` serialized as BCS,
-    /// including package ID, module, sender, type, and contents.
-    /// Use `event_contents_bcs()` for just the event data/contents.
-    pub fn event_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        self.bcs
-            .as_ref()
-            .map(BcsData::as_bytes)
-            .ok_or_else(|| TryFromProtoError::missing(Self::BCS_FIELD.name))
-    }
-
     /// Get the package ID of the Move module that emitted this event.
-    pub fn package_id(&self) -> Result<iota_sdk_types::Address, TryFromProtoError> {
+    pub fn package_id(&self) -> Result<iota_sdk_types::ObjectId, TryFromProtoError> {
         get_inner_field!(self.package_id, Self::PACKAGE_ID_FIELD, try_into)
     }
 
     /// Get the module name of the Move module that emitted this event.
-    pub fn module_name(&self) -> Result<&str, TryFromProtoError> {
+    pub fn module_name(&self) -> Result<iota_sdk_types::Identifier, TryFromProtoError> {
         self.module
             .as_deref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::MODULE_FIELD.name))
+            .ok_or_else(|| TryFromProtoError::missing(Self::MODULE_FIELD.name))?
+            .parse()
+            .map_err(|_e: iota_sdk_types::TypeParseError| {
+                TryFromProtoError::invalid(Self::MODULE_FIELD.name, "invalid identifier format")
+            })
     }
 
     /// Get the sender address of the transaction that emitted this event.
-    pub fn sender_address(&self) -> Result<iota_sdk_types::Address, TryFromProtoError> {
+    pub fn sender(&self) -> Result<iota_sdk_types::Address, TryFromProtoError> {
         get_inner_field!(self.sender, Self::SENDER_FIELD, try_into)
     }
 
     /// Get the type of the event emitted.
-    pub fn type_name(&self) -> Result<&str, TryFromProtoError> {
+    pub fn type_name(&self) -> Result<iota_sdk_types::StructTag, TryFromProtoError> {
         self.event_type
             .as_deref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::EVENT_TYPE_FIELD.name))
+            .ok_or_else(|| TryFromProtoError::missing(Self::EVENT_TYPE_FIELD.name))?
+            .parse()
+            .map_err(|_e: iota_sdk_types::TypeParseError| {
+                TryFromProtoError::invalid(Self::EVENT_TYPE_FIELD.name, "invalid struct tag format")
+            })
     }
 
     /// Get the raw BCS bytes of the event contents/data only.
     ///
     /// This is the serialized event data without the metadata (package, module,
-    /// sender, type). Use `event_bcs()` for the full event structure.
-    pub fn event_contents_bcs(&self) -> Result<&[u8], TryFromProtoError> {
+    /// sender, type).
+    pub fn bcs_contents(&self) -> Result<&[u8], TryFromProtoError> {
         self.bcs_contents
             .as_ref()
             .map(BcsData::as_bytes)
@@ -109,10 +89,10 @@ impl Event {
     }
 }
 
-// Convenience methods for Events (delegate to TryFrom)
+// Convenience methods for Events
 impl Events {
-    /// Deserialize all events.
-    pub fn events(&self) -> Result<Vec<iota_sdk_types::Event>, TryFromProtoError> {
-        self.try_into()
+    /// Get all events.
+    pub fn events(&self) -> &Vec<Event> {
+        &self.events
     }
 }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/event.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/event.rs
@@ -88,11 +88,3 @@ impl Event {
             .ok_or_else(|| TryFromProtoError::missing(Self::JSON_CONTENTS_FIELD.name))
     }
 }
-
-// Convenience methods for Events
-impl Events {
-    /// Get all events.
-    pub fn events(&self) -> &Vec<Event> {
-        &self.events
-    }
-}

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/ledger_service.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/ledger_service.rs
@@ -81,9 +81,9 @@ impl GetServiceInfoResponse {
 
 impl ObjectResult {
     /// Get the object if this result is an object.
-    pub fn object(&self) -> Result<Option<super::object::Object>, TryFromProtoError> {
+    pub fn object(&self) -> Result<Option<&super::object::Object>, TryFromProtoError> {
         match &self.result {
-            Some(object_result::Result::Object(obj)) => Ok(Some(obj.clone())),
+            Some(object_result::Result::Object(obj)) => Ok(Some(obj)),
             _ => Ok(None),
         }
     }
@@ -105,21 +105,6 @@ impl ObjectResult {
     }
 }
 
-// GetObjectsResponse
-//
-
-impl GetObjectsResponse {
-    /// Get all object results.
-    pub fn objects(&self) -> &Vec<ObjectResult> {
-        &self.objects
-    }
-
-    /// Check if there are more results available.
-    pub fn has_more(&self) -> bool {
-        self.has_next
-    }
-}
-
 // TransactionResult
 //
 
@@ -127,9 +112,9 @@ impl TransactionResult {
     /// Get the executed transaction if this result is a transaction.
     pub fn executed_transaction(
         &self,
-    ) -> Result<Option<super::transaction::ExecutedTransaction>, TryFromProtoError> {
+    ) -> Result<Option<&super::transaction::ExecutedTransaction>, TryFromProtoError> {
         match &self.result {
-            Some(transaction_result::Result::Transaction(tx)) => Ok(Some(tx.clone())),
+            Some(transaction_result::Result::Transaction(tx)) => Ok(Some(tx)),
             _ => Ok(None),
         }
     }
@@ -151,27 +136,12 @@ impl TransactionResult {
     }
 }
 
-// GetTransactionsResponse
-//
-
-impl GetTransactionsResponse {
-    pub fn transactions(&self) -> &Vec<TransactionResult> {
-        &self.transactions
-    }
-
-    /// Check if there are more results available.
-    pub fn has_more(&self) -> bool {
-        self.has_next
-    }
-}
-
 // GetEpochResponse
 //
 
 impl GetEpochResponse {
     pub fn epoch(&self) -> Result<&crate::v0::epoch::Epoch, TryFromProtoError> {
-        self
-            .epoch
+        self.epoch
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Self::EPOCH_FIELD.name))
     }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/ledger_service.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/ledger_service.rs
@@ -25,20 +25,24 @@ impl GetServiceInfoResponse {
     }
 
     /// Get the current epoch number.
-    pub fn epoch_number(&self) -> Result<u64, TryFromProtoError> {
+    pub fn epoch_number(&self) -> Result<iota_sdk_types::EpochId, TryFromProtoError> {
         self.epoch
             .ok_or_else(|| TryFromProtoError::missing(Self::EPOCH_FIELD.name))
     }
 
     /// Get the checkpoint height of the most recently executed checkpoint.
-    pub fn checkpoint_height(&self) -> Result<u64, TryFromProtoError> {
+    pub fn checkpoint_executed(
+        &self,
+    ) -> Result<iota_sdk_types::CheckpointSequenceNumber, TryFromProtoError> {
         self.executed_checkpoint_height
             .ok_or_else(|| TryFromProtoError::missing(Self::EXECUTED_CHECKPOINT_HEIGHT_FIELD.name))
     }
 
     /// Get the Unix timestamp of the most recently executed checkpoint in
     /// milliseconds.
-    pub fn checkpoint_timestamp_ms(&self) -> Result<u64, TryFromProtoError> {
+    pub fn checkpoint_executed_timestamp_ms(
+        &self,
+    ) -> Result<iota_sdk_types::CheckpointTimestamp, TryFromProtoError> {
         let ts = self.executed_checkpoint_timestamp.ok_or_else(|| {
             TryFromProtoError::missing(Self::EXECUTED_CHECKPOINT_TIMESTAMP_FIELD.name)
         })?;
@@ -48,13 +52,17 @@ impl GetServiceInfoResponse {
 
     /// Get the lowest checkpoint for which checkpoints and transaction data are
     /// available.
-    pub fn lowest_checkpoint(&self) -> Result<u64, TryFromProtoError> {
+    pub fn checkpoint_lowest(
+        &self,
+    ) -> Result<iota_sdk_types::CheckpointSequenceNumber, TryFromProtoError> {
         self.lowest_available_checkpoint
             .ok_or_else(|| TryFromProtoError::missing(Self::LOWEST_AVAILABLE_CHECKPOINT_FIELD.name))
     }
 
     /// Get the lowest checkpoint for which object data is available.
-    pub fn lowest_checkpoint_objects(&self) -> Result<u64, TryFromProtoError> {
+    pub fn checkpoint_objects_lowest(
+        &self,
+    ) -> Result<iota_sdk_types::CheckpointSequenceNumber, TryFromProtoError> {
         self.lowest_available_checkpoint_objects.ok_or_else(|| {
             TryFromProtoError::missing(Self::LOWEST_AVAILABLE_CHECKPOINT_OBJECTS_FIELD.name)
         })
@@ -73,25 +81,9 @@ impl GetServiceInfoResponse {
 
 impl ObjectResult {
     /// Get the object if this result is an object.
-    pub fn object(&self) -> Result<Option<iota_sdk_types::Object>, TryFromProtoError> {
+    pub fn object(&self) -> Result<Option<super::object::Object>, TryFromProtoError> {
         match &self.result {
-            Some(object_result::Result::Object(obj)) => Ok(Some(obj.object()?)),
-            _ => Ok(None),
-        }
-    }
-
-    /// Get the object ID if this result is an object.
-    pub fn object_id(&self) -> Result<Option<iota_sdk_types::ObjectId>, TryFromProtoError> {
-        match &self.result {
-            Some(object_result::Result::Object(obj)) => Ok(Some(obj.object_id()?)),
-            _ => Ok(None),
-        }
-    }
-
-    /// Get the raw BCS bytes if this result is an object.
-    pub fn object_bcs(&self) -> Result<Option<&[u8]>, TryFromProtoError> {
-        match &self.result {
-            Some(object_result::Result::Object(obj)) => Ok(Some(obj.object_bcs()?)),
+            Some(object_result::Result::Object(obj)) => Ok(Some(obj.clone())),
             _ => Ok(None),
         }
     }
@@ -117,22 +109,14 @@ impl ObjectResult {
 //
 
 impl GetObjectsResponse {
+    /// Get all object results.
+    pub fn objects(&self) -> &Vec<ObjectResult> {
+        &self.objects
+    }
+
     /// Check if there are more results available.
     pub fn has_more(&self) -> bool {
         self.has_next
-    }
-
-    /// Get all successful objects.
-    pub fn objects(&self) -> Result<Vec<iota_sdk_types::Object>, TryFromProtoError> {
-        self.objects
-            .iter()
-            .enumerate()
-            .filter_map(|(i, r)| match r.object() {
-                Ok(Some(obj)) => Some(Ok(obj)),
-                Ok(None) => None,
-                Err(e) => Some(Err(e.nested_at(Self::OBJECTS_FIELD.name, i))),
-            })
-            .collect()
     }
 }
 
@@ -140,35 +124,12 @@ impl GetObjectsResponse {
 //
 
 impl TransactionResult {
-    /// Get the transaction if this result is a transaction.
-    pub fn transaction(&self) -> Result<Option<iota_sdk_types::Transaction>, TryFromProtoError> {
+    /// Get the executed transaction if this result is a transaction.
+    pub fn executed_transaction(
+        &self,
+    ) -> Result<Option<super::transaction::ExecutedTransaction>, TryFromProtoError> {
         match &self.result {
-            Some(transaction_result::Result::Transaction(tx)) => Ok(Some(tx.transaction()?)),
-            _ => Ok(None),
-        }
-    }
-
-    /// Get the transaction digest if this result is a transaction.
-    pub fn digest(&self) -> Result<Option<iota_sdk_types::Digest>, TryFromProtoError> {
-        match &self.result {
-            Some(transaction_result::Result::Transaction(tx)) => Ok(Some(tx.digest()?)),
-            _ => Ok(None),
-        }
-    }
-
-    /// Get the effects if this result is a transaction.
-    pub fn effects(&self) -> Result<Option<iota_sdk_types::TransactionEffects>, TryFromProtoError> {
-        match &self.result {
-            Some(transaction_result::Result::Transaction(tx)) => Ok(Some(tx.effects()?)),
-            _ => Ok(None),
-        }
-    }
-
-    /// Get the raw BCS bytes of the transaction if this result is a
-    /// transaction.
-    pub fn transaction_bcs(&self) -> Result<Option<&[u8]>, TryFromProtoError> {
-        match &self.result {
-            Some(transaction_result::Result::Transaction(tx)) => Ok(Some(tx.transaction_bcs()?)),
+            Some(transaction_result::Result::Transaction(tx)) => Ok(Some(tx.clone())),
             _ => Ok(None),
         }
     }
@@ -194,86 +155,13 @@ impl TransactionResult {
 //
 
 impl GetTransactionsResponse {
+    pub fn transactions(&self) -> &Vec<TransactionResult> {
+        &self.transactions
+    }
+
     /// Check if there are more results available.
     pub fn has_more(&self) -> bool {
         self.has_next
-    }
-
-    /// Get all transaction digests (successful results only).
-    pub fn digests(&self) -> Result<Vec<iota_sdk_types::Digest>, TryFromProtoError> {
-        self.transactions
-            .iter()
-            .enumerate()
-            .filter_map(|(i, r)| match r.digest() {
-                Ok(Some(digest)) => Some(Ok(digest)),
-                Ok(None) => None,
-                Err(e) => Some(Err(e.nested_at(Self::TRANSACTIONS_FIELD.name, i))),
-            })
-            .collect()
-    }
-}
-
-// CheckpointData
-//
-
-impl CheckpointData {
-    /// Get the checkpoint sequence number if this is a checkpoint payload.
-    pub fn checkpoint_sequence_number(&self) -> Result<Option<u64>, TryFromProtoError> {
-        match &self.payload {
-            Some(checkpoint_data::Payload::Checkpoint(cp)) => {
-                Ok(Some(cp.checkpoint_sequence_number()?))
-            }
-            _ => Ok(None),
-        }
-    }
-
-    /// Get the checkpoint summary if this is a checkpoint payload.
-    pub fn checkpoint_summary(
-        &self,
-    ) -> Result<Option<iota_sdk_types::CheckpointSummary>, TryFromProtoError> {
-        match &self.payload {
-            Some(checkpoint_data::Payload::Checkpoint(cp)) => Ok(Some(cp.summary()?)),
-            _ => Ok(None),
-        }
-    }
-
-    /// Get all transactions if this is a transactions payload.
-    pub fn transactions(
-        &self,
-    ) -> Result<Option<Vec<iota_sdk_types::Transaction>>, TryFromProtoError> {
-        match &self.payload {
-            Some(checkpoint_data::Payload::Transactions(txs)) => Ok(Some(txs.transactions()?)),
-            _ => Ok(None),
-        }
-    }
-
-    /// Get all events if this is an events payload.
-    pub fn events(&self) -> Result<Option<Vec<iota_sdk_types::Event>>, TryFromProtoError> {
-        match &self.payload {
-            Some(checkpoint_data::Payload::Events(events)) => Ok(Some(events.events()?)),
-            _ => Ok(None),
-        }
-    }
-
-    /// Get the end marker sequence number if this is an end marker payload.
-    pub fn end_marker_sequence_number(&self) -> Result<Option<u64>, TryFromProtoError> {
-        match &self.payload {
-            Some(checkpoint_data::Payload::EndMarker(marker)) => {
-                Ok(Some(marker.checkpoint_sequence_number()?))
-            }
-            _ => Ok(None),
-        }
-    }
-}
-
-// checkpoint_data::EndMarker
-//
-
-impl checkpoint_data::EndMarker {
-    /// Get the checkpoint sequence number.
-    pub fn checkpoint_sequence_number(&self) -> Result<u64, TryFromProtoError> {
-        self.sequence_number
-            .ok_or_else(|| TryFromProtoError::missing("end_marker.sequence_number"))
     }
 }
 
@@ -281,57 +169,10 @@ impl checkpoint_data::EndMarker {
 //
 
 impl GetEpochResponse {
-    /// Get the epoch number.
-    pub fn epoch_number(&self) -> Result<u64, TryFromProtoError> {
-        get_inner_field!(self.epoch, Self::EPOCH_FIELD, epoch_number)
-    }
-
-    /// Get the validator committee.
-    pub fn committee(&self) -> Result<iota_sdk_types::ValidatorCommittee, TryFromProtoError> {
-        get_inner_field!(self.epoch, Self::EPOCH_FIELD, committee)
-    }
-
-    /// Get the first checkpoint sequence number in this epoch.
-    pub fn first_checkpoint(&self) -> Result<u64, TryFromProtoError> {
-        get_inner_field!(
-            self.epoch,
-            Self::EPOCH_FIELD,
-            first_checkpoint_sequence_number
-        )
-    }
-
-    /// Get the last checkpoint sequence number in this epoch.
-    ///
-    /// Returns `Ok(None)` for the current in-progress epoch (field not yet
-    /// set).
-    pub fn last_checkpoint(&self) -> Result<Option<u64>, TryFromProtoError> {
-        get_inner_field!(
-            self.epoch,
-            Self::EPOCH_FIELD,
-            last_checkpoint_sequence_number
-        )
-    }
-
-    /// Get the epoch start time in milliseconds.
-    pub fn start_ms(&self) -> Result<u64, TryFromProtoError> {
-        get_inner_field!(self.epoch, Self::EPOCH_FIELD, start_ms)
-    }
-
-    /// Get the epoch end time in milliseconds.
-    ///
-    /// Returns `Ok(None)` for the current in-progress epoch (field not yet
-    /// set).
-    pub fn end_ms(&self) -> Result<Option<u64>, TryFromProtoError> {
-        get_inner_field!(self.epoch, Self::EPOCH_FIELD, end_ms)
-    }
-
-    /// Get the reference gas price in NANOS.
-    pub fn gas_price(&self) -> Result<u64, TryFromProtoError> {
-        get_inner_field!(self.epoch, Self::EPOCH_FIELD, gas_price)
-    }
-
-    /// Get the protocol version.
-    pub fn protocol_version(&self) -> Result<u64, TryFromProtoError> {
-        get_inner_field!(self.epoch, Self::EPOCH_FIELD, protocol_version)
+    pub fn epoch(&self) -> Result<&crate::v0::epoch::Epoch, TryFromProtoError> {
+        self
+            .epoch
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::EPOCH_FIELD.name))
     }
 }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/object.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/object.rs
@@ -96,11 +96,3 @@ impl Object {
         self.try_into()
     }
 }
-
-// Convenience methods for Objects (delegate to TryFrom)
-impl Objects {
-    /// Get all objects.
-    pub fn objects(&self) -> &Vec<Object> {
-        &self.objects
-    }
-}

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/object.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/object.rs
@@ -5,10 +5,7 @@
 include!("../../../generated/iota.grpc.v0.object.rs");
 include!("../../../generated/iota.grpc.v0.object.field_info.rs");
 
-use crate::{
-    proto::TryFromProtoError,
-    v0::{bcs::BcsData, types::ObjectReference, versioned::VersionedObject},
-};
+use crate::{proto::TryFromProtoError, v0::types::ObjectReference};
 
 // TryFrom implementations for Object
 impl TryFrom<&Object> for iota_sdk_types::Object {
@@ -20,7 +17,7 @@ impl TryFrom<&Object> for iota_sdk_types::Object {
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Object::BCS_FIELD.name))?;
 
-        bcs.deserialize::<VersionedObject>()
+        bcs.deserialize::<crate::v0::versioned::VersionedObject>()
             .map_err(|e| TryFromProtoError::invalid(Object::BCS_FIELD.name, e))?
             .try_into_v1()
             .map_err(|_| {
@@ -98,77 +95,12 @@ impl Object {
     pub fn object(&self) -> Result<iota_sdk_types::Object, TryFromProtoError> {
         self.try_into()
     }
-
-    /// Get the raw BCS bytes of this object.
-    pub fn object_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        self.bcs
-            .as_ref()
-            .map(BcsData::as_bytes)
-            .ok_or_else(|| TryFromProtoError::missing(Self::BCS_FIELD.name))
-    }
-
-    /// Get the object ID from the reference.
-    pub fn object_id(&self) -> Result<iota_sdk_types::ObjectId, TryFromProtoError> {
-        let reference = self
-            .reference
-            .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::REFERENCE_FIELD.name))?;
-        let object_id_str = reference.object_id.as_ref().ok_or_else(|| {
-            TryFromProtoError::missing(ObjectReference::OBJECT_ID_FIELD.name)
-                .nested(Self::REFERENCE_FIELD.name)
-        })?;
-        object_id_str.parse().map_err(|e| {
-            TryFromProtoError::invalid(ObjectReference::OBJECT_ID_FIELD.name, e)
-                .nested(Self::REFERENCE_FIELD.name)
-        })
-    }
-
-    /// Get the object version from the reference.
-    pub fn object_version(&self) -> Result<u64, TryFromProtoError> {
-        let reference = self
-            .reference
-            .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::REFERENCE_FIELD.name))?;
-        reference.version.ok_or_else(|| {
-            TryFromProtoError::missing(ObjectReference::VERSION_FIELD.name)
-                .nested(Self::REFERENCE_FIELD.name)
-        })
-    }
-
-    /// Get the object digest from the reference.
-    pub fn object_digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
-        let reference = self
-            .reference
-            .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::REFERENCE_FIELD.name))?;
-        let digest = reference.digest.as_ref().ok_or_else(|| {
-            TryFromProtoError::missing(ObjectReference::DIGEST_FIELD.name)
-                .nested(Self::REFERENCE_FIELD.name)
-        })?;
-        digest
-            .try_into()
-            .map_err(|e: TryFromProtoError| e.nested(Self::REFERENCE_FIELD.name))
-    }
 }
 
 // Convenience methods for Objects (delegate to TryFrom)
 impl Objects {
-    /// Deserialize all objects from BCS.
-    pub fn objects(&self) -> Result<Vec<iota_sdk_types::Object>, TryFromProtoError> {
-        self.try_into()
-    }
-
-    /// Get all object references.
-    pub fn object_references(
-        &self,
-    ) -> Result<Vec<iota_sdk_types::ObjectReference>, TryFromProtoError> {
-        self.objects
-            .iter()
-            .enumerate()
-            .map(|(i, o)| {
-                o.object_reference()
-                    .map_err(|e| e.nested_at(Self::OBJECTS_FIELD.name, i))
-            })
-            .collect()
+    /// Get all objects.
+    pub fn objects(&self) -> &Vec<Object> {
+        &self.objects
     }
 }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/signatures.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/signatures.rs
@@ -48,14 +48,6 @@ impl ValidatorAggregatedSignature {
     ) -> Result<iota_sdk_types::ValidatorAggregatedSignature, TryFromProtoError> {
         self.try_into()
     }
-
-    /// Get the raw BCS bytes of this validator aggregated signature.
-    pub fn signature_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        self.bcs
-            .as_ref()
-            .map(BcsData::as_bytes)
-            .ok_or_else(|| TryFromProtoError::missing(Self::BCS_FIELD.name))
-    }
 }
 
 // UserSignature
@@ -93,14 +85,6 @@ impl UserSignature {
     pub fn signature(&self) -> Result<iota_sdk_types::UserSignature, TryFromProtoError> {
         self.try_into()
     }
-
-    /// Get the raw BCS bytes of this user signature.
-    pub fn signature_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        self.bcs
-            .as_ref()
-            .map(BcsData::as_bytes)
-            .ok_or_else(|| TryFromProtoError::missing(Self::BCS_FIELD.name))
-    }
 }
 
 // UserSignatures
@@ -126,8 +110,8 @@ impl TryFrom<&UserSignatures> for Vec<iota_sdk_types::UserSignature> {
 
 // Convenience methods for UserSignatures (delegate to TryFrom)
 impl UserSignatures {
-    /// Deserialize all user signatures.
-    pub fn signatures(&self) -> Result<Vec<iota_sdk_types::UserSignature>, TryFromProtoError> {
-        self.try_into()
+    /// Get all user signatures.
+    pub fn signatures(&self) -> &Vec<UserSignature> {
+        &self.signatures
     }
 }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/signatures.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/signatures.rs
@@ -107,11 +107,3 @@ impl TryFrom<&UserSignatures> for Vec<iota_sdk_types::UserSignature> {
             .collect()
     }
 }
-
-// Convenience methods for UserSignatures (delegate to TryFrom)
-impl UserSignatures {
-    /// Get all user signatures.
-    pub fn signatures(&self) -> &Vec<UserSignature> {
-        &self.signatures
-    }
-}

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/transaction.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/transaction.rs
@@ -6,9 +6,7 @@ include!("../../../generated/iota.grpc.v0.transaction.rs");
 include!("../../../generated/iota.grpc.v0.transaction.field_info.rs");
 include!("../../../generated/iota.grpc.v0.transaction.accessors.rs");
 
-use crate::{
-    proto::{TryFromProtoError, get_inner_field},
-};
+use crate::proto::TryFromProtoError;
 
 // TryFrom implementations for TransactionEffects
 impl TryFrom<&TransactionEffects> for iota_sdk_types::TransactionEffects {
@@ -120,38 +118,28 @@ impl TransactionEvents {
 
 // Lazy conversion methods for ExecutedTransaction
 impl ExecutedTransaction {
-    /// Get the transaction digest.
-    pub fn digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, digest)
+    pub fn transaction(&self) -> Result<&super::transaction::Transaction, TryFromProtoError> {
+        self.transaction
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::TRANSACTION_FIELD.name))
     }
 
-    /// Deserialize the transaction from BCS.
-    pub fn transaction(&self) -> Result<iota_sdk_types::Transaction, TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, transaction)
-    }
-
-    /// Deserialize user signatures.
-    pub fn signatures(&self) -> Result<Vec<iota_sdk_types::UserSignature>, TryFromProtoError> {
+    pub fn signatures(&self) -> Result<&super::signatures::UserSignatures, TryFromProtoError> {
         self.signatures
             .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::SIGNATURES_FIELD.name))?
-            .try_into()
-            .map_err(|e: TryFromProtoError| e.nested(Self::SIGNATURES_FIELD.name))
+            .ok_or_else(|| TryFromProtoError::missing(Self::SIGNATURES_FIELD.name))
     }
 
-    /// Deserialize transaction effects from BCS.
-    pub fn effects(&self) -> Result<iota_sdk_types::TransactionEffects, TryFromProtoError> {
-        get_inner_field!(self.effects, Self::EFFECTS_FIELD, effects)
+    pub fn effects(&self) -> Result<&super::transaction::TransactionEffects, TryFromProtoError> {
+        self.effects
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::EFFECTS_FIELD.name))
     }
 
-    /// Get the effects digest directly.
-    pub fn effects_digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
-        get_inner_field!(self.effects, Self::EFFECTS_FIELD, digest)
-    }
-
-    /// Deserialize transaction events.
-    pub fn events(&self) -> Result<iota_sdk_types::TransactionEvents, TryFromProtoError> {
-        get_inner_field!(self.events, Self::EVENTS_FIELD, events)
+    pub fn events(&self) -> Result<&super::transaction::TransactionEvents, TryFromProtoError> {
+        self.events
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::EVENTS_FIELD.name))
     }
 
     fn events_opt(&self) -> Result<Option<iota_sdk_types::TransactionEvents>, TryFromProtoError> {
@@ -159,11 +147,6 @@ impl ExecutedTransaction {
             .as_ref()
             .map(TransactionEvents::events)
             .transpose()
-    }
-
-    /// Get the events digest directly.
-    pub fn events_digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
-        get_inner_field!(self.events, Self::EVENTS_FIELD, digest)
     }
 
     /// Get checkpoint sequence number.
@@ -204,24 +187,29 @@ impl TryFrom<&ExecutedTransaction> for iota_sdk_types::CheckpointTransaction {
     fn try_from(value: &ExecutedTransaction) -> Result<Self, Self::Error> {
         let input_objects: Result<Vec<_>, _> = value
             .input_objects()?
-            .objects()
+            .objects
             .iter()
             .map(|obj| obj.object())
             .collect();
 
         let output_objects: Result<Vec<_>, _> = value
             .output_objects()?
-            .objects()
+            .objects
             .iter()
             .map(|obj| obj.object())
             .collect();
 
         Ok(Self {
             transaction: iota_sdk_types::SignedTransaction {
-                transaction: value.transaction()?,
-                signatures: value.signatures()?,
+                transaction: value.transaction()?.transaction()?,
+                signatures: value
+                    .signatures()?
+                    .signatures
+                    .iter()
+                    .map(|s| s.signature())
+                    .collect::<Result<Vec<_>, _>>()?,
             },
-            effects: value.effects()?,
+            effects: value.effects()?.effects()?,
             events: value.events_opt()?,
             input_objects: input_objects?,
             output_objects: output_objects?,
@@ -268,16 +256,5 @@ impl Transaction {
     /// Deserialize the transaction from BCS.
     pub fn transaction(&self) -> Result<iota_sdk_types::Transaction, TryFromProtoError> {
         self.try_into()
-    }
-}
-
-// ExecutedTransactions
-//
-
-impl ExecutedTransactions {
-    /// Get all executed transactions.
-    /// Returns `Ok(None)` if transactions were not included in the response.
-    pub fn transactions(&self) -> &Vec<ExecutedTransaction> {
-        &self.transactions
     }
 }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/transaction.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/transaction.rs
@@ -8,7 +8,6 @@ include!("../../../generated/iota.grpc.v0.transaction.accessors.rs");
 
 use crate::{
     proto::{TryFromProtoError, get_inner_field},
-    v0::{bcs::BcsData, object::Objects, versioned::VersionedEvent},
 };
 
 // TryFrom implementations for TransactionEffects
@@ -51,14 +50,6 @@ impl TransactionEffects {
     pub fn effects(&self) -> Result<iota_sdk_types::TransactionEffects, TryFromProtoError> {
         self.try_into()
     }
-
-    /// Get the raw BCS bytes of this TransactionEffects.
-    pub fn effects_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        self.bcs
-            .as_ref()
-            .map(BcsData::as_bytes)
-            .ok_or_else(|| TryFromProtoError::missing(Self::BCS_FIELD.name))
-    }
 }
 
 // TryFrom implementations for TransactionEvents
@@ -80,7 +71,7 @@ impl TryFrom<&TransactionEvents> for iota_sdk_types::TransactionEvents {
                     TryFromProtoError::missing("event.bcs")
                         .nested_at(TransactionEvents::EVENTS_FIELD.name, i)
                 })?;
-                bcs.deserialize::<VersionedEvent>()
+                bcs.deserialize::<crate::v0::versioned::VersionedEvent>()
                     .map_err(|err| {
                         TryFromProtoError::invalid("event.bcs", err)
                             .nested_at(TransactionEvents::EVENTS_FIELD.name, i)
@@ -139,27 +130,13 @@ impl ExecutedTransaction {
         get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, transaction)
     }
 
-    /// Get the raw BCS bytes of the transaction.
-    pub fn transaction_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, transaction_bcs)
-    }
-
     /// Deserialize user signatures.
     pub fn signatures(&self) -> Result<Vec<iota_sdk_types::UserSignature>, TryFromProtoError> {
-        let signatures_proto = self
-            .signatures
+        self.signatures
             .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::SIGNATURES_FIELD.name))?;
-
-        signatures_proto
-            .signatures
-            .iter()
-            .enumerate()
-            .map(|(i, sig)| {
-                <&super::signatures::UserSignature as TryInto<iota_sdk_types::UserSignature>>::try_into(sig)
-                    .map_err(|e: TryFromProtoError| e.nested_at(Self::SIGNATURES_FIELD.name, i))
-            })
-            .collect()
+            .ok_or_else(|| TryFromProtoError::missing(Self::SIGNATURES_FIELD.name))?
+            .try_into()
+            .map_err(|e: TryFromProtoError| e.nested(Self::SIGNATURES_FIELD.name))
     }
 
     /// Deserialize transaction effects from BCS.
@@ -170,11 +147,6 @@ impl ExecutedTransaction {
     /// Get the effects digest directly.
     pub fn effects_digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
         get_inner_field!(self.effects, Self::EFFECTS_FIELD, digest)
-    }
-
-    /// Get the raw BCS bytes of the transaction effects.
-    pub fn effects_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        get_inner_field!(self.effects, Self::EFFECTS_FIELD, effects_bcs)
     }
 
     /// Deserialize transaction events.
@@ -195,13 +167,15 @@ impl ExecutedTransaction {
     }
 
     /// Get checkpoint sequence number.
-    pub fn checkpoint_sequence_number(&self) -> Result<u64, TryFromProtoError> {
+    pub fn checkpoint_sequence_number(
+        &self,
+    ) -> Result<iota_sdk_types::CheckpointSequenceNumber, TryFromProtoError> {
         self.checkpoint
             .ok_or_else(|| TryFromProtoError::missing(Self::CHECKPOINT_FIELD.name))
     }
 
     /// Get timestamp in milliseconds.
-    pub fn timestamp_ms(&self) -> Result<u64, TryFromProtoError> {
+    pub fn timestamp_ms(&self) -> Result<iota_sdk_types::CheckpointTimestamp, TryFromProtoError> {
         let ts = self
             .timestamp
             .ok_or_else(|| TryFromProtoError::missing(Self::TIMESTAMP_FIELD.name))?;
@@ -209,14 +183,14 @@ impl ExecutedTransaction {
     }
 
     /// Get input objects.
-    pub fn input_objects(&self) -> Result<&Objects, TryFromProtoError> {
+    pub fn input_objects(&self) -> Result<&super::object::Objects, TryFromProtoError> {
         self.input_objects
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Self::INPUT_OBJECTS_FIELD.name))
     }
 
     /// Get output objects.
-    pub fn output_objects(&self) -> Result<&Objects, TryFromProtoError> {
+    pub fn output_objects(&self) -> Result<&super::object::Objects, TryFromProtoError> {
         self.output_objects
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Self::OUTPUT_OBJECTS_FIELD.name))
@@ -228,6 +202,20 @@ impl TryFrom<&ExecutedTransaction> for iota_sdk_types::CheckpointTransaction {
     type Error = TryFromProtoError;
 
     fn try_from(value: &ExecutedTransaction) -> Result<Self, Self::Error> {
+        let input_objects: Result<Vec<_>, _> = value
+            .input_objects()?
+            .objects()
+            .iter()
+            .map(|obj| obj.object())
+            .collect();
+
+        let output_objects: Result<Vec<_>, _> = value
+            .output_objects()?
+            .objects()
+            .iter()
+            .map(|obj| obj.object())
+            .collect();
+
         Ok(Self {
             transaction: iota_sdk_types::SignedTransaction {
                 transaction: value.transaction()?,
@@ -235,8 +223,8 @@ impl TryFrom<&ExecutedTransaction> for iota_sdk_types::CheckpointTransaction {
             },
             effects: value.effects()?,
             events: value.events_opt()?,
-            input_objects: value.input_objects()?.objects()?,
-            output_objects: value.output_objects()?.objects()?,
+            input_objects: input_objects?,
+            output_objects: output_objects?,
         })
     }
 }
@@ -281,53 +269,15 @@ impl Transaction {
     pub fn transaction(&self) -> Result<iota_sdk_types::Transaction, TryFromProtoError> {
         self.try_into()
     }
-
-    /// Get the raw BCS bytes of this Transaction.
-    pub fn transaction_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        self.bcs
-            .as_ref()
-            .map(BcsData::as_bytes)
-            .ok_or_else(|| TryFromProtoError::missing(Self::BCS_FIELD.name))
-    }
 }
 
 // ExecutedTransactions
 //
 
 impl ExecutedTransactions {
-    /// Deserialize all transactions.
-    pub fn transactions(&self) -> Result<Vec<iota_sdk_types::Transaction>, TryFromProtoError> {
-        self.transactions
-            .iter()
-            .enumerate()
-            .map(|(i, t)| {
-                t.transaction()
-                    .map_err(|e| e.nested_at(Self::TRANSACTIONS_FIELD.name, i))
-            })
-            .collect()
-    }
-
-    /// Get all transaction digests.
-    pub fn digests(&self) -> Result<Vec<iota_sdk_types::Digest>, TryFromProtoError> {
-        self.transactions
-            .iter()
-            .enumerate()
-            .map(|(i, t)| {
-                t.digest()
-                    .map_err(|e| e.nested_at(Self::TRANSACTIONS_FIELD.name, i))
-            })
-            .collect()
-    }
-
-    /// Deserialize all transaction effects.
-    pub fn effects(&self) -> Result<Vec<iota_sdk_types::TransactionEffects>, TryFromProtoError> {
-        self.transactions
-            .iter()
-            .enumerate()
-            .map(|(i, t)| {
-                t.effects()
-                    .map_err(|e| e.nested_at(Self::TRANSACTIONS_FIELD.name, i))
-            })
-            .collect()
+    /// Get all executed transactions.
+    /// Returns `Ok(None)` if transactions were not included in the response.
+    pub fn transactions(&self) -> &Vec<ExecutedTransaction> {
+        &self.transactions
     }
 }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/transaction_execution_service.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/transaction_execution_service.rs
@@ -12,7 +12,9 @@ use crate::proto::TryFromProtoError;
 //
 
 impl ExecuteTransactionResponse {
-    pub fn executed_transaction(&self) -> Result<&crate::v0::transaction::ExecutedTransaction, TryFromProtoError> {
+    pub fn executed_transaction(
+        &self,
+    ) -> Result<&crate::v0::transaction::ExecutedTransaction, TryFromProtoError> {
         self.transaction
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Self::TRANSACTION_FIELD.name))
@@ -23,7 +25,9 @@ impl ExecuteTransactionResponse {
 //
 
 impl SimulateTransactionResponse {
-    pub fn executed_transaction(&self) -> Result<&crate::v0::transaction::ExecutedTransaction, TryFromProtoError> {
+    pub fn executed_transaction(
+        &self,
+    ) -> Result<&crate::v0::transaction::ExecutedTransaction, TryFromProtoError> {
         self.transaction
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Self::TRANSACTION_FIELD.name))

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/transaction_execution_service.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/transaction_execution_service.rs
@@ -6,79 +6,16 @@ include!("../../../generated/iota.grpc.v0.transaction_execution_service.rs");
 include!("../../../generated/iota.grpc.v0.transaction_execution_service.field_info.rs");
 include!("../../../generated/iota.grpc.v0.transaction_execution_service.accessors.rs");
 
-use crate::proto::{TryFromProtoError, get_inner_field};
+use crate::proto::TryFromProtoError;
 
 // ExecuteTransactionResponse
 //
 
 impl ExecuteTransactionResponse {
-    /// Get the transaction digest.
-    pub fn digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, digest)
-    }
-
-    /// Deserialize the transaction.
-    pub fn transaction(&self) -> Result<iota_sdk_types::Transaction, TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, transaction)
-    }
-
-    /// Deserialize the transaction effects.
-    pub fn effects(&self) -> Result<iota_sdk_types::TransactionEffects, TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, effects)
-    }
-
-    /// Get the effects digest.
-    pub fn effects_digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, effects_digest)
-    }
-
-    /// Deserialize the transaction events.
-    pub fn events(&self) -> Result<iota_sdk_types::TransactionEvents, TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, events)
-    }
-
-    /// Get the events digest directly.
-    pub fn events_digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, events_digest)
-    }
-
-    /// Get checkpoint sequence number.
-    pub fn checkpoint_sequence_number(&self) -> Result<u64, TryFromProtoError> {
-        get_inner_field!(
-            self.transaction,
-            Self::TRANSACTION_FIELD,
-            checkpoint_sequence_number
-        )
-    }
-
-    /// Get timestamp in milliseconds.
-    pub fn timestamp_ms(&self) -> Result<u64, TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, timestamp_ms)
-    }
-
-    /// Get the raw BCS bytes of the transaction.
-    pub fn transaction_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, transaction_bcs)
-    }
-
-    /// Get the raw BCS bytes of the transaction effects.
-    pub fn effects_bcs(&self) -> Result<&[u8], TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, effects_bcs)
-    }
-
-    /// Get input objects.
-    pub fn input_objects(&self) -> Result<&super::object::Objects, TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, input_objects)
-    }
-
-    /// Get output objects.
-    pub fn output_objects(&self) -> Result<&super::object::Objects, TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, output_objects)
-    }
-
-    /// Deserialize user signatures.
-    pub fn signatures(&self) -> Result<Vec<iota_sdk_types::UserSignature>, TryFromProtoError> {
-        get_inner_field!(self.transaction, Self::TRANSACTION_FIELD, signatures)
+    pub fn executed_transaction(&self) -> Result<&crate::v0::transaction::ExecutedTransaction, TryFromProtoError> {
+        self.transaction
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::TRANSACTION_FIELD.name))
     }
 }
 
@@ -86,69 +23,18 @@ impl ExecuteTransactionResponse {
 //
 
 impl SimulateTransactionResponse {
-    pub fn executed_transaction(
-        &self,
-    ) -> Result<&super::transaction::ExecutedTransaction, TryFromProtoError> {
+    pub fn executed_transaction(&self) -> Result<&crate::v0::transaction::ExecutedTransaction, TryFromProtoError> {
         self.transaction
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Self::TRANSACTION_FIELD.name))
     }
 
-    pub fn command_results(&self) -> Result<&super::command::CommandResults, TryFromProtoError> {
+    /// Get the command results.
+    pub fn command_results(
+        &self,
+    ) -> Result<&crate::v0::command::CommandResults, TryFromProtoError> {
         self.command_results
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Self::COMMAND_RESULTS_FIELD.name))
-    }
-
-    /// Get all mutated-by-reference arguments from command results.
-    ///
-    /// Returns intermediate results from executing each command in a
-    /// programmable transaction. Each outer vector element corresponds to a
-    /// command, and each inner vector contains the arguments mutated by that
-    /// command.
-    pub fn command_mutated_by_ref_arguments(
-        &self,
-    ) -> Result<Vec<Vec<iota_sdk_types::transaction::Argument>>, TryFromProtoError> {
-        get_inner_field!(
-            self.command_results,
-            Self::COMMAND_RESULTS_FIELD,
-            all_mutated_by_ref_arguments
-        )
-    }
-
-    /// Get all return value arguments from command results.
-    ///
-    /// Returns the return values from executing each command in a programmable
-    /// transaction. Each outer vector element corresponds to a command.
-    pub fn command_return_values_arguments(
-        &self,
-    ) -> Result<Vec<Vec<iota_sdk_types::transaction::Argument>>, TryFromProtoError> {
-        get_inner_field!(
-            self.command_results,
-            Self::COMMAND_RESULTS_FIELD,
-            all_return_values_arguments
-        )
-    }
-
-    /// Get all mutated-by-reference type tags from command results.
-    pub fn command_mutated_by_ref_type_tags(
-        &self,
-    ) -> Result<Vec<Vec<iota_sdk_types::TypeTag>>, TryFromProtoError> {
-        get_inner_field!(
-            self.command_results,
-            Self::COMMAND_RESULTS_FIELD,
-            all_mutated_by_ref_type_tags
-        )
-    }
-
-    /// Get all return value type tags from command results.
-    pub fn command_return_values_type_tags(
-        &self,
-    ) -> Result<Vec<Vec<iota_sdk_types::TypeTag>>, TryFromProtoError> {
-        get_inner_field!(
-            self.command_results,
-            Self::COMMAND_RESULTS_FIELD,
-            all_return_values_type_tags
-        )
     }
 }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/types.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/types.rs
@@ -43,6 +43,15 @@ impl TryFrom<&Address> for iota_sdk_types::Address {
     }
 }
 
+impl TryFrom<&Address> for iota_sdk_types::ObjectId {
+    type Error = TryFromProtoError;
+
+    fn try_from(value: &Address) -> Result<Self, Self::Error> {
+        let sdk_address: iota_sdk_types::Address = value.try_into()?;
+        Ok(iota_sdk_types::ObjectId::from(sdk_address))
+    }
+}
+
 // ObjectReference conversions
 impl From<iota_sdk_types::ObjectReference> for ObjectReference {
     fn from(value: iota_sdk_types::ObjectReference) -> Self {
@@ -93,11 +102,6 @@ impl Address {
     pub fn address(&self) -> Result<iota_sdk_types::Address, TryFromProtoError> {
         self.try_into()
     }
-
-    /// Get the raw address bytes.
-    pub fn address_bytes(&self) -> &[u8] {
-        &self.address
-    }
 }
 
 impl Digest {
@@ -105,24 +109,12 @@ impl Digest {
     pub fn digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
         self.try_into()
     }
-
-    /// Get the raw digest bytes.
-    pub fn digest_bytes(&self) -> &[u8] {
-        &self.digest
-    }
 }
 
 impl ObjectReference {
     /// Deserialize the full object reference to SDK type.
     pub fn object_reference(&self) -> Result<iota_sdk_types::ObjectReference, TryFromProtoError> {
         self.try_into()
-    }
-
-    /// Get the object ID as a string reference.
-    pub fn object_id_str(&self) -> Result<&str, TryFromProtoError> {
-        self.object_id
-            .as_deref()
-            .ok_or_else(|| TryFromProtoError::missing(Self::OBJECT_ID_FIELD.name))
     }
 
     /// Get the object ID parsed as SDK type.
@@ -141,7 +133,7 @@ impl ObjectReference {
     }
 
     /// Get the object digest.
-    pub fn object_digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
+    pub fn digest(&self) -> Result<iota_sdk_types::Digest, TryFromProtoError> {
         get_inner_field!(self.digest, Self::DIGEST_FIELD, digest)
     }
 }
@@ -218,42 +210,6 @@ impl TypeTag {
     pub fn type_tag(&self) -> Result<iota_sdk_types::TypeTag, TryFromProtoError> {
         self.try_into()
     }
-
-    /// Get the inner type tag if this is a vector type tag.
-    pub fn vector_inner_type(&self) -> Result<Option<iota_sdk_types::TypeTag>, TryFromProtoError> {
-        match &self.type_tag {
-            Some(type_tag::TypeTag::VectorTag(inner)) => {
-                let inner_type = inner
-                    .inner_type
-                    .as_ref()
-                    .ok_or_else(|| TryFromProtoError::missing("type_tag.vector.inner_type"))?;
-                Ok(Some(inner_type.type_tag()?))
-            }
-            _ => Ok(None),
-        }
-    }
-
-    /// Get the struct tag if this is a struct type tag.
-    pub fn struct_tag(&self) -> Result<Option<iota_sdk_types::StructTag>, TryFromProtoError> {
-        match &self.type_tag {
-            Some(type_tag::TypeTag::StructTag(s)) => {
-                let parsed = s
-                    .struct_tag
-                    .parse()
-                    .map_err(|e| TryFromProtoError::invalid("type_tag.struct_tag", e))?;
-                Ok(Some(parsed))
-            }
-            _ => Ok(None),
-        }
-    }
-
-    /// Get the struct tag as a string if this is a struct type tag.
-    pub fn struct_tag_str(&self) -> Option<&str> {
-        match &self.type_tag {
-            Some(type_tag::TypeTag::StructTag(s)) => Some(&s.struct_tag),
-            _ => None,
-        }
-    }
 }
 
 // TypeTags
@@ -270,36 +226,5 @@ impl TypeTags {
                     .map_err(|e| e.nested_at(Self::TYPE_TAGS_FIELD.name, i))
             })
             .collect()
-    }
-}
-
-// TypeTagVector
-//
-
-impl TypeTagVector {
-    /// Deserialize the inner type to SDK type.
-    pub fn inner_type_tag(&self) -> Result<iota_sdk_types::TypeTag, TryFromProtoError> {
-        let inner = self
-            .inner_type
-            .as_ref()
-            .ok_or_else(|| TryFromProtoError::missing("type_tag_vector.inner_type"))?;
-        inner.type_tag()
-    }
-}
-
-// TypeTagStruct
-//
-
-impl TypeTagStruct {
-    /// Get the struct tag as a string.
-    pub fn struct_tag(&self) -> &str {
-        &self.struct_tag
-    }
-
-    /// Parse and deserialize the struct tag to SDK type.
-    pub fn struct_tag_parsed(&self) -> Result<iota_sdk_types::StructTag, TryFromProtoError> {
-        self.struct_tag
-            .parse()
-            .map_err(|e| TryFromProtoError::invalid("struct_tag", e))
     }
 }

--- a/crates/iota-grpc-types/src/proto/iota/grpc/v0/types.rs
+++ b/crates/iota-grpc-types/src/proto/iota/grpc/v0/types.rs
@@ -118,7 +118,7 @@ impl ObjectReference {
     }
 
     /// Get the object ID parsed as SDK type.
-    pub fn parsed_object_id(&self) -> Result<iota_sdk_types::ObjectId, TryFromProtoError> {
+    pub fn object_identifier(&self) -> Result<iota_sdk_types::ObjectId, TryFromProtoError> {
         self.object_id
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Self::OBJECT_ID_FIELD.name))?
@@ -127,7 +127,7 @@ impl ObjectReference {
     }
 
     /// Get the object version number.
-    pub fn object_version(&self) -> Result<u64, TryFromProtoError> {
+    pub fn object_version(&self) -> Result<iota_sdk_types::Version, TryFromProtoError> {
         self.version
             .ok_or_else(|| TryFromProtoError::missing(Self::VERSION_FIELD.name))
     }
@@ -209,22 +209,5 @@ impl TypeTag {
     /// Deserialize the type tag to SDK type.
     pub fn type_tag(&self) -> Result<iota_sdk_types::TypeTag, TryFromProtoError> {
         self.try_into()
-    }
-}
-
-// TypeTags
-//
-
-impl TypeTags {
-    /// Deserialize all type tags to SDK types.
-    pub fn type_tags(&self) -> Result<Vec<iota_sdk_types::TypeTag>, TryFromProtoError> {
-        self.type_tags
-            .iter()
-            .enumerate()
-            .map(|(i, tt)| {
-                tt.type_tag()
-                    .map_err(|e| e.nested_at(Self::TYPE_TAGS_FIELD.name, i))
-            })
-            .collect()
     }
 }


### PR DESCRIPTION
# Description of change

This PR removes several convenience functions, because they bloat the client interface. The user can simply go into the nested types to get the same information.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes