### PR TITLE
fix(tooling): prevent env plugin from blocking amplitude event delivery

### DIFF
--- a/apps/core/src/amplitude/plugins/attachEnvironmentPlugin.ts
+++ b/apps/core/src/amplitude/plugins/attachEnvironmentPlugin.ts
@@ -20,14 +20,9 @@ export function attachEnvironmentPlugin(
         type: 'enrichment' as const,
         setup: async () => {},
         execute: async (event: Event) => {
-            try {
-                if (isDev && event.event_type && !event.event_type.startsWith(DEV_EVENT_PREFIX)) {
-                    return { ...event, event_type: DEV_EVENT_PREFIX + event.event_type };
-                }
-                return event;
-            } catch {
-                return event;
-            }
+            const type = event.event_type;
+            if (!isDev || !type || type.startsWith(DEV_EVENT_PREFIX)) return event;
+            return { ...event, event_type: DEV_EVENT_PREFIX + type };
         },
     };
 }

--- a/apps/core/src/amplitude/plugins/attachEnvironmentPlugin.ts
+++ b/apps/core/src/amplitude/plugins/attachEnvironmentPlugin.ts
@@ -10,25 +10,24 @@ import { BrowserClient, BrowserConfig, EnrichmentPlugin, Event } from '@amplitud
  * This allows developers to test and debug events without polluting production analytics data.
  *
  */
-export function attachEnvironmentPlugin(): EnrichmentPlugin<BrowserClient, BrowserConfig> {
+export function attachEnvironmentPlugin(
+    isDev: boolean,
+): EnrichmentPlugin<BrowserClient, BrowserConfig> {
+    const DEV_EVENT_PREFIX = 'dev_';
+
     return {
         name: 'environment-plugin',
         type: 'enrichment' as const,
         setup: async () => {},
-        execute: async (context: Event) => {
-            // Prefix event name for development
-            const IS_DEVELOPMENT = process.env.NEXT_PUBLIC_BUILD_ENV !== 'production';
-            const DEV_EVENT_PREFIX = 'dev_';
-
-            if (
-                IS_DEVELOPMENT &&
-                context.event_type &&
-                !context.event_type.startsWith(DEV_EVENT_PREFIX)
-            ) {
-                context.event_type = DEV_EVENT_PREFIX + context.event_type;
+        execute: async (event: Event) => {
+            try {
+                if (isDev && event.event_type && !event.event_type.startsWith(DEV_EVENT_PREFIX)) {
+                    return { ...event, event_type: DEV_EVENT_PREFIX + event.event_type };
+                }
+                return event;
+            } catch {
+                return event;
             }
-
-            return context;
         },
     };
 }

--- a/apps/evm-bridge/src/shared/analytics/amplitude.ts
+++ b/apps/evm-bridge/src/shared/analytics/amplitude.ts
@@ -12,6 +12,8 @@ const IS_ENABLED =
     import.meta.env.VITE_BUILD_ENV === 'production' &&
     import.meta.env.VITE_AMPLITUDE_ENABLED === 'true';
 
+const IS_DEV = import.meta.env.VITE_BUILD_ENV !== 'production';
+
 export const persistableStorage = new PersistableStorage<UserSession>();
 
 export enum BridgeDirection {
@@ -63,7 +65,7 @@ export async function initAmplitude() {
     });
 
     // Add environment plugin to set prefix dev events
-    ampli.client.add(attachEnvironmentPlugin());
+    ampli.client.add(attachEnvironmentPlugin(IS_DEV));
 }
 
 export function getUrlWithDeviceId(url: URL) {

--- a/apps/explorer/src/lib/utils/analytics/amplitude.ts
+++ b/apps/explorer/src/lib/utils/analytics/amplitude.ts
@@ -12,6 +12,8 @@ const IS_ENABLED =
     import.meta.env.VITE_BUILD_ENV === 'production' &&
     import.meta.env.VITE_AMPLITUDE_ENABLED === 'true';
 
+const IS_DEV = import.meta.env.VITE_BUILD_ENV !== 'production';
+
 export async function initAmplitude() {
     // Check consent status to determine initial opt-out state
     const consentStatus = getAmplitudeConsentStatus();
@@ -56,5 +58,5 @@ export async function initAmplitude() {
     }, 1000);
 
     // Add environment plugin to set prefix dev events
-    ampli.client.add(attachEnvironmentPlugin());
+    ampli.client.add(attachEnvironmentPlugin(IS_DEV));
 }

--- a/apps/wallet-dashboard/lib/utils/analytics/amplitude.ts
+++ b/apps/wallet-dashboard/lib/utils/analytics/amplitude.ts
@@ -12,6 +12,8 @@ const IS_ENABLED =
     process.env.NEXT_PUBLIC_BUILD_ENV === 'production' &&
     process.env.NEXT_PUBLIC_AMPLITUDE_ENABLED === 'true';
 
+const IS_DEV = process.env.NEXT_PUBLIC_BUILD_ENV !== 'production';
+
 export async function initAmplitude() {
     // Check consent status to determine initial opt-out state
     const consentStatus = getAmplitudeConsentStatus();
@@ -47,5 +49,5 @@ export async function initAmplitude() {
     });
 
     // Add environment plugin to set prefix dev events
-    ampli.client.add(attachEnvironmentPlugin());
+    ampli.client.add(attachEnvironmentPlugin(IS_DEV));
 }

--- a/apps/wallet/src/shared/analytics/amplitude.ts
+++ b/apps/wallet/src/shared/analytics/amplitude.ts
@@ -11,6 +11,8 @@ import { ampli } from './ampli';
 
 const IS_ENABLED = process.env.BUILD_ENV === 'production';
 
+const IS_DEV = process.env.BUILD_ENV !== 'production';
+
 export async function initAmplitude() {
     ampli.load({
         environment: 'iotawallet',
@@ -52,7 +54,7 @@ export async function initAmplitude() {
     });
 
     // Add environment plugin to set prefix dev events
-    ampli.client.add(attachEnvironmentPlugin());
+    ampli.client.add(attachEnvironmentPlugin(IS_DEV));
 }
 
 export function getUrlWithDeviceId(url: URL) {


### PR DESCRIPTION
# Description of change

The dev_ prefix enrichment plugin was failing in the browser because `@iota/core` can’t rely on process.env. This moves env detection to the wallet app and passes an isDev flag to the plugin
