### PR TITLE
feat(iota-protocol-config): enable congestion limit overshoot in all components and separate gas price feedback for randomness on testnet

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1301,7 +1301,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "20",
+              "maxSupportedProtocolVersion": "21",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_passkey_in_multisig": false,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-pub const MAX_PROTOCOL_VERSION: u64 = 20;
+pub const MAX_PROTOCOL_VERSION: u64 = 21;
 
 // Record history of protocol version allocations here:
 //
@@ -113,6 +113,11 @@ pub const MAX_PROTOCOL_VERSION: u64 = 20;
 //             decoupling on Testnet; Devnet and Mainnet behavior remain the
 //             same.
 //             Introduce Dynamic Minimum Commission (IIP-8) on all networks.
+// Version 21: Enable overshoot of 100 in congestion control on testnet.
+//             Enable congestion limit overshoot in the gas price feedback
+//             mechanism on testnet.
+//             Enable a separate gas price feedback mechanism for transactions
+//             using randomness on testnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -2506,6 +2511,23 @@ impl ProtocolConfig {
                         // Passes the calculated validator scores to advance epoch only on Devnet
                         cfg.feature_flags
                             .pass_calculated_validator_scores_to_advance_epoch = true;
+                    }
+                }
+                21 => {
+                    if chain != Chain::Mainnet {
+                        // Enable overshoot of 100 in congestion control on testnet.
+                        // This allows bursts of shared-object transactions
+                        // up to 10 times the average allowable load set by
+                        // `max_accumulated_txn_cost_per_object_in_mysticeti_commit`.
+                        cfg.max_congestion_limit_overshoot_per_commit = Some(100);
+                        // Enable congestion limit overshoot in the gas price feedback
+                        // mechanism on testnet.
+                        cfg.feature_flags
+                            .congestion_limit_overshoot_in_gas_price_feedback_mechanism = true;
+                        // Enable a separate gas price feedback mechanism for transactions using
+                        // randomness on testnet.
+                        cfg.feature_flags
+                            .separate_gas_price_feedback_mechanism_for_randomness = true;
                     }
                 }
 

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_21.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_21.snap
@@ -1,0 +1,304 @@
+---
+source: crates/iota-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 21
+feature_flags:
+  consensus_transaction_ordering: ByGasPrice
+  per_object_congestion_control_mode: TotalTxCount
+  zklogin_max_epoch_upper_bound_delta: 30
+  passkey_auth: true
+  relocate_event_module: true
+  protocol_defined_base_fee: true
+  disallow_new_modules_in_deps_only_packages: true
+  native_charging_v2: true
+  convert_type_argument_error: true
+  consensus_round_prober: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_linearize_subdag_v2: true
+  variant_nodes: true
+  consensus_round_prober_probe_accepted_rounds: true
+  consensus_zstd_compression: true
+  congestion_control_min_free_execution_slot: true
+  consensus_batched_block_sync: true
+  congestion_control_gas_price_feedback_mechanism: true
+  validate_identifier_inputs: true
+  minimize_child_object_mutations: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  normalize_ptb_arguments: true
+  select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
+  consensus_commit_transactions_only_for_traversed_headers: true
+  pass_validator_scores_to_advance_epoch: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 2
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 10000
+reward_slashing_rate: 10000
+storage_gas_price: 76
+base_gas_price: 1000
+validator_target_reward: 767000000000000
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+max_committee_members_count: 100
+consensus_gc_depth: 60

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_21.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_21.snap
@@ -1,0 +1,311 @@
+---
+source: crates/iota-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 21
+feature_flags:
+  consensus_transaction_ordering: ByGasPrice
+  per_object_congestion_control_mode: TotalTxCount
+  consensus_choice: Starfish
+  zklogin_max_epoch_upper_bound_delta: 30
+  passkey_auth: true
+  relocate_event_module: true
+  protocol_defined_base_fee: true
+  disallow_new_modules_in_deps_only_packages: true
+  native_charging_v2: true
+  convert_type_argument_error: true
+  consensus_round_prober: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_linearize_subdag_v2: true
+  variant_nodes: true
+  consensus_round_prober_probe_accepted_rounds: true
+  consensus_zstd_compression: true
+  congestion_control_min_free_execution_slot: true
+  consensus_batched_block_sync: true
+  congestion_control_gas_price_feedback_mechanism: true
+  validate_identifier_inputs: true
+  minimize_child_object_mutations: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  normalize_ptb_arguments: true
+  select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
+  consensus_median_timestamp_with_checkpoint_enforcement: true
+  consensus_commit_transactions_only_for_traversed_headers: true
+  congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
+  separate_gas_price_feedback_mechanism_for_randomness: true
+  pass_validator_scores_to_advance_epoch: true
+  calculate_validator_scores: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 2
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 10000
+reward_slashing_rate: 10000
+storage_gas_price: 76
+base_gas_price: 1000
+validator_target_reward: 767000000000000
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+max_committee_members_count: 100
+consensus_gc_depth: 60
+max_congestion_limit_overshoot_per_commit: 100
+scorer_version: 1

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_21.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_21.snap
@@ -1,0 +1,325 @@
+---
+source: crates/iota-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 21
+feature_flags:
+  consensus_transaction_ordering: ByGasPrice
+  enable_poseidon: true
+  enable_group_ops_native_function_msm: true
+  per_object_congestion_control_mode: TotalTxCount
+  consensus_choice: Starfish
+  zklogin_max_epoch_upper_bound_delta: 30
+  enable_vdf: true
+  passkey_auth: true
+  relocate_event_module: true
+  protocol_defined_base_fee: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  native_charging_v2: true
+  convert_type_argument_error: true
+  consensus_round_prober: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_linearize_subdag_v2: true
+  variant_nodes: true
+  consensus_round_prober_probe_accepted_rounds: true
+  consensus_zstd_compression: true
+  congestion_control_min_free_execution_slot: true
+  accept_passkey_in_multisig: true
+  consensus_batched_block_sync: true
+  congestion_control_gas_price_feedback_mechanism: true
+  validate_identifier_inputs: true
+  minimize_child_object_mutations: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  normalize_ptb_arguments: true
+  select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
+  consensus_median_timestamp_with_checkpoint_enforcement: true
+  consensus_commit_transactions_only_for_traversed_headers: true
+  congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
+  separate_gas_price_feedback_mechanism_for_randomness: true
+  metadata_in_module_bytes: true
+  publish_package_metadata: true
+  enable_move_authentication: true
+  pass_validator_scores_to_advance_epoch: true
+  calculate_validator_scores: true
+  adjust_rewards_by_score: true
+  pass_calculated_validator_scores_to_advance_epoch: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_auth_gas: 250000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 2
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 10000
+reward_slashing_rate: 10000
+storage_gas_price: 76
+base_gas_price: 1000
+validator_target_reward: 767000000000000
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 100
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+vdf_verify_vdf_cost: 1500
+vdf_hash_to_input_cost: 100
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+max_committee_members_count: 100
+consensus_gc_depth: 60
+max_congestion_limit_overshoot_per_commit: 100
+scorer_version: 1

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 20
+  protocol_version: 21
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
 accounts:

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -1,15 +1,14 @@
 ---
 source: crates/iota-swarm-config/tests/snapshot_tests.rs
 expression: genesis.iota_system_object().into_genesis_version_for_tooling()
