### PR TITLE
feat(ci): cleanup ci workflows

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -31,6 +31,9 @@ outputs:
   isReleaseNotesEligible:
     description: True when changes happened in Release Notes eligible paths
     value: "${{ steps.diff.outputs.isReleaseNotesEligible }}"
+  isTypeScriptCodegenSync:
+    description: True when changes happened that affect TypeScript codegen synchronization
+    value: "${{ steps.diff.outputs.isTypeScriptCodegenSync }}"
 
 runs:
   using: composite
@@ -122,3 +125,25 @@ runs:
             - "external-crates/**"
             - "kiosk/**"
             - "iota-execution/**"
+          isTypeScriptCodegenSync:
+            # Generated schema files from Rust (inputs to TypeScript codegen)
+            - "crates/iota-graphql-rpc/schema.graphql"
+            - "crates/iota-open-rpc/spec/openrpc.json"
+            # Generated TypeScript output files
+            - "sdk/typescript/src/graphql/generated/**"
+            - "sdk/typescript/src/graphql/schemas/**"
+            - "sdk/typescript/src/client/types/generated.ts"
+            - "sdk/typescript/src/client/types/params.ts"
+            - "sdk/graphql-transport/src/generated/**"
+            # Configuration files that affect codegen
+            - "package.json"
+            - "pnpm-workspace.yaml"
+            - "turbo.json"
+            - "sdk/typescript/package.json"
+            - "sdk/graphql-transport/package.json"
+            - "sdk/typescript/scripts/**"
+            - "sdk/graphql-transport/codegen.ts"
+            - "sdk/graphql-transport/src/queries/**"
+            - "sdk/typescript/genversion.mjs"
+            # Turbo hierarchy workflow and related scripts
+            - ".github/workflows/turbo_hierarchy.yml"

--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -74,6 +74,18 @@ jobs:
 
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
+      - name: Calculate common conditions
+        id: conditions
+        run: |
+          echo "runExplorer=${{ inputs.isNightly || inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc }}" >> $GITHUB_OUTPUT
+          echo "runDashboard=${{ inputs.isNightly || inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK }}" >> $GITHUB_OUTPUT
+          echo "runWallet=${{ inputs.isNightly || inputs.isWallet || inputs.isRpc || inputs.isTypescriptSDK }}" >> $GITHUB_OUTPUT
+          echo "runEvmBridge=${{ inputs.isNightly || inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK }}" >> $GITHUB_OUTPUT
+          echo "runKiosk=${{ inputs.isNightly || inputs.isRpc || inputs.isTypescriptSDK }}" >> $GITHUB_OUTPUT
+          echo "runAppsBackend=${{ inputs.isNightly || inputs.isAppsBackend }}" >> $GITHUB_OUTPUT
+          echo "runGraphql=${{ inputs.isNightly || inputs.isGraphQlTransport || inputs.isRpc }}" >> $GITHUB_OUTPUT
+          echo "runTsSdk=${{ inputs.isNightly || inputs.isTypescriptSDK || inputs.isRpc }}" >> $GITHUB_OUTPUT
+
       - name: Build Iota binary
         run: cargo build --bin iota --features indexer --profile dev
 
@@ -87,7 +99,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Explorer Playwright Browsers
-        if: (!cancelled()) && (inputs.isNightly || inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc)
+        if: (!cancelled()) && steps.conditions.outputs.runExplorer == 'true'
         run: pnpm --filter iota-explorer playwright install --with-deps chromium
 
       - name: Set environment variables
@@ -96,69 +108,69 @@ jobs:
           echo "E2E_RUN_LOCAL_NET_CMD=(RUST_BACKTRACE=1 $(echo $PWD/target/debug/iota) start --with-faucet --force-regenesis --with-indexer --with-graphql)" >> $GITHUB_ENV
 
       - name: Run TS SDK e2e tests
-        if: (!cancelled()) && (inputs.isNightly || inputs.isTypescriptSDK || inputs.isRpc)
+        if: (!cancelled()) && steps.conditions.outputs.runTsSdk == 'true'
         run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm --filter @iota/iota-sdk test:e2e'
 
       - name: Run RPC/GraphQL compatibility e2e tests
-        if: (!cancelled()) && (inputs.isNightly || inputs.isGraphQlTransport || inputs.isRpc)
+        if: (!cancelled()) && steps.conditions.outputs.runGraphql == 'true'
         run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm --filter @iota/graphql-transport test:e2e'
 
       - name: Build apps-backend
-        if: (!cancelled()) && (inputs.isNightly || inputs.isAppsBackend)
+        if: (!cancelled()) && steps.conditions.outputs.runAppsBackend == 'true'
         run: pnpm turbo --filter apps-backend build
 
       - name: Run apps-backend e2e tests
-        if: (!cancelled()) && (inputs.isNightly || inputs.isAppsBackend)
+        if: (!cancelled()) && steps.conditions.outputs.runAppsBackend == 'true'
         run: pnpm --filter apps-backend test:e2e
 
       - name: Build explorer
