### PR TITLE
feat(consensus, iota-types): Remove VersionedScoringMetrics type

### DIFF
--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -12,7 +12,6 @@ use std::{
 };
 
 use consensus_config::AuthorityIndex;
-use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
 use itertools::Itertools as _;
 use tokio::time::Instant;
 use tracing::{debug, error, info, trace};
@@ -249,7 +248,10 @@ impl DagState {
 
         // Initialize scoring metrics according to the metrics in store and the blocks
         // that were loaded to cache.
-        let recovered_scoring_metrics = state.store.scan_scoring_metrics().expect("Database error");
+        let recovered_scoring_metrics = state
+            .store
+            .scan_scoring_metrics(&state.context.committee)
+            .expect("Database error");
         state
             .context
             .scoring_metrics_store
@@ -1073,16 +1075,18 @@ impl DagState {
                 );
         }
 
-        let metrics_to_write = VersionedStorageScoringMetrics::new_from(
-            &self.context.scoring_metrics_store.uncached_metrics,
-        );
+        let metrics_to_write = self
+            .context
+            .scoring_metrics_store
+            .uncached_metrics
+            .snapshot();
 
         self.store
             .write(WriteBatch::new(
                 blocks,
                 commits,
                 commit_info_to_write,
-                Some(metrics_to_write),
+                metrics_to_write,
             ))
             .unwrap_or_else(|e| panic!("Failed to write to storage: {e:?}"));
         self.context

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use consensus_config::AuthorityIndex;
+use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
 use itertools::Itertools as _;
 use tokio::time::Instant;
 use tracing::{debug, error, info, trace};
@@ -1055,13 +1056,11 @@ impl DagState {
         );
 
         // Update the scoring metrics accordingly to the blocks being flushed.
