### PR TITLE
fix(iota_types): `iota_sdk_types::Object` to `iota_types::Object` type conversion

### DIFF
--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -49,7 +49,7 @@ use iota_sdk_types::{
 use move_core_types::language_storage::ModuleId;
 use tap::Pipe;
 
-use crate::transaction::TransactionDataAPI as _;
+use crate::{object::ObjectInner, transaction::TransactionDataAPI as _};
 
 #[derive(Debug)]
 pub struct SdkTypeConversionError(pub String);
@@ -98,11 +98,12 @@ impl TryFrom<Object> for crate::object::Object {
     type Error = SdkTypeConversionError;
 
     fn try_from(value: Object) -> Result<Self, Self::Error> {
-        Self::new_from_genesis(
-            value.data.try_into()?,
-            value.owner.into(),
-            value.previous_transaction.into(),
-        )
+        Self::from(ObjectInner {
+            data: value.data.try_into()?,
+            owner: value.owner.into(),
+            previous_transaction: value.previous_transaction.into(),
+            storage_rebate: value.storage_rebate,
+        })
         .pipe(Ok)
     }
 }


### PR DESCRIPTION
# Description of change

This patch fixes a conversion issue from `iota_sdk_types::Object` to `iota_types::Object` in `iota_types::iota_sdk_types_conversions`.
Before with `new_from_genesis()` the storage_rebate was hardcoded to 0 which can be wrong.

## Links to any relevant issues

fixes #10382 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