-        if: (!cancelled()) && (inputs.isNightly || inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc)
+        if: (!cancelled()) && steps.conditions.outputs.runExplorer == 'true'
         env:
           IOTA_NETWORKS: '{ "localnet": { "id": "localnet", "name": "Localnet", "url": "http://localhost:9124", "explorer": "http://localhost:3000", "chain": "iota:local", "faucet": "http://localhost:9123" } }'
         run: pnpm turbo --filter=iota-explorer build
 
       - name: Run Explorer e2e tests
-        if: (!cancelled()) && (inputs.isNightly || inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc)
+        if: (!cancelled()) && steps.conditions.outputs.runExplorer == 'true'
         run: pnpm --filter iota-explorer playwright test
 
       - name: Upload Explorer test reports
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: (!cancelled()) && (inputs.isNightly || inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc)
+        if: (!cancelled()) && steps.conditions.outputs.runExplorer == 'true'
         with:
           name: playwright-report-explorer
           path: apps/explorer/playwright-report/
           retention-days: 30
 
       - name: Build Wallet
-        if: (!cancelled()) && (inputs.isNightly || inputs.isWalletDashboard || inputs.isWallet || inputs.isRpc || inputs.isTypescriptSDK)
+        if: (!cancelled()) && (steps.conditions.outputs.runDashboard == 'true' || steps.conditions.outputs.runWallet == 'true')
         run: pnpm wallet build:rc
 
       - name: Build Dashboard
-        if: (!cancelled()) && (inputs.isNightly || inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK)
+        if: (!cancelled()) && steps.conditions.outputs.runDashboard == 'true'
         run: pnpm turbo --filter wallet-dashboard build
 
       - name: Install Dashboard Playwright Browsers
-        if: (!cancelled()) && (inputs.isNightly || inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK)
+        if: (!cancelled()) && steps.conditions.outputs.runDashboard == 'true'
         run: pnpm --filter wallet-dashboard playwright install --with-deps  --only-shell
 
       - name: Run Dashboard e2e tests
-        if: (!cancelled()) && (inputs.isNightly || inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK)
+        if: (!cancelled()) && steps.conditions.outputs.runDashboard == 'true'
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm --filter wallet-dashboard playwright test
 
       - name: Upload Dashboard test reports
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: (!cancelled()) && (inputs.isNightly || inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK)
+        if: (!cancelled()) && steps.conditions.outputs.runDashboard == 'true'
         with:
           name: playwright-report-wallet-dashboard
           path: apps/wallet-dashboard/playwright-report/
           retention-days: 30
 
       - name: Build Kiosk
-        if: (!cancelled()) && (inputs.isNightly || inputs.isRpc || inputs.isTypescriptSDK)
+        if: (!cancelled()) && steps.conditions.outputs.runKiosk == 'true'
         run: pnpm turbo --filter=@iota/kiosk build
 
       - name: Run Kiosk e2e tests
-        if: (!cancelled()) && (inputs.isNightly || inputs.isRpc || inputs.isTypescriptSDK)
+        if: (!cancelled()) && steps.conditions.outputs.runKiosk == 'true'
         run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm --filter=@iota/kiosk test:e2e'
 
       - name: Run Local net
@@ -166,37 +178,37 @@ jobs:
         run: cargo run --bin iota start --force-regenesis --with-faucet --epoch-duration-ms 10000 &
 
       - name: Run Wallet e2e tests
-        if: (!cancelled()) && (inputs.isNightly || inputs.isWallet || inputs.isRpc || inputs.isTypescriptSDK)
+        if: (!cancelled()) && steps.conditions.outputs.runWallet == 'true'
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm --filter iota-wallet playwright test
 
       - name: Upload Wallet test reports
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: (!cancelled()) && (inputs.isNightly || inputs.isWallet || inputs.isRpc || inputs.isTypescriptSDK)
+        if: (!cancelled()) && steps.conditions.outputs.runWallet == 'true'
         with:
           name: playwright-report-wallet
           path: apps/wallet/playwright-report/
           retention-days: 30
 
       - name: Build Evm-bridge
-        if: (!cancelled()) && (inputs.isNightly || inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK)
+        if: (!cancelled()) && steps.conditions.outputs.runEvmBridge == 'true'
         run: pnpm evm-bridge build
 
       - name: Install Playwright Browsers for Evm-bridge
-        if: (!cancelled()) && (inputs.isNightly || inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK)
+        if: (!cancelled()) && steps.conditions.outputs.runEvmBridge == 'true'
         run: pnpm --filter ./apps/evm-bridge playwright install --with-deps chromium
 
       - name: Prepare evm-bridge e2e tests (downloads wallet artifact dist)
-        if: (!cancelled()) && (inputs.isNightly || inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK)
+        if: (!cancelled()) && steps.conditions.outputs.runEvmBridge == 'true'
         working-directory: ./apps/evm-bridge
         run: pnpm run test:prepare
 
       - name: Run evm-bridge tests
-        if: (!cancelled()) && (inputs.isNightly || inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK)
+        if: (!cancelled()) && steps.conditions.outputs.runEvmBridge == 'true'
         working-directory: ./apps/evm-bridge
         run: DEBUG=pw:webserver xvfb-run --auto-servernum pnpm run test:e2e
 
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: (!cancelled()) && (inputs.isNightly || inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK)
+        if: (!cancelled()) && steps.conditions.outputs.runEvmBridge == 'true'
         with:
           name: playwright-report-evm-bridge
           path: apps/evm-bridge/playwright-report/