-snapshot_kind: text
 ---
 epoch: 0
-protocol_version: 20
+protocol_version: 21
 system_state_version: 1
 iota_treasury_cap:
   inner:
     id:
-      id: "0x7e15c773a6be40cf046fe26546aca50e047b214ac7a5994f914db310163d5897"
+      id: "0x7c417f2a21be8ad64cfd220b7d2a7bf6b1f0f80cb07143fff27426daddde7b33"
     total_supply:
       value: "751500000000000000"
 validators:
@@ -245,13 +244,13 @@ validators:
         next_epoch_primary_address: ~
         extra_fields:
           id:
-            id: "0xf27b0d9cf76ab73f05d5061673a323608a937166f71e79d1cf98dc7c9dd7dd8f"
+            id: "0xe1d4c14f54b94f95bb1dcd2ddaca34ad9abe01e639adf70cfd777f7deea8cb9f"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x7b9e539bbeb59725e24dee834810aaef095dee49326edf61f36e35679d7817fa"
+      operation_cap_id: "0xf591130736561f25befe04b4f24b306188351db7f43d3ee3408efc273e03e036"
       gas_price: 1000
       staking_pool:
-        id: "0x38e0be88e1443313fcac74692a456ab02543b9a4e2421e2b9eda54869be94808"
+        id: "0x3fb7b61b55ed37978d376ee3768549f17b296d315b8cfb959b91210c3eb5e408"
         activation_epoch: 0
         deactivation_epoch: ~
         iota_balance: 1500000000000000
