### PR TITLE
feat(core): include rest index in db snapshots

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3540,6 +3540,9 @@ impl AuthorityState {
             if let Some(indexes) = self.indexes.as_ref() {
                 indexes.checkpoint_db(&checkpoint_path_tmp.join("indexes"))?;
             }
+            if let Some(rest_index) = self.rest_index.as_ref() {
+                rest_index.checkpoint_db(&checkpoint_path_tmp.join("grpc_indexes"))?;
+            }
         }
 
         fs::rename(checkpoint_path_tmp, checkpoint_path)

--- a/crates/iota-core/src/rest_index.rs
+++ b/crates/iota-core/src/rest_index.rs
@@ -4,7 +4,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
@@ -14,6 +14,7 @@ use iota_types::{
     committee::EpochId,
     digests::TransactionDigest,
     dynamic_field::visitor as DFV,
+    error::IotaResult,
     full_checkpoint_content::CheckpointData,
     iota_system_state::IotaSystemStateTrait,
     layout_resolver::LayoutResolver,
@@ -702,6 +703,11 @@ impl RestIndexStore {
             tables,
             pending_updates: Default::default(),
         }
+    }
+
+    pub fn checkpoint_db(&self, path: &Path) -> IotaResult {
+        // We are checkpointing the whole db
+        self.tables.meta.checkpoint_db(path).map_err(Into::into)
     }
 
     pub fn prune(

--- a/crates/iota-core/src/rest_index.rs
+++ b/crates/iota-core/src/rest_index.rs
@@ -147,18 +147,21 @@ struct IndexStoreTables {
     ///
     /// Allows an efficient iterator to list all objects currently owned by a
     /// specific user account.
+    /// REST-API only
     owner: DBMap<OwnerIndexKey, OwnerIndexInfo>,
 
     /// An index of dynamic fields (children objects).
     ///
     /// Allows an efficient iterator to list all of the dynamic fields owned by
     /// a particular ObjectID.
+    /// REST-API only
     dynamic_field: DBMap<DynamicFieldKey, DynamicFieldIndexInfo>,
 
     /// An index of Coin Types
     ///
     /// Allows looking up information related to published Coins, like the
     /// ObjectID of its coorisponding CoinMetadata.
+    /// REST-API only
     coin: DBMap<CoinIndexKey, CoinIndexInfo>,
     // NOTE: Authors and Reviewers before adding any new tables ensure that they are either:
     // - bounded in size by the live object set
@@ -587,10 +590,12 @@ impl IndexStoreTables {
         Ok(())
     }
 
+    // only used in "grpc-server"
     fn get_epoch_info(&self, epoch: EpochId) -> Result<Option<EpochInfo>, TypedStoreError> {
         self.epochs.get(&epoch)
     }
 
+    // used in both "grpc-server" and "rest-api"
     fn get_transaction_info(
         &self,
         digest: &TransactionDigest,
@@ -598,6 +603,7 @@ impl IndexStoreTables {
         self.transactions.get(digest)
     }
 
+    // only used in "rest-api"
     fn owner_iter(
         &self,
         owner: IotaAddress,
@@ -613,6 +619,7 @@ impl IndexStoreTables {
             .safe_iter_with_bounds(Some(lower_bound), Some(upper_bound)))
     }
 
+    // only used in "rest-api"
     fn dynamic_field_iter(
         &self,
         parent: ObjectID,
@@ -629,6 +636,7 @@ impl IndexStoreTables {
         Ok(iter)
     }
 
+    // only used in "rest-api"
     fn get_coin_info(
         &self,
         coin_type: &StructTag,
@@ -747,10 +755,12 @@ impl RestIndexStore {
         Ok(batch.write()?)
     }
 
+    // only used in "grpc-server"
     pub fn get_epoch_info(&self, epoch: EpochId) -> Result<Option<EpochInfo>, TypedStoreError> {
         self.tables.get_epoch_info(epoch)
     }
 
+    // used in both "grpc-server" and "rest-api"
     pub fn get_transaction_info(
         &self,
         digest: &TransactionDigest,
@@ -758,6 +768,7 @@ impl RestIndexStore {
         self.tables.get_transaction_info(digest)
     }
 
+    // only used in "rest-api"
     pub fn owner_iter(
         &self,
         owner: IotaAddress,
@@ -769,6 +780,7 @@ impl RestIndexStore {
         self.tables.owner_iter(owner, cursor)
     }
 
+    // only used in "rest-api"
     pub fn dynamic_field_iter(
         &self,
         parent: ObjectID,
@@ -780,6 +792,7 @@ impl RestIndexStore {
         self.tables.dynamic_field_iter(parent, cursor)
     }
 
+    // only used in "rest-api"
     pub fn get_coin_info(
         &self,
         coin_type: &StructTag,

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -548,10 +548,12 @@ impl RestStateReader for RestReadStore {
 }
 
 impl RestIndexes for RestIndexStore {
+    // only used in "grpc-server"
     fn get_epoch_info(&self, epoch: EpochId) -> Result<Option<iota_types::storage::EpochInfo>> {
         self.get_epoch_info(epoch).map_err(StorageError::custom)
     }
 
+    // used in both "grpc-server" and "rest-api"
     fn get_transaction_info(
         &self,
         digest: &TransactionDigest,
@@ -560,6 +562,7 @@ impl RestIndexes for RestIndexStore {
             .map_err(StorageError::custom)
     }
 
+    // only used in "rest-api"
     fn account_owned_objects_info_iter(
         &self,
         owner: IotaAddress,
@@ -582,6 +585,7 @@ impl RestIndexes for RestIndexStore {
         Ok(Box::new(iter) as _)
     }
 
+    // only used in "rest-api"
     fn dynamic_field_iter(
         &self,
         parent: ObjectID,
@@ -596,6 +600,7 @@ impl RestIndexes for RestIndexStore {
         Ok(Box::new(iter) as _)
     }
 
+    // only used in "rest-api"
     fn get_coin_info(
         &self,
         coin_type: &StructTag,

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -1034,7 +1034,8 @@ pub async fn download_db_snapshot(
     files.extend(epoch_manifest.filter_by_prefix("epochs").lines);
     files.extend(epoch_manifest.filter_by_prefix("checkpoints").lines);
     if !skip_indexes {
-        files.extend(epoch_manifest.filter_by_prefix("indexes").lines)
+        files.extend(epoch_manifest.filter_by_prefix("indexes").lines);
+        files.extend(epoch_manifest.filter_by_prefix("grpc_indexes").lines);
     }
     let local_store = ObjectStoreConfig {
         object_store: Some(ObjectStoreType::File),
@@ -1091,6 +1092,17 @@ pub async fn download_db_snapshot(
         .collect::<Result<Vec<_>, _>>()?
         .into_iter()
         .for_each(|result| result.expect("Task failed"));
+
+    // The rest index is stored under the name "grpc_indexes" in the snapshot but
+    // must live at "rest_index" on disk so that RestIndexStore can open it.
+    let grpc_indexes_dir = path.join(format!("epoch_{epoch}")).join("grpc_indexes");
+    if grpc_indexes_dir.exists() {
+        fs::rename(
+            &grpc_indexes_dir,
+            path.join(format!("epoch_{epoch}")).join("rest_index"),
+        )
+        .map_err(|e| anyhow::anyhow!("Failed to rename grpc_indexes to rest_index: {e}"))?;
+    }
 
     let store_dir = path.join("store");
     if store_dir.exists() {

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -880,22 +880,27 @@ pub trait RestStateReader: ObjectStore + ReadStore + Send + Sync {
 pub type DynamicFieldIteratorItem =
     Result<(DynamicFieldKey, DynamicFieldIndexInfo), TypedStoreError>;
 pub trait RestIndexes: Send + Sync {
+    // only used in "grpc-server"
     fn get_epoch_info(&self, epoch: EpochId) -> Result<Option<EpochInfo>>;
 
+    // used in both "grpc-server" and "rest-api"
     fn get_transaction_info(&self, digest: &TransactionDigest) -> Result<Option<TransactionInfo>>;
 
+    // only used in "rest-api"
     fn account_owned_objects_info_iter(
         &self,
         owner: IotaAddress,
         cursor: Option<ObjectID>,
     ) -> Result<Box<dyn Iterator<Item = Result<AccountOwnedObjectInfo, TypedStoreError>> + '_>>;
 
+    // only used in "rest-api"
     fn dynamic_field_iter(
         &self,
         parent: ObjectID,
         cursor: Option<ObjectID>,
     ) -> Result<Box<dyn Iterator<Item = DynamicFieldIteratorItem> + '_>>;
 
+    // only used in "rest-api"
     fn get_coin_info(&self, coin_type: &StructTag) -> Result<Option<CoinInfo>>;
 }
 


### PR DESCRIPTION
# Description of change

Right now the `RestIndexStore` is not included in the database snapshots. When `iota-tool download-db-snapshot --latest    --network testnet --path ./db --num-parallel-downloads 70 --no-sign-request --verbose` is executed, the `rest_index` database doesn't exist.

This PR adds db snapshot creation for the `RestIndexStore` on the node side and extends the `download-db-snapshot` in `iota-tool` to download the new database.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Include `RestIndexStore` in database snapshots
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
