### PR TITLE
feat(consensus): remove block digest from transaction ref

### DIFF
--- a/crates/iota-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/iota-core/src/consensus_types/consensus_output_api.rs
@@ -151,15 +151,14 @@ impl_consensus_output_api! {
 
 // starfish_core::CommittedSubDag:
 // - iterate over `self.transactions` (VerifiedTransactions)
-// - per-item accessors via block_ref(): .round / .author.value()
-// - txs via vt.transactions()
+// - per-item accessors: round()/author().value()/transactions()
 // - committed_header_refs: use committed_header_refs from SubDagBase
 impl_consensus_output_api! {
     type = starfish_core::CommittedSubDag,
     commit_digest = starfish_core::CommitDigest,
     iterate = |self_, vt| self_.transactions.iter(),
-    round   = |vt| vt.block_ref().round,
-    author  = |vt| vt.block_ref().author.value(),
+    round   = |vt| vt.round(),
+    author  = |vt| vt.author().value(),
     txs     = |vt| vt.transactions(),
     committed_header_refs = |self_| &self_.base.committed_header_refs
 }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -221,6 +221,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         let verified_transactions = VerifiedTransactions::new(
             transactions,
             verified_block_header.transaction_ref(),
+            verified_block_header.digest(),
             serialized_transactions,
         );
         let has_transactions = verified_transactions.has_transactions();
@@ -2794,6 +2795,7 @@ mod tests {
             let verified_transactions = VerifiedTransactions::new(
                 transactions,
                 verified_block_header.transaction_ref(),
+                verified_block_header.digest(),
                 serialized_transactions,
             );
             let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);
@@ -2871,6 +2873,7 @@ mod tests {
             let verified_transactions = VerifiedTransactions::new(
                 transactions,
                 verified_block_header.transaction_ref(),
+                verified_block_header.digest(),
                 serialized_transactions,
             );
             let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -221,7 +221,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         let verified_transactions = VerifiedTransactions::new(
             transactions,
             verified_block_header.transaction_ref(),
-            verified_block_header.digest(),
+            Some(verified_block_header.digest()),
             serialized_transactions,
         );
         let has_transactions = verified_transactions.has_transactions();
@@ -2795,7 +2795,7 @@ mod tests {
             let verified_transactions = VerifiedTransactions::new(
                 transactions,
                 verified_block_header.transaction_ref(),
-                verified_block_header.digest(),
+                Some(verified_block_header.digest()),
                 serialized_transactions,
             );
             let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);
@@ -2873,7 +2873,7 @@ mod tests {
             let verified_transactions = VerifiedTransactions::new(
                 transactions,
                 verified_block_header.transaction_ref(),
-                verified_block_header.digest(),
+                Some(verified_block_header.digest()),
                 serialized_transactions,
             );
             let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -220,8 +220,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
 
         let verified_transactions = VerifiedTransactions::new(
             transactions,
-            verified_block_header.reference(),
-            verified_block_header.transactions_commitment(),
+            verified_block_header.transaction_ref(),
             serialized_transactions,
         );
         let has_transactions = verified_transactions.has_transactions();
@@ -2794,8 +2793,7 @@ mod tests {
                 .unwrap();
             let verified_transactions = VerifiedTransactions::new(
                 transactions,
-                verified_block_header.reference(),
-                verified_block_header.transactions_commitment(),
+                verified_block_header.transaction_ref(),
                 serialized_transactions,
             );
             let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);
@@ -2872,8 +2870,7 @@ mod tests {
                 .unwrap();
             let verified_transactions = VerifiedTransactions::new(
                 transactions,
-                verified_block_header.reference(),
-                verified_block_header.transactions_commitment(),
+                verified_block_header.transaction_ref(),
                 serialized_transactions,
             );
             let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -991,7 +991,9 @@ pub struct VerifiedTransactions {
     transaction_ref: TransactionRef,
 
     /// Digest of the block this transaction batch belongs to.
-    block_digest: BlockHeaderDigest,
+    /// `None` when created via the `consensus_transaction_ref` path where no
+    /// block header is available.
+    block_digest: Option<BlockHeaderDigest>,
 
     /// The serialized bytes of the transactions.
     serialized: Bytes,
@@ -1007,7 +1009,7 @@ impl VerifiedTransactions {
     pub(crate) fn new(
         transactions: Vec<Transaction>,
         transaction_ref: TransactionRef,
-        block_digest: BlockHeaderDigest,
+        block_digest: Option<BlockHeaderDigest>,
         serialized: Bytes,
     ) -> Self {
         Self {
@@ -1030,12 +1032,12 @@ impl VerifiedTransactions {
         self.transaction_ref.author
     }
 
-    pub fn block_ref(&self) -> BlockRef {
-        BlockRef {
+    pub fn block_ref(&self) -> Option<BlockRef> {
+        self.block_digest.map(|digest| BlockRef {
             round: self.transaction_ref.round,
             author: self.transaction_ref.author,
-            digest: self.block_digest,
-        }
+            digest,
+        })
     }
 
     pub fn transaction_ref(&self) -> TransactionRef {
@@ -1084,7 +1086,7 @@ impl VerifiedBlock {
         let verified_transactions = VerifiedTransactions::new(
             vec![],
             verified_block_header.transaction_ref(),
-            verified_block_header.digest(),
+            Some(verified_block_header.digest()),
             Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
         );
         Self {
@@ -1099,7 +1101,7 @@ impl VerifiedBlock {
         let verified_transactions = VerifiedTransactions::new(
             vec![],
             verified_block_header.transaction_ref(),
-            verified_block_header.digest(),
+            Some(verified_block_header.digest()),
             Bytes::from(
                 bcs::to_bytes::<Vec<Transaction>>(
                     &vec![vec![tx; 16]]
@@ -1156,7 +1158,7 @@ pub(crate) fn genesis_blocks(context: &Context) -> Vec<VerifiedBlock> {
                 verified_transactions: VerifiedTransactions::new(
                     vec![],
                     verified_block_header.transaction_ref(),
-                    verified_block_header.digest(),
+                    Some(verified_block_header.digest()),
                     Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
                 ),
             }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -990,6 +990,9 @@ pub struct VerifiedTransactions {
     /// Commitment of transactions in the block
     transaction_ref: TransactionRef,
 
+    /// Digest of the block this transaction batch belongs to.
+    block_digest: BlockHeaderDigest,
+
     /// The serialized bytes of the transactions.
     serialized: Bytes,
 }
@@ -1004,11 +1007,13 @@ impl VerifiedTransactions {
     pub(crate) fn new(
         transactions: Vec<Transaction>,
         transaction_ref: TransactionRef,
+        block_digest: BlockHeaderDigest,
         serialized: Bytes,
     ) -> Self {
         Self {
             transactions,
             transaction_ref,
+            block_digest,
             serialized,
         }
     }
@@ -1029,7 +1034,7 @@ impl VerifiedTransactions {
         BlockRef {
             round: self.transaction_ref.round,
             author: self.transaction_ref.author,
-            digest: self.transaction_ref.block_digest,
+            digest: self.block_digest,
         }
     }
 
@@ -1079,6 +1084,7 @@ impl VerifiedBlock {
         let verified_transactions = VerifiedTransactions::new(
             vec![],
             verified_block_header.transaction_ref(),
+            verified_block_header.digest(),
             Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
         );
         Self {
@@ -1093,6 +1099,7 @@ impl VerifiedBlock {
         let verified_transactions = VerifiedTransactions::new(
             vec![],
             verified_block_header.transaction_ref(),
+            verified_block_header.digest(),
             Bytes::from(
                 bcs::to_bytes::<Vec<Transaction>>(
                     &vec![vec![tx; 16]]
@@ -1149,6 +1156,7 @@ pub(crate) fn genesis_blocks(context: &Context) -> Vec<VerifiedBlock> {
                 verified_transactions: VerifiedTransactions::new(
                     vec![],
                     verified_block_header.transaction_ref(),
+                    verified_block_header.digest(),
                     Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
                 ),
             }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1040,6 +1040,10 @@ impl VerifiedTransactions {
         })
     }
 
+    pub fn block_digest(&self) -> Option<BlockHeaderDigest> {
+        self.block_digest
+    }
+
     pub fn transaction_ref(&self) -> TransactionRef {
         self.transaction_ref
     }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -489,7 +489,6 @@ impl ShardWithProof {
                     round: block_ref.round,
                     author: block_ref.author,
                     transactions_commitment: transaction_commitment,
-                    block_digest: block_ref.digest,
                 },
             })
         } else {
@@ -921,7 +920,6 @@ impl VerifiedBlockHeader {
             round: self.round(),
             author: self.author(),
             transactions_commitment: self.signed_block_header.inner.transactions_commitment(),
-            block_digest: self.digest(),
         }
     }
 

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1003,18 +1003,12 @@ impl PartialEq for VerifiedTransactions {
 impl VerifiedTransactions {
     pub(crate) fn new(
         transactions: Vec<Transaction>,
-        block_ref: BlockRef,
-        transactions_commitment: TransactionsCommitment,
+        transaction_ref: TransactionRef,
         serialized: Bytes,
     ) -> Self {
         Self {
             transactions,
-            transaction_ref: TransactionRef {
-                round: block_ref.round,
-                author: block_ref.author,
-                transactions_commitment,
-                block_digest: block_ref.digest,
-            },
+            transaction_ref,
             serialized,
         }
     }
@@ -1084,12 +1078,7 @@ impl VerifiedBlock {
         let verified_block_header = VerifiedBlockHeader::new_for_test(block_header);
         let verified_transactions = VerifiedTransactions::new(
             vec![],
-            BlockRef::new(
-                verified_block_header.round(),
-                verified_block_header.author(),
-                verified_block_header.digest(),
-            ),
-            verified_block_header.transactions_commitment(),
+            verified_block_header.transaction_ref(),
             Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
         );
         Self {
@@ -1103,12 +1092,7 @@ impl VerifiedBlock {
         let verified_block_header = VerifiedBlockHeader::new_for_test(block_header);
         let verified_transactions = VerifiedTransactions::new(
             vec![],
-            BlockRef::new(
-                verified_block_header.round(),
-                verified_block_header.author(),
-                verified_block_header.digest(),
-            ),
-            verified_block_header.transactions_commitment(),
+            verified_block_header.transaction_ref(),
             Bytes::from(
                 bcs::to_bytes::<Vec<Transaction>>(
                     &vec![vec![tx; 16]]
@@ -1164,8 +1148,7 @@ pub(crate) fn genesis_blocks(context: &Context) -> Vec<VerifiedBlock> {
                 verified_block_header: verified_block_header.clone(),
                 verified_transactions: VerifiedTransactions::new(
                     vec![],
-                    verified_block_header.reference(),
-                    verified_block_header.transactions_commitment(),
+                    verified_block_header.transaction_ref(),
                     Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
                 ),
             }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -989,8 +989,9 @@ pub struct VerifiedTransactions {
     transaction_ref: TransactionRef,
 
     /// Digest of the block this transaction batch belongs to.
-    /// `None` when created via the `consensus_transaction_ref` path where no
-    /// block header is available.
+    /// It is necessary when we use BlockRef to fetch transactions.
+    /// When we use TransactionRef, i.e. when `consensus_transaction_ref` is
+    /// true, then it is set to `None`.
     block_digest: Option<BlockHeaderDigest>,
 
     /// The serialized bytes of the transactions.
@@ -1030,6 +1031,8 @@ impl VerifiedTransactions {
         self.transaction_ref.author
     }
 
+    /// Returns the block ref if `block_digest` is set (i.e., when using
+    /// BlockRef-based fetching).
     pub fn block_ref(&self) -> Option<BlockRef> {
         self.block_digest.map(|digest| BlockRef {
             round: self.transaction_ref.round,
@@ -1038,6 +1041,8 @@ impl VerifiedTransactions {
         })
     }
 
+    /// Returns the block digest if available; `None` when using
+    /// TransactionRef-based fetching.
     pub fn block_digest(&self) -> Option<BlockHeaderDigest> {
         self.block_digest
     }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -462,7 +462,6 @@ pub(crate) trait ShardWithProofAPI {
     fn proof(&self) -> &MerkleProofBytes;
     fn transaction_commitment(&self) -> TransactionsCommitment;
     fn round(&self) -> Round;
-    fn block_ref(&self) -> BlockRef;
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -520,10 +519,6 @@ impl ShardWithProofAPI for ShardWithProofV1 {
     fn round(&self) -> Round {
         self.block_ref.round
     }
-
-    fn block_ref(&self) -> BlockRef {
-        self.block_ref
-    }
 }
 
 impl ShardWithProofAPI for ShardWithProofV2 {
@@ -541,14 +536,6 @@ impl ShardWithProofAPI for ShardWithProofV2 {
 
     fn round(&self) -> Round {
         self.transaction_ref.round
-    }
-
-    fn block_ref(&self) -> BlockRef {
-        BlockRef {
-            round: self.transaction_ref.round,
-            author: self.transaction_ref.author,
-            digest: self.transaction_ref.block_digest,
-        }
     }
 }
 
@@ -1034,6 +1021,14 @@ impl VerifiedTransactions {
 
     pub fn transactions_commitment(&self) -> TransactionsCommitment {
         self.transaction_ref.transactions_commitment
+    }
+
+    pub fn round(&self) -> Round {
+        self.transaction_ref.round
+    }
+
+    pub fn author(&self) -> AuthorityIndex {
+        self.transaction_ref.author
     }
 
     pub fn block_ref(&self) -> BlockRef {

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -462,6 +462,8 @@ pub(crate) trait ShardWithProofAPI {
     fn proof(&self) -> &MerkleProofBytes;
     fn transaction_commitment(&self) -> TransactionsCommitment;
     fn round(&self) -> Round;
+    fn author(&self) -> AuthorityIndex;
+    fn block_digest(&self) -> Option<BlockHeaderDigest>;
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -518,6 +520,14 @@ impl ShardWithProofAPI for ShardWithProofV1 {
     fn round(&self) -> Round {
         self.block_ref.round
     }
+
+    fn author(&self) -> AuthorityIndex {
+        self.block_ref.author
+    }
+
+    fn block_digest(&self) -> Option<BlockHeaderDigest> {
+        Some(self.block_ref.digest)
+    }
 }
 
 impl ShardWithProofAPI for ShardWithProofV2 {
@@ -535,6 +545,14 @@ impl ShardWithProofAPI for ShardWithProofV2 {
 
     fn round(&self) -> Round {
         self.transaction_ref.round
+    }
+
+    fn author(&self) -> AuthorityIndex {
+        self.transaction_ref.author
+    }
+
+    fn block_digest(&self) -> Option<BlockHeaderDigest> {
+        None
     }
 }
 

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1007,9 +1007,10 @@ pub struct VerifiedTransactions {
     transaction_ref: TransactionRef,
 
     /// Digest of the block this transaction batch belongs to.
-    /// It is necessary when we use BlockRef to fetch transactions.
-    /// When we use TransactionRef, i.e. when `consensus_transaction_ref` is
-    /// true, then it is set to `None`.
+    /// Present (`Some`) whenever the block header is available at
+    /// construction time, regardless of the `consensus_transaction_ref` flag.
+    /// `None` only when transactions were received without an accompanying
+    /// block header (e.g., fast sync or store loading via TransactionRef).
     block_digest: Option<BlockHeaderDigest>,
 
     /// The serialized bytes of the transactions.

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -610,7 +610,7 @@ impl CommittedSubDag {
             &self
                 .transactions
                 .iter()
-                .map(|t| GenericTransactionRef::BlockRef(t.block_ref()))
+                .map(|t| GenericTransactionRef::TransactionRef(t.transaction_ref()))
                 .collect::<Vec<_>>(),
         )
     }

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -566,7 +566,7 @@ impl CommitObserver {
                 .observe(commit.transactions.len() as f64);
             // Report the number of blocks committed with transactions per authority
             for verified_transaction in &commit.transactions {
-                let authority_index = verified_transaction.block_ref().author;
+                let authority_index = verified_transaction.author();
                 let hostname = &self.context.committee.authority(authority_index).hostname;
                 metrics
                     .committed_non_empty_blocks_per_authority

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -574,10 +574,10 @@ impl CommitObserver {
                     .inc();
             }
 
-            let block_refs_for_committed_txs = commit
+            let tx_refs_for_committed_txs = commit
                 .transactions
                 .iter()
-                .map(|tx| tx.block_ref())
+                .map(|tx| tx.transaction_ref())
                 .collect::<Vec<_>>();
 
             // Read only cached block headers from storage for the transactions in the
@@ -587,7 +587,7 @@ impl CommitObserver {
             let headers_for_committed_txs = self
                 .dag_state
                 .read()
-                .get_cached_block_headers(&block_refs_for_committed_txs)
+                .get_cached_block_headers_for_transaction_refs(&tx_refs_for_committed_txs)
                 .into_iter()
                 .flatten()
                 .collect::<Vec<_>>();

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -820,7 +820,7 @@ mod tests {
     /// - Phase 6: Restart A, fast syncs N2-N3 → stores voting headers
     /// - Phase 7: Restart B, needs N1-N3 → should get N2-N3 from A's voting
     ///   storage
-    #[tokio::test(flavor = "current_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[serial_test::serial]
     async fn test_fast_sync_voting_blocks_served_to_peer() {
         telemetry_subscribers::init_for_testing();
@@ -1198,7 +1198,7 @@ mod tests {
     ///   synchronizer + shard reconstructor stopped to prevent pending subdags
     ///   from being solidified
     /// - Phase 7: Verify fast sync was used and validator caught up
-    #[tokio::test(flavor = "current_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[serial_test::serial]
     async fn test_fast_sync_with_pending_subdags() {
         telemetry_subscribers::init_for_testing();

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -820,7 +820,7 @@ mod tests {
     /// - Phase 6: Restart A, fast syncs N2-N3 → stores voting headers
     /// - Phase 7: Restart B, needs N1-N3 → should get N2-N3 from A's voting
     ///   storage
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[tokio::test(flavor = "current_thread")]
     #[serial_test::serial]
     async fn test_fast_sync_voting_blocks_served_to_peer() {
         telemetry_subscribers::init_for_testing();
@@ -1198,7 +1198,7 @@ mod tests {
     ///   synchronizer + shard reconstructor stopped to prevent pending subdags
     ///   from being solidified
     /// - Phase 7: Verify fast sync was used and validator caught up
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[tokio::test(flavor = "current_thread")]
     #[serial_test::serial]
     async fn test_fast_sync_with_pending_subdags() {
         telemetry_subscribers::init_for_testing();

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -821,6 +821,7 @@ mod tests {
     /// - Phase 7: Restart B, needs N1-N3 → should get N2-N3 from A's voting
     ///   storage
     #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial]
     async fn test_fast_sync_voting_blocks_served_to_peer() {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
@@ -1198,6 +1199,7 @@ mod tests {
     ///   from being solidified
     /// - Phase 7: Verify fast sync was used and validator caught up
     #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial]
     async fn test_fast_sync_with_pending_subdags() {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -62,7 +62,7 @@ use crate::{
     error::{ConsensusError, ConsensusResult},
     network::NetworkClient,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
-    transaction_ref::GenericTransactionRef,
+    transaction_ref::{GenericTransactionRef, TransactionRef},
 };
 pub(crate) enum CommitSyncType {
     Fast,
@@ -319,8 +319,7 @@ pub(crate) fn verify_transactions_with_headers(
         // Step 3: Create a VerifiedTransactions instance and insert into map
         let verified_transactions = VerifiedTransactions::new(
             transactions,
-            block_ref,
-            block_header.transactions_commitment(),
+            TransactionRef::new(block_ref, block_header.transactions_commitment()),
             inner_serialized_transactions,
         );
 
@@ -353,11 +352,6 @@ pub(crate) fn verify_transactions_with_transactions_refs(
                 });
             }
         };
-        let block_ref = BlockRef {
-            round: transaction_ref.round,
-            author: transaction_ref.author,
-            digest: transaction_ref.block_digest,
-        };
         // Step 1: Verify that the transaction commitment matches.
         if transaction_ref.transactions_commitment
             != TransactionsCommitment::compute_transactions_commitment(
@@ -379,12 +373,8 @@ pub(crate) fn verify_transactions_with_transactions_refs(
             .map_err(ConsensusError::MalformedTransactions)?;
 
         // Step 3: Create a VerifiedTransactions instance and insert into map
-        let verified_transactions = VerifiedTransactions::new(
-            transactions,
-            block_ref,
-            transaction_ref.transactions_commitment,
-            inner_serialized_transactions,
-        );
+        let verified_transactions =
+            VerifiedTransactions::new(transactions, transaction_ref, inner_serialized_transactions);
 
         verified_transactions_map.insert(
             GenericTransactionRef::TransactionRef(transaction_ref),

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -320,7 +320,7 @@ pub(crate) fn verify_transactions_with_headers(
         let verified_transactions = VerifiedTransactions::new(
             transactions,
             TransactionRef::new(block_ref, block_header.transactions_commitment()),
-            block_ref.digest,
+            Some(block_ref.digest),
             inner_serialized_transactions,
         );
 
@@ -374,8 +374,12 @@ pub(crate) fn verify_transactions_with_transactions_refs(
             .map_err(ConsensusError::MalformedTransactions)?;
 
         // Step 3: Create a VerifiedTransactions instance and insert into map
-        let verified_transactions =
-            VerifiedTransactions::new(transactions, transaction_ref, transaction_ref.block_digest, inner_serialized_transactions);
+        let verified_transactions = VerifiedTransactions::new(
+            transactions,
+            transaction_ref,
+            None,
+            inner_serialized_transactions,
+        );
 
         verified_transactions_map.insert(
             GenericTransactionRef::TransactionRef(transaction_ref),

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -320,6 +320,7 @@ pub(crate) fn verify_transactions_with_headers(
         let verified_transactions = VerifiedTransactions::new(
             transactions,
             TransactionRef::new(block_ref, block_header.transactions_commitment()),
+            block_ref.digest,
             inner_serialized_transactions,
         );
 
@@ -374,7 +375,7 @@ pub(crate) fn verify_transactions_with_transactions_refs(
 
         // Step 3: Create a VerifiedTransactions instance and insert into map
         let verified_transactions =
-            VerifiedTransactions::new(transactions, transaction_ref, inner_serialized_transactions);
+            VerifiedTransactions::new(transactions, transaction_ref, transaction_ref.block_digest, inner_serialized_transactions);
 
         verified_transactions_map.insert(
             GenericTransactionRef::TransactionRef(transaction_ref),

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -20,7 +20,7 @@ use tokio::{
     task::JoinSet,
     time::{MissedTickBehavior, sleep},
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     CommitConsumerMonitor, CommitIndex,
@@ -337,7 +337,13 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                     {
                         GenericTransactionRef::TransactionRef(verified_txns.transaction_ref())
                     } else {
-                        GenericTransactionRef::BlockRef(verified_txns.block_ref())
+                        let Some(block_ref) = verified_txns.block_ref() else {
+                            error!(
+                                "block_ref unavailable for transactions in non-transaction-ref path"
+                            );
+                            continue;
+                        };
+                        GenericTransactionRef::BlockRef(block_ref)
                     };
                     available_transactions.insert(gen_tx_ref);
                 }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -651,7 +651,6 @@ impl CordialKnowledge {
                         round: acknowledgment.round,
                         author: acknowledgment.author,
                         transactions_commitment,
-                        block_digest: acknowledgment.digest,
                     })
                 } else {
                     continue;

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -1328,7 +1328,11 @@ mod tests {
                             verified_transactions.transaction_ref(),
                         )
                     } else {
-                        GenericTransactionRef::BlockRef(verified_transactions.block_ref())
+                        GenericTransactionRef::BlockRef(
+                            verified_transactions
+                                .block_ref()
+                                .expect("block_ref must be present in non-transaction-ref path"),
+                        )
                     };
                     let shard_for_core = VerifiedOwnShard {
                         serialized_shard: Bytes::from([0u8; 32].to_vec()), /* put some dummy
@@ -1354,7 +1358,11 @@ mod tests {
                 let gen_transaction_ref = if context.protocol_config.consensus_transaction_ref() {
                     GenericTransactionRef::TransactionRef(verified_transactions.transaction_ref())
                 } else {
-                    GenericTransactionRef::BlockRef(verified_transactions.block_ref())
+                    GenericTransactionRef::BlockRef(
+                        verified_transactions
+                            .block_ref()
+                            .expect("block_ref must be present in non-transaction-ref path"),
+                    )
                 };
                 let shard_for_core = VerifiedOwnShard {
                     serialized_shard: Bytes::from([0u8; 32].to_vec()), // put some dummy shard data

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2541,8 +2541,8 @@ mod test {
                 // Transactions from all authors except authority_to_skip should also have a
                 // corresponding block_ref being traversed in the committed sub_dag
                 // Same after num_rounds_with_skip_ancestors
-                if transaction.block_ref().author != authority_to_skip
-                    || transaction.block_ref().round >= num_rounds_with_skip_ancestors
+                if transaction.author() != authority_to_skip
+                    || transaction.round() >= num_rounds_with_skip_ancestors
                 {
                     assert!(
                         existing_headers.contains(&transaction.block_ref()),

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2590,12 +2590,6 @@ mod test {
             .find(|(a, _)| a.author() == authority_to_skip)
             .unwrap()
             .0;
-        let block_ref_for_first_missing_tx = match first_missing_transaction_from_skipped {
-            GenericTransactionRef::BlockRef(ref b) => BlockRef::new(b.round, b.author, b.digest),
-            GenericTransactionRef::TransactionRef(ref t) => {
-                BlockRef::new(t.round, t.author, t.block_digest)
-            }
-        };
         if commit_only_for_traversed_headers {
             assert_eq!(
                 first_missing_transaction_from_skipped.round(),
@@ -2607,14 +2601,23 @@ mod test {
         // Ensure that the block header corresponding to the
         // first_missing_transaction_from_skipped is not in dag_state
         // if commit_only_for_traversed_headers=false and in dag_state otherwise
-        assert_eq!(
-            core_catch_up
-                .dag_state
-                .read()
-                .get_verified_block_headers(&[block_ref_for_first_missing_tx])[0]
-                .is_some(),
-            commit_only_for_traversed_headers
-        );
+        let is_in_dag_state = {
+            let dag = core_catch_up.dag_state.read();
+            match first_missing_transaction_from_skipped {
+                GenericTransactionRef::BlockRef(ref b) => {
+                    let block_ref = BlockRef::new(b.round, b.author, b.digest);
+                    dag.get_verified_block_headers(&[block_ref])[0].is_some()
+                }
+                GenericTransactionRef::TransactionRef(ref t) => {
+                    // resolve_block_ref returns None iff the block header is absent from
+                    // dag_state, which is exactly the condition we want to check.
+                    dag.resolve_block_ref(t).map_or(false, |block_ref| {
+                        dag.get_verified_block_headers(&[block_ref])[0].is_some()
+                    })
+                }
+            }
+        };
+        assert_eq!(is_in_dag_state, commit_only_for_traversed_headers);
         let last_solid_commit_round = core_catch_up
             .dag_state
             .read()

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -945,6 +945,7 @@ impl Core {
         let verified_transactions = VerifiedTransactions::new(
             transactions,
             verified_block_header.transaction_ref(),
+            verified_block_header.digest(),
             serialized_transactions,
         );
         let verified_block = VerifiedBlock {

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -945,7 +945,7 @@ impl Core {
         let verified_transactions = VerifiedTransactions::new(
             transactions,
             verified_block_header.transaction_ref(),
-            verified_block_header.digest(),
+            Some(verified_block_header.digest()),
             serialized_transactions,
         );
         let verified_block = VerifiedBlock {
@@ -2545,16 +2545,27 @@ mod test {
                     || transaction.round() >= num_rounds_with_skip_ancestors
                 {
                     assert!(
-                        existing_headers.contains(&transaction.block_ref()),
+                        existing_headers.contains(
+                            &transaction
+                                .block_ref()
+                                .expect("block_ref should be set in test")
+                        ),
                         "{}",
-                        transaction.block_ref()
+                        transaction
+                            .block_ref()
+                            .expect("block_ref should be set in test")
                     );
                 } else {
                     assert!(
-                        !existing_headers.contains(&transaction.block_ref())
-                            && !commit_only_for_traversed_headers,
+                        !existing_headers.contains(
+                            &transaction
+                                .block_ref()
+                                .expect("block_ref should be set in test")
+                        ) && !commit_only_for_traversed_headers,
                         "{}",
-                        transaction.block_ref()
+                        transaction
+                            .block_ref()
+                            .expect("block_ref should be set in test")
                     );
                 }
             }

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1548,7 +1548,6 @@ mod test {
                         round: block.round(),
                         author: block.author(),
                         transactions_commitment: block.transactions_commitment(),
-                        block_digest: block.digest(),
                     })
                 } else {
                     // When disabled, use BlockRef variant
@@ -2611,7 +2610,7 @@ mod test {
                 GenericTransactionRef::TransactionRef(ref t) => {
                     // resolve_block_ref returns None iff the block header is absent from
                     // dag_state, which is exactly the condition we want to check.
-                    dag.resolve_block_ref(t).map_or(false, |block_ref| {
+                    dag.resolve_block_ref(t).is_some_and(|block_ref| {
                         dag.get_verified_block_headers(&[block_ref])[0].is_some()
                     })
                 }
@@ -3136,7 +3135,6 @@ mod test {
                         round: block.round(),
                         author: block.author(),
                         transactions_commitment: block.transactions_commitment(),
-                        block_digest: block.digest(),
                     })
                 } else {
                     // When disabled, use BlockRef variant

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2629,11 +2629,12 @@ mod test {
         let missing_verified_transactions: Vec<_> = all_sequenced_transactions
             .into_iter()
             .filter(|tx| {
-                let tx_ref = tx.transaction_ref();
                 let generic_ref = if consensus_transaction_ref {
-                    GenericTransactionRef::TransactionRef(tx_ref)
+                    GenericTransactionRef::TransactionRef(tx.transaction_ref())
                 } else {
-                    GenericTransactionRef::BlockRef(BlockRef::from(tx_ref))
+                    GenericTransactionRef::BlockRef(
+                        tx.block_ref().expect("block_ref should be set in test"),
+                    )
                 };
                 missing_transactions.contains_key(&generic_ref)
             })
@@ -2641,7 +2642,7 @@ mod test {
         core_catch_up
             .add_transactions(
                 missing_verified_transactions,
-                crate::dag_state::DataSource::TransactionSynchronizer,
+                DataSource::TransactionSynchronizer,
             )
             .unwrap();
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -944,8 +944,7 @@ impl Core {
         // Construct verified transactions to be used for storing and broadcasting
         let verified_transactions = VerifiedTransactions::new(
             transactions,
-            verified_block_header.reference(),
-            transactions_commitment,
+            verified_block_header.transaction_ref(),
             serialized_transactions,
         );
         let verified_block = VerifiedBlock {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -753,10 +753,15 @@ impl DagState {
                 .accepted_transactions_round_gap
                 .with_label_values(&[source.as_str()])
                 .observe(clock_round_gap as f64);
-            if transaction_ref.round >= min_round {
+            if transaction_ref.round >= min_round
+                && source != DataSource::FastCommitSyncer
+                && source != DataSource::CommitSyncer
+                && source != DataSource::Recover
+            {
                 self.add_pending_acknowledgment(
                     transaction_ref,
                     transactions.block_ref().map(|br| br.digest),
+                    source,
                 );
             }
         } else {
@@ -2031,13 +2036,14 @@ impl DagState {
         &mut self,
         transaction_ref: TransactionRef,
         block_digest: Option<BlockHeaderDigest>,
+        source: DataSource,
     ) {
         let block_ref = if let Some(digest) = block_digest {
             BlockRef::new(transaction_ref.round, transaction_ref.author, digest)
         } else {
             let Some(br) = self.resolve_block_ref(&transaction_ref) else {
                 error!(
-                    "block_digest not found for {transaction_ref:?} when adding pending acknowledgment"
+                    "block_digest not found for {transaction_ref:?} when adding pending acknowledgment, source: {source:?}"
                 );
                 return;
             };

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -150,6 +150,12 @@ pub(crate) struct DagState {
     /// Vec position corresponds to the authority index.
     recent_headers_refs_by_authority: Vec<BTreeSet<BlockRef>>,
 
+    /// Maps (round, transactions_commitment) -> BlockHeaderDigest per
+    /// authority. Used to look up block digests from TransactionRef
+    /// components. Evicted based on solid commits, same as transactions.
+    tx_ref_to_block_digest_by_authority:
+        Vec<BTreeMap<(Round, TransactionsCommitment), BlockHeaderDigest>>,
+
     /// Keeps track of the threshold clock for proposing blocks.
     threshold_clock: ThresholdClock,
 
@@ -302,6 +308,7 @@ impl DagState {
             recent_transactions_by_authority: vec![BTreeMap::new(); num_authorities],
             recent_shards_by_authority: vec![BTreeMap::new(); num_authorities],
             recent_headers_refs_by_authority: vec![BTreeSet::new(); num_authorities],
+            tx_ref_to_block_digest_by_authority: vec![BTreeMap::new(); num_authorities],
             threshold_clock,
             highest_accepted_round: 0,
             last_commit: last_commit.clone(),
@@ -400,6 +407,7 @@ impl DagState {
         self.recent_transactions_by_authority = vec![BTreeMap::new(); num_authorities];
         self.recent_shards_by_authority = vec![BTreeMap::new(); num_authorities];
         self.recent_headers_refs_by_authority = vec![BTreeSet::new(); num_authorities];
+        self.tx_ref_to_block_digest_by_authority = vec![BTreeMap::new(); num_authorities];
         self.pending_commit_votes.clear();
         self.pending_acknowledgments.clear();
 
@@ -637,6 +645,10 @@ impl DagState {
         self.recent_block_headers
             .insert(block_ref, block_header.clone());
         self.recent_headers_refs_by_authority[block_ref.author].insert(block_ref);
+        self.tx_ref_to_block_digest_by_authority[block_ref.author].insert(
+            (block_ref.round, block_header.transactions_commitment()),
+            block_ref.digest,
+        );
         self.threshold_clock.add_block_header(block_ref);
         self.highest_accepted_round = max(self.highest_accepted_round, block_header.round());
         self.context
@@ -1004,33 +1016,18 @@ impl DagState {
             .collect();
 
         if !missing.is_empty() {
-            let missing_refs: Vec<_> = missing.iter().map(|(_, tx)| *tx).collect();
-
-            // Batch 1: Look up block digests
-            let digests = self
-                .store
-                .lookup_block_digests_by_tx_refs(&missing_refs)
-                .unwrap_or_else(|e| {
-                    warn!("Failed to lookup block digests: {e:?}");
-                    vec![None; missing_refs.len()]
-                });
-
-            // Build BlockRefs for found digests
+            // Look up block digests from in-memory map
             let refs_with_indices: Vec<_> = missing
                 .iter()
-                .zip(digests.iter())
-                .filter_map(
-                    |((idx, tx), digest_opt): (
-                        &(usize, TransactionRef),
-                        &Option<BlockHeaderDigest>,
-                    )| {
-                        digest_opt.map(|d| (*idx, BlockRef::new(tx.round, tx.author, d)))
-                    },
-                )
+                .filter_map(|(idx, tx)| {
+                    self.tx_ref_to_block_digest_by_authority[tx.author]
+                        .get(&(tx.round, tx.transactions_commitment))
+                        .map(|&d| (*idx, BlockRef::new(tx.round, tx.author, d)))
+                })
                 .collect();
 
             if !refs_with_indices.is_empty() {
-                // Batch 2: Check block headers exist
+                // Batch: Check block headers exist in storage
                 let block_refs: Vec<_> = refs_with_indices.iter().map(|(_, br)| *br).collect();
                 let headers_exist = self
                     .store
@@ -1952,6 +1949,17 @@ impl DagState {
         }
     }
 
+    pub(crate) fn evict_tx_ref_to_block_digests(&mut self) {
+        let transaction_gc_round = self.gc_round_for_last_solid_commit();
+        for (authority_index, _) in self.context.committee.authorities() {
+            let eviction_round = self.calculate_authority_eviction_round(authority_index);
+            let eviction_round = min(transaction_gc_round, eviction_round + 1);
+            let split_key = (eviction_round, TransactionsCommitment::MIN);
+            self.tx_ref_to_block_digest_by_authority[authority_index] =
+                self.tx_ref_to_block_digest_by_authority[authority_index].split_off(&split_key);
+        }
+    }
+
     /// Return the garbage collection round with respect to the last solid
     /// commit's leader round. Transactions of blocks at or below this round
     /// can be evicted from memory
@@ -2190,6 +2198,9 @@ impl DagState {
 
         // Clean up old transactions depending on the last solid leader round.
         self.evict_transactions();
+
+        // Evict tx_ref_to_block_digest entries aligned with transaction eviction.
+        self.evict_tx_ref_to_block_digests();
 
         // Clean up old acknowledgments.
         self.evict_pending_acknowledgments();

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -750,6 +750,48 @@ impl DagState {
         }
     }
 
+    /// Finds genesis block matching the generic transaction reference.
+    /// For BlockRef: direct lookup. For TransactionRef: range query with transactions_commitment verification.
+    fn get_genesis_block(&self, tx_ref: GenericTransactionRef) -> Option<&VerifiedBlock> {
+        match tx_ref {
+            GenericTransactionRef::BlockRef(block_ref) => self.genesis.get(&block_ref),
+            GenericTransactionRef::TransactionRef(tx_ref) => {
+                let author = tx_ref.author();
+                let min_ref = BlockRef {
+                    round: GENESIS_ROUND,
+                    author,
+                    digest: BlockHeaderDigest::MIN,
+                };
+                let max_ref = BlockRef {
+                    round: GENESIS_ROUND,
+                    author,
+                    digest: BlockHeaderDigest::MAX,
+                };
+
+                let matching: Vec<_> = self
+                    .genesis
+                    .range(min_ref..=max_ref)
+                    .filter(|(_, block)| {
+                        block.verified_transactions.transactions_commitment()
+                            == tx_ref.transactions_commitment
+                    })
+                    .collect();
+
+                match matching.len() {
+                    1 => Some(matching[0].1),
+                    0 => None,
+                    n => {
+                        error!(
+                            "Found {} genesis blocks matching author {} and transactions_commitment, expected 1",
+                            n, author
+                        );
+                        None
+                    }
+                }
+            }
+        }
+    }
+
     /// Accepts block headers into DagState and keeps it in memory.
     pub(crate) fn accept_block_headers(
         &mut self,
@@ -780,9 +822,7 @@ impl DagState {
 
         for (index, transactions_ref) in transactions_refs.iter().enumerate() {
             if transactions_ref.round() == GENESIS_ROUND {
-                // Extract the BlockRef from GenericTransactionRef
-                let genesis_key = transactions_ref.to_block_ref();
-                if let Some(genesis_block) = self.genesis.get(&genesis_key) {
+                if let Some(genesis_block) = self.get_genesis_block(*transactions_ref) {
                     transactions[index] = Some(genesis_block.verified_transactions.clone());
                 }
                 continue;
@@ -856,11 +896,8 @@ impl DagState {
 
         for (index, transactions_ref) in transactions_refs.iter().enumerate() {
             if transactions_ref.round() == GENESIS_ROUND {
-                // Extract the BlockRef from GenericTransactionRef
-                let genesis_ref = transactions_ref.to_block_ref();
                 if let Some(transaction) = self
-                    .genesis
-                    .get(&genesis_ref)
+                    .get_genesis_block(*transactions_ref)
                     .map(|block| block.verified_transactions.clone())
                 {
                     transactions[index] = Some(transaction.serialized().clone());
@@ -1565,9 +1602,7 @@ impl DagState {
 
         for (index, tx_ref) in transaction_refs.into_iter().enumerate() {
             if tx_ref.round() == GENESIS_ROUND {
-                // Check if the genesis block exists
-                let genesis_ref = tx_ref.to_block_ref();
-                exist[index] = self.genesis.contains_key(&genesis_ref);
+                exist[index] = self.get_genesis_block(tx_ref).is_some();
                 continue;
             }
             if self.recent_transactions_by_authority[tx_ref.author()].contains_key(&tx_ref) {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1028,9 +1028,7 @@ impl DagState {
             // Look up block digests from in-memory map
             let refs_with_indices: Vec<_> = missing
                 .iter()
-                .filter_map(|(idx, tx)| {
-                    self.resolve_block_ref(tx).map(|br| (*idx, br))
-                })
+                .filter_map(|(idx, tx)| self.resolve_block_ref(tx).map(|br| (*idx, br)))
                 .collect();
 
             if !refs_with_indices.is_empty() {
@@ -1381,7 +1379,6 @@ impl DagState {
                                 round: last.round,
                                 author: last.author,
                                 transactions_commitment: last_header.transactions_commitment(),
-                                block_digest: last.digest,
                             })
                         } else {
                             GenericTransactionRef::from(*last)
@@ -1451,7 +1448,6 @@ impl DagState {
                         round: block_ref.round,
                         author: block_ref.author,
                         transactions_commitment: header.transactions_commitment(),
-                        block_digest: block_ref.digest,
                     })
                 } else {
                     GenericTransactionRef::from(*block_ref)
@@ -1942,7 +1938,6 @@ impl DagState {
                     round: eviction_round + 1,
                     author: authority_index,
                     transactions_commitment: TransactionsCommitment::MIN,
-                    block_digest: BlockHeaderDigest::MIN,
                 })
             } else {
                 GenericTransactionRef::from(BlockRef::new(
@@ -1974,7 +1969,6 @@ impl DagState {
                     round: transaction_eviction_round,
                     author: authority_index,
                     transactions_commitment: TransactionsCommitment::MIN,
-                    block_digest: BlockHeaderDigest::MIN,
                 })
             } else {
                 GenericTransactionRef::from(BlockRef::new(
@@ -3711,7 +3705,6 @@ mod test {
                 round: 11,
                 author: AuthorityIndex::new_for_test(0),
                 transactions_commitment: TransactionsCommitment::default(),
-                block_digest: BlockHeaderDigest::default(),
             })
         } else {
             GenericTransactionRef::from(BlockRef::new(

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1029,9 +1029,7 @@ impl DagState {
             let refs_with_indices: Vec<_> = missing
                 .iter()
                 .filter_map(|(idx, tx)| {
-                    self.tx_ref_to_block_digest_by_authority[tx.author]
-                        .get(&(tx.round, tx.transactions_commitment))
-                        .map(|&d| (*idx, BlockRef::new(tx.round, tx.author, d)))
+                    self.resolve_block_ref(tx).map(|br| (*idx, br))
                 })
                 .collect();
 
@@ -1229,6 +1227,14 @@ impl DagState {
         block_headers
     }
 
+    /// Resolves a `TransactionRef` to a `BlockRef` using the in-memory
+    /// `tx_ref_to_block_digest_by_authority` lookup table.
+    pub(crate) fn resolve_block_ref(&self, tx_ref: &TransactionRef) -> Option<BlockRef> {
+        self.tx_ref_to_block_digest_by_authority[tx_ref.author]
+            .get(&(tx_ref.round, tx_ref.transactions_commitment))
+            .map(|&digest| BlockRef::new(tx_ref.round, tx_ref.author, digest))
+    }
+
     /// Gets cached block headers for a list of TransactionRefs by first looking
     /// up the block digest from the in-memory tx_ref_to_block_digest map, then
     /// fetching the cached block header.
@@ -1238,12 +1244,9 @@ impl DagState {
     ) -> Vec<Option<VerifiedBlockHeader>> {
         let mut block_headers: Vec<Option<VerifiedBlockHeader>> = vec![None; tx_refs.len()];
         for (index, tx_ref) in tx_refs.iter().enumerate() {
-            let Some(&digest) = self.tx_ref_to_block_digest_by_authority[tx_ref.author]
-                .get(&(tx_ref.round, tx_ref.transactions_commitment))
-            else {
+            let Some(block_ref) = self.resolve_block_ref(tx_ref) else {
                 continue;
             };
-            let block_ref = BlockRef::new(tx_ref.round, tx_ref.author, digest);
             if tx_ref.round == GENESIS_ROUND {
                 if let Some(block) = self.genesis.get(&block_ref) {
                     block_headers[index] = Some(block.verified_block_header.clone());
@@ -2045,23 +2048,17 @@ impl DagState {
         transaction_ref: TransactionRef,
         block_digest: Option<BlockHeaderDigest>,
     ) {
-        let block_digest = if let Some(digest) = block_digest {
-            digest
+        let block_ref = if let Some(digest) = block_digest {
+            BlockRef::new(transaction_ref.round, transaction_ref.author, digest)
         } else {
-            let Some(&digest) = self.tx_ref_to_block_digest_by_authority[transaction_ref.author]
-                .get(&(
-                    transaction_ref.round,
-                    transaction_ref.transactions_commitment,
-                ))
-            else {
+            let Some(br) = self.resolve_block_ref(&transaction_ref) else {
                 error!(
                     "block_digest not found for {transaction_ref:?} when adding pending acknowledgment"
                 );
                 return;
             };
-            digest
+            br
         };
-        let block_ref = BlockRef::new(transaction_ref.round, transaction_ref.author, block_digest);
         self.pending_acknowledgments.insert(block_ref);
     }
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1207,7 +1207,7 @@ impl DagState {
             if block_ref.round == GENESIS_ROUND {
                 // Allow the caller to handle the invalid genesis ancestor error.
                 if let Some(block) = self.genesis.get(block_ref) {
-                    block_headers[index] = Some((**block).clone());
+                    block_headers[index] = Some(block.verified_block_header.clone());
                 }
                 continue;
             }
@@ -1219,6 +1219,33 @@ impl DagState {
 
         block_headers
     }
+
+    /// Gets cached block headers for a list of TransactionRefs by first looking
+    /// up the block digest from the in-memory tx_ref_to_block_digest map, then
+    /// fetching the cached block header.
+    pub(crate) fn get_cached_block_headers_for_transaction_refs(
+        &self,
+        tx_refs: &[TransactionRef],
+    ) -> Vec<Option<VerifiedBlockHeader>> {
+        let mut block_headers: Vec<Option<VerifiedBlockHeader>> = vec![None; tx_refs.len()];
+        for (index, tx_ref) in tx_refs.iter().enumerate() {
+            let Some(&digest) = self.tx_ref_to_block_digest_by_authority[tx_ref.author]
+                .get(&(tx_ref.round, tx_ref.transactions_commitment))
+            else {
+                continue;
+            };
+            let block_ref = BlockRef::new(tx_ref.round, tx_ref.author, digest);
+            if tx_ref.round == GENESIS_ROUND {
+                if let Some(block) = self.genesis.get(&block_ref) {
+                    block_headers[index] = Some(block.verified_block_header.clone());
+                }
+            } else if let Some(block) = self.recent_block_headers.get(&block_ref) {
+                block_headers[index] = Some(block.clone());
+            }
+        }
+        block_headers
+    }
+
     /// Gets shards by checking cached recent shards in memory.
     pub(crate) fn get_cached_shards(
         &self,

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -751,7 +751,8 @@ impl DagState {
     }
 
     /// Finds genesis block matching the generic transaction reference.
-    /// For BlockRef: direct lookup. For TransactionRef: range query with transactions_commitment verification.
+    /// For BlockRef: direct lookup. For TransactionRef: range query with
+    /// transactions_commitment verification.
     fn get_genesis_block(&self, tx_ref: GenericTransactionRef) -> Option<&VerifiedBlock> {
         match tx_ref {
             GenericTransactionRef::BlockRef(block_ref) => self.genesis.get(&block_ref),

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -4018,6 +4018,7 @@ mod test {
                 let verified_transaction = VerifiedTransactions::new(
                     transactions,
                     TransactionRef::new(block_ref, transaction_commitment),
+                    block_ref.digest,
                     serialized,
                 );
                 dag_state.add_transactions(verified_transaction, DataSource::Test);

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -3990,8 +3990,7 @@ mod test {
                     .unwrap();
                 let verified_transaction = VerifiedTransactions::new(
                     transactions,
-                    block_ref,
-                    transaction_commitment,
+                    TransactionRef::new(block_ref, transaction_commitment),
                     serialized,
                 );
                 dag_state.add_transactions(verified_transaction, DataSource::Test);

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -573,7 +573,7 @@ impl DagState {
             .insert(gen_transaction_ref, shard.serialized_shard)
             .is_none()
         {
-            debug!("Adding shard for block ref: {}", gen_transaction_ref);
+            debug!("Adding shard for transaction ref: {}", gen_transaction_ref);
             if let Some((sender, _)) = &self.cordial_knowledge_senders {
                 let cordial_message = CordialKnowledgeMessage::NewShard(gen_transaction_ref);
                 if let Err(TrySendError::Closed(_)) = sender.try_send(cordial_message) {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -562,10 +562,7 @@ impl DagState {
             .insert(gen_transaction_ref, shard.serialized_shard)
             .is_none()
         {
-            debug!(
-                "Adding shard for block ref: {}",
-                gen_transaction_ref.to_block_ref()
-            );
+            debug!("Adding shard for block ref: {}", gen_transaction_ref);
             if let Some((sender, _)) = &self.cordial_knowledge_senders {
                 let cordial_message = CordialKnowledgeMessage::NewShard(gen_transaction_ref);
                 if let Err(TrySendError::Closed(_)) = sender.try_send(cordial_message) {
@@ -970,6 +967,7 @@ impl DagState {
     /// Checks if verified block headers exist for the given transaction refs.
     /// Checks in-memory data (genesis and recent_block_headers) first, then
     /// falls back to storage for blocks not found in memory.
+    #[cfg_attr(test, expect(dead_code))]
     pub(crate) fn contains_verified_block_headers_for_transaction_refs(
         &self,
         tx_refs: &[TransactionRef],

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -531,10 +531,11 @@ impl DagState {
         source: DataSource,
     ) {
         let transaction_ref = transactions.transaction_ref();
+        let block_ref = transactions.block_ref();
         let generic_ref = if self.context.protocol_config.consensus_transaction_ref() {
             GenericTransactionRef::from(transaction_ref)
         } else {
-            GenericTransactionRef::from(BlockRef::from(transaction_ref))
+            GenericTransactionRef::from(block_ref)
         };
         if self.recent_transactions_by_authority[transaction_ref.author].contains_key(&generic_ref)
         {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -539,10 +539,13 @@ impl DagState {
         source: DataSource,
     ) {
         let transaction_ref = transactions.transaction_ref();
-        let block_ref = transactions.block_ref();
         let generic_ref = if self.context.protocol_config.consensus_transaction_ref() {
             GenericTransactionRef::from(transaction_ref)
         } else {
+            let Some(block_ref) = transactions.block_ref() else {
+                error!("block_ref unavailable for transactions in non-transaction-ref path");
+                return;
+            };
             GenericTransactionRef::from(block_ref)
         };
         if self.recent_transactions_by_authority[transaction_ref.author].contains_key(&generic_ref)
@@ -711,15 +714,18 @@ impl DagState {
         source: DataSource,
     ) {
         let transaction_ref = transactions.transaction_ref();
-        let block_ref = transactions.block_ref();
         let generic_ref = if self.context.protocol_config.consensus_transaction_ref() {
             GenericTransactionRef::from(transaction_ref)
         } else {
+            let Some(block_ref) = transactions.block_ref() else {
+                error!("block_ref unavailable for transactions in non-transaction-ref path");
+                return;
+            };
             GenericTransactionRef::from(block_ref)
         };
-        self.recent_transactions_by_authority[block_ref.author]
+        self.recent_transactions_by_authority[transaction_ref.author]
             .insert(generic_ref, transactions.clone());
-        tracing::debug!("Adding transactions for block ref: {block_ref}");
+        tracing::debug!("Adding transactions for {generic_ref}");
 
         // Handle pending acknowledgments for recent blocks
         let has_transactions = transactions.has_transactions();
@@ -728,10 +734,10 @@ impl DagState {
         let hostname = self
             .context
             .committee
-            .authority(block_ref.author)
+            .authority(transaction_ref.author)
             .hostname
             .as_str();
-        let clock_round_gap = clock_round.saturating_sub(block_ref.round);
+        let clock_round_gap = clock_round.saturating_sub(transaction_ref.round);
 
         if has_transactions {
             // Record metrics
@@ -747,8 +753,11 @@ impl DagState {
                 .accepted_transactions_round_gap
                 .with_label_values(&[source.as_str()])
                 .observe(clock_round_gap as f64);
-            if block_ref.round >= min_round {
-                self.add_pending_acknowledgment(block_ref);
+            if transaction_ref.round >= min_round {
+                self.add_pending_acknowledgment(
+                    transaction_ref,
+                    transactions.block_ref().map(|br| br.digest),
+                );
             }
         } else {
             self.context
@@ -2029,8 +2038,30 @@ impl DagState {
         }
     }
 
-    /// Adds a block reference to pending acknowledgments.
-    pub(crate) fn add_pending_acknowledgment(&mut self, block_ref: BlockRef) {
+    /// Adds a block reference to pending acknowledgments by looking up the
+    /// block digest from the transaction ref.
+    pub(crate) fn add_pending_acknowledgment(
+        &mut self,
+        transaction_ref: TransactionRef,
+        block_digest: Option<BlockHeaderDigest>,
+    ) {
+        let block_digest = if let Some(digest) = block_digest {
+            digest
+        } else {
+            let Some(&digest) = self.tx_ref_to_block_digest_by_authority[transaction_ref.author]
+                .get(&(
+                    transaction_ref.round,
+                    transaction_ref.transactions_commitment,
+                ))
+            else {
+                error!(
+                    "block_digest not found for {transaction_ref:?} when adding pending acknowledgment"
+                );
+                return;
+            };
+            digest
+        };
+        let block_ref = BlockRef::new(transaction_ref.round, transaction_ref.author, block_digest);
         self.pending_acknowledgments.insert(block_ref);
     }
 
@@ -4018,7 +4049,7 @@ mod test {
                 let verified_transaction = VerifiedTransactions::new(
                     transactions,
                     TransactionRef::new(block_ref, transaction_commitment),
-                    block_ref.digest,
+                    Some(block_ref.digest),
                     serialized,
                 );
                 dag_state.add_transactions(verified_transaction, DataSource::Test);

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -750,6 +750,49 @@ impl DagState {
         }
     }
 
+    /// Helper to find an item matching a TransactionRef in a BTreeMap keyed by
+    /// BlockRef. Uses range query on (round, author) with
+    /// transactions_commitment filtering.
+    fn find_by_transaction_ref<'a, T, F>(
+        &self,
+        tx_ref: &TransactionRef,
+        data: &'a BTreeMap<BlockRef, T>,
+        get_commitment: F,
+    ) -> Option<&'a T>
+    where
+        F: Fn(&T) -> TransactionsCommitment,
+    {
+        let author = tx_ref.author();
+        let round = tx_ref.round;
+        let min_ref = BlockRef {
+            round,
+            author,
+            digest: BlockHeaderDigest::MIN,
+        };
+        let max_ref = BlockRef {
+            round,
+            author,
+            digest: BlockHeaderDigest::MAX,
+        };
+
+        let matching: Vec<_> = data
+            .range(min_ref..=max_ref)
+            .filter(|(_, item)| get_commitment(item) == tx_ref.transactions_commitment)
+            .collect();
+
+        match matching.len() {
+            1 => Some(matching[0].1),
+            0 => None,
+            n => {
+                error!(
+                    "Found {} items matching slot ({}, {}) and transactions_commitment, expected 1",
+                    n, round, author
+                );
+                None
+            }
+        }
+    }
+
     /// Finds genesis block matching the generic transaction reference.
     /// For BlockRef: direct lookup. For TransactionRef: range query with
     /// transactions_commitment verification.
@@ -757,38 +800,9 @@ impl DagState {
         match tx_ref {
             GenericTransactionRef::BlockRef(block_ref) => self.genesis.get(&block_ref),
             GenericTransactionRef::TransactionRef(tx_ref) => {
-                let author = tx_ref.author();
-                let min_ref = BlockRef {
-                    round: GENESIS_ROUND,
-                    author,
-                    digest: BlockHeaderDigest::MIN,
-                };
-                let max_ref = BlockRef {
-                    round: GENESIS_ROUND,
-                    author,
-                    digest: BlockHeaderDigest::MAX,
-                };
-
-                let matching: Vec<_> = self
-                    .genesis
-                    .range(min_ref..=max_ref)
-                    .filter(|(_, block)| {
-                        block.verified_transactions.transactions_commitment()
-                            == tx_ref.transactions_commitment
-                    })
-                    .collect();
-
-                match matching.len() {
-                    1 => Some(matching[0].1),
-                    0 => None,
-                    n => {
-                        error!(
-                            "Found {} genesis blocks matching author {} and transactions_commitment, expected 1",
-                            n, author
-                        );
-                        None
-                    }
-                }
+                self.find_by_transaction_ref(&tx_ref, &self.genesis, |block| {
+                    block.transactions_commitment()
+                })
             }
         }
     }
@@ -950,6 +964,93 @@ impl DagState {
         self.get_verified_block_headers(&[*reference])
             .pop()
             .expect("Exactly one element should be returned")
+    }
+
+    /// Checks if verified block headers exist for the given transaction refs.
+    /// Checks in-memory data (genesis and recent_block_headers) first, then
+    /// falls back to storage for blocks not found in memory.
+    pub(crate) fn contains_verified_block_headers_for_transaction_refs(
+        &self,
+        tx_refs: &[TransactionRef],
+    ) -> Vec<bool> {
+        let mut results = vec![false; tx_refs.len()];
+
+        for (index, tx_ref) in tx_refs.iter().enumerate() {
+            let round = tx_ref.round;
+
+            // Check genesis blocks
+            if round == GENESIS_ROUND {
+                results[index] = self
+                    .find_by_transaction_ref(tx_ref, &self.genesis, |block| {
+                        block.transactions_commitment()
+                    })
+                    .is_some();
+                continue;
+            }
+
+            // Check recent block headers
+            results[index] = self
+                .find_by_transaction_ref(tx_ref, &self.recent_block_headers, |header| {
+                    header.transactions_commitment()
+                })
+                .is_some();
+        }
+
+        // Collect refs that weren't found in memory
+        let missing: Vec<(usize, TransactionRef)> = tx_refs
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !results[*i])
+            .map(|(i, tx)| (i, *tx))
+            .collect();
+
+        if !missing.is_empty() {
+            let missing_refs: Vec<_> = missing.iter().map(|(_, tx)| *tx).collect();
+
+            // Batch 1: Look up block digests
+            let digests = self
+                .store
+                .lookup_block_digests_by_tx_refs(&missing_refs)
+                .unwrap_or_else(|e| {
+                    warn!("Failed to lookup block digests: {e:?}");
+                    vec![None; missing_refs.len()]
+                });
+
+            // Build BlockRefs for found digests
+            let refs_with_indices: Vec<_> = missing
+                .iter()
+                .zip(digests.iter())
+                .filter_map(
+                    |((idx, tx), digest_opt): (
+                        &(usize, TransactionRef),
+                        &Option<BlockHeaderDigest>,
+                    )| {
+                        digest_opt.map(|d| (*idx, BlockRef::new(tx.round, tx.author, d)))
+                    },
+                )
+                .collect();
+
+            if !refs_with_indices.is_empty() {
+                // Batch 2: Check block headers exist
+                let block_refs: Vec<_> = refs_with_indices.iter().map(|(_, br)| *br).collect();
+                let headers_exist = self
+                    .store
+                    .contains_block_headers(&block_refs)
+                    .unwrap_or_else(|e| {
+                        warn!("Failed to check block headers: {e:?}");
+                        vec![false; block_refs.len()]
+                    });
+
+                // Update results
+                for ((idx, _), exists) in refs_with_indices.iter().zip(headers_exist.iter()) {
+                    if *exists {
+                        results[*idx] = true;
+                    }
+                }
+            }
+        }
+
+        results
     }
 
     /// Gets verified block headers by checking genesis, cached recent block

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -769,18 +769,9 @@ impl DagState {
         }
     }
 
-    /// Helper to find an item matching a TransactionRef in a BTreeMap keyed by
-    /// BlockRef. Uses range query on (round, author) with
-    /// transactions_commitment filtering.
-    fn find_by_transaction_ref<'a, T, F>(
-        &self,
-        tx_ref: &TransactionRef,
-        data: &'a BTreeMap<BlockRef, T>,
-        get_commitment: F,
-    ) -> Option<&'a T>
-    where
-        F: Fn(&T) -> TransactionsCommitment,
-    {
+    /// Finds a genesis block matching the given TransactionRef. Uses a range
+    /// query on (round, author) with transactions_commitment filtering.
+    fn find_genesis_by_transaction_ref(&self, tx_ref: &TransactionRef) -> Option<&VerifiedBlock> {
         let author = tx_ref.author();
         let round = tx_ref.round;
         let min_ref = BlockRef {
@@ -794,9 +785,10 @@ impl DagState {
             digest: BlockHeaderDigest::MAX,
         };
 
-        let matching: Vec<_> = data
+        let matching: Vec<_> = self
+            .genesis
             .range(min_ref..=max_ref)
-            .filter(|(_, item)| get_commitment(item) == tx_ref.transactions_commitment)
+            .filter(|(_, block)| block.transactions_commitment() == tx_ref.transactions_commitment)
             .collect();
 
         match matching.len() {
@@ -804,7 +796,7 @@ impl DagState {
             0 => None,
             n => {
                 error!(
-                    "Found {} items matching slot ({}, {}) and transactions_commitment, expected 1",
+                    "Found {} genesis items matching slot ({}, {}) and transactions_commitment, expected 1 or 0",
                     n, round, author
                 );
                 None
@@ -819,9 +811,7 @@ impl DagState {
         match tx_ref {
             GenericTransactionRef::BlockRef(block_ref) => self.genesis.get(&block_ref),
             GenericTransactionRef::TransactionRef(tx_ref) => {
-                self.find_by_transaction_ref(&tx_ref, &self.genesis, |block| {
-                    block.transactions_commitment()
-                })
+                self.find_genesis_by_transaction_ref(&tx_ref)
             }
         }
     }
@@ -1000,19 +990,17 @@ impl DagState {
 
             // Check genesis blocks
             if round == GENESIS_ROUND {
-                results[index] = self
-                    .find_by_transaction_ref(tx_ref, &self.genesis, |block| {
-                        block.transactions_commitment()
-                    })
-                    .is_some();
+                results[index] = self.find_genesis_by_transaction_ref(tx_ref).is_some();
                 continue;
             }
 
-            // Check recent block headers
+            // Check recent block headers. We are guaranteed to have the block
+            // digest in tx_ref_to_block_digest_by_authority if the header is
+            // still in recent_block_headers, because both are inserted together
+            // and headers are evicted first.
             results[index] = self
-                .find_by_transaction_ref(tx_ref, &self.recent_block_headers, |header| {
-                    header.transactions_commitment()
-                })
+                .resolve_block_ref(tx_ref)
+                .and_then(|block_ref| self.recent_block_headers.get(&block_ref))
                 .is_some();
         }
 
@@ -1242,14 +1230,16 @@ impl DagState {
     ) -> Vec<Option<VerifiedBlockHeader>> {
         let mut block_headers: Vec<Option<VerifiedBlockHeader>> = vec![None; tx_refs.len()];
         for (index, tx_ref) in tx_refs.iter().enumerate() {
+            if tx_ref.round == GENESIS_ROUND {
+                if let Some(block) = self.find_genesis_by_transaction_ref(tx_ref) {
+                    block_headers[index] = Some(block.verified_block_header.clone());
+                }
+                continue;
+            }
             let Some(block_ref) = self.resolve_block_ref(tx_ref) else {
                 continue;
             };
-            if tx_ref.round == GENESIS_ROUND {
-                if let Some(block) = self.genesis.get(&block_ref) {
-                    block_headers[index] = Some(block.verified_block_header.clone());
-                }
-            } else if let Some(block) = self.recent_block_headers.get(&block_ref) {
+            if let Some(block) = self.recent_block_headers.get(&block_ref) {
                 block_headers[index] = Some(block.clone());
             }
         }

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -110,7 +110,7 @@ pub(crate) enum ConsensusError {
         peer: AuthorityIndex,
     },
     #[error(
-        "After reconstruction, the transaction commitment does not match the commitment in {}",
+        "After reconstruction, the transaction commitment does not match the commitment in transaction ref {}",
         transaction_ref
     )]
     TransactionCommitmentMismatch { transaction_ref: TransactionRef },

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -11,7 +11,7 @@ use typed_store::TypedStoreError;
 use crate::{
     block_header::{BlockRef, GENESIS_ROUND, Round},
     commit::{Commit, CommitIndex},
-    transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _},
+    transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _, TransactionRef},
 };
 
 /// Errors that can occur when processing blocks, reading from storage, or
@@ -110,10 +110,10 @@ pub(crate) enum ConsensusError {
         peer: AuthorityIndex,
     },
     #[error(
-        "After reconstruction, the transaction commitment does not match the commitment in the block {}",
-        block_ref
+        "After reconstruction, the transaction commitment does not match the commitment in {}",
+        transaction_ref
     )]
-    TransactionCommitmentMismatch { block_ref: BlockRef },
+    TransactionCommitmentMismatch { transaction_ref: TransactionRef },
 
     #[error("Synchronizer for fetching blocks directly from {0} is saturated")]
     SynchronizerSaturated(AuthorityIndex),

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -9,7 +9,7 @@ use std::{
 
 use parking_lot::RwLock;
 use starfish_config::{AuthorityIndex, Stake};
-use tracing::instrument;
+use tracing::{error, instrument};
 
 use crate::{
     Round,
@@ -380,7 +380,19 @@ impl Linearizer {
         for missing_ref in missing_refs {
             let block_ref = match missing_ref {
                 GenericTransactionRef::BlockRef(br) => br,
-                GenericTransactionRef::TransactionRef(tx_ref) => BlockRef::from(tx_ref),
+                GenericTransactionRef::TransactionRef(tx_ref) => {
+                    let dag = self.dag_state.read();
+                    match dag.resolve_block_ref(&tx_ref) {
+                        Some(br) => br,
+                        None => {
+                            error!(
+                                "block_digest not found for {tx_ref:?} in transactions_ack_tracker lookup; \
+                                 entry should exist since missing txns are above eviction boundary"
+                            );
+                            continue;
+                        }
+                    }
+                }
             };
             if let Some(acknowledgments) = self.transactions_ack_tracker.get(&block_ref) {
                 acknowledged_map.insert(missing_ref, acknowledgments.votes());

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -162,7 +162,6 @@ impl Linearizer {
                             round: block_ref.round,
                             author: block_ref.author,
                             transactions_commitment,
-                            block_digest: block_ref.digest,
                         })
                     })
                     .collect()

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -670,7 +670,8 @@ mod tests {
     use crate::{
         BlockRef, Round, TestBlockHeader, Transaction, VerifiedBlockHeader,
         block_header::{
-            Shard, TransactionsCommitment, VerifiedBlock, VerifiedOwnShard, VerifiedTransactions,
+            Shard, ShardWithProof, TransactionsCommitment, VerifiedBlock, VerifiedOwnShard,
+            VerifiedTransactions,
         },
         commit::CertifiedCommits,
         context::Context,
@@ -1185,5 +1186,62 @@ mod tests {
         }
 
         handle.stop().await.unwrap();
+    }
+
+    /// In a `BlockBundle` the shards belong to blocks from *previous* rounds,
+    /// not to the bundle's own (`carrier`) block. The correct `block_ref` for
+    /// each `ShardMessage` must therefore come from the shard itself, not from
+    /// the carrier block passed to `create_transaction_messages`.
+    #[test]
+    fn test_create_transaction_messages_shard_uses_shard_block_ref_not_carrier_block_ref() {
+        // GIVEN: a carrier block (round 2, authority 0) — the block in the current bundle.
+        let carrier_block = VerifiedBlock::new_for_test(TestBlockHeader::new(2, 0).build());
+
+        // GIVEN: a shard-source block (round 1, authority 1) — the block the shard
+        // was erasure-coded from. It is from a *different* round and author than the
+        // carrier block, which is the normal situation inside a BlockBundle.
+        let shard_source =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(1, 1).build());
+        let shard_source_ref = shard_source.reference();
+
+        // Sanity: the two blocks must have distinct references for the test to be meaningful.
+        assert_ne!(
+            carrier_block.reference(),
+            shard_source_ref,
+            "Test pre-condition: carrier and shard-source blocks must differ"
+        );
+
+        // GIVEN: a ShardWithProof whose block_ref points to shard_source (V1 variant,
+        // transaction_ref_enabled = false).
+        let shard_with_proof = ShardWithProof::new(
+            vec![0u8; 32],
+            vec![],
+            shard_source_ref,
+            shard_source.transactions_commitment(),
+            false,
+        );
+
+        // WHEN: build transaction messages using the carrier block together with a
+        // shard that belongs to shard_source.
+        let messages = TransactionMessage::create_transaction_messages(
+            &carrier_block,
+            &[shard_with_proof],
+            1,
+        );
+
+        // THEN: the shard message must carry the shard's own block reference
+        // (round=1, authority=1), not the carrier block's reference (round=2, authority=0).
+        let shard_msgs: Vec<_> = messages
+            .iter()
+            .filter(|m| matches!(m, TransactionMessage::Shard(_)))
+            .collect();
+
+        assert_eq!(shard_msgs.len(), 1, "Expected exactly one shard message");
+        assert_eq!(
+            shard_msgs[0].block_ref(),
+            shard_source_ref,
+            "ShardMessage.block_ref must point to the block the shard belongs to \
+             (round=1, authority=1), not to the carrier block (round=2, authority=0)"
+        );
     }
 }

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -75,8 +75,6 @@ impl TransactionMessage {
     ) -> Vec<TransactionMessage> {
         let full = TransactionMessage::FullTransaction(block.transaction_ref());
 
-        // Shard messages — each shard belongs to its own source block, not the
-        // carrier block, so we derive the reference from the shard itself.
         let shard_msgs = shards.iter().map(|swp| {
             TransactionMessage::Shard(ShardMessage {
                 transaction_ref: TransactionRef {

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -98,7 +98,7 @@ impl TransactionMessage {
         // Shard messages
         for shard_with_proof in shards {
             let shard_msg = ShardMessage {
-                block_ref: shard_with_proof.block_ref(),
+                block_ref: block.reference(),
                 transactions_commitment: shard_with_proof.transaction_commitment(),
                 shard: shard_with_proof.shard().clone(),
                 shard_index,
@@ -556,7 +556,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             let highest_accepted_round = self.dag_state.read().highest_accepted_round();
             for transaction in &transactions {
                 let difference =
-                    highest_accepted_round.saturating_sub(transaction.block_ref().round);
+                    highest_accepted_round.saturating_sub(transaction.round());
                 self.context
                     .metrics
                     .node_metrics
@@ -1161,7 +1161,7 @@ mod tests {
         // Check all reconstructed transactions correspond to the missing authority
         for vt in &fetched {
             assert_eq!(
-                vt.block_ref().author.value(),
+                vt.author().value(),
                 blocked_authority as usize,
                 "Reconstructed block must belong to the blocked authority"
             );

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -22,8 +22,8 @@ use tracing::{debug, warn};
 use crate::{
     BlockRef, Round, Transaction,
     block_header::{
-        BlockHeaderDigest, GENESIS_ROUND, Shard, ShardWithProof, ShardWithProofAPI,
-        TransactionsCommitment, VerifiedBlock, VerifiedTransactions,
+        GENESIS_ROUND, Shard, ShardWithProof, ShardWithProofAPI, TransactionsCommitment,
+        VerifiedBlock, VerifiedTransactions,
     },
     context::Context,
     core_thread::CoreThreadDispatcher,
@@ -71,7 +71,6 @@ impl FullTransactionMessage {
             round: self.block_ref.round,
             author: self.block_ref.author,
             transactions_commitment: self.transactions_commitment,
-            block_digest: self.block_ref.digest,
         }
     }
 }
@@ -97,7 +96,6 @@ impl TransactionMessage {
             round: block_ref.round,
             author: block_ref.author,
             transactions_commitment: self.transactions_commitment(),
-            block_digest: block_ref.digest,
         }
     }
 
@@ -511,7 +509,6 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             round: transaction_gc_round,
             author: AuthorityIndex::ZERO,
             transactions_commitment: TransactionsCommitment::MIN,
-            block_digest: BlockHeaderDigest::MIN,
         };
 
         self.processed_transactions = self.processed_transactions.split_off(&lower_bound);

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -31,6 +31,7 @@ use crate::{
     decoder::{ShardsDecoder, create_decoder},
     encoder::{ShardEncoder, create_encoder},
     error::{ConsensusError, ConsensusResult},
+    transaction_ref::TransactionRef,
 };
 
 const EVICTION_TIMEOUT: Duration = Duration::from_secs(1);
@@ -64,6 +65,17 @@ pub(crate) struct FullTransactionMessage {
     transactions_commitment: TransactionsCommitment,
 }
 
+impl FullTransactionMessage {
+    pub fn transaction_ref(&self) -> TransactionRef {
+        TransactionRef {
+            round: self.block_ref.round,
+            author: self.block_ref.author,
+            transactions_commitment: self.transactions_commitment,
+            block_digest: self.block_ref.digest,
+        }
+    }
+}
+
 impl TransactionMessage {
     pub fn block_ref(&self) -> BlockRef {
         match self {
@@ -76,6 +88,16 @@ impl TransactionMessage {
         match self {
             TransactionMessage::FullTransaction(msg) => msg.transactions_commitment,
             TransactionMessage::Shard(msg) => msg.transactions_commitment,
+        }
+    }
+
+    pub fn transaction_ref(&self) -> TransactionRef {
+        let block_ref = self.block_ref();
+        TransactionRef {
+            round: block_ref.round,
+            author: block_ref.author,
+            transactions_commitment: self.transactions_commitment(),
+            block_digest: block_ref.digest,
         }
     }
 
@@ -285,15 +307,14 @@ pub struct ShardReconstructor<C: CoreThreadDispatcher> {
     context: Arc<Context>,
     /// Already processed transaction either by authority service or by shard
     /// reconstructor
-    processed_transactions: BTreeSet<BlockRef>,
+    processed_transactions: BTreeSet<TransactionRef>,
     /// A cache of reconstructed transactions that will be periodically sent in
     /// the core
-    reconstructed_transactions: BTreeMap<BlockRef, VerifiedTransactions>,
-    /// A map of all shard accumulators. Periodically evicted. Keyed by a pair
-    /// (BlockRef, TransactionsCommitment) since transaction commitment is not
-    /// supposed to be verified against the block ref when receiving by
-    /// ShardReconstructor
-    shard_accumulators: BTreeMap<(BlockRef, TransactionsCommitment), ShardAccumulator>,
+    reconstructed_transactions: BTreeMap<TransactionRef, VerifiedTransactions>,
+    /// A map of all shard accumulators. Periodically evicted. Keyed by
+    /// TransactionRef which uniquely identifies transactions via
+    /// transactions_commitment
+    shard_accumulators: BTreeMap<TransactionRef, ShardAccumulator>,
     /// Use only read access to the dag state to read the transaction GC round
     /// and check whether the respected headers are available
     dag_state: Arc<RwLock<DagState>>,
@@ -302,7 +323,7 @@ pub struct ShardReconstructor<C: CoreThreadDispatcher> {
     /// After full reconstruction and verification, send data to the core
     core_dispatcher: Arc<C>,
     /// Queue is used to not reconstruct the same data twice
-    reconstruction_queue: BTreeSet<BlockRef>,
+    reconstruction_queue: BTreeSet<TransactionRef>,
     /// Once enough shards are collected, they are sent to reconstructor workers
     ready_to_reconstruct_sender: Sender<ShardAccumulator>,
     /// Channel to receive accumulated shard for reconstruction by workers
@@ -428,9 +449,10 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                     }
                     // A transaction is reconstructed in one of the reconstruction workers
                     Some(verified_transactions) = self.reconstructed_transactions_receiver.recv() => {
-                        self.processed_transactions.insert(verified_transactions.block_ref());
-                        self.reconstruction_queue.remove(&verified_transactions.block_ref());
-                        self.reconstructed_transactions.insert(verified_transactions.block_ref(), verified_transactions);
+                        let tx_ref = verified_transactions.transaction_ref();
+                        self.processed_transactions.insert(tx_ref);
+                        self.reconstruction_queue.remove(&tx_ref);
+                        self.reconstructed_transactions.insert(tx_ref, verified_transactions);
                     }
 
                  () = &mut send_to_core_timeout => {
@@ -485,16 +507,16 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         // Update the internal transaction_gc_round
         self.transaction_gc_round = transaction_gc_round;
 
-        let lower_bound = BlockRef::new(
-            transaction_gc_round,
-            AuthorityIndex::ZERO,
-            BlockHeaderDigest::MIN,
-        );
+        let lower_bound = TransactionRef {
+            round: transaction_gc_round,
+            author: AuthorityIndex::ZERO,
+            transactions_commitment: TransactionsCommitment::MIN,
+            block_digest: BlockHeaderDigest::MIN,
+        };
 
         self.processed_transactions = self.processed_transactions.split_off(&lower_bound);
         self.reconstructed_transactions = self.reconstructed_transactions.split_off(&lower_bound);
-        let lower_bound_key = (lower_bound, TransactionsCommitment::MIN);
-        self.shard_accumulators = self.shard_accumulators.split_off(&lower_bound_key);
+        self.shard_accumulators = self.shard_accumulators.split_off(&lower_bound);
     }
 
     async fn get_transactions_with_headers_in_dag_state(&mut self) -> Vec<VerifiedTransactions> {
@@ -509,12 +531,15 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             {
                 let mut to_stay_transactions = BTreeMap::new();
                 let block_headers_opt = {
-                    let block_refs: Vec<BlockRef> = transactions_map.keys().copied().collect();
+                    let block_refs: Vec<BlockRef> = transactions_map
+                        .keys()
+                        .map(|tx_ref| BlockRef::from(*tx_ref))
+                        .collect();
                     self.dag_state
                         .read()
                         .get_verified_block_headers(&block_refs)
                 };
-                for (block_header_opt, (block_ref, transactions)) in block_headers_opt
+                for (block_header_opt, (tx_ref, transactions)) in block_headers_opt
                     .into_iter()
                     .zip(transactions_map.into_iter())
                 {
@@ -527,7 +552,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                         );
                         ready_to_be_sent_transactions.push(transactions);
                     } else {
-                        to_stay_transactions.insert(block_ref, transactions);
+                        to_stay_transactions.insert(tx_ref, transactions);
                     }
                 }
                 to_stay_transactions
@@ -555,8 +580,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         if !transactions.is_empty() {
             let highest_accepted_round = self.dag_state.read().highest_accepted_round();
             for transaction in &transactions {
-                let difference =
-                    highest_accepted_round.saturating_sub(transaction.round());
+                let difference = highest_accepted_round.saturating_sub(transaction.round());
                 self.context
                     .metrics
                     .node_metrics
@@ -575,18 +599,19 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
 
     /// Handle a message and update internal state
     async fn handle_transaction_message(&mut self, msg: TransactionMessage) -> ConsensusResult<()> {
-        if self.processed_transactions.contains(&msg.block_ref())
-            || self.reconstruction_queue.contains(&msg.block_ref())
-            || msg.block_ref().round < self.transaction_gc_round
+        let tx_ref = msg.transaction_ref();
+
+        if self.processed_transactions.contains(&tx_ref)
+            || self.reconstruction_queue.contains(&tx_ref)
+            || tx_ref.round < self.transaction_gc_round
         {
             return Ok(());
         }
 
-        let key = (msg.block_ref(), msg.transactions_commitment());
         let total_length = self.total_length;
 
         match msg {
-            TransactionMessage::Shard(shard_msg) => match self.shard_accumulators.entry(key) {
+            TransactionMessage::Shard(shard_msg) => match self.shard_accumulators.entry(tx_ref) {
                 Entry::Vacant(v) => {
                     v.insert(ShardAccumulator::new_with_shard(shard_msg, total_length));
                 }
@@ -596,7 +621,8 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             },
 
             TransactionMessage::FullTransaction(full_msg) => {
-                self.processed_transactions.insert(full_msg.block_ref);
+                self.processed_transactions
+                    .insert(full_msg.transaction_ref());
                 return Ok(());
             }
         }
@@ -607,7 +633,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             &mut self.reconstruction_queue,
             &self.ready_to_reconstruct_sender,
             self.info_length,
-            &key,
+            &tx_ref,
         )
         .await?;
 
@@ -617,23 +643,23 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
     /// If the accumulator for the given key is ready to reconstruct, remove it
     /// from the map and enqueue it for reconstruction
     async fn enqueue_if_ready(
-        accumulators: &mut BTreeMap<(BlockRef, TransactionsCommitment), ShardAccumulator>,
-        reconstruction_queue: &mut BTreeSet<BlockRef>,
+        accumulators: &mut BTreeMap<TransactionRef, ShardAccumulator>,
+        reconstruction_queue: &mut BTreeSet<TransactionRef>,
         sender: &Sender<ShardAccumulator>,
         info_length: usize,
-        key: &(BlockRef, TransactionsCommitment),
+        tx_ref: &TransactionRef,
     ) -> ConsensusResult<()> {
-        if let Some(acc) = accumulators.get(key) {
+        if let Some(acc) = accumulators.get(tx_ref) {
             if acc.is_ready_to_reconstruct(info_length) {
                 // take ownership out of map
                 let acc = accumulators
-                    .remove(key)
+                    .remove(tx_ref)
                     .expect("We should expect the shard accumulator to be present");
                 sender
                     .send(acc)
                     .await
                     .map_err(|_| ConsensusError::AccumulatorSenderClosed)?;
-                reconstruction_queue.insert(key.0);
+                reconstruction_queue.insert(*tx_ref);
             }
         }
         Ok(())

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -211,7 +211,7 @@ impl ShardAccumulator {
         Ok(VerifiedTransactions::new(
             transactions,
             TransactionRef::new(self.block_ref, self.transactions_commitment),
-            self.block_ref.digest,
+            Some(self.block_ref.digest),
             serialized,
         ))
     }
@@ -932,7 +932,10 @@ mod tests {
             "Reconstruction should happen after reaching info_length shards"
         );
         let vt = &fetched[0];
-        assert_eq!(vt.block_ref(), block_ref);
+        assert_eq!(
+            vt.block_ref().expect("block_ref should be set in test"),
+            block_ref
+        );
         assert_eq!(vt.transactions(), txs);
 
         handle

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -210,8 +210,7 @@ impl ShardAccumulator {
 
         Ok(VerifiedTransactions::new(
             transactions,
-            self.block_ref,
-            self.transactions_commitment,
+            TransactionRef::new(self.block_ref, self.transactions_commitment),
             serialized,
         ))
     }

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -20,10 +20,10 @@ use tokio::{
 use tracing::{debug, warn};
 
 use crate::{
-    BlockRef, Round, Transaction,
+    Round, Transaction,
     block_header::{
-        GENESIS_ROUND, Shard, ShardWithProof, ShardWithProofAPI, TransactionsCommitment,
-        VerifiedBlock, VerifiedTransactions,
+        BlockHeaderDigest, GENESIS_ROUND, Shard, ShardWithProof, ShardWithProofAPI,
+        TransactionsCommitment, VerifiedBlock, VerifiedTransactions,
     },
     context::Context,
     core_thread::CoreThreadDispatcher,
@@ -47,55 +47,35 @@ pub(crate) enum TransactionMessage {
     Shard(ShardMessage),
 }
 
-/// Shard message contains shard with index and the reference to a block
-/// corresponding to the shard and the commitment in the respected block header
+/// Shard message contains shard with index and the reference to the
+/// transactions the shard was erasure-coded from, plus an optional block digest
+/// (present for V1 shards, absent for V2 shards that use TransactionRef).
 #[derive(Clone, Debug)]
 pub(crate) struct ShardMessage {
-    block_ref: BlockRef,
-    transactions_commitment: TransactionsCommitment,
+    transaction_ref: TransactionRef,
+    block_digest: Option<BlockHeaderDigest>,
     shard: Shard,
     shard_index: usize,
 }
 
-/// Full transaction message acknowledge that the respected transactions from a
+/// Full transaction message acknowledges that the respected transactions from a
 /// given block were verified and locally available
 #[derive(Clone, Debug)]
 pub(crate) struct FullTransactionMessage {
-    block_ref: BlockRef,
-    transactions_commitment: TransactionsCommitment,
+    transaction_ref: TransactionRef,
 }
 
 impl FullTransactionMessage {
     pub fn transaction_ref(&self) -> TransactionRef {
-        TransactionRef {
-            round: self.block_ref.round,
-            author: self.block_ref.author,
-            transactions_commitment: self.transactions_commitment,
-        }
+        self.transaction_ref
     }
 }
 
 impl TransactionMessage {
-    pub fn block_ref(&self) -> BlockRef {
-        match self {
-            TransactionMessage::FullTransaction(msg) => msg.block_ref,
-            TransactionMessage::Shard(msg) => msg.block_ref,
-        }
-    }
-
-    pub fn transactions_commitment(&self) -> TransactionsCommitment {
-        match self {
-            TransactionMessage::FullTransaction(msg) => msg.transactions_commitment,
-            TransactionMessage::Shard(msg) => msg.transactions_commitment,
-        }
-    }
-
     pub fn transaction_ref(&self) -> TransactionRef {
-        let block_ref = self.block_ref();
-        TransactionRef {
-            round: block_ref.round,
-            author: block_ref.author,
-            transactions_commitment: self.transactions_commitment(),
+        match self {
+            TransactionMessage::FullTransaction(msg) => msg.transaction_ref,
+            TransactionMessage::Shard(msg) => msg.transaction_ref,
         }
     }
 
@@ -108,18 +88,22 @@ impl TransactionMessage {
     ) -> Vec<TransactionMessage> {
         let mut messages = Vec::new();
 
-        // Full transaction message
+        // Full transaction message — refers to the carrier block's own transactions
         let full_msg = FullTransactionMessage {
-            block_ref: block.reference(),
-            transactions_commitment: block.transactions_commitment(),
+            transaction_ref: block.transaction_ref(),
         };
         messages.push(TransactionMessage::FullTransaction(full_msg));
 
-        // Shard messages
+        // Shard messages — each shard belongs to its own source block, not the
+        // carrier block, so we derive the reference from the shard itself.
         for shard_with_proof in shards {
             let shard_msg = ShardMessage {
-                block_ref: block.reference(),
-                transactions_commitment: shard_with_proof.transaction_commitment(),
+                transaction_ref: TransactionRef {
+                    round: shard_with_proof.round(),
+                    author: shard_with_proof.author(),
+                    transactions_commitment: shard_with_proof.transaction_commitment(),
+                },
+                block_digest: shard_with_proof.block_digest(),
                 shard: shard_with_proof.shard().clone(),
                 shard_index,
             };
@@ -130,15 +114,15 @@ impl TransactionMessage {
     }
 }
 
-/// A basic structure that represents the collection of shards for a given block
-/// reference and transaction commitment. We track the number of shards and the
-/// shard themselves
+/// A basic structure that represents the collection of shards for a given
+/// transaction reference. We track the number of shards and the shards
+/// themselves.
 #[derive(Clone)]
 pub struct ShardAccumulator {
-    /// Reference to the block these shards correspond to
-    block_ref: BlockRef,
-    /// Commitment to the transactions in the block
-    transactions_commitment: TransactionsCommitment,
+    /// Reference to the transactions these shards were erasure-coded from
+    transaction_ref: TransactionRef,
+    /// Block digest of the source block (present for V1, absent for V2)
+    block_digest: Option<BlockHeaderDigest>,
     /// Collected shards, indexed by their shard index
     collected_shards: Vec<Option<Shard>>,
     /// Number of collected data shards
@@ -149,16 +133,16 @@ impl ShardAccumulator {
     /// Create a new accumulator initialized with the first shard
     fn new_with_shard(msg: ShardMessage, total_length: usize) -> Self {
         let ShardMessage {
-            block_ref,
-            transactions_commitment,
+            transaction_ref,
+            block_digest,
             shard,
             shard_index,
         } = msg;
         let mut collected_shards = vec![None; total_length];
         collected_shards[shard_index] = Some(shard);
         Self {
-            block_ref,
-            transactions_commitment,
+            transaction_ref,
+            block_digest,
             collected_shards,
             number_shards: 1,
         }
@@ -200,16 +184,16 @@ impl ShardAccumulator {
             &codec.context.clone(),
             &mut codec.encoder,
         )?;
-        if computed_commitment != self.transactions_commitment {
+        if computed_commitment != self.transaction_ref.transactions_commitment {
             return Err(ConsensusError::TransactionCommitmentMismatch {
-                block_ref: self.block_ref,
+                transaction_ref: self.transaction_ref,
             });
         }
 
         Ok(VerifiedTransactions::new(
             transactions,
-            TransactionRef::new(self.block_ref, self.transactions_commitment),
-            Some(self.block_ref.digest),
+            self.transaction_ref,
+            self.block_digest,
             serialized,
         ))
     }
@@ -387,8 +371,8 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                             match shard_accumulator.decode_by_codec(&mut codec) {
                                 Ok(verified_transactions) => {
                                     debug!(
-                                        "Successfully reconstructed transactions for block {:?}",
-                                        shard_accumulator.block_ref
+                                        "Successfully reconstructed transactions for {:?}",
+                                        shard_accumulator.transaction_ref
                                     );
                                     if let Err(err) = result_tx.send(verified_transactions).await {
                                         warn!(
@@ -398,8 +382,8 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                                 }
                                 Err(err) => {
                                     warn!(
-                                        "Failed to reconstruct transactions for block {:?}: {:?}",
-                                        shard_accumulator.block_ref, err
+                                        "Failed to reconstruct transactions for {:?}: {:?}",
+                                        shard_accumulator.transaction_ref, err
                                     );
                                 }
                             }
@@ -683,7 +667,7 @@ mod tests {
             FullTransactionMessage, ShardMessage, ShardReconstructor, TransactionMessage,
         },
         storage::mem_store::MemStore,
-        transaction_ref::GenericTransactionRef,
+        transaction_ref::{GenericTransactionRef, TransactionRef},
     };
 
     #[derive(Default)]
@@ -817,8 +801,7 @@ mod tests {
         // 1. FullTransaction for round i (authority j)
         msgs.push(TransactionMessage::FullTransaction(
             FullTransactionMessage {
-                block_ref: header_cur.reference(),
-                transactions_commitment: header_cur.transactions_commitment(),
+                transaction_ref: header_cur.transaction_ref(),
             },
         ));
 
@@ -827,8 +810,8 @@ mod tests {
         for (auth_index, shards) in shards_prev.iter().enumerate() {
             if let Some(shard) = shards.get(j_index) {
                 msgs.push(TransactionMessage::Shard(ShardMessage {
-                    block_ref: headers_prev[auth_index].reference(),
-                    transactions_commitment: headers_prev[auth_index].transactions_commitment(),
+                    transaction_ref: headers_prev[auth_index].transaction_ref(),
+                    block_digest: Some(headers_prev[auth_index].digest()),
                     shard: shard.clone(),
                     shard_index: j_index,
                 }));
@@ -891,8 +874,8 @@ mod tests {
         let mut batch = Vec::new();
         for &i in first_subset {
             batch.push(TransactionMessage::Shard(ShardMessage {
-                block_ref,
-                transactions_commitment: commitment,
+                transaction_ref: TransactionRef::new(block_ref, commitment),
+                block_digest: Some(block_ref.digest),
                 shard: all_shards[i].clone(),
                 shard_index: i,
             }));
@@ -912,8 +895,8 @@ mod tests {
         let extra_shard_index = indices[info_length - 1];
         transaction_message_sender
             .send(vec![TransactionMessage::Shard(ShardMessage {
-                block_ref,
-                transactions_commitment: commitment,
+                transaction_ref: TransactionRef::new(block_ref, commitment),
+                block_digest: Some(block_ref.digest),
                 shard: all_shards[extra_shard_index].clone(),
                 shard_index: extra_shard_index,
             })])
@@ -998,8 +981,8 @@ mod tests {
         // Add all shards except the missing one
         for &i in almost_all {
             batch.push(TransactionMessage::Shard(ShardMessage {
-                block_ref,
-                transactions_commitment,
+                transaction_ref: TransactionRef::new(block_ref, transactions_commitment),
+                block_digest: Some(block_ref.digest),
                 shard: all_shards[i].clone(),
                 shard_index: i,
             }));
@@ -1020,8 +1003,7 @@ mod tests {
         transaction_message_sender
             .send(vec![TransactionMessage::FullTransaction(
                 FullTransactionMessage {
-                    block_ref,
-                    transactions_commitment,
+                    transaction_ref: TransactionRef::new(block_ref, transactions_commitment),
                 },
             )])
             .await
@@ -1031,8 +1013,8 @@ mod tests {
         let extra_shard_index = indices[missing_index];
         transaction_message_sender
             .send(vec![TransactionMessage::Shard(ShardMessage {
-                block_ref,
-                transactions_commitment,
+                transaction_ref: TransactionRef::new(block_ref, transactions_commitment),
+                block_digest: Some(block_ref.digest),
                 shard: all_shards[extra_shard_index].clone(),
                 shard_index: extra_shard_index,
             })])
@@ -1194,17 +1176,18 @@ mod tests {
     /// the carrier block passed to `create_transaction_messages`.
     #[test]
     fn test_create_transaction_messages_shard_uses_shard_block_ref_not_carrier_block_ref() {
-        // GIVEN: a carrier block (round 2, authority 0) — the block in the current bundle.
+        // GIVEN: a carrier block (round 2, authority 0) — the block in the current
+        // bundle.
         let carrier_block = VerifiedBlock::new_for_test(TestBlockHeader::new(2, 0).build());
 
         // GIVEN: a shard-source block (round 1, authority 1) — the block the shard
         // was erasure-coded from. It is from a *different* round and author than the
         // carrier block, which is the normal situation inside a BlockBundle.
-        let shard_source =
-            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(1, 1).build());
+        let shard_source = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(1, 1).build());
         let shard_source_ref = shard_source.reference();
 
-        // Sanity: the two blocks must have distinct references for the test to be meaningful.
+        // Sanity: the two blocks must have distinct references for the test to be
+        // meaningful.
         assert_ne!(
             carrier_block.reference(),
             shard_source_ref,
@@ -1223,25 +1206,28 @@ mod tests {
 
         // WHEN: build transaction messages using the carrier block together with a
         // shard that belongs to shard_source.
-        let messages = TransactionMessage::create_transaction_messages(
-            &carrier_block,
-            &[shard_with_proof],
-            1,
-        );
+        let messages =
+            TransactionMessage::create_transaction_messages(&carrier_block, &[shard_with_proof], 1);
 
-        // THEN: the shard message must carry the shard's own block reference
-        // (round=1, authority=1), not the carrier block's reference (round=2, authority=0).
+        // THEN: the shard message must carry the shard's own transaction reference
+        // (round=1, authority=1), not the carrier block's reference (round=2,
+        // authority=0).
         let shard_msgs: Vec<_> = messages
             .iter()
             .filter(|m| matches!(m, TransactionMessage::Shard(_)))
             .collect();
 
         assert_eq!(shard_msgs.len(), 1, "Expected exactly one shard message");
+
+        let shard_tx_ref = shard_msgs[0].transaction_ref();
         assert_eq!(
-            shard_msgs[0].block_ref(),
-            shard_source_ref,
-            "ShardMessage.block_ref must point to the block the shard belongs to \
-             (round=1, authority=1), not to the carrier block (round=2, authority=0)"
+            shard_tx_ref.round, shard_source_ref.round,
+            "ShardMessage.transaction_ref.round must match the shard-source block's round"
+        );
+        assert_eq!(
+            shard_tx_ref.author, shard_source_ref.author,
+            "ShardMessage.transaction_ref.author must point to the shard-source block's author \
+             (authority=1), not the carrier block's author (authority=0)"
         );
     }
 }

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -43,7 +43,7 @@ const NUMBER_OF_RECONSTRUCTION_WORKERS: usize = 5;
 /// Two types of messages are supported: full transaction and shard
 #[derive(Clone, Debug)]
 pub(crate) enum TransactionMessage {
-    FullTransaction(FullTransactionMessage),
+    FullTransaction(TransactionRef),
     Shard(ShardMessage),
 }
 
@@ -58,23 +58,10 @@ pub(crate) struct ShardMessage {
     shard_index: usize,
 }
 
-/// Full transaction message acknowledges that the respected transactions from a
-/// given block were verified and locally available
-#[derive(Clone, Debug)]
-pub(crate) struct FullTransactionMessage {
-    transaction_ref: TransactionRef,
-}
-
-impl FullTransactionMessage {
-    pub fn transaction_ref(&self) -> TransactionRef {
-        self.transaction_ref
-    }
-}
-
 impl TransactionMessage {
     pub fn transaction_ref(&self) -> TransactionRef {
         match self {
-            TransactionMessage::FullTransaction(msg) => msg.transaction_ref,
+            TransactionMessage::FullTransaction(tx_ref) => *tx_ref,
             TransactionMessage::Shard(msg) => msg.transaction_ref,
         }
     }
@@ -86,31 +73,24 @@ impl TransactionMessage {
         shards: &[ShardWithProof],
         shard_index: usize,
     ) -> Vec<TransactionMessage> {
-        let mut messages = Vec::new();
-
-        // Full transaction message — refers to the carrier block's own transactions
-        let full_msg = FullTransactionMessage {
-            transaction_ref: block.transaction_ref(),
-        };
-        messages.push(TransactionMessage::FullTransaction(full_msg));
+        let full = TransactionMessage::FullTransaction(block.transaction_ref());
 
         // Shard messages — each shard belongs to its own source block, not the
         // carrier block, so we derive the reference from the shard itself.
-        for shard_with_proof in shards {
-            let shard_msg = ShardMessage {
+        let shard_msgs = shards.iter().map(|swp| {
+            TransactionMessage::Shard(ShardMessage {
                 transaction_ref: TransactionRef {
-                    round: shard_with_proof.round(),
-                    author: shard_with_proof.author(),
-                    transactions_commitment: shard_with_proof.transaction_commitment(),
+                    round: swp.round(),
+                    author: swp.author(),
+                    transactions_commitment: swp.transaction_commitment(),
                 },
-                block_digest: shard_with_proof.block_digest(),
-                shard: shard_with_proof.shard().clone(),
+                block_digest: swp.block_digest(),
+                shard: swp.shard().clone(),
                 shard_index,
-            };
-            messages.push(TransactionMessage::Shard(shard_msg));
-        }
+            })
+        });
 
-        messages
+        std::iter::once(full).chain(shard_msgs).collect()
     }
 }
 
@@ -592,9 +572,8 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                 }
             },
 
-            TransactionMessage::FullTransaction(full_msg) => {
-                self.processed_transactions
-                    .insert(full_msg.transaction_ref());
+            TransactionMessage::FullTransaction(tx_ref) => {
+                self.processed_transactions.insert(tx_ref);
                 return Ok(());
             }
         }
@@ -649,7 +628,7 @@ mod tests {
     use parking_lot::RwLock;
     use rand::{seq::SliceRandom, thread_rng};
     use starfish_config::AuthorityIndex;
-    use tokio::sync::Mutex;
+    use tokio::sync::{Mutex, mpsc::Sender};
 
     use crate::{
         BlockRef, Round, TestBlockHeader, Transaction, VerifiedBlockHeader,
@@ -664,11 +643,40 @@ mod tests {
         dag_state::{DagState, DataSource},
         encoder::create_encoder,
         shard_reconstructor::{
-            FullTransactionMessage, ShardMessage, ShardReconstructor, TransactionMessage,
+            ShardMessage, ShardReconstructor, ShardReconstructorHandle, TransactionMessage,
         },
         storage::mem_store::MemStore,
         transaction_ref::{GenericTransactionRef, TransactionRef},
     };
+
+    struct TestHarness {
+        context: Arc<Context>,
+        core_dispatcher: Arc<MockCoreThreadDispatcher>,
+        handle: Arc<ShardReconstructorHandle>,
+        tx: Sender<Vec<TransactionMessage>>,
+    }
+
+    impl TestHarness {
+        fn new(committee_size: usize) -> Self {
+            let (context, _) = Context::new_for_test(committee_size);
+            let context = Arc::new(context);
+            let store = Arc::new(MemStore::new(context.clone()));
+            let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+            let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
+            let handle = ShardReconstructor::start(
+                context.clone(),
+                dag_state.clone(),
+                core_dispatcher.clone(),
+            );
+            let tx = handle.transaction_message_sender();
+            Self {
+                context,
+                core_dispatcher,
+                handle,
+                tx,
+            }
+        }
+    }
 
     #[derive(Default)]
     struct MockCoreThreadDispatcher {
@@ -800,9 +808,7 @@ mod tests {
 
         // 1. FullTransaction for round i (authority j)
         msgs.push(TransactionMessage::FullTransaction(
-            FullTransactionMessage {
-                transaction_ref: header_cur.transaction_ref(),
-            },
+            header_cur.transaction_ref(),
         ));
 
         // 2. The j-th shard of every authority’s transaction data from round i-1
@@ -828,18 +834,9 @@ mod tests {
         telemetry_subscribers::init_for_testing();
 
         // GIVEN
-        let committee_size = 10;
-        let (context, _) = Context::new_for_test(committee_size);
-        let context = Arc::new(context);
-
-        let store = Arc::new(MemStore::new(context.clone()));
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-
-        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
-
-        let handle =
-            ShardReconstructor::start(context.clone(), dag_state.clone(), core_dispatcher.clone());
-        let transaction_message_sender = handle.transaction_message_sender();
+        let h = TestHarness::new(10);
+        let context = &h.context;
+        let transaction_message_sender = h.tx.clone();
 
         // Create block header & transactions
         let header = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 1).build());
@@ -848,10 +845,10 @@ mod tests {
         let txs = Transaction::random_transactions(4, 48);
         let serialized = Transaction::serialize(&txs).unwrap();
 
-        let mut encoder = create_encoder(&context);
+        let mut encoder = create_encoder(context);
         let commitment = TransactionsCommitment::compute_transactions_commitment(
             &serialized,
-            &context,
+            context,
             &mut encoder,
         )
         .unwrap();
@@ -885,7 +882,7 @@ mod tests {
 
         // Wait — should not reconstruct yet
         tokio::time::sleep(Duration::from_millis(400)).await;
-        let fetched = core_dispatcher.get_and_drain_transactions().await;
+        let fetched = h.core_dispatcher.get_and_drain_transactions().await;
         assert!(
             fetched.is_empty(),
             "With header + (info_length - 1) shards, no reconstruction should happen"
@@ -905,7 +902,7 @@ mod tests {
 
         // THEN: reconstruction should happen
         tokio::time::sleep(Duration::from_millis(600)).await;
-        let fetched = core_dispatcher.get_and_drain_transactions().await;
+        let fetched = h.core_dispatcher.get_and_drain_transactions().await;
 
         assert_eq!(
             fetched.len(),
@@ -919,7 +916,7 @@ mod tests {
         );
         assert_eq!(vt.transactions(), txs);
 
-        handle
+        h.handle
             .stop()
             .await
             .expect("We should expect graceful shutdown");
@@ -933,18 +930,9 @@ mod tests {
         telemetry_subscribers::init_for_testing();
 
         // GIVEN
-        let committee_size = 15;
-        let (context, _) = Context::new_for_test(committee_size);
-        let context = Arc::new(context);
-
-        let store = Arc::new(MemStore::new(context.clone()));
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-
-        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
-
-        let handle =
-            ShardReconstructor::start(context.clone(), dag_state.clone(), core_dispatcher.clone());
-        let transaction_message_sender = handle.transaction_message_sender();
+        let h = TestHarness::new(15);
+        let context = &h.context;
+        let transaction_message_sender = h.tx.clone();
 
         // Create block header & transactions
         let header = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(7, 1).build());
@@ -953,10 +941,10 @@ mod tests {
         let txs = Transaction::random_transactions(5, 64);
         let serialized = Transaction::serialize(&txs).unwrap();
 
-        let mut encoder = create_encoder(&context);
+        let mut encoder = create_encoder(context);
         let transactions_commitment = TransactionsCommitment::compute_transactions_commitment(
             &serialized,
-            &context,
+            context,
             &mut encoder,
         )
         .unwrap();
@@ -992,7 +980,7 @@ mod tests {
 
         // Wait — should not reconstruct yet
         tokio::time::sleep(Duration::from_millis(600)).await;
-        let fetched = core_dispatcher.get_and_drain_transactions().await;
+        let fetched = h.core_dispatcher.get_and_drain_transactions().await;
         assert!(
             fetched.is_empty(),
             "With header + (info_length - 1) shards, no reconstruction should happen"
@@ -1002,9 +990,7 @@ mod tests {
         // collecting shards
         transaction_message_sender
             .send(vec![TransactionMessage::FullTransaction(
-                FullTransactionMessage {
-                    transaction_ref: TransactionRef::new(block_ref, transactions_commitment),
-                },
+                TransactionRef::new(block_ref, transactions_commitment),
             )])
             .await
             .unwrap();
@@ -1023,14 +1009,14 @@ mod tests {
 
         // Wait and check that no reconstruction happens
         tokio::time::sleep(Duration::from_millis(600)).await;
-        let fetched = core_dispatcher.get_and_drain_transactions().await;
+        let fetched = h.core_dispatcher.get_and_drain_transactions().await;
         assert!(
             fetched.is_empty(),
             "Once FullTransaction is received, reconstructor should ignore shards and not reconstruct"
         );
 
         // Clean up
-        handle
+        h.handle
             .stop()
             .await
             .expect("We should expect graceful shutdown");
@@ -1044,19 +1030,11 @@ mod tests {
 
         // GIVEN
         let committee_size = 4;
-        let (context, _) = Context::new_for_test(committee_size);
-        let context = Arc::new(context);
+        let h = TestHarness::new(committee_size);
+        let context = &h.context;
+        let tx = h.tx.clone();
 
-        let store = Arc::new(MemStore::new(context.clone()));
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-
-        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
-
-        let handle =
-            ShardReconstructor::start(context.clone(), dag_state.clone(), core_dispatcher.clone());
-        let tx = handle.transaction_message_sender();
-
-        let mut encoder = create_encoder(&context);
+        let mut encoder = create_encoder(context);
         let info_len = context.committee.info_length();
         let parity_len = context.committee.parity_length();
 
@@ -1071,7 +1049,7 @@ mod tests {
             let serialized = Transaction::serialize(&txs).unwrap();
             let commitment = TransactionsCommitment::compute_transactions_commitment(
                 &serialized,
-                &context,
+                context,
                 &mut encoder,
             )
             .unwrap();
@@ -1101,7 +1079,7 @@ mod tests {
                 let serialized = Transaction::serialize(&txs).unwrap();
                 let commitment = TransactionsCommitment::compute_transactions_commitment(
                     &serialized,
-                    &context,
+                    context,
                     &mut encoder,
                 )
                 .unwrap();
@@ -1151,7 +1129,7 @@ mod tests {
 
         // THEN: we should have reconstructed exactly 9 missing sets (from round 1 to 9)
         // for the blocked authority
-        let fetched = core_dispatcher.get_and_drain_transactions().await;
+        let fetched = h.core_dispatcher.get_and_drain_transactions().await;
         assert_eq!(
             fetched.len(),
             9,
@@ -1167,7 +1145,7 @@ mod tests {
             );
         }
 
-        handle.stop().await.unwrap();
+        h.handle.stop().await.unwrap();
     }
 
     /// In a `BlockBundle` the shards belong to blocks from *previous* rounds,

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -530,26 +530,17 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             #[cfg(not(test))]
             {
                 let mut to_stay_transactions = BTreeMap::new();
-                let block_headers_opt = {
-                    let block_refs: Vec<BlockRef> = transactions_map
-                        .keys()
-                        .map(|tx_ref| BlockRef::from(*tx_ref))
-                        .collect();
+                let block_headers_exist = {
+                    let tx_refs: Vec<TransactionRef> = transactions_map.keys().copied().collect();
                     self.dag_state
                         .read()
-                        .get_verified_block_headers(&block_refs)
+                        .contains_verified_block_headers_for_transaction_refs(&tx_refs)
                 };
-                for (block_header_opt, (tx_ref, transactions)) in block_headers_opt
+                for (exists, (tx_ref, transactions)) in block_headers_exist
                     .into_iter()
                     .zip(transactions_map.into_iter())
                 {
-                    if let Some(block_header) = block_header_opt {
-                        // Check the correctness of the transactions commitment
-                        assert_eq!(
-                            block_header.transactions_commitment(),
-                            transactions.transactions_commitment(),
-                            "The network has at least f+1 Byzantine validators"
-                        );
+                    if exists {
                         ready_to_be_sent_transactions.push(transactions);
                     } else {
                         to_stay_transactions.insert(tx_ref, transactions);

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -211,6 +211,7 @@ impl ShardAccumulator {
         Ok(VerifiedTransactions::new(
             transactions,
             TransactionRef::new(self.block_ref, self.transactions_commitment),
+            self.block_ref.digest,
             serialized,
         ))
     }

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -53,9 +53,6 @@ struct Inner {
     voting_block_headers: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedBlockHeader>,
     /// Flag indicating fast commit sync is ongoing.
     fast_sync_ongoing: bool,
-    /// Maps transaction ref components to block digest for quick lookups.
-    tx_ref_to_block_digest:
-        BTreeMap<(AuthorityIndex, Round, TransactionsCommitment), BlockHeaderDigest>,
 }
 
 impl MemStore {
@@ -72,7 +69,6 @@ impl MemStore {
                 commit_info: BTreeMap::new(),
                 voting_block_headers: BTreeMap::new(),
                 fast_sync_ongoing: false,
-                tx_ref_to_block_digest: BTreeMap::new(),
             }),
             context,
         }
@@ -95,15 +91,6 @@ impl Store for MemStore {
                 block_ref.round,
                 block_ref.digest,
             ));
-            // Store tx_ref -> block_digest mapping for fast lookups
-            inner.tx_ref_to_block_digest.insert(
-                (
-                    block_ref.author,
-                    block_ref.round,
-                    block_header.transactions_commitment(),
-                ),
-                block_ref.digest,
-            );
             for vote in block_header.commit_votes() {
                 inner
                     .commit_votes
@@ -522,22 +509,6 @@ impl Store for MemStore {
             })
             .collect();
         Ok(exist)
-    }
-
-    fn lookup_block_digests_by_tx_refs(
-        &self,
-        tx_refs: &[TransactionRef],
-    ) -> ConsensusResult<Vec<Option<BlockHeaderDigest>>> {
-        let inner = self.inner.read();
-        Ok(tx_refs
-            .iter()
-            .map(|tx| {
-                inner
-                    .tx_ref_to_block_digest
-                    .get(&(tx.author, tx.round, tx.transactions_commitment))
-                    .copied()
-            })
-            .collect())
     }
 
     fn read_voting_block_headers(

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -100,7 +100,6 @@ impl Store for MemStore {
 
         // Store transactions data separately
         for transaction in write_batch.transactions {
-            let block_ref = transaction.block_ref();
             let transaction_ref = transaction.transaction_ref();
             if context.protocol_config.consensus_transaction_ref() {
                 inner.transactions_by_tx_refs.insert(
@@ -119,6 +118,9 @@ impl Store for MemStore {
                     transaction_ref.block_digest,
                 ));
             } else {
+                let block_ref = transaction
+                    .block_ref()
+                    .expect("block_ref must be present in non-transaction-ref path");
                 inner.transactions.insert(
                     (block_ref.round, block_ref.author, block_ref.digest),
                     transaction,

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -40,12 +40,7 @@ struct Inner {
         BTreeMap<(Round, AuthorityIndex, TransactionsCommitment), VerifiedTransactions>,
     block_headers: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedBlockHeader>,
     digests_by_authorities: BTreeSet<(AuthorityIndex, Round, BlockHeaderDigest)>,
-    transaction_commitments_by_authorities: BTreeSet<(
-        AuthorityIndex,
-        Round,
-        TransactionsCommitment,
-        BlockHeaderDigest,
-    )>,
+    transaction_commitments_by_authorities: BTreeSet<(AuthorityIndex, Round, TransactionsCommitment)>,
     commits: BTreeMap<(CommitIndex, CommitDigest), TrustedCommit>,
     commit_votes: BTreeSet<(CommitIndex, CommitDigest, BlockRef)>,
     commit_info: BTreeMap<(CommitIndex, CommitDigest), CommitInfo>,
@@ -115,7 +110,6 @@ impl Store for MemStore {
                     transaction_ref.author,
                     transaction_ref.round,
                     transaction_ref.transactions_commitment,
-                    transaction_ref.block_digest,
                 ));
             } else {
                 let block_ref = transaction
@@ -398,24 +392,14 @@ impl Store for MemStore {
         let res = inner
             .transaction_commitments_by_authorities
             .range((
-                Included((
-                    author,
-                    start_round,
-                    TransactionsCommitment::MIN,
-                    BlockHeaderDigest::MIN,
-                )),
-                Included((
-                    author,
-                    Round::MAX,
-                    TransactionsCommitment::MAX,
-                    BlockHeaderDigest::MAX,
-                )),
+                Included((author, start_round, TransactionsCommitment::MIN)),
+                Included((author, Round::MAX, TransactionsCommitment::MAX)),
             ))
-            .map(|(author, round, commitment, digest)| TransactionRef {
+            .map(|(author, round, commitment)| TransactionRef {
                 round: *round,
                 author: *author,
                 transactions_commitment: *commitment,
-                block_digest: *digest,
+                block_digest: BlockHeaderDigest::default(),
             })
             .collect();
         Ok(res)

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -53,6 +53,9 @@ struct Inner {
     voting_block_headers: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedBlockHeader>,
     /// Flag indicating fast commit sync is ongoing.
     fast_sync_ongoing: bool,
+    /// Maps transaction ref components to block digest for quick lookups.
+    tx_ref_to_block_digest:
+        BTreeMap<(AuthorityIndex, Round, TransactionsCommitment), BlockHeaderDigest>,
 }
 
 impl MemStore {
@@ -69,6 +72,7 @@ impl MemStore {
                 commit_info: BTreeMap::new(),
                 voting_block_headers: BTreeMap::new(),
                 fast_sync_ongoing: false,
+                tx_ref_to_block_digest: BTreeMap::new(),
             }),
             context,
         }
@@ -91,6 +95,15 @@ impl Store for MemStore {
                 block_ref.round,
                 block_ref.digest,
             ));
+            // Store tx_ref -> block_digest mapping for fast lookups
+            inner.tx_ref_to_block_digest.insert(
+                (
+                    block_ref.author,
+                    block_ref.round,
+                    block_header.transactions_commitment(),
+                ),
+                block_ref.digest,
+            );
             for vote in block_header.commit_votes() {
                 inner
                     .commit_votes
@@ -509,6 +522,22 @@ impl Store for MemStore {
             })
             .collect();
         Ok(exist)
+    }
+
+    fn lookup_block_digests_by_tx_refs(
+        &self,
+        tx_refs: &[TransactionRef],
+    ) -> ConsensusResult<Vec<Option<BlockHeaderDigest>>> {
+        let inner = self.inner.read();
+        Ok(tx_refs
+            .iter()
+            .map(|tx| {
+                inner
+                    .tx_ref_to_block_digest
+                    .get(&(tx.author, tx.round, tx.transactions_commitment))
+                    .copied()
+            })
+            .collect())
     }
 
     fn read_voting_block_headers(

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -40,7 +40,8 @@ struct Inner {
         BTreeMap<(Round, AuthorityIndex, TransactionsCommitment), VerifiedTransactions>,
     block_headers: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedBlockHeader>,
     digests_by_authorities: BTreeSet<(AuthorityIndex, Round, BlockHeaderDigest)>,
-    transaction_commitments_by_authorities: BTreeSet<(AuthorityIndex, Round, TransactionsCommitment)>,
+    transaction_commitments_by_authorities:
+        BTreeSet<(AuthorityIndex, Round, TransactionsCommitment)>,
     commits: BTreeMap<(CommitIndex, CommitDigest), TrustedCommit>,
     commit_votes: BTreeSet<(CommitIndex, CommitDigest, BlockRef)>,
     commit_info: BTreeMap<(CommitIndex, CommitDigest), CommitInfo>,
@@ -399,7 +400,6 @@ impl Store for MemStore {
                 round: *round,
                 author: *author,
                 transactions_commitment: *commitment,
-                block_digest: BlockHeaderDigest::default(),
             })
             .collect();
         Ok(res)

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -16,7 +16,10 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     CommitIndex,
-    block_header::{BlockRef, Round, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions},
+    block_header::{
+        BlockHeaderDigest, BlockRef, Round, VerifiedBlock, VerifiedBlockHeader,
+        VerifiedTransactions,
+    },
     commit::{CommitInfo, CommitRange, CommitRef, TrustedCommit},
     context::Context,
     error::ConsensusResult,
@@ -62,6 +65,14 @@ pub(crate) trait Store: Send + Sync {
 
     /// Checks if block headers exist in the store.
     fn contains_block_headers(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>>;
+
+    /// Looks up block digests by transaction refs in batch.
+    /// Returns None for transaction refs that don't have a corresponding block
+    /// digest in storage.
+    fn lookup_block_digests_by_tx_refs(
+        &self,
+        tx_refs: &[TransactionRef],
+    ) -> ConsensusResult<Vec<Option<BlockHeaderDigest>>>;
 
     /// Checks whether there is any block at the given slot
     #[allow(dead_code)]

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -16,10 +16,7 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     CommitIndex,
-    block_header::{
-        BlockHeaderDigest, BlockRef, Round, VerifiedBlock, VerifiedBlockHeader,
-        VerifiedTransactions,
-    },
+    block_header::{BlockRef, Round, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions},
     commit::{CommitInfo, CommitRange, CommitRef, TrustedCommit},
     context::Context,
     error::ConsensusResult,
@@ -65,14 +62,6 @@ pub(crate) trait Store: Send + Sync {
 
     /// Checks if block headers exist in the store.
     fn contains_block_headers(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>>;
-
-    /// Looks up block digests by transaction refs in batch.
-    /// Returns None for transaction refs that don't have a corresponding block
-    /// digest in storage.
-    fn lookup_block_digests_by_tx_refs(
-        &self,
-        tx_refs: &[TransactionRef],
-    ) -> ConsensusResult<Vec<Option<BlockHeaderDigest>>>;
 
     /// Checks whether there is any block at the given slot
     #[allow(dead_code)]

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -62,6 +62,9 @@ pub(crate) struct RocksDBStore {
 
     fast_commit_sync_flag: DBMap<(), ()>,
 
+    /// Maps transaction ref components to block digest for quick lookups.
+    tx_ref_to_block_digest:
+        DBMap<(AuthorityIndex, Round, TransactionsCommitment), BlockHeaderDigest>,
     /// Context to access protocol configuration
     #[cfg_attr(not(test), allow(dead_code))]
     context: Arc<Context>,
@@ -79,6 +82,7 @@ impl RocksDBStore {
     const COMMIT_INFO_CF: &'static str = "commit_info";
     const VOTING_BLOCK_HEADERS_CF: &'static str = "voting_block_headers";
     const FAST_COMMIT_SYNC_FLAG_CF: &'static str = "fast_commit_sync_flag";
+    const TX_REF_TO_BLOCK_DIGEST_CF: &'static str = "tx_ref_to_block_digest";
 
     /// Creates a new instance of RocksDB storage.
     pub(crate) fn new(path: &str, context: Arc<Context>) -> Self {
@@ -125,6 +129,7 @@ impl RocksDBStore {
             // so using standard options is sufficient.
             (Self::VOTING_BLOCK_HEADERS_CF, cf_options.clone()),
             (Self::FAST_COMMIT_SYNC_FLAG_CF, cf_options.clone()),
+            (Self::TX_REF_TO_BLOCK_DIGEST_CF, cf_options.clone()),
         ];
         let rocksdb = open_cf_opts(
             path,
@@ -145,6 +150,7 @@ impl RocksDBStore {
             commit_info,
             voting_block_headers,
             fast_commit_sync_flag,
+            tx_ref_to_block_digest,
         ) = reopen!(&rocksdb,
             Self::BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
             Self::TRANSACTIONS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
@@ -156,6 +162,8 @@ impl RocksDBStore {
             Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>,
             Self::VOTING_BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
             Self::FAST_COMMIT_SYNC_FLAG_CF;<(), ()>
+            Self::VOTING_BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
+            Self::TX_REF_TO_BLOCK_DIGEST_CF;<(AuthorityIndex, Round, TransactionsCommitment), BlockHeaderDigest>
         );
 
         Self {
@@ -169,6 +177,7 @@ impl RocksDBStore {
             commit_info,
             voting_block_headers,
             fast_commit_sync_flag,
+            tx_ref_to_block_digest,
             context,
         }
     }
@@ -199,6 +208,20 @@ impl Store for RocksDBStore {
                 .insert_batch(
                     &self.digests_by_authorities,
                     [((block_ref.author, block_ref.round, block_ref.digest), ())],
+                )
+                .map_err(ConsensusError::RocksDBFailure)?;
+            // Store tx_ref -> block_digest mapping for fast lookups
+            batch
+                .insert_batch(
+                    &self.tx_ref_to_block_digest,
+                    [(
+                        (
+                            block_ref.author,
+                            block_ref.round,
+                            block_header.transactions_commitment(),
+                        ),
+                        block_ref.digest,
+                    )],
                 )
                 .map_err(ConsensusError::RocksDBFailure)?;
             // Store commit votes from this block header using the BlockHeaderAPI trait
@@ -564,6 +587,19 @@ impl Store for RocksDBStore {
             .collect::<Vec<_>>();
         let exist = self.block_headers.multi_contains_keys(refs)?;
         Ok(exist)
+    }
+
+    fn lookup_block_digests_by_tx_refs(
+        &self,
+        tx_refs: &[TransactionRef],
+    ) -> ConsensusResult<Vec<Option<BlockHeaderDigest>>> {
+        let keys: Vec<_> = tx_refs
+            .iter()
+            .map(|tx| (tx.author, tx.round, tx.transactions_commitment))
+            .collect();
+        self.tx_ref_to_block_digest
+            .multi_get(keys)
+            .map_err(ConsensusError::RocksDBFailure)
     }
 
     fn contains_block_at_slot(&self, slot: crate::block_header::Slot) -> ConsensusResult<bool> {

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -416,18 +416,13 @@ impl Store for RocksDBStore {
                 let GenericTransactionRef::TransactionRef(tx_ref) = gen_tx_ref else {
                     return Err(ConsensusError::InconsistentTransactionRefVariants);
                 };
-                let block_ref = BlockRef::from(*tx_ref);
                 if let Some(serialized_transactions) = serialized_transactions {
                     let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
                         .map_err(ConsensusError::MalformedTransactions)?;
                     // We don't check the transactions commitment from the header as it's loaded
                     // from storage. Assemble verified transactions
-                    let verified_transactions = VerifiedTransactions::new(
-                        transactions,
-                        block_ref,
-                        tx_ref.transactions_commitment,
-                        serialized_transactions,
-                    );
+                    let verified_transactions =
+                        VerifiedTransactions::new(transactions, *tx_ref, serialized_transactions);
                     result.push(Some(verified_transactions));
                 } else {
                     result.push(None);
@@ -465,8 +460,10 @@ impl Store for RocksDBStore {
                     // from storage. Assemble verified transactions
                     let verified_transactions = VerifiedTransactions::new(
                         transactions,
-                        *block_ref,
-                        signed_block_header.transactions_commitment(),
+                        TransactionRef::new(
+                            *block_ref,
+                            signed_block_header.transactions_commitment(),
+                        ),
                         serialized_transactions,
                     );
                     result.push(Some(verified_transactions));

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -421,8 +421,12 @@ impl Store for RocksDBStore {
                         .map_err(ConsensusError::MalformedTransactions)?;
                     // We don't check the transactions commitment from the header as it's loaded
                     // from storage. Assemble verified transactions
-                    let verified_transactions =
-                        VerifiedTransactions::new(transactions, *tx_ref, serialized_transactions);
+                    let verified_transactions = VerifiedTransactions::new(
+                        transactions,
+                        *tx_ref,
+                        tx_ref.block_digest,
+                        serialized_transactions,
+                    );
                     result.push(Some(verified_transactions));
                 } else {
                     result.push(None);
@@ -464,6 +468,7 @@ impl Store for RocksDBStore {
                             *block_ref,
                             signed_block_header.transactions_commitment(),
                         ),
+                        block_ref.digest,
                         serialized_transactions,
                     );
                     result.push(Some(verified_transactions));

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -244,7 +244,9 @@ impl Store for RocksDBStore {
                             (
                                 transaction_ref.round,
                                 transaction_ref.author,
-                                transaction.block_digest().expect("block digest should exist for consensus_transaction_ref=false"),
+                                transaction.block_digest().expect(
+                                    "block digest should exist for consensus_transaction_ref=false",
+                                ),
                             ),
                             transaction.serialized(),
                         )],
@@ -604,7 +606,6 @@ impl Store for RocksDBStore {
                     round,
                     author,
                     transactions_commitment: commitment,
-                    block_digest: BlockHeaderDigest::default(),
                 })
             })
             .collect()

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -161,8 +161,7 @@ impl RocksDBStore {
             Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
             Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>,
             Self::VOTING_BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
-            Self::FAST_COMMIT_SYNC_FLAG_CF;<(), ()>
-            Self::VOTING_BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
+            Self::FAST_COMMIT_SYNC_FLAG_CF;<(), ()>,
             Self::TX_REF_TO_BLOCK_DIGEST_CF;<(AuthorityIndex, Round, TransactionsCommitment), BlockHeaderDigest>
         );
 

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -39,15 +39,8 @@ pub(crate) struct RocksDBStore {
     /// A secondary index that orders refs first by authors.
     digests_by_authorities: DBMap<(AuthorityIndex, Round, BlockHeaderDigest), ()>,
     /// A secondary index that orders transaction commitments first by authors.
-    transaction_commitments_by_authorities: DBMap<
-        (
-            AuthorityIndex,
-            Round,
-            TransactionsCommitment,
-            BlockHeaderDigest,
-        ),
-        (),
-    >,
+    transaction_commitments_by_authorities:
+        DBMap<(AuthorityIndex, Round, TransactionsCommitment), ()>,
     /// Maps commit index to Commit.
     commits: DBMap<(CommitIndex, CommitDigest), Bytes>,
     /// Collects votes on commits.
@@ -150,7 +143,7 @@ impl RocksDBStore {
             Self::TRANSACTIONS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
             Self::TRANSACTIONS_BY_TX_REF_CF;<(Round, AuthorityIndex, TransactionsCommitment), Bytes>,
             Self::DIGESTS_BY_AUTHORITIES_CF;<(AuthorityIndex, Round, BlockHeaderDigest), ()>,
-            Self::TRANSACTION_COMMITMENTS_BY_AUTHORITIES_CF;<(AuthorityIndex, Round, TransactionsCommitment, BlockHeaderDigest), ()>,
+            Self::TRANSACTION_COMMITMENTS_BY_AUTHORITIES_CF;<(AuthorityIndex, Round, TransactionsCommitment), ()>,
             Self::COMMITS_CF;<(CommitIndex, CommitDigest), Bytes>,
             Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
             Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>,
@@ -238,7 +231,6 @@ impl Store for RocksDBStore {
                                 transaction_ref.author,
                                 transaction_ref.round,
                                 transaction_ref.transactions_commitment,
-                                transaction_ref.block_digest,
                             ),
                             (),
                         )],
@@ -603,26 +595,16 @@ impl Store for RocksDBStore {
     ) -> ConsensusResult<Vec<TransactionRef>> {
         self.transaction_commitments_by_authorities
             .safe_range_iter((
-                Included((
-                    author,
-                    start_round,
-                    TransactionsCommitment::MIN,
-                    BlockHeaderDigest::MIN,
-                )),
-                Included((
-                    author,
-                    Round::MAX,
-                    TransactionsCommitment::MAX,
-                    BlockHeaderDigest::MAX,
-                )),
+                Included((author, start_round, TransactionsCommitment::MIN)),
+                Included((author, Round::MAX, TransactionsCommitment::MAX)),
             ))
             .map(|res| {
-                let ((author, round, commitment, digest), _) = res?;
+                let ((author, round, commitment), _) = res?;
                 Ok(TransactionRef {
                     round,
                     author,
                     transactions_commitment: commitment,
-                    block_digest: digest,
+                    block_digest: BlockHeaderDigest::default(),
                 })
             })
             .collect()

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -244,7 +244,7 @@ impl Store for RocksDBStore {
                             (
                                 transaction_ref.round,
                                 transaction_ref.author,
-                                transaction_ref.block_digest,
+                                transaction.block_digest().expect("block digest should exist for consensus_transaction_ref=false"),
                             ),
                             transaction.serialized(),
                         )],

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -62,9 +62,6 @@ pub(crate) struct RocksDBStore {
 
     fast_commit_sync_flag: DBMap<(), ()>,
 
-    /// Maps transaction ref components to block digest for quick lookups.
-    tx_ref_to_block_digest:
-        DBMap<(AuthorityIndex, Round, TransactionsCommitment), BlockHeaderDigest>,
     /// Context to access protocol configuration
     #[cfg_attr(not(test), allow(dead_code))]
     context: Arc<Context>,
@@ -82,7 +79,6 @@ impl RocksDBStore {
     const COMMIT_INFO_CF: &'static str = "commit_info";
     const VOTING_BLOCK_HEADERS_CF: &'static str = "voting_block_headers";
     const FAST_COMMIT_SYNC_FLAG_CF: &'static str = "fast_commit_sync_flag";
-    const TX_REF_TO_BLOCK_DIGEST_CF: &'static str = "tx_ref_to_block_digest";
 
     /// Creates a new instance of RocksDB storage.
     pub(crate) fn new(path: &str, context: Arc<Context>) -> Self {
@@ -129,7 +125,6 @@ impl RocksDBStore {
             // so using standard options is sufficient.
             (Self::VOTING_BLOCK_HEADERS_CF, cf_options.clone()),
             (Self::FAST_COMMIT_SYNC_FLAG_CF, cf_options.clone()),
-            (Self::TX_REF_TO_BLOCK_DIGEST_CF, cf_options.clone()),
         ];
         let rocksdb = open_cf_opts(
             path,
@@ -150,7 +145,6 @@ impl RocksDBStore {
             commit_info,
             voting_block_headers,
             fast_commit_sync_flag,
-            tx_ref_to_block_digest,
         ) = reopen!(&rocksdb,
             Self::BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
             Self::TRANSACTIONS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
@@ -161,8 +155,7 @@ impl RocksDBStore {
             Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
             Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>,
             Self::VOTING_BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
-            Self::FAST_COMMIT_SYNC_FLAG_CF;<(), ()>,
-            Self::TX_REF_TO_BLOCK_DIGEST_CF;<(AuthorityIndex, Round, TransactionsCommitment), BlockHeaderDigest>
+            Self::FAST_COMMIT_SYNC_FLAG_CF;<(), ()>
         );
 
         Self {
@@ -176,7 +169,6 @@ impl RocksDBStore {
             commit_info,
             voting_block_headers,
             fast_commit_sync_flag,
-            tx_ref_to_block_digest,
             context,
         }
     }
@@ -207,20 +199,6 @@ impl Store for RocksDBStore {
                 .insert_batch(
                     &self.digests_by_authorities,
                     [((block_ref.author, block_ref.round, block_ref.digest), ())],
-                )
-                .map_err(ConsensusError::RocksDBFailure)?;
-            // Store tx_ref -> block_digest mapping for fast lookups
-            batch
-                .insert_batch(
-                    &self.tx_ref_to_block_digest,
-                    [(
-                        (
-                            block_ref.author,
-                            block_ref.round,
-                            block_header.transactions_commitment(),
-                        ),
-                        block_ref.digest,
-                    )],
                 )
                 .map_err(ConsensusError::RocksDBFailure)?;
             // Store commit votes from this block header using the BlockHeaderAPI trait
@@ -586,19 +564,6 @@ impl Store for RocksDBStore {
             .collect::<Vec<_>>();
         let exist = self.block_headers.multi_contains_keys(refs)?;
         Ok(exist)
-    }
-
-    fn lookup_block_digests_by_tx_refs(
-        &self,
-        tx_refs: &[TransactionRef],
-    ) -> ConsensusResult<Vec<Option<BlockHeaderDigest>>> {
-        let keys: Vec<_> = tx_refs
-            .iter()
-            .map(|tx| (tx.author, tx.round, tx.transactions_commitment))
-            .collect();
-        self.tx_ref_to_block_digest
-            .multi_get(keys)
-            .map_err(ConsensusError::RocksDBFailure)
     }
 
     fn contains_block_at_slot(&self, slot: crate::block_header::Slot) -> ConsensusResult<bool> {

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -424,7 +424,7 @@ impl Store for RocksDBStore {
                     let verified_transactions = VerifiedTransactions::new(
                         transactions,
                         *tx_ref,
-                        tx_ref.block_digest,
+                        None,
                         serialized_transactions,
                     );
                     result.push(Some(verified_transactions));
@@ -468,7 +468,7 @@ impl Store for RocksDBStore {
                             *block_ref,
                             signed_block_header.transactions_commitment(),
                         ),
-                        block_ref.digest,
+                        Some(block_ref.digest),
                         serialized_transactions,
                     );
                     result.push(Some(verified_transactions));

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -391,11 +391,14 @@ async fn read_and_contain_transactions(
         let actual = tx_opt.as_ref().unwrap();
         assert_eq!(actual, expected);
 
-        // Verify block reference matches
-        assert_eq!(
-            tx_opt.as_ref().unwrap().block_ref(),
-            written_blocks[i].reference()
-        );
+        // Verify block reference matches (only available in the non-transaction-ref
+        // path)
+        if !transaction_ref_enabled {
+            assert_eq!(
+                tx_opt.as_ref().unwrap().block_ref().unwrap(),
+                written_blocks[i].reference()
+            );
+        }
     }
 
     // Test reading subset of transactions

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -391,12 +391,15 @@ async fn read_and_contain_transactions(
         let actual = tx_opt.as_ref().unwrap();
         assert_eq!(actual, expected);
 
-        // Verify block reference matches (only available in the non-transaction-ref
-        // path)
         if !transaction_ref_enabled {
             assert_eq!(
                 tx_opt.as_ref().unwrap().block_ref().unwrap(),
                 written_blocks[i].reference()
+            );
+        } else {
+            assert_eq!(
+                tx_opt.as_ref().unwrap().transaction_ref(),
+                written_blocks[i].verified_block_header.transaction_ref()
             );
         }
     }

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -623,7 +623,7 @@ impl DagBuilder {
             let verified_transactions = VerifiedTransactions::new(
                 transactions,
                 TransactionRef::new(block_ref, commitment),
-                block_ref.digest,
+                Some(block_ref.digest),
                 serialized_transactions,
             );
             self.transactions.insert(block_ref, verified_transactions);
@@ -1125,7 +1125,7 @@ impl<'a> LayerBuilder<'a> {
                 let verified_transactions = VerifiedTransactions::new(
                     transactions,
                     block_header.transaction_ref(),
-                    block_header.digest(),
+                    Some(block_header.digest()),
                     serialized_transactions,
                 );
 

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -25,6 +25,7 @@ use crate::{
     encoder::{ShardEncoder, create_encoder},
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
     linearizer::{BlockStoreAPI, Linearizer},
+    transaction_ref::TransactionRef,
 };
 
 /// DagBuilder API
@@ -621,8 +622,7 @@ impl DagBuilder {
 
             let verified_transactions = VerifiedTransactions::new(
                 transactions,
-                block_ref,
-                commitment,
+                TransactionRef::new(block_ref, commitment),
                 serialized_transactions,
             );
             self.transactions.insert(block_ref, verified_transactions);
@@ -1123,8 +1123,7 @@ impl<'a> LayerBuilder<'a> {
 
                 let verified_transactions = VerifiedTransactions::new(
                     transactions,
-                    block_header.reference(),
-                    commitment,
+                    block_header.transaction_ref(),
                     serialized_transactions,
                 );
 

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -623,6 +623,7 @@ impl DagBuilder {
             let verified_transactions = VerifiedTransactions::new(
                 transactions,
                 TransactionRef::new(block_ref, commitment),
+                block_ref.digest,
                 serialized_transactions,
             );
             self.transactions.insert(block_ref, verified_transactions);
@@ -1124,6 +1125,7 @@ impl<'a> LayerBuilder<'a> {
                 let verified_transactions = VerifiedTransactions::new(
                     transactions,
                     block_header.transaction_ref(),
+                    block_header.digest(),
                     serialized_transactions,
                 );
 

--- a/crates/starfish/core/src/transaction_ref.rs
+++ b/crates/starfish/core/src/transaction_ref.rs
@@ -81,16 +81,6 @@ impl Hash for TransactionRef {
     }
 }
 
-impl From<TransactionRef> for BlockRef {
-    fn from(tr: TransactionRef) -> Self {
-        BlockRef {
-            round: tr.round,
-            author: tr.author,
-            digest: tr.block_digest,
-        }
-    }
-}
-
 /// Accessors to transaction reference info.
 #[enum_dispatch]
 pub(crate) trait GenericTransactionRefAPI {

--- a/crates/starfish/core/src/transaction_ref.rs
+++ b/crates/starfish/core/src/transaction_ref.rs
@@ -28,6 +28,17 @@ pub struct TransactionRef {
     pub block_digest: BlockHeaderDigest,
 }
 
+impl TransactionRef {
+    pub fn new(block_ref: BlockRef, transactions_commitment: TransactionsCommitment) -> Self {
+        Self {
+            round: block_ref.round,
+            author: block_ref.author,
+            transactions_commitment,
+            block_digest: block_ref.digest,
+        }
+    }
+}
+
 impl Ord for TransactionRef {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.round

--- a/crates/starfish/core/src/transaction_ref.rs
+++ b/crates/starfish/core/src/transaction_ref.rs
@@ -16,7 +16,7 @@ use starfish_config::{AuthorityIndex, DIGEST_LENGTH};
 #[cfg(test)]
 use crate::context::Context;
 use crate::{
-    block_header::{BlockHeaderDigest, BlockRef, Round, TransactionsCommitment},
+    block_header::{BlockRef, Round, TransactionsCommitment},
     error::{ConsensusError, ConsensusResult},
 };
 
@@ -25,7 +25,6 @@ pub struct TransactionRef {
     pub round: Round,
     pub author: AuthorityIndex,
     pub transactions_commitment: TransactionsCommitment,
-    pub block_digest: BlockHeaderDigest,
 }
 
 impl TransactionRef {
@@ -34,7 +33,6 @@ impl TransactionRef {
             round: block_ref.round,
             author: block_ref.author,
             transactions_commitment,
-            block_digest: block_ref.digest,
         }
     }
 }
@@ -205,7 +203,6 @@ pub(crate) fn convert_block_refs_to_generic_transaction_refs(
                     round: block_ref.round,
                     author: block_ref.author,
                     transactions_commitment: header.transactions_commitment(),
-                    block_digest: block_ref.digest,
                 })
             })
             .collect()

--- a/crates/starfish/core/src/transaction_ref.rs
+++ b/crates/starfish/core/src/transaction_ref.rs
@@ -20,7 +20,7 @@ use crate::{
     error::{ConsensusError, ConsensusResult},
 };
 
-#[derive(Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TransactionRef {
     pub round: Round,
     pub author: AuthorityIndex,
@@ -34,26 +34,6 @@ impl TransactionRef {
             author: block_ref.author,
             transactions_commitment,
         }
-    }
-}
-
-impl Ord for TransactionRef {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.round
-            .cmp(&other.round)
-            .then(self.author.cmp(&other.author))
-            .then(
-                self.transactions_commitment
-                    .cmp(&other.transactions_commitment),
-            )
-        // block_digest intentionally excluded - not part of transaction
-        // identity
-    }
-}
-
-impl PartialOrd for TransactionRef {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
     }
 }
 

--- a/crates/starfish/core/src/transaction_ref.rs
+++ b/crates/starfish/core/src/transaction_ref.rs
@@ -33,8 +33,12 @@ impl Ord for TransactionRef {
         self.round
             .cmp(&other.round)
             .then(self.author.cmp(&other.author))
-            .then(self.transactions_commitment.cmp(&other.transactions_commitment))
-        // block_digest intentionally excluded - not part of transaction identity
+            .then(
+                self.transactions_commitment
+                    .cmp(&other.transactions_commitment),
+            )
+        // block_digest intentionally excluded - not part of transaction
+        // identity
     }
 }
 
@@ -130,14 +134,6 @@ impl GenericTransactionRefAPI for TransactionRef {
 }
 
 impl GenericTransactionRef {
-    /// Convert this GenericTransactionRef to a BlockRef
-    pub(crate) fn to_block_ref(self) -> BlockRef {
-        match self {
-            GenericTransactionRef::BlockRef(block_ref) => block_ref,
-            GenericTransactionRef::TransactionRef(tx_ref) => BlockRef::from(tx_ref),
-        }
-    }
-
     /// Extract TransactionRef, returning error if this is a BlockRef variant.
     /// This should only be called when consensus_transaction_ref flag is true.
     pub(crate) fn expect_transaction_ref(self) -> ConsensusResult<TransactionRef> {

--- a/crates/starfish/core/src/transaction_ref.rs
+++ b/crates/starfish/core/src/transaction_ref.rs
@@ -20,12 +20,28 @@ use crate::{
     error::{ConsensusError, ConsensusResult},
 };
 
-#[derive(Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct TransactionRef {
     pub round: Round,
     pub author: AuthorityIndex,
     pub transactions_commitment: TransactionsCommitment,
     pub block_digest: BlockHeaderDigest,
+}
+
+impl Ord for TransactionRef {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.round
+            .cmp(&other.round)
+            .then(self.author.cmp(&other.author))
+            .then(self.transactions_commitment.cmp(&other.transactions_commitment))
+        // block_digest intentionally excluded - not part of transaction identity
+    }
+}
+
+impl PartialOrd for TransactionRef {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl fmt::Display for TransactionRef {

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -2388,18 +2388,18 @@ mod tests {
             let mut filtered: BTreeMap<GenericTransactionRef, BTreeSet<AuthorityIndex>> =
                 BTreeMap::new();
 
-            for (block_ref, authority_set) in missing.iter() {
+            for (gen_tr_ref, authority_set) in missing.iter() {
                 let exists = transactions.iter().any(|txn| {
                     let tx_ref_match =
-                        GenericTransactionRef::TransactionRef(txn.transaction_ref()) == *block_ref;
+                        GenericTransactionRef::TransactionRef(txn.transaction_ref()) == *gen_tr_ref;
                     let block_ref_match = txn
                         .block_ref()
-                        .is_some_and(|br| GenericTransactionRef::BlockRef(br) == *block_ref);
+                        .is_some_and(|br| GenericTransactionRef::BlockRef(br) == *gen_tr_ref);
                     tx_ref_match || block_ref_match
                 });
 
                 if !exists {
-                    filtered.insert(*block_ref, authority_set.clone());
+                    filtered.insert(*gen_tr_ref, authority_set.clone());
                 }
             }
 

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1132,7 +1132,7 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
             transactions.len(),
             transactions
                 .iter()
-                .map(|b| b.block_ref().to_string())
+                .map(|b| b.transaction_ref().to_string())
                 .join(", "),
         );
 
@@ -1240,7 +1240,12 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.transaction_ref(), header.digest(), serialized)
+                VerifiedTransactions::new(
+                    transactions,
+                    header.transaction_ref(),
+                    Some(header.digest()),
+                    serialized,
+                )
             })
             .collect::<Vec<_>>();
 
@@ -1294,7 +1299,7 @@ mod tests {
             assert!(
                 fetched_transactions
                     .iter()
-                    .any(|t| t.block_ref() == transaction.block_ref())
+                    .any(|t| t.transactions_commitment() == transaction.transactions_commitment())
             );
         }
 
@@ -1353,8 +1358,12 @@ mod tests {
 
             block_headers.push(header.clone());
 
-            let verified_transaction =
-                VerifiedTransactions::new(transactions, header.transaction_ref(), header.digest(), serialized);
+            let verified_transaction = VerifiedTransactions::new(
+                transactions,
+                header.transaction_ref(),
+                Some(header.digest()),
+                serialized,
+            );
 
             verified_transactions.push(verified_transaction);
         }
@@ -1474,7 +1483,12 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.transaction_ref(), header.digest(), serialized)
+                VerifiedTransactions::new(
+                    transactions,
+                    header.transaction_ref(),
+                    Some(header.digest()),
+                    serialized,
+                )
             })
             .collect::<Vec<_>>();
 
@@ -1546,7 +1560,7 @@ mod tests {
             assert!(
                 fetched_transactions
                     .iter()
-                    .any(|t| t.block_ref() == transaction.block_ref())
+                    .any(|t| t.transactions_commitment() == transaction.transactions_commitment())
             );
         }
 
@@ -1608,7 +1622,12 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.transaction_ref(), header.digest(), serialized)
+                VerifiedTransactions::new(
+                    transactions,
+                    header.transaction_ref(),
+                    Some(header.digest()),
+                    serialized,
+                )
             })
             .collect::<Vec<_>>();
 
@@ -1669,7 +1688,7 @@ mod tests {
             assert!(
                 fetched_transactions
                     .iter()
-                    .any(|t| t.block_ref() == transaction.block_ref())
+                    .any(|t| t.transactions_commitment() == transaction.transactions_commitment())
             );
         }
 
@@ -1731,7 +1750,12 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.transaction_ref(), header.digest(), serialized)
+                VerifiedTransactions::new(
+                    transactions,
+                    header.transaction_ref(),
+                    Some(header.digest()),
+                    serialized,
+                )
             })
             .collect::<Vec<_>>();
 
@@ -1794,7 +1818,7 @@ mod tests {
             assert!(
                 fetched_transactions
                     .iter()
-                    .any(|t| t.block_ref() == transaction.block_ref())
+                    .any(|t| t.transactions_commitment() == transaction.transactions_commitment())
             );
         }
 
@@ -1858,7 +1882,12 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.transaction_ref(), header.digest(), serialized)
+                VerifiedTransactions::new(
+                    transactions,
+                    header.transaction_ref(),
+                    Some(header.digest()),
+                    serialized,
+                )
             })
             .collect::<Vec<_>>();
 
@@ -1924,7 +1953,7 @@ mod tests {
             assert!(
                 fetched_transactions
                     .iter()
-                    .any(|t| t.block_ref() == transaction.block_ref())
+                    .any(|t| t.transactions_commitment() == transaction.transactions_commitment())
             );
         }
 
@@ -2209,7 +2238,6 @@ mod tests {
         ) {
             let mut transactions_map = self.transactions.lock().await;
             for transaction in transactions {
-                let block_ref = transaction.block_ref();
                 let transaction_ref = transaction.transaction_ref();
 
                 if transaction_ref_enabled {
@@ -2224,6 +2252,9 @@ mod tests {
                     transactions_map.insert((peer, tx_ref), serialized.into());
                 } else {
                     // Create a SerializedTransactionsV1 struct with BlockRef
+                    let block_ref = transaction
+                        .block_ref()
+                        .expect("block_ref must be present in non-transaction-ref path");
                     let serialized_transactions = SerializedTransactionsV1 {
                         block_ref,
                         serialized_transactions: transaction.serialized().clone(),
@@ -2332,11 +2363,11 @@ mod tests {
             let mut seen = BTreeSet::new();
             // Populate with txns
             for transaction in txns.iter() {
-                seen.insert(transaction.block_ref());
+                seen.insert(transaction.transactions_commitment());
             }
             for transaction in transactions {
-                if !seen.contains(&transaction.block_ref()) {
-                    seen.insert(transaction.block_ref());
+                if !seen.contains(&transaction.transactions_commitment()) {
+                    seen.insert(transaction.transactions_commitment());
                     txns.push(transaction);
                 }
             }
@@ -2358,9 +2389,14 @@ mod tests {
                 BTreeMap::new();
 
             for (block_ref, authority_set) in missing.iter() {
-                let exists = transactions
-                    .iter()
-                    .any(|txn| GenericTransactionRef::from(txn.block_ref()) == *block_ref);
+                let exists = transactions.iter().any(|txn| {
+                    let tx_ref_match =
+                        GenericTransactionRef::TransactionRef(txn.transaction_ref()) == *block_ref;
+                    let block_ref_match = txn
+                        .block_ref()
+                        .is_some_and(|br| GenericTransactionRef::BlockRef(br) == *block_ref);
+                    tx_ref_match || block_ref_match
+                });
 
                 if !exists {
                     filtered.insert(*block_ref, authority_set.clone());

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1240,7 +1240,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.reference(), commitment, serialized)
+                VerifiedTransactions::new(transactions, header.transaction_ref(), serialized)
             })
             .collect::<Vec<_>>();
 
@@ -1354,7 +1354,7 @@ mod tests {
             block_headers.push(header.clone());
 
             let verified_transaction =
-                VerifiedTransactions::new(transactions, header.reference(), commitment, serialized);
+                VerifiedTransactions::new(transactions, header.transaction_ref(), serialized);
 
             verified_transactions.push(verified_transaction);
         }
@@ -1474,7 +1474,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.reference(), commitment, serialized)
+                VerifiedTransactions::new(transactions, header.transaction_ref(), serialized)
             })
             .collect::<Vec<_>>();
 
@@ -1608,7 +1608,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.reference(), commitment, serialized)
+                VerifiedTransactions::new(transactions, header.transaction_ref(), serialized)
             })
             .collect::<Vec<_>>();
 
@@ -1731,7 +1731,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.reference(), commitment, serialized)
+                VerifiedTransactions::new(transactions, header.transaction_ref(), serialized)
             })
             .collect::<Vec<_>>();
 
@@ -1858,7 +1858,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.reference(), commitment, serialized)
+                VerifiedTransactions::new(transactions, header.transaction_ref(), serialized)
             })
             .collect::<Vec<_>>();
 

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1119,10 +1119,7 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
             .with_label_values(&[peer_hostname.as_str(), &sync_method.get_string()])
             .inc_by(transactions.len() as u64);
         for transactions in &transactions {
-            let block_hostname = &context
-                .committee
-                .authority(transactions.author())
-                .hostname;
+            let block_hostname = &context.committee.authority(transactions.author()).hostname;
             metrics
                 .transactions_synchronizer_fetched_transactions_by_authority
                 .with_label_values(&[block_hostname.as_str(), &sync_method.get_string()])

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1240,7 +1240,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.transaction_ref(), serialized)
+                VerifiedTransactions::new(transactions, header.transaction_ref(), header.digest(), serialized)
             })
             .collect::<Vec<_>>();
 
@@ -1354,7 +1354,7 @@ mod tests {
             block_headers.push(header.clone());
 
             let verified_transaction =
-                VerifiedTransactions::new(transactions, header.transaction_ref(), serialized);
+                VerifiedTransactions::new(transactions, header.transaction_ref(), header.digest(), serialized);
 
             verified_transactions.push(verified_transaction);
         }
@@ -1474,7 +1474,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.transaction_ref(), serialized)
+                VerifiedTransactions::new(transactions, header.transaction_ref(), header.digest(), serialized)
             })
             .collect::<Vec<_>>();
 
@@ -1608,7 +1608,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.transaction_ref(), serialized)
+                VerifiedTransactions::new(transactions, header.transaction_ref(), header.digest(), serialized)
             })
             .collect::<Vec<_>>();
 
@@ -1731,7 +1731,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.transaction_ref(), serialized)
+                VerifiedTransactions::new(transactions, header.transaction_ref(), header.digest(), serialized)
             })
             .collect::<Vec<_>>();
 
@@ -1858,7 +1858,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(transactions, header.transaction_ref(), serialized)
+                VerifiedTransactions::new(transactions, header.transaction_ref(), header.digest(), serialized)
             })
             .collect::<Vec<_>>();
 

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1121,7 +1121,7 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         for transactions in &transactions {
             let block_hostname = &context
                 .committee
-                .authority(transactions.block_ref().author)
+                .authority(transactions.author())
                 .hostname;
             metrics
                 .transactions_synchronizer_fetched_transactions_by_authority


### PR DESCRIPTION
# Description of change

Remove block_digest from TransactionRef, completing the decoupling of transaction references from block header digests. This is a step toward fully independent transaction addressing in the consensus protocol.

 Key changes:

  - Remove block_digest field from TransactionRef
  - Add block_digest field to VerifiedTransactions and ShardMessage — as an Option<BlockHeaderDigest>, set to Some when using BlockRef-based fetching, None when using TransactionRef-based fetching
  - Add tx_ref_to_block_digest_by_authority lookup table to DagState — maps (round, transactions_commitment) to BlockHeaderDigest per authority, enabling resolution of TransactionRefs to BlockRefs when needed

## Links to any relevant issues

Fixes #9821 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