--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -174,7 +174,7 @@ jobs:
         run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm --filter=@iota/kiosk test:e2e'
 
       - name: Run Local net
-        if: (!cancelled())
+        if: (!cancelled()) && (steps.conditions.outputs.runWallet == 'true' || steps.conditions.outputs.runEvmBridge == 'true')
         run: cargo run --bin iota start --force-regenesis --with-faucet --epoch-duration-ms 10000 &
 
       - name: Run Wallet e2e tests

--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -4,33 +4,36 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      isNightly:
+        type: boolean
+        required: true
       isRpc:
         type: boolean
-        required: false
+        required: true
       isExplorer:
         type: boolean
-        required: false
+        required: true
       isAppsBackend:
         type: boolean
-        required: false
+        required: true
       isTypescriptSDK:
         type: boolean
-        required: false
+        required: true
       isWallet:
         type: boolean
-        required: false
+        required: true
       isGraphQlTransport:
         type: boolean
-        required: false
+        required: true
       isWalletDashboard:
         type: boolean
-        required: false
+        required: true
       isEvmBridge:
         type: boolean
-        required: false
+        required: true
       isIscSDK:
         type: boolean
-        required: false
+        required: true
     secrets:
       EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK:
         required: true
@@ -47,10 +50,9 @@ env:
   VITE_EVM_BRIDGE_CONFIG: ${{ secrets.EVM_BRIDGE_CONFIG }}
 
 jobs:
-  # Run e2e test against localnet built on the develop branch
   localnet:
     name: Localnet
-    if: inputs.isExplorer || inputs.isTypescriptSDK || inputs.isWallet || inputs.isWalletDashboard || inputs.isEvmBridge || inputs.isRpc || github.ref_name == 'develop'
+    if: inputs.isNightly || inputs.isRpc || inputs.isExplorer || inputs.isAppsBackend || inputs.isTypescriptSDK || inputs.isWallet || inputs.isGraphQlTransport || inputs.isWalletDashboard || inputs.isEvmBridge || inputs.isIscSDK
     runs-on: self-hosted-x64
     services:
       postgres:

--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -87,6 +87,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Explorer Playwright Browsers
+        if: (!cancelled()) && (inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc || github.ref_name == 'develop')
         run: pnpm --filter iota-explorer playwright install --with-deps chromium
 
       - name: Set environment variables
@@ -122,7 +123,7 @@ jobs:
 
       - name: Upload Explorer test reports
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: (!cancelled())
+        if: (!cancelled()) && (inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc || github.ref_name == 'develop')
         with:
           name: playwright-report-explorer
           path: apps/explorer/playwright-report/
@@ -137,6 +138,7 @@ jobs:
         run: pnpm turbo --filter wallet-dashboard build
 
       - name: Install Dashboard Playwright Browsers
