### PR TITLE
feat(ci): enable `rust-cache` in all rust workflows

### DIFF
--- a/.github/CACHES.md
+++ b/.github/CACHES.md
@@ -1,0 +1,15 @@
+# GitHub Actions Cache Strategy
+
+This document describes our shared-key caching strategy for GitHub Actions workflows. Jobs with compatible build artifacts share cache keys to maximize cache hits and reduce build times.
+
+## Cache Key Overview
+
+| Cache Key         | Description                                         | Jobs Using This Cache                                                                                                                                           |
+| ----------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **rust-build**    | Main Rust workspace builds with stable toolchain    | • rust-tests<br/>• test-extra<br/>• e2e localnet<br/>• execution-cut<br/>• move-ide-test<br/>• rosetta<br/>• split-cluster<br/>• license-check<br/>• crate-docs |
+| **rust-clippy**   | Clippy-specific metadata and linting artifacts      | • clippy                                                                                                                                                        |
+| **rust-examples** | External examples with separate Cargo.toml files    | • lint-examples                                                                                                                                                 |
+| **rust-udeps**    | Nightly toolchain builds for dependency analysis    | • check-unused-deps                                                                                                                                             |
+| **rust-simtest**  | Simulation testing with patched dependencies        | • nightly simtest<br/>• nightly simtest-with-starfish<br/>• rust-simtests                                                                                       |
+| **rust-llvm-cov** | Coverage builds with special CARGO_PROFILE settings | • llvm-cov                                                                                                                                                      |
+| **default**       | OS-specific default builds (matrix differentiated)  | • release<br/>• release-move-ide                                                                                                                                |

--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -75,6 +75,13 @@ jobs:
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Calculate common conditions

--- a/.github/workflows/_execution_cut.yml
+++ b/.github/workflows/_execution_cut.yml
@@ -12,7 +12,16 @@ jobs:
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Make cut
         run: ./scripts/execution_layer.py cut for_ci_test
+
       - name: Check execution builds
         run: cargo build -p iota-execution

--- a/.github/workflows/_move_ide.yml
+++ b/.github/workflows/_move_ide.yml
@@ -41,6 +41,13 @@ jobs:
         with:
           ref: ${{ github.event.inputs.iota_repo_ref || github.ref }}
 
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Setup Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:

--- a/.github/workflows/_rosetta.yml
+++ b/.github/workflows/_rosetta.yml
@@ -38,6 +38,13 @@ jobs:
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Setup environment
         run: .github/scripts/rosetta/setup.sh
         shell: bash

--- a/.github/workflows/_rust_examples.yml
+++ b/.github/workflows/_rust_examples.yml
@@ -34,6 +34,14 @@ jobs:
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-examples"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Check examples
         # Set the globstar opt here to enable recursive glob.
         run: |

--- a/.github/workflows/_rust_lints.yml
+++ b/.github/workflows/_rust_lints.yml
@@ -73,12 +73,13 @@ jobs:
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      # TODO(bradh): debug and re-enable this; the caching is breaking the clippy build
-      # Enable caching of the 'librocksdb-sys' crate by additionally caching the
-      # 'librocksdb-sys' src directory which is managed by cargo
-      # - uses: bmwill/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # v1.4.0 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
-      #   with:
-      #     path: ~/.cargo/registry/src/**/librocksdb-sys-*
+
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-clippy"
+          cache-on-failure: true
+          cache-bin: "false"
 
       # See '.cargo/config' for list of enabled/disabled clippy lints
       - name: Check Clippy Lints

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -87,11 +87,22 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Setup db
         run: |
           PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U $POSTGRES_USER -c 'CREATE DATABASE iota_indexer;' -c 'ALTER SYSTEM SET max_connections = 500;'
+
       - run: docker restart --time 0 postgres_container
+
       - run: sleep 5
+
       - name: rust tests
         # test using filters, to only include changed crates and all their dependent crates.
         # "--tests-crates-external" is added when "isRust" is set because we also want to test the
@@ -144,11 +155,22 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-simtest"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Setup db
         run: |
           PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U $POSTGRES_USER -c 'CREATE DATABASE iota_indexer;' -c 'ALTER SYSTEM SET max_connections = 500;'
+
       - run: docker restart --time 0 postgres_container
+
       - run: sleep 5
+
       - name: rust tests
         # test using filters, to only include changed crates and all their dependent crates.
         # "RESTART_POSTGRES" is set in the env variables above.
@@ -169,6 +191,7 @@ jobs:
           ARGS="$ARGS --changed-crates '${{ inputs.changedCrates }}'"
 
           eval "./scripts/ci_tests/rust_tests.sh $ARGS"
+
       - name: check new tests for flakiness
         run: |
           ARGS="--run-stress-new-tests-check-for-flakiness"
@@ -186,8 +209,17 @@ jobs:
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-udeps"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Run Cargo Udeps
         run: cargo +nightly-2026-01-07 ci-udeps ${{ matrix.flags }}
+
       - name: Run Cargo Udeps (external crates)
         run: cargo +nightly-2026-01-07 ci-udeps-external ${{ matrix.flags }}
 
@@ -206,20 +238,33 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: benchmark (smoke)
         run: |
           cargo run --package iota-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --transfer-object 50 --shared-counter 50 --run-duration 10s --stress-stat-collection
+
       - name: doctests
         run: |
           cargo test --doc
