### PR TITLE
refactor(iota-types): add versioning to MoveAuthenticator

### DIFF
--- a/.changeset/silent-beds-complain.md
+++ b/.changeset/silent-beds-complain.md
@@ -1,0 +1,5 @@
+---
+'@iota/iota-sdk': minor
+---
+
+Support MoveAuthenticator versioning.

--- a/apps/explorer/src/pages/transaction-result/Signatures.tsx
+++ b/apps/explorer/src/pages/transaction-result/Signatures.tsx
@@ -105,14 +105,15 @@ export function Signatures({ transaction }: SignaturesProps) {
 
             if (parsed.signatureScheme === 'MoveAuthenticator') {
                 const authenticatedObjectId =
-                    parsed.moveAuthenticator.objectToAuthenticate.Object?.$kind ===
+                    parsed.moveAuthenticator.V1.objectToAuthenticate.Object?.$kind ===
                     'ImmOrOwnedObject'
-                        ? parsed.moveAuthenticator.objectToAuthenticate.Object.ImmOrOwnedObject
+                        ? parsed.moveAuthenticator.V1.objectToAuthenticate.Object.ImmOrOwnedObject
                               .objectId
-                        : parsed.moveAuthenticator.objectToAuthenticate.Object?.$kind ===
+                        : parsed.moveAuthenticator.V1.objectToAuthenticate.Object?.$kind ===
                             'Receiving'
-                          ? parsed.moveAuthenticator.objectToAuthenticate.Object.Receiving.objectId
-                          : parsed.moveAuthenticator.objectToAuthenticate.Object?.SharedObject
+                          ? parsed.moveAuthenticator.V1.objectToAuthenticate.Object.Receiving
+                                .objectId
+                          : parsed.moveAuthenticator.V1.objectToAuthenticate.Object?.SharedObject
                                 ?.objectId;
                 return {
                     ...parsed,

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable.snap
@@ -40,4 +40,4 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
 
 task 5, lines 22-23:
 //# abstract --account object(4,2) --ptb-inputs 100 @A
-Error: Error checking transaction input objects: Feature is not supported: MoveAuthenticator cannot authenticate mutable shared objects
+Error: Error checking transaction input objects: Feature is not supported: MoveAuthenticatorV1 cannot authenticate mutable shared objects

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -1289,11 +1289,9 @@ impl TestEnvironment {
         .take(Ed25519Signature::LENGTH * 2)
         .collect();
         let signature_call_arg = CallArg::Pure(bcs::to_bytes(&hex_encoded_signature)?);
-        Ok(GenericSignature::MoveAuthenticator(MoveAuthenticator::new(
-            vec![signature_call_arg],
-            vec![],
-            self_call_arg,
-        )))
+        Ok(GenericSignature::MoveAuthenticator(
+            MoveAuthenticator::new_v1(vec![signature_call_arg], vec![], self_call_arg),
+        ))
     }
 
     // Create the MoveAuthenticator for the free access authenticator:
@@ -1311,11 +1309,9 @@ impl TestEnvironment {
             initial_shared_version: aa_ref.1,
             mutable: false,
         });
-        Ok(GenericSignature::MoveAuthenticator(MoveAuthenticator::new(
-            vec![],
-            vec![],
-            self_call_arg,
-        )))
+        Ok(GenericSignature::MoveAuthenticator(
+            MoveAuthenticator::new_v1(vec![], vec![], self_call_arg),
+        ))
     }
 
     // -----------------------------------------------

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -7740,7 +7740,7 @@
             ],
             "properties": {
               "MoveAuthenticator": {
-                "$ref": "#/components/schemas/MoveAuthenticator"
+                "$ref": "#/components/schemas/MoveAuthenticatorVersioned"
               }
             },
             "additionalProperties": false
@@ -10138,8 +10138,11 @@
           }
         }
       },
-      "MoveAuthenticator": {
-        "description": "MoveAuthenticator is a GenericSignature variant that enables a new method of authentication through Move code. This function represents the data received by the Move authenticate function during the Account Abstraction authentication flow.",
+      "MoveAuthenticatorAsBytes": {
+        "$ref": "#/components/schemas/Base64"
+      },
+      "MoveAuthenticatorV1": {
+        "description": "MoveAuthenticatorV1 is the first version of MoveAuthenticator.",
         "type": "object",
         "required": [
           "call_args",
@@ -10171,8 +10174,22 @@
           }
         }
       },
-      "MoveAuthenticatorAsBytes": {
-        "$ref": "#/components/schemas/Base64"
+      "MoveAuthenticatorVersioned": {
+        "description": "MoveAuthenticatorVersioned is an enum that represents the different versions of MoveAuthenticator.",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "V1"
+            ],
+            "properties": {
+              "V1": {
+                "$ref": "#/components/schemas/MoveAuthenticatorV1"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "MoveCallMetrics": {
         "type": "object",

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -7740,7 +7740,7 @@
             ],
             "properties": {
               "MoveAuthenticator": {
-                "$ref": "#/components/schemas/MoveAuthenticatorVersioned"
+                "$ref": "#/components/schemas/MoveAuthenticator"
               }
             },
             "additionalProperties": false
@@ -10138,6 +10138,24 @@
           }
         }
       },
+      "MoveAuthenticator": {
+        "description": "MoveAuthenticator is a GenericSignature variant that enables a new method of authentication through Move code. This function represents the data received by the Move authenticate function during the Account Abstraction authentication flow.",
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "V1"
+            ],
+            "properties": {
+              "V1": {
+                "$ref": "#/components/schemas/MoveAuthenticatorV1"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
       "MoveAuthenticatorAsBytes": {
         "$ref": "#/components/schemas/Base64"
       },
@@ -10173,23 +10191,6 @@
             }
           }
         }