+        if: (!cancelled()) && (inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop')
         run: pnpm --filter wallet-dashboard playwright install --with-deps  --only-shell
 
       - name: Run Dashboard e2e tests
@@ -145,7 +147,7 @@ jobs:
 
       - name: Upload Dashboard test reports
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: (!cancelled())
+        if: (!cancelled()) && (inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop')
         with:
           name: playwright-report-wallet-dashboard
           path: apps/wallet-dashboard/playwright-report/
@@ -169,7 +171,7 @@ jobs:
 
       - name: Upload Wallet test reports
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: (!cancelled())
+        if: (!cancelled()) && (inputs.isWallet || inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop')
         with:
           name: playwright-report-wallet
           path: apps/wallet/playwright-report/
@@ -194,7 +196,7 @@ jobs:
         run: DEBUG=pw:webserver xvfb-run --auto-servernum pnpm run test:e2e
 
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: (!cancelled())
+        if: (!cancelled()) && (inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK || github.ref_name == 'develop')
         with:
           name: playwright-report-evm-bridge
           path: apps/evm-bridge/playwright-report/

--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -87,7 +87,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Explorer Playwright Browsers
-        if: (!cancelled()) && (inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc)
         run: pnpm --filter iota-explorer playwright install --with-deps chromium
 
       - name: Set environment variables
@@ -96,69 +96,69 @@ jobs:
           echo "E2E_RUN_LOCAL_NET_CMD=(RUST_BACKTRACE=1 $(echo $PWD/target/debug/iota) start --with-faucet --force-regenesis --with-indexer --with-graphql)" >> $GITHUB_ENV
 
       - name: Run TS SDK e2e tests
-        if: (!cancelled()) && (inputs.isTypescriptSDK || inputs.isRpc || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isTypescriptSDK || inputs.isRpc)
         run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm --filter @iota/iota-sdk test:e2e'
 
       - name: Run RPC/GraphQL compatibility e2e tests
-        if: (!cancelled()) && (inputs.isGraphQlTransport || inputs.isRpc || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isGraphQlTransport || inputs.isRpc)
         run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm --filter @iota/graphql-transport test:e2e'
 
       - name: Build apps-backend
-        if: (!cancelled()) && (inputs.isAppsBackend || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isAppsBackend)
         run: pnpm turbo --filter apps-backend build
 
       - name: Run apps-backend e2e tests
-        if: (!cancelled()) && (inputs.isAppsBackend || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isAppsBackend)
         run: pnpm --filter apps-backend test:e2e
 
       - name: Build explorer
-        if: (!cancelled()) && (inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc)
         env:
           IOTA_NETWORKS: '{ "localnet": { "id": "localnet", "name": "Localnet", "url": "http://localhost:9124", "explorer": "http://localhost:3000", "chain": "iota:local", "faucet": "http://localhost:9123" } }'
         run: pnpm turbo --filter=iota-explorer build
 
       - name: Run Explorer e2e tests
-        if: (!cancelled()) && (inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc)
         run: pnpm --filter iota-explorer playwright test
 
       - name: Upload Explorer test reports
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: (!cancelled()) && (inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRpc)
         with:
           name: playwright-report-explorer
           path: apps/explorer/playwright-report/
           retention-days: 30
 
       - name: Build Wallet
-        if: (!cancelled()) && (inputs.isWalletDashboard || inputs.isWallet || inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isWalletDashboard || inputs.isWallet || inputs.isRpc || inputs.isTypescriptSDK)
         run: pnpm wallet build:rc
 
       - name: Build Dashboard
-        if: (!cancelled()) && (inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK)
         run: pnpm turbo --filter wallet-dashboard build
 
       - name: Install Dashboard Playwright Browsers
-        if: (!cancelled()) && (inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK)
         run: pnpm --filter wallet-dashboard playwright install --with-deps  --only-shell
 
       - name: Run Dashboard e2e tests
-        if: (!cancelled()) && (inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK)
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm --filter wallet-dashboard playwright test
 
       - name: Upload Dashboard test reports
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: (!cancelled()) && (inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK)
         with:
           name: playwright-report-wallet-dashboard
           path: apps/wallet-dashboard/playwright-report/
           retention-days: 30
 
       - name: Build Kiosk
-        if: (!cancelled()) && (inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isRpc || inputs.isTypescriptSDK)
         run: pnpm turbo --filter=@iota/kiosk build
 
       - name: Run Kiosk e2e tests
-        if: (!cancelled()) && (inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isRpc || inputs.isTypescriptSDK)
         run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm --filter=@iota/kiosk test:e2e'
 
       - name: Run Local net
@@ -166,37 +166,37 @@ jobs:
         run: cargo run --bin iota start --force-regenesis --with-faucet --epoch-duration-ms 10000 &
 
       - name: Run Wallet e2e tests
-        if: (!cancelled()) && (inputs.isWallet || inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isWallet || inputs.isRpc || inputs.isTypescriptSDK)
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm --filter iota-wallet playwright test
 
       - name: Upload Wallet test reports
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: (!cancelled()) && (inputs.isWallet || inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isWallet || inputs.isRpc || inputs.isTypescriptSDK)
         with:
           name: playwright-report-wallet
           path: apps/wallet/playwright-report/
           retention-days: 30
 
       - name: Build Evm-bridge
-        if: (!cancelled()) && (inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK)
         run: pnpm evm-bridge build
 
       - name: Install Playwright Browsers for Evm-bridge
-        if: (!cancelled()) && (inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK)
         run: pnpm --filter ./apps/evm-bridge playwright install --with-deps chromium
 
       - name: Prepare evm-bridge e2e tests (downloads wallet artifact dist)
-        if: (!cancelled()) && (inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK)
         working-directory: ./apps/evm-bridge
         run: pnpm run test:prepare
 
       - name: Run evm-bridge tests
-        if: (!cancelled()) && (inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK)
         working-directory: ./apps/evm-bridge
         run: DEBUG=pw:webserver xvfb-run --auto-servernum pnpm run test:e2e
 
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: (!cancelled()) && (inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK || github.ref_name == 'develop')
+        if: (!cancelled()) && (inputs.isNightly || inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK)
         with:
           name: playwright-report-evm-bridge
           path: apps/evm-bridge/playwright-report/

--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -34,6 +34,9 @@ on:
       isIscSDK:
         type: boolean
         required: true
+      isKiosk:
+        type: boolean
+        required: true
     secrets:
       EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK:
         required: true
@@ -81,7 +84,7 @@ jobs:
           echo "runDashboard=${{ inputs.isNightly || inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK }}" >> $GITHUB_OUTPUT
           echo "runWallet=${{ inputs.isNightly || inputs.isWallet || inputs.isRpc || inputs.isTypescriptSDK }}" >> $GITHUB_OUTPUT
           echo "runEvmBridge=${{ inputs.isNightly || inputs.isEvmBridge || inputs.isIscSDK || inputs.isTypescriptSDK }}" >> $GITHUB_OUTPUT
-          echo "runKiosk=${{ inputs.isNightly || inputs.isRpc || inputs.isTypescriptSDK }}" >> $GITHUB_OUTPUT
+          echo "runKiosk=${{ inputs.isNightly || inputs.isRpc || inputs.isKiosk || inputs.isTypescriptSDK }}" >> $GITHUB_OUTPUT
           echo "runAppsBackend=${{ inputs.isNightly || inputs.isAppsBackend }}" >> $GITHUB_OUTPUT
           echo "runGraphql=${{ inputs.isNightly || inputs.isGraphQlTransport || inputs.isRpc }}" >> $GITHUB_OUTPUT
           echo "runTsSdk=${{ inputs.isNightly || inputs.isTypescriptSDK || inputs.isRpc }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -77,12 +77,12 @@ jobs:
 
   docusaurus:
     needs: diff
-    if: (!cancelled() && needs.diff.outputs.isDoc == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isDoc == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_docusaurus.yml
 
   docs-lint:
     needs: diff
-    if: (!cancelled() && needs.diff.outputs.isDoc == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isDoc == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_docs_lint.yml
 
   rust:

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -19,16 +19,16 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
     if: (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]'))
     outputs:
-      isRust: ${{ steps.diff.outputs.isRust }}
-      isRustWorkspaceConfig: ${{ steps.diff.outputs.isRustWorkspaceConfig }}
-      isRustExample: ${{ steps.diff.outputs.isRustExample }}
-      isRpc: ${{ steps.diff.outputs.isRpc }}
-      isPgIntegration: ${{ steps.diff.outputs.isPgIntegration }}
-      isMoveExampleUsedByOthers: ${{ steps.diff.outputs.isMoveExampleUsedByOthers }}
-      isRosetta: ${{ steps.diff.outputs.isRosetta }}
-      isDoc: ${{ steps.diff.outputs.isDoc }}
-      isReleaseNotesEligible: ${{ steps.diff.outputs.isReleaseNotesEligible }}
-      isExternalCrates: ${{ steps.diff.outputs.isExternalCrates }}
+      isRust: ${{ steps.diff.outputs.isRust == 'true' }}
+      isRustWorkspaceConfig: ${{ steps.diff.outputs.isRustWorkspaceConfig == 'true' }}
+      isRustExample: ${{ steps.diff.outputs.isRustExample == 'true' }}
+      isRpc: ${{ steps.diff.outputs.isRpc == 'true' }}
+      isPgIntegration: ${{ steps.diff.outputs.isPgIntegration == 'true' }}
+      isMoveExampleUsedByOthers: ${{ steps.diff.outputs.isMoveExampleUsedByOthers == 'true' }}
+      isRosetta: ${{ steps.diff.outputs.isRosetta == 'true' }}
+      isDoc: ${{ steps.diff.outputs.isDoc == 'true' }}
+      isReleaseNotesEligible: ${{ steps.diff.outputs.isReleaseNotesEligible == 'true' }}
+      isExternalCrates: ${{ steps.diff.outputs.isExternalCrates == 'true' }}
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Detect Changes (diff)
@@ -68,7 +68,7 @@ jobs:
       group: license-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
     needs: diff
-    if: (!cancelled() && needs.diff.outputs.isRust == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && needs.diff.outputs.isRust && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -77,12 +77,12 @@ jobs:
 
   docusaurus:
     needs: diff
-    if: (!cancelled() && needs.diff.outputs.isDoc == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && needs.diff.outputs.isDoc && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_docusaurus.yml
 
   docs-lint:
     needs: diff
-    if: (!cancelled() && needs.diff.outputs.isDoc == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && needs.diff.outputs.isDoc && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_docs_lint.yml
 
   rust:
@@ -95,18 +95,18 @@ jobs:
     uses: ./.github/workflows/_rust.yml
     secrets: inherit
     with:
-      isRust: ${{ needs.diff.outputs.isRust == 'true' }}
-      isRustWorkspaceConfig: ${{ needs.diff.outputs.isRustWorkspaceConfig == 'true' }}
-      isRustExample: ${{ needs.diff.outputs.isRustExample == 'true' }}
-      isPgIntegration: ${{ needs.diff.outputs.isPgIntegration == 'true' }}
-      isMoveExampleUsedByOthers: ${{ needs.diff.outputs.isMoveExampleUsedByOthers == 'true' }}
+      isRust: ${{ needs.diff.outputs.isRust }}
+      isRustWorkspaceConfig: ${{ needs.diff.outputs.isRustWorkspaceConfig }}
+      isRustExample: ${{ needs.diff.outputs.isRustExample }}
+      isPgIntegration: ${{ needs.diff.outputs.isPgIntegration }}
+      isMoveExampleUsedByOthers: ${{ needs.diff.outputs.isMoveExampleUsedByOthers }}
 
   rosetta:
     needs:
       - diff
       - dprint-format
       - typos
-    if: (!cancelled() && !failure() && needs.diff.outputs.isRosetta == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isRosetta && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_rosetta.yml
 
   move-ide:
@@ -115,12 +115,12 @@ jobs:
       - dprint-format
       - license-check
       - typos
-    if: (!cancelled() && !failure() && needs.diff.outputs.isExternalCrates == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isExternalCrates && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_move_ide.yml
 
   split-cluster:
     needs:
       - diff
       - rust
-    if: (!cancelled() && !failure() && needs.diff.outputs.isRust == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isRust && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_split_cluster.yml

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -19,16 +19,16 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
     if: (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]'))
     outputs:
-      isRust: ${{ steps.diff.outputs.isRust == 'true' }}
-      isRustWorkspaceConfig: ${{ steps.diff.outputs.isRustWorkspaceConfig == 'true' }}
-      isRustExample: ${{ steps.diff.outputs.isRustExample == 'true' }}
-      isRpc: ${{ steps.diff.outputs.isRpc == 'true' }}
-      isPgIntegration: ${{ steps.diff.outputs.isPgIntegration == 'true' }}
-      isMoveExampleUsedByOthers: ${{ steps.diff.outputs.isMoveExampleUsedByOthers == 'true' }}
-      isRosetta: ${{ steps.diff.outputs.isRosetta == 'true' }}
-      isDoc: ${{ steps.diff.outputs.isDoc == 'true' }}
-      isReleaseNotesEligible: ${{ steps.diff.outputs.isReleaseNotesEligible == 'true' }}
-      isExternalCrates: ${{ steps.diff.outputs.isExternalCrates == 'true' }}
+      isRust: ${{ steps.diff.outputs.isRust }}
+      isRustWorkspaceConfig: ${{ steps.diff.outputs.isRustWorkspaceConfig }}
+      isRustExample: ${{ steps.diff.outputs.isRustExample }}
+      isRpc: ${{ steps.diff.outputs.isRpc }}
+      isPgIntegration: ${{ steps.diff.outputs.isPgIntegration }}
+      isMoveExampleUsedByOthers: ${{ steps.diff.outputs.isMoveExampleUsedByOthers }}
+      isRosetta: ${{ steps.diff.outputs.isRosetta }}
+      isDoc: ${{ steps.diff.outputs.isDoc }}
+      isReleaseNotesEligible: ${{ steps.diff.outputs.isReleaseNotesEligible }}
+      isExternalCrates: ${{ steps.diff.outputs.isExternalCrates }}
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Detect Changes (diff)
@@ -68,7 +68,7 @@ jobs:
       group: license-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
     needs: diff
-    if: (!cancelled() && needs.diff.outputs.isRust && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && needs.diff.outputs.isRust == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -77,12 +77,12 @@ jobs:
 
   docusaurus:
     needs: diff
-    if: (!cancelled() && needs.diff.outputs.isDoc && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && needs.diff.outputs.isDoc == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_docusaurus.yml
 
   docs-lint:
     needs: diff
-    if: (!cancelled() && needs.diff.outputs.isDoc && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && needs.diff.outputs.isDoc == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_docs_lint.yml
 
   rust:
@@ -95,18 +95,18 @@ jobs:
     uses: ./.github/workflows/_rust.yml
     secrets: inherit
     with:
-      isRust: ${{ needs.diff.outputs.isRust }}
-      isRustWorkspaceConfig: ${{ needs.diff.outputs.isRustWorkspaceConfig }}
-      isRustExample: ${{ needs.diff.outputs.isRustExample }}
-      isPgIntegration: ${{ needs.diff.outputs.isPgIntegration }}
-      isMoveExampleUsedByOthers: ${{ needs.diff.outputs.isMoveExampleUsedByOthers }}
+      isRust: ${{ needs.diff.outputs.isRust == 'true' }}
+      isRustWorkspaceConfig: ${{ needs.diff.outputs.isRustWorkspaceConfig == 'true' }}
+      isRustExample: ${{ needs.diff.outputs.isRustExample == 'true' }}
+      isPgIntegration: ${{ needs.diff.outputs.isPgIntegration == 'true' }}
+      isMoveExampleUsedByOthers: ${{ needs.diff.outputs.isMoveExampleUsedByOthers == 'true' }}
 
   rosetta:
     needs:
       - diff
       - dprint-format
       - typos
-    if: (!cancelled() && !failure() && needs.diff.outputs.isRosetta && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isRosetta == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_rosetta.yml
 
   move-ide:
@@ -115,12 +115,12 @@ jobs:
       - dprint-format
       - license-check
       - typos
-    if: (!cancelled() && !failure() && needs.diff.outputs.isExternalCrates && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isExternalCrates == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_move_ide.yml
 
   split-cluster:
     needs:
       - diff
       - rust
-    if: (!cancelled() && !failure() && needs.diff.outputs.isRust && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isRust == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_split_cluster.yml

--- a/.github/workflows/turbo_hierarchy.yml
+++ b/.github/workflows/turbo_hierarchy.yml
@@ -18,8 +18,8 @@ jobs:
       group: turbo-diff-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
     outputs:
-      isRpc: ${{ steps.diff.outputs.isRpc == 'true' }}
-      isTypeScriptCodegenSync: ${{ steps.diff.outputs.isTypeScriptCodegenSync == 'true' }}
+      isRpc: ${{ steps.diff.outputs.isRpc }}
+      isTypeScriptCodegenSync: ${{ steps.diff.outputs.isTypeScriptCodegenSync }}
       isWallet: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), 'iota-wallet')) }}
       isExplorer: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), 'iota-explorer')) }}
       isTypescriptSDK: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), '@iota/iota-sdk')) }}
@@ -46,7 +46,7 @@ jobs:
     concurrency:
       group: turbo-sync-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
-    if: (!cancelled() && needs.diff.outputs.isTypeScriptCodegenSync && (github.ref_name == 'develop' || github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && needs.diff.outputs.isTypeScriptCodegenSync == 'true' && (github.ref_name == 'develop' || github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -146,22 +146,22 @@ jobs:
     uses: ./.github/workflows/_e2e.yml
     with:
       isNightly: false
-      isRpc: ${{ needs.diff.outputs.isRpc }}
-      isWallet: ${{ needs.diff.outputs.isWallet }}
-      isExplorer: ${{ needs.diff.outputs.isExplorer }}
-      isAppsBackend: ${{ needs.diff.outputs.isAppsBackend }}
-      isTypescriptSDK: ${{ needs.diff.outputs.isTypescriptSDK }}
-      isGraphQlTransport: ${{ needs.diff.outputs.isGraphQlTransport }}
-      isWalletDashboard: ${{ needs.diff.outputs.isWalletDashboard }}
-      isEvmBridge: ${{ needs.diff.outputs.isEvmBridge }}
-      isIscSDK: ${{ needs.diff.outputs.isIscSDK }}
-      isKiosk: ${{ needs.diff.outputs.isKiosk }}
+      isRpc: ${{ needs.diff.outputs.isRpc == 'true' }}
+      isWallet: ${{ needs.diff.outputs.isWallet == 'true' }}
+      isExplorer: ${{ needs.diff.outputs.isExplorer == 'true' }}
+      isAppsBackend: ${{ needs.diff.outputs.isAppsBackend == 'true' }}
+      isTypescriptSDK: ${{ needs.diff.outputs.isTypescriptSDK == 'true' }}
+      isGraphQlTransport: ${{ needs.diff.outputs.isGraphQlTransport == 'true' }}
+      isWalletDashboard: ${{ needs.diff.outputs.isWalletDashboard == 'true' }}
+      isEvmBridge: ${{ needs.diff.outputs.isEvmBridge == 'true' }}
+      isIscSDK: ${{ needs.diff.outputs.isIscSDK == 'true' }}
+      isKiosk: ${{ needs.diff.outputs.isKiosk == 'true' }}
     secrets:
       EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK: ${{ secrets.EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK }}
       EVM_BRIDGE_CONFIG: ${{ secrets.EVM_BRIDGE_CONFIG }}
 
   ledgernano:
-    if: (!cancelled() && !failure() && needs.diff.outputs.isLedgerjs && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isLedgerjs == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     needs: diff
     uses: ./.github/workflows/_ledgernano.yml
     secrets: inherit

--- a/.github/workflows/turbo_hierarchy.yml
+++ b/.github/workflows/turbo_hierarchy.yml
@@ -145,20 +145,20 @@ jobs:
     uses: ./.github/workflows/_e2e.yml
     with:
       isRpc: ${{ needs.diff.outputs.isRpc }}
-      isWallet: ${{ needs.diff.outputs.isWallet == 'true' }}
-      isExplorer: ${{ needs.diff.outputs.isExplorer == 'true' }}
-      isAppsBackend: ${{ needs.diff.outputs.isAppsBackend == 'true' }}
-      isTypescriptSDK: ${{ needs.diff.outputs.isTypescriptSDK == 'true' }}
-      isGraphQlTransport: ${{ needs.diff.outputs.isGraphQlTransport == 'true' }}
-      isWalletDashboard: ${{ needs.diff.outputs.isWalletDashboard == 'true' }}
-      isEvmBridge: ${{ needs.diff.outputs.isEvmBridge == 'true' }}
-      isIscSDK: ${{ needs.diff.outputs.isIscSDK == 'true' }}
+      isWallet: ${{ needs.diff.outputs.isWallet }}
+      isExplorer: ${{ needs.diff.outputs.isExplorer }}
+      isAppsBackend: ${{ needs.diff.outputs.isAppsBackend }}
+      isTypescriptSDK: ${{ needs.diff.outputs.isTypescriptSDK }}
+      isGraphQlTransport: ${{ needs.diff.outputs.isGraphQlTransport }}
+      isWalletDashboard: ${{ needs.diff.outputs.isWalletDashboard }}
+      isEvmBridge: ${{ needs.diff.outputs.isEvmBridge }}
+      isIscSDK: ${{ needs.diff.outputs.isIscSDK }}
     secrets:
       EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK: ${{ secrets.EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK }}
       EVM_BRIDGE_CONFIG: ${{ secrets.EVM_BRIDGE_CONFIG }}
 
   ledgernano:
-    if: (!cancelled() && !failure() && needs.diff.outputs.isLedgerjs == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isLedgerjs && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     needs: diff
     uses: ./.github/workflows/_ledgernano.yml
     secrets: inherit

--- a/.github/workflows/turbo_hierarchy.yml
+++ b/.github/workflows/turbo_hierarchy.yml
@@ -140,10 +140,11 @@ jobs:
           retention-days: 7
 
   e2e:
-    if: (!cancelled() && !failure() && github.ref_name != 'develop' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && (github.ref_name == 'develop' || github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     needs: diff
     uses: ./.github/workflows/_e2e.yml
     with:
+      isNightly: false
       isRpc: ${{ needs.diff.outputs.isRpc }}
       isWallet: ${{ needs.diff.outputs.isWallet }}
       isExplorer: ${{ needs.diff.outputs.isExplorer }}

--- a/.github/workflows/turbo_hierarchy.yml
+++ b/.github/workflows/turbo_hierarchy.yml
@@ -29,6 +29,7 @@ jobs:
       isGraphQlTransport: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), '@iota/graphql-transport')) }}
       isEvmBridge: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), 'iota-evm-bridge')) }}
       isLedgerjs: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), '@iota/ledgerjs-hw-app-iota')) }}