@@ -259,14 +258,14 @@ validators:
           value: 0
         pool_token_balance: 1500000000000000
         exchange_rates:
-          id: "0x2b55cf630fa569214cd69c0d87cebc9b59a4e68c95d3a85592d53afac1e0aaa7"
+          id: "0x5fb99ecbf72ca58fba05ae946a7d99b381f89283df5d5134e268a1be45e9fc9d"
           size: 1
         pending_stake: 0
         pending_total_iota_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x52d33daca05d4c5a5b58fb343a3d17b1d30866799d391e3c475e86b1a770a79f"
+            id: "0xcdf0538417a5b581794be46680f86217b2c7237e63572cd1b6a46225c730ad5d"
           size: 0
       commission_rate: 200
       next_epoch_stake: 1500000000000000
@@ -274,27 +273,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x32503038a0c564d946e8ec400461275bc6dd0bdec8b581e4218d790cef0eefc7"
+          id: "0x387b2f823c73375ed992bcb5eedda3ab408f0de1e804deaf1631a266d36ae226"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xe9643f5163048fe395f334e17dea9307f8687dff73f63ecc9d0229f22e1b46ea"
+      id: "0x5133c9eee6752e82b86f64ced34a6a69695ffd6d626467b083fc26b3c37e3b8e"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x38ded140b84c4a8a64aebe5635b31a2a417ebd2a9a3b9d2b6a9f1a4c1ac04ece"
+    id: "0xb0238925dd78259ec53eb3d30c2e1a6b1f88c5ec759d66e946e129d2edfb03d6"
     size: 1
   inactive_validators:
-    id: "0xb946f70ab109439125e030033649e97fbc650d087cec0a57e056a15397733a34"
+    id: "0x186600cbd39db7fb7b6c9363a776a546d52f42a88116dbe53da7631ba4278266"
     size: 0
   validator_candidates:
-    id: "0x44e95ede986c5b2de703778a31ec5a3b8c49f1772f4462b60da8bfa0d529abf7"
+    id: "0x263a4934134d8e165c86c44b339a13c6d27470cf3eadbef0f1f73ecce65aa82c"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x1ef155fd0c854f58e10be3bcc4a8f46754cf9065059ff96cdbfe1d05cd0987ce"
+      id: "0xa0b8c076664f5936f3b4982b78865773578626551a08a58bbac103b4f58072ec"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -311,7 +310,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x5ac26d6c68ac5fad8c048f5a49732ca5c25b2699b0303e5e391cba47339a13d5"
+      id: "0xe929c1dd4d650a9e2e4455f34ec4bf0daf3f3669e2cf2be2e21ca12e18710f25"
     size: 0
 iota_system_admin_cap:
   dummy_field: false
@@ -328,5 +327,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x1dc9cc014c8dc5c81740d6288462c449a6b672c4272bb76311e3b3024ee0fcb3"
+    id: "0xf4eb9513ce18cb49f62dc90d85c6be74b04eb861db0d6d798f61565261eefcc4"
   size: 0


### PR DESCRIPTION
# Description of change

This PR enables the following on `testnet`:

- Congestion limit overshoot of 100 in the shared-object congestion tracker.
- Congestion limit overshoot in the gas price feedback mechanism.
- A separate gas price feedback mechanism for transactions using randomness.

## Links to any relevant issues

The stress-testing of the gas price feedback mechanism with overshoot was conducted on `alphanet` and it was successful (see the results here: https://github.com/iotaledger/iota-private/issues/313), so we proceed to enabling this feature on `testnet`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Enable congestion limit overshoot of 100 in the shared-object congestion tracker on `testnet`. Enable congestion limit overshoot in the gas price feedback mechanism on `testnet`. Enable a separate gas price feedback mechanism for transactions using randomness on `testnet`.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
