### PR TITLE
fix(ci): exclude `docs/examples/` folder as trigger to `wiki-preview` workflow

### DIFF
--- a/.github/workflows/preview_wiki.yml
+++ b/.github/workflows/preview_wiki.yml
@@ -14,6 +14,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "docs/**"
+      - "!docs/examples/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
The examples are only referenced in the wiki via `file=xyz.rs`, but there are many other folders all over the repository where this is the case, which are not included in the trigger. On the other hand any change to for example `Cargo.toml` or `Cargo.lock` in the examples, triggers this long running workflow, which should be avoided.