+      isKiosk: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), '@iota/kiosk')) }}
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Detect Changes (turbo)
@@ -154,6 +155,7 @@ jobs:
       isWalletDashboard: ${{ needs.diff.outputs.isWalletDashboard }}
       isEvmBridge: ${{ needs.diff.outputs.isEvmBridge }}
       isIscSDK: ${{ needs.diff.outputs.isIscSDK }}
+      isKiosk: ${{ needs.diff.outputs.isKiosk }}
     secrets:
       EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK: ${{ secrets.EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK }}
       EVM_BRIDGE_CONFIG: ${{ secrets.EVM_BRIDGE_CONFIG }}

--- a/.github/workflows/turbo_hierarchy.yml
+++ b/.github/workflows/turbo_hierarchy.yml
@@ -18,7 +18,8 @@ jobs:
       group: turbo-diff-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
     outputs:
-      isRpc: ${{ steps.diff.outputs.isRpc }}
+      isRpc: ${{ steps.diff.outputs.isRpc == 'true' }}
+      isTypeScriptCodegenSync: ${{ steps.diff.outputs.isTypeScriptCodegenSync == 'true' }}
       isWallet: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), 'iota-wallet')) }}
       isExplorer: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), 'iota-explorer')) }}
       isTypescriptSDK: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), '@iota/iota-sdk')) }}
@@ -39,11 +40,12 @@ jobs:
 
   sync:
     name: ts-sdk sync with Node Changes
+    needs: diff
     runs-on: self-hosted-x64
     concurrency:
       group: turbo-sync-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
-    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]'))
+    if: (!cancelled() && needs.diff.outputs.isTypeScriptCodegenSync && (github.ref_name == 'develop' || github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -83,7 +85,7 @@ jobs:
     concurrency:
       group: turbo-build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
-    if: (github.ref_name == 'develop' || github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')) && (needs.diff.outputs.isExplorer || needs.diff.outputs.isTypescriptSDK || needs.diff.outputs.isWallet || needs.diff.outputs.isWalletDashboard || needs.diff.outputs.isEvmBridge)
+    if: (!cancelled() && !failure() && (needs.diff.outputs.isExplorer || needs.diff.outputs.isTypescriptSDK || needs.diff.outputs.isWallet || needs.diff.outputs.isWalletDashboard || needs.diff.outputs.isEvmBridge) && (github.ref_name == 'develop' || github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -138,11 +140,11 @@ jobs:
           retention-days: 7
 
   e2e:
-    if: (!cancelled() && !failure() && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')) && github.ref_name != 'develop')
+    if: (!cancelled() && !failure() && github.ref_name != 'develop' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     needs: diff
     uses: ./.github/workflows/_e2e.yml
     with:
-      isRpc: ${{ needs.diff.outputs.isRpc == 'true' }}
+      isRpc: ${{ needs.diff.outputs.isRpc }}
       isWallet: ${{ needs.diff.outputs.isWallet == 'true' }}
       isExplorer: ${{ needs.diff.outputs.isExplorer == 'true' }}
       isAppsBackend: ${{ needs.diff.outputs.isAppsBackend == 'true' }}

--- a/.github/workflows/turbo_nightly.yml
+++ b/.github/workflows/turbo_nightly.yml
@@ -33,6 +33,7 @@ jobs:
       isWalletDashboard: true
       isEvmBridge: true
       isIscSDK: true
+      isKiosk: true
     secrets:
       EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK: ${{ secrets.EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK }}
       EVM_BRIDGE_CONFIG: ${{ secrets.EVM_BRIDGE_CONFIG }}

--- a/.github/workflows/turbo_nightly.yml
+++ b/.github/workflows/turbo_nightly.yml
@@ -22,8 +22,20 @@ jobs:
 
   e2e:
     uses: ./.github/workflows/_e2e.yml
+    with:
+      isNightly: true
+      isRpc: true
+      isExplorer: true
+      isAppsBackend: true
+      isTypescriptSDK: true
+      isWallet: true
+      isGraphQlTransport: true
+      isWalletDashboard: true
+      isEvmBridge: true
+      isIscSDK: true
     secrets:
       EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK: ${{ secrets.EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK }}
       EVM_BRIDGE_CONFIG: ${{ secrets.EVM_BRIDGE_CONFIG }}
+
   check-sri-integrity-webassets:
     uses: ./.github/workflows/check_sri.yml

--- a/.github/workflows/upload-docs-to-aws.yml
+++ b/.github/workflows/upload-docs-to-aws.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build Rust documentation
-        run: cargo test --manifest-path crates/iota-framework/Cargo.toml
+        run: UPDATE=1 cargo test --manifest-path crates/iota-framework/Cargo.toml
 
       # ----------- Build TypeScript and GraphQL Docs with pnpm -----------
       - name: Set up Node


### PR DESCRIPTION
# Description of change

This PR reduces the amount of CI runs for `TS e2e Localnet tests`, `ts-sdk sync with Node Changes` and `Lint, Build, and Test`. This should free some CI runner capacities, because tests are only run if there are changes to certain files, or if nightly is run.