### PR TITLE
chore(indexer): ignore flaky test temporarily

### DIFF
--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -1961,6 +1961,7 @@ async fn failed_stored_tx_into_transaction_block() {
 }
 
 #[test]
+#[ignore = "https://github.com/iotaledger/iota/issues/10291"]
 fn get_chain_identifier_with_pruning_enabled() {
     let ApiTestSetup { runtime, .. } = ApiTestSetup::get_or_init();
 

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -881,6 +881,7 @@ fn test_repeatedly_update_display() {
 }
 
 #[tokio::test]
+#[ignore = "https://github.com/iotaledger/iota/issues/10291"]
 async fn test_optimistic_tables_pruning() -> IndexerResult<()> {
     let optimistic_pruner_batch_size = 5;
     let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(


### PR DESCRIPTION
# Description of change

The patch ignores a test that was found to be flaky, until we sort it out.

## Links to any relevant issues

Due to #10291 