-      },
-      "MoveAuthenticatorVersioned": {
-        "description": "MoveAuthenticatorVersioned is an enum that represents the different versions of MoveAuthenticator.",
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "V1"
-            ],
-            "properties": {
-              "V1": {
-                "$ref": "#/components/schemas/MoveAuthenticatorV1"
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
       },
       "MoveCallMetrics": {
         "type": "object",

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -1425,7 +1425,7 @@ impl IotaTestAdapter {
 
         Ok((
             aa_id,
-            GenericSignature::MoveAuthenticator(MoveAuthenticator::new(
+            GenericSignature::MoveAuthenticator(MoveAuthenticator::new_v1(
                 auth_inputs,
                 vec![],
                 CallArg::Object(aa_arg),

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -1516,8 +1516,7 @@ where
     fn write(&self, writer: &mut W) {
         let name = "MoveAuthenticator";
         write!(writer, "{name}::").expect("Hasher should not fail");
-        bcs::serialize_into(writer, &self.inner)
-            .expect("Message serialization should not fail");
+        bcs::serialize_into(writer, &self.inner).expect("Message serialization should not fail");
     }
 }
 

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -1480,7 +1480,6 @@ mod bcs_signable {
     impl BcsSignable for crate::effects::TransactionEffects {}
     impl BcsSignable for crate::effects::TransactionEvents {}
     impl BcsSignable for crate::transaction::TransactionData {}
-    impl BcsSignable for crate::move_authenticator::MoveAuthenticator {}
     impl BcsSignable for crate::transaction::SenderSignedData {}
     impl BcsSignable for crate::object::ObjectInner {}
 
@@ -1501,6 +1500,37 @@ where
         // Note: This assumes that names never contain the separator `::`.
         write!(writer, "{name}::").expect("Hasher should not fail");
         bcs::serialize_into(writer, &self).expect("Message serialization should not fail");
+    }
+}
+
+/// Manual [`Signable`] impl for [`MoveAuthenticator`].
+///
+/// `serde_name::trace_name` returns `None` for types that carry
+/// `#[serde(flatten)]`, so the blanket impl via `BcsSignable` panics.
+/// We hardcode the tag and serialise via `self.inner` — the same
+/// representation that `AsRef<[u8]>` already uses.
+impl<W> Signable<W> for crate::move_authenticator::MoveAuthenticator
+where
+    W: std::io::Write,
+{
+    fn write(&self, writer: &mut W) {
+        let name = "MoveAuthenticator";
+        write!(writer, "{name}::").expect("Hasher should not fail");
+        bcs::serialize_into(writer, &self.inner)
+            .expect("Message serialization should not fail");
+    }
+}
+
+impl SignableBytes for crate::move_authenticator::MoveAuthenticator {
+    fn from_signable_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        let name = "MoveAuthenticator";
+        let name_byte_len = format!("{name}::").bytes().len();
+        let inner = bcs::from_bytes(
+            bytes
+                .get(name_byte_len..)
+                .ok_or_else(|| anyhow!("Failed to deserialize to {name}."))?,
+        )?;
+        Ok(Self::from_inner(inner))
     }
 }
 

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -1503,7 +1503,7 @@ where
     }
 }
 
-/// Manual [`Signable`] impl for [`MoveAuthenticator`].
+/// Manual [`Signable`] impl for MoveAuthenticator.
 ///
 /// `serde_name::trace_name` returns `None` for types that carry
 /// `#[serde(flatten)]`, so the blanket impl via `BcsSignable` panics.

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -32,11 +32,8 @@ use crate::{
 /// This function represents the data received by the Move authenticate function
 /// during the Account Abstraction authentication flow.
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
-// The `transparent` attribute allows us to get rid of one level of nesting in the serialized form,
-// which is reasonable since `MoveAuthenticator` will not be extended with more fields in the
-// future, and it simplifies the serialization logic.
-#[serde(transparent)]
 pub struct MoveAuthenticator {
+    #[serde(flatten)]
     inner: MoveAuthenticatorVersioned,
     /// A bytes representation of [struct MoveAuthenticator]. This helps with
     /// implementing trait [AsRef](core::convert::AsRef).
@@ -174,9 +171,12 @@ impl ToFromBytes for MoveAuthenticator {
             return Err(FastCryptoError::InvalidInput);
         }
 
-        let move_auth =
+        let inner: MoveAuthenticatorVersioned =
             bcs::from_bytes(&bytes[1..]).map_err(|_| FastCryptoError::InvalidSignature)?;
-        Ok(move_auth)
+        Ok(Self {
+            inner,
+            bytes: OnceCell::new(),
+        })
     }
 }
 
@@ -189,7 +189,7 @@ impl ToFromBytes for MoveAuthenticator {
 impl AsRef<[u8]> for MoveAuthenticator {
     fn as_ref(&self) -> &[u8] {
         self.bytes.get_or_init(|| {
-            let as_bytes = bcs::to_bytes(self).expect("BCS serialization should not fail");
+            let as_bytes = bcs::to_bytes(&self.inner).expect("BCS serialization should not fail");
             let mut bytes = Vec::with_capacity(1 + as_bytes.len());
             bytes.push(SignatureScheme::MoveAuthenticator.flag());
             bytes.extend_from_slice(as_bytes.as_slice());

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -144,13 +144,23 @@ impl AuthenticatorTrait for MoveAuthenticator {
 }
 
 /// Necessary trait for
-/// [SenderSignerData](crate::transaction::SenderSignedData).
+/// [SenderSignerData](crate::transaction::SenderSignedData). This trait is
+/// implemented only for MoveAuthenticator and not for specific versions of
+/// MoveAuthenticator (e.g., MoveAuthenticatorV1) because the custom
+/// serialization/deserialization signature logic is defined on the
+/// MoveAuthenticator level.
 impl Hash for MoveAuthenticator {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.as_ref().hash(state);
     }
 }
 
+/// Necessary trait for
+/// [GenericSignature](crate::signature::GenericSignature). This trait is
+/// implemented only for MoveAuthenticator and not for specific versions of
+/// MoveAuthenticator (e.g., MoveAuthenticatorV1) because the custom
+/// serialization/deserialization signature logic is defined on the
+/// MoveAuthenticator level.
 impl ToFromBytes for MoveAuthenticator {
     fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
         // The first byte matches the flag of MoveAuthenticator.
@@ -166,6 +176,12 @@ impl ToFromBytes for MoveAuthenticator {
     }
 }
 
+/// Necessary trait for
+/// [GenericSignature](crate::signature::GenericSignature). This trait is
+/// implemented only for MoveAuthenticator and not for specific versions of
+/// MoveAuthenticator (e.g., MoveAuthenticatorV1) because the custom
+/// serialization/deserialization signature logic is defined on the
+/// MoveAuthenticator level.
 impl AsRef<[u8]> for MoveAuthenticator {
     fn as_ref(&self) -> &[u8] {
         self.bytes.get_or_init(|| {
@@ -179,7 +195,11 @@ impl AsRef<[u8]> for MoveAuthenticator {
 }
 
 /// Necessary trait for
-/// [SenderSignerData](crate::transaction::SenderSignedData).
+/// [SenderSignerData](crate::transaction::SenderSignedData). This trait is
+/// implemented only for MoveAuthenticator and not for specific versions of
+/// MoveAuthenticator (e.g., MoveAuthenticatorV1) because the custom
+/// serialization/deserialization signature logic is defined on the
+/// MoveAuthenticator level. This trait is
 impl PartialEq for MoveAuthenticator {
     fn eq(&self, other: &Self) -> bool {
         self.as_ref() == other.as_ref()
@@ -187,7 +207,11 @@ impl PartialEq for MoveAuthenticator {
 }
 
 /// Necessary trait for
-/// [SenderSignerData](crate::transaction::SenderSignedData).
+/// [SenderSignerData](crate::transaction::SenderSignedData). This trait is
+/// implemented only for MoveAuthenticator and not for specific versions of
+/// MoveAuthenticator (e.g., MoveAuthenticatorV1) because the custom
+/// serialization/deserialization signature logic is defined at the
+/// MoveAuthenticator level.
 impl Eq for MoveAuthenticator {}
 
 /// MoveAuthenticatorKind is an enum that represents the different versions of

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -496,3 +496,66 @@ impl AuthenticatorTrait for MoveAuthenticatorV1 {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use fastcrypto::traits::ToFromBytes;
+
+    use super::*;
+    use crate::{
+        base_types::{ObjectID, SequenceNumber},
+        digests::ObjectDigest,
+        transaction::{CallArg, ObjectArg},
+    };
+
+    fn make_simple_authenticator() -> MoveAuthenticator {
+        let object_to_authenticate = CallArg::Object(ObjectArg::ImmOrOwnedObject((
+            ObjectID::ZERO,
+            SequenceNumber::default(),
+            ObjectDigest::MIN,
+        )));
+        MoveAuthenticator::new_v1(vec![], vec![], object_to_authenticate)
+    }
+
+    #[test]
+    fn round_trip() {
+        let auth = make_simple_authenticator();
+        let bytes = auth.as_ref().to_vec();
+        let decoded = MoveAuthenticator::from_bytes(&bytes).expect("round-trip should succeed");
+        assert_eq!(auth, decoded);
+    }
+
+    #[test]
+    fn as_ref_starts_with_flag_byte() {
+        let auth = make_simple_authenticator();
+        let bytes = auth.as_ref();
+        assert_eq!(bytes[0], SignatureScheme::MoveAuthenticator.flag());
+    }
+
+    #[test]
+    fn as_ref_is_cached() {
+        let auth = make_simple_authenticator();
+        let bytes1 = auth.as_ref();
+        let bytes2 = auth.as_ref();
+        assert!(std::ptr::eq(bytes1.as_ptr(), bytes2.as_ptr()));
+    }
+
+    #[test]
+    fn from_bytes_rejects_wrong_flag() {
+        let auth = make_simple_authenticator();
+        let mut bytes = auth.as_ref().to_vec();
+        bytes[0] = SignatureScheme::ED25519.flag();
+        assert!(MoveAuthenticator::from_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn from_bytes_rejects_empty_input() {
+        assert!(MoveAuthenticator::from_bytes(&[]).is_err());
+    }
+
+    #[test]
+    fn from_bytes_rejects_flag_only() {
+        let flag = SignatureScheme::MoveAuthenticator.flag();
+        assert!(MoveAuthenticator::from_bytes(&[flag]).is_err());
+    }
+}

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -567,4 +567,81 @@ mod tests {
         let flag = SignatureScheme::MoveAuthenticator.flag();
         assert!(MoveAuthenticator::from_bytes(&[flag]).is_err());
     }
+
+    // ---- Signable / SignableBytes round-trip tests ----
+
+    use crate::crypto::{Signable, SignableBytes};
+
+    /// Helper: produce the signable bytes for a MoveAuthenticator (the
+    /// `"MoveAuthenticator::" ++ BCS(inner)` format).
+    fn signable_bytes(auth: &MoveAuthenticator) -> Vec<u8> {
+        let mut buf = Vec::new();
+        auth.write(&mut buf);
+        buf
+    }
+
+    #[test]
+    fn signable_round_trip() {
+        let auth = make_simple_authenticator();
+        let bytes = signable_bytes(&auth);
+        let decoded = MoveAuthenticator::from_signable_bytes(&bytes)
+            .expect("round-trip via signable bytes should succeed");
+        assert_eq!(auth, decoded);
+    }
+
+    #[test]
+    fn signable_bytes_start_with_name_tag() {
+        let auth = make_simple_authenticator();
+        let bytes = signable_bytes(&auth);
+        let tag = b"MoveAuthenticator::";
+        assert!(
+            bytes.starts_with(tag),
+            "signable bytes must start with the hardcoded name tag"
+        );
+    }
+
+    #[test]
+    fn signable_bytes_payload_is_bcs_of_inner() {
+        let auth = make_simple_authenticator();
+        let bytes = signable_bytes(&auth);
+        let tag_len = "MoveAuthenticator::".len();
+        let payload = &bytes[tag_len..];
+        let expected_bcs = bcs::to_bytes(&auth.inner).expect("BCS serialization should not fail");
+        assert_eq!(payload, expected_bcs.as_slice());
+    }
+
+    #[test]
+    fn from_signable_bytes_rejects_empty() {
+        assert!(MoveAuthenticator::from_signable_bytes(&[]).is_err());
+    }
+
+    #[test]
+    fn from_signable_bytes_rejects_short_input() {
+        // Shorter than the name tag — should fail, not panic.
+        assert!(MoveAuthenticator::from_signable_bytes(b"Move").is_err());
+    }
+
+    #[test]
+    fn from_signable_bytes_rejects_tag_only() {
+        // Exact tag with no BCS payload.
+        assert!(MoveAuthenticator::from_signable_bytes(b"MoveAuthenticator::").is_err());
+    }
+
+    #[test]
+    fn from_signable_bytes_rejects_corrupt_payload() {
+        let auth = make_simple_authenticator();
+        let mut bytes = signable_bytes(&auth);
+        // Truncate the BCS payload so it is incomplete.
+        let tag_len = "MoveAuthenticator::".len();
+        bytes.truncate(tag_len + 1);
+        assert!(MoveAuthenticator::from_signable_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn digest_is_stable() {
+        let auth = make_simple_authenticator();
+        let d1 = auth.digest();
+        let d2 = auth.digest();
+        assert_eq!(d1, d2, "digest must be deterministic");
+    }
 }

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -34,7 +34,7 @@ use crate::{
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
 pub struct MoveAuthenticator {
     #[serde(flatten)]
-    inner: MoveAuthenticatorInner,
+    pub(crate) inner: MoveAuthenticatorInner,
     /// A bytes representation of [struct MoveAuthenticator]. This helps with
     /// implementing trait [AsRef](core::convert::AsRef).
     #[serde(skip)]
@@ -54,6 +54,15 @@ impl MoveAuthenticator {
                 type_arguments,
                 object_to_authenticate,
             ),
+            bytes: OnceCell::new(),
+        }
+    }
+
+    /// Constructs a `MoveAuthenticator` from a deserialized
+    /// [`MoveAuthenticatorInner`].
+    pub(crate) fn from_inner(inner: MoveAuthenticatorInner) -> Self {
+        Self {
+            inner,
             bytes: OnceCell::new(),
         }
     }

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -37,7 +37,7 @@ use crate::{
 // future, and it simplifies the serialization logic.
 #[serde(transparent)]
 pub struct MoveAuthenticator {
-    inner: MoveAuthenticatorKind,
+    inner: MoveAuthenticatorVersioned,
     /// A bytes representation of [struct MoveAuthenticator]. This helps with
     /// implementing trait [AsRef](core::convert::AsRef).
     #[serde(skip)]
@@ -52,7 +52,11 @@ impl MoveAuthenticator {
         object_to_authenticate: CallArg,
     ) -> Self {
         Self {
-            inner: MoveAuthenticatorKind::new_v1(call_args, type_arguments, object_to_authenticate),
+            inner: MoveAuthenticatorVersioned::new_v1(
+                call_args,
+                type_arguments,
+                object_to_authenticate,
+            ),
             bytes: OnceCell::new(),
         }
     }
@@ -214,21 +218,21 @@ impl PartialEq for MoveAuthenticator {
 /// MoveAuthenticator level.
 impl Eq for MoveAuthenticator {}
 
-/// MoveAuthenticatorKind is an enum that represents the different versions of
-/// MoveAuthenticator.
+/// MoveAuthenticatorVersioned is an enum that represents the different versions
+/// of MoveAuthenticator.
 #[enum_dispatch(AuthenticatorTrait)]
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
-pub enum MoveAuthenticatorKind {
+pub enum MoveAuthenticatorVersioned {
     V1(MoveAuthenticatorV1),
 }
 
-impl MoveAuthenticatorKind {
+impl MoveAuthenticatorVersioned {
     pub fn new_v1(
         call_args: Vec<CallArg>,
         type_arguments: Vec<TypeInput>,
         object_to_authenticate: CallArg,
     ) -> Self {
-        MoveAuthenticatorKind::V1(MoveAuthenticatorV1::new(
+        MoveAuthenticatorVersioned::V1(MoveAuthenticatorV1::new(
             call_args,
             type_arguments,
             object_to_authenticate,
@@ -237,31 +241,31 @@ impl MoveAuthenticatorKind {
 
     pub fn version(&self) -> u64 {
         match self {
-            MoveAuthenticatorKind::V1(_) => 1,
+            MoveAuthenticatorVersioned::V1(_) => 1,
         }
     }
 
     pub fn address(&self) -> IotaResult<IotaAddress> {
         match self {
-            MoveAuthenticatorKind::V1(v1) => v1.address(),
+            MoveAuthenticatorVersioned::V1(v1) => v1.address(),
         }
     }
 
     pub fn call_args(&self) -> &Vec<CallArg> {
         match self {
-            MoveAuthenticatorKind::V1(v1) => v1.call_args(),
+            MoveAuthenticatorVersioned::V1(v1) => v1.call_args(),
         }
     }
 
     pub fn type_arguments(&self) -> &Vec<TypeInput> {
         match self {
-            MoveAuthenticatorKind::V1(v1) => v1.type_arguments(),
+            MoveAuthenticatorVersioned::V1(v1) => v1.type_arguments(),
         }
     }
 
     pub fn object_to_authenticate(&self) -> &CallArg {
         match self {
-            MoveAuthenticatorKind::V1(v1) => v1.object_to_authenticate(),
+            MoveAuthenticatorVersioned::V1(v1) => v1.object_to_authenticate(),
         }
     }
 
@@ -269,31 +273,31 @@ impl MoveAuthenticatorKind {
         &self,
     ) -> UserInputResult<(ObjectID, Option<SequenceNumber>, Option<ObjectDigest>)> {
         match self {
-            MoveAuthenticatorKind::V1(v1) => v1.object_to_authenticate_components(),
+            MoveAuthenticatorVersioned::V1(v1) => v1.object_to_authenticate_components(),
         }
     }
 
     pub fn input_objects(&self) -> Vec<InputObjectKind> {
         match self {
-            MoveAuthenticatorKind::V1(v1) => v1.input_objects(),
+            MoveAuthenticatorVersioned::V1(v1) => v1.input_objects(),
         }
     }
 
     pub fn receiving_objects(&self) -> Vec<ObjectRef> {
         match self {
-            MoveAuthenticatorKind::V1(v1) => v1.receiving_objects(),
+            MoveAuthenticatorVersioned::V1(v1) => v1.receiving_objects(),
         }
     }
 
     pub fn shared_objects(&self) -> Vec<SharedInputObject> {
         match self {
-            MoveAuthenticatorKind::V1(v1) => v1.shared_objects(),
+            MoveAuthenticatorVersioned::V1(v1) => v1.shared_objects(),
         }
     }
 
     pub fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult {
         match self {
-            MoveAuthenticatorKind::V1(v1) => v1.validity_check(config),
+            MoveAuthenticatorVersioned::V1(v1) => v1.validity_check(config),
         }
     }
 }

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -34,7 +34,7 @@ use crate::{
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
 pub struct MoveAuthenticator {
     #[serde(flatten)]
-    inner: MoveAuthenticatorVersioned,
+    inner: MoveAuthenticatorInner,
     /// A bytes representation of [struct MoveAuthenticator]. This helps with
     /// implementing trait [AsRef](core::convert::AsRef).
     #[serde(skip)]
@@ -49,7 +49,7 @@ impl MoveAuthenticator {
         object_to_authenticate: CallArg,
     ) -> Self {
         Self {
-            inner: MoveAuthenticatorVersioned::new_v1(
+            inner: MoveAuthenticatorInner::new_v1(
                 call_args,
                 type_arguments,
                 object_to_authenticate,
@@ -171,7 +171,7 @@ impl ToFromBytes for MoveAuthenticator {
             return Err(FastCryptoError::InvalidInput);
         }
 
-        let inner: MoveAuthenticatorVersioned =
+        let inner: MoveAuthenticatorInner =
             bcs::from_bytes(&bytes[1..]).map_err(|_| FastCryptoError::InvalidSignature)?;
         Ok(Self {
             inner,
@@ -218,21 +218,21 @@ impl PartialEq for MoveAuthenticator {
 /// MoveAuthenticator level.
 impl Eq for MoveAuthenticator {}
 
-/// MoveAuthenticatorVersioned is an enum that represents the different versions
+/// MoveAuthenticatorInner is an enum that represents the different versions
 /// of MoveAuthenticator.
 #[enum_dispatch(AuthenticatorTrait)]
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
-pub enum MoveAuthenticatorVersioned {
+pub enum MoveAuthenticatorInner {
     V1(MoveAuthenticatorV1),
 }
 
-impl MoveAuthenticatorVersioned {
+impl MoveAuthenticatorInner {
     pub fn new_v1(
         call_args: Vec<CallArg>,
         type_arguments: Vec<TypeInput>,
         object_to_authenticate: CallArg,
     ) -> Self {
-        MoveAuthenticatorVersioned::V1(MoveAuthenticatorV1::new(
+        MoveAuthenticatorInner::V1(MoveAuthenticatorV1::new(
             call_args,
             type_arguments,
             object_to_authenticate,
@@ -241,31 +241,31 @@ impl MoveAuthenticatorVersioned {
 
     pub fn version(&self) -> u64 {
         match self {
-            MoveAuthenticatorVersioned::V1(_) => 1,
+            MoveAuthenticatorInner::V1(_) => 1,
         }
     }
 
     pub fn address(&self) -> IotaResult<IotaAddress> {
         match self {
-            MoveAuthenticatorVersioned::V1(v1) => v1.address(),
+            MoveAuthenticatorInner::V1(v1) => v1.address(),
         }
     }
 
     pub fn call_args(&self) -> &Vec<CallArg> {
         match self {
-            MoveAuthenticatorVersioned::V1(v1) => v1.call_args(),
+            MoveAuthenticatorInner::V1(v1) => v1.call_args(),
         }
     }
 
     pub fn type_arguments(&self) -> &Vec<TypeInput> {
         match self {
-            MoveAuthenticatorVersioned::V1(v1) => v1.type_arguments(),
+            MoveAuthenticatorInner::V1(v1) => v1.type_arguments(),
         }
     }
 
     pub fn object_to_authenticate(&self) -> &CallArg {
         match self {
-            MoveAuthenticatorVersioned::V1(v1) => v1.object_to_authenticate(),
+            MoveAuthenticatorInner::V1(v1) => v1.object_to_authenticate(),
         }
     }
 
@@ -273,31 +273,31 @@ impl MoveAuthenticatorVersioned {
         &self,
     ) -> UserInputResult<(ObjectID, Option<SequenceNumber>, Option<ObjectDigest>)> {
         match self {
-            MoveAuthenticatorVersioned::V1(v1) => v1.object_to_authenticate_components(),
+            MoveAuthenticatorInner::V1(v1) => v1.object_to_authenticate_components(),
         }
     }
 
     pub fn input_objects(&self) -> Vec<InputObjectKind> {
         match self {
-            MoveAuthenticatorVersioned::V1(v1) => v1.input_objects(),
+            MoveAuthenticatorInner::V1(v1) => v1.input_objects(),
         }
     }
 
     pub fn receiving_objects(&self) -> Vec<ObjectRef> {
         match self {
-            MoveAuthenticatorVersioned::V1(v1) => v1.receiving_objects(),
+            MoveAuthenticatorInner::V1(v1) => v1.receiving_objects(),
         }
     }
 
     pub fn shared_objects(&self) -> Vec<SharedInputObject> {
         match self {
-            MoveAuthenticatorVersioned::V1(v1) => v1.shared_objects(),
+            MoveAuthenticatorInner::V1(v1) => v1.shared_objects(),
         }
     }
 
     pub fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult {
         match self {
-            MoveAuthenticatorVersioned::V1(v1) => v1.validity_check(config),
+            MoveAuthenticatorInner::V1(v1) => v1.validity_check(config),
         }
     }
 }

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -212,7 +212,7 @@ impl AsRef<[u8]> for MoveAuthenticator {
 /// implemented only for MoveAuthenticator and not for specific versions of
 /// MoveAuthenticator (e.g., MoveAuthenticatorV1) because the custom
 /// serialization/deserialization signature logic is defined on the
-/// MoveAuthenticator level. This trait is
+/// MoveAuthenticator level.
 impl PartialEq for MoveAuthenticator {
     fn eq(&self, other: &Self) -> bool {
         self.as_ref() == other.as_ref()

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -7,6 +7,7 @@ use std::{
     sync::Arc,
 };
 
+use enum_dispatch::enum_dispatch;
 use fastcrypto::{error::FastCryptoError, traits::ToFromBytes};
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::crypto::IntentMessage;
@@ -30,8 +31,160 @@ use crate::{
 /// method of authentication through Move code.
 /// This function represents the data received by the Move authenticate function
 /// during the Account Abstraction authentication flow.
+#[enum_dispatch(AuthenticatorTrait)]
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
-pub struct MoveAuthenticator {
+pub enum MoveAuthenticator {
+    V1(MoveAuthenticatorV1),
+}
+
+impl MoveAuthenticator {
+    /// Creates a new MoveAuthenticator of version 1.
+    pub fn new_v1(
+        call_args: Vec<CallArg>,
+        type_arguments: Vec<TypeInput>,
+        object_to_authenticate: CallArg,
+    ) -> Self {
+        Self::V1(MoveAuthenticatorV1::new(
+            call_args,
+            type_arguments,
+            object_to_authenticate,
+        ))
+    }
+
+    /// Returns the version of the MoveAuthenticator.
+    pub fn version(&self) -> u64 {
+        match self {
+            MoveAuthenticator::V1(_) => 1,
+        }
+    }
+
+    /// Computes the digest of the MoveAuthenticator.
+    pub fn digest(&self) -> MoveAuthenticatorDigest {
+        MoveAuthenticatorDigest::new(default_hash(self))
+    }
+
+    /// Returns the address of the MoveAuthenticator.
+    pub fn address(&self) -> IotaResult<IotaAddress> {
+        match self {
+            MoveAuthenticator::V1(v1) => v1.address(),
+        }
+    }
+
+    /// Returns the call arguments of the MoveAuthenticator.
+    pub fn call_args(&self) -> &Vec<CallArg> {
+        match self {
+            MoveAuthenticator::V1(v1) => v1.call_args(),
+        }
+    }
+
+    /// Returns the type arguments of the MoveAuthenticator.
+    pub fn type_arguments(&self) -> &Vec<TypeInput> {
+        match self {
+            MoveAuthenticator::V1(v1) => v1.type_arguments(),
+        }
+    }
+
+    /// Returns the object to authenticate of the MoveAuthenticator.
+    pub fn object_to_authenticate(&self) -> &CallArg {
+        match self {
+            MoveAuthenticator::V1(v1) => v1.object_to_authenticate(),
+        }
+    }
+
+    /// Returns the components of the object to authenticate.
+    pub fn object_to_authenticate_components(
+        &self,
+    ) -> UserInputResult<(ObjectID, Option<SequenceNumber>, Option<ObjectDigest>)> {
+        match self {
+            MoveAuthenticator::V1(v1) => v1.object_to_authenticate_components(),
+        }
+    }
+
+    /// Returns all input objects used by the MoveAuthenticator,
+    /// including those from the object to authenticate.
+    pub fn input_objects(&self) -> Vec<InputObjectKind> {
+        match self {
+            MoveAuthenticator::V1(v1) => v1.input_objects(),
+        }
+    }
+
+    /// Returns all receiving objects used by the MoveAuthenticator.
+    pub fn receiving_objects(&self) -> Vec<ObjectRef> {
+        match self {
+            MoveAuthenticator::V1(v1) => v1.receiving_objects(),
+        }
+    }
+
+    /// Returns all shared input objects used by the MoveAuthenticator,
+    /// including those from the object to authenticate.
+    pub fn shared_objects(&self) -> Vec<SharedInputObject> {
+        match self {
+            MoveAuthenticator::V1(v1) => v1.shared_objects(),
+        }
+    }
+
+    /// Validity check for MoveAuthenticator.
+    pub fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult {
+        match self {
+            MoveAuthenticator::V1(v1) => v1.validity_check(config),
+        }
+    }
+}
+
+/// Necessary trait for
+/// [SenderSignerData](crate::transaction::SenderSignedData).
+impl Hash for MoveAuthenticator {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state);
+    }
+}
+
+impl ToFromBytes for MoveAuthenticator {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        // The first byte matches the flag of MoveAuthenticator.
+        if bytes.first().ok_or(FastCryptoError::InvalidInput)?
+            != &SignatureScheme::MoveAuthenticator.flag()
+        {
+            return Err(FastCryptoError::InvalidInput);
+        }
+
+        let move_auth: MoveAuthenticator =
+            bcs::from_bytes(&bytes[1..]).map_err(|_| FastCryptoError::InvalidSignature)?;
+        Ok(move_auth)
+    }
+}
+
+impl AsRef<[u8]> for MoveAuthenticator {
+    fn as_ref(&self) -> &[u8] {
+        let to_bytes = || -> Vec<u8> {
+            let as_bytes = bcs::to_bytes(self).expect("BCS serialization should not fail");
+            let mut bytes = Vec::with_capacity(1 + as_bytes.len());
+            bytes.push(SignatureScheme::MoveAuthenticator.flag());
+            bytes.extend_from_slice(as_bytes.as_slice());
+            bytes
+        };
+
+        match self {
+            MoveAuthenticator::V1(v1) => v1.bytes.get_or_init(to_bytes),
+        }
+    }
+}
+
+/// Necessary trait for
+/// [SenderSignerData](crate::transaction::SenderSignedData).
+impl PartialEq for MoveAuthenticator {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+/// Necessary trait for
+/// [SenderSignerData](crate::transaction::SenderSignedData).
+impl Eq for MoveAuthenticator {}
+
+/// MoveAuthenticatorV1 is the first version of MoveAuthenticator.
+#[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
+pub struct MoveAuthenticatorV1 {
     /// Input objects or primitive values
     call_args: Vec<CallArg>,
     /// Type arguments for the Move authenticate function
@@ -46,15 +199,7 @@ pub struct MoveAuthenticator {
     bytes: OnceCell<Vec<u8>>,
 }
 
-/// Necessary trait for
-/// [SenderSignerData](crate::transaction::SenderSignedData).
-impl Hash for MoveAuthenticator {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.as_ref().hash(state);
-    }
-}
-
-impl MoveAuthenticator {
+impl MoveAuthenticatorV1 {
     pub fn new(
         call_args: Vec<CallArg>,
         type_arguments: Vec<TypeInput>,
@@ -68,13 +213,11 @@ impl MoveAuthenticator {
         }
     }
 
+    /// Returns the address of the MoveAuthenticatorV1, which is derived from
+    /// the object to authenticate.
     pub fn address(&self) -> IotaResult<IotaAddress> {
         let (id, _, _) = self.object_to_authenticate_components()?;
         Ok(IotaAddress::from(id))
-    }
-
-    pub fn digest(&self) -> MoveAuthenticatorDigest {
-        MoveAuthenticatorDigest::new(default_hash(self))
     }
 
     pub fn call_args(&self) -> &Vec<CallArg> {
@@ -95,7 +238,7 @@ impl MoveAuthenticator {
         Ok(match self.object_to_authenticate() {
             CallArg::Pure(_) => {
                 return Err(UserInputError::Unsupported(
-                    "MoveAuthenticator cannot authenticate pure inputs".to_string(),
+                    "MoveAuthenticatorV1 cannot authenticate pure inputs".to_string(),
                 ));
             }
             CallArg::Object(object_arg) => match object_arg {
@@ -105,7 +248,7 @@ impl MoveAuthenticator {
                 ObjectArg::SharedObject { id, mutable, .. } => {
                     if *mutable {
                         return Err(UserInputError::Unsupported(
-                            "MoveAuthenticator cannot authenticate mutable shared objects"
+                            "MoveAuthenticatorV1 cannot authenticate mutable shared objects"
                                 .to_string(),
                         ));
                     }
@@ -114,14 +257,14 @@ impl MoveAuthenticator {
                 }
                 ObjectArg::Receiving(_) => {
                     return Err(UserInputError::Unsupported(
-                        "MoveAuthenticator cannot authenticate receiving objects".to_string(),
+                        "MoveAuthenticatorV1 cannot authenticate receiving objects".to_string(),
                     ));
                 }
             },
         })
     }
 
-    /// Returns all input objects used by the MoveAuthenticator,
+    /// Returns all input objects used by the MoveAuthenticatorV1,
     /// including those from the object to authenticate.
     pub fn input_objects(&self) -> Vec<InputObjectKind> {
         self.call_args
@@ -138,7 +281,7 @@ impl MoveAuthenticator {
             .collect()
     }
 
-    /// Returns all shared input objects used by the MoveAuthenticator,
+    /// Returns all shared input objects used by the MoveAuthenticatorV1,
     /// including those from the object to authenticate.
     pub fn shared_objects(&self) -> Vec<SharedInputObject> {
         self.call_args
@@ -148,7 +291,7 @@ impl MoveAuthenticator {
             .collect()
     }
 
-    /// Validity check for MoveAuthenticator.
+    /// Validity check for MoveAuthenticatorV1.
     pub fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult {
         // Check that the object to authenticate is valid.
         self.object_to_authenticate_components()?;
@@ -159,7 +302,7 @@ impl MoveAuthenticator {
         // already validated with a dedicated function.
 
         // `ProtocolConfig::max_function_parameters` is used to check the call arguments
-        // because MoveAuthenticator is considered as a simple programmable call to a
+        // because MoveAuthenticatorV1 is considered as a simple programmable call to a
         // Move function.
         //
         // The limit includes the object to authenticate, the auth context and the tx
@@ -168,7 +311,7 @@ impl MoveAuthenticator {
         fp_ensure!(
             self.call_args().len() < max_args,
             UserInputError::SizeLimitExceeded {
-                limit: "maximum arguments in MoveAuthenticator".to_string(),
+                limit: "maximum arguments in MoveAuthenticatorV1".to_string(),
                 value: max_args.to_string()
             }
         );
@@ -176,7 +319,7 @@ impl MoveAuthenticator {
         fp_ensure!(
             self.receiving_objects().is_empty(),
             UserInputError::Unsupported(
-                "MoveAuthenticator cannot have receiving objects as input".to_string(),
+                "MoveAuthenticatorV1 cannot have receiving objects as input".to_string(),
             )
         );
 
@@ -209,7 +352,7 @@ impl MoveAuthenticator {
     }
 }
 
-impl AuthenticatorTrait for MoveAuthenticator {
+impl AuthenticatorTrait for MoveAuthenticatorV1 {
     fn verify_user_authenticator_epoch(
         &self,
         _epoch: EpochId,
@@ -236,45 +379,5 @@ impl AuthenticatorTrait for MoveAuthenticator {
         };
 
         Ok(())
-    }
-}
-
-/// Necessary trait for
-/// [SenderSignerData](crate::transaction::SenderSignedData).
-impl PartialEq for MoveAuthenticator {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_ref() == other.as_ref()
-    }
-}
-
-impl ToFromBytes for MoveAuthenticator {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        // The first byte matches the flag of MultiSig.
-        if bytes.first().ok_or(FastCryptoError::InvalidInput)?
-            != &SignatureScheme::MoveAuthenticator.flag()
-        {
-            return Err(FastCryptoError::InvalidInput);
-        }
-        let move_auth: MoveAuthenticator =
-            bcs::from_bytes(&bytes[1..]).map_err(|_| FastCryptoError::InvalidSignature)?;
-        Ok(move_auth)
-    }
-}
-
-/// Necessary trait for
-/// [SenderSignerData](crate::transaction::SenderSignedData).
-impl Eq for MoveAuthenticator {}
-
-impl AsRef<[u8]> for MoveAuthenticator {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes
-            .get_or_try_init::<_, eyre::Report>(|| {
-                let as_bytes = bcs::to_bytes(self).expect("BCS serialization should not fail");
-                let mut bytes = Vec::with_capacity(1 + as_bytes.len());
-                bytes.push(SignatureScheme::MoveAuthenticator.flag());
-                bytes.extend_from_slice(as_bytes.as_slice());
-                Ok(bytes)
-            })
-            .expect("OnceCell invariant violated")
     }
 }

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -31,10 +31,17 @@ use crate::{
 /// method of authentication through Move code.
 /// This function represents the data received by the Move authenticate function
 /// during the Account Abstraction authentication flow.
-#[enum_dispatch(AuthenticatorTrait)]
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
-pub enum MoveAuthenticator {
-    V1(MoveAuthenticatorV1),
+// The `transparent` attribute allows us to get rid of one level of nesting in the serialized form,
+// which is reasonable since `MoveAuthenticator` will not be extended with more fields in the
+// future, and it simplifies the serialization logic.
+#[serde(transparent)]
+pub struct MoveAuthenticator {
+    inner: MoveAuthenticatorKind,
+    /// A bytes representation of [struct MoveAuthenticator]. This helps with
+    /// implementing trait [AsRef](core::convert::AsRef).
+    #[serde(skip)]
+    bytes: OnceCell<Vec<u8>>,
 }
 
 impl MoveAuthenticator {
@@ -44,17 +51,9 @@ impl MoveAuthenticator {
         type_arguments: Vec<TypeInput>,
         object_to_authenticate: CallArg,
     ) -> Self {
-        Self::V1(MoveAuthenticatorV1::new(
-            call_args,
-            type_arguments,
-            object_to_authenticate,
-        ))
-    }
-
-    /// Returns the version of the MoveAuthenticator.
-    pub fn version(&self) -> u64 {
-        match self {
-            MoveAuthenticator::V1(_) => 1,
+        Self {
+            inner: MoveAuthenticatorKind::new_v1(call_args, type_arguments, object_to_authenticate),
+            bytes: OnceCell::new(),
         }
     }
 
@@ -63,71 +62,84 @@ impl MoveAuthenticator {
         MoveAuthenticatorDigest::new(default_hash(self))
     }
 
+    /// Returns the version of the MoveAuthenticator.
+    pub fn version(&self) -> u64 {
+        self.inner.version()
+    }
+
     /// Returns the address of the MoveAuthenticator.
     pub fn address(&self) -> IotaResult<IotaAddress> {
-        match self {
-            MoveAuthenticator::V1(v1) => v1.address(),
-        }
+        self.inner.address()
     }
 
     /// Returns the call arguments of the MoveAuthenticator.
     pub fn call_args(&self) -> &Vec<CallArg> {
-        match self {
-            MoveAuthenticator::V1(v1) => v1.call_args(),
-        }
+        self.inner.call_args()
     }
 
     /// Returns the type arguments of the MoveAuthenticator.
     pub fn type_arguments(&self) -> &Vec<TypeInput> {
-        match self {
-            MoveAuthenticator::V1(v1) => v1.type_arguments(),
-        }
+        self.inner.type_arguments()
     }
 
     /// Returns the object to authenticate of the MoveAuthenticator.
     pub fn object_to_authenticate(&self) -> &CallArg {
-        match self {
-            MoveAuthenticator::V1(v1) => v1.object_to_authenticate(),
-        }
+        self.inner.object_to_authenticate()
     }
 
     /// Returns the components of the object to authenticate.
     pub fn object_to_authenticate_components(
         &self,
     ) -> UserInputResult<(ObjectID, Option<SequenceNumber>, Option<ObjectDigest>)> {
-        match self {
-            MoveAuthenticator::V1(v1) => v1.object_to_authenticate_components(),
-        }
+        self.inner.object_to_authenticate_components()
     }
 
     /// Returns all input objects used by the MoveAuthenticator,
     /// including those from the object to authenticate.
     pub fn input_objects(&self) -> Vec<InputObjectKind> {
-        match self {
-            MoveAuthenticator::V1(v1) => v1.input_objects(),
-        }
+        self.inner.input_objects()
     }
 
     /// Returns all receiving objects used by the MoveAuthenticator.
     pub fn receiving_objects(&self) -> Vec<ObjectRef> {
-        match self {
-            MoveAuthenticator::V1(v1) => v1.receiving_objects(),
-        }
+        self.inner.receiving_objects()
     }
 
     /// Returns all shared input objects used by the MoveAuthenticator,
     /// including those from the object to authenticate.
     pub fn shared_objects(&self) -> Vec<SharedInputObject> {
-        match self {
-            MoveAuthenticator::V1(v1) => v1.shared_objects(),
-        }
+        self.inner.shared_objects()
     }
 
     /// Validity check for MoveAuthenticator.
     pub fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult {
-        match self {
-            MoveAuthenticator::V1(v1) => v1.validity_check(config),
-        }
+        self.inner.validity_check(config)
+    }
+}
+
+impl AuthenticatorTrait for MoveAuthenticator {
+    fn verify_user_authenticator_epoch(
+        &self,
+        epoch: EpochId,
+        max_epoch_upper_bound_delta: Option<u64>,
+    ) -> IotaResult {
+        self.inner
+            .verify_user_authenticator_epoch(epoch, max_epoch_upper_bound_delta)
+    }
+    // This function accepts all inputs, as signature verification is performed
+    // later on the Move side.
+    fn verify_claims<T>(
+        &self,
+        value: &IntentMessage<T>,
+        author: IotaAddress,
+        aux_verify_data: &VerifyParams,
+        zklogin_inputs_cache: Arc<VerifiedDigestCache<ZKLoginInputsDigest>>,
+    ) -> IotaResult
+    where
+        T: Serialize,
+    {
+        self.inner
+            .verify_claims(value, author, aux_verify_data, zklogin_inputs_cache)
     }
 }
 
@@ -148,7 +160,7 @@ impl ToFromBytes for MoveAuthenticator {
             return Err(FastCryptoError::InvalidInput);
         }
 
-        let move_auth: MoveAuthenticator =
+        let move_auth =
             bcs::from_bytes(&bytes[1..]).map_err(|_| FastCryptoError::InvalidSignature)?;
         Ok(move_auth)
     }
@@ -156,17 +168,13 @@ impl ToFromBytes for MoveAuthenticator {
 
 impl AsRef<[u8]> for MoveAuthenticator {
     fn as_ref(&self) -> &[u8] {
-        let to_bytes = || -> Vec<u8> {
+        self.bytes.get_or_init(|| {
             let as_bytes = bcs::to_bytes(self).expect("BCS serialization should not fail");
             let mut bytes = Vec::with_capacity(1 + as_bytes.len());
             bytes.push(SignatureScheme::MoveAuthenticator.flag());
             bytes.extend_from_slice(as_bytes.as_slice());
             bytes
-        };
-
-        match self {
-            MoveAuthenticator::V1(v1) => v1.bytes.get_or_init(to_bytes),
-        }
+        })
     }
 }
 
@@ -182,6 +190,90 @@ impl PartialEq for MoveAuthenticator {
 /// [SenderSignerData](crate::transaction::SenderSignedData).
 impl Eq for MoveAuthenticator {}
 
+/// MoveAuthenticatorKind is an enum that represents the different versions of
+/// MoveAuthenticator.
+#[enum_dispatch(AuthenticatorTrait)]
+#[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
+pub enum MoveAuthenticatorKind {
+    V1(MoveAuthenticatorV1),
+}
+
+impl MoveAuthenticatorKind {
+    pub fn new_v1(
+        call_args: Vec<CallArg>,
+        type_arguments: Vec<TypeInput>,
+        object_to_authenticate: CallArg,
+    ) -> Self {
+        MoveAuthenticatorKind::V1(MoveAuthenticatorV1::new(
+            call_args,
+            type_arguments,
+            object_to_authenticate,
+        ))
+    }
+
+    pub fn version(&self) -> u64 {
+        match self {
+            MoveAuthenticatorKind::V1(_) => 1,
+        }
+    }
+
+    pub fn address(&self) -> IotaResult<IotaAddress> {
+        match self {
+            MoveAuthenticatorKind::V1(v1) => v1.address(),
+        }
+    }
+
+    pub fn call_args(&self) -> &Vec<CallArg> {
+        match self {
+            MoveAuthenticatorKind::V1(v1) => v1.call_args(),
+        }
+    }
+
+    pub fn type_arguments(&self) -> &Vec<TypeInput> {
+        match self {
+            MoveAuthenticatorKind::V1(v1) => v1.type_arguments(),
+        }
+    }
+
+    pub fn object_to_authenticate(&self) -> &CallArg {
+        match self {
+            MoveAuthenticatorKind::V1(v1) => v1.object_to_authenticate(),
+        }
+    }
+
+    pub fn object_to_authenticate_components(
+        &self,
+    ) -> UserInputResult<(ObjectID, Option<SequenceNumber>, Option<ObjectDigest>)> {
+        match self {
+            MoveAuthenticatorKind::V1(v1) => v1.object_to_authenticate_components(),
+        }
+    }
+
+    pub fn input_objects(&self) -> Vec<InputObjectKind> {
+        match self {
+            MoveAuthenticatorKind::V1(v1) => v1.input_objects(),
+        }
+    }
+
+    pub fn receiving_objects(&self) -> Vec<ObjectRef> {
+        match self {
+            MoveAuthenticatorKind::V1(v1) => v1.receiving_objects(),
+        }
+    }
+
+    pub fn shared_objects(&self) -> Vec<SharedInputObject> {
+        match self {
+            MoveAuthenticatorKind::V1(v1) => v1.shared_objects(),
+        }
+    }
+
+    pub fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult {
+        match self {
+            MoveAuthenticatorKind::V1(v1) => v1.validity_check(config),
+        }
+    }
+}
+
 /// MoveAuthenticatorV1 is the first version of MoveAuthenticator.
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
 pub struct MoveAuthenticatorV1 {
@@ -193,10 +285,6 @@ pub struct MoveAuthenticatorV1 {
     /// The object that is authenticated. Represents the account being the
     /// sender of the transaction.
     object_to_authenticate: CallArg,
-    /// A bytes representation of [struct MoveAuthenticator]. This helps with
-    /// implementing trait [AsRef](core::convert::AsRef).
-    #[serde(skip)]
-    bytes: OnceCell<Vec<u8>>,
 }
 
 impl MoveAuthenticatorV1 {
@@ -209,7 +297,6 @@ impl MoveAuthenticatorV1 {
             call_args,
             type_arguments,
             object_to_authenticate,
-            bytes: OnceCell::new(),
         }
     }
 

--- a/crates/iota-types/src/signature.rs
+++ b/crates/iota-types/src/signature.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     digests::ZKLoginInputsDigest,
     error::{IotaError, IotaResult},
-    move_authenticator::MoveAuthenticator,
+    move_authenticator::{MoveAuthenticator, MoveAuthenticatorV1},
     multisig::MultiSig,
     passkey_authenticator::PasskeyAuthenticator,
     signature_verification::VerifiedDigestCache,

--- a/crates/iota-types/src/signature.rs
+++ b/crates/iota-types/src/signature.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     digests::ZKLoginInputsDigest,
     error::{IotaError, IotaResult},
-    move_authenticator::{MoveAuthenticator, MoveAuthenticatorKind, MoveAuthenticatorV1},
+    move_authenticator::{MoveAuthenticator, MoveAuthenticatorV1, MoveAuthenticatorVersioned},
     multisig::MultiSig,
     passkey_authenticator::PasskeyAuthenticator,
     signature_verification::VerifiedDigestCache,

--- a/crates/iota-types/src/signature.rs
+++ b/crates/iota-types/src/signature.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     digests::ZKLoginInputsDigest,
     error::{IotaError, IotaResult},
-    move_authenticator::{MoveAuthenticator, MoveAuthenticatorV1},
+    move_authenticator::{MoveAuthenticator, MoveAuthenticatorKind, MoveAuthenticatorV1},
     multisig::MultiSig,
     passkey_authenticator::PasskeyAuthenticator,
     signature_verification::VerifiedDigestCache,

--- a/crates/iota-types/src/signature.rs
+++ b/crates/iota-types/src/signature.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     digests::ZKLoginInputsDigest,
     error::{IotaError, IotaResult},
-    move_authenticator::{MoveAuthenticator, MoveAuthenticatorV1, MoveAuthenticatorVersioned},
+    move_authenticator::{MoveAuthenticator, MoveAuthenticatorInner, MoveAuthenticatorV1},
     multisig::MultiSig,
     passkey_authenticator::PasskeyAuthenticator,
     signature_verification::VerifiedDigestCache,

--- a/crates/iota-types/src/unit_tests/utils.rs
+++ b/crates/iota-types/src/unit_tests/utils.rs
@@ -328,7 +328,7 @@ mod move_authenticator {
             initial_shared_version: OBJECT_START_VERSION,
             mutable: false,
         });
-        let authenticator = GenericSignature::MoveAuthenticator(MoveAuthenticator::new(
+        let authenticator = GenericSignature::MoveAuthenticator(MoveAuthenticator::new_v1(
             vec![],
             vec![],
             self_call_arg,

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -4005,13 +4005,15 @@ async fn create_move_authenticator_signature(
 
     let initial_shared_version = get_shared_object_version(client, &address).await?;
 
-    Ok(GenericSignature::MoveAuthenticator(MoveAuthenticator::new(
-        call_args,
-        type_args.into_iter().map(TypeInput::from).collect(),
-        CallArg::Object(iota_types::transaction::ObjectArg::SharedObject {
-            id: ObjectID::from(address),
-            initial_shared_version,
-            mutable: false,
-        }),
-    )))
+    Ok(GenericSignature::MoveAuthenticator(
+        MoveAuthenticator::new_v1(
+            call_args,
+            type_args.into_iter().map(TypeInput::from).collect(),
+            CallArg::Object(iota_types::transaction::ObjectArg::SharedObject {
+                id: ObjectID::from(address),
+                initial_shared_version,
+                mutable: false,
+            }),
+        ),
+    ))
 }

--- a/crates/iota/src/signing.rs
+++ b/crates/iota/src/signing.rs
@@ -80,15 +80,17 @@ pub(crate) async fn sign_transaction(
         let initial_shared_version =
             get_shared_object_version(&iota_client, signer_address).await?;
 
-        return Ok(GenericSignature::MoveAuthenticator(MoveAuthenticator::new(
-            auth_call_args,
-            auth_type_args,
-            CallArg::Object(iota_types::transaction::ObjectArg::SharedObject {
-                id: ObjectID::from(*signer_address),
-                initial_shared_version,
-                mutable: false,
-            }),
-        )));
+        return Ok(GenericSignature::MoveAuthenticator(
+            MoveAuthenticator::new_v1(
+                auth_call_args,
+                auth_type_args,
+                CallArg::Object(iota_types::transaction::ObjectArg::SharedObject {
+                    id: ObjectID::from(*signer_address),
+                    initial_shared_version,
+                    mutable: false,
+                }),
+            ),
+        ));
     }
 
     let key = context.config().keystore().get_key(signer_address)?;

--- a/crates/iota/src/unit_tests/keytool_tests.rs
+++ b/crates/iota/src/unit_tests/keytool_tests.rs
@@ -884,7 +884,7 @@ async fn test_decode_sig() -> Result<(), anyhow::Error> {
     }
 
     // Test 2: Decode a MoveAuthenticator signature
-    let move_auth_sig = "BwEAggGAAWRjNTczYTU4YzdkYTAxNmFmYzYwMmQyYWU1NWFiZGFhNmRkYzNlNzljMmY0YzA4NTM5NGM2YzI0YjQ4MzllYzRlMDEyMGRiNjkwMmIwOTc3NzIxMThhNzhhYmE2MjA4OTg4MjAwNTEwOWYxZmEzYTVjMDc4ZDkxNjQ0NDU2NjBjAAEByLo1vvdMf/26NtUKB9kj0Pu354Q/ITlRsZ5jYimoCR4EAAAAAAAAAAA=";
+    let move_auth_sig = "BwABAIIBgAFkYzU3M2E1OGM3ZGEwMTZhZmM2MDJkMmFlNTVhYmRhYTZkZGMzZTc5YzJmNGMwODUzOTRjNmMyNGI0ODM5ZWM0ZTAxMjBkYjY5MDJiMDk3NzcyMTE4YTc4YWJhNjIwODk4ODIwMDUxMDlmMWZhM2E1YzA3OGQ5MTY0NDQ1NjYwYwABAci6Nb73TH/9ujbVCgfZI9D7t+eEPyE5UbGeY2IpqAkeBAAAAAAAAAAA";
     let output = KeyToolCommand::DecodeSig {
         sig: move_auth_sig.to_string(),
     }

--- a/sdk/typescript/src/bcs/bcs.ts
+++ b/sdk/typescript/src/bcs/bcs.ts
@@ -320,12 +320,18 @@ export const PasskeyAuthenticator = bcs.struct('PasskeyAuthenticator', {
     userSignature: bcs.vector(bcs.u8()),
 });
 
-/**
- * MoveAuthenticator allows authenticating transactions via a Move function call
- * as part of Account Abstraction.
- */
-export const MoveAuthenticator = bcs.struct('MoveAuthenticator', {
+const MoveAuthenticatorV1 = bcs.struct('MoveAuthenticatorV1', {
     callArgs: bcs.vector(CallArg),
     typeArgs: bcs.vector(TypeTag),
     objectToAuthenticate: CallArg,
+});
+
+/**
+ * MoveAuthenticator allows authenticating transactions via a Move function call
+ * as part of Account Abstraction.
+ * The enum wrapper matches the Rust `MoveAuthenticatorInner` enum, which adds a
+ * one-byte variant prefix to the BCS representation.
+ */
+export const MoveAuthenticator = bcs.enum('MoveAuthenticator', {
+    V1: MoveAuthenticatorV1,
 });

--- a/sdk/typescript/src/client/types/generated.ts
+++ b/sdk/typescript/src/client/types/generated.ts
@@ -1098,7 +1098,11 @@ export interface IotaValidatorSummary {
  * Move code. This function represents the data received by the Move authenticate function during the
  * Account Abstraction authentication flow.
  */
-export interface MoveAuthenticator {
+export type MoveAuthenticator = {
+    V1: MoveAuthenticatorV1;
+};
+/** MoveAuthenticatorV1 is the first version of MoveAuthenticator. */
+export interface MoveAuthenticatorV1 {
     /** Input objects or primitive values */
     call_args: CallArg[];
     /** The object that is authenticated. Represents the account being the sender of the transaction. */

--- a/sdk/typescript/src/keypairs/move-authenticator/builder.ts
+++ b/sdk/typescript/src/keypairs/move-authenticator/builder.ts
@@ -251,6 +251,7 @@ export class MoveAuthenticatorBuilder {
         }
 
         return {
+            version: 'V1' as const,
             callArgs: resolvedCallArgs,
             typeArgs: this.typeArgs,
             objectToAuthenticate,

--- a/sdk/typescript/src/keypairs/move-authenticator/signer.ts
+++ b/sdk/typescript/src/keypairs/move-authenticator/signer.ts
@@ -55,8 +55,12 @@ export class MoveSigner extends Signer {
      * based on the object ID.
      */
     getPublicKey(): PublicKey {
-        const objectId = getObjectIdFromCallArg(this.data.objectToAuthenticate);
-        return new MoveAuthenticatorPublicKey(objectId);
+        if (this.data.version === 'V1') {
+            return new MoveAuthenticatorPublicKey(
+                getObjectIdFromCallArg(this.data.objectToAuthenticate),
+            );
+        }
+        throw new Error(`Unsupported MoveAuthenticator version: ${this.data.version}`);
     }
 
     /**
@@ -66,13 +70,18 @@ export class MoveSigner extends Signer {
      * @returns The BCS-serialized MoveAuthenticator bytes
      */
     async sign(): Promise<Uint8Array> {
-        return bcs.MoveAuthenticator.serialize({
-            callArgs: this.data.callArgs,
-            typeArgs: this.data.typeArgs,
-            objectToAuthenticate: {
-                Object: this.data.objectToAuthenticate,
-            },
-        }).toBytes();
+        if (this.data.version === 'V1') {
+            return bcs.MoveAuthenticator.serialize({
+                V1: {
+                    callArgs: this.data.callArgs,
+                    typeArgs: this.data.typeArgs,
+                    objectToAuthenticate: {
+                        Object: this.data.objectToAuthenticate,
+                    },
+                },
+            }).toBytes();
+        }
+        throw new Error(`Unsupported MoveAuthenticator version: ${this.data.version}`);
     }
 
     /**

--- a/sdk/typescript/src/keypairs/move-authenticator/types.ts
+++ b/sdk/typescript/src/keypairs/move-authenticator/types.ts
@@ -17,10 +17,13 @@ export type MoveAuthenticatorCallArg =
     | { Pure: Uint8Array };
 
 /**
- * The resolved MoveAuthenticator data structure.
- * Fields match the Rust MoveAuthenticator struct.
+ * The resolved MoveAuthenticator data structure, versioned as a discriminated
+ * union. Add new variants here when new versions are introduced on the Rust side.
  */
-export interface MoveAuthenticatorData {
+export type MoveAuthenticatorData = MoveAuthenticatorDataV1; // future: | MoveAuthenticatorDataV2;
+
+export interface MoveAuthenticatorDataV1 {
+    version: 'V1';
     callArgs: CallArg[];
     typeArgs: string[];
     objectToAuthenticate: ObjectArg;

--- a/sdk/typescript/src/verify/verify.ts
+++ b/sdk/typescript/src/verify/verify.ts
@@ -91,16 +91,21 @@ function parseSignature(signature: string) {
     }
 
     if (parsedSignature.signatureScheme === 'MoveAuthenticator') {
-        const authenticatedObjectId =
-            parsedSignature.moveAuthenticator.objectToAuthenticate.Object?.$kind ===
-            'ImmOrOwnedObject'
-                ? parsedSignature.moveAuthenticator.objectToAuthenticate.Object.ImmOrOwnedObject
-                      .objectId
-                : parsedSignature.moveAuthenticator.objectToAuthenticate.Object?.$kind ===
-                    'Receiving'
-                  ? parsedSignature.moveAuthenticator.objectToAuthenticate.Object.Receiving.objectId
-                  : parsedSignature.moveAuthenticator.objectToAuthenticate.Object?.SharedObject
-                        ?.objectId;
+        const moveAuth = parsedSignature.moveAuthenticator;
+        let authenticatedObjectId: string | undefined;
+
+        if (moveAuth.$kind === 'V1') {
+            const { objectToAuthenticate } = moveAuth.V1;
+            authenticatedObjectId =
+                objectToAuthenticate.Object?.$kind === 'ImmOrOwnedObject'
+                    ? objectToAuthenticate.Object.ImmOrOwnedObject.objectId
+                    : objectToAuthenticate.Object?.$kind === 'Receiving'
+                      ? objectToAuthenticate.Object.Receiving.objectId
+                      : objectToAuthenticate.Object?.SharedObject?.objectId;
+        } else {
+            throw new Error(`Unsupported MoveAuthenticator version: ${moveAuth.$kind}`);
+        }
+
         return {
             ...parsedSignature,
             publicKey: new MoveAuthenticatorPublicKey(authenticatedObjectId!),


### PR DESCRIPTION
# Description of change

MoveAuthenticator was changed to support versioning.

## Links to any relevant issues

fixes #10344
