### PR TITLE
feat(dashboard+explorer): Compute effectiveCommission rate (IIP8) in staking related forms

### DIFF
--- a/apps/core/src/hooks/stake/useValidatorInfo.ts
+++ b/apps/core/src/hooks/stake/useValidatorInfo.ts
@@ -29,7 +29,17 @@ export function useValidatorInfo({ validatorAddress }: { validatorAddress: strin
         apy: null,
     };
 
-    const commission = validatorSummary ? Number(validatorSummary.commissionRate) / 100 : 0;
+    // Temporarily needed to compute the effectiveCommissionRate until infra exposes it in commissionRate directly
+    const hasEffectiveCommissionRate = Number(system?.protocolVersion ?? 0) >= 20;
+
+    const commission = validatorSummary
+        ? hasEffectiveCommissionRate
+            ? Math.max(
+                  Number(validatorSummary.commissionRate),
+                  Number(validatorSummary.votingPower),
+              ) / 100
+            : Number(validatorSummary.commissionRate) / 100
+        : 0;
 
     return {
         system,

--- a/apps/core/src/hooks/useGetStakingValidatorDetails.ts
+++ b/apps/core/src/hooks/useGetStakingValidatorDetails.ts
@@ -76,6 +76,9 @@ export function useGetStakingValidatorDetails({
     const totalStakeFormatted = useFormatCoin({ balance: totalStake });
     const totalValidatorsStakeFormatted = useFormatCoin({ balance: totalValidatorStake });
 
+    // Temporarily needed to compute the effectiveCommissionRate until infra exposes it in commissionRate directly
+    const hasEffectiveCommissionRate = Number(system?.protocolVersion ?? 0) >= 20;
+
     return {
         epoch: Number(system?.epoch) || 0,
         totalStake: totalStakeFormatted,
@@ -85,6 +88,6 @@ export function useGetStakingValidatorDetails({
         validatorApy,
         systemDataResult,
         delegatedStakeDataResult,
-        commission: getValidatorCommission(validatorData),
+        commission: getValidatorCommission(validatorData, hasEffectiveCommissionRate),
     };
 }

--- a/apps/core/src/utils/stake/getValidatorCommission.ts
+++ b/apps/core/src/utils/stake/getValidatorCommission.ts
@@ -4,7 +4,16 @@
 import { IotaValidatorSummary } from '@iota/iota-sdk/client';
 import { formatPercentageDisplay } from '../formatPercentageDisplay';
 
-export function getValidatorCommission(validatorData?: IotaValidatorSummary | null) {
-    const commission = validatorData ? Number(validatorData.commissionRate) / 100 : 0;
+export function getValidatorCommission(
+    validatorData?: IotaValidatorSummary | null,
+    hasEffectiveCommissionRate?: boolean,
+) {
+    const showEffectiveCommissionRate = !!hasEffectiveCommissionRate;
+    const commission = validatorData
+        ? showEffectiveCommissionRate
+            ? Math.max(Number(validatorData.commissionRate), Number(validatorData.votingPower)) /
+              100
+            : Number(validatorData.commissionRate) / 100
+        : 0;
     return formatPercentageDisplay(commission, '--');
 }

--- a/apps/explorer/src/components/validator/ValidatorStats.tsx
+++ b/apps/explorer/src/components/validator/ValidatorStats.tsx
@@ -66,6 +66,15 @@ export function ValidatorStats({
                         />
                     </div>
                     <div className="grid grid-rows-1 gap-md">
+                        {hasEffectiveCommissionRate && (
+                            <LabelText
+                                size={LabelTextSize.Medium}
+                                label="Effective Commission Rate"
+                                text={effectiveCommissionRate}
+                                tooltipText="The share of rewards retained by the validator. This rate includes a protocol-enforced minimum to help maintain network decentralization."
+                                tooltipPosition={TooltipPosition.Right}
+                            />
+                        )}
                         <LabelText
                             size={LabelTextSize.Medium}
                             label="Commission"
@@ -73,15 +82,6 @@ export function ValidatorStats({
                             tooltipText="The charge imposed by the validator for their staking services."
                             tooltipPosition={TooltipPosition.Right}
                         />
-                        {hasEffectiveCommissionRate && (
-                            <LabelText
-                                size={LabelTextSize.Medium}
-                                label="Effective Commission rate"
-                                text={effectiveCommissionRate}
-                                tooltipText="The share of rewards retained by the validator. This rate includes a protocol-enforced minimum to help maintain network decentralization."
-                                tooltipPosition={TooltipPosition.Right}
-                            />
-                        )}
                     </div>
                 </div>
             </Panel>

--- a/apps/explorer/src/components/validator/ValidatorStats.tsx
+++ b/apps/explorer/src/components/validator/ValidatorStats.tsx
@@ -5,6 +5,7 @@
 import type { IotaValidatorSummary } from '@iota/iota-sdk/client';
 import { LabelText, LabelTextSize, Panel, Title, TooltipPosition } from '@iota/apps-ui-kit';
 import { getValidatorCommission, useFormatCoin } from '@iota/core';
+import { useIotaClientQuery } from '@iota/dapp-kit';
 
 type StatsCardProps = {
     validatorData: IotaValidatorSummary;
@@ -20,13 +21,19 @@ export function ValidatorStats({
     apy,
     tallyingScore,
 }: StatsCardProps): JSX.Element {
+    const { data: systemState } = useIotaClientQuery('getLatestIotaSystemState');
     // TODO: Add logic for validator stats https://github.com/iotaledger/iota/issues/2449
-    const numberOfDelegators = 0;
     const networkStakingParticipation = 0;
     const votedLastRound = 0;
 
     const totalStake = Number(validatorData.stakingPoolIotaBalance);
 
+    // Temporarily needed to compute the effectiveCommissionRate until infra exposes it in commissionRate directly
+    const hasEffectiveCommissionRate = Number(systemState?.protocolVersion ?? 0) >= 20;
+    const effectiveCommissionRate = getValidatorCommission(
+        validatorData,
+        hasEffectiveCommissionRate,
+    );
     const commission = getValidatorCommission(validatorData);
     const rewardsPoolBalance = Number(validatorData.rewardsPool);
 
@@ -66,17 +73,15 @@ export function ValidatorStats({
                             tooltipText="The charge imposed by the validator for their staking services."
                             tooltipPosition={TooltipPosition.Right}
                         />
-                        <LabelText
-                            size={LabelTextSize.Medium}
-                            label="Delegators"
-                            text={numberOfDelegators || '--'}
-                            tooltipText={
-                                !numberOfDelegators
-                                    ? 'Coming soon'
-                                    : 'The number of delegators who have staked on this validator.'
-                            }
-                            tooltipPosition={TooltipPosition.Right}
-                        />
+                        {hasEffectiveCommissionRate && (
+                            <LabelText
+                                size={LabelTextSize.Medium}
+                                label="Effective Commission rate"
+                                text={effectiveCommissionRate}
+                                tooltipText="The share of rewards retained by the validator. This rate includes a protocol-enforced minimum to help maintain network decentralization."
+                                tooltipPosition={TooltipPosition.Right}
+                            />
+                        )}
                     </div>
                 </div>
             </Panel>

--- a/apps/explorer/src/lib/ui/utils/generateValidatorsTableColumns.tsx
+++ b/apps/explorer/src/lib/ui/utils/generateValidatorsTableColumns.tsx
@@ -185,6 +185,25 @@ export function generateValidatorsTableColumns({
             },
         },
         {
+            header: 'Effective Commission',
+            accessorKey: 'effectiveCommissionRate',
+            id: 'effectiveCommissionRate',
+            enableSorting: true,
+            sortingFn: sortByNumber,
+            cell({ row }) {
+                const { original: validator } = row;
+                const commissionRate = Number(validator.commissionRate);
+                const votingPower = Number(validator.votingPower);
+                const effectiveCommissionRate = Math.max(commissionRate, votingPower);
+
+                return (
+                    <TableCellBase>
+                        <TableCellText>{`${effectiveCommissionRate / 100}%`}</TableCellText>
+                    </TableCellBase>
+                );
+            },
+        },
+        {
             header: 'Commission',
             accessorKey: 'commissionRate',
             enableSorting: true,
@@ -206,25 +225,6 @@ export function generateValidatorsTableColumns({
                 return (
                     <TableCellBase>
                         <TableCellText>{`${Number(getValue()) / 100}%`}</TableCellText>
-                    </TableCellBase>
-                );
-            },
-        },
-        {
-            header: 'Effective Commission',
-            accessorKey: 'effectiveCommissionRate',
-            id: 'effectiveCommissionRate',
-            enableSorting: true,
-            sortingFn: sortByNumber,
-            cell({ row }) {
-                const { original: validator } = row;
-                const commissionRate = Number(validator.commissionRate);
-                const votingPower = Number(validator.votingPower);
-                const effectiveCommissionRate = Math.max(commissionRate, votingPower);
-
-                return (
-                    <TableCellBase>
-                        <TableCellText>{`${effectiveCommissionRate / 100}%`}</TableCellText>
                     </TableCellBase>
                 );
             },

--- a/apps/explorer/src/lib/ui/utils/generateValidatorsTableColumns.tsx
+++ b/apps/explorer/src/lib/ui/utils/generateValidatorsTableColumns.tsx
@@ -211,6 +211,25 @@ export function generateValidatorsTableColumns({
             },
         },
         {
+            header: 'Effective Commission',
+            accessorKey: 'effectiveCommissionRate',
+            id: 'effectiveCommissionRate',
+            enableSorting: true,
+            sortingFn: sortByNumber,
+            cell({ row }) {
+                const { original: validator } = row;
+                const commissionRate = Number(validator.commissionRate);
+                const votingPower = Number(validator.votingPower);
+                const effectiveCommissionRate = Math.max(commissionRate, votingPower);
+
+                return (
+                    <TableCellBase>
+                        <TableCellText>{`${effectiveCommissionRate / 100}%`}</TableCellText>
+                    </TableCellBase>
+                );
+            },
+        },
+        {
             header: 'Next Epoch Stake',
             accessorKey: 'nextEpochStake',
             id: 'nextEpochStake',

--- a/apps/explorer/src/pages/epochs/EpochDetail.tsx
+++ b/apps/explorer/src/pages/epochs/EpochDetail.tsx
@@ -76,6 +76,9 @@ export function EpochDetail() {
             (committeeMemberIndex) => epochData.validators[Number(committeeMemberIndex)],
         ) ?? [];
 
+    // Temporarily needed to compute the effectiveCommissionRate until infra exposes it in commissionRate directly
+    const hasEffectiveCommissionRate = Number(systemState?.protocolVersion ?? 0) >= 20;
+
     const tableColumns = useMemo(() => {
         if (!epochData?.validators || epochData.validators.length === 0) return null;
         const includeColumns = [
@@ -83,6 +86,7 @@ export function EpochDetail() {
             'Stake',
             'APY',
             'Commission',
+            ...(hasEffectiveCommissionRate ? ['Effective Commission'] : []),
             'Last Epoch Rewards',
             'Voting Power',
             'Status',
@@ -97,7 +101,7 @@ export function EpochDetail() {
             includeColumns,
             currentEpoch: epochData.epoch,
         });
-    }, [epochData, validatorEvents, committeeMembers]);
+    }, [epochData, validatorEvents, committeeMembers, hasEffectiveCommissionRate]);
 
     if (isPending) return <PageLayout content={<LoadingIndicator />} />;
 

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -135,6 +135,9 @@ function ValidatorPageResult(): JSX.Element {
             : activeValidators
         : [];
 
+    // Temporarily needed to compute the effectiveCommissionRate until infra exposes it in commissionRate directly
+    const hasEffectiveCommissionRate = Number(data?.protocolVersion ?? 0) >= 20;
+
     const tableColumns = useMemo(() => {
         if (!data || !maxCommitteeSize || !validatorEvents) return null;
         const includeColumns = [
@@ -143,6 +146,7 @@ function ValidatorPageResult(): JSX.Element {
             'APY',
             'Commission',
             'Next Epoch Commission',
+            ...(hasEffectiveCommissionRate ? ['Effective Commission'] : []),
             'Next Epoch Stake',
             'Last Epoch Rewards',
             'Voting Power',
@@ -162,7 +166,14 @@ function ValidatorPageResult(): JSX.Element {
             includeColumns,
             currentEpoch: data.epoch,
         });
-    }, [data, activeAndPendingValidators, validatorEvents, validatorsApy, maxCommitteeSize]);
+    }, [
+        data,
+        activeAndPendingValidators,
+        validatorEvents,
+        validatorsApy,
+        maxCommitteeSize,
+        hasEffectiveCommissionRate,
+    ]);
 
     const [formattedTotalStakedAmount, totalStakedSymbol] = useFormatCoin({ balance: totalStaked });
     const [formattedlastEpochRewardOnAllValidatorsAmount, lastEpochRewardOnAllValidatorsSymbol] =


### PR DESCRIPTION
# Description of change

- Updates commissionRate to the new "effective commission rate" conditionally on protocolVersion >= 20

To be removed easily once infra includes this computation in the API directly. To remove just follow `hasEffectiveCommissionRate`.

## Links to any relevant issues

Related to https://github.com/iotaledger/iota/issues/10314