+
       - name: rustdoc
         run: |
           cargo doc --all-features --workspace --no-deps
+
       - name: Install nightly rustfmt
         run: rustup toolchain install nightly --component rustfmt --allow-downgrade
+
       - name: iota-execution
         run: |
           ./scripts/execution_layer.py generate-lib
+
       # Ensure there are no uncommitted changes in the repo after running tests
       - run: scripts/changed-files.sh
         shell: bash

--- a/.github/workflows/_split_cluster.yml
+++ b/.github/workflows/_split_cluster.yml
@@ -23,12 +23,21 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: 0
+
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Run split cluster check script
         id: mn-split-cluster-check
         run: |
           WORKING_DIR=/tmp/mainnet-split-cluster-${{ github.run_id }} \
           IOTA_PROTOCOL_CONFIG_CHAIN_OVERRIDE=mainnet \
           scripts/compatibility/split-cluster-check.sh origin/mainnet ${{ github.sha }}
+
       - name: Upload mainnet split cluster logs on failure
         if: failure()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -37,6 +46,7 @@ jobs:
           path: /tmp/mainnet-split-cluster-${{ github.run_id }}/logs/
           retention-days: 5
           if-no-files-found: warn
+
   validate-testnet:
     runs-on: self-hosted-x64
     if: (!cancelled() && !failure())
@@ -45,12 +55,21 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: 0
+
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Run split cluster check script
         id: tn-split-cluster-check
         run: |
           WORKING_DIR=/tmp/testnet-split-cluster-${{ github.run_id }} \
           IOTA_PROTOCOL_CONFIG_CHAIN_OVERRIDE=testnet \
           scripts/compatibility/split-cluster-check.sh origin/testnet ${{ github.sha }}
+
       - name: Upload testnet split cluster logs on failure
         if: failure()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/cargo_llvm_cov.yml
+++ b/.github/workflows/cargo_llvm_cov.yml
@@ -50,7 +50,12 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch-or-commit || github.ref }}
 
-      - uses: bmwill/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # v1.4.0
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-llvm-cov"
+          cache-on-failure: true
+          cache-bin: "false"
 
       - name: Set Swap Space
         uses: actionhippie/swap-space@73376950a0019f8e1f6a3d3d2673fe2aed74ae17 # v1.0.2

--- a/.github/workflows/crate_docs.yml
+++ b/.github/workflows/crate_docs.yml
@@ -19,6 +19,13 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Generate documentation
         uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
         with:

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -72,6 +72,14 @@ jobs:
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Run license check
         run: cargo ci-license
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -126,10 +126,19 @@ jobs:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           ref: ${{ env.IOTA_REF }}
+
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-simtest"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Get latest simtest script from commit that triggered this workflow
         run: |
           git fetch origin ${{ github.sha }}
           git checkout ${{ github.sha }} -- scripts/simtest/simtest-run.sh
+
       - name: Run simtest
         run: scripts/simtest/simtest-run.sh
 
@@ -144,9 +153,18 @@ jobs:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           ref: ${{ env.IOTA_REF }}
+
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: "rust-simtest"
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Get latest simtest script from commit that triggered this workflow
         run: |
           git fetch origin ${{ github.sha }}
           git checkout ${{ github.sha }} -- scripts/simtest/simtest-run.sh
+
       - name: Run simtest
         run: scripts/simtest/simtest-run.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,8 +119,10 @@ jobs:
           echo "extension=$(echo ".exe")" >> $GITHUB_ENV
 
       - name: Setup caching
-        # Fork of 'Swatinem/rust-cache' which allows caching additional paths
-        uses: bmwill/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # v1.4.0
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          cache-on-failure: true
+          cache-bin: "false"
 
       - name: Install postgres (Windows)
         if: ${{ matrix.os_type == 'windows-x86_64' }}

--- a/.github/workflows/release_move_ide.yml
+++ b/.github/workflows/release_move_ide.yml
@@ -43,6 +43,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
+
+      - name: Setup caching
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          cache-on-failure: true
+          cache-bin: "false"
+
       - name: Set os/arch variables (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         shell: bash


### PR DESCRIPTION
# Description of change

This PR enables the `Swatinem/rust-cache` action in all rust workflows to save compilation time.

Maybe we should also consider using https://github.com/falcondev-oss/github-actions-cache-server on our self hosted runners.

[run-ci]

## Cache Key Overview

| Cache Key | Description | Jobs Using This Cache |
|-----------|-------------|----------------------|
| **rust-build** | Main Rust workspace builds with stable toolchain | • rust-tests<br/>• test-extra<br/>• e2e localnet<br/>• execution-cut<br/>• move-ide-test<br/>• rosetta<br/>• split-cluster<br/>• license-check<br/>• crate-docs |
| **rust-clippy** | Clippy-specific metadata and linting artifacts | • clippy |
| **rust-examples** | External examples with separate Cargo.toml files | • lint-examples |
| **rust-udeps** | Nightly toolchain builds for dependency analysis | • check-unused-deps |
| **rust-simtest** | Simulation testing with patched dependencies | • nightly simtest<br/>• nightly simtest-with-starfish<br/>• rust-simtests |
| **rust-llvm-cov** | Coverage builds with special CARGO_PROFILE settings | • llvm-cov |
| **default** | OS-specific default builds (matrix differentiated) | • release<br/>• release-move-ide |