-        let mut metrics_to_write = vec![];
         let threshold_clock_round = self.threshold_clock_round();
         for (authority_index, authority) in self.context.committee.authorities() {
             let last_eviction_round = self.evicted_rounds[authority_index];
             let current_eviction_round = self.calculate_authority_eviction_round(authority_index);
-            let metrics_to_write_from_authority = self
-                .context
+            self.context
                 .scoring_metrics_store
                 .update_scoring_metrics_on_eviction(
                     authority_index,
@@ -1072,15 +1071,18 @@ impl DagState {
                     threshold_clock_round,
                     &self.context,
                 );
-            metrics_to_write.push((authority_index, metrics_to_write_from_authority));
         }
+
+        let metrics_to_write = VersionedStorageScoringMetrics::new_from(
+            &self.context.scoring_metrics_store.uncached_metrics,
+        );
 
         self.store
             .write(WriteBatch::new(
                 blocks,
                 commits,
                 commit_info_to_write,
-                metrics_to_write,
+                Some(metrics_to_write),
             ))
             .unwrap_or_else(|e| panic!("Failed to write to storage: {e:?}"));
         self.context

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -1072,9 +1072,7 @@ impl DagState {
                     threshold_clock_round,
                     &self.context,
                 );
-            if let Some(metrics_to_write_from_authority) = metrics_to_write_from_authority {
-                metrics_to_write.push((authority_index, metrics_to_write_from_authority));
-            }
+            metrics_to_write.push((authority_index, metrics_to_write_from_authority));
         }
 
         self.store

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -38,7 +38,7 @@ impl MysticetiScoringMetricsStore {
     // recovered_scoring_metrics and blocks_in_cache_by_authority.
     pub(crate) fn initialize_scoring_metrics(
         &self,
-        recovered_scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
+        recovered_scoring_metrics: Option<VersionedStorageScoringMetrics>,
         blocks_in_cache_by_authority: &Vec<BTreeSet<BlockRef>>,
         threshold_clock_round: u32,
         eviction_rounds: &Vec<u32>,
@@ -46,9 +46,9 @@ impl MysticetiScoringMetricsStore {
     ) {
         // At the beginning of the epoch (i.e., before the epoch's first eviction),
         // there is nothing to be recovered from storage, so recovered_scoring_metrics
-        // will be empty. In this case, the initialization functions will simply
+        // will be None. In this case, the initialization functions will simply
         // initialize zeroed metrics for all authorities, so we can return here.
-        if recovered_scoring_metrics.is_empty() {
+        if recovered_scoring_metrics.is_none() {
             return;
         }
 
@@ -56,7 +56,7 @@ impl MysticetiScoringMetricsStore {
         // them.
         match &context.protocol_config.scorer_version_as_option() {
             None | Some(1) => self.initialize_scoring_metrics_v1(
-                recovered_scoring_metrics,
+                recovered_scoring_metrics.unwrap(),
                 blocks_in_cache_by_authority,
                 threshold_clock_round,
                 eviction_rounds,
@@ -70,37 +70,36 @@ impl MysticetiScoringMetricsStore {
     // recovered_scoring_metrics and blocks_in_cache_by_authority.
     pub(crate) fn initialize_scoring_metrics_v1(
         &self,
-        recovered_scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
+        recovered_scoring_metrics: VersionedStorageScoringMetrics,
         blocks_in_cache_by_authority: &Vec<BTreeSet<BlockRef>>,
         threshold_clock_round: u32,
         eviction_rounds: &Vec<u32>,
         context: &Arc<Context>,
     ) {
-        let hostnames = context
+        let indices_and_hostnames = context
             .committee
             .authorities()
-            .map(|(_, x)| x.hostname.as_str())
+            .map(|(i, x)| (i, x.hostname.as_str()))
             .collect::<Vec<_>>();
+        let VersionedStorageScoringMetrics::V1(inner) = recovered_scoring_metrics;
 
-        for ((authority_index, metrics), hostname, blocks_in_cache, &eviction_round) in izip!(
-            recovered_scoring_metrics,
-            hostnames,
+        for ((authority_index, hostname), blocks_in_cache, &eviction_round) in izip!(
+            indices_and_hostnames,
             blocks_in_cache_by_authority,
             eviction_rounds
         ) {
             // Initialize the uncached scoring metrics according to
             // recovered_scoring_metrics
-            let VersionedStorageScoringMetrics::V1(inner) = &metrics;
             self.initialize_faulty_blocks_metrics(
-                *inner.faulty_blocks_provable(),
-                *inner.faulty_blocks_unprovable(),
+                inner.faulty_blocks_provable()[authority_index.value() as usize],
+                inner.faulty_blocks_unprovable()[authority_index.value() as usize],
                 hostname,
                 authority_index,
                 &context.metrics.node_metrics,
             );
             self.update_missing_blocks_and_equivocations(
-                *inner.missing_proposals(),
-                *inner.equivocations(),
+                inner.missing_proposals()[authority_index.value() as usize],
+                inner.equivocations()[authority_index.value() as usize],
                 hostname,
                 authority_index,
                 StoreType::Uncached,
@@ -286,14 +285,11 @@ impl MysticetiScoringMetricsStore {
         last_eviction_round: u32,
         threshold_clock_round: u32,
         context: &Arc<Context>,
-    ) -> VersionedStorageScoringMetrics {
+    ) {
         let node_metrics = &context.metrics.node_metrics;
         // threshold_clock_round should be always at least 1.
         if threshold_clock_round == 0 {
-            return VersionedStorageScoringMetrics::new_from(
-                &self.uncached_metrics,
-                authority_index.value(),
-            );
+            return;
         }
 
         // Get the blocks rounds that were not evicted.
@@ -323,10 +319,7 @@ impl MysticetiScoringMetricsStore {
         // If no eviction happened, we do not update the current local metrics counts
         // and the metrics on storage.
         if eviction_round == last_eviction_round {
-            return VersionedStorageScoringMetrics::new_from(
-                &self.uncached_metrics,
-                authority_index.value(),
-            );
+            return;
         }
 
         // Get the evicted blocks rounds.
@@ -360,8 +353,6 @@ impl MysticetiScoringMetricsStore {
         // since the last eviction (e.g., faulty blocks metrics updated on block
         // receival).
         self.update_current_local_metrics_count(authority_index);
-
-        VersionedStorageScoringMetrics::new_from(&self.uncached_metrics, authority_index.value())
     }
 
     // The `authority_index` should be a valid index, otherwise the function will
@@ -537,7 +528,6 @@ mod tests {
     use std::{collections::BTreeSet, sync::Arc, vec};
 
     use consensus_config::{AuthorityIndex, NetworkKeyPair, ProtocolKeyPair};
-    use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
     use parking_lot::RwLock;
     use tokio::sync::broadcast;
 
@@ -706,6 +696,10 @@ mod tests {
         metrics
     }
 
+    fn is_all_zeroes(metrics: &[u64]) -> bool {
+        metrics.iter().all(|&v| v == 0)
+    }
+
     fn get_faulty_blocks_provable(
         context: &Arc<Context>,
         source: &ErrorSource,
@@ -773,11 +767,11 @@ mod tests {
 
         // Unexpected because: threshold_clock_round = last_evicted_round means that a
         // round with blocks from less than 2f+1 stake was evicted.
-        // Return: Zeroed metrics, because nothing is currently being evicted.
+        // Uncached metrics unchanged (all zeros) because nothing is evicted.
         let last_evicted_round = 5;
         let eviction_round = 5;
         let threshold_clock_round = 5;
-        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+        scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -786,23 +780,25 @@ mod tests {
             threshold_clock_round,
             &context,
         );
-
-        assert_eq!(
-            stored_metrics,
-            VersionedStorageScoringMetrics::new_v1_for_test(
-                0, // faulty_blocks_provable
-                0, // faulty_blocks_unprovable
-                0, // missing_proposals
-                0, // equivocations
-            )
-        );
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.uncached_equivocations_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_provable_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_unprovable_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.uncached_missing_proposals_by_authority()
+        ));
 
         // Unexpected because: threshold_clock_round = 0 means that genesis is missing.
-        // Return: Zeroed metrics, because nothing is currently being evicted.
+        // Uncached metrics unchanged (all zeros) because of early return.
         let last_evicted_round = 0;
         let eviction_round = 0;
         let threshold_clock_round = 0;
-        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+        scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -811,24 +807,26 @@ mod tests {
             threshold_clock_round,
             &context,
         );
-
-        assert_eq!(
-            stored_metrics,
-            VersionedStorageScoringMetrics::new_v1_for_test(
-                0, // faulty_blocks_provable
-                0, // faulty_blocks_unprovable
-                0, // missing_proposals
-                0, // equivocations
-            )
-        );
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.uncached_equivocations_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_provable_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_unprovable_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.uncached_missing_proposals_by_authority()
+        ));
 
         // Unexpected because: threshold_clock_round < eviction_round means that a
-        // round with blocks from less than 2f+1 stake in being evicted.
-        // Return: 3 missing proposals, from rounds 1 to 3(eviction_round).
+        // round with blocks from less than 2f+1 stake is being evicted.
+        // Uncached: 3 missing proposals for authority 0, from rounds 1 to 3.
         let last_evicted_round = 0;
         let eviction_round = 3;
         let threshold_clock_round = 2;
-        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+        scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -837,25 +835,27 @@ mod tests {
             threshold_clock_round,
             &context,
         );
-
         assert_eq!(
-            stored_metrics,
-            VersionedStorageScoringMetrics::new_v1_for_test(
-                0, // faulty_blocks_provable
-                0, // faulty_blocks_unprovable
-                3, // missing_proposals
-                0, // equivocations
-            )
+            scoring_metrics_store.uncached_missing_proposals_by_authority(),
+            vec![3, 0, 0, 0]
         );
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.uncached_equivocations_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_provable_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_unprovable_by_authority()
+        ));
 
         // Unexpected because: eviction_round < last_evicted_round means that blocks
         // below or in last_evicted_round were accepted.
-        // Return: metrics won't be updated here, so it should return the same as in the
-        // last step.
+        // Uncached metrics unchanged because evicted range [2, 0] is inverted.
         let last_evicted_round = 1;
         let eviction_round = 0;
         let threshold_clock_round = 2;
-        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+        scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -864,25 +864,27 @@ mod tests {
             threshold_clock_round,
             &context,
         );
-
         assert_eq!(
-            stored_metrics,
-            VersionedStorageScoringMetrics::new_v1_for_test(
-                0, // faulty_blocks_provable
-                0, // faulty_blocks_unprovable
-                3, // missing_proposals
-                0, // equivocations
-            )
+            scoring_metrics_store.uncached_missing_proposals_by_authority(),
+            vec![3, 0, 0, 0]
         );
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.uncached_equivocations_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_provable_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_unprovable_by_authority()
+        ));
 
         // Unexpected because: threshold_clock_round < eviction_round <
         // last_evicted_round and threshold_clock_round.
-        // Return: metrics won't be updated here, so it should return the same as in the
-        // last step.
+        // Uncached metrics unchanged because evicted range [3, 0] is inverted.
         let last_evicted_round = 2;
         let eviction_round = 0;
         let threshold_clock_round = 1;
-        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+        scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -891,25 +893,28 @@ mod tests {
             threshold_clock_round,
             &context,
         );
-
         assert_eq!(
-            stored_metrics,
-            VersionedStorageScoringMetrics::new_v1_for_test(
-                0, // faulty_blocks_provable
-                0, // faulty_blocks_unprovable
-                3, // missing_proposals
-                0, // equivocations
-            )
+            scoring_metrics_store.uncached_missing_proposals_by_authority(),
+            vec![3, 0, 0, 0]
         );
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.uncached_equivocations_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_provable_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_unprovable_by_authority()
+        ));
 
         // Unexpected because: threshold_clock_round < last_evicted_round means that a
         // round with blocks from less than 2f+1 stake was evicted.
-        // Return: metrics won't be updated here, so it should return the same as in the
-        // last step.
+        // Uncached metrics unchanged because threshold_clock_round = 0 causes
+        // early return.
         let last_evicted_round = 1;
         let eviction_round = 2;
         let threshold_clock_round = 0;
-        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+        scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -918,21 +923,25 @@ mod tests {
             threshold_clock_round,
             &context,
         );
-
         assert_eq!(
-            stored_metrics,
-            VersionedStorageScoringMetrics::new_v1_for_test(
-                0, // faulty_blocks_provable
-                0, // faulty_blocks_unprovable
-                3, // missing_proposals
-                0, // equivocations
-            )
+            scoring_metrics_store.uncached_missing_proposals_by_authority(),
+            vec![3, 0, 0, 0]
         );
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.uncached_equivocations_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_provable_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_unprovable_by_authority()
+        ));
 
+        // Same as above but with eviction_round < last_evicted_round.
         let last_evicted_round = 2;
         let eviction_round = 1;
         let threshold_clock_round = 0;
-        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
+        scoring_metrics_store.update_scoring_metrics_on_eviction(
             authority_index,
             hostname,
             &recent_refs_by_authority,
@@ -941,16 +950,19 @@ mod tests {
             threshold_clock_round,
             &context,
         );
-
         assert_eq!(
-            stored_metrics,
-            VersionedStorageScoringMetrics::new_v1_for_test(
-                0, // faulty_blocks_provable
-                0, // faulty_blocks_unprovable
-                3, // missing_proposals
-                0, // equivocations
-            )
+            scoring_metrics_store.uncached_missing_proposals_by_authority(),
+            vec![3, 0, 0, 0]
         );
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.uncached_equivocations_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_provable_by_authority()
+        ));
+        assert!(is_all_zeroes(
+            &scoring_metrics_store.faulty_blocks_unprovable_by_authority()
+        ));
     }
 
     #[tokio::test]

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -10,6 +10,7 @@ use consensus_config::AuthorityIndex;
 use iota_common::scoring_metrics::VersionedScoringMetrics;
 use iota_protocol_config::ProtocolConfig;
 use itertools::izip;
+use tracing::warn;
 
 use crate::{BlockRef, context::Context, error::ConsensusError, metrics::NodeMetrics};
 /// Struct that holds the scoring metrics for all authorities in the committee,
@@ -76,42 +77,43 @@ impl MysticetiScoringMetricsStore {
         eviction_rounds: &Vec<u32>,
         context: &Arc<Context>,
     ) {
-        let faulty_blocks_provable = recovered_scoring_metrics.load_faulty_blocks_provable();
-        let faulty_blocks_unprovable = recovered_scoring_metrics.load_faulty_blocks_unprovable();
-        let missing_proposals = recovered_scoring_metrics.load_missing_proposals();
-        let equivocations = recovered_scoring_metrics.load_equivocations();
+        let faulty_blocks_provable_vec = recovered_scoring_metrics.load_faulty_blocks_provable();
+        let faulty_blocks_unprovable_vec =
+            recovered_scoring_metrics.load_faulty_blocks_unprovable();
+        let missing_proposals_vec = recovered_scoring_metrics.load_missing_proposals();
+        let equivocations_vec = recovered_scoring_metrics.load_equivocations();
 
         for (
             (authority_index, authority),
             blocks_in_cache,
             &eviction_round,
-            &fbp,
-            &fbu,
-            &mp,
-            &eq,
+            &faulty_blocks_provable,
+            &faulty_blocks_unprovable,
+            &missing_proposals,
+            &equivocations,
         ) in izip!(
             context.committee.authorities(),
             blocks_in_cache_by_authority,
             eviction_rounds,
-            &faulty_blocks_provable,
-            &faulty_blocks_unprovable,
-            &missing_proposals,
-            &equivocations
+            &faulty_blocks_provable_vec,
+            &faulty_blocks_unprovable_vec,
+            &missing_proposals_vec,
+            &equivocations_vec
         ) {
             let hostname = authority.hostname.as_str();
 
             // Initialize the uncached scoring metrics according to
             // recovered_scoring_metrics
             self.initialize_faulty_blocks_metrics(
-                fbp,
-                fbu,
+                faulty_blocks_provable,
+                faulty_blocks_unprovable,
                 hostname,
                 authority_index,
                 &context.metrics.node_metrics,
             );
             self.update_missing_blocks_and_equivocations(
-                mp,
-                eq,
+                missing_proposals,
+                equivocations,
                 hostname,
                 authority_index,
                 StoreType::Uncached,
@@ -298,6 +300,7 @@ impl MysticetiScoringMetricsStore {
         let node_metrics = &context.metrics.node_metrics;
         // threshold_clock_round should be always at least 1.
         if threshold_clock_round == 0 {
+            warn!("update_scoring_metrics_on_eviction called with threshold clock round = 0.");
             return;
         }
 

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -371,16 +371,15 @@ impl MysticetiScoringMetricsStore {
     // panic. This check is not performed here, as it is assumed that the caller has
     // already checked it.
     pub(crate) fn update_current_local_metrics_count(&self, authority_index: AuthorityIndex) {
-        let uncached_metrics = &self
+        let uncached_metrics = self
             .uncached_metrics
             .iter()
-            .map(|metric_vec| metric_vec[authority_index].load(Ordering::Relaxed))
-            .collect::<Vec<u64>>();
+            .map(|metric_vec| metric_vec[authority_index].load(Ordering::Relaxed));
         self.current_local_metrics_count
             .iter()
             .zip(uncached_metrics)
             .for_each(|(local_metric_vec, uncached_metric)| {
-                local_metric_vec[authority_index].store(*uncached_metric, Ordering::Relaxed);
+                local_metric_vec[authority_index].store(uncached_metric, Ordering::Relaxed);
             });
     }
 }

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -38,38 +38,22 @@ impl MysticetiScoringMetricsStore {
     // recovered_scoring_metrics and blocks_in_cache_by_authority.
     pub(crate) fn initialize_scoring_metrics(
         &self,
-        mut recovered_scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
+        recovered_scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
         blocks_in_cache_by_authority: &Vec<BTreeSet<BlockRef>>,
         threshold_clock_round: u32,
         eviction_rounds: &Vec<u32>,
         context: &Arc<Context>,
     ) {
-        // It is possible that the vector recovered_scoring_metrics does not have a
-        // component for every authority. A perfectly functioning validator, for
-        // example, will never have its metrics updated, so no metric will ever be
-        // stored. For this reason, we manually "fill" this vector.
-        if recovered_scoring_metrics.len() < context.committee.size() {
-            for (i, _) in context.committee.authorities() {
-                if !recovered_scoring_metrics
-                    .iter()
-                    .any(|(index, _)| *index == i)
-                {
-                    // We add a component with zeroed metrics for the authority with index i.
-                    // This will ensure that every authority has its metrics initialized.
-                    // They are initialized as zero because if an authority does not have any
-                    // recovered metrics, it means that it never misbehaved in a way that was
-                    // detected by the node.
-                    recovered_scoring_metrics.insert(
-                        i.value(),
-                        (
-                            i,
-                            VersionedStorageScoringMetrics::new_zeroed(&context.protocol_config),
-                        ),
-                    );
-                }
-            }
+        // At the beginning of the epoch (i.e., before the epoch's first eviction),
+        // there is nothing to be recovered from storage, so recovered_scoring_metrics
+        // will be empty. In this case, the initialization functions will simply
+        // initialize zeroed metrics for all authorities, so we can return here.
+        if recovered_scoring_metrics.is_empty() {
+            return;
         }
 
+        // If recovered_scoring_metrics is not empty, we initialize metrics according to
+        // them.
         match &context.protocol_config.scorer_version_as_option() {
             None | Some(1) => self.initialize_scoring_metrics_v1(
                 recovered_scoring_metrics,
@@ -291,7 +275,8 @@ impl MysticetiScoringMetricsStore {
     // Updates the authority's scoring metrics according to the recent changes in
     // the DAG state, i.e., recent evictions and additions to cache. It also
     // updates the current local metrics count used by Scorer. It returns metrics
-    // changes that should be updated in disk storage.
+    // changes that should be updated in disk storage. authority_index should be a
+    // valid AuthorityIndex, otherwise this function will panic.
     pub(crate) fn update_scoring_metrics_on_eviction(
         &self,
         authority_index: AuthorityIndex,
@@ -301,13 +286,14 @@ impl MysticetiScoringMetricsStore {
         last_eviction_round: u32,
         threshold_clock_round: u32,
         context: &Arc<Context>,
-    ) -> Option<VersionedStorageScoringMetrics> {
-        let committee_size = context.committee.size();
+    ) -> VersionedStorageScoringMetrics {
         let node_metrics = &context.metrics.node_metrics;
-        // threshold_clock_round should be always at least 1.  Analogously,
-        // authority_index should be a valid index.
-        if threshold_clock_round == 0 || authority_index.value() >= committee_size {
-            return None;
+        // threshold_clock_round should be always at least 1.
+        if threshold_clock_round == 0 {
+            return VersionedStorageScoringMetrics::new_from(
+                &self.uncached_metrics,
+                authority_index.value(),
+            );
         }
 
         // Get the blocks rounds that were not evicted.
@@ -334,9 +320,13 @@ impl MysticetiScoringMetricsStore {
             node_metrics,
         );
 
-        // If no eviction happened, we do not update the metrics on storage.
+        // If no eviction happened, we do not update the current local metrics counts
+        // and the metrics on storage.
         if eviction_round == last_eviction_round {
-            return None;
+            return VersionedStorageScoringMetrics::new_from(
+                &self.uncached_metrics,
+                authority_index.value(),
+            );
         }
 
         // Get the evicted blocks rounds.
@@ -346,7 +336,7 @@ impl MysticetiScoringMetricsStore {
             .filter(|&round| round <= eviction_round)
             .collect::<Vec<u32>>();
 
-        // Update metrics according to the blocks from evicted rounds.
+        // Calculate metrics according to the blocks from evicted rounds.
         let (evicted_equivocations, missing_blocks_in_evicted_rounds) =
             calculate_scoring_metrics_for_range(
                 evicted_block_rounds,
@@ -354,6 +344,7 @@ impl MysticetiScoringMetricsStore {
                 eviction_round,
             );
 
+        // Update metrics according to the blocks from evicted rounds.
         self.update_missing_blocks_and_equivocations(
             missing_blocks_in_evicted_rounds,
             evicted_equivocations,
@@ -363,13 +354,14 @@ impl MysticetiScoringMetricsStore {
             node_metrics,
         );
 
-        // Update current local metrics count.
+        // Update current local metrics count according to the uncached metrics at this
+        // point in time. Note that this will update the counts for the metrics
+        // calculated above, but also for the other uncached metrics that were changed
+        // since the last eviction (e.g., faulty blocks metrics updated on block
+        // receival).
         self.update_current_local_metrics_count(authority_index);
 
-        Some(VersionedStorageScoringMetrics::new_from(
-            &self.uncached_metrics,
-            authority_index.value(),
-        ))
+        VersionedStorageScoringMetrics::new_from(&self.uncached_metrics, authority_index.value())
     }
 
     // The `authority_index` should be a valid index, otherwise the function will
@@ -781,7 +773,7 @@ mod tests {
 
         // Unexpected because: threshold_clock_round = last_evicted_round means that a
         // round with blocks from less than 2f+1 stake was evicted.
-        // Return: None, because nothing is currently being evicted.
+        // Return: Zeroed metrics, because nothing is currently being evicted.
         let last_evicted_round = 5;
         let eviction_round = 5;
         let threshold_clock_round = 5;
@@ -794,10 +786,19 @@ mod tests {
             threshold_clock_round,
             &context,
         );
-        assert!(stored_metrics.is_none());
+
+        assert_eq!(
+            stored_metrics,
+            VersionedStorageScoringMetrics::new_v1_for_test(
+                0, // faulty_blocks_provable
+                0, // faulty_blocks_unprovable
+                0, // missing_proposals
+                0, // equivocations
+            )
+        );
 
         // Unexpected because: threshold_clock_round = 0 means that genesis is missing.
-        // Return: None, because nothing is currently being evicted.
+        // Return: Zeroed metrics, because nothing is currently being evicted.
         let last_evicted_round = 0;
         let eviction_round = 0;
         let threshold_clock_round = 0;
@@ -810,7 +811,16 @@ mod tests {
             threshold_clock_round,
             &context,
         );
-        assert!(stored_metrics.is_none());
+
+        assert_eq!(
+            stored_metrics,
+            VersionedStorageScoringMetrics::new_v1_for_test(
+                0, // faulty_blocks_provable
+                0, // faulty_blocks_unprovable
+                0, // missing_proposals
+                0, // equivocations
+            )
+        );
 
         // Unexpected because: threshold_clock_round < eviction_round means that a
         // round with blocks from less than 2f+1 stake in being evicted.
@@ -827,14 +837,15 @@ mod tests {
             threshold_clock_round,
             &context,
         );
+
         assert_eq!(
             stored_metrics,
-            Some(VersionedStorageScoringMetrics::new_v1_for_test(
+            VersionedStorageScoringMetrics::new_v1_for_test(
                 0, // faulty_blocks_provable
                 0, // faulty_blocks_unprovable
                 3, // missing_proposals
                 0, // equivocations
-            ))
+            )
         );
 
         // Unexpected because: eviction_round < last_evicted_round means that blocks
@@ -853,19 +864,21 @@ mod tests {
             threshold_clock_round,
             &context,
         );
+
         assert_eq!(
             stored_metrics,
-            Some(VersionedStorageScoringMetrics::new_v1_for_test(
+            VersionedStorageScoringMetrics::new_v1_for_test(
                 0, // faulty_blocks_provable
                 0, // faulty_blocks_unprovable
                 3, // missing_proposals
                 0, // equivocations
-            ))
+            )
         );
 
         // Unexpected because: threshold_clock_round < eviction_round <
-        // last_evicted_round and threshold_clock_round. Return: metrics won't
-        // be updated here, so it should return the same as in the last step.
+        // last_evicted_round and threshold_clock_round.
+        // Return: metrics won't be updated here, so it should return the same as in the
+        // last step.
         let last_evicted_round = 2;
         let eviction_round = 0;
         let threshold_clock_round = 1;
@@ -878,19 +891,21 @@ mod tests {
             threshold_clock_round,
             &context,
         );
+
         assert_eq!(
             stored_metrics,
-            Some(VersionedStorageScoringMetrics::new_v1_for_test(
+            VersionedStorageScoringMetrics::new_v1_for_test(
                 0, // faulty_blocks_provable
                 0, // faulty_blocks_unprovable
                 3, // missing_proposals
                 0, // equivocations
-            ))
+            )
         );
 
         // Unexpected because: threshold_clock_round < last_evicted_round means that a
         // round with blocks from less than 2f+1 stake was evicted.
-        // Return: None, because nothing is currently being evicted.
+        // Return: metrics won't be updated here, so it should return the same as in the
+        // last step.
         let last_evicted_round = 1;
         let eviction_round = 2;
         let threshold_clock_round = 0;
@@ -903,7 +918,16 @@ mod tests {
             threshold_clock_round,
             &context,
         );
-        assert!(stored_metrics.is_none());
+
+        assert_eq!(
+            stored_metrics,
+            VersionedStorageScoringMetrics::new_v1_for_test(
+                0, // faulty_blocks_provable
+                0, // faulty_blocks_unprovable
+                3, // missing_proposals
+                0, // equivocations
+            )
+        );
 
         let last_evicted_round = 2;
         let eviction_round = 1;
@@ -917,27 +941,16 @@ mod tests {
             threshold_clock_round,
             &context,
         );
-        assert!(stored_metrics.is_none());
 
-        // The function should not panic if the authority index is out of
-        // bounds.
-        // Unexpected because: threshold_clock_round = last_evicted_round means that a
-        // round with blocks from less than 2f+1 stake was evicted.
-        // Return: None, because nothing is currently being evicted.
-        let out_of_bounds_authority_index = AuthorityIndex::new_for_test(4);
-        let last_evicted_round = 1;
-        let eviction_round = 2;
-        let threshold_clock_round = 3;
-        let stored_metrics = scoring_metrics_store.update_scoring_metrics_on_eviction(
-            out_of_bounds_authority_index,
-            hostname,
-            &recent_refs_by_authority,
-            eviction_round,
-            last_evicted_round,
-            threshold_clock_round,
-            &context,
+        assert_eq!(
+            stored_metrics,
+            VersionedStorageScoringMetrics::new_v1_for_test(
+                0, // faulty_blocks_provable
+                0, // faulty_blocks_unprovable
+                3, // missing_proposals
+                0, // equivocations
+            )
         );
-        assert!(stored_metrics.is_none());
     }
 
     #[tokio::test]

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use consensus_config::AuthorityIndex;
-use iota_common::scoring_metrics::{VersionedScoringMetrics, VersionedStorageScoringMetrics};
+use iota_common::scoring_metrics::VersionedScoringMetrics;
 use iota_protocol_config::ProtocolConfig;
 use itertools::izip;
 
@@ -38,7 +38,7 @@ impl MysticetiScoringMetricsStore {
     // recovered_scoring_metrics and blocks_in_cache_by_authority.
     pub(crate) fn initialize_scoring_metrics(
         &self,
-        recovered_scoring_metrics: Option<VersionedStorageScoringMetrics>,
+        recovered_scoring_metrics: Option<VersionedScoringMetrics>,
         blocks_in_cache_by_authority: &Vec<BTreeSet<BlockRef>>,
         threshold_clock_round: u32,
         eviction_rounds: &Vec<u32>,
@@ -70,36 +70,41 @@ impl MysticetiScoringMetricsStore {
     // recovered_scoring_metrics and blocks_in_cache_by_authority.
     pub(crate) fn initialize_scoring_metrics_v1(
         &self,
-        recovered_scoring_metrics: VersionedStorageScoringMetrics,
+        recovered_scoring_metrics: VersionedScoringMetrics,
         blocks_in_cache_by_authority: &Vec<BTreeSet<BlockRef>>,
         threshold_clock_round: u32,
         eviction_rounds: &Vec<u32>,
         context: &Arc<Context>,
     ) {
-        let indices_and_hostnames = context
-            .committee
-            .authorities()
-            .map(|(i, x)| (i, x.hostname.as_str()))
-            .collect::<Vec<_>>();
-        let VersionedStorageScoringMetrics::V1(inner) = recovered_scoring_metrics;
-
-        for ((authority_index, hostname), blocks_in_cache, &eviction_round) in izip!(
-            indices_and_hostnames,
+        let (faulty_blocks_provable, faulty_blocks_unprovable, missing_proposals, equivocations) = (
+            recovered_scoring_metrics.faulty_blocks_provable(),
+            recovered_scoring_metrics.faulty_blocks_unprovable(),
+            recovered_scoring_metrics.missing_proposals(),
+            recovered_scoring_metrics.equivocations(),
+        );
+        for ((authority_index, authority), blocks_in_cache, &eviction_round, fbp, fbu, mp, eq) in izip!(
+            context.committee.authorities(),
             blocks_in_cache_by_authority,
-            eviction_rounds
+            eviction_rounds,
+            faulty_blocks_provable,
+            faulty_blocks_unprovable,
+            missing_proposals,
+            equivocations
         ) {
+            let hostname = authority.hostname.as_str();
+
             // Initialize the uncached scoring metrics according to
             // recovered_scoring_metrics
             self.initialize_faulty_blocks_metrics(
-                inner.faulty_blocks_provable()[authority_index.value() as usize],
-                inner.faulty_blocks_unprovable()[authority_index.value() as usize],
+                fbp.load(Ordering::Relaxed),
+                fbu.load(Ordering::Relaxed),
                 hostname,
                 authority_index,
                 &context.metrics.node_metrics,
             );
             self.update_missing_blocks_and_equivocations(
-                inner.missing_proposals()[authority_index.value() as usize],
-                inner.equivocations()[authority_index.value() as usize],
+                mp.load(Ordering::Relaxed),
+                eq.load(Ordering::Relaxed),
                 hostname,
                 authority_index,
                 StoreType::Uncached,

--- a/consensus/core/src/scoring_metrics_store.rs
+++ b/consensus/core/src/scoring_metrics_store.rs
@@ -48,15 +48,15 @@ impl MysticetiScoringMetricsStore {
         // there is nothing to be recovered from storage, so recovered_scoring_metrics
         // will be None. In this case, the initialization functions will simply
         // initialize zeroed metrics for all authorities, so we can return here.
-        if recovered_scoring_metrics.is_none() {
+        let Some(recovered_scoring_metrics) = recovered_scoring_metrics else {
             return;
-        }
+        };
 
         // If recovered_scoring_metrics is not empty, we initialize metrics according to
         // them.
         match &context.protocol_config.scorer_version_as_option() {
             None | Some(1) => self.initialize_scoring_metrics_v1(
-                recovered_scoring_metrics.unwrap(),
+                recovered_scoring_metrics,
                 blocks_in_cache_by_authority,
                 threshold_clock_round,
                 eviction_rounds,
@@ -76,35 +76,42 @@ impl MysticetiScoringMetricsStore {
         eviction_rounds: &Vec<u32>,
         context: &Arc<Context>,
     ) {
-        let (faulty_blocks_provable, faulty_blocks_unprovable, missing_proposals, equivocations) = (
-            recovered_scoring_metrics.faulty_blocks_provable(),
-            recovered_scoring_metrics.faulty_blocks_unprovable(),
-            recovered_scoring_metrics.missing_proposals(),
-            recovered_scoring_metrics.equivocations(),
-        );
-        for ((authority_index, authority), blocks_in_cache, &eviction_round, fbp, fbu, mp, eq) in izip!(
+        let faulty_blocks_provable = recovered_scoring_metrics.load_faulty_blocks_provable();
+        let faulty_blocks_unprovable = recovered_scoring_metrics.load_faulty_blocks_unprovable();
+        let missing_proposals = recovered_scoring_metrics.load_missing_proposals();
+        let equivocations = recovered_scoring_metrics.load_equivocations();
+
+        for (
+            (authority_index, authority),
+            blocks_in_cache,
+            &eviction_round,
+            &fbp,
+            &fbu,
+            &mp,
+            &eq,
+        ) in izip!(
             context.committee.authorities(),
             blocks_in_cache_by_authority,
             eviction_rounds,
-            faulty_blocks_provable,
-            faulty_blocks_unprovable,
-            missing_proposals,
-            equivocations
+            &faulty_blocks_provable,
+            &faulty_blocks_unprovable,
+            &missing_proposals,
+            &equivocations
         ) {
             let hostname = authority.hostname.as_str();
 
             // Initialize the uncached scoring metrics according to
             // recovered_scoring_metrics
             self.initialize_faulty_blocks_metrics(
-                fbp.load(Ordering::Relaxed),
-                fbu.load(Ordering::Relaxed),
+                fbp,
+                fbu,
                 hostname,
                 authority_index,
                 &context.metrics.node_metrics,
             );
             self.update_missing_blocks_and_equivocations(
-                mp.load(Ordering::Relaxed),
-                eq.load(Ordering::Relaxed),
+                mp,
+                eq,
                 hostname,
                 authority_index,
                 StoreType::Uncached,
@@ -173,13 +180,11 @@ impl MysticetiScoringMetricsStore {
         source: ErrorSource,
         node_metrics: &NodeMetrics,
     ) {
-        let (metric_type, source_str) = match source {
-            ErrorSource::CommitSyncer => (classify_commit_syncer_error_v1(&error), "fetch_once"),
-            ErrorSource::Subscriber => (classify_subscriber_error_v1(&error), "handle_send_block"),
-            ErrorSource::Synchronizer => (
-                classify_synchronizer_error_v1(&error),
-                "process_fetched_blocks",
-            ),
+        let source_str = source.as_str();
+        let metric_type = match source {
+            ErrorSource::CommitSyncer => classify_commit_syncer_error_v1(&error),
+            ErrorSource::Subscriber => classify_subscriber_error_v1(&error),
+            ErrorSource::Synchronizer => classify_synchronizer_error_v1(&error),
         };
         match metric_type {
             MetricType::Provable => {
@@ -278,9 +283,8 @@ impl MysticetiScoringMetricsStore {
 
     // Updates the authority's scoring metrics according to the recent changes in
     // the DAG state, i.e., recent evictions and additions to cache. It also
-    // updates the current local metrics count used by Scorer. It returns metrics
-    // changes that should be updated in disk storage. authority_index should be a
-    // valid AuthorityIndex, otherwise this function will panic.
+    // updates the current local metrics count used by Scorer. authority_index
+    // should be a valid AuthorityIndex, otherwise this function will panic.
     pub(crate) fn update_scoring_metrics_on_eviction(
         &self,
         authority_index: AuthorityIndex,
@@ -366,11 +370,11 @@ impl MysticetiScoringMetricsStore {
     pub(crate) fn update_current_local_metrics_count(&self, authority_index: AuthorityIndex) {
         let uncached_metrics = &self
             .uncached_metrics
-            .iterate_over_metrics()
+            .iter()
             .map(|metric_vec| metric_vec[authority_index].load(Ordering::Relaxed))
             .collect::<Vec<u64>>();
         self.current_local_metrics_count
-            .iterate_over_metrics()
+            .iter()
             .zip(uncached_metrics)
             .for_each(|(local_metric_vec, uncached_metric)| {
                 local_metric_vec[authority_index].store(*uncached_metric, Ordering::Relaxed);
@@ -511,6 +515,16 @@ pub(crate) enum ErrorSource {
     Synchronizer,
 }
 
+impl ErrorSource {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            ErrorSource::CommitSyncer => "fetch_once",
+            ErrorSource::Subscriber => "handle_send_block",
+            ErrorSource::Synchronizer => "process_fetched_blocks",
+        }
+    }
+}
+
 #[cfg(test)]
 impl MysticetiScoringMetricsStore {
     // Creates a dummy scoring metrics store for testing purposes (i.e., without any
@@ -631,74 +645,90 @@ mod tests {
         }
     }
 
-    fn get_uncached_missing_proposals(context: &Arc<Context>) -> Vec<u64> {
-        let mut metrics = Vec::new();
-        for authority in context.committee.authorities() {
-            let hostname = authority.1.hostname.as_str();
-            metrics.push(
-                context
-                    .metrics
-                    .node_metrics
-                    .uncached_missing_proposals_by_authority
-                    .get_metric_with_label_values(&[hostname])
+    fn read_counter_metric(context: &Arc<Context>, metric: &prometheus::IntCounterVec) -> Vec<u64> {
+        context
+            .committee
+            .authorities()
+            .map(|(_, authority)| {
+                metric
+                    .get_metric_with_label_values(&[authority.hostname.as_str()])
                     .unwrap()
-                    .get(),
-            )
-        }
-        metrics
+                    .get()
+            })
+            .collect()
+    }
+
+    fn read_gauge_metric(context: &Arc<Context>, metric: &prometheus::IntGaugeVec) -> Vec<u64> {
+        context
+            .committee
+            .authorities()
+            .map(|(_, authority)| {
+                metric
+                    .get_metric_with_label_values(&[authority.hostname.as_str()])
+                    .unwrap()
+                    .get()
+                    .unsigned_abs()
+            })
+            .collect()
+    }
+
+    fn read_faulty_blocks_metric(
+        context: &Arc<Context>,
+        metric: &prometheus::IntCounterVec,
+        source: &ErrorSource,
+        error: &str,
+    ) -> Vec<u64> {
+        let source_str = source.as_str();
+        context
+            .committee
+            .authorities()
+            .map(|(_, authority)| {
+                metric
+                    .get_metric_with_label_values(&[authority.hostname.as_str(), source_str, error])
+                    .unwrap()
+                    .get()
+            })
+            .collect()
+    }
+
+    fn get_uncached_missing_proposals(context: &Arc<Context>) -> Vec<u64> {
+        read_counter_metric(
+            context,
+            &context
+                .metrics
+                .node_metrics
+                .uncached_missing_proposals_by_authority,
+        )
     }
 
     fn get_missing_proposals_in_cache(context: &Arc<Context>) -> Vec<u64> {
-        let mut metrics = Vec::new();
-        for authority in context.committee.authorities() {
-            let hostname = authority.1.hostname.as_str();
-            metrics.push(
-                context
-                    .metrics
-                    .node_metrics
-                    .missing_proposals_in_cache_by_authority
-                    .get_metric_with_label_values(&[hostname])
-                    .unwrap()
-                    .get()
-                    .unsigned_abs(),
-            )
-        }
-        metrics
+        read_gauge_metric(
+            context,
+            &context
+                .metrics
+                .node_metrics
+                .missing_proposals_in_cache_by_authority,
+        )
     }
 
     fn get_uncached_equivocations(context: &Arc<Context>) -> Vec<u64> {
-        let mut metrics = Vec::new();
-        for authority in context.committee.authorities() {
-            let hostname = authority.1.hostname.as_str();
-            metrics.push(
-                context
-                    .metrics
-                    .node_metrics
-                    .uncached_equivocations_by_authority
-                    .get_metric_with_label_values(&[hostname])
-                    .unwrap()
-                    .get(),
-            )
-        }
-        metrics
+        read_counter_metric(
+            context,
+            &context
+                .metrics
+                .node_metrics
+                .uncached_equivocations_by_authority,
+        )
     }
 
     fn get_equivocations_in_cache(context: &Arc<Context>) -> Vec<u64> {
-        let mut metrics = Vec::new();
-        for authority in context.committee.authorities() {
-            let hostname = authority.1.hostname.as_str();
-            metrics.push(
-                context
-                    .metrics
-                    .node_metrics
-                    .equivocations_in_cache_by_authority
-                    .get_metric_with_label_values(&[hostname])
-                    .unwrap()
-                    .get()
-                    .unsigned_abs(),
-            )
-        }
-        metrics
+        read_gauge_metric(
+            context,
+            &context
+                .metrics
+                .node_metrics
+                .equivocations_in_cache_by_authority,
+        )
     }
 
     fn is_all_zeroes(metrics: &[u64]) -> bool {
@@ -710,25 +740,15 @@ mod tests {
         source: &ErrorSource,
         error: &str,
     ) -> Vec<u64> {
-        let source_str = match source {
-            ErrorSource::CommitSyncer => "fetch_once",
-            ErrorSource::Subscriber => "handle_send_block",
-            ErrorSource::Synchronizer => "process_fetched_blocks",
-        };
-        let mut metrics = Vec::new();
-        for authority in context.committee.authorities() {
-            let hostname = authority.1.hostname.as_str();
-            metrics.push(
-                context
-                    .metrics
-                    .node_metrics
-                    .faulty_blocks_provable_by_authority
-                    .get_metric_with_label_values(&[hostname, source_str, error])
-                    .unwrap()
-                    .get(),
-            )
-        }
-        metrics
+        read_faulty_blocks_metric(
+            context,
+            &context
+                .metrics
+                .node_metrics
+                .faulty_blocks_provable_by_authority,
+            source,
+            error,
+        )
     }
 
     fn get_faulty_blocks_unprovable(
@@ -736,25 +756,15 @@ mod tests {
         source: &ErrorSource,
         error: &str,
     ) -> Vec<u64> {
-        let source_str = match source {
-            ErrorSource::CommitSyncer => "fetch_once",
-            ErrorSource::Subscriber => "handle_send_block",
-            ErrorSource::Synchronizer => "process_fetched_blocks",
-        };
-        let mut metrics = Vec::new();
-        for authority in context.committee.authorities() {
-            let hostname = authority.1.hostname.as_str();
-            metrics.push(
-                context
-                    .metrics
-                    .node_metrics
-                    .faulty_blocks_unprovable_by_authority
-                    .get_metric_with_label_values(&[hostname, source_str, error])
-                    .unwrap()
-                    .get(),
-            )
-        }
-        metrics
+        read_faulty_blocks_metric(
+            context,
+            &context
+                .metrics
+                .node_metrics
+                .faulty_blocks_unprovable_by_authority,
+            source,
+            error,
+        )
     }
 
     #[tokio::test]
@@ -1590,7 +1600,6 @@ mod tests {
 
         // Clear and check all metrics
         scoring_metrics.uncached_metrics.reset();
-        scoring_metrics.cached_metrics.reset();
         scoring_metrics.cached_metrics.reset();
         node_metrics
             .uncached_missing_proposals_by_authority

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -19,9 +19,8 @@ use crate::{
         TrustedCommit,
     },
     error::ConsensusResult,
+    storage::rocksdb_store::SCORING_METRICS_V2_KEY,
 };
-
-const SCORING_METRICS_V2_KEY: u32 = 0;
 
 /// In-memory storage for testing.
 pub(crate) struct MemStore {

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -31,7 +31,7 @@ struct Inner {
     commits: BTreeMap<(CommitIndex, CommitDigest), TrustedCommit>,
     commit_votes: BTreeSet<(CommitIndex, CommitDigest, BlockRef)>,
     commit_info: BTreeMap<(CommitIndex, CommitDigest), CommitInfo>,
-    scoring_metrics: BTreeMap<AuthorityIndex, VersionedStorageScoringMetrics>,
+    scoring_metrics: BTreeMap<u32, VersionedStorageScoringMetrics>,
 }
 
 impl MemStore {
@@ -83,9 +83,10 @@ impl Store for MemStore {
                 .insert((commit_ref.index, commit_ref.digest), commit_info);
         }
 
-        for (authority, metrics) in write_batch.scoring_metrics {
-            inner.scoring_metrics.insert(authority, metrics);
+        if let Some(metrics) = write_batch.scoring_metrics {
+            inner.scoring_metrics.insert(0u32, metrics);
         }
+
         Ok(())
     }
 
@@ -132,16 +133,9 @@ impl Store for MemStore {
         Ok(blocks)
     }
 
-    fn scan_scoring_metrics(
-        &self,
-    ) -> ConsensusResult<Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>> {
+    fn scan_scoring_metrics(&self) -> ConsensusResult<Option<VersionedStorageScoringMetrics>> {
         let inner = self.inner.read();
-        let metrics_by_author = inner
-            .scoring_metrics
-            .iter()
-            .map(|(&authority_index, metrics)| (authority_index, metrics.clone()))
-            .collect::<Vec<_>>();
-        Ok(metrics_by_author)
+        Ok(inner.scoring_metrics.get(&0u32).cloned())
     }
 
     fn contains_block_at_slot(&self, slot: Slot) -> ConsensusResult<bool> {

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -19,7 +19,6 @@ use crate::{
         TrustedCommit,
     },
     error::ConsensusResult,
-    storage::rocksdb_store::SCORING_METRICS_V2_KEY,
 };
 
 /// In-memory storage for testing.
@@ -33,7 +32,7 @@ struct Inner {
     commits: BTreeMap<(CommitIndex, CommitDigest), TrustedCommit>,
     commit_votes: BTreeSet<(CommitIndex, CommitDigest, BlockRef)>,
     commit_info: BTreeMap<(CommitIndex, CommitDigest), CommitInfo>,
-    scoring_metrics: BTreeMap<u32, VersionedScoringMetrics>,
+    scoring_metrics: BTreeMap<(), VersionedScoringMetrics>,
 }
 
 impl MemStore {
@@ -86,9 +85,7 @@ impl Store for MemStore {
         }
 
         if let Some(metrics) = write_batch.scoring_metrics {
-            inner
-                .scoring_metrics
-                .insert(SCORING_METRICS_V2_KEY, metrics);
+            inner.scoring_metrics.insert((), metrics);
         }
 
         Ok(())
@@ -142,10 +139,7 @@ impl Store for MemStore {
         _committee: &Committee,
     ) -> ConsensusResult<Option<VersionedScoringMetrics>> {
         let inner = self.inner.read();
-        Ok(inner
-            .scoring_metrics
-            .get(&SCORING_METRICS_V2_KEY)
-            .map(|m| m.snapshot()))
+        Ok(inner.scoring_metrics.get(&()).map(|m| m.snapshot()))
     }
 
     fn contains_block_at_slot(&self, slot: Slot) -> ConsensusResult<bool> {

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -20,6 +20,9 @@ use crate::{
     },
     error::ConsensusResult,
 };
+
+const SCORING_METRICS_V2_KEY: u32 = 0;
+
 /// In-memory storage for testing.
 pub(crate) struct MemStore {
     inner: RwLock<Inner>,
@@ -84,7 +87,9 @@ impl Store for MemStore {
         }
 
         if let Some(metrics) = write_batch.scoring_metrics {
-            inner.scoring_metrics.insert(0u32, metrics);
+            inner
+                .scoring_metrics
+                .insert(SCORING_METRICS_V2_KEY, metrics);
         }
 
         Ok(())
@@ -138,7 +143,10 @@ impl Store for MemStore {
         _committee: &Committee,
     ) -> ConsensusResult<Option<VersionedScoringMetrics>> {
         let inner = self.inner.read();
-        Ok(inner.scoring_metrics.get(&0u32).map(|m| m.snapshot()))
+        Ok(inner
+            .scoring_metrics
+            .get(&SCORING_METRICS_V2_KEY)
+            .map(|m| m.snapshot()))
     }
 
     fn contains_block_at_slot(&self, slot: Slot) -> ConsensusResult<bool> {

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -32,7 +32,7 @@ struct Inner {
     commits: BTreeMap<(CommitIndex, CommitDigest), TrustedCommit>,
     commit_votes: BTreeSet<(CommitIndex, CommitDigest, BlockRef)>,
     commit_info: BTreeMap<(CommitIndex, CommitDigest), CommitInfo>,
-    scoring_metrics: BTreeMap<(), VersionedScoringMetrics>,
+    scoring_metrics: Option<VersionedScoringMetrics>,
 }
 
 impl MemStore {
@@ -44,7 +44,7 @@ impl MemStore {
                 commits: BTreeMap::new(),
                 commit_votes: BTreeSet::new(),
                 commit_info: BTreeMap::new(),
-                scoring_metrics: BTreeMap::new(),
+                scoring_metrics: None,
             }),
         }
     }
@@ -85,7 +85,7 @@ impl Store for MemStore {
         }
 
         if let Some(metrics) = write_batch.scoring_metrics {
-            inner.scoring_metrics.insert((), metrics);
+            inner.scoring_metrics = Some(metrics);
         }
 
         Ok(())
@@ -138,8 +138,10 @@ impl Store for MemStore {
         &self,
         _committee: &Committee,
     ) -> ConsensusResult<Option<VersionedScoringMetrics>> {
-        let inner = self.inner.read();
-        Ok(inner.scoring_metrics.get(&()).map(|m| m.snapshot()))
+        match &self.inner.read().scoring_metrics {
+            Some(metrics) => Ok(Some(metrics.snapshot())),
+            None => Ok(None),
+        }
     }
 
     fn contains_block_at_slot(&self, slot: Slot) -> ConsensusResult<bool> {

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -7,8 +7,8 @@ use std::{
     ops::Bound::Included,
 };
 
-use consensus_config::AuthorityIndex;
-use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
+use consensus_config::{AuthorityIndex, Committee};
+use iota_common::scoring_metrics::VersionedScoringMetrics;
 use parking_lot::RwLock;
 
 use super::{Store, WriteBatch};
@@ -31,7 +31,7 @@ struct Inner {
     commits: BTreeMap<(CommitIndex, CommitDigest), TrustedCommit>,
     commit_votes: BTreeSet<(CommitIndex, CommitDigest, BlockRef)>,
     commit_info: BTreeMap<(CommitIndex, CommitDigest), CommitInfo>,
-    scoring_metrics: BTreeMap<u32, VersionedStorageScoringMetrics>,
+    scoring_metrics: BTreeMap<u32, VersionedScoringMetrics>,
 }
 
 impl MemStore {
@@ -133,9 +133,12 @@ impl Store for MemStore {
         Ok(blocks)
     }
 
-    fn scan_scoring_metrics(&self) -> ConsensusResult<Option<VersionedStorageScoringMetrics>> {
+    fn scan_scoring_metrics(
+        &self,
+        _committee: &Committee,
+    ) -> ConsensusResult<Option<VersionedScoringMetrics>> {
         let inner = self.inner.read();
-        Ok(inner.scoring_metrics.get(&0u32).cloned())
+        Ok(inner.scoring_metrics.get(&0u32).map(|m| m.snapshot()))
     }
 
     fn contains_block_at_slot(&self, slot: Slot) -> ConsensusResult<bool> {

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -9,8 +9,8 @@ pub(crate) mod rocksdb_store;
 #[cfg(test)]
 mod store_tests;
 
-use consensus_config::AuthorityIndex;
-use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
+use consensus_config::{AuthorityIndex, Committee};
+use iota_common::scoring_metrics::VersionedScoringMetrics;
 
 use crate::{
     CommitIndex,
@@ -43,7 +43,10 @@ pub(crate) trait Store: Send + Sync {
 
     /// Reads and returns all metrics stored. Used for restoring the scoring
     /// metrics in case of DagState initialization from storage
-    fn scan_scoring_metrics(&self) -> ConsensusResult<Option<VersionedStorageScoringMetrics>>;
+    fn scan_scoring_metrics(
+        &self,
+        committee: &Committee,
+    ) -> ConsensusResult<Option<VersionedScoringMetrics>>;
 
     /// Returns the last `num_of_rounds` rounds blocks by author in round
     /// ascending order. When a `before_round` is defined then the blocks of
@@ -76,7 +79,7 @@ pub(crate) struct WriteBatch {
     pub(crate) blocks: Vec<VerifiedBlock>,
     pub(crate) commits: Vec<TrustedCommit>,
     pub(crate) commit_info: Vec<(CommitRef, CommitInfo)>,
-    pub(crate) scoring_metrics: Option<VersionedStorageScoringMetrics>,
+    pub(crate) scoring_metrics: Option<VersionedScoringMetrics>,
 }
 
 impl WriteBatch {
@@ -84,13 +87,13 @@ impl WriteBatch {
         blocks: Vec<VerifiedBlock>,
         commits: Vec<TrustedCommit>,
         commit_info: Vec<(CommitRef, CommitInfo)>,
-        scoring_metrics: Option<VersionedStorageScoringMetrics>,
+        scoring_metrics: VersionedScoringMetrics,
     ) -> Self {
         WriteBatch {
             blocks,
             commits,
             commit_info,
-            scoring_metrics,
+            scoring_metrics: Some(scoring_metrics),
         }
     }
 
@@ -115,10 +118,7 @@ impl WriteBatch {
     }
 
     #[cfg(test)]
-    pub(crate) fn scoring_metrics(
-        mut self,
-        scoring_metrics: VersionedStorageScoringMetrics,
-    ) -> Self {
+    pub(crate) fn scoring_metrics(mut self, scoring_metrics: VersionedScoringMetrics) -> Self {
         self.scoring_metrics = Some(scoring_metrics);
         self
     }
@@ -132,4 +132,15 @@ pub(crate) struct StorageScoringMetrics {
     pub(crate) faulty_blocks_unprovable: u64,
     pub(crate) equivocations: u64,
     pub(crate) missing_proposals: u64,
+}
+
+impl StorageScoringMetrics {
+    fn new_zeroed() -> Self {
+        StorageScoringMetrics {
+            faulty_blocks_provable: 0,
+            faulty_blocks_unprovable: 0,
+            equivocations: 0,
+            missing_proposals: 0,
+        }
+    }
 }

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -43,9 +43,7 @@ pub(crate) trait Store: Send + Sync {
 
     /// Reads and returns all metrics stored. Used for restoring the scoring
     /// metrics in case of DagState initialization from storage
-    fn scan_scoring_metrics(
-        &self,
-    ) -> ConsensusResult<Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>>;
+    fn scan_scoring_metrics(&self) -> ConsensusResult<Option<VersionedStorageScoringMetrics>>;
 
     /// Returns the last `num_of_rounds` rounds blocks by author in round
     /// ascending order. When a `before_round` is defined then the blocks of
@@ -78,7 +76,7 @@ pub(crate) struct WriteBatch {
     pub(crate) blocks: Vec<VerifiedBlock>,
     pub(crate) commits: Vec<TrustedCommit>,
     pub(crate) commit_info: Vec<(CommitRef, CommitInfo)>,
-    pub(crate) scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
+    pub(crate) scoring_metrics: Option<VersionedStorageScoringMetrics>,
 }
 
 impl WriteBatch {
@@ -86,7 +84,7 @@ impl WriteBatch {
         blocks: Vec<VerifiedBlock>,
         commits: Vec<TrustedCommit>,
         commit_info: Vec<(CommitRef, CommitInfo)>,
-        scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
+        scoring_metrics: Option<VersionedStorageScoringMetrics>,
     ) -> Self {
         WriteBatch {
             blocks,
@@ -119,17 +117,15 @@ impl WriteBatch {
     #[cfg(test)]
     pub(crate) fn scoring_metrics(
         mut self,
-        scoring_metrics: Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>,
+        scoring_metrics: VersionedStorageScoringMetrics,
     ) -> Self {
-        self.scoring_metrics = scoring_metrics;
+        self.scoring_metrics = Some(scoring_metrics);
         self
     }
 }
 
-// This struct is used in storage. It holds the same data as
-// `UncachedScoringMetrics`, but uses `u64` instead of `AtomicU64`.
-// NOTE: This type is deprecated and should be removed once the metrics are
-// migrated to VersionedStorageScoringMetrics type.
+// Legacy storage type for scoring metrics. Kept only for migration from
+// the old per-authority format to the new single-blob VersionedScoringMetrics.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub(crate) struct StorageScoringMetrics {
     pub(crate) faulty_blocks_provable: u64,

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -133,14 +133,3 @@ pub(crate) struct StorageScoringMetrics {
     pub(crate) equivocations: u64,
     pub(crate) missing_proposals: u64,
 }
-
-impl StorageScoringMetrics {
-    fn new_zeroed() -> Self {
-        StorageScoringMetrics {
-            faulty_blocks_provable: 0,
-            faulty_blocks_unprovable: 0,
-            equivocations: 0,
-            missing_proposals: 0,
-        }
-    }
-}

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -23,8 +23,6 @@ use crate::{
     storage::StorageScoringMetrics,
 };
 
-pub(crate) const SCORING_METRICS_V2_KEY: u32 = 0;
-
 /// Persistent storage with RocksDB.
 pub(crate) struct RocksDBStore {
     /// Stores SignedBlock by refs.
@@ -40,9 +38,10 @@ pub(crate) struct RocksDBStore {
     commit_info: DBMap<(CommitIndex, CommitDigest), CommitInfo>,
     /// Legacy scoring metrics (read-only).
     /// TODO: remove this field after migration is done.
+    #[deprecated]
     scoring_metrics: DBMap<AuthorityIndex, StorageScoringMetrics>,
     /// Stores versioned scoring metrics as a single blob under key 0.
-    scoring_metrics_v2: DBMap<u32, VersionedScoringMetrics>,
+    scoring_metrics_v2: DBMap<(), VersionedScoringMetrics>,
 }
 
 impl RocksDBStore {
@@ -101,7 +100,7 @@ impl RocksDBStore {
             Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
             Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>,
             Self::SCORING_METRICS_CF;<AuthorityIndex, StorageScoringMetrics>,
-            Self::SCORING_METRICS_V2_CF;<u32, VersionedScoringMetrics>
+            Self::SCORING_METRICS_V2_CF;<(), VersionedScoringMetrics>
         );
 
         Self {
@@ -110,6 +109,7 @@ impl RocksDBStore {
             commits,
             commit_votes,
             commit_info,
+            #[allow(deprecated)]
             scoring_metrics,
             scoring_metrics_v2,
         }
@@ -167,10 +167,7 @@ impl Store for RocksDBStore {
         }
         if let Some(metrics) = &write_batch.scoring_metrics {
             batch
-                .insert_batch(
-                    &self.scoring_metrics_v2,
-                    [(&SCORING_METRICS_V2_KEY, metrics)],
-                )
+                .insert_batch(&self.scoring_metrics_v2, [(&(), metrics)])
                 .map_err(ConsensusError::RocksDBFailure)?;
         }
 
@@ -255,12 +252,13 @@ impl Store for RocksDBStore {
         committee: &Committee,
     ) -> ConsensusResult<Option<VersionedScoringMetrics>> {
         // Try to read the single blob from the v2 CF first.
-        if let Some(metrics) = self.scoring_metrics_v2.get(&SCORING_METRICS_V2_KEY)? {
+        if let Some(metrics) = self.scoring_metrics_v2.get(&())? {
             return Ok(Some(metrics));
         }
 
         // Fall back to v1 (per-authority) CF.
         let mut legacy_entries = vec![];
+        #[allow(deprecated)]
         for kv in self.scoring_metrics.safe_iter() {
             legacy_entries.push(kv?);
         }
@@ -437,6 +435,7 @@ impl RocksDBStore {
         &self,
         entries: Vec<(AuthorityIndex, [u64; 4])>,
     ) -> ConsensusResult<()> {
+        #[allow(deprecated)]
         let mut batch = self.scoring_metrics.batch();
         for (authority, [fbp, fbu, missing, equiv]) in entries {
             let legacy = StorageScoringMetrics {
@@ -445,6 +444,7 @@ impl RocksDBStore {
                 missing_proposals: missing,
                 equivocations: equiv,
             };
+            #[allow(deprecated)]
             batch
                 .insert_batch(&self.scoring_metrics, [(authority, legacy)])
                 .map_err(ConsensusError::RocksDBFailure)?;

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -23,6 +23,8 @@ use crate::{
     storage::StorageScoringMetrics,
 };
 
+const SCORING_METRICS_V2_KEY: u32 = 0;
+
 /// Persistent storage with RocksDB.
 pub(crate) struct RocksDBStore {
     /// Stores SignedBlock by refs.
@@ -164,7 +166,10 @@ impl Store for RocksDBStore {
         }
         if let Some(metrics) = &write_batch.scoring_metrics {
             batch
-                .insert_batch(&self.scoring_metrics_v2, [(&0u32, metrics)])
+                .insert_batch(
+                    &self.scoring_metrics_v2,
+                    [(&SCORING_METRICS_V2_KEY, metrics)],
+                )
                 .map_err(ConsensusError::RocksDBFailure)?;
         }
 
@@ -249,7 +254,7 @@ impl Store for RocksDBStore {
         committee: &Committee,
     ) -> ConsensusResult<Option<VersionedScoringMetrics>> {
         // Try to read the single blob from the v2 CF first.
-        if let Some(metrics) = self.scoring_metrics_v2.get(&0u32)? {
+        if let Some(metrics) = self.scoring_metrics_v2.get(&SCORING_METRICS_V2_KEY)? {
             return Ok(Some(metrics));
         }
 

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -370,26 +370,10 @@ impl Store for RocksDBStore {
 // TODO: delete this function after the migration is done and the legacy
 // `StorageScoringMetrics` field is removed.
 fn migrate_stored_metrics(
-    mut legacy_entries: Vec<(AuthorityIndex, StorageScoringMetrics)>,
+    legacy_entries: Vec<(AuthorityIndex, StorageScoringMetrics)>,
     committee: &Committee,
 ) -> VersionedScoringMetrics {
-    // The legacy data does not always contain entries for all authorities. This can
-    // happen in case no misbehaviors were observed for some authorities, so no
-    // entry was written for them. Thus, we add zeroed entries for missing
-    // authorities to reconstruct the full vectors.
     let committee_size = committee.size();
-    if legacy_entries.len() < committee_size {
-        for (i, _) in committee.authorities() {
-            if !legacy_entries.iter().any(|(index, _)| *index == i) {
-                // We add a component with zeroed metrics for the authority with index i.
-                // This will ensure that every authority has an entry here.
-                // They are initialized as zero because if an authority does not have any
-                // recovered metrics, it means that it never misbehaved in a way that was
-                // detected by the node.
-                legacy_entries.insert(i.value(), (i, StorageScoringMetrics::new_zeroed()));
-            }
-        }
-    }
 
     // Reconstruct vectors from per-authority entries.
     let mut faulty_blocks_provable = vec![0u64; committee_size];

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -5,10 +5,8 @@
 use std::{ops::Bound::Included, time::Duration};
 
 use bytes::Bytes;
-use consensus_config::AuthorityIndex;
-use iota_common::{
-    misbehavior_counts::MisbehaviorsV1, scoring_metrics::VersionedStorageScoringMetrics,
-};
+use consensus_config::{AuthorityIndex, Committee};
+use iota_common::{misbehavior_counts::MisbehaviorsV1, scoring_metrics::VersionedScoringMetrics};
 use iota_macros::fail_point;
 use typed_store::{
     Map as _,
@@ -41,7 +39,7 @@ pub(crate) struct RocksDBStore {
     /// Legacy scoring metrics (read-only).
     scoring_metrics: DBMap<AuthorityIndex, StorageScoringMetrics>,
     /// Stores versioned scoring metrics as a single blob under key 0.
-    scoring_metrics_v2: DBMap<u32, VersionedStorageScoringMetrics>,
+    scoring_metrics_v2: DBMap<u32, VersionedScoringMetrics>,
 }
 
 impl RocksDBStore {
@@ -100,7 +98,7 @@ impl RocksDBStore {
             Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
             Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>,
             Self::SCORING_METRICS_CF;<AuthorityIndex, StorageScoringMetrics>,
-            Self::SCORING_METRICS_V2_CF;<u32, VersionedStorageScoringMetrics>
+            Self::SCORING_METRICS_V2_CF;<u32, VersionedScoringMetrics>
         );
 
         Self {
@@ -242,18 +240,20 @@ impl Store for RocksDBStore {
         Ok(blocks)
     }
 
-    // Reads scoring metrics from the v2 CF (single blob under key 0). If not
-    // found, falls back to the legacy per-authority `StorageScoringMetrics` CF,
-    // reconstructs a single `VersionedScoringMetrics` blob, and writes it to the
-    // v2 CF for future reads. The legacy migration logic should be deleted after
-    // `StorageScoringMetrics` is removed.
-    fn scan_scoring_metrics(&self) -> ConsensusResult<Option<VersionedStorageScoringMetrics>> {
+    // Reads scoring metrics from the v2 CF (single blob under key 0). If not found,
+    // falls back to the legacy per-authority `StorageScoringMetrics` CF, and
+    // reconstructs a single `VersionedScoringMetrics` blob. The legacy migration
+    // logic should be deleted after `StorageScoringMetrics` is removed.
+    fn scan_scoring_metrics(
+        &self,
+        committee: &Committee,
+    ) -> ConsensusResult<Option<VersionedScoringMetrics>> {
         // Try to read the single blob from the v2 CF first.
         if let Some(metrics) = self.scoring_metrics_v2.get(&0u32)? {
             return Ok(Some(metrics));
         }
 
-        // Fall back to legacy per-authority CF.
+        // Fall back to v1 (per-authority) CF.
         let mut legacy_entries = vec![];
         for kv in self.scoring_metrics.safe_iter() {
             legacy_entries.push(kv?);
@@ -263,48 +263,12 @@ impl Store for RocksDBStore {
             return Ok(None);
         }
 
-        // Determine the committee size from the max authority index.
-        let committee_size = legacy_entries
-            .iter()
-            .map(|(idx, _)| idx.value() + 1)
-            .max()
-            .unwrap_or(0);
+        // If v1 (per-authority) CF is not empty, return the data migrated to v2 format.
+        // Note that we do not write the migrated data to the v2 CF here, since the data
+        // will be added to the v2 CF after the first write.
+        let scoring_metrics_v2 = migrate_stored_metrics_v1_to_v2(legacy_entries, committee);
 
-        // Reconstruct vectors from per-authority entries.
-        let mut faulty_blocks_provable = vec![0u64; committee_size];
-        let mut faulty_blocks_unprovable = vec![0u64; committee_size];
-        let mut missing_proposals = vec![0u64; committee_size];
-        let mut equivocations = vec![0u64; committee_size];
-
-        for (authority, old) in &legacy_entries {
-            let idx = authority.value();
-            faulty_blocks_provable[idx] = old.faulty_blocks_provable;
-            faulty_blocks_unprovable[idx] = old.faulty_blocks_unprovable;
-            // Note: legacy StorageScoringMetrics has equivocations before
-            // missing_proposals, but MisbehaviorsV1 has missing_proposals before
-            // equivocations.
-            missing_proposals[idx] = old.missing_proposals;
-            equivocations[idx] = old.equivocations;
-        }
-
-        let blob = VersionedStorageScoringMetrics::V1(MisbehaviorsV1::new(
-            faulty_blocks_provable,
-            faulty_blocks_unprovable,
-            missing_proposals,
-            equivocations,
-        ));
-
-        tracing::info!(
-            "Migrating {} legacy scoring metrics entries to single-blob format",
-            legacy_entries.len()
-        );
-        let mut batch = self.scoring_metrics_v2.batch();
-        batch
-            .insert_batch(&self.scoring_metrics_v2, [(0u32, blob.clone())])
-            .map_err(ConsensusError::RocksDBFailure)?;
-        batch.write()?;
-
-        Ok(Some(blob))
+        Ok(Some(scoring_metrics_v2))
     }
 
     // The method returns the last `num_of_rounds` rounds blocks by author in round
@@ -399,6 +363,60 @@ impl Store for RocksDBStore {
     }
 }
 
+fn migrate_stored_metrics_v1_to_v2(
+    mut legacy_entries: Vec<(AuthorityIndex, StorageScoringMetrics)>,
+    committee: &Committee,
+) -> VersionedScoringMetrics {
+    // The legacy data does not always contain entries for all authorities. This can
+    // happen in case no misbehaviors were observed for some authorities, so no
+    // entry was written for them. Thus, we add zeroed entries for missing
+    // authorities to reconstruct the full vectors.
+    let committee_size = committee.size();
+    if legacy_entries.len() < committee_size {
+        for (i, _) in committee.authorities() {
+            if !legacy_entries.iter().any(|(index, _)| *index == i) {
+                // We add a component with zeroed metrics for the authority with index i.
+                // This will ensure that every authority has an entry here.
+                // They are initialized as zero because if an authority does not have any
+                // recovered metrics, it means that it never misbehaved in a way that was
+                // detected by the node.
+                legacy_entries.insert(i.value(), (i, StorageScoringMetrics::new_zeroed()));
+            }
+        }
+    }
+
+    // Reconstruct vectors from per-authority entries.
+    let mut faulty_blocks_provable = vec![0u64; committee_size];
+    let mut faulty_blocks_unprovable = vec![0u64; committee_size];
+    let mut missing_proposals = vec![0u64; committee_size];
+    let mut equivocations = vec![0u64; committee_size];
+
+    for (authority_index, old) in &legacy_entries {
+        let idx = authority_index.value();
+        faulty_blocks_provable[idx] = old.faulty_blocks_provable;
+        faulty_blocks_unprovable[idx] = old.faulty_blocks_unprovable;
+        missing_proposals[idx] = old.missing_proposals;
+        equivocations[idx] = old.equivocations;
+    }
+
+    let blob = VersionedScoringMetrics::V1(
+        MisbehaviorsV1::new(
+            faulty_blocks_provable,
+            faulty_blocks_unprovable,
+            missing_proposals,
+            equivocations,
+        )
+        .as_atomic(),
+    );
+
+    tracing::info!(
+        "Migrating {} legacy scoring metrics entries to single-blob format",
+        legacy_entries.len()
+    );
+
+    blob
+}
+
 // The following method is only used for testing and simulates the existence of
 // legacy-format scoring metrics in the old `StorageScoringMetrics` field. It
 // should be removed after the migration is done and the legacy field is
@@ -412,12 +430,12 @@ impl RocksDBStore {
         entries: Vec<(AuthorityIndex, [u64; 4])>,
     ) -> ConsensusResult<()> {
         let mut batch = self.scoring_metrics.batch();
-        for (authority, [fbp, fbu, equiv, missing]) in entries {
+        for (authority, [fbp, fbu, missing, equiv]) in entries {
             let legacy = StorageScoringMetrics {
                 faulty_blocks_provable: fbp,
                 faulty_blocks_unprovable: fbu,
-                equivocations: equiv,
                 missing_proposals: missing,
+                equivocations: equiv,
             };
             batch
                 .insert_batch(&self.scoring_metrics, [(authority, legacy)])
@@ -428,90 +446,95 @@ impl RocksDBStore {
     }
 }
 
-/// Verifies that legacy `StorageScoringMetrics` written to store are correctly
-/// read, converted, and ported to the new single-blob `VersionedScoringMetrics`
-/// by `scan_scoring_metrics()`.
+/// Tests all scan_scoring_metrics scenarios: empty store, legacy-only,
+/// legacy updates, v2-only, v2 updates, and v2 taking priority over legacy.
 #[tokio::test]
 async fn scan_scoring_metrics_legacy_migration() {
+    use consensus_config::{AuthorityIndex, Stake, local_committee_and_keys};
     use tempfile::TempDir;
 
     let temp_dir = TempDir::new().unwrap();
     let store = RocksDBStore::new(temp_dir.path().to_str().unwrap());
+    let epoch = 100;
+    let authority_stakes = (1..=2).map(|s| s as Stake).collect();
+    let (committee, _) = local_committee_and_keys(epoch, authority_stakes);
 
-    // Write legacy-format data: [faulty_blocks_provable, faulty_blocks_unprovable,
-    // equivocations, missing_proposals] — note the old struct has equivocations
-    // before missing_proposals.
+    // Case 1: Empty store — no legacy, no v2. Should return None.
+    let result = store.scan_scoring_metrics(&committee).unwrap();
+    assert!(result.is_none());
+
+    // Case 2: Only legacy data — falls back to legacy CF and returns migrated data.
+    // Array order: [faulty_blocks_provable, faulty_blocks_unprovable,
+    // missing_proposals, equivocations].
     store
         .write_legacy_scoring_metrics(vec![
-            (AuthorityIndex::new_for_test(0), [10, 20, 40, 30]),
+            (AuthorityIndex::new_for_test(0), [10, 20, 30, 40]),
             (AuthorityIndex::new_for_test(1), [0, 0, 0, 0]),
         ])
         .unwrap();
 
-    // First scan: new CF is empty, falls back to legacy and ports data.
-    if let Some(VersionedStorageScoringMetrics::V1(scanned)) = store
-        .scan_scoring_metrics()
-        .expect("scan_scoring_metrics should not fail")
-    {
-        assert_eq!(*scanned.faulty_blocks_provable(), vec![10, 0]);
-        assert_eq!(*scanned.faulty_blocks_unprovable(), vec![20, 0]);
-        assert_eq!(*scanned.missing_proposals(), vec![30, 0]);
-        assert_eq!(*scanned.equivocations(), vec![40, 0]);
-    } else {
-        panic!("scan_scoring_metrics should return Some after migration");
-    }
+    let scanned = store.scan_scoring_metrics(&committee).unwrap().unwrap();
+    assert_eq!(scanned.load_faulty_blocks_provable(), vec![10, 0]);
+    assert_eq!(scanned.load_faulty_blocks_unprovable(), vec![20, 0]);
+    assert_eq!(scanned.load_missing_proposals(), vec![30, 0]);
+    assert_eq!(scanned.load_equivocations(), vec![40, 0]);
 
-    // Update legacy-format data: [faulty_blocks_provable, faulty_blocks_unprovable,
-    // equivocations, missing_proposals].
+    // Case 3: Legacy data updated — scan does not cache to v2, so the updated
+    // legacy values are returned.
     store
         .write_legacy_scoring_metrics(vec![
-            (AuthorityIndex::new_for_test(0), [40, 50, 60, 70]),
+            (AuthorityIndex::new_for_test(0), [50, 60, 70, 80]),
             (AuthorityIndex::new_for_test(1), [0, 0, 0, 0]),
         ])
         .unwrap();
 
-    // Second scan: data was ported to the new CF by the first scan, so this
-    // reads from the new CF directly (the legacy fallback path is not taken
-    // because the new CF is no longer empty). The legacy updates should not affect
-    // the scanned data, which should be the same as after the first scan.
-    if let Some(VersionedStorageScoringMetrics::V1(scanned)) = store
-        .scan_scoring_metrics()
-        .expect("scan_scoring_metrics should not fail")
-    {
-        assert_eq!(*scanned.faulty_blocks_provable(), vec![10, 0]);
-        assert_eq!(*scanned.faulty_blocks_unprovable(), vec![20, 0]);
-        assert_eq!(*scanned.missing_proposals(), vec![30, 0]);
-        assert_eq!(*scanned.equivocations(), vec![40, 0]);
-    } else {
-        panic!("scan_scoring_metrics should return Some after migration");
-    }
+    let scanned = store.scan_scoring_metrics(&committee).unwrap().unwrap();
+    assert_eq!(scanned.load_faulty_blocks_provable(), vec![50, 0]);
+    assert_eq!(scanned.load_faulty_blocks_unprovable(), vec![60, 0]);
+    assert_eq!(scanned.load_missing_proposals(), vec![70, 0]);
+    assert_eq!(scanned.load_equivocations(), vec![80, 0]);
 
-    // Directly read from the legacy field to verify that the data there is indeed
-    // updated, but it did not affect the scan results.
-    let mut scanned_from_legacy = vec![];
-    for kv in store.scoring_metrics.safe_iter() {
-        scanned_from_legacy.push(kv.unwrap());
-    }
+    // Case 4: Write v2 data via WriteBatch. V2 should now take priority over
+    // legacy.
+    let v2_blob = VersionedScoringMetrics::V1(
+        MisbehaviorsV1::new(vec![1, 2], vec![3, 4], vec![5, 6], vec![7, 8]).as_atomic(),
+    );
+    store
+        .write(WriteBatch::default().scoring_metrics(v2_blob.snapshot()))
+        .unwrap();
 
-    let expected_from_legacy = vec![
-        (
-            AuthorityIndex::new_for_test(0),
-            StorageScoringMetrics {
-                faulty_blocks_provable: 40,
-                faulty_blocks_unprovable: 50,
-                equivocations: 60,
-                missing_proposals: 70,
-            },
-        ),
-        (
-            AuthorityIndex::new_for_test(1),
-            StorageScoringMetrics {
-                faulty_blocks_provable: 0,
-                faulty_blocks_unprovable: 0,
-                equivocations: 0,
-                missing_proposals: 0,
-            },
-        ),
-    ];
-    assert_eq!(scanned_from_legacy, expected_from_legacy);
+    let scanned = store.scan_scoring_metrics(&committee).unwrap().unwrap();
+    assert_eq!(scanned.load_faulty_blocks_provable(), vec![1, 2]);
+    assert_eq!(scanned.load_faulty_blocks_unprovable(), vec![3, 4]);
+    assert_eq!(scanned.load_missing_proposals(), vec![5, 6]);
+    assert_eq!(scanned.load_equivocations(), vec![7, 8]);
+
+    // Case 5: Update legacy while v2 exists — v2 still takes priority,
+    // legacy changes are ignored.
+    store
+        .write_legacy_scoring_metrics(vec![
+            (AuthorityIndex::new_for_test(0), [99, 99, 99, 99]),
+            (AuthorityIndex::new_for_test(1), [99, 99, 99, 99]),
+        ])
+        .unwrap();
+
+    let scanned = store.scan_scoring_metrics(&committee).unwrap().unwrap();
+    assert_eq!(scanned.load_faulty_blocks_provable(), vec![1, 2]);
+    assert_eq!(scanned.load_faulty_blocks_unprovable(), vec![3, 4]);
+    assert_eq!(scanned.load_missing_proposals(), vec![5, 6]);
+    assert_eq!(scanned.load_equivocations(), vec![7, 8]);
+
+    // Case 6: Update v2 data — scan returns the updated v2 values.
+    let v2_updated = VersionedScoringMetrics::V1(
+        MisbehaviorsV1::new(vec![11, 22], vec![33, 44], vec![55, 66], vec![77, 88]).as_atomic(),
+    );
+    store
+        .write(WriteBatch::default().scoring_metrics(v2_updated.snapshot()))
+        .unwrap();
+
+    let scanned = store.scan_scoring_metrics(&committee).unwrap().unwrap();
+    assert_eq!(scanned.load_faulty_blocks_provable(), vec![11, 22]);
+    assert_eq!(scanned.load_faulty_blocks_unprovable(), vec![33, 44]);
+    assert_eq!(scanned.load_missing_proposals(), vec![55, 66]);
+    assert_eq!(scanned.load_equivocations(), vec![77, 88]);
 }

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -40,7 +40,7 @@ pub(crate) struct RocksDBStore {
     /// TODO: remove this field after migration is done.
     #[deprecated]
     scoring_metrics: DBMap<AuthorityIndex, StorageScoringMetrics>,
-    /// Stores versioned scoring metrics as a single blob under key 0.
+    /// Stores versioned scoring metrics as a single blob under key `()`.
     scoring_metrics_v2: DBMap<(), VersionedScoringMetrics>,
 }
 
@@ -243,10 +243,11 @@ impl Store for RocksDBStore {
         Ok(blocks)
     }
 
-    // Reads scoring metrics from the v2 CF (single blob under key 0). If not found,
-    // falls back to the legacy per-authority `StorageScoringMetrics` CF, and
-    // reconstructs a single `VersionedScoringMetrics` blob. The legacy migration
-    // logic should be deleted after `StorageScoringMetrics` is removed.
+    // Reads scoring metrics from the v2 CF (single blob under key `()`). If not
+    // found, falls back to the legacy per-authority `StorageScoringMetrics` CF,
+    // and reconstructs a single `VersionedScoringMetrics` blob. The legacy
+    // migration logic should be deleted after `StorageScoringMetrics` is
+    // removed.
     fn scan_scoring_metrics(
         &self,
         committee: &Committee,

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -40,8 +40,8 @@ pub(crate) struct RocksDBStore {
     commit_info: DBMap<(CommitIndex, CommitDigest), CommitInfo>,
     /// Legacy scoring metrics (read-only).
     scoring_metrics: DBMap<AuthorityIndex, StorageScoringMetrics>,
-    /// Stores versioned scoring metrics for each authority.
-    scoring_metrics_v2: DBMap<AuthorityIndex, VersionedStorageScoringMetrics>,
+    /// Stores versioned scoring metrics as a single blob under key 0.
+    scoring_metrics_v2: DBMap<u32, VersionedStorageScoringMetrics>,
 }
 
 impl RocksDBStore {
@@ -100,7 +100,7 @@ impl RocksDBStore {
             Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
             Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>,
             Self::SCORING_METRICS_CF;<AuthorityIndex, StorageScoringMetrics>,
-            Self::SCORING_METRICS_V2_CF;<AuthorityIndex, VersionedStorageScoringMetrics>
+            Self::SCORING_METRICS_V2_CF;<u32, VersionedStorageScoringMetrics>
         );
 
         Self {
@@ -164,11 +164,12 @@ impl Store for RocksDBStore {
                 )
                 .map_err(ConsensusError::RocksDBFailure)?;
         }
-        for (authority, metrics) in write_batch.scoring_metrics {
+        if let Some(metrics) = &write_batch.scoring_metrics {
             batch
-                .insert_batch(&self.scoring_metrics_v2, [(authority, metrics)])
+                .insert_batch(&self.scoring_metrics_v2, [(&0u32, metrics)])
                 .map_err(ConsensusError::RocksDBFailure)?;
         }
+
         batch.write()?;
         fail_point!("consensus-store-after-write");
         Ok(())
@@ -241,52 +242,69 @@ impl Store for RocksDBStore {
         Ok(blocks)
     }
 
-    // This method is currently not only a scan, but it also performs migration from
-    // the legacy `StorageScoringMetrics` type to the new
-    // `VersionedStorageScoringMetrics`. This migration logic should be deleted
-    // after `StorageScoringMetrics` is removed. The writes in this method are
-    // only triggered once (for a one-time migration).
-    fn scan_scoring_metrics(
-        &self,
-    ) -> ConsensusResult<Vec<(AuthorityIndex, VersionedStorageScoringMetrics)>> {
-        // Check the new scoring metrics field first. If it is not empty, it means the
-        // migration has been done and we can ignore the legacy field entirely. If
-        // the new scoring metrics field is empty, then we read from the legacy field,
-        // convert the data to the new format, and write them to the new field for
-        // future reads.
-        let mut metrics_by_author = vec![];
-        for kv in self.scoring_metrics_v2.safe_iter() {
-            metrics_by_author.push(kv?);
+    // Reads scoring metrics from the v2 CF (single blob under key 0). If not
+    // found, falls back to the legacy per-authority `StorageScoringMetrics` CF,
+    // reconstructs a single `VersionedScoringMetrics` blob, and writes it to the
+    // v2 CF for future reads. The legacy migration logic should be deleted after
+    // `StorageScoringMetrics` is removed.
+    fn scan_scoring_metrics(&self) -> ConsensusResult<Option<VersionedStorageScoringMetrics>> {
+        // Try to read the single blob from the v2 CF first.
+        if let Some(metrics) = self.scoring_metrics_v2.get(&0u32)? {
+            return Ok(Some(metrics));
         }
 
-        if metrics_by_author.is_empty() {
-            for kv in self.scoring_metrics.safe_iter() {
-                let (authority, old) = kv?;
-                let converted = VersionedStorageScoringMetrics::V1(MisbehaviorsV1::new(
-                    old.faulty_blocks_provable,
-                    old.faulty_blocks_unprovable,
-                    old.missing_proposals,
-                    old.equivocations,
-                ));
-                metrics_by_author.push((authority, converted));
-            }
-
-            if !metrics_by_author.is_empty() {
-                tracing::info!(
-                    "Migrating {} legacy scoring metrics entries to new type",
-                    metrics_by_author.len()
-                );
-                let mut batch = self.scoring_metrics_v2.batch();
-                for (authority, metrics) in &metrics_by_author {
-                    batch
-                        .insert_batch(&self.scoring_metrics_v2, [(*authority, metrics.clone())])
-                        .map_err(ConsensusError::RocksDBFailure)?;
-                }
-                batch.write()?;
-            }
+        // Fall back to legacy per-authority CF.
+        let mut legacy_entries = vec![];
+        for kv in self.scoring_metrics.safe_iter() {
+            legacy_entries.push(kv?);
         }
 
-        Ok(metrics_by_author)
+        if legacy_entries.is_empty() {
+            return Ok(None);
+        }
+
+        // Determine the committee size from the max authority index.
+        let committee_size = legacy_entries
+            .iter()
+            .map(|(idx, _)| idx.value() + 1)
+            .max()
+            .unwrap_or(0);
+
+        // Reconstruct vectors from per-authority entries.
+        let mut faulty_blocks_provable = vec![0u64; committee_size];
+        let mut faulty_blocks_unprovable = vec![0u64; committee_size];
+        let mut missing_proposals = vec![0u64; committee_size];
+        let mut equivocations = vec![0u64; committee_size];
+
+        for (authority, old) in &legacy_entries {
+            let idx = authority.value();
+            faulty_blocks_provable[idx] = old.faulty_blocks_provable;
+            faulty_blocks_unprovable[idx] = old.faulty_blocks_unprovable;
+            // Note: legacy StorageScoringMetrics has equivocations before
+            // missing_proposals, but MisbehaviorsV1 has missing_proposals before
+            // equivocations.
+            missing_proposals[idx] = old.missing_proposals;
+            equivocations[idx] = old.equivocations;
+        }
+
+        let blob = VersionedStorageScoringMetrics::V1(MisbehaviorsV1::new(
+            faulty_blocks_provable,
+            faulty_blocks_unprovable,
+            missing_proposals,
+            equivocations,
+        ));
+
+        tracing::info!(
+            "Migrating {} legacy scoring metrics entries to single-blob format",
+            legacy_entries.len()
+        );
+        let mut batch = self.scoring_metrics_v2.batch();
+        batch
+            .insert_batch(&self.scoring_metrics_v2, [(0u32, blob.clone())])
+            .map_err(ConsensusError::RocksDBFailure)?;
+        batch.write()?;
+
+        Ok(Some(blob))
     }
 
     // The method returns the last `num_of_rounds` rounds blocks by author in round
@@ -411,8 +429,8 @@ impl RocksDBStore {
 }
 
 /// Verifies that legacy `StorageScoringMetrics` written to store are correctly
-/// read, converted, and ported to the new `VersionedStorageScoringMetrics`
-/// field by `scan_scoring_metrics()`.
+/// read, converted, and ported to the new single-blob `VersionedScoringMetrics`
+/// by `scan_scoring_metrics()`.
 #[tokio::test]
 async fn scan_scoring_metrics_legacy_migration() {
     use tempfile::TempDir;
@@ -420,44 +438,35 @@ async fn scan_scoring_metrics_legacy_migration() {
     let temp_dir = TempDir::new().unwrap();
     let store = RocksDBStore::new(temp_dir.path().to_str().unwrap());
 
-    let authorities = [
-        AuthorityIndex::new_for_test(0),
-        AuthorityIndex::new_for_test(1),
-    ];
-
     // Write legacy-format data: [faulty_blocks_provable, faulty_blocks_unprovable,
     // equivocations, missing_proposals] — note the old struct has equivocations
     // before missing_proposals.
     store
         .write_legacy_scoring_metrics(vec![
-            (authorities[0], [10, 20, 40, 30]),
-            (authorities[1], [0, 0, 0, 0]),
+            (AuthorityIndex::new_for_test(0), [10, 20, 40, 30]),
+            (AuthorityIndex::new_for_test(1), [0, 0, 0, 0]),
         ])
         .unwrap();
 
-    let expected = vec![
-        (
-            authorities[0],
-            VersionedStorageScoringMetrics::V1(MisbehaviorsV1::new(10, 20, 30, 40)),
-        ),
-        (
-            authorities[1],
-            VersionedStorageScoringMetrics::V1(MisbehaviorsV1::new(0, 0, 0, 0)),
-        ),
-    ];
-
     // First scan: new CF is empty, falls back to legacy and ports data.
-    let scanned = store
+    if let Some(VersionedStorageScoringMetrics::V1(scanned)) = store
         .scan_scoring_metrics()
-        .expect("scan_scoring_metrics should not fail");
-    assert_eq!(scanned, expected);
+        .expect("scan_scoring_metrics should not fail")
+    {
+        assert_eq!(*scanned.faulty_blocks_provable(), vec![10, 0]);
+        assert_eq!(*scanned.faulty_blocks_unprovable(), vec![20, 0]);
+        assert_eq!(*scanned.missing_proposals(), vec![30, 0]);
+        assert_eq!(*scanned.equivocations(), vec![40, 0]);
+    } else {
+        panic!("scan_scoring_metrics should return Some after migration");
+    }
 
     // Update legacy-format data: [faulty_blocks_provable, faulty_blocks_unprovable,
     // equivocations, missing_proposals].
     store
         .write_legacy_scoring_metrics(vec![
-            (authorities[0], [40, 50, 60, 70]),
-            (authorities[1], [0, 0, 0, 0]),
+            (AuthorityIndex::new_for_test(0), [40, 50, 60, 70]),
+            (AuthorityIndex::new_for_test(1), [0, 0, 0, 0]),
         ])
         .unwrap();
 
@@ -465,10 +474,17 @@ async fn scan_scoring_metrics_legacy_migration() {
     // reads from the new CF directly (the legacy fallback path is not taken
     // because the new CF is no longer empty). The legacy updates should not affect
     // the scanned data, which should be the same as after the first scan.
-    let scanned = store
+    if let Some(VersionedStorageScoringMetrics::V1(scanned)) = store
         .scan_scoring_metrics()
-        .expect("scan_scoring_metrics should not fail");
-    assert_eq!(scanned, expected);
+        .expect("scan_scoring_metrics should not fail")
+    {
+        assert_eq!(*scanned.faulty_blocks_provable(), vec![10, 0]);
+        assert_eq!(*scanned.faulty_blocks_unprovable(), vec![20, 0]);
+        assert_eq!(*scanned.missing_proposals(), vec![30, 0]);
+        assert_eq!(*scanned.equivocations(), vec![40, 0]);
+    } else {
+        panic!("scan_scoring_metrics should return Some after migration");
+    }
 
     // Directly read from the legacy field to verify that the data there is indeed
     // updated, but it did not affect the scan results.
@@ -479,7 +495,7 @@ async fn scan_scoring_metrics_legacy_migration() {
 
     let expected_from_legacy = vec![
         (
-            authorities[0],
+            AuthorityIndex::new_for_test(0),
             StorageScoringMetrics {
                 faulty_blocks_provable: 40,
                 faulty_blocks_unprovable: 50,
@@ -488,7 +504,7 @@ async fn scan_scoring_metrics_legacy_migration() {
             },
         ),
         (
-            authorities[1],
+            AuthorityIndex::new_for_test(1),
             StorageScoringMetrics {
                 faulty_blocks_provable: 0,
                 faulty_blocks_unprovable: 0,

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -23,7 +23,7 @@ use crate::{
     storage::StorageScoringMetrics,
 };
 
-const SCORING_METRICS_V2_KEY: u32 = 0;
+pub(crate) const SCORING_METRICS_V2_KEY: u32 = 0;
 
 /// Persistent storage with RocksDB.
 pub(crate) struct RocksDBStore {
@@ -39,6 +39,7 @@ pub(crate) struct RocksDBStore {
     /// Stores info related to Commit that helps recovery.
     commit_info: DBMap<(CommitIndex, CommitDigest), CommitInfo>,
     /// Legacy scoring metrics (read-only).
+    /// TODO: remove this field after migration is done.
     scoring_metrics: DBMap<AuthorityIndex, StorageScoringMetrics>,
     /// Stores versioned scoring metrics as a single blob under key 0.
     scoring_metrics_v2: DBMap<u32, VersionedScoringMetrics>,
@@ -271,7 +272,7 @@ impl Store for RocksDBStore {
         // If v1 (per-authority) CF is not empty, return the data migrated to v2 format.
         // Note that we do not write the migrated data to the v2 CF here, since the data
         // will be added to the v2 CF after the first write.
-        let scoring_metrics_v2 = migrate_stored_metrics_v1_to_v2(legacy_entries, committee);
+        let scoring_metrics_v2 = migrate_stored_metrics(legacy_entries, committee);
 
         Ok(Some(scoring_metrics_v2))
     }
@@ -368,7 +369,9 @@ impl Store for RocksDBStore {
     }
 }
 
-fn migrate_stored_metrics_v1_to_v2(
+// TODO: delete this function after the migration is done and the legacy
+// `StorageScoringMetrics` field is removed.
+fn migrate_stored_metrics(
     mut legacy_entries: Vec<(AuthorityIndex, StorageScoringMetrics)>,
     committee: &Committee,
 ) -> VersionedScoringMetrics {

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use consensus_config::AuthorityIndex;
-use iota_common::{
-    misbehavior_counts::MisbehaviorsV1, scoring_metrics::VersionedStorageScoringMetrics,
-};
+use iota_common::{misbehavior_counts::MisbehaviorsV1, scoring_metrics::VersionedScoringMetrics};
 use rstest::rstest;
 use tempfile::TempDir;
 
@@ -307,53 +305,46 @@ async fn read_and_scan_commits(
 async fn scan_scoring_metrics(
     #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
+    use consensus_config::{Stake, local_committee_and_keys};
+
+    let epoch = 100;
+    let authority_stakes = (1..=3).map(|s| s as Stake).collect();
+    let (committee, _) = local_committee_and_keys(epoch, authority_stakes);
     let store = test_store.store();
 
     // Create a VersionedScoringMetrics blob with 3 authorities.
-    let blob = VersionedStorageScoringMetrics::V1(MisbehaviorsV1::new(
-        vec![1, 0, 0],
-        vec![2, 0, 0],
-        vec![3, 0, 0],
-        vec![4, 0, 0],
-    ));
+    let blob = VersionedScoringMetrics::V1(
+        MisbehaviorsV1::new(vec![1, 0, 0], vec![2, 0, 0], vec![3, 0, 0], vec![4, 0, 0]).as_atomic(),
+    );
 
     store
-        .write(WriteBatch::default().scoring_metrics(blob))
+        .write(WriteBatch::default().scoring_metrics(blob.snapshot()))
         .unwrap();
 
     {
-        if let Some(VersionedStorageScoringMetrics::V1(scanned)) = store
-            .scan_scoring_metrics()
-            .expect("Scan scoring_metrics should not fail here")
-        {
-            assert_eq!(*scanned.faulty_blocks_provable(), vec![1, 0, 0]);
-            assert_eq!(*scanned.faulty_blocks_unprovable(), vec![2, 0, 0]);
-            assert_eq!(*scanned.missing_proposals(), vec![3, 0, 0]);
-            assert_eq!(*scanned.equivocations(), vec![4, 0, 0]);
-        };
+        if let Ok(Some(scanned)) = store.scan_scoring_metrics(&committee) {
+            assert_eq!(scanned.load_faulty_blocks_provable(), vec![1, 0, 0]);
+            assert_eq!(scanned.load_faulty_blocks_unprovable(), vec![2, 0, 0]);
+            assert_eq!(scanned.load_missing_proposals(), vec![3, 0, 0]);
+            assert_eq!(scanned.load_equivocations(), vec![4, 0, 0]);
+        }
     }
 
     // Overwrite with zeroed blob.
-    let zeroed_blob = VersionedStorageScoringMetrics::V1(MisbehaviorsV1::new(
-        vec![0, 0, 0],
-        vec![0, 0, 0],
-        vec![0, 0, 0],
-        vec![0, 0, 0],
-    ));
+    let zeroed_blob = VersionedScoringMetrics::V1(
+        MisbehaviorsV1::new(vec![0, 0, 0], vec![0, 0, 0], vec![0, 0, 0], vec![0, 0, 0]).as_atomic(),
+    );
 
     store
-        .write(WriteBatch::default().scoring_metrics(zeroed_blob))
+        .write(WriteBatch::default().scoring_metrics(zeroed_blob.snapshot()))
         .unwrap();
 
     {
-        if let Some(VersionedStorageScoringMetrics::V1(scanned)) = store
-            .scan_scoring_metrics()
-            .expect("Scan scoring_metrics should not fail here")
-        {
-            assert_eq!(*scanned.faulty_blocks_provable(), vec![0, 0, 0]);
-            assert_eq!(*scanned.faulty_blocks_unprovable(), vec![0, 0, 0]);
-            assert_eq!(*scanned.missing_proposals(), vec![0, 0, 0]);
-            assert_eq!(*scanned.equivocations(), vec![0, 0, 0]);
-        };
+        if let Ok(Some(scanned)) = store.scan_scoring_metrics(&committee) {
+            assert_eq!(scanned.load_faulty_blocks_provable(), vec![0, 0, 0]);
+            assert_eq!(scanned.load_faulty_blocks_unprovable(), vec![0, 0, 0]);
+            assert_eq!(scanned.load_missing_proposals(), vec![0, 0, 0]);
+            assert_eq!(scanned.load_equivocations(), vec![0, 0, 0]);
+        }
     }
 }

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use consensus_config::AuthorityIndex;
-use iota_common::scoring_metrics::VersionedStorageScoringMetrics;
+use iota_common::{
+    misbehavior_counts::MisbehaviorsV1, scoring_metrics::VersionedStorageScoringMetrics,
+};
 use rstest::rstest;
 use tempfile::TempDir;
 
@@ -306,58 +308,52 @@ async fn scan_scoring_metrics(
     #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
     let store = test_store.store();
-    let metrics_updates = [
-        VersionedStorageScoringMetrics::new_v1_for_test(
-            1, // faulty_blocks_provable
-            2, // faulty_blocks_unprovable
-            3, // missing_proposals
-            4, // equivocations
-        ),
-        VersionedStorageScoringMetrics::new_v1_for_test(
-            0, // faulty_blocks_provable
-            0, // faulty_blocks_unprovable
-            0, // missing_proposals
-            0, // equivocations
-        ),
-    ];
-    let authories = [
-        AuthorityIndex::new_for_test(0),
-        AuthorityIndex::new_for_test(1),
-        AuthorityIndex::new_for_test(2),
-    ];
 
-    let metrics_to_write = vec![
-        (authories[0], metrics_updates[0].clone()),
-        (authories[1], metrics_updates[1].clone()),
-    ];
+    // Create a VersionedScoringMetrics blob with 3 authorities.
+    let blob = VersionedStorageScoringMetrics::V1(MisbehaviorsV1::new(
+        vec![1, 0, 0],
+        vec![2, 0, 0],
+        vec![3, 0, 0],
+        vec![4, 0, 0],
+    ));
 
     store
-        .write(WriteBatch::default().scoring_metrics(metrics_to_write.clone()))
+        .write(WriteBatch::default().scoring_metrics(blob))
         .unwrap();
 
     {
-        let scanned_metrics = store
+        if let Some(VersionedStorageScoringMetrics::V1(scanned)) = store
             .scan_scoring_metrics()
-            .expect("Scan scoring_metrics should not fail");
-        assert_eq!(&scanned_metrics, &metrics_to_write);
+            .expect("Scan scoring_metrics should not fail here")
+        {
+            assert_eq!(*scanned.faulty_blocks_provable(), vec![1, 0, 0]);
+            assert_eq!(*scanned.faulty_blocks_unprovable(), vec![2, 0, 0]);
+            assert_eq!(*scanned.missing_proposals(), vec![3, 0, 0]);
+            assert_eq!(*scanned.equivocations(), vec![4, 0, 0]);
+        };
     }
 
-    let metrics_to_write = vec![(authories[0], metrics_updates[1].clone())];
+    // Overwrite with zeroed blob.
+    let zeroed_blob = VersionedStorageScoringMetrics::V1(MisbehaviorsV1::new(
+        vec![0, 0, 0],
+        vec![0, 0, 0],
+        vec![0, 0, 0],
+        vec![0, 0, 0],
+    ));
 
     store
-        .write(WriteBatch::default().scoring_metrics(metrics_to_write.clone()))
+        .write(WriteBatch::default().scoring_metrics(zeroed_blob))
         .unwrap();
 
     {
-        let scanned_metrics = store
+        if let Some(VersionedStorageScoringMetrics::V1(scanned)) = store
             .scan_scoring_metrics()
-            .expect("Scan scoring_metrics should not fail");
-        assert_eq!(
-            &scanned_metrics,
-            &vec![
-                (authories[0], metrics_updates[1].clone()),
-                (authories[1], metrics_updates[1].clone())
-            ]
-        );
+            .expect("Scan scoring_metrics should not fail here")
+        {
+            assert_eq!(*scanned.faulty_blocks_provable(), vec![0, 0, 0]);
+            assert_eq!(*scanned.faulty_blocks_unprovable(), vec![0, 0, 0]);
+            assert_eq!(*scanned.missing_proposals(), vec![0, 0, 0]);
+            assert_eq!(*scanned.equivocations(), vec![0, 0, 0]);
+        };
     }
 }

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -227,7 +227,7 @@ fn calculate_median_report(
     // process.
     assert!(!reports_and_voting_power.is_empty());
 
-    let number_of_metrics = reports_and_voting_power[0].0.iterate_over_metrics().len();
+    let number_of_metrics = reports_and_voting_power[0].0.iter().len();
 
     // In the case of the example in the method documentation,
     // reports_and_voting_power_per_metric should be
@@ -238,7 +238,7 @@ fn calculate_median_report(
     let mut reports_and_voting_power_per_metric: Vec<Vec<(MetricVec, VotingPower)>> =
         vec![vec![]; number_of_metrics];
     for (versioned_report, voting_power) in reports_and_voting_power.iter() {
-        for (i, metric) in versioned_report.iterate_over_metrics().enumerate() {
+        for (i, metric) in versioned_report.iter().enumerate() {
             reports_and_voting_power_per_metric[i].push((metric.clone(), *voting_power));
         }
     }

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -315,7 +315,7 @@ impl VersionedMisbehaviorReport {
     }
 
     /// Returns an iterator over references to the fields in the report.
-    pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&Vec<u64>> {
+    pub fn iter(&self) -> std::vec::IntoIter<&Vec<u64>> {
         match self {
             VersionedMisbehaviorReport::V1(report, _) => report.iter(),
         }

--- a/crates/iota-types/src/misbehavior_counts.rs
+++ b/crates/iota-types/src/misbehavior_counts.rs
@@ -100,19 +100,13 @@ impl<T> FromIterator<T> for MisbehaviorsV1<T> {
     }
 }
 
-impl MisbehaviorsV1<u64> {
-    pub fn new_zeroed() -> Self {
-        Self::new(0, 0, 0, 0)
-    }
-}
-
 impl MisbehaviorsV1<Vec<u64>> {
     pub fn new_zeroed(committee_size: usize) -> Self {
         Self::new(
-            (0..committee_size).map(|_| 0).collect(),
-            (0..committee_size).map(|_| 0).collect(),
-            (0..committee_size).map(|_| 0).collect(),
-            (0..committee_size).map(|_| 0).collect(),
+            vec![0; committee_size],
+            vec![0; committee_size],
+            vec![0; committee_size],
+            vec![0; committee_size],
         )
     }
 
@@ -130,12 +124,6 @@ impl MisbehaviorsV1<Vec<u64>> {
                     .collect::<Vec<AtomicU64>>()
             })
             .collect::<MisbehaviorsV1<Vec<AtomicU64>>>()
-    }
-
-    pub fn misbehaviors_from_authority(&self, authority: usize) -> MisbehaviorsV1<u64> {
-        self.iter()
-            .map(|metric| metric[authority])
-            .collect::<MisbehaviorsV1<u64>>()
     }
 }
 
@@ -158,12 +146,6 @@ impl MisbehaviorsV1<Vec<AtomicU64>> {
                     .collect::<Vec<u64>>()
             })
             .collect::<MisbehaviorsV1<Vec<u64>>>()
-    }
-
-    pub fn misbehaviors_from_authority(&self, authority: usize) -> MisbehaviorsV1<u64> {
-        self.iter()
-            .map(|metric| metric[authority].load(std::sync::atomic::Ordering::Relaxed))
-            .collect::<MisbehaviorsV1<u64>>()
     }
 }
 

--- a/crates/iota-types/src/misbehavior_counts.rs
+++ b/crates/iota-types/src/misbehavior_counts.rs
@@ -16,7 +16,6 @@ use serde::{Deserialize, Serialize};
 // - `T = Vec<u64>` for reports (one value per authority)
 // - `T = Vec<AtomicU64>` for atomic metrics collected and stored locally (one
 //   atomic per authority)
-// - `T = Vec<u64>` for storage (one value per authority)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MisbehaviorsV1<T> {
     faulty_blocks_provable: T,

--- a/crates/iota-types/src/misbehavior_counts.rs
+++ b/crates/iota-types/src/misbehavior_counts.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 // - `T = Vec<u64>` for reports (one value per authority)
 // - `T = Vec<AtomicU64>` for atomic metrics collected and stored locally (one
 //   atomic per authority)
-// - `T = u64` for per-authority persistent storage
+// - `T = Vec<u64>` for storage (one value per authority)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MisbehaviorsV1<T> {
     faulty_blocks_provable: T,
@@ -108,6 +108,15 @@ impl MisbehaviorsV1<u64> {
 }
 
 impl MisbehaviorsV1<Vec<u64>> {
+    pub fn new_zeroed(committee_size: usize) -> Self {
+        Self::new(
+            (0..committee_size).map(|_| 0).collect(),
+            (0..committee_size).map(|_| 0).collect(),
+            (0..committee_size).map(|_| 0).collect(),
+            (0..committee_size).map(|_| 0).collect(),
+        )
+    }
+
     // Verifies that all fields have the expected committee size.
     pub fn verify(&self, committee_size: usize) -> bool {
         self.iter().all(|metric| metric.len() == committee_size)

--- a/crates/iota-types/src/scoring_metrics.rs
+++ b/crates/iota-types/src/scoring_metrics.rs
@@ -237,11 +237,7 @@ impl VersionedScoringMetrics {
                 "Metrics counts being updated according to a report with incompatible version, but report versions were already checked before this point!"
             );
         }
-        for (current_value, new_value) in self
-            .iter()
-            .flatten()
-            .zip(report.iter().flatten())
-        {
+        for (current_value, new_value) in self.iter().flatten().zip(report.iter().flatten()) {
             current_value.fetch_max(*new_value, Ordering::Relaxed);
         }
     }

--- a/crates/iota-types/src/scoring_metrics.rs
+++ b/crates/iota-types/src/scoring_metrics.rs
@@ -23,6 +23,7 @@ enum SerializableScoringMetrics {
 }
 
 // Versioned container for scoring metrics using atomic counters.
+#[derive(Debug)]
 pub enum VersionedScoringMetrics {
     V1(ScoringMetricsV1),
 }
@@ -289,54 +290,14 @@ impl VersionedScoringMetrics {
             (VersionedScoringMetrics::V1(_), VersionedMisbehaviorReport::V1(_, _)) => true,
         }
     }
-}
 
-// Misbehavior counts using u64, used for storage. Given an authority, each
-// field of this type is a u64 with the metric value for that specific
-// authority.
-type StorageScoringMetricsV1 = MisbehaviorsV1<Vec<u64>>;
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub enum VersionedStorageScoringMetrics {
-    V1(StorageScoringMetricsV1),
-}
-
-impl VersionedStorageScoringMetrics {
-    pub fn new_zeroed(committee_size: usize, protocol_config: &ProtocolConfig) -> Self {
-        match protocol_config.scorer_version_as_option() {
-            None | Some(1) => VersionedStorageScoringMetrics::V1(
-                StorageScoringMetricsV1::new_zeroed(committee_size),
-            ),
-            _ => panic!("Unsupported scorer version"),
-        }
-    }
-
-    pub fn new_from(scoring_metrics: &VersionedScoringMetrics) -> Self {
-        match scoring_metrics {
-            VersionedScoringMetrics::V1(inner) => {
-                VersionedStorageScoringMetrics::V1(inner.as_non_atomic())
+    // Creates an independent snapshot by reading all atomic values and creating
+    // new atomics. Used to produce an owned copy for storage writes.
+    pub fn snapshot(&self) -> Self {
+        match self {
+            VersionedScoringMetrics::V1(metrics) => {
+                VersionedScoringMetrics::V1(metrics.as_non_atomic().as_atomic())
             }
         }
-    }
-
-    // Returns an iterator over references to the metric values.
-    pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&Vec<u64>> {
-        match self {
-            VersionedStorageScoringMetrics::V1(inner) => inner.iter(),
-        }
-    }
-
-    pub fn new_v1_for_test(
-        faulty_blocks_provable: Vec<u64>,
-        faulty_blocks_unprovable: Vec<u64>,
-        missing_proposals: Vec<u64>,
-        equivocations: Vec<u64>,
-    ) -> Self {
-        VersionedStorageScoringMetrics::V1(StorageScoringMetricsV1::new(
-            faulty_blocks_provable,
-            faulty_blocks_unprovable,
-            missing_proposals,
-            equivocations,
-        ))
     }
 }

--- a/crates/iota-types/src/scoring_metrics.rs
+++ b/crates/iota-types/src/scoring_metrics.rs
@@ -212,25 +212,12 @@ impl VersionedScoringMetrics {
     }
 
     pub fn reset(&self) {
-        match self {
-            VersionedScoringMetrics::V1(metrics) => {
-                for metric in metrics.faulty_blocks_provable() {
-                    metric.store(0, Ordering::Relaxed);
-                }
-                for metric in metrics.faulty_blocks_unprovable() {
-                    metric.store(0, Ordering::Relaxed);
-                }
-                for metric in metrics.equivocations() {
-                    metric.store(0, Ordering::Relaxed);
-                }
-                for metric in metrics.missing_proposals() {
-                    metric.store(0, Ordering::Relaxed);
-                }
-            }
+        for metric in self.iter().flatten() {
+            metric.store(0, Ordering::Relaxed);
         }
     }
 
-    pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&Vec<AtomicU64>> {
+    pub fn iter(&self) -> std::vec::IntoIter<&Vec<AtomicU64>> {
         match self {
             VersionedScoringMetrics::V1(metrics) => metrics.iter(),
         }
@@ -251,9 +238,9 @@ impl VersionedScoringMetrics {
             );
         }
         for (current_value, new_value) in self
-            .iterate_over_metrics()
+            .iter()
             .flatten()
-            .zip(report.iterate_over_metrics().flatten())
+            .zip(report.iter().flatten())
         {
             current_value.fetch_max(*new_value, Ordering::Relaxed);
         }

--- a/crates/iota-types/src/scoring_metrics.rs
+++ b/crates/iota-types/src/scoring_metrics.rs
@@ -4,7 +4,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use iota_protocol_config::ProtocolConfig;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tracing::warn;
 
 use crate::{messages_consensus::VersionedMisbehaviorReport, misbehavior_counts::MisbehaviorsV1};
@@ -13,9 +13,40 @@ use crate::{messages_consensus::VersionedMisbehaviorReport, misbehavior_counts::
 // Each field is a `Vec<AtomicU64>` with one entry per authority.
 type ScoringMetricsV1 = MisbehaviorsV1<Vec<AtomicU64>>;
 
+// We can't serialize VersionedScoringMetrics directly because it contains
+// atomic types. This type is only introduces to enable this serialization.
+// Converts between atomic (in-memory) and non-atomic (serialized)
+// representations.
+#[derive(Serialize, Deserialize)]
+enum SerializableScoringMetrics {
+    V1(MisbehaviorsV1<Vec<u64>>),
+}
+
 // Versioned container for scoring metrics using atomic counters.
 pub enum VersionedScoringMetrics {
     V1(ScoringMetricsV1),
+}
+
+impl Serialize for VersionedScoringMetrics {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let serializable = match self {
+            VersionedScoringMetrics::V1(metrics) => {
+                SerializableScoringMetrics::V1(metrics.as_non_atomic())
+            }
+        };
+        serializable.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for VersionedScoringMetrics {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let serializable = SerializableScoringMetrics::deserialize(deserializer)?;
+        Ok(match serializable {
+            SerializableScoringMetrics::V1(non_atomic) => {
+                VersionedScoringMetrics::V1(non_atomic.as_atomic())
+            }
+        })
+    }
 }
 
 // Basic getters, setters and increments for the metrics. We also introduce

--- a/crates/iota-types/src/scoring_metrics.rs
+++ b/crates/iota-types/src/scoring_metrics.rs
@@ -263,7 +263,7 @@ impl VersionedScoringMetrics {
 // Misbehavior counts using u64, used for storage. Given an authority, each
 // field of this type is a u64 with the metric value for that specific
 // authority.
-type StorageScoringMetricsV1 = MisbehaviorsV1<u64>;
+type StorageScoringMetricsV1 = MisbehaviorsV1<Vec<u64>>;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum VersionedStorageScoringMetrics {
@@ -271,36 +271,35 @@ pub enum VersionedStorageScoringMetrics {
 }
 
 impl VersionedStorageScoringMetrics {
-    pub fn new_zeroed(protocol_config: &ProtocolConfig) -> Self {
+    pub fn new_zeroed(committee_size: usize, protocol_config: &ProtocolConfig) -> Self {
         match protocol_config.scorer_version_as_option() {
-            None | Some(1) => {
-                VersionedStorageScoringMetrics::V1(StorageScoringMetricsV1::new_zeroed())
-            }
+            None | Some(1) => VersionedStorageScoringMetrics::V1(
+                StorageScoringMetricsV1::new_zeroed(committee_size),
+            ),
             _ => panic!("Unsupported scorer version"),
         }
     }
 
-    pub fn new_from(scoring_metrics: &VersionedScoringMetrics, authority_index: usize) -> Self {
+    pub fn new_from(scoring_metrics: &VersionedScoringMetrics) -> Self {
         match scoring_metrics {
-            VersionedScoringMetrics::V1(misbehavior_vectors) => {
-                let inner = misbehavior_vectors.misbehaviors_from_authority(authority_index);
-                VersionedStorageScoringMetrics::V1(inner)
+            VersionedScoringMetrics::V1(inner) => {
+                VersionedStorageScoringMetrics::V1(inner.as_non_atomic())
             }
         }
     }
 
     // Returns an iterator over references to the metric values.
-    pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&u64> {
+    pub fn iterate_over_metrics(&self) -> std::vec::IntoIter<&Vec<u64>> {
         match self {
             VersionedStorageScoringMetrics::V1(inner) => inner.iter(),
         }
     }
 
     pub fn new_v1_for_test(
-        faulty_blocks_provable: u64,
-        faulty_blocks_unprovable: u64,
-        missing_proposals: u64,
-        equivocations: u64,
+        faulty_blocks_provable: Vec<u64>,
+        faulty_blocks_unprovable: Vec<u64>,
+        missing_proposals: Vec<u64>,
+        equivocations: Vec<u64>,
     ) -> Self {
         VersionedStorageScoringMetrics::V1(StorageScoringMetricsV1::new(
             faulty_blocks_provable,


### PR DESCRIPTION
# Description of change

Removes the `VersionedStorageScoringMetrics` type by reusing `VersionedScoringMetrics`:
  - Before this PR, each authority's scoring metrics were stored as a separate entry keyed by `AuthorityIndex`, using `VersionedStorageScoringMetrics` (wrapping of `MisbehaviorsV1<u64>`). Now, all authorities' metrics are stored as a single blob using `VersionedScoringMetrics` directly (wrapping of `MisbehaviorsV1<Vec<AtomicU64>>`). For that, custom `Serialize/Deserialize` impls were added to `VersionedScoringMetrics`.
- Simplified eviction code: `update_scoring_metrics_on_eviction()` used to return an update per authority; the caller collected these into a `Vec` for writing. Now, the method only updates state, and a single `snapshot()` call after all evictions captures the full metrics blob for persistence.
- Simplified initialization/recovery: Before this PR, `initialize_scoring_metrics()` used a vector of `VersionedStorageScoringMetrics` that was not guaranteed to have entries for all authorities, so it had to "manually" fill in missing authorities. Now, it uses `Option<VersionedScoringMetrics>`, so either the full blob exists or it doesn't. 
- Since now the full blob is persisted after eviction (instead of only the metrics for some authorities), the migration in RocksDB is now lazy (migrated blob returned directly, v2 CF written on the first flush) instead of forced during `scan_scoring_metrics()`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes