### PR TITLE
chore: fix/allow typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -4,10 +4,12 @@ extend-ignore-identifiers-re = [
   "^[a-f0-9]{7}$",
   "^[a-f0-9]{12}$",
   # Base64
+  "^[a-zA-Z0-9_]{30}$",
   "^[a-zA-Z0-9_]{43}$",
   "^[a-zA-Z0-9_]{44}$",
   "^[a-zA-Z0-9_]{47}$",
   "^[a-zA-Z0-9_]{49}$",
+  "^[a-zA-Z0-9_]{50}$",
   "^[a-zA-Z0-9_]{56,}$",
 ]
 
@@ -36,6 +38,8 @@ nd = "nd"
 tto = "tto"
 ser = "ser"
 groth = "groth"
+typ = "typ"
+cpy = "cpy"
 # Identity
 AAS = "AAS"
 # actual typos purposely used in tests
@@ -45,7 +49,6 @@ tring = "tring"
 transferer = "transferrer"
 # not in the correction dictionary
 checkpoitn = "checkpoint"
-typ = "typ"
 # crates
 bimap = "bimap"
 # plurals

--- a/crates/iota-rest-kv/src/aws.rs
+++ b/crates/iota-rest-kv/src/aws.rs
@@ -126,7 +126,7 @@ pub struct KvStoreClient {
     table_name: String,
     /// The representation of the uptime of the service.
     start_time: Instant,
-    /// Cached AWS components sttaus.
+    /// Cached AWS components status.
     cached_status: Arc<RwLock<Option<CachedAwsStatus>>>,
     /// The TTL of the [`CachedAwsStatus`].
     cache_duration: Duration,


### PR DESCRIPTION
```
error: `cpy` should be `cpu`, `copy`
    ╭▸ ./iota-execution/cut/src/path.rs:327:35
    │
327 │         deep_copy(&src, dst.join("cpy-0"), &mut |_| true).unwrap();
    ╰╴                                  ━━━
error: `cpy` should be `cpu`, `copy`
    ╭▸ ./iota-execution/cut/src/path.rs:334:35
    │
334 │         deep_copy(&src, dst.join("cpy-1"), &mut |p| !p.ends_with("foo")).unwrap();
    ╰╴                                  ━━━
error: `cpy` should be `cpu`, `copy`
    ╭▸ ./iota-execution/cut/src/path.rs:341:35
    │
341 │         deep_copy(&src, dst.join("cpy-2"), &mut |p| !p.ends_with("baz")).unwrap();
    ╰╴                                  ━━━
error: `cpy` should be `cpu`, `copy`
    ╭▸ ./iota-execution/cut/src/path.rs:347:35
    │
347 │         deep_copy(&src, dst.join("cpy-3"), &mut |p| !p.ends_with("quy")).unwrap();
    ╰╴                                  ━━━
error: `Iz` should be `Is`
    ╭▸ ./crates/iota-graphql-e2e-tests/tests/transactions/system.snap:416:54
    │
416 │ …                     "cursor": "eyJuIjoiYmxzMTIzODEiLCJjIjowfQ",
    ╰╴                                               ━━
error: `sttaus` should be `status`
    ╭▸ ./crates/iota-rest-kv/src/aws.rs:129:31
    │
129 │     /// Cached AWS components sttaus.
    ╰╴                              ━━━━━━
error: `Iz` should be `Is`
    ╭▸ ./docs/content/developer/iota-identity/how-tos/verifiable-credentials/zero-knowledge-selective-disclosure.mdx:106:38
    │
106 │   "presentation": "eyJub25jZSI6InVURUIzNzFsMXB6V0psN2FmQjB3aTBIV1VOaz
    ╰╴  
```