### PR TITLE
fix(open-rpc): correct example for iota_getEvents

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -786,30 +786,23 @@
           ],
           "result": {
             "name": "Result",
-            "value": {
-              "data": [
-                {
-                  "id": {
-                    "txDigest": "11a72GCQ5hGNpWGh2QhQkkusTEGS6EDqifJqxr7nSYX",
-                    "eventSeq": "0"
-                  },
-                  "packageId": "0xc54ab30a3d9adc07c1429c4d6bbecaf9457c9af77a91f631760853934d383634",
-                  "transactionModule": "test_module",
-                  "sender": "0xbcf7c32655009a61f1de0eae420a2e4ae1bb772ab2dd5d5a7dfa949c0ef06908",
-                  "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestEvent",
-                  "parsedJson": {
-                    "test": "example value"
-                  },
-                  "bcsEncoding": "base64",
-                  "bcs": ""
-                }
-              ],
-              "nextCursor": {
-                "txDigest": "11a72GCQ5hGNpWGh2QhQkkusTEGS6EDqifJqxr7nSYX",
-                "eventSeq": "5"
-              },
-              "hasNextPage": false
-            }
+            "value": [
+              {
+                "id": {
+                  "txDigest": "11a72GCQ5hGNpWGh2QhQkkusTEGS6EDqifJqxr7nSYX",
+                  "eventSeq": "0"
+                },
+                "packageId": "0xc54ab30a3d9adc07c1429c4d6bbecaf9457c9af77a91f631760853934d383634",
+                "transactionModule": "test_module",
+                "sender": "0xbcf7c32655009a61f1de0eae420a2e4ae1bb772ab2dd5d5a7dfa949c0ef06908",
+                "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestEvent",
+                "parsedJson": {
+                  "test": "example value"
+                },
+                "bcsEncoding": "base64",
+                "bcs": ""
+              }
+            ]
           }
         }
       ]

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -797,17 +797,12 @@ impl RpcExampleProvider {
             timestamp_ms: None,
         };
 
-        let page = EventPage {
-            data: vec![event],
-            next_cursor: Some((tx_dig, 5).into()),
-            has_next_page: false,
-        };
         Examples::new(
             "iota_getEvents",
             vec![ExamplePairing::new(
                 "Returns the events the transaction in the request emits.",
                 vec![("transaction_digest", json!(tx_dig))],
-                json!(page),
+                json!(vec![event]),
             )],
         )
     }


### PR DESCRIPTION
# Description of change

Fixes a long standing oversight in the example of the `iota_getEvents` endpoint.

cc: @iotaledger/devrel requires update of the docs

