### PR TITLE
feat(wallet): Compute effectiveCommission rate (IIP8)

### DIFF
--- a/apps/core/src/hooks/useGetStakingValidatorDetails.ts
+++ b/apps/core/src/hooks/useGetStakingValidatorDetails.ts
@@ -76,8 +76,8 @@ export function useGetStakingValidatorDetails({
     const totalStakeFormatted = useFormatCoin({ balance: totalStake });
     const totalValidatorsStakeFormatted = useFormatCoin({ balance: totalValidatorStake });
 
-    // Temporarily needed to compute the effectiveCommisionRate until infra exposes it in commisionRate directly
-    const hasEffectiveCommisionRate = Number(system?.protocolVersion ?? 0) >= 20;
+    // Temporarily needed to compute the effectiveCommissionRate until infra exposes it in commisionRate directly
+    const hasEffectiveCommissionRate = Number(system?.protocolVersion ?? 0) >= 20;
 
     return {
         epoch: Number(system?.epoch) || 0,
@@ -88,6 +88,6 @@ export function useGetStakingValidatorDetails({
         validatorApy,
         systemDataResult,
         delegatedStakeDataResult,
-        commission: getValidatorCommission(validatorData, hasEffectiveCommisionRate),
+        commission: getValidatorCommission(validatorData, hasEffectiveCommissionRate),
     };
 }

--- a/apps/core/src/hooks/useGetStakingValidatorDetails.ts
+++ b/apps/core/src/hooks/useGetStakingValidatorDetails.ts
@@ -76,7 +76,7 @@ export function useGetStakingValidatorDetails({
     const totalStakeFormatted = useFormatCoin({ balance: totalStake });
     const totalValidatorsStakeFormatted = useFormatCoin({ balance: totalValidatorStake });
 
-    // Temporarily needed to compute the effectiveCommissionRate until infra exposes it in commisionRate directly
+    // Temporarily needed to compute the effectiveCommissionRate until infra exposes it in commissionRate directly
     const hasEffectiveCommissionRate = Number(system?.protocolVersion ?? 0) >= 20;
 
     return {

--- a/apps/core/src/hooks/useGetStakingValidatorDetails.ts
+++ b/apps/core/src/hooks/useGetStakingValidatorDetails.ts
@@ -76,6 +76,9 @@ export function useGetStakingValidatorDetails({
     const totalStakeFormatted = useFormatCoin({ balance: totalStake });
     const totalValidatorsStakeFormatted = useFormatCoin({ balance: totalValidatorStake });
 
+    // Temporarily needed to compute the effectiveCommisionRate until infra exposes it in commisionRate directly
+    const hasEffectiveCommisionRate = Number(system?.protocolVersion ?? 0) >= 20;
+
     return {
         epoch: Number(system?.epoch) || 0,
         totalStake: totalStakeFormatted,
@@ -85,6 +88,6 @@ export function useGetStakingValidatorDetails({
         validatorApy,
         systemDataResult,
         delegatedStakeDataResult,
-        commission: getValidatorCommission(validatorData),
+        commission: getValidatorCommission(validatorData, hasEffectiveCommisionRate),
     };
 }

--- a/apps/core/src/utils/stake/getValidatorCommission.ts
+++ b/apps/core/src/utils/stake/getValidatorCommission.ts
@@ -4,7 +4,16 @@
 import { IotaValidatorSummary } from '@iota/iota-sdk/client';
 import { formatPercentageDisplay } from '../formatPercentageDisplay';
 
-export function getValidatorCommission(validatorData?: IotaValidatorSummary | null) {
-    const commission = validatorData ? Number(validatorData.commissionRate) / 100 : 0;
+export function getValidatorCommission(
+    validatorData?: IotaValidatorSummary | null,
+    hasEffectiveCommissionRate?: boolean,
+) {
+    const showEffectiveCommissionRate = !!hasEffectiveCommissionRate;
+    const commission = validatorData
+        ? showEffectiveCommissionRate
+            ? Math.max(Number(validatorData.commissionRate), Number(validatorData.votingPower)) /
+              100
+            : Number(validatorData.commissionRate) / 100
+        : 0;
     return formatPercentageDisplay(commission, '--');
 }

--- a/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
+++ b/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
@@ -134,8 +134,8 @@ export function DelegationDetailCard({ validatorAddress, stakedId }: DelegationD
         toast.error(error?.message ?? 'An error occurred fetching validator information');
     }
 
-    // Temporarily needed to compute the effectiveCommisionRate until infra exposes it in commisionRate directly
-    const hasEffectiveCommisionRate = Number(system?.protocolVersion ?? 0) >= 20;
+    // Temporarily needed to compute the effectiveCommissionRate until infra exposes it in commisionRate directly
+    const hasEffectiveCommissionRate = Number(system?.protocolVersion ?? 0) >= 20;
 
     function handleAddNewStake() {
         navigate(stakeByValidatorAddress);
@@ -196,7 +196,10 @@ export function DelegationDetailCard({ validatorAddress, stakedId }: DelegationD
                         />
                         <KeyValueInfo
                             keyText="Commission"
-                            value={getValidatorCommission(validatorData, hasEffectiveCommisionRate)}
+                            value={getValidatorCommission(
+                                validatorData,
+                                hasEffectiveCommissionRate,
+                            )}
                             fullwidth
                             tooltipText="The share of rewards retained by the validator. This rate includes a protocol-enforced minimum to help maintain network decentralization."
                             tooltipPosition={TooltipPosition.Right}

--- a/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
+++ b/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
@@ -134,7 +134,7 @@ export function DelegationDetailCard({ validatorAddress, stakedId }: DelegationD
         toast.error(error?.message ?? 'An error occurred fetching validator information');
     }
 
-    // Temporarily needed to compute the effectiveCommissionRate until infra exposes it in commisionRate directly
+    // Temporarily needed to compute the effectiveCommissionRate until infra exposes it in commissionRate directly
     const hasEffectiveCommissionRate = Number(system?.protocolVersion ?? 0) >= 20;
 
     function handleAddNewStake() {

--- a/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
+++ b/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
@@ -133,6 +133,10 @@ export function DelegationDetailCard({ validatorAddress, stakedId }: DelegationD
     if (isError || errorValidators) {
         toast.error(error?.message ?? 'An error occurred fetching validator information');
     }
+
+    // Temporarily needed to compute the effectiveCommisionRate until infra exposes it in commisionRate directly
+    const hasEffectiveCommisionRate = Number(system?.protocolVersion ?? 0) >= 20;
+
     function handleAddNewStake() {
         navigate(stakeByValidatorAddress);
         ampli.stakeClicked({
@@ -192,9 +196,9 @@ export function DelegationDetailCard({ validatorAddress, stakedId }: DelegationD
                         />
                         <KeyValueInfo
                             keyText="Commission"
-                            value={getValidatorCommission(validatorData)}
+                            value={getValidatorCommission(validatorData, hasEffectiveCommisionRate)}
                             fullwidth
-                            tooltipText="The charge imposed by the validator for their staking services."
+                            tooltipText="The share of rewards retained by the validator. This rate includes a protocol-enforced minimum to help maintain network decentralization."
                             tooltipPosition={TooltipPosition.Right}
                         />
                     </div>

--- a/apps/wallet/src/ui/app/staking/stake/ValidatorFormDetail.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/ValidatorFormDetail.tsx
@@ -82,7 +82,7 @@ export function ValidatorFormDetail({ validatorAddress, unstake }: ValidatorForm
                         keyText="Commission"
                         value={commission}
                         fullwidth
-                        tooltipText="The charge imposed by the validator for their staking services."
+                        tooltipText="The share of rewards retained by the validator. This rate includes a protocol-enforced minimum to help maintain network decentralization."
                         tooltipPosition={TooltipPosition.Bottom}
                     />
                     <KeyValueInfo


### PR DESCRIPTION
# Description of change

- Updates commissionRate to the new "effective commission rate" conditionally on protocolVersion >= 20
- Updates the labels unconditionally

To be removed easily once infra includes this computation in the API directly. To remove just follow `hasEffectiveCommissionRate`.

## Links to any relevant issues

Related to https://github.com/iotaledger/iota/issues/10314

## How the change has been tested

Looked at the wallet (devnet) on staking related views
