### PR TITLE
fix(ci): Run Rust Examples CI if Rust changes

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -9,7 +9,7 @@ outputs:
     value: "${{ steps.diff.outputs.isRust }}"
   isRustExample:
     description: True when changes happened to the Rust example code
-    value: "${{ steps.diff.outputs.isRustExample }}"
+    value: "${{ steps.diff.outputs.isRustExample || steps.diff.outputs.isRust }}"
   isRpc:
     description: True when changes happened to the RPC code
     value: "${{ steps.diff.outputs.isRpc }}"


### PR DESCRIPTION
this way https://github.com/iotaledger/iota/actions/runs/21984075659/job/63513816264?pr=9896 would have been caught earlier in https://github.com/iotaledger/iota/pull/10222